### PR TITLE
Prevent deletion of running jobs

### DIFF
--- a/src/controllers/JobController.test.ts
+++ b/src/controllers/JobController.test.ts
@@ -20,6 +20,7 @@ describe('JobController', () => {
       send: jest.fn(),
       status: jest.fn().mockReturnThis(),
       redirect: jest.fn(),
+      json: jest.fn(),
     };
     jest.spyOn(getOwnerModule, 'getOwner').mockReturnValue('owner1');
   });
@@ -58,6 +59,20 @@ describe('JobController', () => {
     );
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.send).toHaveBeenCalled();
+  });
+
+  it('should handle job in progress error with 409 status', async () => {
+    (jobService.deleteJobById as jest.Mock).mockRejectedValue(
+      new Error('Cannot delete job while it is in progress')
+    );
+    await jobController.deleteJobByOwner(
+      req as express.Request,
+      res as express.Response
+    );
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({ 
+      error: 'Cannot delete job while it is in progress' 
+    });
   });
 
   it('should redirect to login if owner is missing when getting jobs', async () => {

--- a/src/controllers/JobController.ts
+++ b/src/controllers/JobController.ts
@@ -23,6 +23,17 @@ class JobController {
 
       res.status(200).send();
     } catch (error) {
+      // Check if it's a job in progress error
+      if (
+        error instanceof Error &&
+        error.message === 'Cannot delete job while it is in progress'
+      ) {
+        res
+          .status(409)
+          .json({ error: 'Cannot delete job while it is in progress' });
+        return;
+      }
+
       res.status(500).send();
       console.info('Delete job failed');
       console.error(error);

--- a/src/services/JobService.ts
+++ b/src/services/JobService.ts
@@ -7,7 +7,23 @@ class JobService {
     return this.repository.getJobsByOwner(owner);
   }
 
-  deleteJobById(id: string, owner: string) {
+  async deleteJobById(id: string, owner: string) {
+    // The id parameter here is actually the database primary key (job.id)
+    // We need to find the job by its database ID first to check its status
+    const jobs = await this.repository.getJobsByOwner(owner);
+    const job = jobs.find((j) => j.id.toString() === id);
+
+    if (!job) {
+      // Job doesn't exist, nothing to do
+      return;
+    }
+
+    // Prevent deleting jobs that are in progress
+    if (job.status === 'started' || job.status.startsWith('step')) {
+      throw new Error('Cannot delete job while it is in progress');
+    }
+
+    // Delete the job using the database ID
     return this.repository.deleteJob(id, owner);
   }
 


### PR DESCRIPTION
Return 409 Conflict when attempting to delete jobs that are currently running. Prevents background process crashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a job that’s currently in progress now returns HTTP 409 Conflict with a clear error message instead of a generic failure.
  * Improved error handling during job deletion, providing more accurate status codes and responses.
  * Graceful handling when a job ID is not found, avoiding unnecessary errors.

* **Tests**
  * Added test coverage to verify the 409 Conflict response and error message when attempting to delete an in-progress job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->