### PR TITLE
fix: do not fail due to unoconv exit code

### DIFF
--- a/src/lib/pdf/ConvertPPTToPDF.ts
+++ b/src/lib/pdf/ConvertPPTToPDF.ts
@@ -41,7 +41,10 @@ export function convertPPTToPDF(
               stderr
             );
             if (error) {
-              reject(new Error(error.message || 'Conversion failed'));
+              await fs.writeFile(
+                path.join(workspace.location, 'error.log'),
+                error.message || 'Conversion failed'
+              );
             }
             resolve(await fs.readFile(pdfFile));
           }


### PR DESCRIPTION
We can get bad exit code for warnings.