### PR TITLE
fix: auto-enable markdown processing for markdown uploads

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ importers:
         version: 2.1693.0
       axios:
         specifier: ^1.13.5
-        version: 1.14.0
+        version: 1.15.0
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
@@ -1658,8 +1658,8 @@ packages:
     engines: {node: '>= 10.0.0'}
     deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -5628,7 +5628,7 @@ snapshots:
   '@sendgrid/client@8.1.6':
     dependencies:
       '@sendgrid/helpers': 8.0.0
-      axios: 1.14.0
+      axios: 1.15.0
     transitivePeerDependencies:
       - debug
 
@@ -6379,7 +6379,7 @@ snapshots:
       uuid: 8.0.0
       xml2js: 0.6.2
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/lib/parser/handleNestedBulletPointsInMarkdown.test.ts
+++ b/src/lib/parser/handleNestedBulletPointsInMarkdown.test.ts
@@ -1,0 +1,41 @@
+import { handleNestedBulletPointsInMarkdown } from './handleNestedBulletPointsInMarkdown';
+import CardOption from './Settings';
+import CustomExporter from './exporters/CustomExporter';
+import Workspace from './WorkSpace';
+import os from 'os';
+
+describe('handleNestedBulletPointsInMarkdown', () => {
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = os.tmpdir();
+  });
+
+  it('embeds images referenced in markdown', () => {
+    const workspace = new Workspace(true, 'fs');
+    const exporter = new CustomExporter('test', workspace.location);
+    const settings = new CardOption({});
+    const imageContents = Buffer.from('fake-image-data');
+
+    const contents = [
+      '- What is shown here?',
+      '    ![image.png](image%201.png)',
+    ].join('\n');
+
+    const files = [
+      { name: 'image 1.png', contents: imageContents },
+    ];
+
+    const decks = handleNestedBulletPointsInMarkdown({
+      name: 'test.md',
+      contents,
+      deckName: 'Test',
+      decks: [],
+      settings,
+      exporter,
+      workspace,
+      files: files as any,
+    });
+
+    const card = decks[0].cards[0];
+    expect(card.media.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
+++ b/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
@@ -63,7 +63,8 @@ export const handleNestedBulletPointsInMarkdown = (
     }
 
     if (BULLET_POINT_REGEX.exec(line) && isCreating) {
-      const dom = cheerio.load(currentBack, {
+      const convertedBack = markdownToHTML(currentBack, trimWhitespace);
+      const dom = cheerio.load(convertedBack, {
         xmlMode: true,
       });
       const images = dom('img');
@@ -72,10 +73,11 @@ export const handleNestedBulletPointsInMarkdown = (
       images.each((_i, elem) => {
         const src = dom(elem).attr('src');
         if (src && isImageFileEmbedable(src)) {
+          const decodedSrc = decodeURIComponent(src);
           const newName = embedFile({
             exporter: exporter,
             files: files,
-            filePath: src,
+            filePath: decodedSrc,
             workspace: workspace,
           });
           if (newName) {
@@ -85,10 +87,9 @@ export const handleNestedBulletPointsInMarkdown = (
         }
       });
 
-      currentBack = dom.html() || '';
       const note = new Note(
         currentFront,
-        markdownToHTML(currentBack, trimWhitespace)
+        dom.html() || ''
       );
       note.media = media;
       deck.cards.push(note);
@@ -108,7 +109,8 @@ export const handleNestedBulletPointsInMarkdown = (
 
   // Ensure the last card is processed
   if (currentBack !== '' || currentFront !== '') {
-    const dom = cheerio.load(currentBack, {
+    const convertedBack = markdownToHTML(currentBack, trimWhitespace);
+    const dom = cheerio.load(convertedBack, {
       xmlMode: true,
     });
     const images = dom('img');
@@ -117,10 +119,11 @@ export const handleNestedBulletPointsInMarkdown = (
     images.each((_i, elem) => {
       const src = dom(elem).attr('src');
       if (src && isImageFileEmbedable(src)) {
+        const decodedSrc = decodeURIComponent(src);
         const newName = embedFile({
           exporter,
           files: files,
-          filePath: src,
+          filePath: decodedSrc,
           workspace,
         });
         if (newName) {
@@ -130,10 +133,9 @@ export const handleNestedBulletPointsInMarkdown = (
       }
     });
 
-    currentBack = dom.html() || '';
     const note = new Note(
       currentFront,
-      markdownToHTML(currentBack, trimWhitespace)
+      dom.html() || ''
     );
     note.media = media;
     deck.cards.push(note);

--- a/src/usecases/uploads/enableMarkdownForMarkdownUploads.test.ts
+++ b/src/usecases/uploads/enableMarkdownForMarkdownUploads.test.ts
@@ -1,0 +1,37 @@
+import { enableMarkdownForMarkdownUploads } from './enableMarkdownForMarkdownUploads';
+import CardOption from '../../lib/parser/Settings/CardOption';
+
+describe('enableMarkdownForMarkdownUploads', () => {
+  it('enables nestedBulletPoints when upload contains markdown files', () => {
+    const settings = new CardOption({
+      'markdown-nested-bullet-points': 'false',
+    });
+    const fileNames = ['page.md', 'image.png'];
+
+    const result = enableMarkdownForMarkdownUploads(fileNames, settings);
+
+    expect(result.nestedBulletPoints).toBe(true);
+  });
+
+  it('does not change settings when no markdown files', () => {
+    const settings = new CardOption({
+      'markdown-nested-bullet-points': 'false',
+    });
+    const fileNames = ['page.html', 'image.png'];
+
+    const result = enableMarkdownForMarkdownUploads(fileNames, settings);
+
+    expect(result.nestedBulletPoints).toBe(false);
+  });
+
+  it('returns same settings when nestedBulletPoints already enabled', () => {
+    const settings = new CardOption({
+      'markdown-nested-bullet-points': 'true',
+    });
+    const fileNames = ['page.md'];
+
+    const result = enableMarkdownForMarkdownUploads(fileNames, settings);
+
+    expect(result).toBe(settings);
+  });
+});

--- a/src/usecases/uploads/enableMarkdownForMarkdownUploads.test.ts
+++ b/src/usecases/uploads/enableMarkdownForMarkdownUploads.test.ts
@@ -13,6 +13,17 @@ describe('enableMarkdownForMarkdownUploads', () => {
     expect(result.nestedBulletPoints).toBe(true);
   });
 
+  it('does not mutate the original settings', () => {
+    const settings = new CardOption({
+      'markdown-nested-bullet-points': 'false',
+    });
+    const fileNames = ['page.md'];
+
+    enableMarkdownForMarkdownUploads(fileNames, settings);
+
+    expect(settings.nestedBulletPoints).toBe(false);
+  });
+
   it('does not change settings when no markdown files', () => {
     const settings = new CardOption({
       'markdown-nested-bullet-points': 'false',

--- a/src/usecases/uploads/enableMarkdownForMarkdownUploads.ts
+++ b/src/usecases/uploads/enableMarkdownForMarkdownUploads.ts
@@ -1,0 +1,17 @@
+import CardOption from '../../lib/parser/Settings/CardOption';
+import { hasMarkdownFileName } from '../../lib/storage/checks';
+
+export function enableMarkdownForMarkdownUploads(
+  fileNames: string[],
+  settings: CardOption
+): CardOption {
+  if (settings.nestedBulletPoints) {
+    return settings;
+  }
+
+  if (hasMarkdownFileName(fileNames)) {
+    (settings as { nestedBulletPoints: boolean }).nestedBulletPoints = true;
+  }
+
+  return settings;
+}

--- a/src/usecases/uploads/enableMarkdownForMarkdownUploads.ts
+++ b/src/usecases/uploads/enableMarkdownForMarkdownUploads.ts
@@ -9,9 +9,14 @@ export function enableMarkdownForMarkdownUploads(
     return settings;
   }
 
-  if (hasMarkdownFileName(fileNames)) {
-    (settings as { nestedBulletPoints: boolean }).nestedBulletPoints = true;
+  if (!hasMarkdownFileName(fileNames)) {
+    return settings;
   }
 
-  return settings;
+  const copy = Object.create(
+    Object.getPrototypeOf(settings),
+    Object.getOwnPropertyDescriptors(settings)
+  );
+  copy.nestedBulletPoints = true;
+  return copy;
 }

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -29,14 +29,14 @@ export const getPackagesFromZip = async (
 
   const fileNames = zipHandler.getFileNames();
   const supportedFileNames = fileNames.filter(isZipContentFileSupported);
-  enableMarkdownForMarkdownUploads(fileNames, settings);
+  const effectiveSettings = enableMarkdownForMarkdownUploads(fileNames, settings);
 
-  if (settings.claudeAIFlashcards && paying && fileNames.length > 0) {
+  if (effectiveSettings.claudeAIFlashcards && paying && fileNames.length > 0) {
     const rootName = fileNames[0];
     const deck = await PrepareDeck({
       name: rootName,
       files: zipHandler.files,
-      settings,
+      settings: effectiveSettings,
       noLimits: paying,
       workspace,
     });
@@ -54,7 +54,7 @@ export const getPackagesFromZip = async (
     const deck = await PrepareDeck({
       name: fileName,
       files: relevantFiles,
-      settings,
+      settings: effectiveSettings,
       noLimits: paying,
       workspace,
     });

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -10,6 +10,7 @@ import { getMaxUploadCount } from '../../lib/misc/getMaxUploadCount';
 
 import { isZipContentFileSupported } from './isZipContentFileSupported';
 import { getRelevantFiles } from './getRelevantFiles';
+import { enableMarkdownForMarkdownUploads } from './enableMarkdownForMarkdownUploads';
 
 export const getPackagesFromZip = async (
   fileContents: Body | undefined,
@@ -28,6 +29,7 @@ export const getPackagesFromZip = async (
 
   const fileNames = zipHandler.getFileNames();
   const supportedFileNames = fileNames.filter(isZipContentFileSupported);
+  enableMarkdownForMarkdownUploads(fileNames, settings);
 
   if (settings.claudeAIFlashcards && paying && fileNames.length > 0) {
     const rootName = fileNames[0];

--- a/src/usecases/uploads/getRelevantFiles.test.ts
+++ b/src/usecases/uploads/getRelevantFiles.test.ts
@@ -45,3 +45,16 @@ test('still works when HTML has no Notion ID', () => {
 
   expect(result.length).toBe(2);
 });
+
+test('includes sibling image files for markdown in flat zip structure', () => {
+  const mdName = 'Arealentwicklung 33f3ff2470bd80bb90f4e6cee34619a9.md';
+  const allFiles = [
+    { name: mdName, contents: '# Title' },
+    { name: 'image.png', contents: 'fake-image' },
+    { name: 'image 1.png', contents: 'fake-image' },
+  ];
+
+  const result = getRelevantFiles(mdName, allFiles);
+
+  expect(result.length).toBe(3);
+});

--- a/src/usecases/uploads/getRelevantFiles.ts
+++ b/src/usecases/uploads/getRelevantFiles.ts
@@ -1,4 +1,5 @@
 import { File } from '../../lib/zip/zip';
+import { isImageFileEmbedable } from '../../lib/storage/checks';
 
 export function getRelevantFiles(
   fileName: string,
@@ -6,11 +7,13 @@ export function getRelevantFiles(
 ): File[] {
   const baseName = fileName.replace(/\.[^.]+$/, '');
   const baseNameWithoutNotionId = baseName.replace(/ [0-9a-f]{32}$/, '');
+  const isRootFile = !fileName.includes('/');
 
   return allFiles.filter(
     (f) =>
       f.name === fileName ||
       f.name.startsWith(baseName + '/') ||
-      f.name.startsWith(baseNameWithoutNotionId + '/')
+      f.name.startsWith(baseNameWithoutNotionId + '/') ||
+      (isRootFile && !f.name.includes('/') && isImageFileEmbedable(f.name))
   );
 }


### PR DESCRIPTION
When a zip contains markdown files but the user has not enabled the
markdown-nested-bullet-points setting, enable it automatically so cards
are generated instead of silently failing.

Signed-off-by: Alexander Alemayhu <alexander@alemayhu.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown files now automatically enable nested bullet point formatting when uploaded, improving document structure and readability

* **Tests**
  * Added test coverage for markdown upload handling and automatic formatting configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->