### PR TITLE
fix: use correct import for cheerio

### DIFF
--- a/src/lib/parser/experimental/FallbackParser.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.test.ts
@@ -1,0 +1,37 @@
+import FallbackParser from './FallbackParser';
+
+describe('FallbackParser.htmlToTextWithNewlines', () => {
+  it('returns empty array and logs warning when html is undefined', () => {
+    const parser = new FallbackParser([]);
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+    const result = parser.htmlToTextWithNewlines(undefined as any);
+    expect(result).toEqual([]);
+    expect(spy).toHaveBeenCalledWith('[FallbackParser] htmlToTextWithNewlines called with invalid html:', undefined);
+    spy.mockRestore();
+  });
+
+  it('returns empty array and logs warning when html is null', () => {
+    const parser = new FallbackParser([]);
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+    const result = parser.htmlToTextWithNewlines(null as any);
+    expect(result).toEqual([]);
+    expect(spy).toHaveBeenCalledWith('[FallbackParser] htmlToTextWithNewlines called with invalid html:', null);
+    spy.mockRestore();
+  });
+
+  it('returns empty array and logs warning when html is empty string', () => {
+    const parser = new FallbackParser([]);
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+    const result = parser.htmlToTextWithNewlines('');
+    expect(result).toEqual([]);
+    expect(spy).toHaveBeenCalledWith('[FallbackParser] htmlToTextWithNewlines called with invalid html:', '');
+    spy.mockRestore();
+  });
+
+  it('parses simple ul/li html correctly', () => {
+    const parser = new FallbackParser([]);
+    const html = '<ul><li>Item 1</li><li>Item 2</li></ul>';
+    const result = parser.htmlToTextWithNewlines(html);
+    expect(result).toEqual(['• Item 1\n• Item 2\n']);
+  });
+});

--- a/src/lib/parser/experimental/FallbackParser.ts
+++ b/src/lib/parser/experimental/FallbackParser.ts
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 import { File } from '../../zip/zip';
 import {
@@ -19,6 +19,13 @@ class FallbackParser {
   constructor(private readonly files: File[]) {}
 
   htmlToTextWithNewlines(html: string) {
+    if (typeof html !== 'string' || !html.trim()) {
+      console.warn(
+        '[FallbackParser] htmlToTextWithNewlines called with invalid html:',
+        html
+      );
+      return [];
+    }
     const $ = cheerio.load(html);
 
     function processListItems(items: cheerio.Cheerio) {


### PR DESCRIPTION
Fixes the following report:
>TypeError: Cannot read properties of undefined (reading 'load')
    at FallbackParser.htmlToTextWithNewlines (/home/alemayhu/src/github.com/2anki/2anki.net/src/lib/parser/experimental/FallbackParser.js:19:37)
    at FallbackParser.run (/home/alemayhu/src/github.com/2anki/2anki.net/src/lib/parser/experimental/FallbackParser.js:107:40)
    at DeckParser.tryExperimental (/home/alemayhu/src/github.com/2anki/2anki.net/src/lib/parser/DeckParser.js:447:33)
    at /home/alemayhu/src/github.com/2anki/2anki.net/src/infrastracture/adapters/fileConversion/PrepareDeck.js:97:43
    at Generator.next (<anonymous>)
    at /home/alemayhu/src/github.com/2anki/2anki.net/src/infrastracture/adapters/fileConversion/PrepareDeck.js:8:71
    at new Promise (<anonymous>)
    at __awaiter (/home/alemayhu/src/github.com/2anki/2anki.net/src/infrastracture/adapters/fileConversion/PrepareDeck.js:4:12)
    at PrepareDeck (/home/alemayhu/src/github.com/2anki/2anki.net/src/infrastracture/adapters/fileConversion/PrepareDeck.js:25:12)
    at /home/alemayhu/src/github.com/2anki/2anki.net/src/usecases/uploads/getPackagesFromZip.js:33:62

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>