### PR TITLE
fix(claude): register audio files so they ship with the .apkg

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -1,6 +1,7 @@
 import {
   looksLikeEmptyContentExplanation,
   EMPTY_CONTENT_USER_MESSAGE,
+  rewriteAudioAnchors,
 } from './ClaudeService';
 
 describe('looksLikeEmptyContentExplanation', () => {
@@ -30,6 +31,66 @@ describe('looksLikeEmptyContentExplanation', () => {
 
   it('does not match an empty JSON array', () => {
     expect(looksLikeEmptyContentExplanation('[]')).toBe(false);
+  });
+});
+
+describe('rewriteAudioAnchors', () => {
+  it('replaces an mp3 anchor with a [sound:] token and lists the filename', () => {
+    const { back, audioFilenames } = rewriteAudioAnchors(
+      '<p>Listen: <a href="pronunciation.mp3">play</a></p>'
+    );
+    expect(audioFilenames).toEqual(['pronunciation.mp3']);
+    expect(back).toContain('[sound:pronunciation.mp3]');
+    expect(back).not.toContain('<a href');
+  });
+
+  it('strips the wrapping <figure> when present', () => {
+    const { back } = rewriteAudioAnchors(
+      '<figure><a href="word.ogg">🔊</a><figcaption>word</figcaption></figure>'
+    );
+    expect(back).not.toContain('<figure');
+    expect(back).not.toContain('<a');
+    expect(back).toContain('[sound:word.ogg]');
+  });
+
+  it('deduplicates if the same file is referenced twice on one card', () => {
+    const { audioFilenames, back } = rewriteAudioAnchors(
+      '<a href="a.mp3">x</a><a href="a.mp3">y</a>'
+    );
+    expect(audioFilenames).toEqual(['a.mp3']);
+    expect(back.match(/\[sound:a\.mp3\]/g)).toHaveLength(1);
+  });
+
+  it('leaves http(s) audio links alone', () => {
+    const input = '<a href="https://example.com/hello.mp3">play</a>';
+    const { back, audioFilenames } = rewriteAudioAnchors(input);
+    expect(audioFilenames).toEqual([]);
+    expect(back).toContain(input);
+  });
+
+  it('decodes URL-encoded filenames before emitting the sound token', () => {
+    const { back, audioFilenames } = rewriteAudioAnchors(
+      '<a href="my%20word.m4a">play</a>'
+    );
+    expect(audioFilenames).toEqual(['my word.m4a']);
+    expect(back).toContain('[sound:my word.m4a]');
+  });
+
+  it('supports ogg, wav, flac, m4a, aac, opus', () => {
+    const exts = ['ogg', 'wav', 'flac', 'm4a', 'aac', 'opus'];
+    for (const ext of exts) {
+      const { audioFilenames } = rewriteAudioAnchors(
+        `<a href="clip.${ext}">x</a>`
+      );
+      expect(audioFilenames).toEqual([`clip.${ext}`]);
+    }
+  });
+
+  it('does nothing when the card has no audio links', () => {
+    const input = '<p>No audio here</p><img src="x.png"/>';
+    const { back, audioFilenames } = rewriteAudioAnchors(input);
+    expect(audioFilenames).toEqual([]);
+    expect(back).toBe(input);
   });
 });
 

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -139,6 +139,43 @@ function stripPathsFromCardHtml(html: string): string {
   return body.length ? body.html() ?? html : html;
 }
 
+const AUDIO_EXTENSIONS = /\.(mp3|ogg|oga|opus|wav|flac|m4a|aac)$/i;
+
+function isLocalAudioHref(href: string): boolean {
+  if (!href) return false;
+  if (href.startsWith('http://') || href.startsWith('https://')) return false;
+  return AUDIO_EXTENSIONS.test(href);
+}
+
+interface AudioRewriteResult {
+  back: string;
+  audioFilenames: string[];
+}
+
+export function rewriteAudioAnchors(back: string): AudioRewriteResult {
+  const $ = cheerio.load(back);
+  const audioFilenames: string[] = [];
+  let mutated = false;
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href') ?? '';
+    if (!isLocalAudioHref(href)) return;
+    const filename = decodeURIComponent(href).split('/').pop() ?? href;
+    if (!audioFilenames.includes(filename)) audioFilenames.push(filename);
+    const figure = $(el).closest('figure');
+    if (figure.length) {
+      figure.remove();
+    } else {
+      $(el).remove();
+    }
+    mutated = true;
+  });
+  if (!mutated) return { back, audioFilenames };
+  const body = $('body');
+  const stripped = body.length ? body.html() ?? back : back;
+  const tokens = audioFilenames.map((name) => `[sound:${name}]`).join('');
+  return { back: stripped + tokens, audioFilenames };
+}
+
 function expandCompactDeckInfo(compact: CompactDeck[], availableMediaFiles: string[], style: string | null): DeckInfo[] {
   return compact.map((d) => ({
     name: d.deck,
@@ -152,17 +189,29 @@ function expandCompactDeckInfo(compact: CompactDeck[], availableMediaFiles: stri
       inputModelName: 'n2a-input',
       useNotionId: true,
     },
-    cards: d.cards.map((c) => ({
-      name: stripPathsFromCardHtml(c.q),
-      back: stripPathsFromCardHtml(c.a),
-      tags: c.tags ?? [],
-      cloze: c.cloze ?? false,
-      number: 0,
-      enableInput: false,
-      answer: '',
-      notionId: deterministicId(c.q),
-      media: (c.media ?? []).map((m) => resolveMediaPath(m, availableMediaFiles)),
-    })),
+    cards: d.cards.map((c) => {
+      const { back: rewrittenBack, audioFilenames } = rewriteAudioAnchors(
+        stripPathsFromCardHtml(c.a)
+      );
+      const declaredMedia = (c.media ?? []).map((m) =>
+        resolveMediaPath(m, availableMediaFiles)
+      );
+      const audioMedia = audioFilenames.map((name) =>
+        resolveMediaPath(name, availableMediaFiles)
+      );
+      const media = Array.from(new Set([...declaredMedia, ...audioMedia]));
+      return {
+        name: stripPathsFromCardHtml(c.q),
+        back: rewrittenBack,
+        tags: c.tags ?? [],
+        cloze: c.cloze ?? false,
+        number: 0,
+        enableInput: false,
+        answer: '',
+        notionId: deterministicId(c.q),
+        media,
+      };
+    }),
   }));
 }
 


### PR DESCRIPTION
## Summary
DeckParser has always converted a Notion audio anchor into Anki's \`[sound:…]\` syntax and registered the file with the exporter. The Claude conversion path didn't — it left \`<a href=\"foo.mp3\">\` in the card back untouched and never added the filename to the card's \`media\` array, so audio blocks showed as a plain dead link in Anki with nothing bundled into the .apkg.

## Fix
Add a \`rewriteAudioAnchors\` step to \`expandCompactDeckInfo\` that runs per card:

- Detect local \`<a href>\` links pointing at common audio extensions (mp3 / ogg / oga / opus / wav / flac / m4a / aac), decode the filename, and emit a \`[sound:<filename>]\` token at the end of the back HTML.
- Drop the original \`<a>\` (and its enclosing \`<figure>\` if any) so the dead link disappears.
- Deduplicate within a card and merge the resolved path into the card's \`media[]\` alongside anything Claude already listed — the Python packager's \`media_files\` list then actually includes the bytes.

No changes to DeckParser — it already works. No changes to the Python packager or the APKG preview.

## Test plan
- [x] 7 new unit tests on \`rewriteAudioAnchors\` — basic mp3, \`<figure>\` stripping, dedup, external URL passthrough, URL-decoded filenames, each supported extension, no-op path.
- [x] Manual: convert a Notion page containing a recorded audio block via the Claude path → open the generated .apkg in Anki → the back side plays the audio inline.
- [ ] Manual: same page via the DeckParser path → no regression (the only touched function is ClaudeService-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)