### PR TITLE
fix(notion): skip image instead of failing deck on expired S3 URL

### DIFF
--- a/src/lib/parser/exporters/CustomExporter.ts
+++ b/src/lib/parser/exporters/CustomExporter.ts
@@ -17,7 +17,7 @@ class CustomExporter {
     this.media = [];
   }
 
-  addMedia(newName: string, contents: string) {
+  addMedia(newName: string, contents: string | Buffer) {
     console.debug(`Adding media: ${newName}`);
     const abs = path.join(this.workspace, newName);
     this.media.push(abs);

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -27,6 +27,7 @@ import { NOTION_STYLE } from '../../../templates/helper';
 import NotionAPIWrapper from '../NotionAPIWrapper';
 import BlockColumn from '../blocks/lists/BlockColumn';
 import { blockToStaticMarkup } from '../helpers/blockToStaticMarkup';
+import { downloadMediaOrSkip } from '../helpers/downloadMediaOrSkip';
 import { getAudioUrl } from '../helpers/getAudioUrl';
 import getClozeDeletionCard from '../helpers/getClozeDeletionCard';
 import getColumn from '../helpers/getColumn';
@@ -82,10 +83,10 @@ class BlockHandler {
 
     const suffix = SuffixFrom(S3FileName(url));
     const newName = getUniqueFileName(url) + (suffix ?? '');
-    const imageRequest = await axios.get(url, {
-      responseType: 'arraybuffer',
-    });
-    const contents = imageRequest.data;
+    const contents = await downloadMediaOrSkip(url);
+    if (contents == null) {
+      return '';
+    }
     this.exporter.addMedia(newName, contents);
     return `<img src="${newName}" />`;
   }

--- a/src/services/NotionService/helpers/downloadMediaOrSkip.test.ts
+++ b/src/services/NotionService/helpers/downloadMediaOrSkip.test.ts
@@ -1,0 +1,86 @@
+import axios, { AxiosError } from 'axios';
+
+import { downloadMediaOrSkip } from './downloadMediaOrSkip';
+
+jest.mock('axios', () => {
+  const actual = jest.requireActual('axios');
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      isAxiosError: actual.isAxiosError,
+    },
+  };
+});
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const makeAxiosError = (status: number): AxiosError => {
+  const err = new Error(
+    `Request failed with status code ${status}`
+  ) as AxiosError;
+  err.isAxiosError = true;
+  err.response = {
+    status,
+    statusText: '',
+    headers: {},
+    config: {} as never,
+    data: null,
+  };
+  return err;
+};
+
+describe('downloadMediaOrSkip', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns axios response data on success', async () => {
+    const data = Buffer.from('fake bytes');
+    mockedAxios.get.mockResolvedValueOnce({ data });
+
+    const result = await downloadMediaOrSkip('https://example.test/asset.png');
+
+    expect(result).toBe(data);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://example.test/asset.png',
+      { responseType: 'arraybuffer' }
+    );
+  });
+
+  test('returns null and does not throw on 403 Forbidden', async () => {
+    mockedAxios.get.mockRejectedValueOnce(makeAxiosError(403));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await downloadMediaOrSkip('https://example.test/expired.png');
+
+    expect(result).toBeNull();
+    warn.mockRestore();
+  });
+
+  test('returns null on 404 Not Found', async () => {
+    mockedAxios.get.mockRejectedValueOnce(makeAxiosError(404));
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await downloadMediaOrSkip('https://example.test/missing.png');
+
+    expect(result).toBeNull();
+    warn.mockRestore();
+  });
+
+  test('rethrows non-4xx axios errors', async () => {
+    mockedAxios.get.mockRejectedValueOnce(makeAxiosError(500));
+
+    await expect(
+      downloadMediaOrSkip('https://example.test/broken.png')
+    ).rejects.toThrow('Request failed with status code 500');
+  });
+
+  test('rethrows non-axios errors', async () => {
+    mockedAxios.get.mockRejectedValueOnce(new Error('socket hang up'));
+
+    await expect(
+      downloadMediaOrSkip('https://example.test/broken.png')
+    ).rejects.toThrow('socket hang up');
+  });
+});

--- a/src/services/NotionService/helpers/downloadMediaOrSkip.ts
+++ b/src/services/NotionService/helpers/downloadMediaOrSkip.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const isExpiredOrMissing = (status: number | undefined): boolean =>
+  status === 403 || status === 404;
+
+export async function downloadMediaOrSkip(url: string): Promise<Buffer | null> {
+  try {
+    const response = await axios.get(url, { responseType: 'arraybuffer' });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && isExpiredOrMissing(error.response?.status)) {
+      console.warn(
+        `Skipping media fetch for ${url} — received ${error.response?.status} (URL likely expired)`
+      );
+      return null;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Notion hands out short-lived pre-signed S3 URLs for embedded images (~1h TTL). When the URL had expired, `BlockHandler.embedImage` threw `AxiosError: Request failed with status code 403` and the entire deck conversion failed.
- Introduce `downloadMediaOrSkip(url)` which returns `null` on 403/404 (expired/missing) and rethrows everything else. `embedImage` drops the image and continues when it gets null.

## Evidence
- 95 `AxiosError: Request failed with status code 403` hits in recent `logs/server-error*.log`, all originating from `BlockHandler.embedImage`:
  ```
  at BlockHandler.embedImage (src/services/NotionService/BlockHandler/BlockHandler.ts:84:26)
  at blockToStaticMarkup (src/services/NotionService/helpers/blockToStaticMarkup.ts:33:21)
  ```

## Notes
- `embedAudioFile` and `embedFile` have the same axios pattern, but no log evidence of failures yet. Left untouched per the "don't deduplicate before three occurrences" guidance.

## Test plan
- [x] `pnpm test src/services/NotionService/helpers/downloadMediaOrSkip.test.ts` — success path, 403, 404, 500 rethrow, non-axios rethrow.
- [x] `pnpm test` full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)