### PR TITLE
fix(notion): route audio/file downloads through downloadMediaOrSkip

### DIFF
--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -8,7 +8,6 @@ import {
   ListBlockChildrenResponse,
   PageObjectResponse,
 } from '@notionhq/client/build/src/api-endpoints';
-import axios from 'axios';
 
 import getDeckName from '../../../lib/anki/getDeckname';
 import sanitizeTags from '../../../lib/anki/sanitizeTags';
@@ -99,8 +98,10 @@ class BlockHandler {
     }
     const newName = getUniqueFileName(url);
 
-    const audioRequest = await axios.get(url, { responseType: 'arraybuffer' });
-    const contents = audioRequest.data;
+    const contents = await downloadMediaOrSkip(url);
+    if (contents == null) {
+      return '';
+    }
     this.exporter.addMedia(newName, contents);
     return `[sound:${newName}]`;
   }
@@ -111,8 +112,10 @@ class BlockHandler {
       return '';
     }
     const newName = getUniqueFileName(url);
-    const fileRequest = await axios.get(url, { responseType: 'arraybuffer' });
-    const contents = fileRequest.data;
+    const contents = await downloadMediaOrSkip(url);
+    if (contents == null) {
+      return '';
+    }
     this.exporter.addMedia(newName, contents);
     return `<embed src="${newName}" />`;
   }


### PR DESCRIPTION
## Why

Log audit: **110 hits of \`AxiosError: Request failed with status code 403\`** on \`prod-files-secure.s3.us-west-2.amazonaws.com\`. These are Notion's signed image URLs which expire after 1 hour (\`X-Amz-Expires=3600\`). When a conversion runs past that window, media fetches 403.

\`embedImage\` already handles this via \`downloadMediaOrSkip\` (returns \`null\` on 403/404, the deck builds without the asset). \`embedAudioFile\` and \`embedFile\` were still using raw \`axios.get\` — one expired audio URL aborts the whole conversion with no deck delivered.

## Change

Route both through the existing \`downloadMediaOrSkip\` helper. Missing media → empty string from the embed function, deck continues. Existing test coverage on \`downloadMediaOrSkip\` holds.

## Test plan
- [x] Typecheck clean; existing \`downloadMediaOrSkip.test.ts\` still passes.
- [ ] After deploy, 403s should stop showing as uncaught errors; look for \`Skipping media fetch for …\` warn lines instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)