### PR TITLE
fix: enforce 401 in RequireAuthentication when session is invalid

### DIFF
--- a/src/routes/middleware/RequireAuthentication.test.ts
+++ b/src/routes/middleware/RequireAuthentication.test.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+
+jest.mock('../../data_layer', () => ({
+  getDatabase: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../../services/AuthenticationService');
+jest.mock('../../data_layer/TokenRepository');
+jest.mock('../../data_layer/UsersRepository');
+
+import AuthenticationService from '../../services/AuthenticationService';
+import RequireAuthentication from './RequireAuthentication';
+
+const mockedAuthService =
+  AuthenticationService as jest.MockedClass<typeof AuthenticationService>;
+
+function mockRequest(): express.Request {
+  return {
+    query: {},
+    cookies: { token: 'abc' },
+  } as unknown as express.Request;
+}
+
+function mockResponse() {
+  return {
+    locals: {},
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  } as unknown as express.Response;
+}
+
+describe('RequireAuthentication', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls next when the user is authenticated', async () => {
+    mockedAuthService.prototype.getUserFrom = jest
+      .fn()
+      .mockResolvedValue({ id: 1, owner: 1, email: 'test@test.com' });
+
+    const next = jest.fn();
+    await RequireAuthentication(mockRequest(), mockResponse(), next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 401 when the user is not authenticated', async () => {
+    mockedAuthService.prototype.getUserFrom = jest.fn().mockResolvedValue(null);
+
+    const res = mockResponse();
+    const next = jest.fn();
+    await RequireAuthentication(mockRequest(), res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.send).toHaveBeenCalledWith({ error: 'Unauthorized' });
+  });
+});

--- a/src/routes/middleware/RequireAuthentication.test.ts
+++ b/src/routes/middleware/RequireAuthentication.test.ts
@@ -39,10 +39,13 @@ describe('RequireAuthentication', () => {
       .fn()
       .mockResolvedValue({ id: 1, owner: 1, email: 'test@test.com' });
 
+    const res = mockResponse();
     const next = jest.fn();
-    await RequireAuthentication(mockRequest(), mockResponse(), next);
+    await RequireAuthentication(mockRequest(), res, next);
 
     expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
   });
 
   it('returns 401 when the user is not authenticated', async () => {

--- a/src/routes/middleware/RequireAuthentication.ts
+++ b/src/routes/middleware/RequireAuthentication.ts
@@ -27,6 +27,10 @@ const RequireAuthentication = async (
   if (shouldDebug)
     console.debug('RequireAuthentication: User local configured');
 
+  if (!res.locals.owner) {
+    return res.status(401).send({ error: 'Unauthorized' });
+  }
+
   return next();
 };
 

--- a/src/routes/middleware/RequireAuthentication.ts
+++ b/src/routes/middleware/RequireAuthentication.ts
@@ -27,7 +27,7 @@ const RequireAuthentication = async (
   if (shouldDebug)
     console.debug('RequireAuthentication: User local configured');
 
-  if (!res.locals.owner) {
+  if (res.locals.owner == null) {
     return res.status(401).send({ error: 'Unauthorized' });
   }
 


### PR DESCRIPTION
Previously the middleware always called next() regardless of whether authentication succeeded, allowing requests with expired or missing cookies to reach handlers with undefined owner, causing Knex binding errors. Added a test to cover both authenticated and unauthenticated cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication middleware to properly validate user authorization. Unauthorized requests now receive a 401 Unauthorized response instead of proceeding.

* **Tests**
  * Added comprehensive test coverage for authentication middleware, validating both authorized and unauthorized access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->