### PR TITLE
fix: handle bug where child page titles would cause crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "notion2anki-server",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "notion2anki-server",
-      "version": "1.0.0-alpha.9",
+      "version": "1.0.0-alpha.10",
       "license": "MIT",
       "dependencies": {
         "@notionhq/client": "^0.4.12",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "notion2anki"
   ],
   "author": "Alexander Alemayhu",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/src/lib/notion/BlockHandler.ts
+++ b/src/lib/notion/BlockHandler.ts
@@ -42,7 +42,7 @@ import perserveNewlinesIfApplicable from './helpers/preserveNewlinesIfApplicable
 import getDeckName from '../anki/getDeckname';
 import LinkToPage from './blocks/LinkToPage';
 import getUniqueFileName from '../misc/getUniqueFileName';
-import getPlainText from './helpers/getPlainText';
+import getSubDeckName from './helpers/getSubDeckName';
 
 interface Finder {
   parentType: string;
@@ -453,13 +453,15 @@ class BlockHandler {
             'utf8'
           );
           /* @ts-ignore */
-          const text = sd[sd.type].text;
+          const block = sd[sd.type];
+          let subDeckName = getSubDeckName(block);
+
           decks.push(
             new Deck(
               /* @ts-ignore */
               getDeckName(
                 this.settings.deckName || this.firstPageTitle,
-                getPlainText(text)
+                subDeckName
               ),
               cards,
               undefined,

--- a/src/lib/notion/helpers/getSubDeckName.test.ts
+++ b/src/lib/notion/helpers/getSubDeckName.test.ts
@@ -1,0 +1,41 @@
+import getSubDeckName from './getSubDeckName';
+
+const MOCK_CHILD_PAGE = JSON.parse(`
+{
+	"properties": {
+		"title": {
+			"id": "title",
+			"type": "title",
+			"title": [
+				{
+					"type": "text",
+					"text": {
+						"content": "Basic Only",
+						"link": null
+					},
+					"annotations": {
+						"bold": false,
+						"italic": false,
+						"strikethrough": false,
+						"underline": false,
+						"code": false,
+						"color": "default"
+					},
+					"plain_text": "Basic Only",
+					"href": null
+				}
+			]
+		}
+	}
+}
+`);
+
+describe('getSubDeckName', () => {
+  it.each([
+    ['name from title', { title: 'cool' }, 'cool'],
+    ['empty', {}, 'Untitled'],
+    ['child page', MOCK_CHILD_PAGE, 'Basic Only'],
+  ])('%s', (_, input, expected) => {
+    expect(getSubDeckName(input)).toBe(expected);
+  });
+});

--- a/src/lib/notion/helpers/getSubDeckName.ts
+++ b/src/lib/notion/helpers/getSubDeckName.ts
@@ -1,0 +1,26 @@
+import { GetBlockResponse } from '@notionhq/client/build/src/api-endpoints';
+import { captureException } from '@sentry/node';
+import getPlainText from './getPlainText';
+
+const getSubDeckName = (block: GetBlockResponse | Object) => {
+  let subDeckName = 'Untitled';
+  /* @ts-ignore */
+  const text = block.text;
+  /* @ts-ignore */
+  const title = block.title;
+  try {
+    if (text) {
+      subDeckName = getPlainText(text);
+    } else if (title) {
+      subDeckName = title;
+    } else {
+      /* @ts-ignore */
+      subDeckName = block?.properties.title.title[0].plain_text;
+    }
+  } catch (error) {
+    captureException(error);
+  }
+  return subDeckName;
+};
+
+export default getSubDeckName;


### PR DESCRIPTION
We can't assume that the block is a text-like block. So we need to
either use a top-level title or title nested in properties.

Fixes: https://github.com/2anki/server/issues/696