### PR TITLE
fix: always paginate Notion blocks to fetch all content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Git
 
 Use conventional commit prefixes for all commits (e.g. fix:, feat:, chore:, refactor:, test:, docs:).
+Suggest a branch name before starting any code changes.
 
 ## General
 

--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -35,7 +35,6 @@ describe('SettingsController', () => {
     testDefaultSettings('client', {
       'add-notion-link': 'false',
       'use-notion-id': 'true',
-      all: 'true',
       paragraph: 'false',
       cherry: 'false',
       avocado: 'false',
@@ -61,7 +60,6 @@ describe('SettingsController', () => {
     testDefaultSettings('server', {
       'add-notion-link': 'false',
       'use-notion-id': 'true',
-      all: 'true',
       paragraph: 'false',
       cherry: 'false',
       avocado: 'false',

--- a/src/controllers/CardOptionsController/supportedOptions.ts
+++ b/src/controllers/CardOptionsController/supportedOptions.ts
@@ -15,12 +15,6 @@ const supportedOptions = (): CardOptionDetail[] => {
       true
     ),
     new CardOptionDetail(
-      'all',
-      'Use All Toggle Lists',
-      'By default we only check for toggle lists in the first page. Use this option to retreive toggle lists from anywhere in the page.',
-      true
-    ),
-    new CardOptionDetail(
       'paragraph',
       'Use Plain Text for Back',
       'This option will remove formatting and get the text content only.',

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -61,6 +61,8 @@ class NotionController {
           err.message += `You can renew it <a href='${renewalLink}'>here</a>.`;
         }
         sendErrorResponse(err, res);
+      } else {
+        sendErrorResponse(err, res);
       }
     }
   }

--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -1,0 +1,149 @@
+import express from 'express';
+import { StripeController } from './StripeController';
+
+jest.mock('../../data_layer', () => ({
+  getDatabase: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../services/EmailService/EmailService', () => ({
+  useDefaultEmailService: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('./extractTokenFromCookies', () => ({
+  extractTokenFromCookies: jest.fn(),
+}));
+
+jest.mock('../../services/SubscriptionService', () => ({
+  getUserActiveSubscriptions: jest.fn(),
+}));
+
+jest.mock('../../lib/integrations/stripe', () => ({
+  getStripe: jest.fn().mockReturnValue({
+    checkout: {
+      sessions: {
+        retrieve: jest.fn(),
+      },
+    },
+    subscriptions: {
+      retrieve: jest.fn(),
+    },
+    customers: {
+      retrieve: jest.fn(),
+    },
+  }),
+  updateStoreSubscription: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../services/AuthenticationService');
+jest.mock('../../data_layer/TokenRepository');
+jest.mock('../../data_layer/UsersRepository');
+
+import { extractTokenFromCookies } from './extractTokenFromCookies';
+import SubscriptionService from '../../services/SubscriptionService';
+import { getStripe } from '../../lib/integrations/stripe';
+import AuthenticationService from '../../services/AuthenticationService';
+
+const mockedExtractToken = extractTokenFromCookies as jest.MockedFunction<typeof extractTokenFromCookies>;
+const mockedGetActiveSubscriptions = SubscriptionService.getUserActiveSubscriptions as jest.MockedFunction<typeof SubscriptionService.getUserActiveSubscriptions>;
+const mockedStripe = getStripe() as any;
+
+function mockRequest(query: Record<string, string> = {}, cookies?: string): express.Request {
+  return {
+    get: jest.fn().mockReturnValue(cookies || 'token=abc'),
+    query,
+  } as unknown as express.Request;
+}
+
+function mockResponse(): express.Response {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  } as unknown as express.Response;
+  return res;
+}
+
+function setupAuthenticatedUser(user = { email: 'test@example.com', name: 'Test', patreon: false }) {
+  mockedExtractToken.mockReturnValue('abc');
+  (AuthenticationService as jest.MockedClass<typeof AuthenticationService>).prototype.getUserFrom = jest.fn().mockResolvedValue(user);
+}
+
+describe('StripeController', () => {
+  let controller: StripeController;
+
+  beforeEach(() => {
+    controller = new StripeController();
+    jest.clearAllMocks();
+  });
+
+  describe('checkSubscriptionStatus', () => {
+    it('returns hasActiveSubscription true when session_id is provided and session is paid', async () => {
+      setupAuthenticatedUser();
+      mockedGetActiveSubscriptions.mockResolvedValue([]);
+      mockedStripe.checkout.sessions.retrieve.mockResolvedValue({
+        payment_status: 'paid',
+        subscription: 'sub_123',
+      });
+      mockedStripe.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_123',
+        customer: 'cus_123',
+        status: 'active',
+      });
+      mockedStripe.customers.retrieve.mockResolvedValue({
+        id: 'cus_123',
+        email: 'test@example.com',
+      });
+
+      const req = mockRequest({ session_id: 'cs_test_123' });
+      const res = mockResponse();
+
+      await controller.checkSubscriptionStatus(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ hasActiveSubscription: true })
+      );
+    });
+
+    it('returns hasActiveSubscription true when user has patreon flag', async () => {
+      setupAuthenticatedUser({ email: 'test@example.com', name: 'Test', patreon: true });
+      mockedGetActiveSubscriptions.mockResolvedValue([]);
+
+      const req = mockRequest();
+      const res = mockResponse();
+
+      await controller.checkSubscriptionStatus(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ hasActiveSubscription: true })
+      );
+    });
+
+    it('returns hasActiveSubscription true when DB has active subscription', async () => {
+      setupAuthenticatedUser();
+      mockedGetActiveSubscriptions.mockResolvedValue([{ id: 1, email: 'test@example.com', active: true } as any]);
+
+      const req = mockRequest();
+      const res = mockResponse();
+
+      await controller.checkSubscriptionStatus(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ hasActiveSubscription: true })
+      );
+    });
+
+    it('returns hasActiveSubscription false when no subscription found anywhere', async () => {
+      setupAuthenticatedUser();
+      mockedGetActiveSubscriptions.mockResolvedValue([]);
+
+      const req = mockRequest();
+      const res = mockResponse();
+
+      await controller.checkSubscriptionStatus(req, res);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ hasActiveSubscription: false })
+      );
+    });
+  });
+});

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -10,6 +10,39 @@ import { getStripe, updateStoreSubscription } from '../../lib/integrations/strip
 import { extractTokenFromCookies } from './extractTokenFromCookies';
 import SubscriptionService from '../../services/SubscriptionService';
 import Stripe from 'stripe';
+import { Knex } from 'knex';
+
+async function persistStripeSession(database: Knex, sessionId: string): Promise<boolean> {
+  const stripe = getStripe();
+  const session = await stripe.checkout.sessions.retrieve(sessionId);
+  if (session.payment_status !== 'paid') {
+    return false;
+  }
+  if (session.subscription) {
+    const subscriptionId = typeof session.subscription === 'string'
+      ? session.subscription
+      : session.subscription.id;
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    const customerId = typeof subscription.customer === 'string'
+      ? subscription.customer
+      : subscription.customer.id;
+    const customer = await stripe.customers.retrieve(customerId) as Stripe.Customer;
+    await updateStoreSubscription(database, customer, subscription);
+  }
+  return true;
+}
+
+async function getAuthenticatedUser(cookies: string | undefined) {
+  const token = extractTokenFromCookies(cookies);
+  if (!token) {
+    return null;
+  }
+  const database = getDatabase();
+  const userRepository = new UsersRepository(database);
+  const tokenRepository = new TokenRepository(database);
+  const authService = new AuthenticationService(tokenRepository, userRepository);
+  return authService.getUserFrom(token);
+}
 
 export class StripeController {
   async getSuccessfulCheckout(req: express.Request, res: express.Response) {
@@ -53,54 +86,18 @@ export class StripeController {
 
   async checkSubscriptionStatus(req: express.Request, res: express.Response) {
     try {
-      const cookies = req.get('cookie');
-      const token = extractTokenFromCookies(cookies);
-
-      if (!token) {
-        return res.status(401).json({ authenticated: false, hasActiveSubscription: false });
-      }
-
-      const database = getDatabase();
-      const userRepository = new UsersRepository(database);
-      const tokenRepository = new TokenRepository(database);
-      const authService = new AuthenticationService(
-        tokenRepository,
-        userRepository
-      );
-
-      const user = await authService.getUserFrom(token);
+      const user = await getAuthenticatedUser(req.get('cookie'));
       if (!user) {
         return res.status(401).json({ authenticated: false, hasActiveSubscription: false });
       }
 
-      // Check if user has active subscription using SubscriptionService
       const activeSubscriptions = await SubscriptionService.getUserActiveSubscriptions(user.email);
-      let hasActiveSubscription = activeSubscriptions.length > 0;
-
-      if (!hasActiveSubscription && user.patreon) {
-        hasActiveSubscription = true;
-      }
+      let hasActiveSubscription = activeSubscriptions.length > 0 || user.patreon;
 
       if (!hasActiveSubscription) {
         const sessionId = req.query.session_id as string;
         if (sessionId) {
-          const stripe = getStripe();
-          const session = await stripe.checkout.sessions.retrieve(sessionId);
-          if (session.payment_status === 'paid') {
-            if (session.subscription) {
-              const subscriptionId = typeof session.subscription === 'string'
-                ? session.subscription
-                : session.subscription.id;
-              const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-              const customerId = typeof subscription.customer === 'string'
-                ? subscription.customer
-                : subscription.customer.id;
-              const customer = await stripe.customers.retrieve(customerId) as Stripe.Customer;
-
-              await updateStoreSubscription(database, customer, subscription);
-            }
-            hasActiveSubscription = true;
-          }
+          hasActiveSubscription = await persistStripeSession(getDatabase(), sessionId);
         }
       }
 

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -6,9 +6,10 @@ import UsersRepository from '../../data_layer/UsersRepository';
 import UsersService from '../../services/UsersService';
 import TokenRepository from '../../data_layer/TokenRepository';
 import AuthenticationService from '../../services/AuthenticationService';
-import { getStripe } from '../../lib/integrations/stripe';
+import { getStripe, updateStoreSubscription } from '../../lib/integrations/stripe';
 import { extractTokenFromCookies } from './extractTokenFromCookies';
 import SubscriptionService from '../../services/SubscriptionService';
+import Stripe from 'stripe';
 
 export class StripeController {
   async getSuccessfulCheckout(req: express.Request, res: express.Response) {
@@ -74,7 +75,34 @@ export class StripeController {
 
       // Check if user has active subscription using SubscriptionService
       const activeSubscriptions = await SubscriptionService.getUserActiveSubscriptions(user.email);
-      const hasActiveSubscription = activeSubscriptions.length > 0;
+      let hasActiveSubscription = activeSubscriptions.length > 0;
+
+      if (!hasActiveSubscription && user.patreon) {
+        hasActiveSubscription = true;
+      }
+
+      if (!hasActiveSubscription) {
+        const sessionId = req.query.session_id as string;
+        if (sessionId) {
+          const stripe = getStripe();
+          const session = await stripe.checkout.sessions.retrieve(sessionId);
+          if (session.payment_status === 'paid') {
+            if (session.subscription) {
+              const subscriptionId = typeof session.subscription === 'string'
+                ? session.subscription
+                : session.subscription.id;
+              const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+              const customerId = typeof subscription.customer === 'string'
+                ? subscription.customer
+                : subscription.customer.id;
+              const customer = await stripe.customers.retrieve(customerId) as Stripe.Customer;
+
+              await updateStoreSubscription(database, customer, subscription);
+            }
+            hasActiveSubscription = true;
+          }
+        }
+      }
 
       return res.json({
         authenticated: true,

--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -143,9 +143,9 @@ test('Markdown nested bullet points', async () => {
 test('Notion new export: display:contents and fragmented ul.toggle', async () => {
   const deck = await getDeck(
     'notion-new-export-nested.html',
-    new CardOption({ maxOne: 'true', cherry: 'false' })
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false' })
   );
-  
+
   expect(deck.cards.length).toBe(1);
   expect(deck.cards[0].name).toContain('Parent');
   expect(deck.cards[0].back).toContain('Child');
@@ -156,9 +156,9 @@ test('Notion new export: display:contents and fragmented ul.toggle', async () =>
 test('Notion new export: display:contents for toggles', async () => {
   const deck = await getDeck(
     'Toggles test 2cd7ab29a11e80bea100ed002a880884.html',
-    new CardOption({ maxOne: 'true', cherry: 'false', useInput: 'false' })
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false', 'enable-input': 'false' })
   );
-  
+
   // Should extract 2 cards from this structure
   expect(deck.cards.length).toBe(2);
   
@@ -217,9 +217,9 @@ test('Notion figure image: embeds image when file found via backslash path (Wind
 test('Notion new export: deeply nested toggles (3 levels)', async () => {
   const deck = await getDeck(
     'Notion Page grandchildren 2ce7ab29a11e809998e3d22ed65fc5f2.html',
-    new CardOption({ maxOne: 'true', cherry: 'false', useInput: 'false' })
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false', 'enable-input': 'false' })
   );
-  
+
   expect(deck.cards.length).toBe(1);
   
   expect(deck.cards[0].name).toContain('Parent');

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -685,7 +685,7 @@ export class DeckParser {
   private extractToggleLists(dom: cheerio.Root) {
     const foundToggleLists = findNotionToggleLists(dom, {
       isCherry: this.settings.isCherry,
-      isAll: this.noLimits,
+      isAll: false,
       disableIndentedBulletPoints: this.settings.disableIndentedBulletPoints,
     });
 

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -685,7 +685,7 @@ export class DeckParser {
   private extractToggleLists(dom: cheerio.Root) {
     const foundToggleLists = findNotionToggleLists(dom, {
       isCherry: this.settings.isCherry,
-      isAll: this.settings.isAll,
+      isAll: this.noLimits,
       disableIndentedBulletPoints: this.settings.disableIndentedBulletPoints,
     });
 

--- a/src/lib/parser/ParserRules.ts
+++ b/src/lib/parser/ParserRules.ts
@@ -10,8 +10,6 @@ class ParserRules {
 
   TAGS = 'strikethrough';
 
-  UNLIMITED = false;
-
   EMAIL_NOTIFICATION = false;
 
   /**

--- a/src/lib/parser/Settings/CardOption.ts
+++ b/src/lib/parser/Settings/CardOption.ts
@@ -16,8 +16,6 @@ class CardOption {
 
   readonly isAvocado: boolean;
 
-  readonly isAll: boolean;
-
   readonly fontSize: string;
 
   readonly isTextOnlyBack: boolean;
@@ -87,7 +85,6 @@ class CardOption {
     this.noUnderline = input['no-underline'] === 'true';
     this.isCherry = input.cherry === 'true';
     this.isAvocado = input.avocado === 'true';
-    this.isAll = input.all === 'true';
     this.fontSize = input['font-size'];
     this.isTextOnlyBack = input.paragraph === 'true';
     this.toggleMode = input['toggle-mode'] || 'close_toggle';
@@ -145,7 +142,6 @@ class CardOption {
     return {
       'add-notion-link': 'false',
       'use-notion-id': 'true',
-      all: 'true',
       paragraph: 'false',
       cherry: 'false',
       avocado: 'false',

--- a/src/lib/parser/findNotionToggleLists.ts
+++ b/src/lib/parser/findNotionToggleLists.ts
@@ -4,14 +4,11 @@ import CardOption from './Settings';
 
 export function findNotionToggleLists(
   dom: cheerio.Root,
-  context: Pick<
-    CardOption,
-    'isAll' | 'isCherry' | 'disableIndentedBulletPoints'
-  >
+  context: Pick<CardOption, 'isCherry' | 'disableIndentedBulletPoints'> & {
+    isAll: boolean;
+  }
 ): cheerio.Element[] {
   if (context.isCherry || context.isAll) {
-    // When isAll is true, find all .toggle elements including nested ones
-    // This ensures nested toggles are treated as separate cards
     return dom('.toggle').toArray();
   }
   if (!context.disableIndentedBulletPoints) {

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -84,7 +84,7 @@ export default async function performConversion(
 
     const createWorkSpace = new CreateJobWorkSpaceUseCase(jobRepository);
     const { ws, exporter, settings, bl, rules } = await createWorkSpace.execute(
-      { api, id, owner, jobRepository }
+      { api, id, owner, jobRepository, isPaying: isPaying(res?.locals) }
     );
 
     const createFlashcards = new CreateFlashcardsForJobUseCase(jobRepository);

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -313,7 +313,7 @@ class BlockHandler {
       createdAt: (page as PageObjectResponse).created_time,
       lastEditedAt: (page as PageObjectResponse).last_edited_time,
       id: topLevelId,
-      all: rules.UNLIMITED,
+      all: this.useAll,
       type: 'page',
     });
     const blocks = response.results;
@@ -346,7 +346,6 @@ class BlockHandler {
         tags,
         notionBaseLink
       );
-      // Deduplicate by globalSeenIds
       cards = cards.filter(card => {
         if (typeof card.notionId === 'string' && globalSeenIds.has(card.notionId)) {
           return false;
@@ -387,7 +386,6 @@ class BlockHandler {
           return rules.SUB_DECKS.includes(b.type);
         }
       });
-
       for (const sd of subDecks) {
         if (isFullBlock(sd)) {
           if (
@@ -403,7 +401,7 @@ class BlockHandler {
             createdAt: sd.created_time,
             lastEditedAt: sd.last_edited_time,
             id: sd.id,
-            all: rules.UNLIMITED,
+            all: this.useAll,
             type: sd.type,
           });
           let cBlocks = res.results.filter((b: GetBlockResponse) =>

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -324,6 +324,8 @@ class BlockHandler {
       this.firstPageTitle = title;
     }
 
+    const currentDeckName = toText(getDeckName(parentName, title));
+
     // Depth-first traversal: process current page, then children
     if (rules.permitsDeckAsPage() && page) {
       const cBlocks = blocks.filter((b: GetBlockResponse) => {
@@ -354,7 +356,7 @@ class BlockHandler {
         return true;
       });
       const deck = new Deck(
-        toText(getDeckName(parentName, title)),
+        currentDeckName,
         Deck.CleanCards(cards),
         undefined,
         NOTION_STYLE,
@@ -374,7 +376,7 @@ class BlockHandler {
             topLevelId: block.id,
             rules,
             decks,
-            parentName: parentName,
+            parentName: currentDeckName,
           }, globalSeenIds);
         }
       }
@@ -447,7 +449,7 @@ class BlockHandler {
             topLevelId: sd.id,
             rules,
             decks,
-            parentName: parentName,
+            parentName: currentDeckName,
           }, globalSeenIds);
         }
       }

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -382,7 +382,7 @@ class BlockHandler {
       }
     }
 
-    if (this.settings.isAll) {
+    if (this.useAll) {
       const subDecks = blocks.filter((b) => {
         if ('type' in b) {
           return rules.SUB_DECKS.includes(b.type);

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -69,14 +69,12 @@ class NotionAPIWrapper {
       };
     }
 
-    const cachedPayload = all
-      ? await getBlockCache({
+    const cachedPayload = await getBlockCache({
           database: getDatabase(),
           id,
           owner: this.owner,
           lastEditedAt,
-        })
-      : null;
+        });
     if (cachedPayload) {
       console.log('using payload cache');
       console.timeEnd(`getBlocks:${id}${all}`);
@@ -88,7 +86,7 @@ class NotionAPIWrapper {
     });
     console.log('received', response.results.length, 'blocks');
 
-    if (all && response.has_more && response.next_cursor) {
+    if (response.has_more && response.next_cursor) {
       while (true) {
         const { results, next_cursor: nextCursor }: ListBlockChildrenResponse =
           await this.notion.blocks.children.list({

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -69,12 +69,14 @@ class NotionAPIWrapper {
       };
     }
 
-    const cachedPayload = await getBlockCache({
+    const cachedPayload = all
+      ? await getBlockCache({
           database: getDatabase(),
           id,
           owner: this.owner,
           lastEditedAt,
-        });
+        })
+      : null;
     if (cachedPayload) {
       console.log('using payload cache');
       console.timeEnd(`getBlocks:${id}${all}`);
@@ -86,7 +88,7 @@ class NotionAPIWrapper {
     });
     console.log('received', response.results.length, 'blocks');
 
-    if (response.has_more && response.next_cursor) {
+    if (all && response.has_more && response.next_cursor) {
       while (true) {
         const { results, next_cursor: nextCursor }: ListBlockChildrenResponse =
           await this.notion.blocks.children.list({

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -220,13 +220,11 @@ class NotionAPIWrapper {
   }
 
   async getTopLevelTags(pageId: string, rules: ParserRules) {
-    console.time('[NO_CACHE] - getTopLevelTags');
     const useHeadings = rules.TAGS === 'heading';
     const response = await this.getBlocks({
       createdAt: '',
       lastEditedAt: '',
       id: pageId,
-      all: rules.UNLIMITED,
       type: 'page',
     });
     const globalTags = [];
@@ -262,7 +260,6 @@ class NotionAPIWrapper {
         }
       }
     }
-    console.timeEnd('[NO_CACHE] - getTopLevelTags');
     return sanitizeTags(globalTags);
   }
 

--- a/src/services/NotionService/blocks/getBlockIcon.ts
+++ b/src/services/NotionService/blocks/getBlockIcon.ts
@@ -3,6 +3,8 @@ export type WithIcon = {
     | { emoji: string; type?: 'emoji' }
     | { external: { url: string }; type?: 'external' }
     | { file: { url: string }; type?: 'file' }
+    | { custom_emoji: { id: string; name: string; url: string }; type?: 'custom_emoji' }
+    | { icon: { name: string; color?: string }; type?: 'icon' }
     | null;
 };
 
@@ -18,6 +20,10 @@ export default function getBlockIcon(p?: WithIcon, emoji?: string): string {
       return p.icon.external.url;
     case 'file':
       return p.icon.file.url;
+    case 'custom_emoji':
+      return p.icon.custom_emoji.url;
+    case 'icon':
+      return '';
     default:
       return '';
   }

--- a/src/services/NotionService/helpers/renderIcon.tsx
+++ b/src/services/NotionService/helpers/renderIcon.tsx
@@ -5,15 +5,17 @@ export default async function renderIcon(icon?: string) {
   if (!icon) {
     return null;
   }
-  if (icon.startsWith('http')) {
-    let validIcon = true;
-    await axios.get(icon).catch(function (error) {
-      if (error.response && error.response.status === 404) {
-        validIcon = false;
+  if (icon.startsWith('http') || icon.startsWith('data:image')) {
+    if (icon.startsWith('http')) {
+      let validIcon = true;
+      await axios.get(icon).catch(function (error) {
+        if (error.response && error.response.status === 404) {
+          validIcon = false;
+        }
+      });
+      if (!validIcon) {
+        return null;
       }
-    });
-    if (!validIcon) {
-      return null;
     }
     return renderToStaticMarkup(<img src={icon} width="32" />);
   }

--- a/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
+++ b/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
@@ -1,0 +1,58 @@
+import { CreateJobWorkSpaceUseCase } from './CreateJobWorkSpaceUseCase';
+import JobRepository from '../../data_layer/JobRepository';
+
+jest.mock('../../data_layer', () => ({
+  getDatabase: () => jest.fn().mockReturnValue({
+    where: jest.fn().mockReturnValue({
+      returning: jest.fn().mockReturnValue({
+        first: jest.fn().mockResolvedValue(null),
+      }),
+    }),
+  }),
+}));
+
+jest.mock('../../lib/parser/Settings/loadSettingsFromDatabase', () => ({
+  loadSettingsFromDatabase: jest.fn().mockResolvedValue({
+    pageEmoji: 'first_emoji',
+  }),
+}));
+
+beforeAll(() => {
+  process.env.WORKSPACE_BASE = '/tmp/test-workspace';
+});
+
+describe('CreateJobWorkSpaceUseCase', () => {
+  const mockJobRepository = {
+    updateJobStatus: jest.fn().mockResolvedValue(true),
+  } as unknown as JobRepository;
+
+  const mockApi = {} as any;
+
+  it('sets useAll to true when isPaying is true', async () => {
+    const useCase = new CreateJobWorkSpaceUseCase(mockJobRepository);
+
+    const result = await useCase.execute({
+      id: 'test-id',
+      owner: 'test-owner',
+      api: mockApi,
+      jobRepository: mockJobRepository,
+      isPaying: true,
+    });
+
+    expect(result.bl.useAll).toBe(true);
+  });
+
+  it('sets useAll to false when isPaying is false', async () => {
+    const useCase = new CreateJobWorkSpaceUseCase(mockJobRepository);
+
+    const result = await useCase.execute({
+      id: 'test-id',
+      owner: 'test-owner',
+      api: mockApi,
+      jobRepository: mockJobRepository,
+      isPaying: false,
+    });
+
+    expect(result.bl.useAll).toBe(false);
+  });
+});

--- a/src/usecases/jobs/CreateJobWorkSpaceUseCase.ts
+++ b/src/usecases/jobs/CreateJobWorkSpaceUseCase.ts
@@ -13,6 +13,7 @@ export interface CreateJobWorkSpaceUseCaseInput {
   owner: string;
   api: NotionAPIWrapper;
   jobRepository: JobRepository;
+  isPaying: boolean;
 }
 
 export interface CreateJobWorkSpaceUseCaseOutput {
@@ -53,7 +54,7 @@ export class CreateJobWorkSpaceUseCase {
     const bl = new BlockHandler(exporter, api, settings);
     // TODO: refactor ParserRules.load out
     const rules = await ParserRules.Load(owner, id);
-    bl.useAll = rules.UNLIMITED;
+    bl.useAll = input.isPaying;
 
     return { ws, exporter, settings, bl, rules };
   }


### PR DESCRIPTION
Previously getBlocks only paginated when the 'all' flag was true, but this flag was always false because ParserRules.UNLIMITED was never loaded from the database. This caused pages with 100+ blocks to be silently truncated, resulting in missing flashcards for subscribers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Stripe subscription verification with checkout session validation
  * Added support for custom emoji and icon types in Notion blocks
  * Support for data URL images in icon rendering

* **Bug Fixes**
  * Improved error handling in search endpoint to catch all exception types
  * Fixed icon rendering for additional Notion icon variants

* **Removed Features**
  * Removed "Use All Toggle Lists" toggle option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->