### PR TITLE
fix: allow multiple users to convert the same Notion page

### DIFF
--- a/migrations/20260412_job_unique_object_id_owner.js
+++ b/migrations/20260412_job_unique_object_id_owner.js
@@ -1,0 +1,25 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('jobs', function (table) {
+    table.dropUnique(['object_id']);
+    table.unique(['object_id', 'owner']);
+  });
+};
+
+exports.down = function (knex) {
+  return knex('jobs')
+    .select('object_id')
+    .groupBy('object_id')
+    .havingRaw('COUNT(*) > 1')
+    .first()
+    .then(function (duplicate) {
+      if (duplicate) {
+        throw new Error(
+          'Cannot rollback: duplicate object_id values exist across different owners'
+        );
+      }
+      return knex.schema.alterTable('jobs', function (table) {
+        table.dropUnique(['object_id', 'owner']);
+        table.unique(['object_id']);
+      });
+    });
+};

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -27,7 +27,7 @@ class JobRepository {
         status: 'started',
         last_edited_time: new Date(),
       })
-      .onConflict('object_id')
+      .onConflict(['object_id', 'owner'])
       .ignore();
   }
 

--- a/src/usecases/jobs/FindOrCreateJobUseCase.test.ts
+++ b/src/usecases/jobs/FindOrCreateJobUseCase.test.ts
@@ -1,0 +1,44 @@
+import { FindOrCreateJobUseCase } from './FindOrCreateJobUseCase';
+import JobRepository from '../../data_layer/JobRepository';
+
+describe('FindOrCreateJobUseCase', () => {
+  it('creates separate jobs for different owners with the same object_id', async () => {
+    const jobs: Record<string, any> = {};
+    let idCounter = 1;
+
+    const jobRepository = {
+      create: async (id: string, owner: string, title?: string | null, type?: string) => {
+        const key = `${id}:${owner}`;
+        if (!jobs[key]) {
+          jobs[key] = { id: idCounter++, object_id: id, owner, status: 'started', title, type };
+        }
+        return [jobs[key].id];
+      },
+      findJobById: async (id: string, owner: string) => {
+        const key = `${id}:${owner}`;
+        return jobs[key] || null;
+      },
+    } as unknown as JobRepository;
+
+    const useCase = new FindOrCreateJobUseCase(jobRepository);
+    const notionPageId = '33e3e244-8dee-8044-916c-db66d504d507';
+
+    const jobA = await useCase.execute({
+      id: notionPageId,
+      owner: 'user-a',
+      title: 'Test Page',
+      type: 'page',
+    });
+
+    const jobB = await useCase.execute({
+      id: notionPageId,
+      owner: 'user-b',
+      title: 'Test Page',
+      type: 'page',
+    });
+
+    expect(jobA.owner).toBe('user-a');
+    expect(jobB.owner).toBe('user-b');
+    expect(jobA.id).not.toBe(jobB.id);
+  });
+});


### PR DESCRIPTION
Change jobs table unique constraint from object_id to (object_id, owner) so different users can create jobs for the same Notion page. Previously the insert was silently ignored, causing 'Job not found' errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Job management system now properly supports independent ownership by multiple users for the same job object, allowing each user to maintain their own instance without conflicts.

* **Tests**
  * Added comprehensive test coverage for job creation and retrieval across different user ownership scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->