### PR TITLE
fix: show useful error when password protected pdf is uploaded

### DIFF
--- a/src/lib/pdf/getPageCount.ts
+++ b/src/lib/pdf/getPageCount.ts
@@ -36,6 +36,15 @@ export function getPageCount(pdfPath: string): Promise<number> {
       );
 
       if (code !== 0) {
+        // Check if the error is due to a password-protected PDF
+        if (stderr.includes('Encrypted') || stderr.includes('password')) {
+          reject(
+            new Error(
+              'The PDF file is password-protected. Please remove the password protection and try again, or you can turn off PDF processing by unchecking "Process PDF Files" in the settings to skip PDF processing of ZIP files containing PDFs.'
+            )
+          );
+          return;
+        }
         reject(new Error('Failed to execute pdfinfo'));
         return;
       }


### PR DESCRIPTION
Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for password-protected PDFs, providing clearer feedback when a PDF cannot be processed due to encryption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->