### PR TITLE
refactor: use plain text for error messages

### DIFF
--- a/server/lib/misc/ErrorHandler.ts
+++ b/server/lib/misc/ErrorHandler.ts
@@ -1,20 +1,10 @@
-import path from 'path';
-import fs from 'fs';
-
 import * as Sentry from '@sentry/node';
 import express from 'express';
-
-import { TEMPLATE_DIR } from '../constants';
-
-const errorPage = fs
-  .readFileSync(path.join(TEMPLATE_DIR, 'error-message.html'))
-  .toString();
 
 export default function ErrorHandler(res: express.Response, err: Error) {
   if (process.env.NODE_ENV === 'production') {
     Sentry.captureException(err);
   }
-  res.set('Content-Type', 'text/html');
-  const info = errorPage.replace('{err.message}', err.message);
-  res.status(400).send(info);
+  res.set('Content-Type', 'text/plain');
+  res.status(400).send(err.message);
 }

--- a/server/templates/error-message.html
+++ b/server/templates/error-message.html
@@ -1,3 +1,0 @@
-<div class="has-text-centered">
-        <h1 class="title">{err.message}</h1>
-</div>


### PR DESCRIPTION
The clients will no longer treat it as HTML.