### PR TITLE
fix(logging): downgrade Notion Unauthorized to info

### DIFF
--- a/src/lib/sendErrorResponse.ts
+++ b/src/lib/sendErrorResponse.ts
@@ -1,6 +1,14 @@
 import { Response } from 'express';
 
-import { APIResponseError } from '@notionhq/client/build/src';
+import { APIErrorCode, APIResponseError } from '@notionhq/client';
+
+function isExpectedUserError(error: unknown): boolean {
+  if (!(error instanceof APIResponseError)) return false;
+  // Notion returning Unauthorized means the user revoked access or
+  // the stored token expired — it's an expected outcome that triggers
+  // a reconnect flow, not a server bug.
+  return error.code === APIErrorCode.Unauthorized;
+}
 
 export default function sendErrorResponse(
   error: Error | APIResponseError | unknown,
@@ -14,7 +22,14 @@ export default function sendErrorResponse(
     body = { message: error.message };
   }
 
-  console.error(error);
+  if (isExpectedUserError(error)) {
+    console.info(
+      '[notion] expected user error',
+      (error as APIResponseError).code
+    );
+  } else {
+    console.error(error);
+  }
 
   return response.status(status).json(body).send();
 }


### PR DESCRIPTION
## Why

Log audit: **16 hits of \`APIResponseError: API token is invalid. You can renew it …\`** going to \`server-error*.log\`. This isn't a bug — it's the expected signal that a user revoked the Notion integration or the token expired, and it triggers a reconnect prompt on the client. Currently \`sendErrorResponse\` \`console.error\`s every error including this one.

## Change

Keep the error stream for actual errors; route \`APIErrorCode.Unauthorized\` from Notion through \`console.info\` with a tagged \`[notion] expected user error <code>\` summary. HTTP status + body returned to the client are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)