### PR TITLE
fix: handle no filename in zip check

### DIFF
--- a/src/lib/storage/checks.test.ts
+++ b/src/lib/storage/checks.test.ts
@@ -28,3 +28,9 @@ test('isPotentialZipFile identifies potential zip files', () => {
   expect(isPotentialZipFile(HAS_EXTENSION_TAR_GZ)).toBe(false);
   expect(isPotentialZipFile(ENDS_WITH_DOUBLE_PERIOD)).toBe(true);
 });
+
+test('isPotentialZipFile handles undefined input gracefully', () => {
+  expect(isPotentialZipFile(undefined)).toBe(false);
+  expect(isPotentialZipFile(null)).toBe(false);
+  expect(isPotentialZipFile('')).toBe(false);
+});

--- a/src/lib/storage/checks.ts
+++ b/src/lib/storage/checks.ts
@@ -34,6 +34,11 @@ export const isPPTFile = (fileName: string) => /\.(ppt|pptx)$/i.exec(fileName);
  * @param filename
  * @returns
  */
-export const isPotentialZipFile = (filename: string): boolean => {
+export const isPotentialZipFile = (
+  filename: string | null | undefined
+): boolean => {
+  if (!filename) {
+    return false;
+  }
   return filename.trim().endsWith('.') || !filename.includes('.');
 };

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -43,7 +43,8 @@ function doGenerationWork(data: GenerationData) {
       } else if (
         isZIPFile(filename) ||
         isZIPFile(key) ||
-        isPotentialZipFile(filename)
+        isPotentialZipFile(filename) ||
+        isPotentialZipFile(key)
       ) {
         const { packages: extraPackages } = await getPackagesFromZip(
           fileContents,


### PR DESCRIPTION
Fixes the following crash:

> 2024-12-04T13:06:45.039Z - TypeError:
> Cannot read properties of undefined (reading 'trim')
> TypeError: Cannot read properties of undefined (reading 'trim')