### PR TITLE
fix: ignore PPT in zip

### DIFF
--- a/src/usecases/uploads/isZipContentFileSupported.ts
+++ b/src/usecases/uploads/isZipContentFileSupported.ts
@@ -4,7 +4,6 @@ import {
   isPlainText,
   isCSVFile,
   isPDFFile,
-  isPPTFile,
 } from '../../lib/storage/checks';
 
 /**
@@ -15,5 +14,4 @@ export const isZipContentFileSupported = (filename: string) =>
   isMarkdownFile(filename) ??
   isPlainText(filename) ??
   isCSVFile(filename) ??
-  isPDFFile(filename) ??
-  isPPTFile(filename);
+  isPDFFile(filename);

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -7,6 +7,7 @@ import { PrepareDeck } from '../../lib/parser/PrepareDeck';
 import {
   isImageFile,
   isPotentialZipFile,
+  isPPTFile,
   isZIPFile,
 } from '../../lib/storage/checks';
 import { getPackagesFromZip } from './getPackagesFromZip';
@@ -34,7 +35,11 @@ function doGenerationWork(data: GenerationData) {
 
       const allowImageQuizHtmlToAnki =
         paying && settings.imageQuizHtmlToAnki && isImageFile(filename);
-      if (isZipContentFileSupported(filename) || allowImageQuizHtmlToAnki) {
+      const isValidSingleFile =
+        isZipContentFileSupported(filename) ||
+        isPPTFile(filename) ||
+        allowImageQuizHtmlToAnki;
+      if (isValidSingleFile) {
         const d = await PrepareDeck({
           name: filename,
           files: [{ name: filename, contents: fileContents }],
@@ -47,6 +52,7 @@ function doGenerationWork(data: GenerationData) {
           packages = packages.concat(pkg);
         }
       } else if (
+        /* compressed file upload */
         isZIPFile(filename) ||
         isZIPFile(key) ||
         isPotentialZipFile(filename) ||


### PR DESCRIPTION
It's currently unreliable and the output produces clipped images.
