### PR TITLE
fix: increase file cleanup age from 21 minutes to 2 hours

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,7 +34,7 @@ export function resolvePath(dir: string, x: string) {
   return x.endsWith('/') ? `${p}/` : p;
 }
 
-export const TIME_21_MINUTES_AS_SECONDS = 1260;
+export const CLEANUP_AGE_SECONDS = 7200;
 
 export const ONE_HOUR = 60 * 60 * 1000;
 

--- a/src/lib/storage/jobs/helpers/deleteOldFiles.ts
+++ b/src/lib/storage/jobs/helpers/deleteOldFiles.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 
 import findRemoveSync from 'find-remove';
-import { TIME_21_MINUTES_AS_SECONDS } from '../../../constants';
+import { CLEANUP_AGE_SECONDS } from '../../../constants';
 
 /**
  * Locally stored files are deleted after 21 minutes. This is to prevent the server from running out of space.
@@ -10,12 +10,12 @@ import { TIME_21_MINUTES_AS_SECONDS } from '../../../constants';
  * @param loc
  */
 function deleteFile(loc: string) {
-  console.time(`finding & removing ${loc} files older than 21 minutes`);
+  console.time(`finding & removing old ${loc} files`);
   findRemoveSync(path.join(os.tmpdir(), loc), {
     files: '*.*',
-    age: { seconds: TIME_21_MINUTES_AS_SECONDS },
+    age: { seconds: CLEANUP_AGE_SECONDS },
   });
-  console.timeEnd(`finding & removing ${loc} files older than 21 minutes`);
+  console.timeEnd(`finding & removing old ${loc} files`);
 }
 
 /**

--- a/src/lib/storage/jobs/helpers/deleteOldUploads.ts
+++ b/src/lib/storage/jobs/helpers/deleteOldUploads.ts
@@ -1,11 +1,11 @@
 import { Knex } from 'knex';
 
-import { TIME_21_MINUTES_AS_SECONDS } from '../../../constants';
+import { CLEANUP_AGE_SECONDS } from '../../../constants';
 import StorageHandler from '../../StorageHandler';
 import { deleteNonSubScriberUploadsInDatabase } from './deleteNonSubScriberUploadsInDatabase';
 import { deleteDanglingUploadsInBucket } from './deleteDanglingUploadsInBucket';
 
-export const MS_21 = TIME_21_MINUTES_AS_SECONDS * 1000;
+export const MS_21 = CLEANUP_AGE_SECONDS * 1000;
 export const MS_24_HOURS = 1000 * 60 * 60 * 24;
 
 const deleteResolvedFeedbackAttachments = async (


### PR DESCRIPTION
Prevents workspace files from being deleted while conversions are still in progress.