### PR TITLE
fix: update dokku-github-action from v7.0 to v7.1

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -15,7 +15,7 @@ jobs:
           git config --global --add safe.directory /github/workspace
       - uses: actions/checkout@v1
       - name: Dokku deploy
-        uses: vitalyliber/dokku-github-action@v7.0
+        uses: vitalyliber/dokku-github-action@v7.1
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           HOST: 2anki.net


### PR DESCRIPTION
This fixes current deployment failures to production
> 2022-12-25T09:03:18.8375118Z fatal: detected dubious ownership in repository at '/github/workspace'
  2022-12-25T09:03:18.8375726Z To add an exception for this directory, call:
  2022-12-25T09:03:18.8375926Z
  2022-12-25T09:03:18.8376189Z 	git config --global --add safe.directory /github/workspace
  2022-12-25T09:03:18.8392298Z fatal: detected dubious ownership in repository at '/github/workspace'
  2022-12-25T09:03:18.8392682Z Default is master
  2022-12-25T09:03:18.8397015Z To add an exception for this directory, call:
  2022-12-25T09:03:18.8397225Z
  2022-12-25T09:03:18.8397504Z 	git config --global --add safe.directory /github/workspace
  2022-12-25T09:03:18.8397947Z Disabling host key checking
  2022-12-25T09:03:18.8398302Z The deploy is starting
  2022-12-25T09:03:18.9838664Z Cleaning up orphan processes