### PR TITLE
feat: restore Use All Toggle Lists card option

### DIFF
--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -35,6 +35,7 @@ describe('SettingsController', () => {
     testDefaultSettings('client', {
       'add-notion-link': 'false',
       'use-notion-id': 'true',
+      all: 'true',
       paragraph: 'false',
       cherry: 'false',
       avocado: 'false',
@@ -61,6 +62,7 @@ describe('SettingsController', () => {
     testDefaultSettings('server', {
       'add-notion-link': 'false',
       'use-notion-id': 'true',
+      all: 'true',
       paragraph: 'false',
       cherry: 'false',
       avocado: 'false',

--- a/src/controllers/CardOptionsController/supportedOptions.ts
+++ b/src/controllers/CardOptionsController/supportedOptions.ts
@@ -15,6 +15,12 @@ const supportedOptions = (): CardOptionDetail[] => {
       true
     ),
     new CardOptionDetail(
+      'all',
+      'Use All Toggle Lists',
+      'By default we only check for toggle lists in the first page. Use this option to retrieve toggle lists from anywhere in the page.',
+      true
+    ),
+    new CardOptionDetail(
       'paragraph',
       'Use Plain Text for Back',
       'This option will remove formatting and get the text content only.',

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -697,7 +697,7 @@ export class DeckParser {
   private extractToggleLists(dom: cheerio.CheerioAPI): Element[] {
     const foundToggleLists = findNotionToggleLists(dom, {
       isCherry: this.settings.isCherry,
-      isAll: false,
+      isAll: this.settings.isAll,
       disableIndentedBulletPoints: this.settings.disableIndentedBulletPoints,
     });
 

--- a/src/lib/parser/Settings/CardOption.ts
+++ b/src/lib/parser/Settings/CardOption.ts
@@ -16,6 +16,8 @@ class CardOption {
 
   readonly isAvocado: boolean;
 
+  readonly isAll: boolean;
+
   readonly fontSize: string;
 
   readonly isTextOnlyBack: boolean;
@@ -87,6 +89,7 @@ class CardOption {
     this.noUnderline = input['no-underline'] === 'true';
     this.isCherry = input.cherry === 'true';
     this.isAvocado = input.avocado === 'true';
+    this.isAll = input.all === 'true';
     this.fontSize = input['font-size'];
     this.isTextOnlyBack = input.paragraph === 'true';
     this.toggleMode = input['toggle-mode'] || 'close_toggle';
@@ -145,6 +148,7 @@ class CardOption {
     return {
       'add-notion-link': 'false',
       'use-notion-id': 'true',
+      all: 'true',
       paragraph: 'false',
       cherry: 'false',
       avocado: 'false',


### PR DESCRIPTION
## Summary

- Restores the "Use All Toggle Lists" checkbox to Card Options
- The option was removed in 45b84fa with the intention of inferring it from payment status, but that was never implemented — users lost the ability to create cards from deeply nested toggles
- The `isAll: false` left behind in `DeckParser.extractToggleLists` was silently disabling the feature even for users who had it enabled from before

## What changed

- `CardOption`: restored `isAll` property reading the `all` key; default is `true`
- `supportedOptions`: re-added the `CardOptionDetail` so the checkbox appears in the UI
- `DeckParser`: wires `settings.isAll` instead of the hardcoded `false`

## Test plan

- [ ] Card Options page shows "Use All Toggle Lists" checkbox
- [ ] Enabling it causes cards to be created from nested toggle lists, not just the first-level ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)