### PR TITLE
fix: do not throw on empty package

### DIFF
--- a/src/routes/upload/helpers/handleUpload.ts
+++ b/src/routes/upload/helpers/handleUpload.ts
@@ -88,7 +88,7 @@ export default async function handleUpload(
     } else if (packages.length > 1) {
       sendBundle(packages, storage, res);
     } else {
-      throw NO_PACKAGE_ERROR;
+      ErrorHandler(res, NO_PACKAGE_ERROR);
     }
   } catch (err) {
     captureException(err);


### PR DESCRIPTION
Users still see a message and can get to the settings.