### PR TITLE
fix: support pages with newlines in title

### DIFF
--- a/src/lib/extractDeckName.test.ts
+++ b/src/lib/extractDeckName.test.ts
@@ -1,0 +1,56 @@
+import { extractName } from "./extractDeckName";
+
+const createInput = (name: string, pageIcon: string | null, decksCount: number, pageEmoji: string) => ({
+    name,
+    pageIcon,
+    decksCount,
+    settings: { pageEmoji }
+});
+
+const createExpectedOutput = (name: string, pageIcon: string | null, pageEmoji: string) => {
+    if (pageIcon === null || name.includes(pageIcon)) {
+        return name;
+    }
+    return pageEmoji === 'first_emoji' ? `${pageIcon} ${name}` : `${name} ${pageIcon}`;
+};
+
+const testCases = [
+    {
+        description: 'should return the correct deck name when pageIcon is null',
+        input: createInput('Default::My Deck', null, 0, 'first_emoji'),
+        expected: 'Default::My Deck'
+    },
+    {
+        description: 'should return the name with pageIcon prefixed when settings.pageEmoji is "first_emoji"',
+        input: createInput('My Deck', 'Default', 0, 'first_emoji'),
+        expected: 'Default My Deck'
+    },
+    {
+        description: 'should return the name with pageIcon suffixed when settings.pageEmoji is not "first_emoji"',
+        input: createInput('My Deck', 'Default', 0, 'last_emoji'),
+        expected: 'My Deck Default'
+    },
+    {
+        description: 'should handle names with "::" correctly',
+        input: createInput('Default::My Deck', 'Default', 0, 'first_emoji'),
+        expected: 'Default::My Deck'
+    },
+    {
+        description: 'should return the original name if pageIcon is included in the name',
+        input: createInput('Default::My Deck', 'Default', 1, 'first_emoji'),
+        expected: 'Default::My Deck'
+    },
+    {
+        description: 'should handle newlines in the deck name correctly',
+        input: createInput('Default\nMy Deck', 'Default', 0, 'first_emoji'),
+        expected: 'Default My Deck'
+    },
+];
+
+describe('extractDeckName', () => {
+    testCases.forEach(({ description, input, expected }) => {
+        it(description, () => {
+            expect(extractName(input)).toBe(expected);
+        });
+    });
+});

--- a/src/lib/extractDeckName.ts
+++ b/src/lib/extractDeckName.ts
@@ -1,0 +1,39 @@
+export interface ExtractNameInput {
+  name: string;
+  pageIcon: string | null;
+  decksCount: number;
+  settings: {
+    pageEmoji: string;
+  };
+}
+
+export function extractName(input: ExtractNameInput): string {
+  const { name, pageIcon: pi, decksCount, settings } = input;
+  if (!pi) {
+    return name;
+  }
+  if (settings.pageEmoji === 'disable_emoji') {
+    return name;
+  }
+
+  const cleanName = name.replace(/\n/g, ' ');
+
+  if (!cleanName.includes(pi) && decksCount === 0) {
+    if (!cleanName.includes('::') && !cleanName.startsWith(pi)) {
+      return settings.pageEmoji === 'first_emoji'
+        ? `${pi} ${cleanName}`
+        : `${cleanName} ${pi}`;
+    } else {
+      const names = cleanName.split(/::/);
+      const end = names.length - 1;
+      const last = names[end];
+      names[end] =
+        settings.pageEmoji === 'first_emoji'
+          ? `${pi} ${last}`
+          : `${last} ${pi}`;
+      return names.join('::');
+    }
+  }
+
+  return cleanName;
+}

--- a/src/lib/parser/Deck.ts
+++ b/src/lib/parser/Deck.ts
@@ -27,7 +27,7 @@ export default class Deck {
     settings: CardOption
   ) {
     this.settings = settings;
-    this.name = name;
+    this.name = name.replace(/\n/g, ' ');
     this.cards = cards;
     this.image = image;
     this.style = style;


### PR DESCRIPTION
We are just stripping it away since it causes the export to produce
file names with newlines.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>
