### PR TITLE
fix: ensure the payload is passed into the setting

### DIFF
--- a/src/lib/parser/Settings/loadSettingsFromDatabase.ts
+++ b/src/lib/parser/Settings/loadSettingsFromDatabase.ts
@@ -19,7 +19,7 @@ export const loadSettingsFromDatabase = async (
       return new Settings(Settings.LoadDefaultOptions());
     }
 
-    const settings = new Settings(result.payload);
+    const settings = new Settings(result.payload.payload);
     const templates = await DB('templates')
       .where({ owner: owner })
       .returning(['payload'])


### PR DESCRIPTION
I got a bug report where wrong settings where being applied and after debugging further the saved payload was never used due to the nested data.