### PR TITLE
fix: resolve crash caused by images being overwritten with HTML

### DIFF
--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -19,7 +19,11 @@ import { embedFile } from './exporters/embedFile';
 import getYouTubeEmbedLink from './helpers/getYouTubeEmbedLink';
 import getYouTubeID from './helpers/getYouTubeID';
 import { isFileNameEqual } from '../storage/types';
-import { isImageFileEmbedable, isMarkdownFile } from '../storage/checks';
+import {
+  isHTMLFile,
+  isImageFileEmbedable,
+  isMarkdownFile,
+} from '../storage/checks';
 import { getFileContents } from './getFileContents';
 import { handleNestedBulletPointsInMarkdown } from './handleNestedBulletPointsInMarkdown';
 import { checkFlashcardsLimits } from '../User/checkFlashcardsLimits';
@@ -60,30 +64,34 @@ export class DeckParser {
     this.firstDeckName = input.name;
     this.noLimits = input.noLimits;
     this.globalTags = null;
+    this.payload = [];
+    this.processFirstFile(input.name);
+  }
 
-    const firstFile = this.files.find((file) =>
-      isFileNameEqual(file, input.name)
-    );
+  processFirstFile(name: string) {
+    const firstFile = this.files.find((file) => isFileNameEqual(file, name));
 
-    if (this.settings.nestedBulletPoints && isMarkdownFile(input.name)) {
+    if (this.settings.nestedBulletPoints && isMarkdownFile(name)) {
       const contents = getFileContents(firstFile, false);
       this.payload = handleNestedBulletPointsInMarkdown(
-        input.name,
+        name,
         contents?.toString(),
         this.settings.deckName,
         [],
         this.settings
       );
-    } else {
+    } else if (isHTMLFile(name)) {
       const contents = getFileContents(firstFile, true);
       this.payload = contents
         ? this.handleHTML(
-            input.name,
+            name,
             contents.toString(),
             this.settings.deckName || '',
             []
           )
         : [];
+    } else {
+      this.payload = [];
     }
   }
 

--- a/src/lib/parser/experimental/FallbackParser.ts
+++ b/src/lib/parser/experimental/FallbackParser.ts
@@ -121,7 +121,7 @@ class FallbackParser {
         const plainTextParser = new PlainTextParser();
         const found = plainTextParser.parse(plainText);
         cards = this.mapCardsToNotes(found);
-        deckName = this.getTitleFromHTML(contents);
+        deckName = this.getTitleFromHTML(contents) ?? file.name;
       } else if (isMarkdownFile(file.name) || isPlainText(file.name)) {
         const plainTextParser = new PlainTextParser();
         const items = this.getMarkdownBulletLists(contents);

--- a/src/lib/parser/experimental/VertexAPI/convertImageToHTML.ts
+++ b/src/lib/parser/experimental/VertexAPI/convertImageToHTML.ts
@@ -1,5 +1,6 @@
 import { VertexAI } from '@google-cloud/vertexai';
 import { SAFETY_SETTINGS } from './constants';
+import { removeFirstAndLastLine } from './removeFirstAndLastLine';
 
 export const convertImageToHTML = async (
   imageData: string
@@ -8,7 +9,7 @@ export const convertImageToHTML = async (
     project: 'notion-to-anki',
     location: 'europe-west3',
   });
-  const model = 'gemini-1.5-flash-002';
+  const model = 'gemini-1.5-pro-002';
 
   const generativeModel = vertexAI.preview.getGenerativeModel({
     model: model,
@@ -21,7 +22,7 @@ export const convertImageToHTML = async (
   });
 
   const text1 = {
-    text: `Convert the text in this image to the following format: 
+    text: `Convert the text in this image to the following format for (every question is their own ul):
 
         <ul class=\"toggle\">
           <li>
@@ -71,6 +72,7 @@ export const convertImageToHTML = async (
   } catch (error) {
     console.error('Error generating content stream:', error);
   }
+  htmlContent = removeFirstAndLastLine(htmlContent);
 
   return htmlContent;
 };

--- a/src/lib/parser/experimental/VertexAPI/removeFirstAndLastLine.ts
+++ b/src/lib/parser/experimental/VertexAPI/removeFirstAndLastLine.ts
@@ -1,0 +1,11 @@
+/**
+ * Google VertexAI is returning Markdown:
+ * ```html
+ * [...]
+ * ```
+ * So we need to remove the first and last line
+ */
+export function removeFirstAndLastLine(content: string): string {
+  const lines = content.split('\n');
+  return lines.slice(1, -1).join('\n');
+}

--- a/src/usecases/uploads/isZipContentFileSupported.ts
+++ b/src/usecases/uploads/isZipContentFileSupported.ts
@@ -4,6 +4,7 @@ import {
   isPlainText,
   isCSVFile,
   isPDFFile,
+  isImageFile,
 } from '../../lib/storage/checks';
 
 /**
@@ -14,4 +15,5 @@ export const isZipContentFileSupported = (filename: string) =>
   isMarkdownFile(filename) ??
   isPlainText(filename) ??
   isCSVFile(filename) ??
-  isPDFFile(filename);
+  isPDFFile(filename) ??
+  isImageFile(filename);


### PR DESCRIPTION
This is backwards compatible and should only trigger with the
imageQuizHtmlToAnki card option.
