### PR TITLE
fix(subscription): rework cancellation flow and reconcile Stripe drift

### DIFF
--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -6,7 +6,7 @@ jest.mock('../../data_layer', () => ({
 }));
 
 jest.mock('../../services/EmailService/EmailService', () => ({
-  useDefaultEmailService: jest.fn().mockReturnValue({}),
+  getDefaultEmailService: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('./extractTokenFromCookies', () => ({

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -117,6 +117,6 @@ export class StripeController {
   }
 
   async cancelUserSubscriptions(userEmail: string): Promise<void> {
-    return SubscriptionService.cancelUserSubscriptions(userEmail);
+    await SubscriptionService.cancelUserSubscriptions(userEmail);
   }
 }

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { getIndexFileContents } from '../IndexController/getIndexFileContents';
 import { getDatabase } from '../../data_layer';
-import { useDefaultEmailService } from '../../services/EmailService/EmailService';
+import { getDefaultEmailService } from '../../services/EmailService/EmailService';
 import UsersRepository from '../../data_layer/UsersRepository';
 import UsersService from '../../services/UsersService';
 import TokenRepository from '../../data_layer/TokenRepository';
@@ -54,7 +54,7 @@ export class StripeController {
     }
 
     const database = getDatabase();
-    const emailService = useDefaultEmailService();
+    const emailService = getDefaultEmailService();
     const userRepository = new UsersRepository(database);
     const usersService = new UsersService(userRepository, emailService);
     const tokenRepository = new TokenRepository(database);

--- a/src/controllers/Upload/helpers/handleUploadLimitError.ts
+++ b/src/controllers/Upload/helpers/handleUploadLimitError.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { useDefaultEmailService } from '../../../services/EmailService/EmailService';
+import { getDefaultEmailService } from '../../../services/EmailService/EmailService';
 import UsersService from '../../../services/UsersService';
 import UsersRepository from '../../../data_layer/UsersRepository';
 import { getDatabase } from '../../../data_layer';
@@ -13,7 +13,7 @@ export const handleUploadLimitError = async (
   // If the user is already logged in, redirect to the pricing page
   if (owner) {
     const database = getDatabase();
-    const emailService = useDefaultEmailService();
+    const emailService = getDefaultEmailService();
     const usersService = new UsersService(
       new UsersRepository(database),
       emailService

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -256,16 +256,20 @@ class UsersController {
     }
 
     try {
-      // Get user details before deletion to access email for subscription cancellation
       const user = await this.userService.getUserById(owner);
       if (!user) {
         return res.status(404).json({ message: 'User not found' });
       }
 
-      // Cancel active Stripe subscriptions using SubscriptionService
-      await SubscriptionService.cancelUserSubscriptions(user.email);
+      try {
+        await SubscriptionService.cancelUserSubscriptions(user.email);
+      } catch (cancelError) {
+        console.error(
+          'Subscription cancellation failed during account deletion:',
+          cancelError
+        );
+      }
 
-      // Delete the user account
       await this.userService.deleteUser(owner);
       res.status(200).json({});
     } catch (error) {
@@ -281,21 +285,81 @@ class UsersController {
       return res.status(401).json({ message: 'Authentication required' });
     }
 
+    const requestedMode = req.body?.mode === 'immediate' ? 'immediate' : 'period_end';
+
     try {
-      // Get user details to access email for subscription cancellation
       const user = await this.userService.getUserById(owner);
       if (!user) {
         return res.status(404).json({ message: 'User not found' });
       }
 
-      // Cancel active Stripe subscriptions using SubscriptionService
-      await SubscriptionService.cancelUserSubscriptions(user.email);
+      const processedCount = await SubscriptionService.cancelUserSubscriptions(
+        user.email,
+        requestedMode
+      );
 
-      res.status(200).json({ message: 'Subscription cancelled successfully' });
+      if (processedCount === 0) {
+        return res.status(404).json({
+          message:
+            'No active subscription found for your account. If you subscribed with a different email, link it under Subscription Management first or email support@2anki.net.',
+        });
+      }
+
+      const message =
+        requestedMode === 'immediate'
+          ? 'Your subscription has been cancelled. A confirmation email is on its way.'
+          : 'Your subscription is scheduled to cancel at the end of the current billing period. A confirmation email is on its way.';
+
+      res.status(200).json({ message });
     } catch (error) {
       console.info('Cancel subscription failed');
       console.error(error);
       return res.status(500).json({ message: 'Failed to cancel subscription' });
+    }
+  }
+
+  async getSubscriptionStatus(req: express.Request, res: express.Response) {
+    const { owner } = res.locals;
+    if (!owner) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    try {
+      const user = await this.userService.getUserById(owner);
+      if (!user) {
+        return res.status(404).json({ message: 'User not found' });
+      }
+
+      const subs = await SubscriptionService.findRecentStripeSubscriptions(
+        user.email
+      );
+
+      const subscriptions = subs.map((sub) => {
+        const firstItem = sub.items?.data?.[0];
+        const price = firstItem?.price;
+        return {
+          id: sub.id,
+          status: sub.status,
+          cancel_at_period_end: sub.cancel_at_period_end === true,
+          current_period_end: sub.current_period_end ?? null,
+          canceled_at: sub.canceled_at ?? null,
+          plan: price
+            ? {
+                amount: price.unit_amount ?? null,
+                currency: price.currency ?? null,
+                interval: price.recurring?.interval ?? null,
+              }
+            : null,
+        };
+      });
+
+      res.status(200).json({ subscriptions });
+    } catch (error) {
+      console.info('Get subscription status failed');
+      console.error(error);
+      return res
+        .status(500)
+        .json({ message: 'Failed to load subscription status' });
     }
   }
 

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
@@ -1,0 +1,132 @@
+import { reconcileActiveSubscriptions } from './reconcileActiveSubscriptions';
+
+type DbMock = jest.Mock & { updateSpy: jest.Mock };
+
+function buildDbMock(activeRows: Array<{ id: number; email: string; payload: unknown }>): DbMock {
+  const updateSpy = jest.fn().mockResolvedValue(1);
+
+  const db = jest.fn().mockImplementation(() => {
+    const builder: Record<string, unknown> = {
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      update: updateSpy,
+      then: (resolve: (value: unknown) => void) => resolve(activeRows),
+    };
+    return builder;
+  }) as DbMock;
+  db.updateSpy = updateSpy;
+  return db;
+}
+
+function buildStripeMock(retrieveImpl: (id: string) => Promise<any>) {
+  return {
+    subscriptions: {
+      retrieve: jest.fn().mockImplementation(retrieveImpl),
+    },
+  } as any;
+}
+
+describe('reconcileActiveSubscriptions', () => {
+  it('flips DB row inactive when Stripe no longer reports the sub as active', async () => {
+    const db = buildDbMock([
+      { id: 1, email: 'user@example.com', payload: { id: 'sub_1' } },
+    ]);
+    const stripe = buildStripeMock(async () => ({
+      id: 'sub_1',
+      status: 'canceled',
+    }));
+
+    await reconcileActiveSubscriptions(db as any, stripe);
+
+    expect(stripe.subscriptions.retrieve).toHaveBeenCalledWith('sub_1');
+    expect(db.updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false })
+    );
+  });
+
+  it('leaves DB row alone when Stripe still reports the sub as active', async () => {
+    const db = buildDbMock([
+      { id: 1, email: 'user@example.com', payload: { id: 'sub_1' } },
+    ]);
+    const stripe = buildStripeMock(async () => ({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: false,
+    }));
+
+    await reconcileActiveSubscriptions(db as any, stripe);
+
+    expect(db.updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('flips DB row inactive for scheduled-cancel subs past their period end', async () => {
+    const pastSeconds = Math.floor(Date.now() / 1000) - 60;
+    const db = buildDbMock([
+      { id: 1, email: 'user@example.com', payload: { id: 'sub_1' } },
+    ]);
+    const stripe = buildStripeMock(async () => ({
+      id: 'sub_1',
+      status: 'active',
+      cancel_at_period_end: true,
+      current_period_end: pastSeconds,
+    }));
+
+    await reconcileActiveSubscriptions(db as any, stripe);
+
+    expect(db.updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false })
+    );
+  });
+
+  it('flips DB row inactive when Stripe returns 404 for the sub', async () => {
+    const db = buildDbMock([
+      { id: 1, email: 'user@example.com', payload: { id: 'sub_missing' } },
+    ]);
+    const stripe = {
+      subscriptions: {
+        retrieve: jest.fn().mockRejectedValue({
+          statusCode: 404,
+          message: 'No such subscription',
+        }),
+      },
+    } as any;
+
+    await reconcileActiveSubscriptions(db as any, stripe);
+
+    expect(db.updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false })
+    );
+  });
+
+  it('skips rows with missing or malformed payload without throwing', async () => {
+    const db = buildDbMock([
+      { id: 1, email: 'a@example.com', payload: null },
+      { id: 2, email: 'b@example.com', payload: 'not-json' },
+    ]);
+    const stripe = buildStripeMock(async () => ({ status: 'canceled' }));
+
+    await expect(
+      reconcileActiveSubscriptions(db as any, stripe)
+    ).resolves.toBeUndefined();
+
+    expect(stripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    expect(db.updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when a single Stripe lookup fails; continues to next row', async () => {
+    const db = buildDbMock([
+      { id: 1, email: 'a@example.com', payload: { id: 'sub_1' } },
+      { id: 2, email: 'b@example.com', payload: { id: 'sub_2' } },
+    ]);
+    const retrieve = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ status: 'canceled' });
+    const stripe = { subscriptions: { retrieve } } as any;
+
+    await reconcileActiveSubscriptions(db as any, stripe);
+
+    expect(retrieve).toHaveBeenCalledTimes(2);
+    expect(db.updateSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
@@ -1,0 +1,88 @@
+import { Knex } from 'knex';
+import Stripe from 'stripe';
+
+interface ActiveSubscriptionRow {
+  id: number;
+  email: string;
+  payload: unknown;
+}
+
+function parseSubscriptionId(payload: unknown): string | null {
+  if (payload == null) return null;
+  if (typeof payload === 'object') {
+    const id = (payload as { id?: unknown }).id;
+    return typeof id === 'string' ? id : null;
+  }
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload);
+      return typeof parsed?.id === 'string' ? parsed.id : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function stripeReportsInactive(subscription: Stripe.Subscription): boolean {
+  if (subscription.status !== 'active') return true;
+
+  if (subscription.cancel_at_period_end && subscription.current_period_end) {
+    const periodEndMs = subscription.current_period_end * 1000;
+    return Date.now() >= periodEndMs;
+  }
+  return false;
+}
+
+async function deactivateRow(
+  db: Knex,
+  row: ActiveSubscriptionRow,
+  subscription?: Stripe.Subscription
+): Promise<void> {
+  const update: { active: boolean; payload?: string } = { active: false };
+  if (subscription) {
+    update.payload = JSON.stringify(subscription);
+  }
+  await db('subscriptions').where({ id: row.id }).update(update);
+  console.info(
+    `[stripe-sync] Flipped subscription row ${row.id} (${row.email}) to inactive`
+  );
+}
+
+export async function reconcileActiveSubscriptions(
+  db: Knex,
+  stripe: Pick<Stripe, 'subscriptions'>
+): Promise<void> {
+  const rows: ActiveSubscriptionRow[] = await db('subscriptions')
+    .select('id', 'email', 'payload')
+    .where({ active: true });
+
+  console.info(`[stripe-sync] Reconciling ${rows.length} active DB row(s)`);
+
+  for (const row of rows) {
+    const subscriptionId = parseSubscriptionId(row.payload);
+    if (!subscriptionId) {
+      console.warn(
+        `[stripe-sync] Row ${row.id} (${row.email}) has no parseable subscription id; skipping`
+      );
+      continue;
+    }
+
+    try {
+      const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+      if (stripeReportsInactive(subscription)) {
+        await deactivateRow(db, row, subscription);
+      }
+    } catch (error) {
+      const statusCode = (error as { statusCode?: number })?.statusCode;
+      if (statusCode === 404) {
+        await deactivateRow(db, row);
+        continue;
+      }
+      console.error(
+        `[stripe-sync] Failed to reconcile row ${row.id} (${row.email}):`,
+        error
+      );
+    }
+  }
+}

--- a/src/lib/storage/jobs/helpers/sendVatNotificationEmail.ts
+++ b/src/lib/storage/jobs/helpers/sendVatNotificationEmail.ts
@@ -1,11 +1,11 @@
-import { useDefaultEmailService } from '../../../../services/EmailService/EmailService';
+import { getDefaultEmailService } from '../../../../services/EmailService/EmailService';
 import { getStripe } from '../../../integrations/stripe';
 import Stripe from 'stripe';
 
 const stripe = getStripe();
 
 const sendVatNotificationEmail = async () => {
-  const emailService = useDefaultEmailService();
+  const emailService = getDefaultEmailService();
   let hasMore = true;
   let startingAfter: string | undefined = undefined;
 

--- a/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
@@ -2,6 +2,7 @@ import { getStripe } from '../../../integrations/stripe';
 import { getDatabase } from '../../../../data_layer';
 import { Knex } from 'knex';
 import Stripe from 'stripe';
+import { reconcileActiveSubscriptions } from './reconcileActiveSubscriptions';
 
 const stripe = getStripe();
 const database = getDatabase();
@@ -252,6 +253,9 @@ async function updateStripeSubscriptions(): Promise<void> {
       startingAfter = pagination.startingAfter;
     }
 
+    console.info('Forward sync from Stripe completed successfully');
+
+    await reconcileActiveSubscriptions(database, stripe);
     console.info('Subscription sync completed successfully');
   } catch (error) {
     console.error('Error in updateStripeSubscriptions:', error);

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -7,7 +7,7 @@ import TokenRepository from '../data_layer/TokenRepository';
 import AuthenticationService from '../services/AuthenticationService';
 import { getDatabase } from '../data_layer';
 import UsersService from '../services/UsersService';
-import { useDefaultEmailService } from '../services/EmailService/EmailService';
+import { getDefaultEmailService } from '../services/EmailService/EmailService';
 
 const UserRouter = () => {
   const router = express.Router();
@@ -17,7 +17,7 @@ const UserRouter = () => {
     new UsersRepository(database)
   );
 
-  const emailService = useDefaultEmailService();
+  const emailService = getDefaultEmailService();
   const controller = new UsersController(
     new UsersService(new UsersRepository(database), emailService),
     authService

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -326,6 +326,45 @@ const UserRouter = () => {
 
   /**
    * @swagger
+   * /api/users/subscription-status:
+   *   get:
+   *     summary: Get live subscription status from Stripe
+   *     description: Returns active subscriptions for the authenticated user, fetched directly from Stripe
+   *     tags: [Users]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     responses:
+   *       200:
+   *         description: Subscription status retrieved
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 subscriptions:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       id:
+   *                         type: string
+   *                       status:
+   *                         type: string
+   *                       cancel_at_period_end:
+   *                         type: boolean
+   *                       current_period_end:
+   *                         type: integer
+   *                         nullable: true
+   *       401:
+   *         description: Authentication required
+   */
+  router.get('/api/users/subscription-status', RequireAuthentication, (req, res) =>
+    controller.getSubscriptionStatus(req, res)
+  );
+
+  /**
+   * @swagger
    * /api/users/debug/locals:
    *   get:
    *     summary: Get debug information

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -9,7 +9,7 @@ import {
 import { getDatabase } from '../data_layer';
 import { StripeController } from '../controllers/StripeController/StripeController';
 import UsersRepository from '../data_layer/UsersRepository';
-import { useDefaultEmailService } from '../services/EmailService/EmailService';
+import { getDefaultEmailService } from '../services/EmailService/EmailService';
 
 const WebhooksRouter = () => {
   const router = express.Router();
@@ -97,7 +97,7 @@ const WebhooksRouter = () => {
             const cancelDate = new Date(
               customerSubscriptionUpdated.current_period_end * 1000
             );
-            const emailService = useDefaultEmailService();
+            const emailService = getDefaultEmailService();
             if ('email' in customer) {
               // Log the scheduled cancellation for debugging purposes
               console.info(
@@ -133,7 +133,7 @@ const WebhooksRouter = () => {
             );
 
             if ('email' in customerDeleted) {
-              const emailService = useDefaultEmailService();
+              const emailService = getDefaultEmailService();
               await emailService.sendSubscriptionCancelledEmail(
                 customerDeleted.email!,
                 customerDeleted.name || 'there',

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import swaggerRouter from './routes/SwaggerRouter';
 
 import { getDatabase, setupDatabase } from './data_layer';
 import JobRepository from './data_layer/JobRepository';
+import { updateStripeSubscriptions } from './lib/storage/jobs/helpers/updateStripeSubscriptions';
 
 function registerSignalHandlers(server: http.Server) {
   process.on('uncaughtException', (error) => {
@@ -110,6 +111,13 @@ const serve = async () => {
   const interruptedCount = await new JobRepository(database).markInterruptedClaudeJobs();
   if (interruptedCount > 0) {
     console.info(`[startup] Marked ${interruptedCount} Claude job(s) as interrupted`);
+  }
+
+  if (process.env.STRIPE_SYNC_ON_STARTUP === 'true') {
+    console.info('[startup] Running Stripe subscription sync in background');
+    updateStripeSubscriptions().catch((error) => {
+      console.error('[startup] Stripe subscription sync failed:', error);
+    });
   }
 };
 

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -402,7 +402,7 @@ export class UnimplementedEmailService implements IEmailService {
   }
 }
 
-export const useDefaultEmailService = () => {
+export const getDefaultEmailService = () => {
   if (process.env.SENDGRID_API_KEY !== undefined) {
     return new EmailService(process.env.SENDGRID_API_KEY!, DEFAULT_SENDER);
   }

--- a/src/services/SubscriptionService.test.ts
+++ b/src/services/SubscriptionService.test.ts
@@ -7,12 +7,12 @@ jest.mock('../lib/integrations/stripe', () => ({
 }));
 
 jest.mock('./EmailService/EmailService', () => ({
-  useDefaultEmailService: jest.fn(),
+  getDefaultEmailService: jest.fn(),
 }));
 
 import { getDatabase } from '../data_layer';
 import { getStripe } from '../lib/integrations/stripe';
-import { useDefaultEmailService } from './EmailService/EmailService';
+import { getDefaultEmailService } from './EmailService/EmailService';
 import SubscriptionService from './SubscriptionService';
 
 function buildDbMock(linkedRows: Array<{ email: string }> = []): jest.Mock & {
@@ -75,7 +75,7 @@ describe('SubscriptionService.findActiveStripeSubscriptions', () => {
     stripe = buildStripeMock();
     (getStripe as jest.Mock).mockReturnValue(stripe);
     (getDatabase as jest.Mock).mockReturnValue(buildDbMock());
-    (useDefaultEmailService as jest.Mock).mockReturnValue({});
+    (getDefaultEmailService as jest.Mock).mockReturnValue({});
   });
 
   it('returns active subscriptions for the user email', async () => {
@@ -148,7 +148,7 @@ describe('SubscriptionService.findRecentStripeSubscriptions', () => {
     stripe = buildStripeMock();
     (getStripe as jest.Mock).mockReturnValue(stripe);
     (getDatabase as jest.Mock).mockReturnValue(buildDbMock());
-    (useDefaultEmailService as jest.Mock).mockReturnValue({});
+    (getDefaultEmailService as jest.Mock).mockReturnValue({});
   });
 
   it('returns subscriptions with any status from Stripe', async () => {
@@ -202,7 +202,7 @@ describe('SubscriptionService.cancelUserSubscriptions', () => {
 
     sendScheduledEmail = jest.fn().mockResolvedValue(undefined);
     sendCancelledEmail = jest.fn().mockResolvedValue(undefined);
-    (useDefaultEmailService as jest.Mock).mockReturnValue({
+    (getDefaultEmailService as jest.Mock).mockReturnValue({
       sendSubscriptionScheduledCancellationEmail: sendScheduledEmail,
       sendSubscriptionCancelledEmail: sendCancelledEmail,
     });

--- a/src/services/SubscriptionService.test.ts
+++ b/src/services/SubscriptionService.test.ts
@@ -1,0 +1,285 @@
+jest.mock('../data_layer', () => ({
+  getDatabase: jest.fn(),
+}));
+
+jest.mock('../lib/integrations/stripe', () => ({
+  getStripe: jest.fn(),
+}));
+
+jest.mock('./EmailService/EmailService', () => ({
+  useDefaultEmailService: jest.fn(),
+}));
+
+import { getDatabase } from '../data_layer';
+import { getStripe } from '../lib/integrations/stripe';
+import { useDefaultEmailService } from './EmailService/EmailService';
+import SubscriptionService from './SubscriptionService';
+
+function buildDbMock(linkedRows: Array<{ email: string }> = []): jest.Mock & {
+  updateSpy: jest.Mock;
+} {
+  const updateSpy = jest.fn().mockResolvedValue(0);
+  const queryBuilder: Record<string, unknown> = {
+    select: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orWhere: jest.fn().mockReturnThis(),
+    update: updateSpy,
+    then: (resolve: (value: unknown) => void) => resolve(linkedRows),
+  };
+  const db = jest.fn().mockReturnValue(queryBuilder) as jest.Mock & {
+    updateSpy: jest.Mock;
+  };
+  db.updateSpy = updateSpy;
+  return db;
+}
+
+type StripeMock = {
+  customers: { list: jest.Mock };
+  subscriptions: {
+    list: jest.Mock;
+    update: jest.Mock;
+    cancel: jest.Mock;
+  };
+};
+
+function buildStripeMock(overrides: Partial<StripeMock> = {}): StripeMock {
+  return {
+    customers: {
+      list: jest.fn().mockResolvedValue({ data: [] }),
+    },
+    subscriptions: {
+      list: jest.fn().mockResolvedValue({ data: [] }),
+      update: jest.fn().mockResolvedValue({}),
+      cancel: jest.fn().mockResolvedValue({}),
+    },
+    ...overrides,
+  };
+}
+
+const email = 'user@example.com';
+const periodEndSeconds = 1800000000;
+
+const activeSub = {
+  id: 'sub_123',
+  status: 'active',
+  cancel_at_period_end: false,
+  current_period_end: periodEndSeconds,
+};
+
+describe('SubscriptionService.findActiveStripeSubscriptions', () => {
+  let stripe: StripeMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stripe = buildStripeMock();
+    (getStripe as jest.Mock).mockReturnValue(stripe);
+    (getDatabase as jest.Mock).mockReturnValue(buildDbMock());
+    (useDefaultEmailService as jest.Mock).mockReturnValue({});
+  });
+
+  it('returns active subscriptions for the user email', async () => {
+    stripe.customers.list.mockResolvedValue({
+      data: [{ id: 'cus_1', email }],
+    });
+    stripe.subscriptions.list.mockResolvedValue({ data: [activeSub] });
+
+    const result = await SubscriptionService.findActiveStripeSubscriptions(email);
+
+    expect(stripe.customers.list).toHaveBeenCalledWith({
+      email,
+      limit: 10,
+    });
+    expect(stripe.subscriptions.list).toHaveBeenCalledWith({
+      customer: 'cus_1',
+      status: 'active',
+      limit: 10,
+    });
+    expect(result).toEqual([activeSub]);
+  });
+
+  it('returns an empty array when Stripe has no customer for the email', async () => {
+    stripe.customers.list.mockResolvedValue({ data: [] });
+
+    const result = await SubscriptionService.findActiveStripeSubscriptions(email);
+
+    expect(result).toEqual([]);
+    expect(stripe.subscriptions.list).not.toHaveBeenCalled();
+  });
+
+  it('also looks up subscriptions under linked Stripe emails', async () => {
+    (getDatabase as jest.Mock).mockReturnValue(
+      buildDbMock([{ email: 'stripe@example.com' }])
+    );
+    stripe.customers.list
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValueOnce({ data: [{ id: 'cus_2', email: 'stripe@example.com' }] });
+    stripe.subscriptions.list.mockResolvedValue({ data: [activeSub] });
+
+    const result = await SubscriptionService.findActiveStripeSubscriptions(email);
+
+    expect(stripe.customers.list).toHaveBeenCalledWith({
+      email: 'stripe@example.com',
+      limit: 10,
+    });
+    expect(result).toEqual([activeSub]);
+  });
+
+  it('dedupes subscriptions returned under multiple customers', async () => {
+    stripe.customers.list.mockResolvedValue({
+      data: [
+        { id: 'cus_1', email },
+        { id: 'cus_2', email },
+      ],
+    });
+    stripe.subscriptions.list.mockResolvedValue({ data: [activeSub] });
+
+    const result = await SubscriptionService.findActiveStripeSubscriptions(email);
+
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('SubscriptionService.findRecentStripeSubscriptions', () => {
+  let stripe: StripeMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stripe = buildStripeMock();
+    (getStripe as jest.Mock).mockReturnValue(stripe);
+    (getDatabase as jest.Mock).mockReturnValue(buildDbMock());
+    (useDefaultEmailService as jest.Mock).mockReturnValue({});
+  });
+
+  it('returns subscriptions with any status from Stripe', async () => {
+    const canceled = {
+      id: 'sub_old',
+      status: 'canceled',
+      cancel_at_period_end: false,
+      current_period_end: periodEndSeconds,
+      canceled_at: periodEndSeconds - 100,
+    };
+    stripe.customers.list.mockResolvedValue({
+      data: [{ id: 'cus_1', email }],
+    });
+    stripe.subscriptions.list.mockResolvedValue({
+      data: [activeSub, canceled],
+    });
+
+    const result = await SubscriptionService.findRecentStripeSubscriptions(
+      email
+    );
+
+    expect(stripe.subscriptions.list).toHaveBeenCalledWith({
+      customer: 'cus_1',
+      status: 'all',
+      limit: 10,
+    });
+    expect(result).toEqual([activeSub, canceled]);
+  });
+
+  it('returns empty array when Stripe has no customer for email', async () => {
+    stripe.customers.list.mockResolvedValue({ data: [] });
+
+    const result = await SubscriptionService.findRecentStripeSubscriptions(
+      email
+    );
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('SubscriptionService.cancelUserSubscriptions', () => {
+  let stripe: StripeMock;
+  let sendScheduledEmail: jest.Mock;
+  let sendCancelledEmail: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stripe = buildStripeMock();
+    (getStripe as jest.Mock).mockReturnValue(stripe);
+    (getDatabase as jest.Mock).mockReturnValue(buildDbMock());
+
+    sendScheduledEmail = jest.fn().mockResolvedValue(undefined);
+    sendCancelledEmail = jest.fn().mockResolvedValue(undefined);
+    (useDefaultEmailService as jest.Mock).mockReturnValue({
+      sendSubscriptionScheduledCancellationEmail: sendScheduledEmail,
+      sendSubscriptionCancelledEmail: sendCancelledEmail,
+    });
+
+    stripe.customers.list.mockResolvedValue({
+      data: [{ id: 'cus_1', email }],
+    });
+    stripe.subscriptions.list.mockResolvedValue({ data: [activeSub] });
+    stripe.subscriptions.update.mockResolvedValue({
+      ...activeSub,
+      cancel_at_period_end: true,
+    });
+  });
+
+  it('schedules cancellation at period end by default', async () => {
+    await SubscriptionService.cancelUserSubscriptions(email);
+
+    expect(stripe.subscriptions.update).toHaveBeenCalledWith('sub_123', {
+      cancel_at_period_end: true,
+    });
+    expect(stripe.subscriptions.cancel).not.toHaveBeenCalled();
+    expect(sendScheduledEmail).toHaveBeenCalledTimes(1);
+    expect(sendCancelledEmail).not.toHaveBeenCalled();
+  });
+
+  it('cancels immediately when mode is "immediate"', async () => {
+    await SubscriptionService.cancelUserSubscriptions(email, 'immediate');
+
+    expect(stripe.subscriptions.cancel).toHaveBeenCalledWith('sub_123');
+    expect(stripe.subscriptions.update).not.toHaveBeenCalled();
+    expect(sendCancelledEmail).toHaveBeenCalledTimes(1);
+    expect(sendScheduledEmail).not.toHaveBeenCalled();
+  });
+
+  it('marks the local DB subscription inactive on immediate cancel', async () => {
+    const db = buildDbMock();
+    (getDatabase as jest.Mock).mockReturnValue(db);
+
+    await SubscriptionService.cancelUserSubscriptions(email, 'immediate');
+
+    expect(db.updateSpy).toHaveBeenCalledWith({ active: false });
+  });
+
+  it('does not flip the DB active flag for period_end cancel', async () => {
+    const db = buildDbMock();
+    (getDatabase as jest.Mock).mockReturnValue(db);
+
+    await SubscriptionService.cancelUserSubscriptions(email, 'period_end');
+
+    expect(db.updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the count of processed subscriptions', async () => {
+    stripe.subscriptions.list.mockResolvedValue({
+      data: [activeSub, { ...activeSub, id: 'sub_456' }],
+    });
+
+    const result = await SubscriptionService.cancelUserSubscriptions(email);
+
+    expect(result).toBe(2);
+    expect(stripe.subscriptions.update).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 0 when Stripe has no active subscriptions', async () => {
+    stripe.subscriptions.list.mockResolvedValue({ data: [] });
+
+    const result = await SubscriptionService.cancelUserSubscriptions(email);
+
+    expect(result).toBe(0);
+    expect(stripe.subscriptions.update).not.toHaveBeenCalled();
+  });
+
+  it('propagates Stripe API errors', async () => {
+    stripe.subscriptions.update.mockRejectedValue(new Error('stripe is down'));
+
+    await expect(
+      SubscriptionService.cancelUserSubscriptions(email)
+    ).rejects.toThrow('stripe is down');
+  });
+});

--- a/src/services/SubscriptionService.ts
+++ b/src/services/SubscriptionService.ts
@@ -1,83 +1,138 @@
+import Stripe from 'stripe';
 import { getDatabase } from '../data_layer';
 import { getStripe } from '../lib/integrations/stripe';
+import { useDefaultEmailService } from './EmailService/EmailService';
 import Subscriptions from '../data_layer/public/Subscriptions';
 
-export class SubscriptionService {
-  static async cancelUserSubscriptions(userEmail: string): Promise<void> {
-    try {
-      const database = getDatabase();
-      const stripe = getStripe();
+export type CancelMode = 'immediate' | 'period_end';
 
-      // Find active subscriptions for this user (both direct and linked email)
-      const subscriptions: Subscriptions[] = await database('subscriptions')
-        .where(function() {
-          this.where({ email: userEmail.toLowerCase() })
-              .orWhere({ linked_email: userEmail.toLowerCase() });
-        })
-        .andWhere({ active: true });
+async function collectCandidateEmails(userEmail: string): Promise<string[]> {
+  const normalized = userEmail.toLowerCase();
+  const db = getDatabase();
+  const linked: Array<{ email: string }> = await db('subscriptions')
+    .select('email')
+    .where({ linked_email: normalized });
 
-      console.log(`Found ${subscriptions.length} active subscriptions for user ${userEmail}`);
+  const emails = new Set<string>([normalized]);
+  for (const row of linked) {
+    if (row.email) {
+      emails.add(row.email.toLowerCase());
+    }
+  }
+  return [...emails];
+}
 
-      // Cancel each subscription in Stripe
-      for (const subscription of subscriptions) {
-        try {
-          let stripeSubscription: any = null;
-          
-          // Handle different payload types
-          if (typeof subscription.payload === 'object' && subscription.payload !== null) {
-            // Payload is already an object
-            stripeSubscription = subscription.payload;
-          } else if (typeof subscription.payload === 'string') {
-            // Payload is a JSON string that needs parsing
-            try {
-              stripeSubscription = JSON.parse(subscription.payload);
-            } catch (parseError) {
-              console.error(`Failed to parse subscription payload for ID ${subscription.id}:`, parseError);
-              continue;
-            }
-          } else {
-            console.error(`Invalid payload type for subscription ${subscription.id}:`, typeof subscription.payload);
-            continue;
-          }
-          
-          if (stripeSubscription?.id) {
-            console.log(`Cancelling Stripe subscription ${stripeSubscription.id}`);
-            await stripe.subscriptions.cancel(stripeSubscription.id);
-            
-            // Update local database to mark as inactive
-            await database('subscriptions')
-              .where({ id: subscription.id })
-              .update({ active: false });
-              
-            console.log(`Successfully cancelled subscription ${stripeSubscription.id}`);
-          } else {
-            console.error(`No Stripe subscription ID found in payload for subscription ${subscription.id}`);
-          }
-        } catch (subscriptionError) {
-          console.error(`Failed to cancel subscription ${subscription.id}:`, subscriptionError);
-          // Continue with other subscriptions even if one fails
+async function listStripeSubscriptionsFor(
+  userEmail: string,
+  status: Stripe.SubscriptionListParams['status']
+): Promise<Stripe.Subscription[]> {
+  const stripe = getStripe();
+  const candidateEmails = await collectCandidateEmails(userEmail);
+
+  const seen = new Set<string>();
+  const subs: Stripe.Subscription[] = [];
+
+  for (const email of candidateEmails) {
+    const customers = await stripe.customers.list({ email, limit: 10 });
+    for (const customer of customers.data) {
+      const list = await stripe.subscriptions.list({
+        customer: customer.id,
+        status,
+        limit: 10,
+      });
+      for (const sub of list.data) {
+        if (!seen.has(sub.id)) {
+          seen.add(sub.id);
+          subs.push(sub);
         }
       }
-    } catch (error) {
-      console.error('Error cancelling user subscriptions:', error);
-      // Don't throw here - we still want to allow account deletion even if subscription cancellation fails
     }
   }
 
-  static async getUserActiveSubscriptions(userEmail: string): Promise<Subscriptions[]> {
+  return subs;
+}
+
+export class SubscriptionService {
+  static findActiveStripeSubscriptions(
+    userEmail: string
+  ): Promise<Stripe.Subscription[]> {
+    return listStripeSubscriptionsFor(userEmail, 'active');
+  }
+
+  static findRecentStripeSubscriptions(
+    userEmail: string
+  ): Promise<Stripe.Subscription[]> {
+    return listStripeSubscriptionsFor(userEmail, 'all');
+  }
+
+  static async cancelUserSubscriptions(
+    userEmail: string,
+    mode: CancelMode = 'period_end'
+  ): Promise<number> {
+    const stripe = getStripe();
+    const emailService = useDefaultEmailService();
+    const subs = await this.findActiveStripeSubscriptions(userEmail);
+
+    console.log(
+      `Found ${subs.length} active Stripe subscriptions for ${userEmail}`
+    );
+
+    for (const sub of subs) {
+      if (mode === 'immediate') {
+        console.log(`Cancelling Stripe subscription ${sub.id} immediately`);
+        await stripe.subscriptions.cancel(sub.id);
+        await emailService.sendSubscriptionCancelledEmail(userEmail, '', sub.id);
+      } else {
+        console.log(
+          `Scheduling cancellation at period end for Stripe subscription ${sub.id}`
+        );
+        const updated = await stripe.subscriptions.update(sub.id, {
+          cancel_at_period_end: true,
+        });
+        const periodEndSeconds =
+          updated.current_period_end ?? sub.current_period_end;
+        if (periodEndSeconds) {
+          await emailService.sendSubscriptionScheduledCancellationEmail(
+            userEmail,
+            '',
+            new Date(periodEndSeconds * 1000)
+          );
+        }
+      }
+    }
+
+    if (mode === 'immediate' && subs.length > 0) {
+      const normalized = userEmail.toLowerCase();
+      const db = getDatabase();
+      await db('subscriptions')
+        .where(function () {
+          this.where({ email: normalized }).orWhere({
+            linked_email: normalized,
+          });
+        })
+        .update({ active: false });
+    }
+
+    return subs.length;
+  }
+
+  static async getUserActiveSubscriptions(
+    userEmail: string
+  ): Promise<Subscriptions[]> {
     const database = getDatabase();
-    
+
     return database('subscriptions')
-      .where(function() {
-        this.where({ email: userEmail.toLowerCase() })
-            .orWhere({ linked_email: userEmail.toLowerCase() });
+      .where(function () {
+        this.where({ email: userEmail.toLowerCase() }).orWhere({
+          linked_email: userEmail.toLowerCase(),
+        });
       })
       .andWhere({ active: true });
   }
 
   async deactivateSubscription(subscriptionId: number): Promise<void> {
     const database = getDatabase();
-    
+
     await database('subscriptions')
       .where({ id: subscriptionId })
       .update({ active: false });

--- a/src/services/SubscriptionService.ts
+++ b/src/services/SubscriptionService.ts
@@ -1,7 +1,7 @@
 import Stripe from 'stripe';
 import { getDatabase } from '../data_layer';
 import { getStripe } from '../lib/integrations/stripe';
-import { useDefaultEmailService } from './EmailService/EmailService';
+import { getDefaultEmailService } from './EmailService/EmailService';
 import Subscriptions from '../data_layer/public/Subscriptions';
 
 export type CancelMode = 'immediate' | 'period_end';
@@ -70,7 +70,7 @@ export class SubscriptionService {
     mode: CancelMode = 'period_end'
   ): Promise<number> {
     const stripe = getStripe();
-    const emailService = useDefaultEmailService();
+    const emailService = getDefaultEmailService();
     const subs = await this.findActiveStripeSubscriptions(userEmail);
 
     console.log(

--- a/src/usecases/jobs/NotifyUserUseCase.ts
+++ b/src/usecases/jobs/NotifyUserUseCase.ts
@@ -2,7 +2,7 @@ import JobRepository from '../../data_layer/JobRepository';
 import ParserRules from '../../lib/parser/ParserRules';
 import { Knex } from 'knex';
 import getEmailFromOwner from '../../lib/User/getEmailFromOwner';
-import { useDefaultEmailService } from '../../services/EmailService/EmailService';
+import { getDefaultEmailService } from '../../services/EmailService/EmailService';
 
 export interface NotifyUserUseCaseInput {
   owner: string;
@@ -23,7 +23,7 @@ export class NotifyUserUseCase {
     console.debug('rules.email', rules.EMAIL_NOTIFICATION);
     // TODO: use UserRepository to get user email
     const email = await getEmailFromOwner(db, owner);
-    const emailService = useDefaultEmailService();
+    const emailService = getDefaultEmailService();
 
     // Notify for files bigger than 24MB or if email notifications are not enabled
     if (size > 24) {


### PR DESCRIPTION
Cancellation through the Account page silently failed in several ways: the service returned success when nothing matched, errors were swallowed, and the DB cache hid live Stripe state. Rework the flow to query Stripe directly, accept a mode flag for immediate vs period-end, surface real errors, and flip the local DB row immediately on immediate cancel so locals.subscriber reflects reality without waiting for the webhook.

Add reconcileActiveSubscriptions that iterates DB rows marked active and flips them off when Stripe no longer reports the sub as active, catching webhook misses. Wire it into the existing sync job and into server startup behind STRIPE_SYNC_ON_STARTUP so restarts heal drift.

Expose GET /api/users/subscription-status for the web UI to render live Stripe state (active + recently canceled, with plan info).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription status endpoint to view current subscription details
  * Added subscription cancellation mode options (immediate cancellation or end-of-period)
  * Background subscription synchronization on startup

* **Bug Fixes**
  * Improved account deletion to handle subscription cancellation failures gracefully
  * Added automatic subscription status reconciliation with payment provider
  * Enhanced error messages for subscription management scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->