### PR TITLE
fix: handle paying field is undefined

### DIFF
--- a/src/lib/User/checkFlashcardsLimits.ts
+++ b/src/lib/User/checkFlashcardsLimits.ts
@@ -8,11 +8,9 @@ interface UserOptions {
 }
 
 const getCardCount = (initial: number, decks?: Deck[]) => {
-  let start = initial ?? 0;
+  if (decks === undefined) return initial ?? 0;
 
-  if (decks === undefined) return start;
-
-  return decks.reduce((acc, deck) => acc + deck.cards.length, initial) + start;
+  return decks.reduce((acc, deck) => acc + deck.cards.length, initial);
 };
 
 export const checkFlashcardsLimits = ({
@@ -21,7 +19,8 @@ export const checkFlashcardsLimits = ({
   paying,
 }: UserOptions) => {
   const CARD_LIMIT = 100;
-  const isAbove100 = getCardCount(cards ?? 0, decks) > CARD_LIMIT;
+  const cardCount = getCardCount(cards ?? 0, decks);
+  const isAbove100 = cardCount > CARD_LIMIT;
 
   if (paying) return;
 

--- a/src/lib/User/checkLimits.test.ts
+++ b/src/lib/User/checkLimits.test.ts
@@ -1,25 +1,40 @@
 import { checkFlashcardsLimits } from './checkFlashcardsLimits';
 
 describe('checkLimits', () => {
-
   test('throws an error if more than 100 cards are added for anon', () => {
-    expect(() => checkFlashcardsLimits({
-      decks: [],
-      paying: false,
-      cards: 101
-    })).toThrow();
+    expect(() =>
+      checkFlashcardsLimits({
+        decks: [],
+        paying: false,
+        cards: 101,
+      })
+    ).toThrow();
   });
 
   test('does not throw an error if 100 cards are added by patreon or subscriber', () => {
-    expect(() => checkFlashcardsLimits({
-      decks: [],
-      paying: true,
-      cards: 200
-    })).not.toThrow();
-    expect(() => checkFlashcardsLimits({
-      decks: [],
-      cards: 500,
-      paying: true,
-    })).not.toThrow();
-  })
+    expect(() =>
+      checkFlashcardsLimits({
+        decks: [],
+        paying: true,
+        cards: 200,
+      })
+    ).not.toThrow();
+    expect(() =>
+      checkFlashcardsLimits({
+        decks: [],
+        cards: 500,
+        paying: true,
+      })
+    ).not.toThrow();
+  });
+
+  test('does not throw an error if 51 cards are added by anon', () => {
+    expect(() =>
+      checkFlashcardsLimits({
+        decks: [],
+        paying: undefined,
+        cards: 51,
+      })
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
This fixes a regression where limits were enforced wrongly.
