### PR TITLE
feat: add process-pdfs option to control PDF processing

### DIFF
--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -27,6 +27,8 @@ function testDefaultSettings(
 ) {
   const settingsController = new CardOptionsController(new FakeSettingsService());
   const defaultOptions = settingsController.getDefaultCardOptions(type);
+  console.log('Actual options:', defaultOptions);
+  console.log('Expected options:', expectedOptions);
   expect(defaultOptions).toStrictEqual(expectedOptions);
 }
 
@@ -41,7 +43,6 @@ describe('SettingsController', () => {
       avocado: 'false',
       tags: 'false',
       cloze: 'true',
-      'markdown-nested-bullet-points': 'true',
       'enable-input': 'false',
       'basic-reversed': 'false',
       reversed: 'false',
@@ -49,6 +50,8 @@ describe('SettingsController', () => {
       'max-one-toggle-per-card': 'true',
       'remove-mp3-links': 'true',
       'perserve-newlines': 'true',
+      'process-pdfs': 'true',
+      'markdown-nested-bullet-points': 'true',
       'vertex-ai-pdf-questions': 'false',
       'disable-indented-bullets': 'false',
       'image-quiz-html-to-anki': 'false',
@@ -71,6 +74,7 @@ describe('SettingsController', () => {
       'no-underline': 'false',
       'max-one-toggle-per-card': 'true',
       'perserve-newlines': 'false',
+      'process-pdfs': 'true',
       'page-emoji': 'first-emoji',
       'image-quiz-html-to-anki': 'false',
       'markdown-nested-bullet-points': 'true',

--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -27,8 +27,6 @@ function testDefaultSettings(
 ) {
   const settingsController = new CardOptionsController(new FakeSettingsService());
   const defaultOptions = settingsController.getDefaultCardOptions(type);
-  console.log('Actual options:', defaultOptions);
-  console.log('Expected options:', expectedOptions);
   expect(defaultOptions).toStrictEqual(expectedOptions);
 }
 

--- a/src/controllers/CardOptionsController/supportedOptions.ts
+++ b/src/controllers/CardOptionsController/supportedOptions.ts
@@ -116,6 +116,12 @@ const supportedOptions = (): CardOptionDetail[] => {
       'Use OCR to extract images and answers from HTML quizzes and convert them into Anki flashcards for review. This is a premium experimental feature.',
       false
     ),
+    new CardOptionDetail(
+      'process-pdfs',
+      'Process PDF Files',
+      'When enabled, PDF files in ZIP uploads will be processed and converted to Anki cards. Disable this to skip PDF processing and speed up conversion of ZIP files containing PDFs.',
+      true
+    ),
   ];
 
   return v.filter(Boolean);

--- a/src/controllers/CardOptionsController/supportedOptions.ts
+++ b/src/controllers/CardOptionsController/supportedOptions.ts
@@ -121,8 +121,8 @@ const supportedOptions = (): CardOptionDetail[] => {
       'Convert Image Quiz HTML to Anki Cards',
       'Use OCR to extract images and answers from HTML quizzes and convert them into Anki flashcards for review. This is a premium experimental feature.',
       false
-    )
-    ];
+    ),
+  ];
 
   return v.filter(Boolean);
 };

--- a/src/controllers/CardOptionsController/supportedOptions.ts
+++ b/src/controllers/CardOptionsController/supportedOptions.ts
@@ -93,6 +93,12 @@ const supportedOptions = (): CardOptionDetail[] => {
       true
     ),
     new CardOptionDetail(
+      'process-pdfs',
+      'Process PDF Files',
+      'When enabled, PDF files in ZIP uploads will be processed and converted to Anki cards. Disable this to skip PDF processing and speed up conversion of ZIP files containing PDFs.',
+      true
+    ),
+    new CardOptionDetail(
       'markdown-nested-bullet-points',
       'Markdown Nested Bullet Points',
       'Enable conversion of bullet and sub bullet points in Markdown. If you are a Obsidian user, enable this',
@@ -115,14 +121,8 @@ const supportedOptions = (): CardOptionDetail[] => {
       'Convert Image Quiz HTML to Anki Cards',
       'Use OCR to extract images and answers from HTML quizzes and convert them into Anki flashcards for review. This is a premium experimental feature.',
       false
-    ),
-    new CardOptionDetail(
-      'process-pdfs',
-      'Process PDF Files',
-      'When enabled, PDF files in ZIP uploads will be processed and converted to Anki cards. Disable this to skip PDF processing and speed up conversion of ZIP files containing PDFs.',
-      true
-    ),
-  ];
+    )
+    ];
 
   return v.filter(Boolean);
 };

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -58,7 +58,8 @@ export async function PrepareDeck(
     if (
       isPDFFile(file.name) &&
       input.noLimits &&
-      input.settings.vertexAIPDFQuestions
+      input.settings.vertexAIPDFQuestions &&
+      input.settings.processPDFs !== false
     ) {
       file.contents = await convertPDFToHTML(file.contents.toString('base64'));
     } else if (isPPTFile(file.name)) {
@@ -73,17 +74,19 @@ export async function PrepareDeck(
         workspace: input.workspace,
         noLimits: input.noLimits,
         contents: pdContents,
+        settings: input.settings,
       });
       convertedFiles.push({
         name: `${file.name}.html`,
         contents: convertedContents,
       });
-    } else if (isPDFFile(file.name)) {
+    } else if (isPDFFile(file.name) && input.settings.processPDFs !== false) {
       const convertedContents = await convertPDFToImages({
         name: file.name,
         workspace: input.workspace,
         noLimits: input.noLimits,
         contents: file.contents,
+        settings: input.settings,
       });
       convertedFiles.push({
         name: `${file.name}.html`,

--- a/src/infrastracture/adapters/fileConversion/convertPDFToImages.ts
+++ b/src/infrastracture/adapters/fileConversion/convertPDFToImages.ts
@@ -6,12 +6,14 @@ import { getPageCount } from '../../../lib/pdf/getPageCount';
 import { convertPage } from '../../../lib/pdf/convertPage';
 import { combineIntoHTML } from '../../../lib/pdf/combineIntoHTML';
 import { existsSync } from 'fs';
+import CardOption from '../../../lib/parser/Settings/CardOption';
 
 interface ConvertPDFToImagesInput {
   workspace: Workspace;
   noLimits: boolean;
   contents?: S3.Body;
   name?: string;
+  settings?: CardOption;
 }
 
 export const PDF_EXCEEDS_MAX_PAGE_LIMIT =
@@ -20,7 +22,12 @@ export const PDF_EXCEEDS_MAX_PAGE_LIMIT =
 export async function convertPDFToImages(
   input: ConvertPDFToImagesInput
 ): Promise<string> {
-  const { contents, workspace, noLimits, name } = input;
+  const { contents, workspace, noLimits, name, settings } = input;
+
+  // Skip PDF processing if the option is disabled
+  if (settings?.processPDFs === false) {
+    return '';
+  }
   const fileName = name
     ? path.basename(name).replace(/\.pptx?$/i, '.pdf')
     : 'Default.pdf';

--- a/src/lib/parser/Settings/CardOption.ts
+++ b/src/lib/parser/Settings/CardOption.ts
@@ -148,10 +148,10 @@ class CardOption {
       'no-underline': 'false',
       'max-one-toggle-per-card': 'true',
       'perserve-newlines': 'false',
+      'process-pdfs': 'true',
       'page-emoji': 'first-emoji',
       'image-quiz-html-to-anki': 'false',
       'markdown-nested-bullet-points': 'true',
-      'process-pdfs': 'true',
     };
   }
 }

--- a/src/lib/parser/Settings/CardOption.ts
+++ b/src/lib/parser/Settings/CardOption.ts
@@ -70,6 +70,8 @@ class CardOption {
 
   readonly imageQuizHtmlToAnki: boolean;
 
+  readonly processPDFs: boolean;
+
   constructor(input: { [key: string]: string }) {
     this.deckName = input.deckName;
     if (this.deckName && !this.deckName.trim()) {
@@ -105,6 +107,7 @@ class CardOption {
     this.disableIndentedBulletPoints =
       input['disable-indented-bullets'] === 'true';
     this.imageQuizHtmlToAnki = input['image-quiz-html-to-anki'] === 'true';
+    this.processPDFs = input['process-pdfs'] !== 'false';
     /* Is this really needed? */
     if (this.parentBlockId) {
       this.addNotionLink = true;
@@ -148,6 +151,7 @@ class CardOption {
       'page-emoji': 'first-emoji',
       'image-quiz-html-to-anki': 'false',
       'markdown-nested-bullet-points': 'true',
+      'process-pdfs': 'true',
     };
   }
 }

--- a/src/lib/zip/zip.tsx
+++ b/src/lib/zip/zip.tsx
@@ -7,6 +7,7 @@ import {
   isHTMLFile,
   isImageFile,
   isMarkdownFile,
+  isPDFFile,
 } from '../storage/checks';
 import { processAndPrepareArchiveData } from './fallback/processAndPrepareArchiveData';
 import CardOption from '../parser/Settings';
@@ -103,6 +104,9 @@ class ZipHandler {
       this.files.push({ name, contents: strFromU8(file) });
     } else if (paying && settings.imageQuizHtmlToAnki && isImageFile(name)) {
       await this.convertAndAddImageToHTML(name, file);
+    } else if (isPDFFile(name) && settings.processPDFs === false) {
+      // Skip PDF processing when processPDFs is false
+      return;
     } else {
       this.files.push({ name, contents: file });
     }


### PR DESCRIPTION
This feature allows users to skip PDF processing by setting process-pdfs=false, addressing performance concerns when handling ZIP files containing PDFs.

Key changes:
- Add processPDFs boolean property to CardOption class
- Add process-pdfs to supported options with default true
- Update PDF processing logic in PrepareDeck and convertPDFToImages
- Add early return in ZipHandler for PDFs when processing is disabled