### PR TITLE
feat: emit packaging step so step 4 is reached on both paths

### DIFF
--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -109,6 +109,7 @@ class UploadService {
     if (!apkgFilename) {
       throw new Error('No APKG file found in workspace');
     }
+    await this.jobRepository.updateJobStatus(objectId, owner, 'step3_building_deck', '');
     const apkgPath = path.join(workspaceDir, apkgFilename);
     const apkgBuffer = fs.readFileSync(apkgPath);
     const storage = new StorageHandler();

--- a/src/usecases/jobs/BuildDeckForJobUseCase.ts
+++ b/src/usecases/jobs/BuildDeckForJobUseCase.ts
@@ -40,7 +40,8 @@ export class BuildDeckForJobUseCase {
     input: BuildDeckForJobUseCaseInput
   ): Promise<BuildDeckForJobUseCaseOutput> {
     const { bl, exporter, decks, ws, settings, storage, id, owner } = input;
-    // Filter out decks with no cards
+    await this.jobRepository.updateJobStatus(id, owner, 'step3_building_deck', '');
+
     const filteredDecks = decks.filter(
       (deck) => deck.cards && deck.cards.length > 0
     );


### PR DESCRIPTION
BuildDeckForJobUseCase (Notion path) and promoteClaudeJobToUpload (Claude/file upload path) now write the step3_building_deck status so the downstream step indicator can light its final pill across all conversion paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job status tracking for deck building and upload operations, providing earlier visibility into workflow progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->