### PR TITLE
fix: retry Stripe API calls on StripeRateLimitError with exponential backoff

### DIFF
--- a/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
@@ -3,6 +3,7 @@ import { getDatabase } from '../../../../data_layer';
 import { Knex } from 'knex';
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 import { reconcileActiveSubscriptions } from './reconcileActiveSubscriptions';
+import { withStripeRetry } from './withStripeRetry';
 
 const stripe = getStripe();
 const database = getDatabase();
@@ -11,11 +12,10 @@ const database = getDatabase();
  * Fetches a batch of active subscriptions from Stripe
  */
 function fetchSubscriptionBatch(startingAfter?: string) {
-  return stripe.subscriptions.list({
-    limit: 100,
-    status: 'active',
-    starting_after: startingAfter,
-  });
+  return withStripeRetry(
+    () => stripe.subscriptions.list({ limit: 100, status: 'active', starting_after: startingAfter }),
+    'fetchSubscriptionBatch'
+  );
 }
 
 /**
@@ -25,7 +25,10 @@ async function getCustomer(
   customerId: string
 ): Promise<StripeTypes.Customer | null> {
   try {
-    const customer = await stripe.customers.retrieve(customerId);
+    const customer = await withStripeRetry(
+      () => stripe.customers.retrieve(customerId),
+      'getCustomer'
+    );
     if ('email' in customer && customer.email) {
       return customer as StripeTypes.Customer;
     }

--- a/src/lib/storage/jobs/helpers/withStripeRetry.test.ts
+++ b/src/lib/storage/jobs/helpers/withStripeRetry.test.ts
@@ -1,0 +1,45 @@
+import { withStripeRetry } from './withStripeRetry';
+
+const rateLimitError = { type: 'StripeRateLimitError', message: 'rate limited' };
+const genericError = new Error('something else');
+
+describe('withStripeRetry', () => {
+  it('returns result when operation succeeds on first attempt', async () => {
+    const operation = jest.fn().mockResolvedValue('ok');
+    await expect(withStripeRetry(operation, 'test', { baseDelayMs: 1 })).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on StripeRateLimitError and returns result on second attempt', async () => {
+    const operation = jest.fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce('ok');
+    await expect(withStripeRetry(operation, 'test', { baseDelayMs: 1 })).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws immediately on non-rate-limit errors without retrying', async () => {
+    const operation = jest.fn().mockRejectedValue(genericError);
+    await expect(withStripeRetry(operation, 'test', { baseDelayMs: 1 })).rejects.toBe(genericError);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws after exhausting max attempts on persistent rate limits', async () => {
+    const operation = jest.fn().mockRejectedValue(rateLimitError);
+    await expect(
+      withStripeRetry(operation, 'test', { maxAttempts: 3, baseDelayMs: 1 })
+    ).rejects.toBe(rateLimitError);
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries up to maxAttempts and succeeds on last attempt', async () => {
+    const operation = jest.fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce('recovered');
+    await expect(
+      withStripeRetry(operation, 'test', { maxAttempts: 3, baseDelayMs: 1 })
+    ).resolves.toBe('recovered');
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/storage/jobs/helpers/withStripeRetry.ts
+++ b/src/lib/storage/jobs/helpers/withStripeRetry.ts
@@ -1,0 +1,37 @@
+export interface WithStripeRetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+}
+
+function isStripeRateLimitError(error: unknown): boolean {
+  return (error as { type?: string })?.type === 'StripeRateLimitError';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function withStripeRetry<T>(
+  operation: () => Promise<T>,
+  label: string,
+  options: WithStripeRetryOptions = {}
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 5;
+  const baseDelayMs = options.baseDelayMs ?? 1000;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt === maxAttempts || !isStripeRateLimitError(error)) {
+        throw error;
+      }
+      const delay = Math.floor(baseDelayMs * 2 ** (attempt - 1) * (0.5 + Math.random()));
+      console.warn(`[${label}] rate limited; retrying in ${delay}ms (attempt ${attempt}/${maxAttempts})`);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary

- Adds `withStripeRetry` helper that wraps Stripe API calls with exponential backoff on `StripeRateLimitError`
- Wraps `fetchSubscriptionBatch` and `getCustomer` in `updateStripeSubscriptions.ts` with the retry logic
- Up to 5 attempts with jittered exponential backoff starting at 1 second

## Test plan

- [ ] `withStripeRetry` unit tests cover: success on first attempt, retry on rate limit, no retry on non-rate-limit errors, exhausting max attempts
- [ ] All 11 tests in `src/lib/storage/jobs/helpers/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)