### PR TITLE
fix(debug): skip uploaded files missing path or originalname

### DIFF
--- a/src/lib/debug/preserveFilesForDebugging.test.ts
+++ b/src/lib/debug/preserveFilesForDebugging.test.ts
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import express from 'express';
+
+import { preserveFilesForDebugging } from './preserveFilesForDebugging';
+import { UploadedFile } from '../storage/types';
+
+const mockRequest = {
+  body: { scope: 'test' },
+} as unknown as express.Request;
+
+const makeFile = (overrides: Partial<UploadedFile>): UploadedFile =>
+  ({
+    fieldname: 'file',
+    encoding: '7bit',
+    mimetype: 'text/plain',
+    size: 0,
+    destination: '',
+    filename: '',
+    buffer: Buffer.alloc(0),
+    stream: undefined as unknown as NodeJS.ReadableStream,
+    key: '',
+    ...overrides,
+  } as UploadedFile);
+
+const findDebugDir = (before: string[]): string | undefined => {
+  const entries = fs.readdirSync(path.join(os.tmpdir(), 'debug'));
+  return entries.find((name) => !before.includes(name));
+};
+
+describe('preserveFilesForDebugging', () => {
+  beforeEach(() => {
+    const debugBase = path.join(os.tmpdir(), 'debug');
+    if (!fs.existsSync(debugBase)) {
+      fs.mkdirSync(debugBase, { recursive: true });
+    }
+  });
+
+  test('skips files with no path or originalname instead of crashing', () => {
+    const debugBase = path.join(os.tmpdir(), 'debug');
+    const before = fs.readdirSync(debugBase);
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const invalidFile = makeFile({
+      originalname: undefined as unknown as string,
+      path: undefined as unknown as string,
+    });
+
+    preserveFilesForDebugging(
+      mockRequest,
+      [invalidFile],
+      new Error('simulated failure')
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    const created = findDebugDir(before);
+    expect(created).toBeDefined();
+    const createdPath = path.join(debugBase, created as string);
+    expect(fs.existsSync(path.join(createdPath, 'error.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(createdPath, 'request.json'))).toBe(true);
+
+    errorSpy.mockRestore();
+    fs.rmSync(createdPath, { recursive: true, force: true });
+  });
+
+  test('preserves valid files and skips invalid ones in the same batch', () => {
+    const debugBase = path.join(os.tmpdir(), 'debug');
+    const before = fs.readdirSync(debugBase);
+
+    const source = path.join(os.tmpdir(), `sample-${Date.now()}.txt`);
+    fs.writeFileSync(source, 'sample-bytes');
+
+    const validFile = makeFile({
+      originalname: 'sample.txt',
+      path: source,
+      size: 12,
+    });
+    const invalidFile = makeFile({
+      originalname: undefined as unknown as string,
+      path: undefined as unknown as string,
+    });
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    preserveFilesForDebugging(
+      mockRequest,
+      [validFile, invalidFile],
+      new Error('simulated failure')
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    const created = findDebugDir(before);
+    expect(created).toBeDefined();
+    const createdPath = path.join(debugBase, created as string);
+    expect(fs.existsSync(path.join(createdPath, '0-sample.txt'))).toBe(true);
+
+    errorSpy.mockRestore();
+    fs.rmSync(createdPath, { recursive: true, force: true });
+    fs.rmSync(source, { force: true });
+  });
+});

--- a/src/lib/debug/preserveFilesForDebugging.ts
+++ b/src/lib/debug/preserveFilesForDebugging.ts
@@ -33,6 +33,12 @@ export function preserveFilesForDebugging(
     fs.writeFileSync(`${debugDirectory}/error.txt`, errorMessage);
 
     uploadedFiles.forEach((file, index) => {
+      if (file?.path == null || file?.originalname == null) {
+        console.info(
+          `Skipping file at index ${index} without path or originalname`
+        );
+        return;
+      }
       const destPath = path.join(
         debugDirectory,
         `${index}-${path.basename(file.originalname)}`
@@ -42,6 +48,6 @@ export function preserveFilesForDebugging(
       console.log(`Copied file ${file.path} to ${destPath}`);
     });
   } catch (error) {
-    console.error(`Error in perserveFilesForDebugging: ${error}`);
+    console.error(`Error in preserveFilesForDebugging: ${error}`);
   }
 }


### PR DESCRIPTION
## Summary
- `preserveFilesForDebugging` crashed with `TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined` when multer aborted an upload and handed back files with undefined `path`/`originalname`. The catch-all caught it, but the debug artifacts for the rest of the batch were lost.
- Also fixes the `perserveFilesForDebugging` typo in the error log message so it can be grepped under its real name.

## Evidence
- ~20 hits of this error across `logs/server-error__2026-04-10..16`, always on the failure path right after a multer abort.

## Test plan
- [x] `pnpm test src/lib/debug/preserveFilesForDebugging.test.ts` — two new cases: invalid-only batch and mixed valid/invalid batch.
- [x] Full suite: `pnpm test` (229 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for file preservation logic with various file scenarios.

* **Bug Fixes**
  * Enhanced validation to skip invalid file entries during processing.
  * Corrected error message text for accurate logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->