### PR TITLE
fix(data): guard knex queries against undefined owner

### DIFF
--- a/src/data_layer/DownloadRepository.ts
+++ b/src/data_layer/DownloadRepository.ts
@@ -8,11 +8,21 @@ class DownloadRepository {
   }
 
   getFile(owner: string, key: string) {
+    if (owner == null) {
+      console.warn('[DownloadRepository] getFile called with no owner');
+      return Promise.resolve(undefined);
+    }
     const query = { key, owner };
     return this.database(this.table).where(query).returning(['key']).first();
   }
 
   deleteMissingFile(owner: string, key: string) {
+    if (owner == null) {
+      console.warn(
+        '[DownloadRepository] deleteMissingFile called with no owner'
+      );
+      return Promise.resolve(0);
+    }
     console.warn(`Deleting missing file ${key} for ${owner}`);
     return this.database.table('uploads').where({ owner, key }).delete();
   }

--- a/src/data_layer/NotionRespository.ts
+++ b/src/data_layer/NotionRespository.ts
@@ -69,6 +69,10 @@ class NotionRepository implements INotionRepository {
    * @returns unhashed token
    */
   async getNotionToken(owner: string): Promise<string | null> {
+    if (owner == null) {
+      console.warn('[NotionRepository] getNotionToken called with no owner');
+      return null;
+    }
     const row = await this.database('notion_tokens')
       .where({ owner })
       .returning('token')

--- a/src/data_layer/UploadRespository.test.ts
+++ b/src/data_layer/UploadRespository.test.ts
@@ -1,0 +1,44 @@
+import UploadRepository from './UploadRespository';
+
+describe('UploadRepository owner guards', () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  afterEach(() => warn.mockClear());
+
+  function makeRepo() {
+    const called: string[] = [];
+    const db = () => {
+      called.push('db(table)');
+      return {
+        where: () => {
+          called.push('where');
+          return {
+            orderBy: () => ({ returning: () => Promise.resolve([]) }),
+          };
+        },
+        del: () => ({ where: () => Promise.resolve(0) }),
+      };
+    };
+    return { repo: new UploadRepository(db as unknown as never), called };
+  }
+
+  it('returns empty list and skips query when owner is undefined', async () => {
+    const { repo, called } = makeRepo();
+    const result = await repo.getUploadsByOwner(
+      undefined as unknown as number
+    );
+    expect(result).toEqual([]);
+    expect(called).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('returns 0 and skips delete when owner is null', async () => {
+    const { repo, called } = makeRepo();
+    const result = await repo.deleteUpload(
+      null as unknown as number,
+      'some-key'
+    );
+    expect(result).toBe(0);
+    expect(called).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -17,10 +17,20 @@ class UploadRepository implements IUploadRepository {
   constructor(private readonly database: Knex) {}
 
   deleteUpload(owner: number, key: string): Promise<number> {
+    if (owner == null) {
+      console.warn('[UploadRepository] deleteUpload called with no owner');
+      return Promise.resolve(0);
+    }
     return this.database(this.table).del().where({ owner, key });
   }
 
   getUploadsByOwner(owner: number): Promise<Uploads[]> {
+    if (owner == null) {
+      console.warn(
+        '[UploadRepository] getUploadsByOwner called with no owner'
+      );
+      return Promise.resolve([]);
+    }
     return this.database(this.table)
       .where({ owner: owner })
       .orderBy('id', 'desc')


### PR DESCRIPTION
## Why

Log audit found **50 hits across 9 days** of:

> \`Error: Undefined binding(s) detected when compiling … Undefined column(s): [owner] query: …\`

from three queries: \`uploads where owner\` (both the list + key-scoped variants) and \`notion_tokens where owner\`. Root cause is upstream — \`res.locals.owner\` isn't populated on some paths — but the symptom is a 500 for the user. This PR stops the bleed at the repository layer.

## Change

Each repository method short-circuits when \`owner == null\`, logs a tagged warning, and returns the "no rows" value for its shape (\`[]\`, \`undefined\`, \`0\`, \`null\`). Two tests on \`UploadRepository\` assert the guard skips the knex call entirely.

The warnings give us a clean signal to grep for to find the upstream bug (probably a middleware-ordering issue on some auth path).

## Test plan
- [x] \`pnpm test src/data_layer/UploadRespository.test.ts\` green.
- [ ] Deploy, then \`pm2 logs server --raw --nostream --lines 2000 | grep 'called with no owner'\` should surface the upstream caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)