### PR TITLE
fix: error reports for missing job owners

### DIFF
--- a/src/controllers/JobController.test.ts
+++ b/src/controllers/JobController.test.ts
@@ -1,0 +1,72 @@
+import express from 'express';
+import JobController from './JobController';
+import JobService from '../services/JobService';
+import * as getOwnerModule from '../lib/User/getOwner';
+
+describe('JobController', () => {
+  let jobService: JobService;
+  let jobController: JobController;
+  let req: Partial<express.Request>;
+  let res: Partial<express.Response>;
+
+  beforeEach(() => {
+    jobService = {
+      getJobsByOwner: jest.fn(),
+      deleteJobById: jest.fn(),
+    } as any;
+    jobController = new JobController(jobService);
+    req = { params: { id: '123' } };
+    res = {
+      send: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      redirect: jest.fn(),
+    };
+    jest.spyOn(getOwnerModule, 'getOwner').mockReturnValue('owner1');
+  });
+
+  it('should get jobs by owner and send them', async () => {
+    (jobService.getJobsByOwner as jest.Mock).mockResolvedValue([
+      'job1',
+      'job2',
+    ]);
+    await jobController.getJobsByOwner(
+      req as express.Request,
+      res as express.Response
+    );
+    expect(jobService.getJobsByOwner).toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith(['job1', 'job2']);
+  });
+
+  it('should delete job by owner and send 200', async () => {
+    (jobService.deleteJobById as jest.Mock).mockResolvedValue(undefined);
+    await jobController.deleteJobByOwner(
+      req as express.Request,
+      res as express.Response
+    );
+    expect(jobService.deleteJobById).toHaveBeenCalledWith('123', 'owner1');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it('should handle error in deleteJobByOwner', async () => {
+    (jobService.deleteJobById as jest.Mock).mockRejectedValue(
+      new Error('fail')
+    );
+    await jobController.deleteJobByOwner(
+      req as express.Request,
+      res as express.Response
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it('should redirect to login if owner is missing when getting jobs', async () => {
+    (getOwnerModule.getOwner as jest.Mock).mockReturnValue(undefined);
+    await jobController.getJobsByOwner(
+      req as express.Request,
+      res as express.Response
+    );
+    expect(res.redirect).toHaveBeenCalledWith('/login');
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/JobController.ts
+++ b/src/controllers/JobController.ts
@@ -7,7 +7,12 @@ class JobController {
   constructor(private readonly service: JobService) {}
 
   async getJobsByOwner(_req: express.Request, res: express.Response) {
-    const jobs = await this.service.getJobsByOwner(getOwner(res));
+    const owner = getOwner(res);
+    if (!owner) {
+      res.redirect('/login');
+      return;
+    }
+    const jobs = await this.service.getJobsByOwner(owner);
     res.send(jobs);
   }
 


### PR DESCRIPTION
Resolves the following error:
> Error: Undefined binding(s) detected when compiling SELECT. Undefined column(s): [owner] query: select * from "jobs" where "owner" = ?
      at QueryCompiler_PG.toSQL (/home/alemayhu/src/github.com/2anki/2anki.net/node_modules/knex/lib/query/querycompiler.js:112:13)
      at QueryBuilder_PostgreSQL.toSQL (/home/alemayhu/src/github.com/2anki/2anki.net/node_modules/knex/lib/query/querybuilder.js:84:44)
      at ensureConnectionCallback (/home/alemayhu/src/github.com/2anki/2anki.net/node_modules/knex/lib/execution/internal/ensure-connection-callback.js:4:30)
      at Runner.ensureConnection (/home/alemayhu/src/github.com/2anki/2anki.net/node_modules/knex/lib/execution/runner.js:318:20)
      at Runner.run (/home/alemayhu/src/github.com/2anki/2anki.net/node_modules/knex/lib/execution/runner.js:30:19)

  Request path: /api/upload/jobs
  Method: GET
  Query: {}
  Body: undefined