### PR TITLE
feat(uploads): emit X-Card-Count header on sync conversions

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -25,6 +25,7 @@ interface PrepareDeckResult {
   name: string;
   apkg: Buffer;
   deck: Deck[];
+  cardCount: number;
 }
 
 async function convertFile(
@@ -227,9 +228,18 @@ export async function PrepareDeck(
     exporter.configure(deckInfo as unknown as Deck[]);
     const tExport = Date.now();
     const apkg = await exporter.save();
+    const claudeCardCount = deckInfo.reduce(
+      (sum, d) => sum + d.cards.length,
+      0
+    );
     console.log('[PrepareDeck] Claude branch: exporter.save done', { durationMs: Date.now() - tExport });
     console.log('[PrepareDeck] done (Claude path)', { totalMs: Date.now() - tTotal });
-    return { name: getDeckFilename(deckName), apkg, deck: [] };
+    return {
+      name: getDeckFilename(deckName),
+      apkg,
+      deck: [],
+      cardCount: claudeCardCount,
+    };
   }
 
   const parser = new DeckParser({ ...input, files: allFiles });
@@ -244,6 +254,7 @@ export async function PrepareDeck(
         name: getDeckFilename(parser.name ?? input.name),
         apkg,
         deck: parser.payload,
+        cardCount: parser.totalCardCount(),
       };
     }
   }
@@ -253,5 +264,6 @@ export async function PrepareDeck(
     name: getDeckFilename(parser.name),
     apkg,
     deck: parser.payload,
+    cardCount: parser.totalCardCount(),
   };
 }

--- a/src/lib/parser/Package.ts
+++ b/src/lib/parser/Package.ts
@@ -1,8 +1,11 @@
 class Package {
   name: string;
 
-  constructor(name: string) {
+  cardCount: number;
+
+  constructor(name: string, cardCount: number = 0) {
     this.name = name;
+    this.cardCount = cardCount;
   }
 }
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -246,8 +246,17 @@ class UploadService {
         throw new Error(`Could not produce APKG for ${name}`);
       }
       const plen = Buffer.byteLength(apkg);
+      const totalCards = packages.reduce(
+        (sum, p) => sum + (p.cardCount ?? 0),
+        0
+      );
       res.set('Content-Type', 'application/apkg');
       res.set('Content-Length', plen.toString());
+      res.set('X-Card-Count', totalCards.toString());
+      res.set(
+        'Access-Control-Expose-Headers',
+        'File-Name, X-Card-Count'
+      );
       first.name = toText(first.name);
       try {
         res.set('File-Name', encodeURIComponent(first.name));

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -43,7 +43,7 @@ export const getPackagesFromZip = async (
     });
 
     if (deck) {
-      packages.push(new Package(deck.name));
+      packages.push(new Package(deck.name, deck.cardCount ?? 0));
     }
 
     return { packages };
@@ -61,7 +61,7 @@ export const getPackagesFromZip = async (
     });
 
     if (deck) {
-      packages.push(new Package(deck.name));
+      packages.push(new Package(deck.name, deck.cardCount ?? 0));
       cardCount += deck.deck.reduce((acc, d) => acc + d.cards.length, 0);
 
       checkFlashcardsLimits({

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -77,7 +77,7 @@ async function processFile(
     });
 
     if (d) {
-      packages.push(new Package(d.name));
+      packages.push(new Package(d.name, d.cardCount ?? 0));
     }
   }
   // Check if it's a compressed file


### PR DESCRIPTION
## Summary
Users have reported downloading an `.apkg`, importing into Anki, and only then discovering it's empty. This PR gives the frontend what it needs to warn before the download triggers.

- `Package` gains a `cardCount` field.
- `PrepareDeck` now returns `cardCount` — sourced from `parser.totalCardCount()` on the HTML path and the Claude branch's already-computed `deckInfo.reduce(...)` sum on the Claude path.
- `worker.ts` and `getPackagesFromZip.ts` thread the count into each `new Package(...)`.
- `handleSyncUpload` sums across packages and sets:
  - `X-Card-Count: <n>`
  - `Access-Control-Expose-Headers: File-Name, X-Card-Count` so browser JS can read it.

Pair PR on the web side (coming next) consumes the header and prompts the user when the count is 0.

## Out of scope
The async/Claude-job path still returns the `.apkg` via a separate download link. Wiring card count through there requires storing it on the `jobs` table (schema migration). Flagged as follow-up, not in this PR.

## Test plan
- [x] `pnpm exec tsc -p . --noEmit` clean.
- [x] `pnpm test` — 272 pass, no regressions.
- [ ] Manual: upload a file that yields zero cards → response headers include `X-Card-Count: 0`.
- [ ] Manual: upload a normal file → `X-Card-Count` matches what the logs report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)