### PR TITLE
fix: allow PDF files in zip uploads

### DIFF
--- a/src/lib/zip/zip.tsx
+++ b/src/lib/zip/zip.tsx
@@ -7,7 +7,6 @@ import {
   isHTMLFile,
   isImageFile,
   isMarkdownFile,
-  isPDFFile,
 } from '../storage/checks';
 import { processAndPrepareArchiveData } from './fallback/processAndPrepareArchiveData';
 import CardOption from '../parser/Settings';
@@ -95,7 +94,7 @@ class ZipHandler {
     paying: boolean,
     settings: CardOption
   ) {
-    if (name.includes('__MACOSX/') || isPDFFile(name)) return;
+    if (name.includes('__MACOSX/')) return;
 
     if (name.endsWith('.zip')) {
       this.zipFileCount++;

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -29,9 +29,6 @@ export const getPackagesFromZip = async (
 
   let cardCount = 0;
   for (const fileName of fileNames) {
-    /**
-     * XXX: Should we also support files without extensions?
-     */
     if (isZipContentFileSupported(fileName)) {
       const deck = await PrepareDeck({
         name: fileName,

--- a/src/usecases/uploads/isZipContentFileSupported.ts
+++ b/src/usecases/uploads/isZipContentFileSupported.ts
@@ -7,13 +7,14 @@ import {
   isXLSXFile,
 } from '../../lib/storage/checks';
 
-/**
- * XXX: Should we also support files without extensions?
- */
+const isFileWithoutExtension = (filename: string) =>
+  filename && filename.indexOf('.') === -1;
+
 export const isZipContentFileSupported = (filename: string) =>
   isHTMLFile(filename) ??
   isMarkdownFile(filename) ??
   isPlainText(filename) ??
   isCSVFile(filename) ??
   isPDFFile(filename) ??
-  isXLSXFile(filename);
+  isXLSXFile(filename) ??
+  isFileWithoutExtension(filename);


### PR DESCRIPTION
Initially I was worried that the Vertex AI usage could trigger too many requests in Google cloud but from testing I can see that Google has rate limiting in place so it will likely be triggered if batch zip with vertex enabled. 