### PR TITLE
fix(notion): use unique console.time labels to stop collision warnings

### DIFF
--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -19,6 +19,7 @@ import getBlockIcon, { WithIcon } from './blocks/getBlockIcon';
 import { isHeading } from './helpers/isHeading';
 import { getHeadingText } from './helpers/getHeadingText';
 import { getBlockCache } from './helpers/getBlockCache';
+import { uniqueTimerLabel } from './helpers/uniqueTimerLabel';
 import { getDatabase } from '../../data_layer';
 import { ValidNotionType } from './types';
 
@@ -55,9 +56,6 @@ class NotionAPIWrapper {
     all,
     type,
   }: GetBlockParams): Promise<ListBlockChildrenResponse> {
-    console.time(`getBlocks:${id}${all}`);
-
-    // Skip unsupported types to prevent validation errors
     if (type === 'unsupported') {
       return {
         type: 'block',
@@ -69,6 +67,9 @@ class NotionAPIWrapper {
       };
     }
 
+    const getBlocksLabel = uniqueTimerLabel(`getBlocks:${id}${all}`);
+    console.time(getBlocksLabel);
+
     const cachedPayload = all
       ? await getBlockCache({
           database: getDatabase(),
@@ -79,7 +80,7 @@ class NotionAPIWrapper {
       : null;
     if (cachedPayload) {
       console.log('using payload cache');
-      console.timeEnd(`getBlocks:${id}${all}`);
+      console.timeEnd(getBlocksLabel);
       return cachedPayload;
     }
     const response = await this.notion.blocks.children.list({
@@ -121,7 +122,7 @@ class NotionAPIWrapper {
         .onConflict('object_id')
         .merge();
     }
-    console.timeEnd(`getBlocks:${id}${all}`);
+    console.timeEnd(getBlocksLabel);
     return response;
   }
 
@@ -155,7 +156,8 @@ class NotionAPIWrapper {
     id: string,
     all?: boolean
   ): Promise<QueryDatabaseResponse> {
-    console.time(`queryDatabase:${id}${all}`);
+    const queryLabel = uniqueTimerLabel(`queryDatabase:${id}${all}`);
+    console.time(queryLabel);
     const response = await this.notion.databases.query({
       database_id: id,
       page_size: DEFAULT_PAGE_SIZE_LIMIT,
@@ -176,12 +178,13 @@ class NotionAPIWrapper {
         }
       }
     }
-    console.timeEnd(`queryDatabase:${id}${all}`);
+    console.timeEnd(queryLabel);
     return response;
   }
 
   async search(query: string, all?: boolean) {
-    console.time(`search:${all}`);
+    const searchLabel = uniqueTimerLabel(`search:${all}`);
+    console.time(searchLabel);
     const response = await this.notion.search({
       page_size: DEFAULT_PAGE_SIZE_LIMIT,
       query,
@@ -211,7 +214,7 @@ class NotionAPIWrapper {
       }
     }
 
-    console.timeEnd(`search:${all}`);
+    console.timeEnd(searchLabel);
     return response;
   }
 

--- a/src/services/NotionService/helpers/uniqueTimerLabel.test.ts
+++ b/src/services/NotionService/helpers/uniqueTimerLabel.test.ts
@@ -1,0 +1,20 @@
+import { uniqueTimerLabel } from './uniqueTimerLabel';
+
+describe('uniqueTimerLabel', () => {
+  test('returns distinct labels for repeated calls with the same prefix', () => {
+    const first = uniqueTimerLabel('search:true');
+    const second = uniqueTimerLabel('search:true');
+    expect(first).not.toBe(second);
+  });
+
+  test('includes the provided prefix in the label', () => {
+    const label = uniqueTimerLabel('search:true');
+    expect(label.startsWith('search:true')).toBe(true);
+  });
+
+  test('handles prefixes with undefined substrings', () => {
+    const label = uniqueTimerLabel(`search:${undefined}`);
+    expect(label).toMatch(/^search:undefined/);
+    expect(label).not.toBe('search:undefined');
+  });
+});

--- a/src/services/NotionService/helpers/uniqueTimerLabel.ts
+++ b/src/services/NotionService/helpers/uniqueTimerLabel.ts
@@ -1,0 +1,6 @@
+let sequence = 0;
+
+export function uniqueTimerLabel(prefix: string): string {
+  sequence += 1;
+  return `${prefix}#${sequence}`;
+}


### PR DESCRIPTION
## Summary
- Concurrent Notion-API calls shared `console.time` labels (`search:undefined`, `getBlocks:<id>undefined`, `queryDatabase:<id>undefined`), producing ~300 `Label already exists` / `No such label` warnings per day in pm2 error logs.
- Route every timer through `uniqueTimerLabel(prefix)` which appends an in-process counter so each call gets its own label.
- Move the `getBlocks` timer past the `type === 'unsupported'` early return so it no longer starts a timer it never ends.

## Evidence
- Warning counts per log file:
  - `server-error__2026-04-14`: 90
  - `server-error__2026-04-15`: 103
  - `server-error__2026-04-16`: 67
  - current `server-error.log`: 54

## Test plan
- [x] `pnpm test src/services/NotionService/helpers/uniqueTimerLabel.test.ts` — 3 cases covering uniqueness, prefix, undefined-substring labels.
- [x] Full suite `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)