### PR TITLE
fix(auth): make RequireAuthentication actually reject anon requests

### DIFF
--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 
-import RequireAuthentication from './middleware/RequireAuthentication';
+import RequireAuthentication, {
+  OptionalAuthentication,
+} from './middleware/RequireAuthentication';
 import UsersController from '../controllers/UsersControllers';
 import UsersRepository from '../data_layer/UsersRepository';
 import TokenRepository from '../data_layer/TokenRepository';
@@ -388,7 +390,7 @@ const UserRouter = () => {
    *             schema:
    *               $ref: '#/components/schemas/Error'
    */
-  router.get('/api/users/debug/locals', RequireAuthentication, (req, res) =>
+  router.get('/api/users/debug/locals', OptionalAuthentication, (req, res) =>
     controller.getLocals(req, res)
   );
 

--- a/src/routes/middleware/RequireAuthentication.ts
+++ b/src/routes/middleware/RequireAuthentication.ts
@@ -5,28 +5,33 @@ import AuthenticationService from '../../services/AuthenticationService';
 import { getDatabase } from '../../data_layer';
 import { configureUserLocal } from './configureUserLocal';
 
+async function attachUserLocals(req: express.Request, res: express.Response) {
+  const database = getDatabase();
+  const authService = new AuthenticationService(
+    new TokenRepository(database),
+    new UsersRepository(database)
+  );
+  await configureUserLocal(req, res, authService, database);
+}
+
+export const OptionalAuthentication = async (
+  req: express.Request,
+  res: express.Response,
+  next: NextFunction
+) => {
+  await attachUserLocals(req, res);
+  return next();
+};
+
 const RequireAuthentication = async (
   req: express.Request,
   res: express.Response,
   next: NextFunction
 ) => {
-  const shouldDebug = req.query.debug === 'true';
-  if (shouldDebug)
-    console.info('RequireAuthentication: Starting authentication check');
-
-  const database = getDatabase();
-  if (shouldDebug) console.debug('RequireAuthentication: Database initialized');
-
-  const authService = new AuthenticationService(
-    new TokenRepository(database),
-    new UsersRepository(database)
-  );
-  if (shouldDebug) console.debug('RequireAuthentication: Auth service created');
-
-  await configureUserLocal(req, res, authService, database);
-  if (shouldDebug)
-    console.debug('RequireAuthentication: User local configured');
-
+  await attachUserLocals(req, res);
+  if (!res.locals.owner) {
+    return res.status(401).json({ message: 'Authentication required' });
+  }
   return next();
 };
 

--- a/src/services/FavoriteService.ts
+++ b/src/services/FavoriteService.ts
@@ -39,9 +39,7 @@ class FavoriteService {
      * What is happening here is that we fetch the Notion block so we can present the user
      * with a rich object (with title and emoji) instead of just the ID.
      */
-    const api = await notionService
-      .getNotionAPI(owner)
-      .catch(() => null);
+    const api = await notionService.tryGetNotionAPI(owner);
     if (!api) {
       return [];
     }

--- a/src/services/FavoriteService.ts
+++ b/src/services/FavoriteService.ts
@@ -39,7 +39,9 @@ class FavoriteService {
      * What is happening here is that we fetch the Notion block so we can present the user
      * with a rich object (with title and emoji) instead of just the ID.
      */
-    const api = await notionService.getNotionAPI(owner);
+    const api = await notionService
+      .getNotionAPI(owner)
+      .catch(() => null);
     if (!api) {
       return [];
     }

--- a/src/services/NotionService/NotionService.ts
+++ b/src/services/NotionService/NotionService.ts
@@ -47,6 +47,16 @@ export class NotionService {
     return new NotionAPIWrapper(token!, owner);
   };
 
+  tryGetNotionAPI = async (
+    owner: string
+  ): Promise<NotionAPIWrapper | null> => {
+    const token = await this.notionRepository.getNotionToken(owner);
+    if (!token) {
+      return null;
+    }
+    return new NotionAPIWrapper(token, owner);
+  };
+
   async getNotionDatabaseBlock(id: string, owner: string) {
     let cleanId = id.replace(/-/g, '');
 


### PR DESCRIPTION
The existing middleware only attached user locals from the cookie and
then called next() unconditionally — every route using it was reachable
by anonymous visitors and only happened to fail downstream if the
controller checked res.locals.owner. Rework it so missing auth returns
a plain 401.

Split out OptionalAuthentication for the one endpoint that needs to
report unauthenticated state back to the frontend (/api/users/debug/locals).
Without that split, the web useUserLocals hook would 401 on every anon
page load and trigger a redirect loop.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>