### PR TITLE
refactor: move api docs from /docs to /api/docs

### DIFF
--- a/src/config/swagger.test.ts
+++ b/src/config/swagger.test.ts
@@ -52,7 +52,7 @@ describe('Swagger Documentation Coverage', () => {
 
           // Skip middleware-only routes and Swagger documentation routes
           if (
-            !routePath.includes('/docs') &&
+            !routePath.includes('/api/docs') &&
             !routePath.includes('swagger') &&
             !line.includes('swaggerUi.serve') &&
             !line.includes('swaggerUi.setup')

--- a/src/routes/SwaggerRouter.ts
+++ b/src/routes/SwaggerRouter.ts
@@ -5,15 +5,13 @@ import { swaggerSpec, swaggerUiOptions } from '../config/swagger';
 const SwaggerRouter = () => {
   const router = express.Router();
 
-  // Serve swagger JSON spec
-  router.get('/docs/swagger.json', (req, res) => {
+  router.get('/api/docs/swagger.json', (req, res) => {
     res.setHeader('Content-Type', 'application/json');
     res.send(swaggerSpec);
   });
 
-  // Serve swagger UI
-  router.use('/docs', swaggerUi.serve);
-  router.get('/docs', swaggerUi.setup(swaggerSpec, swaggerUiOptions));
+  router.use('/api/docs', swaggerUi.serve);
+  router.get('/api/docs', swaggerUi.setup(swaggerSpec, swaggerUiOptions));
 
   return router;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * API documentation endpoints reorganized; Swagger UI and specification are now accessible at `/api/docs` instead of the previous `/docs` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->