### PR TITLE
fix(middleware): skip response writes when headers already sent

### DIFF
--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -1,0 +1,95 @@
+import express from 'express';
+
+import ErrorHandler from './ErrorHandler';
+
+const makeRequest = (): express.Request =>
+  ({
+    body: {},
+    path: '/api/sample',
+    method: 'POST',
+    query: {},
+    files: [],
+  } as unknown as express.Request);
+
+interface FakeResponse {
+  headersSent: boolean;
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string | undefined;
+  set: jest.Mock;
+  status: jest.Mock;
+  send: jest.Mock;
+}
+
+const makeResponse = (headersSent: boolean): FakeResponse => {
+  const state: FakeResponse = {
+    headersSent,
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+  } as FakeResponse;
+
+  state.set = jest.fn((name: string, value: string) => {
+    if (state.headersSent) {
+      throw Object.assign(
+        new Error('Cannot set headers after they are sent to the client'),
+        { code: 'ERR_HTTP_HEADERS_SENT' }
+      );
+    }
+    state.headers[name] = value;
+    return state;
+  });
+
+  state.status = jest.fn((code: number) => {
+    if (state.headersSent) {
+      throw Object.assign(
+        new Error('Cannot set headers after they are sent to the client'),
+        { code: 'ERR_HTTP_HEADERS_SENT' }
+      );
+    }
+    state.statusCode = code;
+    return state;
+  });
+
+  state.send = jest.fn((body: string) => {
+    state.body = body;
+    state.headersSent = true;
+    return state;
+  });
+
+  return state;
+};
+
+describe('ErrorHandler', () => {
+  test('writes 400 response with error message when headers not yet sent', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    await ErrorHandler(
+      res as unknown as express.Response,
+      req,
+      new Error('something failed')
+    );
+
+    expect(res.headers['Content-Type']).toBe('text/plain');
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toBe('something failed');
+  });
+
+  test('does not throw when headers have already been sent', async () => {
+    const res = makeResponse(true);
+    const req = makeRequest();
+
+    await expect(
+      ErrorHandler(
+        res as unknown as express.Response,
+        req,
+        new Error('late failure')
+      )
+    ).resolves.toBeUndefined();
+
+    expect(res.set).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -93,6 +93,11 @@ export default async function ErrorHandler(
     console.info('User no limit reached');
   }
 
+  if (res.headersSent) {
+    console.info('Skipping error response: headers already sent');
+    return;
+  }
+
   res.set('Content-Type', 'text/plain');
   res.status(400).send(err.message);
 }


### PR DESCRIPTION
## Summary
- `ErrorHandler` always called `res.set` + `res.status(400).send(err.message)`, even when the response had already been flushed by the handler that threw. Result: `ERR_HTTP_HEADERS_SENT` got logged on top of the original failure. Guard on `res.headersSent` and return early.

## Evidence
- `logs/server-error__2026-04-11_00-00-00.log`:
  ```
  Error: Cannot set headers after they are sent to the client
      at ErrorHandler (src/routes/middleware/ErrorHandler.tsx:93:7) { code: 'ERR_HTTP_HEADERS_SENT' }
  ```

## Test plan
- [x] `pnpm test src/routes/middleware/ErrorHandler.test.ts` — covers both the normal 400 path and the headers-already-sent case.
- [x] Full suite (`pnpm test`) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)