### PR TITLE
fix(upload): guard isAnkiDeck against non-string originalname

### DIFF
--- a/src/lib/upload/getUploadValidationError.test.ts
+++ b/src/lib/upload/getUploadValidationError.test.ts
@@ -71,4 +71,10 @@ describe('getUploadValidationError', () => {
     );
     expect(error).toBeNull();
   });
+
+  test('does not throw if a file arrives with a non-string originalname', () => {
+    const suspect = makeFile({ size: 1024 });
+    (suspect as unknown as { originalname: unknown }).originalname = 42;
+    expect(() => getUploadValidationError([suspect])).not.toThrow();
+  });
 });

--- a/src/lib/upload/getUploadValidationError.ts
+++ b/src/lib/upload/getUploadValidationError.ts
@@ -1,7 +1,9 @@
 import { UploadedFile } from '../storage/types';
 
 function isAnkiDeck(file: UploadedFile): boolean {
-  return file.originalname.toLowerCase().endsWith('.apkg');
+  return typeof file.originalname === 'string'
+    ? file.originalname.toLowerCase().endsWith('.apkg')
+    : false;
 }
 
 function isEmptyFile(file: UploadedFile): boolean {


### PR DESCRIPTION
## Why

From the prod error-log audit: **20 hits of \`TypeError: Cannot read properties of undefined (reading 'toLowerCase')\`** at \`getUploadValidationError.ts:4\`. The pre-existing \`if (!file.originalname)\` guard catches \`undefined\`/empty string but not non-string values, and something upstream occasionally passes one.

## Change

Guard \`isAnkiDeck\` with a \`typeof === 'string'\` check. Non-strings fall through as \"not an apkg\" — conversion continues; the rest of validation still runs.

## Test

New case in \`getUploadValidationError.test.ts\` feeds a numeric \`originalname\` and asserts no throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)