### PR TITLE
chore(deps): dependency updates 2026-05-04 (stripe 22, TypeScript 6, security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "dependencies": {
     "@2anki/csv-to-apkg": "^1.4.4",
-    "@anthropic-ai/sdk": "^0.91.0",
+    "@anthropic-ai/sdk": "^0.91.1",
     "@google-cloud/vertexai": "^1.9.0",
     "@notionhq/client": "^5.18.0",
     "@sendgrid/mail": "^8.1.3",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "pretty-quick": "^4.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "~5.7.0"
+    "typescript": "~6.0.3"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "archiver": "^7.0.1",
     "aws-sdk": "^2.1502.0",
     "axios": "^1.13.5",
-    "bcryptjs": "^2.4.3",
+    "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.9.0",
     "cheerio": "^1.0.0",
     "cookie-parser": "^1.4.6",
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@types/archiver": "^7.0.0",
     "@types/base-64": "^1.0.0",
-    "@types/bcryptjs": "^2.4.6",
+    "@types/bcryptjs": "^3.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/cheerio": "^1.0.0",
     "@types/cookie-parser": "^1.4.6",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-dom": "^19.2.4",
     "sanitize-html": "^2.17.3",
     "showdown": "^2.1.0",
-    "stripe": "^16.8.0",
+    "stripe": "^22.0.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "cheerio": "^1.0.0",
     "cookie-parser": "^1.4.6",
     "crypto-js": "^4.2.0",
-    "domhandler": "5.0.3",
+    "domhandler": "6.0.1",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "express-session": "^1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       domhandler:
-        specifier: 5.0.3
-        version: 5.0.3
+        specifier: 6.0.1
+        version: 6.0.1
       dotenv:
         specifier: ^17.0.0
         version: 17.4.2
@@ -2214,9 +2214,17 @@ packages:
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
+
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -7047,9 +7055,15 @@ snapshots:
 
   domelementtype@2.3.0: {}
 
+  domelementtype@3.0.0: {}
+
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   domutils@3.2.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^1.13.5
         version: 1.15.2
       bcryptjs:
-        specifier: ^2.4.3
-        version: 2.4.3
+        specifier: ^3.0.3
+        version: 3.0.3
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -158,8 +158,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.2
       '@types/bcryptjs':
-        specifier: ^2.4.6
-        version: 2.4.6
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
@@ -1334,8 +1334,9 @@ packages:
   '@types/base-64@1.0.2':
     resolution: {integrity: sha512-uPgKMmM9fmn7I+Zi6YBqctOye4SlJsHKcisjHIMWpb2YKZRc36GpKyNuQ03JcT+oNXg1m7Uv4wU94EVltn8/cw==}
 
-  '@types/bcryptjs@2.4.6':
-    resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
+  '@types/bcryptjs@3.0.0':
+    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
+    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
 
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
@@ -1785,8 +1786,9 @@ packages:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
 
-  bcryptjs@2.4.3:
-    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
+    hasBin: true
 
   better-sqlite3@12.9.0:
     resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
@@ -6163,7 +6165,9 @@ snapshots:
 
   '@types/base-64@1.0.2': {}
 
-  '@types/bcryptjs@2.4.6': {}
+  '@types/bcryptjs@3.0.0':
+    dependencies:
+      bcryptjs: 3.0.3
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
@@ -6621,7 +6625,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.1.2
 
-  bcryptjs@2.4.3: {}
+  bcryptjs@3.0.3: {}
 
   better-sqlite3@12.9.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       stripe:
-        specifier: ^16.8.0
-        version: 16.12.0
+        specifier: ^22.0.2
+        version: 22.0.2(@types/node@25.6.0)
       swagger-jsdoc:
         specifier: ^6.2.8
         version: 6.2.8(openapi-types@12.1.3)
@@ -4126,9 +4126,14 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  stripe@16.12.0:
-    resolution: {integrity: sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==}
-    engines: {node: '>=12.*'}
+  stripe@22.0.2:
+    resolution: {integrity: sha512-2/BLrQ3oB1zlNfeL/LfHFjTGx6EQn0j+ztrrTJHuDjV5VVIpk92oSDaxyKLUr3pG3dnee2LZqhFUv2Bf0G1/3g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   strnum@2.2.2:
     resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
@@ -9288,10 +9293,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  stripe@16.12.0:
-    dependencies:
+  stripe@22.0.2(@types/node@25.6.0):
+    optionalDependencies:
       '@types/node': 25.6.0
-      qs: 6.15.0
 
   strnum@2.2.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,10 +240,10 @@ importers:
         version: 3.1.14
       prettier:
         specifier: ^3.2.5
-        version: 3.8.1
+        version: 3.8.3
       pretty-quick:
         specifier: ^4.0.0
-        version: 4.2.2(prettier@3.8.1)
+        version: 4.2.2(prettier@3.8.3)
       ts-jest:
         specifier: ^29.1.1
         version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3)))(typescript@5.7.3)
@@ -3721,8 +3721,8 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -8840,7 +8840,7 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   pretty-format@30.3.0:
     dependencies:
@@ -8852,14 +8852,14 @@ snapshots:
     dependencies:
       parse-ms: 2.1.0
 
-  pretty-quick@4.2.2(prettier@3.8.1):
+  pretty-quick@4.2.2(prettier@3.8.3):
     dependencies:
       '@pkgr/core': 0.2.9
       ignore: 7.0.5
       mri: 1.2.0
       picocolors: 1.1.1
       picomatch: 4.0.4
-      prettier: 3.8.1
+      prettier: 3.8.3
       tinyexec: 0.3.2
       tslib: 2.8.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         specifier: ^1.4.4
         version: 1.4.9
       '@anthropic-ai/sdk':
-        specifier: ^0.91.0
+        specifier: ^0.91.1
         version: 0.91.1
       '@google-cloud/vertexai':
         specifier: ^1.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
         version: 10.1.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))
+        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
       lint-staged:
         specifier: ^16.1.2
         version: 16.4.0
@@ -246,13 +246,13 @@ importers:
         version: 4.2.2(prettier@3.8.3)
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@25.6.0)(typescript@5.7.3)
+        version: 10.9.2(@types/node@25.6.0)(typescript@6.0.3)
       typescript:
-        specifier: ~5.7.0
-        version: 5.7.3
+        specifier: ~6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -4332,8 +4332,8 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5458,7 +5458,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))':
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -5473,7 +5473,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))
+      jest-config: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -7849,15 +7849,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3)):
+  jest-cli@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))
+      jest-config: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -7868,7 +7868,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3)):
+  jest-config@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -7895,7 +7895,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.6.0
-      ts-node: 10.9.2(@types/node@25.6.0)(typescript@5.7.3)
+      ts-node: 10.9.2(@types/node@25.6.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8115,12 +8115,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3)):
+  jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))
+      jest-cli: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9437,18 +9437,18 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3)))(typescript@5.7.3):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3))
+      jest: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.7.4
       type-fest: 4.41.0
-      typescript: 5.7.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.0
@@ -9457,7 +9457,7 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-node@10.9.2(@types/node@25.6.0)(typescript@5.7.3):
+  ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -9471,7 +9471,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.7.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -9507,7 +9507,7 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript@5.7.3: {}
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -9,7 +9,7 @@ import AuthenticationService from '../../services/AuthenticationService';
 import { getStripe, updateStoreSubscription } from '../../lib/integrations/stripe';
 import { extractTokenFromCookies } from './extractTokenFromCookies';
 import SubscriptionService from '../../services/SubscriptionService';
-import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 import { Knex } from 'knex';
 
 async function persistStripeSession(database: Knex, sessionId: string): Promise<boolean> {
@@ -26,7 +26,7 @@ async function persistStripeSession(database: Knex, sessionId: string): Promise<
     const customerId = typeof subscription.customer === 'string'
       ? subscription.customer
       : subscription.customer.id;
-    const customer = await stripe.customers.retrieve(customerId) as Stripe.Customer;
+    const customer = await stripe.customers.retrieve(customerId) as StripeTypes.Customer;
     await updateStoreSubscription(database, customer, subscription);
   }
   return true;

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -341,7 +341,7 @@ class UsersController {
           id: sub.id,
           status: sub.status,
           cancel_at_period_end: sub.cancel_at_period_end === true,
-          current_period_end: sub.current_period_end ?? null,
+          cancel_at: sub.cancel_at ?? null,
           canceled_at: sub.canceled_at ?? null,
           plan: price
             ? {

--- a/src/lib/integrations/stripe.ts
+++ b/src/lib/integrations/stripe.ts
@@ -1,4 +1,5 @@
 import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 import { Knex } from 'knex';
 
 const stripe = new Stripe(process.env.STRIPE_KEY!);
@@ -6,7 +7,7 @@ const stripe = new Stripe(process.env.STRIPE_KEY!);
 export const getStripe = () => stripe;
 
 export const getCustomerId = (
-  customer: string | Stripe.Customer | Stripe.DeletedCustomer | null
+  customer: string | StripeTypes.Customer | StripeTypes.DeletedCustomer | null
 ) => {
   if (typeof customer === 'string') {
     return customer;
@@ -16,23 +17,17 @@ export const getCustomerId = (
 
 export const updateStoreSubscription = async (
   db: Knex,
-  customer: Stripe.Customer,
-  subscription: Stripe.Subscription
+  customer: StripeTypes.Customer,
+  subscription: StripeTypes.Subscription
 ) => {
   const email = customer.email;
-  // A subscription should be considered active if:
-  // 1. Its status is 'active' AND
-  // 2. Either it's not scheduled for cancellation OR it is scheduled but hasn't reached the end date yet
   const isActive = subscription.status === 'active';
   const isCancelScheduled = subscription.cancel_at_period_end === true;
 
-  // If cancellation is scheduled, we need to check if we're still within the paid period
   let shouldRemainActive = isActive;
   if (isActive && isCancelScheduled) {
-    // current_period_end is in seconds since epoch, so convert to milliseconds for Date
-    const periodEndDate = new Date(subscription.current_period_end * 1000);
+    const periodEndDate = new Date((subscription.cancel_at ?? 0) * 1000);
     const currentDate = new Date();
-    // Keep active if current date is before the period end date
     shouldRemainActive = currentDate < periodEndDate;
   }
 

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.test.ts
@@ -68,7 +68,7 @@ describe('reconcileActiveSubscriptions', () => {
       id: 'sub_1',
       status: 'active',
       cancel_at_period_end: true,
-      current_period_end: pastSeconds,
+      cancel_at: pastSeconds,
     }));
 
     await reconcileActiveSubscriptions(db as any, stripe);

--- a/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/reconcileActiveSubscriptions.ts
@@ -1,5 +1,5 @@
 import { Knex } from 'knex';
-import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 
 interface ActiveSubscriptionRow {
   id: number;
@@ -24,11 +24,11 @@ function parseSubscriptionId(payload: unknown): string | null {
   return null;
 }
 
-function stripeReportsInactive(subscription: Stripe.Subscription): boolean {
+function stripeReportsInactive(subscription: StripeTypes.Subscription): boolean {
   if (subscription.status !== 'active') return true;
 
-  if (subscription.cancel_at_period_end && subscription.current_period_end) {
-    const periodEndMs = subscription.current_period_end * 1000;
+  if (subscription.cancel_at_period_end && subscription.cancel_at) {
+    const periodEndMs = subscription.cancel_at * 1000;
     return Date.now() >= periodEndMs;
   }
   return false;
@@ -37,7 +37,7 @@ function stripeReportsInactive(subscription: Stripe.Subscription): boolean {
 async function deactivateRow(
   db: Knex,
   row: ActiveSubscriptionRow,
-  subscription?: Stripe.Subscription
+  subscription?: StripeTypes.Subscription
 ): Promise<void> {
   const update: { active: boolean; payload?: string } = { active: false };
   if (subscription) {
@@ -51,7 +51,7 @@ async function deactivateRow(
 
 export async function reconcileActiveSubscriptions(
   db: Knex,
-  stripe: Pick<Stripe, 'subscriptions'>
+  stripe: Pick<StripeTypes, 'subscriptions'>
 ): Promise<void> {
   const rows: ActiveSubscriptionRow[] = await db('subscriptions')
     .select('id', 'email', 'payload')

--- a/src/lib/storage/jobs/helpers/sendVatNotificationEmail.ts
+++ b/src/lib/storage/jobs/helpers/sendVatNotificationEmail.ts
@@ -1,7 +1,5 @@
 import { getDefaultEmailService } from '../../../../services/EmailService/EmailService';
 import { getStripe } from '../../../integrations/stripe';
-import Stripe from 'stripe';
-
 const stripe = getStripe();
 
 const sendVatNotificationEmail = async () => {
@@ -10,8 +8,7 @@ const sendVatNotificationEmail = async () => {
   let startingAfter: string | undefined = undefined;
 
   while (hasMore) {
-    const subscriptions: Stripe.ApiList<Stripe.Subscription> =
-      await stripe.subscriptions.list({
+    const subscriptions = await stripe.subscriptions.list({
         limit: 100,
         status: 'active',
         starting_after: startingAfter,

--- a/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
@@ -1,7 +1,7 @@
 import { getStripe } from '../../../integrations/stripe';
 import { getDatabase } from '../../../../data_layer';
 import { Knex } from 'knex';
-import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 import { reconcileActiveSubscriptions } from './reconcileActiveSubscriptions';
 
 const stripe = getStripe();
@@ -10,9 +10,7 @@ const database = getDatabase();
 /**
  * Fetches a batch of active subscriptions from Stripe
  */
-function fetchSubscriptionBatch(
-  startingAfter?: string
-): Promise<Stripe.ApiList<Stripe.Subscription>> {
+function fetchSubscriptionBatch(startingAfter?: string) {
   return stripe.subscriptions.list({
     limit: 100,
     status: 'active',
@@ -25,11 +23,11 @@ function fetchSubscriptionBatch(
  */
 async function getCustomer(
   customerId: string
-): Promise<Stripe.Customer | null> {
+): Promise<StripeTypes.Customer | null> {
   try {
     const customer = await stripe.customers.retrieve(customerId);
     if ('email' in customer && customer.email) {
-      return customer as Stripe.Customer;
+      return customer as StripeTypes.Customer;
     }
     console.warn('Customer does not have an email', customerId);
     return null;
@@ -46,7 +44,7 @@ async function getCustomer(
  * Determines if a subscription should be considered active based on its status and cancellation schedule
  */
 function determineSubscriptionActiveStatus(
-  subscription: Stripe.Subscription,
+  subscription: StripeTypes.Subscription,
   email: string
 ): boolean {
   const isActive = subscription.status === 'active';
@@ -58,7 +56,7 @@ function determineSubscriptionActiveStatus(
   }
 
   // For subscriptions scheduled for cancellation, check if we're still in the paid period
-  const periodEndDate = new Date(subscription.current_period_end * 1000);
+  const periodEndDate = new Date((subscription.cancel_at ?? 0) * 1000);
   const currentDate = new Date();
   const shouldRemainActive = currentDate < periodEndDate;
 
@@ -77,7 +75,7 @@ function determineSubscriptionActiveStatus(
 async function updateExistingSubscription(
   db: Knex,
   email: string,
-  subscription: Stripe.Subscription,
+  subscription: StripeTypes.Subscription,
   shouldRemainActive: boolean,
   existingActive: boolean
 ): Promise<void> {
@@ -107,7 +105,7 @@ async function createNewSubscription(
   db: Knex,
   email: string,
   customerId: string,
-  subscription: Stripe.Subscription,
+  subscription: StripeTypes.Subscription,
   shouldRemainActive: boolean
 ): Promise<void> {
   console.info(
@@ -125,8 +123,8 @@ async function createNewSubscription(
  */
 async function updateSubscriptionRecord(
   db: Knex,
-  customer: Stripe.Customer,
-  subscription: Stripe.Subscription
+  customer: StripeTypes.Customer,
+  subscription: StripeTypes.Subscription
 ): Promise<void> {
   const email = customer.email!.toLowerCase();
 
@@ -173,7 +171,7 @@ async function updateSubscriptionRecord(
  */
 async function processSubscription(
   db: Knex,
-  subscription: Stripe.Subscription
+  subscription: StripeTypes.Subscription
 ): Promise<void> {
   try {
     if (typeof subscription.customer !== 'string') {
@@ -195,7 +193,7 @@ async function processSubscription(
  * Updates the pagination parameters based on the subscription batch
  */
 function updatePaginationParams(
-  subscriptions: Stripe.ApiList<Stripe.Subscription>
+  subscriptions: StripeTypes.ApiList<StripeTypes.Subscription>
 ): {
   hasMore: boolean;
   startingAfter?: string;

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 
 import {
   getCustomerId,
@@ -86,7 +86,7 @@ const WebhooksRouter = () => {
 
           await updateStoreSubscription(
             getDatabase(),
-            customer as Stripe.Customer,
+            customer as StripeTypes.Customer,
             customerSubscriptionUpdated
           );
 
@@ -95,7 +95,7 @@ const WebhooksRouter = () => {
             event.data.previous_attributes?.cancel_at_period_end === false
           ) {
             const cancelDate = new Date(
-              customerSubscriptionUpdated.current_period_end * 1000
+              (customerSubscriptionUpdated.cancel_at ?? 0) * 1000
             );
             const emailService = getDefaultEmailService();
             if ('email' in customer) {
@@ -136,7 +136,7 @@ const WebhooksRouter = () => {
 
             await updateStoreSubscription(
               getDatabase(),
-              customerDeleted as Stripe.Customer,
+              customerDeleted as StripeTypes.Customer,
               customerSubscriptionDeleted
             );
 
@@ -151,7 +151,7 @@ const WebhooksRouter = () => {
           }
           break;
         case 'checkout.session.completed':
-          const session: Stripe.Checkout.Session = event.data.object;
+          const session: StripeTypes.Checkout.Session = event.data.object;
           const amount = session.amount_total ?? 0;
 
           const LIFE_TIME_PRICE = 9600;

--- a/src/services/SubscriptionService.test.ts
+++ b/src/services/SubscriptionService.test.ts
@@ -69,7 +69,7 @@ const activeSub = {
   id: 'sub_123',
   status: 'active',
   cancel_at_period_end: false,
-  current_period_end: periodEndSeconds,
+  cancel_at: null,
 };
 
 describe('SubscriptionService.findActiveStripeSubscriptions', () => {
@@ -161,7 +161,7 @@ describe('SubscriptionService.findRecentStripeSubscriptions', () => {
       id: 'sub_old',
       status: 'canceled',
       cancel_at_period_end: false,
-      current_period_end: periodEndSeconds,
+      cancel_at: null,
       canceled_at: periodEndSeconds - 100,
     };
     stripe.customers.list.mockResolvedValue({
@@ -219,6 +219,7 @@ describe('SubscriptionService.cancelUserSubscriptions', () => {
     stripe.subscriptions.update.mockResolvedValue({
       ...activeSub,
       cancel_at_period_end: true,
+      cancel_at: periodEndSeconds,
     });
   });
 

--- a/src/services/SubscriptionService.ts
+++ b/src/services/SubscriptionService.ts
@@ -1,4 +1,4 @@
-import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 import { getDatabase } from '../data_layer';
 import { getStripe } from '../lib/integrations/stripe';
 import { getDefaultEmailService } from './EmailService/EmailService';
@@ -24,13 +24,13 @@ async function collectCandidateEmails(userEmail: string): Promise<string[]> {
 
 async function listStripeSubscriptionsFor(
   userEmail: string,
-  status: Stripe.SubscriptionListParams['status']
-): Promise<Stripe.Subscription[]> {
+  status: StripeTypes.SubscriptionListParams['status']
+): Promise<StripeTypes.Subscription[]> {
   const stripe = getStripe();
   const candidateEmails = await collectCandidateEmails(userEmail);
 
   const seen = new Set<string>();
-  const subs: Stripe.Subscription[] = [];
+  const subs: StripeTypes.Subscription[] = [];
 
   for (const email of candidateEmails) {
     const customers = await stripe.customers.list({ email, limit: 10 });
@@ -55,13 +55,13 @@ async function listStripeSubscriptionsFor(
 export class SubscriptionService {
   static findActiveStripeSubscriptions(
     userEmail: string
-  ): Promise<Stripe.Subscription[]> {
+  ): Promise<StripeTypes.Subscription[]> {
     return listStripeSubscriptionsFor(userEmail, 'active');
   }
 
   static findRecentStripeSubscriptions(
     userEmail: string
-  ): Promise<Stripe.Subscription[]> {
+  ): Promise<StripeTypes.Subscription[]> {
     return listStripeSubscriptionsFor(userEmail, 'all');
   }
 
@@ -95,13 +95,12 @@ export class SubscriptionService {
         const updated = await stripe.subscriptions.update(sub.id, {
           cancel_at_period_end: true,
         });
-        const periodEndSeconds =
-          updated.current_period_end ?? sub.current_period_end;
-        if (periodEndSeconds) {
+        const cancelAt = updated.cancel_at ?? sub.cancel_at;
+        if (cancelAt) {
           await emailService.sendSubscriptionScheduledCancellationEmail(
             userEmail,
             '',
-            new Date(periodEndSeconds * 1000)
+            new Date(cancelAt * 1000)
           );
         }
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
+    "ignoreDeprecations": "6.0",
     "target": "es2021",
     "module": "commonjs",
     "lib": ["es2021", "dom"],
@@ -47,7 +48,7 @@
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    "types": ["jest", "node"],                       /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
## Summary

- Upgrades stripe from 16.12.0 to 22.0.2, migrating type imports from `StripeConstructor` namespace (removed in v22) to `stripe/cjs/stripe.core`, and replacing the removed `current_period_end` field with `cancel_at`
- Upgrades TypeScript from 5.7.3 to 6.0.3 with `"ignoreDeprecations": "6.0"` and explicit `"types": ["jest", "node"]` to fix `@types/jest` v30 auto-include regression
- Upgrades `@anthropic-ai/sdk` from 0.91.0 to 0.91.1 (security patch)
- Upgrades bcryptjs, @types/bcryptjs, domhandler, and prettier

## Test plan

- [ ] `pnpm tsc --noEmit` passes with zero errors
- [ ] `pnpm test src/services/SubscriptionService.test.ts` — all 15 tests pass
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)