### PR TITLE
refactor(route): redirect post-upload traffic to /downloads

### DIFF
--- a/src/controllers/DownloadController.ts
+++ b/src/controllers/DownloadController.ts
@@ -30,7 +30,7 @@ class DownloadController {
       console.error(error);
       if (this.service.isMissingDownloadError(error)) {
         this.service.deleteMissingFile(owner, key);
-        res.redirect('/uploads');
+        res.redirect('/downloads');
       } else {
         console.info('Download failed');
         console.error(error);

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -51,7 +51,7 @@ export default async function performConversion(
     const hasInProgressJob = await checkInProgress.execute(id, owner);
     if (!hasInProgressJob) {
       console.log(`job ${id} was not started. Job is already active.`);
-      return res ? res.redirect('/uploads') : null;
+      return res ? res.redirect('/downloads') : null;
     }
 
     const checkLimit = new CheckJobLimitUseCase(jobRepository);
@@ -66,7 +66,7 @@ export default async function performConversion(
         owner,
         reason: 'You have reached the limit of free jobs. Max 1 at a time.',
       });
-      return res ? res.redirect('/uploads') : null;
+      return res ? res.redirect('/downloads') : null;
     }
 
     console.log(`job ${id} is not active, starting`);


### PR DESCRIPTION
## Summary
Pair with [2anki/web#868](https://github.com/2anki/web/pull/868) which renames the Downloads page route. Server redirects users back to the page after uploads/conversions; these three call sites were pointed at \`/uploads\` and now point at \`/downloads\`.

- \`DownloadController\`: when a tracked file is missing on S3, redirect the user back to the listing.
- \`performConversion\`: early-return when a job is already active.
- \`performConversion\`: early-return when the free-tier job limit is hit.

Web keeps \`/uploads\` as a \`<Navigate replace>\` to \`/downloads\` so an older client build hitting the new server still lands correctly.

## Test plan
- [ ] Trigger a conversion while another job is active → redirected to \`/downloads\`.
- [ ] Hit the free-tier limit → redirected to \`/downloads\`.
- [ ] Open a download URL whose S3 object was deleted → redirected to \`/downloads\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)