### PR TITLE
fix: auto-detect nested bullets in markdown without explicit setting

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -140,6 +140,21 @@ test('Markdown nested bullet points', async () => {
   expect(deck.cards.length).toBe(4);
 });
 
+test('Markdown nested bullets auto-detected without explicit setting', () => {
+  const fixturePath = path.join(__dirname, '../../test/fixtures/notion-nested-bullets.md');
+  const contents = fs.readFileSync(fixturePath).toString();
+  const info = [{ name: 'notion-nested-bullets.md', contents }];
+  const parser = new DeckParser({
+    name: 'notion-nested-bullets.md',
+    settings: new CardOption({ reversed: 'false', 'basic-reversed': 'false' }),
+    files: info,
+    noLimits: true,
+    workspace: new Workspace(true, 'fs'),
+  });
+  expect(parser.payload.length).toBe(1);
+  expect(parser.payload[0].cards.length).toBe(2);
+});
+
 test('Notion new export: display:contents and fragmented ul.toggle', async () => {
   const deck = await getDeck(
     'notion-new-export-nested.html',

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -44,7 +44,7 @@ export interface DeckParserInput {
 
 function hasNestedBullets(content: string | undefined): boolean {
   if (!content) return false;
-  return /^\s+[-*+][ \t]/m.test(content);
+  return /^[ \t]+[-*+][ \t]/m.test(content);
 }
 
 export class DeckParser {

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -42,6 +42,11 @@ export interface DeckParserInput {
   onProgress?: (step: string) => void;
 }
 
+function hasNestedBullets(content: string | undefined): boolean {
+  if (!content) return false;
+  return /^\s+[-*+][ \t]/m.test(content);
+}
+
 export class DeckParser {
   globalTags: cheerio.Cheerio | null;
 
@@ -80,18 +85,23 @@ export class DeckParser {
   processFirstFile(name: string) {
     const firstFile = this.files.find((file) => isFileNameEqual(file, name));
 
-    if (this.settings.nestedBulletPoints && isMarkdownFile(name)) {
+    if (isMarkdownFile(name)) {
       const contents = getFileContents(firstFile, false);
-      this.payload = handleNestedBulletPointsInMarkdown({
-        name,
-        contents: contents?.toString(),
-        deckName: this.settings.deckName,
-        decks: [],
-        settings: this.settings,
-        exporter: this.customExporter,
-        workspace: this.workspace,
-        files: this.files,
-      });
+      const contentsStr = contents?.toString();
+      if (this.settings.nestedBulletPoints || hasNestedBullets(contentsStr)) {
+        this.payload = handleNestedBulletPointsInMarkdown({
+          name,
+          contents: contentsStr,
+          deckName: this.settings.deckName,
+          decks: [],
+          settings: this.settings,
+          exporter: this.customExporter,
+          workspace: this.workspace,
+          files: this.files,
+        });
+      } else {
+        this.payload = [];
+      }
     } else if (isHTMLFile(name)) {
       const contents = getFileContents(firstFile, true);
       this.payload = contents

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -43,7 +43,7 @@ export interface DeckParserInput {
 }
 
 function hasNestedBullets(content: string | undefined): boolean {
-  if (!content) return false;
+  if (content == null || content === '') return false;
   return /^[ \t]+[-*+][ \t]/m.test(content);
 }
 

--- a/src/test/fixtures/notion-nested-bullets.md
+++ b/src/test/fixtures/notion-nested-bullets.md
@@ -1,0 +1,9 @@
+# Norway
+
+- What is the capital city of Norway?
+    - Oslo is the capital and most populous city
+    - It sits at the head of the Oslofjord
+
+- What are the official languages of Norway?
+    - Norwegian Bokmål
+    - Norwegian Nynorsk


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parser now automatically detects nested bullet points in Markdown, ensuring nested lists are recognized and produced as separate cards even without explicit configuration.

* **Tests**
  * Added test coverage with a new Markdown fixture containing nested lists (two top-level items with indented sub-bullets) to validate automatic nested-bullet detection and resulting card output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->