### PR TITLE
fix: handle file.path is not for buffer

### DIFF
--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -86,7 +86,7 @@ class GeneratePackagesUseCase {
     let packages: Package[] = [];
 
     for (const file of files) {
-      const fileContents = fs.readFileSync(file.path);
+      const fileContents = file.path ? fs.readFileSync(file.path) : file.buffer;
       const filename = file.originalname;
       const key = file.key;
 


### PR DESCRIPTION
Fixes:
The "path" argument must be of type string or an instance of Buffer or URL. Received undefined