### PR TITLE
fix: use correct id for deleting jobs

### DIFF
--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -12,7 +12,7 @@ class JobRepository {
 
   deleteJob(id: string, owner: string) {
     return this.database(this.tableName).delete().where({
-      object_id: id,
+      id: id,
       owner: owner,
     });
   }


### PR DESCRIPTION
Previously the deletion would fail since the id and object_id do not
match.
