### PR TITLE
fix(anki): surface Python stdout when stderr is empty on failure

### DIFF
--- a/src/lib/anki/CardGenerator.ts
+++ b/src/lib/anki/CardGenerator.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import path from 'node:path';
 
 import { CREATE_DECK_DIR, CREATE_DECK_SCRIPT_PATH, resolvePath } from '../constants';
+import { buildPythonExitError } from './buildPythonExitError';
 
 function tryCommand(command: string): boolean {
   try {
@@ -96,9 +97,12 @@ class CardGenerator {
 
       process.on('close', (code) => {
         if (code !== 0) {
-          const errorOutput = stderrData.join('').trim();
           return reject(
-            new Error(`Python script exited with code ${code}: ${errorOutput}`)
+            buildPythonExitError({
+              code,
+              stdout: stdoutData.join(''),
+              stderr: stderrData.join(''),
+            })
           );
         }
         const lastLine = stdoutData.join('').trim().split('\n').pop();

--- a/src/lib/anki/buildPythonExitError.test.ts
+++ b/src/lib/anki/buildPythonExitError.test.ts
@@ -1,0 +1,43 @@
+import { buildPythonExitError } from './buildPythonExitError';
+
+describe('buildPythonExitError', () => {
+  test('uses stderr when present', () => {
+    const error = buildPythonExitError({
+      code: 1,
+      stdout: 'progress output\n',
+      stderr: 'Traceback (most recent call last):\n  ...\nValueError: bad deck\n',
+    });
+    expect(error.message).toContain('Python script exited with code 1');
+    expect(error.message).toContain('ValueError: bad deck');
+  });
+
+  test('falls back to stdout when stderr is empty', () => {
+    const error = buildPythonExitError({
+      code: 1,
+      stdout: 'fatal: missing template\n',
+      stderr: '',
+    });
+    expect(error.message).toContain('Python script exited with code 1');
+    expect(error.message).toContain('fatal: missing template');
+  });
+
+  test('uses a placeholder when both streams are empty', () => {
+    const error = buildPythonExitError({
+      code: 2,
+      stdout: '',
+      stderr: '   \n',
+    });
+    expect(error.message).toContain('Python script exited with code 2');
+    expect(error.message).toContain('(no output)');
+  });
+
+  test('handles null exit code', () => {
+    const error = buildPythonExitError({
+      code: null,
+      stdout: '',
+      stderr: 'killed by signal',
+    });
+    expect(error.message).toContain('Python script exited with code null');
+    expect(error.message).toContain('killed by signal');
+  });
+});

--- a/src/lib/anki/buildPythonExitError.ts
+++ b/src/lib/anki/buildPythonExitError.ts
@@ -1,0 +1,16 @@
+interface PythonExitInfo {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export function buildPythonExitError({
+  code,
+  stdout,
+  stderr,
+}: PythonExitInfo): Error {
+  const trimmedStderr = stderr.trim();
+  const trimmedStdout = stdout.trim();
+  const output = trimmedStderr || trimmedStdout || '(no output)';
+  return new Error(`Python script exited with code ${code}: ${output}`);
+}


### PR DESCRIPTION
## Summary
- Most of the 125 `Error: Python script exited with code 1:` entries in `logs/server-error*.log` have nothing after the colon — stderr was empty, so operators had no signal to investigate.
- Extract the error-message construction into `buildPythonExitError` so it falls back to stdout (then to `(no output)`) when stderr is empty. Pure function, covered in isolation.

## Evidence
- 125 occurrences, e.g. `logs/server-error__2026-04-16_00-00-00.log`:
  ```
  Error: Python script exited with code 1:
      at ChildProcess.<anonymous> (src/lib/anki/CardGenerator.ts:101:13)
  ```

## Test plan
- [x] `pnpm test src/lib/anki/buildPythonExitError.test.ts` — 4 cases: stderr-only, stdout fallback, empty-both, null exit code.
- [x] `pnpm test` full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when Python operations encounter failures, now clearly displaying process exit codes and relevant output information to facilitate better troubleshooting and diagnostics.

* **Tests**
  * Added comprehensive test coverage for Python error handling, thoroughly validating error message formatting and output display across multiple scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->