### PR TITLE
fix: stop leaking pg result internals from rules create endpoint

### DIFF
--- a/src/controllers/ParserRulesController.test.ts
+++ b/src/controllers/ParserRulesController.test.ts
@@ -1,0 +1,75 @@
+import express from 'express';
+import RulesController from './ParserRulesController';
+import ParserRulesService from '../services/ParserRulesService';
+import * as getOwnerModule from '../lib/User/getOwner';
+
+describe('ParserRulesController', () => {
+  let service: ParserRulesService;
+  let controller: RulesController;
+  let req: Partial<express.Request>;
+  let res: Partial<express.Response>;
+
+  beforeEach(() => {
+    service = {
+      createRule: jest.fn(),
+      getById: jest.fn(),
+    } as any;
+    controller = new RulesController(service);
+    req = {
+      params: { id: '7ccef4f6-b50c-4599-878e-f6fb61415ce2' },
+      body: { payload: { FLASHCARD: 'a', DECK: 'b' } },
+    };
+    res = {
+      send: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    jest.spyOn(getOwnerModule, 'getOwner').mockReturnValue('owner1');
+  });
+
+  it('does not leak database driver internals when creating a rule', async () => {
+    const pgResultLikeObject = {
+      command: 'INSERT',
+      rowCount: 1,
+      rows: [],
+      fields: [],
+      _types: { builtins: { BOOL: 16 } },
+      RowCtor: null,
+      rowAsArray: false,
+    };
+    (service.createRule as jest.Mock).mockResolvedValue(pgResultLikeObject);
+
+    await controller.createRule(
+      req as express.Request,
+      res as express.Response
+    );
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    const sentBody = (res.send as jest.Mock).mock.calls[0]?.[0];
+    const sentJson = (res.json as jest.Mock).mock.calls[0]?.[0];
+    const payload = sentBody ?? sentJson;
+    const serialized = JSON.stringify(payload ?? '');
+    expect(serialized).not.toContain('_types');
+    expect(serialized).not.toContain('RowCtor');
+    expect(serialized).not.toContain('rowAsArray');
+    expect(serialized).not.toContain('command');
+  });
+
+  it('returns 400 when id is missing', async () => {
+    req.params = {};
+    await controller.createRule(
+      req as express.Request,
+      res as express.Response
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when service throws', async () => {
+    (service.createRule as jest.Mock).mockRejectedValue(new Error('fail'));
+    await controller.createRule(
+      req as express.Request,
+      res as express.Response
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/src/controllers/ParserRulesController.ts
+++ b/src/controllers/ParserRulesController.ts
@@ -14,12 +14,8 @@ class RulesController {
     }
 
     try {
-      const result = await this.service.createRule(
-        id,
-        getOwner(res),
-        req.body.payload
-      );
-      res.status(200).send(result);
+      await this.service.createRule(id, getOwner(res), req.body.payload);
+      res.status(201).json({ message: 'Rule created' });
     } catch (error) {
       console.info('Create rule failed');
       console.error(error);

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -21,6 +21,7 @@ import ParserRules from '../../../lib/parser/ParserRules';
 import CardOption from '../../../lib/parser/Settings';
 import TagRegistry from '../../../lib/parser/TagRegistry';
 import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
+import { withFontSize } from '../../../lib/parser/withFontSize';
 import get16DigitRandomId from '../../../shared/helpers/get16DigitRandomId';
 import { NOTION_STYLE } from '../../../templates/helper';
 import NotionAPIWrapper from '../NotionAPIWrapper';
@@ -359,7 +360,7 @@ class BlockHandler {
         currentDeckName,
         Deck.CleanCards(cards),
         undefined,
-        NOTION_STYLE,
+        withFontSize(NOTION_STYLE, this.settings.fontSize),
         get16DigitRandomId(),
         this.settings
       );
@@ -435,7 +436,7 @@ class BlockHandler {
               ),
               cards,
               undefined,
-              NOTION_STYLE,
+              withFontSize(NOTION_STYLE, this.settings.fontSize),
               get16DigitRandomId(),
               this.settings
             )

--- a/src/services/NotionService/blocks/BlockCallout.tsx
+++ b/src/services/NotionService/blocks/BlockCallout.tsx
@@ -34,7 +34,9 @@ export const BlockCallout = (
       <div style={{ width: '100%' }}>
         {richText.map((t: RichTextItemResponse) => {
           const { annotations } = t;
-          return HandleBlockAnnotations(annotations, t);
+          return HandleBlockAnnotations(annotations, t, {
+            noUnderline: handler.settings?.noUnderline,
+          });
         })}
       </div>
     </figure>

--- a/src/services/NotionService/blocks/BlockCode.tsx
+++ b/src/services/NotionService/blocks/BlockCode.tsx
@@ -20,7 +20,9 @@ const BlockCode = (block: CodeBlockObjectResponse, handler: BlockHandler) => {
       <code>
         {richText.map((t: RichTextItemResponse) => {
           const { annotations } = t;
-          return HandleBlockAnnotations(annotations, t);
+          return HandleBlockAnnotations(annotations, t, {
+            noUnderline: handler.settings?.noUnderline,
+          });
         })}
       </code>
     </pre>

--- a/src/services/NotionService/blocks/HandleBlockAnnotations.tsx
+++ b/src/services/NotionService/blocks/HandleBlockAnnotations.tsx
@@ -12,9 +12,14 @@ interface Annotations {
   color?: string;
 }
 
+interface HandleBlockAnnotationsOptions {
+  noUnderline?: boolean;
+}
+
 const HandleBlockAnnotations = (
   annotations: Annotations,
-  text: RichTextItemResponse
+  text: RichTextItemResponse,
+  options: HandleBlockAnnotationsOptions = {}
 ) => {
   if (!text) {
     return null;
@@ -36,7 +41,7 @@ const HandleBlockAnnotations = (
   if (annotations.bold) {
     styledContent = <strong>{styledContent}</strong>;
   }
-  if (annotations.underline) {
+  if (annotations.underline && !options.noUnderline) {
     styledContent = (
       <span style={{ borderBottom: '0.05em solid' }}>{styledContent}</span>
     );

--- a/src/services/NotionService/helpers/renderTextChildren.tsx
+++ b/src/services/NotionService/helpers/renderTextChildren.tsx
@@ -26,7 +26,11 @@ export default function renderTextChildren(
 
       if (isText(t)) {
         return ReactDOMServer.renderToStaticMarkup(
-          <>{HandleBlockAnnotations(t.annotations, t)}</>
+          <>
+            {HandleBlockAnnotations(t.annotations, t, {
+              noUnderline: settings.noUnderline,
+            })}
+          </>
         );
       }
 


### PR DESCRIPTION
POST /api/rules/create/:id was returning the raw node-postgres Result object, exposing driver internals like _types, RowCtor, and PG type OIDs. Respond with a minimal 201 payload matching the Swagger contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for parser rule creation, validating success, missing-parameter, and failure responses.

* **Bug Fixes**
  * Rule creation endpoint now returns HTTP 201 with a standardized success message on create.

* **New Features**
  * Rich-text rendering now respects a configurable no-underline option.
  * Deck/style rendering now applies the configured font size to improve visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->