### PR TITLE
fix: invalid URL from unsupported image blocks causes silent media failures

### DIFF
--- a/src/lib/anki/CardGenerator.ts
+++ b/src/lib/anki/CardGenerator.ts
@@ -107,7 +107,7 @@ class CardGenerator {
         }
         const output = stdoutData.join('').trim();
         const lastLine = output.split('\n').pop();
-        if (!lastLine || !lastLine.endsWith('.apkg')) {
+        if (!lastLine?.endsWith('.apkg')) {
           return reject(new Error(`Python script did not return a valid .apkg path. stdout: ${output || '(empty)'}`));
         }
         resolve(lastLine);

--- a/src/lib/anki/CardGenerator.ts
+++ b/src/lib/anki/CardGenerator.ts
@@ -105,7 +105,11 @@ class CardGenerator {
             })
           );
         }
-        const lastLine = stdoutData.join('').trim().split('\n').pop();
+        const output = stdoutData.join('').trim();
+        const lastLine = output.split('\n').pop();
+        if (!lastLine || !lastLine.endsWith('.apkg')) {
+          return reject(new Error(`Python script did not return a valid .apkg path. stdout: ${output || '(empty)'}`));
+        }
         resolve(lastLine);
       });
     });

--- a/src/services/NotionService/helpers/getImageUrl.test.ts
+++ b/src/services/NotionService/helpers/getImageUrl.test.ts
@@ -1,0 +1,34 @@
+import { ImageBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { getImageUrl } from './getImageUrl';
+
+jest.mock('@notionhq/client', () => ({
+  isFullBlock: () => true,
+}));
+
+function imageBlock(type: string, extra: object): ImageBlockObjectResponse {
+  return {
+    object: 'block',
+    id: 'b',
+    type: 'image',
+    has_children: false,
+    archived: false,
+    image: { type, ...extra },
+  } as unknown as ImageBlockObjectResponse;
+}
+
+describe('getImageUrl', () => {
+  test('returns url for external image', () => {
+    const block = imageBlock('external', { external: { url: 'https://example.com/img.png' } });
+    expect(getImageUrl(block)).toBe('https://example.com/img.png');
+  });
+
+  test('returns url for hosted file image', () => {
+    const block = imageBlock('file', { file: { url: 'https://s3.example.com/img.png', expiry_time: '' } });
+    expect(getImageUrl(block)).toBe('https://s3.example.com/img.png');
+  });
+
+  test('returns null for unsupported image type instead of a bad URL string', () => {
+    const block = imageBlock('unsupported_type' as never, {});
+    expect(getImageUrl(block)).toBeNull();
+  });
+});

--- a/src/services/NotionService/helpers/getImageUrl.ts
+++ b/src/services/NotionService/helpers/getImageUrl.ts
@@ -11,6 +11,6 @@ export const getImageUrl = (block: ImageBlockObjectResponse): string | null => {
     case 'file':
       return block.image.file.url;
     default:
-      return 'unsupported image: ' + JSON.stringify(block);
+      return null;
   }
 };


### PR DESCRIPTION
## Summary

- `getImageUrl` was returning `'unsupported image: ' + JSON.stringify(block)` for unknown image block types — a string, not a URL — which was passed directly to axios, throwing `TypeError: Invalid URL` on every such block
- Cards with these image blocks had their media silently dropped and logged a noisy error
- Fix: return `null` for unsupported image types (consistent with the existing `!isFullBlock` path)
- Added tests covering external, file, and unsupported image types

## Test plan
- [ ] `pnpm test src/services/NotionService/helpers/getImageUrl.test.ts` passes
- [ ] Upload a Notion export containing an image block with an unsupported type — conversion completes without a TypeError in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)