### PR TITLE
Fixed a minor typo in the header

### DIFF
--- a/src/components/n2a-header.imba
+++ b/src/components/n2a-header.imba
@@ -30,7 +30,7 @@ tag n2a-header
 							<a.button[bg: rgb(232, 91, 70) c: white border-radius: 0.3rem] target="_blank" href="https://www.patreon.com/alemayhu">
 								<span .icon .is-large>
 									<i.fab.fa-patreon>
-								<span[tt: uppercase fw: bold]> "Become a Patreon"							
+								<span[tt: uppercase fw: bold]> "Become a Patron"							
 						<div.navbar-item>
 							<div.field.is-grouped>
 								<p.control[p:2]>


### PR DESCRIPTION
- Become a Patreon -> Become a Patron

I double-checked it, the platform is Patreon but the supporters are patrons, without 'e'.

---
Screenshot from Patreon's website as a proof, just in case. 
<img width="143" alt="2020-08-22 21_13_48-Creator Home _ Patreon" src="https://user-images.githubusercontent.com/68744864/90962927-6f450400-e4bc-11ea-8cd5-4520e66ec3b1.png">
