### PR TITLE
fix(notion): validate page id before pages.retrieve

### DIFF
--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -22,6 +22,7 @@ import { getBlockCache } from './helpers/getBlockCache';
 import { uniqueTimerLabel } from './helpers/uniqueTimerLabel';
 import { withRetry } from './helpers/withRetry';
 import { getDatabase } from '../../data_layer';
+import { isValidNotionId } from './isValidNotionId';
 import { ValidNotionType } from './types';
 
 const DEFAULT_PAGE_SIZE_LIMIT = 100 * 2;
@@ -47,6 +48,13 @@ class NotionAPIWrapper {
   }
 
   getPage(id: string): Promise<GetPageResponse | null> {
+    if (!isValidNotionId(id)) {
+      console.info(
+        '[notion] skipping pages.retrieve for non-UUID id:',
+        JSON.stringify(id).slice(0, 80)
+      );
+      return Promise.resolve(null);
+    }
     return withRetry(() => this.notion.pages.retrieve({ page_id: id }), {
       label: 'pages.retrieve',
     });

--- a/src/services/NotionService/isValidNotionId.test.ts
+++ b/src/services/NotionService/isValidNotionId.test.ts
@@ -1,0 +1,43 @@
+import { isValidNotionId } from './isValidNotionId';
+
+describe('isValidNotionId', () => {
+  it('accepts a dashed UUID', () => {
+    expect(
+      isValidNotionId('34440b54-5033-80e7-829e-f1e74c5295fd')
+    ).toBe(true);
+  });
+
+  it('accepts a 32-hex undashed id', () => {
+    expect(isValidNotionId('34440b545033801a829ef1e74c5295fd')).toBe(true);
+  });
+
+  it('is case-insensitive on hex', () => {
+    expect(
+      isValidNotionId('34440B54-5033-80E7-829E-F1E74C5295FD')
+    ).toBe(true);
+  });
+
+  it('rejects plain text (a leaked page title)', () => {
+    expect(isValidNotionId('03 Obstructive pulmonary disease')).toBe(false);
+    expect(isValidNotionId('lecture 11: ciliary body & accom')).toBe(false);
+  });
+
+  it('rejects empty / non-string values', () => {
+    expect(isValidNotionId('')).toBe(false);
+    expect(isValidNotionId(undefined)).toBe(false);
+    expect(isValidNotionId(null)).toBe(false);
+    expect(isValidNotionId(42 as unknown)).toBe(false);
+  });
+
+  it('rejects almost-UUIDs', () => {
+    expect(
+      isValidNotionId('34440b54-5033-80e7-829e-f1e74c5295f')
+    ).toBe(false);
+    expect(
+      isValidNotionId('34440b54-5033-80e7-829e-f1e74c5295fdff')
+    ).toBe(false);
+    expect(
+      isValidNotionId('34440b54_5033_80e7_829e_f1e74c5295fd')
+    ).toBe(false);
+  });
+});

--- a/src/services/NotionService/isValidNotionId.ts
+++ b/src/services/NotionService/isValidNotionId.ts
@@ -1,0 +1,12 @@
+// Notion accepts both dashed and undashed 32-hex UUIDs as resource
+// identifiers. Anything else is a client mistake (often a page title
+// leaked into the id slot) and should be rejected without burning a
+// Notion API call.
+
+const DASHED = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UNDASHED = /^[0-9a-f]{32}$/i;
+
+export function isValidNotionId(id: unknown): id is string {
+  if (typeof id !== 'string') return false;
+  return DASHED.test(id) || UNDASHED.test(id);
+}


### PR DESCRIPTION
## Why

Log audit: **10 hits of \`APIResponseError: path failed validation: path.page_id should be a valid uuid, instead was '<text>'\`** — page titles (\"03 Obstructive pulmonary disease\", \"lecture 11: ciliary body & accom\") getting handed to Notion as ids. The request burns a Notion API call and surfaces to the user as a 500.

## Change

New \`isValidNotionId\` helper (accepts dashed and undashed 32-hex UUIDs). \`NotionAPIWrapper.getPage\` validates the input and returns \`null\` — the same shape callers already handle for \"page the user doesn't have access to\" — instead of calling Notion. Bad ids are tagged-info logged once so the upstream bug can be located.

## Test plan
- [x] 6 cases on the helper (dashed / undashed / case / plain text / empty / almost-UUID).
- [ ] After deploy: \`pm2 logs server --raw --nostream --lines 2000 | grep '\\[notion\\] skipping pages.retrieve'\` surfaces the calling context to fix the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)