### PR TITLE
fix: ensure handleChildDatabase picks up all decks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10273,11 +10273,12 @@
       }
     },
     "node_modules/metascraper-description": {
-      "version": "5.45.25",
-      "resolved": "https://registry.npmjs.org/metascraper-description/-/metascraper-description-5.45.25.tgz",
-      "integrity": "sha512-ysbsUtgwcEfmPU1tfT7VBcw7nITHnFFamNiUpRirWGR90kJ82YzIMUk5NW/pWantpvVSJjjFOPqZM768RuelfQ==",
+      "version": "5.46.5",
+      "resolved": "https://registry.npmjs.org/metascraper-description/-/metascraper-description-5.46.5.tgz",
+      "integrity": "sha512-RJKfwVPXRy8+w7mSjJM+6oe1ws3AtPA5CspcJty1fdKD1S4jF0nFzgwtrTgOCtggMK8iHG01/qAunPobFEbs+w==",
+      "license": "MIT",
       "dependencies": {
-        "@metascraper/helpers": "^5.45.25"
+        "@metascraper/helpers": "5.46.5"
       },
       "engines": {
         "node": ">= 16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13195,10 +13195,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -344,7 +344,8 @@ class BlockHandler {
             sd.type === 'child_database' &&
             rules.SUB_DECKS.includes('child_database')
           ) {
-            decks = await this.handleChildDatabase(sd, rules, decks);
+            const dbDecks = await this.handleChildDatabase(sd, rules);
+            decks.push(...dbDecks);
             continue;
           }
 
@@ -401,23 +402,24 @@ class BlockHandler {
 
   private async handleChildDatabase(
     sd: BlockObjectResponse,
-    rules: ParserRules,
-    decks: Deck[]
+    rules: ParserRules
   ): Promise<Deck[]> {
     const dbResult = await this.api.queryDatabase(sd.id);
     const database = await this.api.getDatabase(sd.id);
     const dbName = await this.api.getDatabaseTitle(database, this.settings);
+    let dbDecks: Deck[] = [];
 
     for (const entry of dbResult.results) {
-      decks = await this.findFlashcardsFromPage({
+      const entryDecks = await this.findFlashcardsFromPage({
         parentType: 'database',
         topLevelId: entry.id,
         rules,
-        decks,
+        decks: [],
         parentName: dbName,
       });
+      dbDecks.push(...entryDecks);
     }
-    return decks;
+    return dbDecks;
   }
 }
 


### PR DESCRIPTION
In the previous implementation it was overwriting resulting in only one
deck.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>
