### PR TITLE
feat: show friendly error when Claude finds no page content

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -1,0 +1,47 @@
+import {
+  looksLikeEmptyContentExplanation,
+  EMPTY_CONTENT_USER_MESSAGE,
+} from './ClaudeService';
+
+describe('looksLikeEmptyContentExplanation', () => {
+  it('detects the reported empty-page explanation', () => {
+    const cleaned =
+      '{ }\n\nThe provided HTML content is a flashcard application interface template with UI elements (buttons, progress bars, card display areas) but has no actual question-and-answer content to convert into flashcards. The document consists only of structural elements like divs, buttons, and placeholder elements with IDs for dynamic content injection.';
+    expect(looksLikeEmptyContentExplanation(cleaned)).toBe(true);
+  });
+
+  it('detects a variety of no-content phrasings', () => {
+    const samples = [
+      'I cannot find any flashcard material in this document.',
+      "I couldn't find any question-and-answer pairs to extract.",
+      'The page has no extractable flashcard content.',
+      'Nothing to convert — the page appears to be a template.',
+    ];
+    for (const sample of samples) {
+      expect(looksLikeEmptyContentExplanation(sample)).toBe(true);
+    }
+  });
+
+  it('does not match a malformed but real attempt at JSON', () => {
+    const truncated =
+      '[{"deck":"Biology","cards":[{"q":"What is mitosis","a":"Cell div';
+    expect(looksLikeEmptyContentExplanation(truncated)).toBe(false);
+  });
+
+  it('does not match an empty JSON array', () => {
+    expect(looksLikeEmptyContentExplanation('[]')).toBe(false);
+  });
+});
+
+describe('EMPTY_CONTENT_USER_MESSAGE', () => {
+  it('is friendly and free of technical jargon', () => {
+    expect(EMPTY_CONTENT_USER_MESSAGE).toMatch(/Claude/);
+    expect(EMPTY_CONTENT_USER_MESSAGE.toLowerCase()).not.toMatch(
+      /html|<div|dom|dynamic content injection/
+    );
+    expect(EMPTY_CONTENT_USER_MESSAGE.toLowerCase()).toContain('notion page');
+    expect(EMPTY_CONTENT_USER_MESSAGE.toLowerCase()).toMatch(
+      /empty|layout element/
+    );
+  });
+});

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -222,6 +222,50 @@ function mergeDeckInfoArrays(decks: DeckInfo[]): DeckInfo[] {
   return Array.from(byName.values());
 }
 
+function buildUserMessage(
+  strippedContent: string,
+  availableMediaFiles: string[],
+  userInstructions: string | undefined
+): string {
+  const mediaFilesList =
+    availableMediaFiles.length > 0
+      ? `\n\nAvailable local media files:\n${availableMediaFiles.map((f) => `- ${f}`).join('\n')}`
+      : '';
+
+  const instructionsSection = userInstructions?.trim()
+    ? `\n\nAdditional instructions:\n${userInstructions.trim()}`
+    : '';
+
+  return `Convert this HTML content into the compact deck JSON:\n\n${strippedContent}${mediaFilesList}${instructionsSection}`;
+}
+
+function parseDeckResponse(
+  cleaned: string,
+  raw: string,
+  chunkIndex: number
+): CompactDeck[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    console.error('[Claude] Failed to parse response as JSON', { raw, chunkIndex });
+    if (
+      !cleaned.trim().startsWith('[') &&
+      looksLikeEmptyContentExplanation(cleaned)
+    ) {
+      throw new Error(EMPTY_CONTENT_USER_MESSAGE);
+    }
+    throw new Error(`Claude returned invalid JSON:\n${raw}`);
+  }
+
+  if (!Array.isArray(parsed)) {
+    console.error('[Claude] Response is not an array', { raw, cleaned, chunkIndex });
+    throw new Error('Claude returned unexpected JSON structure (not an array)');
+  }
+
+  return parsed as CompactDeck[];
+}
+
 async function generateDeckInfoFromChunk(
   strippedContent: string,
   pageStyle: string,
@@ -234,17 +278,7 @@ async function generateDeckInfoFromChunk(
   const tChunk0 = Date.now();
   const client = getAnthropicClient();
 
-  const mediaFilesList =
-    availableMediaFiles.length > 0
-      ? `\n\nAvailable local media files:\n${availableMediaFiles.map((f) => `- ${f}`).join('\n')}`
-      : '';
-
-  const instructionsSection = userInstructions?.trim()
-    ? `\n\nAdditional instructions:\n${userInstructions.trim()}`
-    : '';
-
-  const userMessage = `Convert this HTML content into the compact deck JSON:\n\n${strippedContent}${mediaFilesList}${instructionsSection}`;
-
+  const userMessage = buildUserMessage(strippedContent, availableMediaFiles, userInstructions);
   const maxTokens = strippedContent.length > 20000 ? 16384 : 4096;
 
   onProgress?.(`claude:chunk:${chunkIndex + 1}:${totalChunks}`);
@@ -321,26 +355,8 @@ async function generateDeckInfoFromChunk(
   const cleaned = raw.replace(/```json|```/g, '').trim();
 
   const tParse0 = Date.now();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(cleaned);
-  } catch {
-    console.error('[Claude] Failed to parse response as JSON', { raw, chunkIndex });
-    if (
-      !cleaned.trim().startsWith('[') &&
-      looksLikeEmptyContentExplanation(cleaned)
-    ) {
-      throw new Error(EMPTY_CONTENT_USER_MESSAGE);
-    }
-    throw new Error(`Claude returned invalid JSON:\n${raw}`);
-  }
-
-  if (!Array.isArray(parsed)) {
-    console.error('[Claude] Response is not an array', { raw, cleaned, chunkIndex });
-    throw new Error('Claude returned unexpected JSON structure (not an array)');
-  }
-
-  const deckInfo = expandCompactDeckInfo(parsed as CompactDeck[], availableMediaFiles, pageStyle || null);
+  const parsed = parseDeckResponse(cleaned, raw, chunkIndex);
+  const deckInfo = expandCompactDeckInfo(parsed, availableMediaFiles, pageStyle || null);
   const parseMs = Date.now() - tParse0;
   console.log('[Claude] chunk done', {
     chunkIndex,

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -1,3 +1,8 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { Message } from '@anthropic-ai/sdk/resources/messages';
+import * as cheerio from 'cheerio';
+import { createHash } from 'node:crypto';
+
 const SYSTEM_PROMPT = `
 You are an Anki flashcard generator. Output ONLY a compact JSON array.
 
@@ -18,10 +23,27 @@ Extraction rules:
 - Never invent content — only use text present in the document
 `.trim();
 
-import type Anthropic from '@anthropic-ai/sdk';
-import type { Message } from '@anthropic-ai/sdk/resources/messages';
-import * as cheerio from 'cheerio';
-import { createHash } from 'node:crypto';
+export const EMPTY_CONTENT_USER_MESSAGE =
+  "Claude couldn't find any content to turn into flashcards in this Notion page. The page looks empty or only contains layout elements like buttons or placeholders. Try adding headings with explanations, toggle lists, or question-and-answer text, then convert again.";
+
+const EMPTY_CONTENT_SIGNALS = [
+  'no actual',
+  'no extractable',
+  'no flashcard',
+  'no question',
+  'nothing to convert',
+  "couldn't find",
+  'cannot find',
+  'unable to find',
+  'no q&a',
+  'no q/a',
+  'consists only of',
+];
+
+export function looksLikeEmptyContentExplanation(cleaned: string): boolean {
+  const lower = cleaned.toLowerCase();
+  return EMPTY_CONTENT_SIGNALS.some((signal) => lower.includes(signal));
+}
 
 function causeMessage(err: unknown): string | undefined {
   if (err instanceof Error) return err.message;
@@ -319,6 +341,9 @@ async function generateDeckInfoFromChunk(
     return deckInfo;
   } catch {
     console.error('[Claude] Failed to parse response as JSON', { raw, chunkIndex });
+    if (looksLikeEmptyContentExplanation(cleaned)) {
+      throw new Error(EMPTY_CONTENT_USER_MESSAGE);
+    }
     throw new Error(`Claude returned invalid JSON:\n${raw}`);
   }
 }

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -321,31 +321,37 @@ async function generateDeckInfoFromChunk(
   const cleaned = raw.replace(/```json|```/g, '').trim();
 
   const tParse0 = Date.now();
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(cleaned);
-    if (!Array.isArray(parsed)) {
-      console.error('[Claude] Response is not an array', { raw, cleaned, chunkIndex });
-      throw new Error('Claude returned unexpected JSON structure (not an array)');
-    }
-    const deckInfo = expandCompactDeckInfo(parsed as CompactDeck[], availableMediaFiles, pageStyle || null);
-    const parseMs = Date.now() - tParse0;
-    console.log('[Claude] chunk done', {
-      chunkIndex,
-      totalChunks,
-      decksCount: deckInfo.length,
-      totalCards: deckInfo.reduce((sum, deck) => sum + deck.cards.length, 0),
-      apiMs,
-      parseMs,
-      chunkTotalMs: Date.now() - tChunk0,
-    });
-    return deckInfo;
+    parsed = JSON.parse(cleaned);
   } catch {
     console.error('[Claude] Failed to parse response as JSON', { raw, chunkIndex });
-    if (looksLikeEmptyContentExplanation(cleaned)) {
+    if (
+      !cleaned.trim().startsWith('[') &&
+      looksLikeEmptyContentExplanation(cleaned)
+    ) {
       throw new Error(EMPTY_CONTENT_USER_MESSAGE);
     }
     throw new Error(`Claude returned invalid JSON:\n${raw}`);
   }
+
+  if (!Array.isArray(parsed)) {
+    console.error('[Claude] Response is not an array', { raw, cleaned, chunkIndex });
+    throw new Error('Claude returned unexpected JSON structure (not an array)');
+  }
+
+  const deckInfo = expandCompactDeckInfo(parsed as CompactDeck[], availableMediaFiles, pageStyle || null);
+  const parseMs = Date.now() - tParse0;
+  console.log('[Claude] chunk done', {
+    chunkIndex,
+    totalChunks,
+    decksCount: deckInfo.length,
+    totalCards: deckInfo.reduce((sum, deck) => sum + deck.cards.length, 0),
+    apiMs,
+    parseMs,
+    chunkTotalMs: Date.now() - tChunk0,
+  });
+  return deckInfo;
 }
 
 export async function generateDeckInfo(


### PR DESCRIPTION
When a Notion page has no extractable Q&A, Claude sometimes replies with prose instead of JSON. The raw prose was surfaced verbatim in the job's failure reason ("Claude returned invalid JSON: ..."). Detect these explanations via keyword heuristics and show a short, jargon-free message guiding the user to add real content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed content extraction from Claude, providing clearer user-friendly error messages.
  * Enhanced response validation to better detect and handle edge cases in extracted data.

* **Tests**
  * Added comprehensive test coverage for content validation and error message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->