### PR TITLE
fix: allow for zip uploads without suffix

### DIFF
--- a/src/lib/storage/checks.ts
+++ b/src/lib/storage/checks.ts
@@ -25,3 +25,12 @@ export const isImageFileEmbedable = (url: string) => {
 export const isCSVFile = (fileName: string) => /.csv$/i.exec(fileName);
 
 export const isPDFFile = (fileName: string) => /.pdf$/i.exec(fileName);
+
+/**
+ * A file is considered a potential zip file if it does not contain a period.
+ * Since zip files are not named with a period, but it is possible to upload such files using drag and drop.
+ * @param filename
+ * @returns
+ */
+export const isPotentialZipFile = (filename: string): boolean =>
+  !filename.includes('.');

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -4,7 +4,7 @@ import Settings from '../../lib/parser/Settings';
 import Package from '../../lib/parser/Package';
 import fs from 'fs';
 import { PrepareDeck } from '../../lib/parser/PrepareDeck';
-import { isZIPFile } from '../../lib/storage/checks';
+import { isPotentialZipFile, isZIPFile } from '../../lib/storage/checks';
 import { getPackagesFromZip } from './getPackagesFromZip';
 import Workspace from '../../lib/parser/WorkSpace';
 import { isZipContentFileSupported } from './isZipContentFileSupported';
@@ -40,7 +40,11 @@ function doGenerationWork(data: GenerationData) {
           const pkg = new Package(d.name);
           packages = packages.concat(pkg);
         }
-      } else if (isZIPFile(filename) || isZIPFile(key)) {
+      } else if (
+        isZIPFile(filename) ||
+        isZIPFile(key) ||
+        isPotentialZipFile(filename)
+      ) {
         const { packages: extraPackages } = await getPackagesFromZip(
           fileContents,
           paying,


### PR DESCRIPTION
A file is considered a potential zip file if it does not contain a
period.  Since zip files are not named with a period, but it is possible
to upload such files using drag and drop.
