### PR TITLE
fix(payments): unlock lifetime quota regardless of email casing

### DIFF
--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -1,0 +1,45 @@
+import UsersRepository from './UsersRepository';
+
+function buildKnexMock() {
+  const updateSpy = jest.fn().mockResolvedValue(1);
+  const whereRawSpy = jest.fn().mockReturnValue({ update: updateSpy });
+  const whereSpy = jest.fn().mockReturnValue({ update: updateSpy });
+  const tableBuilder = { whereRaw: whereRawSpy, where: whereSpy };
+  const knex = jest.fn().mockReturnValue(tableBuilder) as unknown as jest.Mock & {
+    whereRawSpy: jest.Mock;
+    whereSpy: jest.Mock;
+    updateSpy: jest.Mock;
+  };
+  knex.whereRawSpy = whereRawSpy;
+  knex.whereSpy = whereSpy;
+  knex.updateSpy = updateSpy;
+  return knex;
+}
+
+describe('UsersRepository.updatePatreonByEmail', () => {
+  it('matches the user by email using TRIM + lowercase so Stripe casing differences still update', async () => {
+    const knex = buildKnexMock();
+    const repo = new UsersRepository(knex as any);
+
+    await repo.updatePatreonByEmail('  John@Example.COM ', true);
+
+    expect(knex.whereRawSpy).toHaveBeenCalledWith(
+      'TRIM(LOWER(email)) = ?',
+      ['john@example.com']
+    );
+    expect(knex.updateSpy).toHaveBeenCalledWith({ patreon: true });
+  });
+
+  it('returns the number of rows affected', async () => {
+    const knex = buildKnexMock();
+    knex.updateSpy.mockResolvedValue(1);
+    const repo = new UsersRepository(knex as any);
+
+    const rowsAffected = await repo.updatePatreonByEmail(
+      'user@example.com',
+      true
+    );
+
+    expect(rowsAffected).toBe(1);
+  });
+});

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -109,8 +109,10 @@ class UsersRepository {
     });
   }
 
-  updatePatreonByEmail(email: string, patreon: boolean) {
-    return this.database(this.table).where({ email }).update({ patreon });
+  updatePatreonByEmail(email: string, patreon: boolean): Promise<number> {
+    return this.database(this.table)
+      .whereRaw('TRIM(LOWER(email)) = ?', [email.toLowerCase().trim()])
+      .update({ patreon });
   }
 
   async checkSubscriptionEmailExists(email: string): Promise<boolean> {

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -148,14 +148,40 @@ const WebhooksRouter = () => {
 
           const LIFE_TIME_PRICE = 9600;
           if (amount >= LIFE_TIME_PRICE) {
-            const lifeTimeCustomer = await stripe.customers.retrieve(
-              // @ts-ignore
-              getCustomerId(session.customer)
-            );
+            try {
+              const lifeTimeCustomer = await stripe.customers.retrieve(
+                // @ts-ignore
+                getCustomerId(session.customer)
+              );
+              const lifeTimeEmail =
+                'email' in lifeTimeCustomer ? lifeTimeCustomer.email : null;
 
-            const users = new UsersRepository(getDatabase());
-            // @ts-ignore
-            await users.updatePatreonByEmail(lifeTimeCustomer.email, true);
+              if (!lifeTimeEmail) {
+                console.error(
+                  `[webhook] checkout.session.completed: lifetime customer ${lifeTimeCustomer.id} has no email; quota not unlocked`
+                );
+              } else {
+                const users = new UsersRepository(getDatabase());
+                const rowsAffected = await users.updatePatreonByEmail(
+                  lifeTimeEmail,
+                  true
+                );
+                if (rowsAffected === 0) {
+                  console.error(
+                    `[webhook] checkout.session.completed: no user row matched email=${lifeTimeEmail} for lifetime purchase; quota NOT unlocked. Check for email casing or whitespace mismatch.`
+                  );
+                } else {
+                  console.info(
+                    `[webhook] checkout.session.completed: unlocked lifetime access for email=${lifeTimeEmail} (${rowsAffected} row(s) updated)`
+                  );
+                }
+              }
+            } catch (error) {
+              console.error(
+                '[webhook] checkout.session.completed: failed to unlock lifetime access',
+                error
+              );
+            }
           }
           console.log('checkout.session.completed');
           break;


### PR DESCRIPTION
At least one user paid for lifetime access but their quota was never unlocked. Root cause: the Stripe checkout.session.completed webhook calls UsersRepository.updatePatreonByEmail with the customer email exactly as Stripe sends it, but the repository used an exact where({ email }) match. A user registered as "John@Example.com" with Stripe email "john@example.com" produced a 0-row update — silent failure, no quota flip, no error.

Normalise the lookup to TRIM(LOWER(email)) = <lowercased, trimmed input> so the match tolerates casing and whitespace — mirrors the pattern already used in getByEmail. Return the affected row count so callers can detect silent misses.

Wrap the lifetime branch of the webhook in a try/catch, check the returned row count, and log success / "no user matched, quota NOT unlocked" / full error so we have an audit trail for future cases. Also guard against the rare case where the retrieved Stripe customer has no email attached.