### PR TITLE
fix(parser): support cloze deletion with backticks and equals separator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "pretty-quick": "^4.0.0",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
-        "typescript": "^5.2.2"
+        "typescript": "~5.7.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -14656,9 +14656,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "pretty-quick": "^4.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "typescript": "~5.7.0"
   }
 }

--- a/src/lib/debug/preserveFilesForDebugging.ts
+++ b/src/lib/debug/preserveFilesForDebugging.ts
@@ -2,20 +2,30 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 
+import express from 'express';
+
 import { getRandomUUID } from '../../shared/helpers/getRandomUUID';
 import { UploadedFile } from '../storage/types';
 
-export function perserveFilesForDebugging(
+export function preserveFilesForDebugging(
+  request: express.Request,
   uploadedFiles: UploadedFile[],
   err: Error
 ) {
+  console.info('Preserving files for debugging...');
   const debugDirectory = path.join(os.tmpdir(), 'debug', getRandomUUID());
+  console.info('Debug directory:', debugDirectory);
 
   try {
     if (!fs.existsSync(debugDirectory)) {
       fs.mkdirSync(debugDirectory, { recursive: true });
       console.log(`Created debug directory: ${debugDirectory}`);
     }
+
+    fs.writeFileSync(
+      `${debugDirectory}/request.json`,
+      JSON.stringify(request.body, null, 2)
+    );
 
     const timestamp = new Date().toISOString();
     const errorMessage = `${timestamp} - ${err.name}: \n${err.message}\n${err.stack}`;

--- a/src/lib/parser/experimental/FallbackParser.getMarkdownBulletLists.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.getMarkdownBulletLists.test.ts
@@ -1,59 +1,91 @@
-import FallbackParser from './FallbackParser';
+import {
+  testCases,
+  runFallbackParserTest,
+  assertBulletPoints,
+} from './testHelpers';
 
 describe('FallbackParser.getMarkdownBulletLists', () => {
+  // Define additional test cases specific to FallbackParser
+  const fallbackTestCases = {
+    basicBulletWithDash: {
+      input: '- Item 1\n- Item 2\n- Item 3',
+      expected: ['- Item 1', '- Item 2', '- Item 3'],
+    },
+    basicBulletWithAsterisk: {
+      input: '* Item 1\n* Item 2\n* Item 3',
+      expected: ['* Item 1', '* Item 2', '* Item 3'],
+    },
+    basicBulletWithPlus: {
+      input: '+ Item 1\n+ Item 2\n+ Item 3',
+      expected: ['+ Item 1', '+ Item 2', '+ Item 3'],
+    },
+    bulletWithMultipleSpaces: {
+      input: '-  Item with two spaces\n-   Item with three spaces',
+      expected: ['-  Item with two spaces', '-   Item with three spaces'],
+    },
+    bulletWithMinimalContent: {
+      input: '- A\n- Item 2',
+      expected: ['- A', '- Item 2'],
+    },
+    bulletWithinOtherText: {
+      input: 'Some text before\n- Item 1\n- Item 2\nSome text after',
+      expected: ['- Item 1', '- Item 2'],
+    },
+  };
+
   it('should extract basic bullet points with - character', () => {
-    const parser = new FallbackParser([]);
-    const markdown = '- Item 1\n- Item 2\n- Item 3';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['- Item 1', '- Item 2', '- Item 3']);
+    runFallbackParserTest(
+      fallbackTestCases.basicBulletWithDash,
+      (result) => expect(result).toEqual(fallbackTestCases.basicBulletWithDash.expected)
+    );
   });
 
   it('should extract basic bullet points with * character', () => {
-    const parser = new FallbackParser([]);
-    const markdown = '* Item 1\n* Item 2\n* Item 3';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['* Item 1', '* Item 2', '* Item 3']);
+    runFallbackParserTest(
+      fallbackTestCases.basicBulletWithAsterisk,
+      (result) => expect(result).toEqual(fallbackTestCases.basicBulletWithAsterisk.expected)
+    );
   });
 
   it('should extract basic bullet points with + character', () => {
-    const parser = new FallbackParser([]);
-    const markdown = '+ Item 1\n+ Item 2\n+ Item 3';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['+ Item 1', '+ Item 2', '+ Item 3']);
+    runFallbackParserTest(
+      fallbackTestCases.basicBulletWithPlus,
+      (result) => expect(result).toEqual(fallbackTestCases.basicBulletWithPlus.expected)
+    );
   });
 
   it('should extract bullet points with cloze deletion format using backticks and = separator', () => {
-    const parser = new FallbackParser([]);
-    const markdown = '- hübsch, schön = `bonito`';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['- hübsch, schön = `bonito`']);
+    runFallbackParserTest(
+      testCases.clozeWithBackticksAndEquals,
+      (result) => assertBulletPoints(result, testCases.clozeWithBackticksAndEquals.expected.bulletPoint)
+    );
   });
 
   it('should extract bullet points with cloze deletion format using underscores and - separator', () => {
-    const parser = new FallbackParser([]);
-    const markdown = '- hübsch, schön - ___';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['- hübsch, schön - ___']);
+    runFallbackParserTest(
+      testCases.clozeWithUnderscoresAndDash,
+      (result) => assertBulletPoints(result, testCases.clozeWithUnderscoresAndDash.expected.bulletPoint)
+    );
   });
 
   it('should extract bullet points with multiple spaces after the bullet character', () => {
-    const parser = new FallbackParser([]);
-    const markdown = '-  Item with two spaces\n-   Item with three spaces';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['-  Item with two spaces', '-   Item with three spaces']);
+    runFallbackParserTest(
+      fallbackTestCases.bulletWithMultipleSpaces,
+      (result) => expect(result).toEqual(fallbackTestCases.bulletWithMultipleSpaces.expected)
+    );
   });
 
   it('should handle bullet points with minimal content', () => {
-    const parser = new FallbackParser([]);
-    const markdown = '- A\n- Item 2';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['- A', '- Item 2']);
+    runFallbackParserTest(
+      fallbackTestCases.bulletWithMinimalContent,
+      (result) => expect(result).toEqual(fallbackTestCases.bulletWithMinimalContent.expected)
+    );
   });
 
   it('should handle bullet points within other text', () => {
-    const parser = new FallbackParser([]);
-    const markdown = 'Some text before\n- Item 1\n- Item 2\nSome text after';
-    const result = parser.getMarkdownBulletLists(markdown);
-    expect(result).toEqual(['- Item 1', '- Item 2']);
+    runFallbackParserTest(
+      fallbackTestCases.bulletWithinOtherText,
+      (result) => expect(result).toEqual(fallbackTestCases.bulletWithinOtherText.expected)
+    );
   });
 });

--- a/src/lib/parser/experimental/FallbackParser.getMarkdownBulletLists.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.getMarkdownBulletLists.test.ts
@@ -1,0 +1,59 @@
+import FallbackParser from './FallbackParser';
+
+describe('FallbackParser.getMarkdownBulletLists', () => {
+  it('should extract basic bullet points with - character', () => {
+    const parser = new FallbackParser([]);
+    const markdown = '- Item 1\n- Item 2\n- Item 3';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['- Item 1', '- Item 2', '- Item 3']);
+  });
+
+  it('should extract basic bullet points with * character', () => {
+    const parser = new FallbackParser([]);
+    const markdown = '* Item 1\n* Item 2\n* Item 3';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['* Item 1', '* Item 2', '* Item 3']);
+  });
+
+  it('should extract basic bullet points with + character', () => {
+    const parser = new FallbackParser([]);
+    const markdown = '+ Item 1\n+ Item 2\n+ Item 3';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['+ Item 1', '+ Item 2', '+ Item 3']);
+  });
+
+  it('should extract bullet points with cloze deletion format using backticks and = separator', () => {
+    const parser = new FallbackParser([]);
+    const markdown = '- hübsch, schön = `bonito`';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['- hübsch, schön = `bonito`']);
+  });
+
+  it('should extract bullet points with cloze deletion format using underscores and - separator', () => {
+    const parser = new FallbackParser([]);
+    const markdown = '- hübsch, schön - ___';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['- hübsch, schön - ___']);
+  });
+
+  it('should extract bullet points with multiple spaces after the bullet character', () => {
+    const parser = new FallbackParser([]);
+    const markdown = '-  Item with two spaces\n-   Item with three spaces';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['-  Item with two spaces', '-   Item with three spaces']);
+  });
+
+  it('should handle bullet points with minimal content', () => {
+    const parser = new FallbackParser([]);
+    const markdown = '- A\n- Item 2';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['- A', '- Item 2']);
+  });
+
+  it('should handle bullet points within other text', () => {
+    const parser = new FallbackParser([]);
+    const markdown = 'Some text before\n- Item 1\n- Item 2\nSome text after';
+    const result = parser.getMarkdownBulletLists(markdown);
+    expect(result).toEqual(['- Item 1', '- Item 2']);
+  });
+});

--- a/src/lib/parser/experimental/FallbackParser.ts
+++ b/src/lib/parser/experimental/FallbackParser.ts
@@ -64,8 +64,18 @@ class FallbackParser {
     return styleTag.text() ?? '';
   }
 
+  /**
+   * Extract bullet points from markdown content
+   *
+   * Matches lines starting with -, *, or + followed by one or more spaces or tabs,
+   * and then any characters. This handles standard Markdown bullet point formats
+   * as well as cloze deletion formats with backticks and equals separator.
+   *
+   * @param markdown markdown content
+   * @returns array of bullet points or null if no bullet points found
+   */
   getMarkdownBulletLists(markdown: string) {
-    const bulletListRegex = /[-*+]( .*)+/g;
+    const bulletListRegex = /[-*+][ \t]+.*/g;
     return markdown.match(bulletListRegex);
   }
 

--- a/src/lib/parser/experimental/PlainTextParser/PlainTextParser.test.ts
+++ b/src/lib/parser/experimental/PlainTextParser/PlainTextParser.test.ts
@@ -1,0 +1,60 @@
+import { PlainTextParser } from './PlainTextParser';
+import { isClozeFlashcard } from './types';
+
+describe('PlainTextParser', () => {
+  describe('parse', () => {
+    it('should correctly identify cloze deletion with backticks and = separator', () => {
+      const parser = new PlainTextParser();
+      const input = '- hübsch, schön = `bonito`';
+      const result = parser.parse(input);
+
+      expect(result.length).toBe(1);
+      expect(isClozeFlashcard(result[0])).toBe(true);
+
+      if (isClozeFlashcard(result[0])) {
+        expect(result[0].front).toContain('{{c1::bonito}}');
+      }
+    });
+
+    it('should correctly identify cloze deletion with underscores and - separator', () => {
+      const parser = new PlainTextParser();
+      const input = '- hübsch, schön - ___';
+      const result = parser.parse(input);
+
+      expect(result.length).toBe(1);
+      expect(isClozeFlashcard(result[0])).toBe(true);
+
+      if (isClozeFlashcard(result[0])) {
+        expect(result[0].front).toContain('{{c1::hübsch}}');
+      }
+    });
+
+    it('should correctly handle basic flashcards with - separator', () => {
+      const parser = new PlainTextParser();
+      const input = '- Question - Answer';
+      const result = parser.parse(input);
+
+      expect(result.length).toBe(1);
+      expect(isClozeFlashcard(result[0])).toBe(false);
+
+      if (!isClozeFlashcard(result[0])) {
+        expect(result[0].front).toBe('- Question');
+        expect(result[0].back).toBe('Answer');
+      }
+    });
+
+    it('should correctly handle basic flashcards with = separator', () => {
+      const parser = new PlainTextParser();
+      const input = '- Question = Answer';
+      const result = parser.parse(input);
+
+      expect(result.length).toBe(1);
+      expect(isClozeFlashcard(result[0])).toBe(false);
+
+      if (!isClozeFlashcard(result[0])) {
+        expect(result[0].front).toBe('- Question');
+        expect(result[0].back).toBe('Answer');
+      }
+    });
+  });
+});

--- a/src/lib/parser/experimental/PlainTextParser/PlainTextParser.test.ts
+++ b/src/lib/parser/experimental/PlainTextParser/PlainTextParser.test.ts
@@ -1,60 +1,47 @@
-import { PlainTextParser } from './PlainTextParser';
 import { isClozeFlashcard } from './types';
+import {
+  testCases,
+  runPlainTextParserTest,
+  assertClozeCard,
+  assertBasicCard,
+} from '../testHelpers';
 
 describe('PlainTextParser', () => {
   describe('parse', () => {
     it('should correctly identify cloze deletion with backticks and = separator', () => {
-      const parser = new PlainTextParser();
-      const input = '- hübsch, schön = `bonito`';
-      const result = parser.parse(input);
-
-      expect(result.length).toBe(1);
-      expect(isClozeFlashcard(result[0])).toBe(true);
-
-      if (isClozeFlashcard(result[0])) {
-        expect(result[0].front).toContain('{{c1::bonito}}');
-      }
+      runPlainTextParserTest(
+        testCases.clozeWithBackticksAndEquals,
+        (card) => assertClozeCard(card, testCases.clozeWithBackticksAndEquals.expected.clozeContent)
+      );
     });
 
     it('should correctly identify cloze deletion with underscores and - separator', () => {
-      const parser = new PlainTextParser();
-      const input = '- hübsch, schön - ___';
-      const result = parser.parse(input);
-
-      expect(result.length).toBe(1);
-      expect(isClozeFlashcard(result[0])).toBe(true);
-
-      if (isClozeFlashcard(result[0])) {
-        expect(result[0].front).toContain('{{c1::hübsch}}');
-      }
+      runPlainTextParserTest(
+        testCases.clozeWithUnderscoresAndDash,
+        (card) => assertClozeCard(card, testCases.clozeWithUnderscoresAndDash.expected.clozeContent)
+      );
     });
 
     it('should correctly handle basic flashcards with - separator', () => {
-      const parser = new PlainTextParser();
-      const input = '- Question - Answer';
-      const result = parser.parse(input);
-
-      expect(result.length).toBe(1);
-      expect(isClozeFlashcard(result[0])).toBe(false);
-
-      if (!isClozeFlashcard(result[0])) {
-        expect(result[0].front).toBe('- Question');
-        expect(result[0].back).toBe('Answer');
-      }
+      runPlainTextParserTest(
+        testCases.basicWithDash,
+        (card) => assertBasicCard(
+          card,
+          testCases.basicWithDash.expected.front,
+          testCases.basicWithDash.expected.back
+        )
+      );
     });
 
     it('should correctly handle basic flashcards with = separator', () => {
-      const parser = new PlainTextParser();
-      const input = '- Question = Answer';
-      const result = parser.parse(input);
-
-      expect(result.length).toBe(1);
-      expect(isClozeFlashcard(result[0])).toBe(false);
-
-      if (!isClozeFlashcard(result[0])) {
-        expect(result[0].front).toBe('- Question');
-        expect(result[0].back).toBe('Answer');
-      }
+      runPlainTextParserTest(
+        testCases.basicWithEquals,
+        (card) => assertBasicCard(
+          card,
+          testCases.basicWithEquals.expected.front,
+          testCases.basicWithEquals.expected.back
+        )
+      );
     });
   });
 });

--- a/src/lib/parser/experimental/PlainTextParser/PlainTextParser.ts
+++ b/src/lib/parser/experimental/PlainTextParser/PlainTextParser.ts
@@ -92,6 +92,37 @@ export class PlainTextParser {
         continue;
       }
 
+      // Check if answers contain backticks (cloze markers)
+      if (answers && answers.includes('`')) {
+        // Extract the content inside backticks
+        const backtickMatch = answers.match(/`([^`]+)`/);
+        if (backtickMatch && backtickMatch[1]) {
+          const clozeContent = backtickMatch[1];
+          // Create a cloze card with the content from backticks
+          flashcards.push({
+            front: question.replace(/^- /, '') + ` {{c1::${clozeContent}}}`,
+            isCloze: true,
+          });
+          continue;
+        }
+      }
+
+      // Check if answers contain underscores (cloze markers)
+      if (answers && answers.includes('_')) {
+        // If answer is just underscores, use the first word from the question
+        if (answers.trim() === '___') {
+          const firstWord = question.replace(/^- /, '').split(',')[0].trim();
+          flashcards.push({
+            front: question
+              .replace(/^- /, '')
+              .replace(firstWord, `{{c1::${firstWord}}}`),
+            isCloze: true,
+          });
+          continue;
+        }
+      }
+
+      // Check if question might be a cloze card
       if (answers && isPossiblyClozeFlashcard(question)) {
         const clozeCard = this.fillInTheBlanks(question, answers);
 

--- a/src/lib/parser/experimental/PlainTextParser/types.ts
+++ b/src/lib/parser/experimental/PlainTextParser/types.ts
@@ -25,6 +25,6 @@ export const isBasicFlashcard = (
 export const isPossiblyClozeFlashcard = (question: string) => {
   return (
     (question.includes('_') || question.includes('`')) &&
-    (question.includes('-') || question.includes('='))
+    (question.split('-') || question.split('='))
   );
 };

--- a/src/lib/parser/experimental/PlainTextParser/types.ts
+++ b/src/lib/parser/experimental/PlainTextParser/types.ts
@@ -23,5 +23,8 @@ export const isBasicFlashcard = (
   'back' in flashcard && flashcard.back !== undefined;
 
 export const isPossiblyClozeFlashcard = (question: string) => {
-  return question.includes('_') && question.split('-');
+  return (
+    (question.includes('_') || question.includes('`')) &&
+    (question.split('-') || question.split('='))
+  );
 };

--- a/src/lib/parser/experimental/testHelpers.ts
+++ b/src/lib/parser/experimental/testHelpers.ts
@@ -1,6 +1,6 @@
 import { PlainTextParser } from './PlainTextParser/PlainTextParser';
 import FallbackParser from './FallbackParser';
-import { isClozeFlashcard } from './PlainTextParser/types';
+import { isClozeFlashcard, Flashcard } from './PlainTextParser/types';
 
 // Common test data
 export const testCases = {
@@ -34,8 +34,30 @@ export const testCases = {
   },
 };
 
+// Define test case interfaces
+interface TestCaseWithObjectExpected {
+  input: string;
+  expected: {
+    bulletPoint?: string;
+    clozeContent?: string;
+    front?: string;
+    back?: string;
+  };
+}
+
+interface TestCaseWithArrayExpected {
+  input: string;
+  expected: string[];
+}
+
+// Union type for both test case formats
+type TestCase = TestCaseWithObjectExpected | TestCaseWithArrayExpected;
+
 // Helper functions for PlainTextParser tests
-export const runPlainTextParserTest = (testCase, assertion) => {
+export const runPlainTextParserTest = (
+  testCase: TestCase,
+  assertion: (card: Flashcard) => void
+) => {
   const parser = new PlainTextParser();
   const result = parser.parse(testCase.input);
 
@@ -44,7 +66,10 @@ export const runPlainTextParserTest = (testCase, assertion) => {
 };
 
 // Helper functions for FallbackParser tests
-export const runFallbackParserTest = (testCase, assertion) => {
+export const runFallbackParserTest = (
+  testCase: TestCase,
+  assertion: (result: RegExpMatchArray | null) => void
+) => {
   const parser = new FallbackParser([]);
   const result = parser.getMarkdownBulletLists(testCase.input);
 
@@ -52,7 +77,7 @@ export const runFallbackParserTest = (testCase, assertion) => {
 };
 
 // Common assertions
-export const assertClozeCard = (card, expectedContent) => {
+export const assertClozeCard = (card: Flashcard, expectedContent: string) => {
   expect(isClozeFlashcard(card)).toBe(true);
 
   if (isClozeFlashcard(card)) {
@@ -60,7 +85,11 @@ export const assertClozeCard = (card, expectedContent) => {
   }
 };
 
-export const assertBasicCard = (card, expectedFront, expectedBack) => {
+export const assertBasicCard = (
+  card: Flashcard,
+  expectedFront: string,
+  expectedBack: string
+) => {
   expect(isClozeFlashcard(card)).toBe(false);
 
   if (!isClozeFlashcard(card)) {
@@ -69,6 +98,9 @@ export const assertBasicCard = (card, expectedFront, expectedBack) => {
   }
 };
 
-export const assertBulletPoints = (result, expected) => {
+export const assertBulletPoints = (
+  result: RegExpMatchArray | null,
+  expected: string
+) => {
   expect(result).toEqual([expected]);
 };

--- a/src/lib/parser/experimental/testHelpers.ts
+++ b/src/lib/parser/experimental/testHelpers.ts
@@ -1,0 +1,74 @@
+import { PlainTextParser } from './PlainTextParser/PlainTextParser';
+import FallbackParser from './FallbackParser';
+import { isClozeFlashcard } from './PlainTextParser/types';
+
+// Common test data
+export const testCases = {
+  clozeWithBackticksAndEquals: {
+    input: '- hübsch, schön = `bonito`',
+    expected: {
+      bulletPoint: '- hübsch, schön = `bonito`',
+      clozeContent: 'bonito',
+    },
+  },
+  clozeWithUnderscoresAndDash: {
+    input: '- hübsch, schön - ___',
+    expected: {
+      bulletPoint: '- hübsch, schön - ___',
+      clozeContent: 'hübsch',
+    },
+  },
+  basicWithDash: {
+    input: '- Question - Answer',
+    expected: {
+      front: '- Question',
+      back: 'Answer',
+    },
+  },
+  basicWithEquals: {
+    input: '- Question = Answer',
+    expected: {
+      front: '- Question',
+      back: 'Answer',
+    },
+  },
+};
+
+// Helper functions for PlainTextParser tests
+export const runPlainTextParserTest = (testCase, assertion) => {
+  const parser = new PlainTextParser();
+  const result = parser.parse(testCase.input);
+
+  expect(result.length).toBe(1);
+  assertion(result[0]);
+};
+
+// Helper functions for FallbackParser tests
+export const runFallbackParserTest = (testCase, assertion) => {
+  const parser = new FallbackParser([]);
+  const result = parser.getMarkdownBulletLists(testCase.input);
+
+  assertion(result);
+};
+
+// Common assertions
+export const assertClozeCard = (card, expectedContent) => {
+  expect(isClozeFlashcard(card)).toBe(true);
+
+  if (isClozeFlashcard(card)) {
+    expect(card.front).toContain(`{{c1::${expectedContent}}}`);
+  }
+};
+
+export const assertBasicCard = (card, expectedFront, expectedBack) => {
+  expect(isClozeFlashcard(card)).toBe(false);
+
+  if (!isClozeFlashcard(card)) {
+    expect(card.front).toBe(expectedFront);
+    expect(card.back).toBe(expectedBack);
+  }
+};
+
+export const assertBulletPoints = (result, expected) => {
+  expect(result).toEqual([expected]);
+};

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -3,7 +3,7 @@ import nodemailer from 'nodemailer';
 import { UploadedFile } from '../../lib/storage/types';
 import { isLimitError } from '../../lib/misc/isLimitError';
 import { isEmptyPayload } from '../../lib/misc/isEmptyPayload';
-import { perserveFilesForDebugging } from '../../lib/debug/perserveFilesForDebugging';
+import { preserveFilesForDebugging } from '../../lib/debug/preserveFilesForDebugging';
 import * as cheerio from 'cheerio';
 
 const transporter = nodemailer.createTransport({
@@ -52,7 +52,7 @@ export default async function ErrorHandler(
     console.info('Send error');
     console.error(err);
     if (!isEmptyPayload(uploadedFiles)) {
-      perserveFilesForDebugging(uploadedFiles, err);
+      preserveFilesForDebugging(req, uploadedFiles, err);
     }
 
     try {

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -29,7 +29,7 @@ function getFileContents(file: UploadedFile): Buffer {
   }
 
   try {
-    // Check if file exists before trying to read it
+    // Check if a file exists before trying to read it
     if (fs.existsSync(file.path)) {
       return fs.readFileSync(file.path);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced flashcard parser to support multiple cloze deletion syntaxes (underscore-based and backtick-enclosed) and multiple front/back separators (" - " and " = ").
  * Improved detection of cloze flashcards for greater parsing flexibility.

* **Bug Fixes**
  * Corrected function and import name from "perserveFilesForDebugging" to "preserveFilesForDebugging" in debugging and error handling.
  * Updated debugging to save request data for improved traceability.

* **Tests**
  * Added comprehensive unit tests for the flashcard parser to validate new parsing behaviors.
  * Added tests for markdown bullet list extraction covering various bullet characters and cloze formats.

* **Style**
  * Minor comment wording improvement for clarity.

* **Documentation**
  * Added detailed documentation for markdown bullet list extraction method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->