### PR TITLE
feat: make debug file sharing opt-in on conversion errors

### DIFF
--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -53,6 +53,7 @@ describe('SettingsController', () => {
       'vertex-ai-pdf-questions': 'false',
       'disable-indented-bullets': 'false',
       'image-quiz-html-to-anki': 'false',
+      'share-files-for-debugging': 'false',
     });
   });
 
@@ -76,6 +77,7 @@ describe('SettingsController', () => {
       'page-emoji': 'first-emoji',
       'image-quiz-html-to-anki': 'false',
       'markdown-nested-bullet-points': 'true',
+      'share-files-for-debugging': 'false',
     });
   });
 });

--- a/src/controllers/CardOptionsController/supportedOptions.ts
+++ b/src/controllers/CardOptionsController/supportedOptions.ts
@@ -122,6 +122,12 @@ const supportedOptions = (): CardOptionDetail[] => {
       'Use Claude Anthropic to generate flashcards from your content. Produces more reliable results for complex documents. This is a premium feature available to subscribers.',
       false
     ),
+    new CardOptionDetail(
+      'share-files-for-debugging',
+      'Share Files for Debugging When Conversion Fails',
+      'When a conversion fails, send the uploaded files and error details to the 2anki team so we can reproduce and fix the issue. Off by default to keep your notes private.',
+      false
+    ),
   ];
 
   return v.filter(Boolean);

--- a/src/lib/parser/Settings/CardOption.ts
+++ b/src/lib/parser/Settings/CardOption.ts
@@ -73,6 +73,8 @@ class CardOption {
 
   readonly claudeAIFlashcards: boolean;
 
+  readonly shareFilesForDebugging: boolean;
+
   readonly userInstructions?: string;
 
   constructor(input: { [key: string]: string }) {
@@ -111,6 +113,7 @@ class CardOption {
     this.imageQuizHtmlToAnki = input['image-quiz-html-to-anki'] === 'true';
     this.processPDFs = input['process-pdfs'] !== 'false';
     this.claudeAIFlashcards = input['claude-ai-flashcards'] === 'true';
+    this.shareFilesForDebugging = input['share-files-for-debugging'] === 'true';
     /* Is this really needed? */
     if (this.parentBlockId) {
       this.addNotionLink = true;
@@ -158,6 +161,7 @@ class CardOption {
       'image-quiz-html-to-anki': 'false',
       'markdown-nested-bullet-points': 'true',
       'claude-ai-flashcards': 'false',
+      'share-files-for-debugging': 'false',
     };
   }
 }

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -5,6 +5,7 @@ import { UploadedFile } from '../../lib/storage/types';
 import { isLimitError } from '../../lib/misc/isLimitError';
 import { isEmptyPayload } from '../../lib/misc/isEmptyPayload';
 import { preserveFilesForDebugging } from '../../lib/debug/preserveFilesForDebugging';
+import { shouldShareFilesForDebugging } from './shouldShareFilesForDebugging';
 import * as cheerio from 'cheerio';
 
 const transporter = nodemailer.createTransport({
@@ -38,6 +39,7 @@ function buildAttachments(uploadedFiles: UploadedFile[]) {
 
 async function sendErrorEmail(error: Error, req: express.Request) {
   if (process.env.NODE_ENV !== 'production') return;
+  if (!shouldShareFilesForDebugging(req.body)) return;
 
   const $ = cheerio.load(error.message);
   const plainTextMessage = $.root().text();
@@ -77,7 +79,8 @@ export default async function ErrorHandler(
   if (!skipError) {
     console.info('Send error');
     console.error(err);
-    if (!isEmptyPayload(uploadedFiles)) {
+    const canShareFiles = shouldShareFilesForDebugging(req.body);
+    if (canShareFiles && !isEmptyPayload(uploadedFiles)) {
       preserveFilesForDebugging(req, uploadedFiles, err);
     }
 

--- a/src/routes/middleware/shouldShareFilesForDebugging.test.ts
+++ b/src/routes/middleware/shouldShareFilesForDebugging.test.ts
@@ -1,0 +1,43 @@
+import {
+  shouldShareFilesForDebugging,
+  SHARE_FILES_FOR_DEBUGGING_KEY,
+} from './shouldShareFilesForDebugging';
+
+describe('shouldShareFilesForDebugging', () => {
+  it('defaults to false when body is missing', () => {
+    expect(shouldShareFilesForDebugging(undefined)).toBe(false);
+    expect(shouldShareFilesForDebugging(null)).toBe(false);
+  });
+
+  it('defaults to false when the flag is absent', () => {
+    expect(shouldShareFilesForDebugging({})).toBe(false);
+    expect(shouldShareFilesForDebugging({ other: 'true' })).toBe(false);
+  });
+
+  it('returns true when flag is the string "true"', () => {
+    expect(
+      shouldShareFilesForDebugging({ [SHARE_FILES_FOR_DEBUGGING_KEY]: 'true' })
+    ).toBe(true);
+  });
+
+  it('returns true when flag is boolean true', () => {
+    expect(
+      shouldShareFilesForDebugging({ [SHARE_FILES_FOR_DEBUGGING_KEY]: true })
+    ).toBe(true);
+  });
+
+  it('returns false when flag is the string "false"', () => {
+    expect(
+      shouldShareFilesForDebugging({ [SHARE_FILES_FOR_DEBUGGING_KEY]: 'false' })
+    ).toBe(false);
+  });
+
+  it('returns false for unexpected values', () => {
+    expect(
+      shouldShareFilesForDebugging({ [SHARE_FILES_FOR_DEBUGGING_KEY]: 'yes' })
+    ).toBe(false);
+    expect(
+      shouldShareFilesForDebugging({ [SHARE_FILES_FOR_DEBUGGING_KEY]: 1 })
+    ).toBe(false);
+  });
+});

--- a/src/routes/middleware/shouldShareFilesForDebugging.ts
+++ b/src/routes/middleware/shouldShareFilesForDebugging.ts
@@ -1,0 +1,7 @@
+export const SHARE_FILES_FOR_DEBUGGING_KEY = 'share-files-for-debugging';
+
+export function shouldShareFilesForDebugging(body: unknown): boolean {
+  if (body == null || typeof body !== 'object') return false;
+  const value = (body as Record<string, unknown>)[SHARE_FILES_FOR_DEBUGGING_KEY];
+  return value === 'true' || value === true;
+}


### PR DESCRIPTION
Adds a share-files-for-debugging card option (off by default). When a conversion errors out, the debug email with user attachments and the on-disk preserveFilesForDebugging call are both skipped unless the user has toggled the option on. Server-side error logs are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configurable debugging option that allows users to opt-in to sharing uploaded files and error details with the support team when conversion fails. This helps expedite troubleshooting. The option is disabled by default.

* **Tests**
  * Added test coverage for the debugging file-sharing toggle functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->