### PR TITLE
refactor(route): point post-OAuth and fallback redirects at /notion

### DIFF
--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -93,17 +93,17 @@ class NotionController {
   async connect(req: Request, res: Response) {
     const { code } = req.query;
     if (!code) {
-      return res.redirect('/search');
+      return res.redirect('/notion');
     }
 
     try {
       const authorizationCode = code as string;
       await this.service.connectToNotion(authorizationCode, res.locals.owner);
-      return res.redirect('/search');
+      return res.redirect('/notion');
     } catch (err) {
       console.info('Connect to Notion failed');
       console.error(err);
-      return res.redirect('/search');
+      return res.redirect('/notion');
     }
   }
 

--- a/src/controllers/helpers/getRedirect.test.ts
+++ b/src/controllers/helpers/getRedirect.test.ts
@@ -10,22 +10,23 @@ const createMockRequest = (redirectParam?: string): Request => {
 
 describe('getRedirect security tests', () => {
   describe('should return safe default for missing redirect', () => {
-    it('should return /search when no redirect param', () => {
+    it('should return /notion when no redirect param', () => {
       const req = createMockRequest();
-      expect(getRedirect(req)).toBe('/search');
+      expect(getRedirect(req)).toBe('/notion');
     });
 
-    it('should return /search when redirect param is undefined', () => {
+    it('should return /notion when redirect param is undefined', () => {
       const req = createMockRequest(undefined);
-      expect(getRedirect(req)).toBe('/search');
+      expect(getRedirect(req)).toBe('/notion');
     });
   });
 
   describe('should allow valid internal paths', () => {
     const validPaths = [
+      '/notion',
       '/search',
       '/upload',
-      '/downloads', 
+      '/downloads',
       '/favorites',
       '/templates',
       '/pricing',
@@ -60,7 +61,7 @@ describe('getRedirect security tests', () => {
     maliciousUrls.forEach(url => {
       it(`should block malicious URL: ${url}`, () => {
         const req = createMockRequest(url);
-        expect(getRedirect(req)).toBe('/search');
+        expect(getRedirect(req)).toBe('/notion');
       });
     });
   });
@@ -95,7 +96,7 @@ describe('getRedirect security tests', () => {
     invalidPaths.forEach(path => {
       it(`should block invalid internal path: ${path}`, () => {
         const req = createMockRequest(path);
-        expect(getRedirect(req)).toBe('/search');
+        expect(getRedirect(req)).toBe('/notion');
       });
     });
   });
@@ -103,17 +104,17 @@ describe('getRedirect security tests', () => {
   describe('should handle edge cases', () => {
     it('should block empty string', () => {
       const req = createMockRequest('');
-      expect(getRedirect(req)).toBe('/search');
+      expect(getRedirect(req)).toBe('/notion');
     });
 
     it('should block invalid URL formats', () => {
       const req = createMockRequest('not-a-url');
-      expect(getRedirect(req)).toBe('/search');
+      expect(getRedirect(req)).toBe('/notion');
     });
 
     it('should block non-HTTPS external URLs (except localhost)', () => {
       const req = createMockRequest('http://2anki.net');
-      expect(getRedirect(req)).toBe('/search');
+      expect(getRedirect(req)).toBe('/notion');
     });
   });
 });

--- a/src/controllers/helpers/getRedirect.ts
+++ b/src/controllers/helpers/getRedirect.ts
@@ -2,6 +2,7 @@ import { Request } from 'express';
 import { ALLOWED_ORIGINS } from '../../lib/constants';
 
 const ALLOWED_REDIRECT_PATHS = [
+  '/notion',
   '/search',
   '/upload',
   '/downloads',
@@ -53,7 +54,7 @@ export const getRedirect = (req: Request): string => {
   const redirectParam = req.query.redirect?.toString();
 
   if (!redirectParam) {
-    return '/search';
+    return '/notion';
   }
 
   if (isValidRedirectUrl(redirectParam)) {
@@ -61,5 +62,5 @@ export const getRedirect = (req: Request): string => {
   }
 
   // If redirect URL is not valid, return safe default
-  return '/search';
+  return '/notion';
 };

--- a/src/routes/DefaultRouter.ts
+++ b/src/routes/DefaultRouter.ts
@@ -56,7 +56,7 @@ const DefaultRouter = () => {
    *             schema:
    *               $ref: '#/components/schemas/Error'
    */
-  router.get('/search', async (req, res) => {
+  router.get(['/notion', '/search'], async (req, res) => {
     const isLoggedIn = await ensureIsLoggedIn(req, res);
     if (!isLoggedIn) {
       return;


### PR DESCRIPTION
## Summary
Pair with [2anki/web#870](https://github.com/2anki/web/pull/870) which renames \`/search\` → \`/notion\`. Three places on the server redirect users back to the page; they all point at \`/notion\` now. Both paths stay accepted so in-flight OAuth started against an older client still lands safely.

- **NotionController** — the three post-OAuth redirects (no auth code, connect success, connect failure) go to \`/notion\`.
- **getRedirect** — default return value is now \`/notion\`; the allowed-redirect whitelist now accepts both \`/notion\` and \`/search\`.
- **DefaultRouter** — the SSR handler responds to both \`/notion\` and \`/search\`.
- **getRedirect tests** — default-value assertions updated.

## Test plan
- [ ] Kick off a fresh Notion OAuth → lands on \`/notion\` post-connect.
- [ ] Hit a redirect endpoint with \`?redirect=/notion\` → passes validation, redirects to \`/notion\`.
- [ ] Hit one with \`?redirect=/search\` → still passes validation (legacy).
- [ ] Hit one with \`?redirect=https://evil.com\` → fallback to \`/notion\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)