### PR TITLE
fix: limit unique filenames to be less 101

### DIFF
--- a/src/lib/misc/getUniqueFileName.test.ts
+++ b/src/lib/misc/getUniqueFileName.test.ts
@@ -1,0 +1,7 @@
+import getUniqueFileName from './getUniqueFileName';
+
+describe('getUniqueFileName', () => {
+  test('default max is less than 101 characters', () => {
+    expect(getUniqueFileName('my image.jpg').length).toBeLessThan(101);
+  });
+});

--- a/src/lib/misc/getUniqueFileName.ts
+++ b/src/lib/misc/getUniqueFileName.ts
@@ -6,10 +6,10 @@ import crypto from 'crypto';
  * @param input user supplied filename
  * @returns hex digest
  */
-const getUniqueFileName = (input: string) => {
+const getUniqueFileName = (input: string, max: number = 100) => {
   const shasum = crypto.createHash('sha512');
   shasum.update(input);
-  return shasum.digest('hex');
+  return shasum.digest('hex').slice(0, max);
 };
 
 export default getUniqueFileName;


### PR DESCRIPTION
Anki will not handle filenames that are longer. Not sure what the exact
length is but if we are below 119 it should be safer than the current
132.