### PR TITLE
feat: heuristic markdown card detection with X-Warning header

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -26,6 +26,7 @@ interface PrepareDeckResult {
   apkg: Buffer;
   deck: Deck[];
   cardCount: number;
+  warning?: string;
 }
 
 async function convertFile(
@@ -255,6 +256,7 @@ export async function PrepareDeck(
         apkg,
         deck: parser.payload,
         cardCount: parser.totalCardCount(),
+        warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
       };
     }
   }
@@ -265,5 +267,6 @@ export async function PrepareDeck(
     apkg,
     deck: parser.payload,
     cardCount: parser.totalCardCount(),
+    warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
   };
 }

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -26,6 +26,8 @@ import {
 } from '../storage/checks';
 import { getFileContents } from './getFileContents';
 import { handleNestedBulletPointsInMarkdown } from './handleNestedBulletPointsInMarkdown';
+import { guessMarkdownCards } from './guessMarkdownCards';
+import { getTitleFromMarkdown } from './getTitleFromMarkdown';
 import { checkFlashcardsLimits } from '../User/checkFlashcardsLimits';
 import { extractStyles } from './extractStyles';
 import { withFontSize } from './withFontSize';
@@ -61,6 +63,8 @@ export class DeckParser {
 
   noLimits: boolean;
 
+  usedHeuristic: boolean;
+
   workspace: Workspace;
   customExporter: CustomExporter;
 
@@ -73,6 +77,7 @@ export class DeckParser {
     this.files = input.files || [];
     this.firstDeckName = input.name;
     this.noLimits = input.noLimits;
+    this.usedHeuristic = false;
     this.globalTags = null;
     this.payload = [];
     this.workspace = input.workspace ?? new Workspace(true, 'fs');
@@ -100,8 +105,21 @@ export class DeckParser {
           workspace: this.workspace,
           files: this.files,
         });
-      } else {
-        this.payload = [];
+      }
+      if (this.payload.every((d) => d.cards.length === 0)) {
+        const heuristic = guessMarkdownCards(contentsStr ?? '');
+        if (heuristic) {
+          const deck = new Deck(
+            this.settings.deckName ?? getTitleFromMarkdown(contentsStr) ?? name,
+            heuristic.notes,
+            '',
+            '',
+            get16DigitRandomId(),
+            this.settings
+          );
+          this.payload = [deck];
+          this.usedHeuristic = true;
+        }
       }
     } else if (isHTMLFile(name)) {
       const contents = getFileContents(firstFile, true);

--- a/src/lib/parser/guessMarkdownCards.test.ts
+++ b/src/lib/parser/guessMarkdownCards.test.ts
@@ -1,0 +1,132 @@
+import { guessMarkdownCards } from './guessMarkdownCards';
+
+describe('guessMarkdownCards', () => {
+  it('returns null for empty content', () => {
+    expect(guessMarkdownCards('')).toBeNull();
+  });
+
+  it('returns null when no known pattern is found', () => {
+    expect(guessMarkdownCards('just some random text\nwith multiple lines')).toBeNull();
+  });
+
+  describe('details-summary (Notion export)', () => {
+    it('extracts a single card', () => {
+      const md = `<details>\n<summary>What is the capital of France?</summary>\nParis\n</details>`;
+      const result = guessMarkdownCards(md);
+      expect(result).not.toBeNull();
+      expect(result!.formatDetected).toBe('details-summary');
+      expect(result!.notes).toHaveLength(1);
+      expect(result!.notes[0].name).toBe('What is the capital of France?');
+      expect(result!.notes[0].back).toContain('Paris');
+    });
+
+    it('extracts multiple cards', () => {
+      const md = [
+        '<details>\n<summary>Q1</summary>\nA1\n</details>',
+        '<details>\n<summary>Q2</summary>\nA2\n</details>',
+      ].join('\n\n');
+      const result = guessMarkdownCards(md);
+      expect(result!.notes).toHaveLength(2);
+    });
+
+    it('ignores details blocks with empty summary or empty body', () => {
+      const md = `<details>\n<summary></summary>\nSome answer\n</details>`;
+      expect(guessMarkdownCards(md)).toBeNull();
+    });
+  });
+
+  describe('heading-body (markdown-anki-decks style)', () => {
+    it('extracts cards from ## headings', () => {
+      const md = `# Deck\n\n## What is photosynthesis?\n\nThe process by which plants convert sunlight to glucose.\n\n## What is mitosis?\n\nCell division producing two identical daughter cells.`;
+      const result = guessMarkdownCards(md);
+      expect(result).not.toBeNull();
+      expect(result!.formatDetected).toBe('heading-body');
+      expect(result!.notes).toHaveLength(2);
+      expect(result!.notes[0].name).toContain('photosynthesis');
+      expect(result!.notes[0].back).toContain('glucose');
+    });
+
+    it('ignores headings with no body', () => {
+      const md = `## Question without body\n\n## Another heading\n\nThis one has a body.`;
+      const result = guessMarkdownCards(md);
+      expect(result!.notes).toHaveLength(1);
+    });
+  });
+
+  describe('qa-labels style', () => {
+    it('extracts Q:/A: pairs', () => {
+      const md = `Q: What is the powerhouse of the cell?\nA: The mitochondria.`;
+      const result = guessMarkdownCards(md);
+      expect(result).not.toBeNull();
+      expect(result!.formatDetected).toBe('qa-labels');
+      expect(result!.notes).toHaveLength(1);
+      expect(result!.notes[0].name).toContain('powerhouse');
+      expect(result!.notes[0].back).toContain('mitochondria');
+    });
+
+    it('handles multiple Q:/A: pairs', () => {
+      const md = `Q: Question one\nA: Answer one\n\nQ: Question two\nA: Answer two`;
+      const result = guessMarkdownCards(md);
+      expect(result!.notes).toHaveLength(2);
+    });
+
+    it('is case-insensitive for Q: and A:', () => {
+      const md = `q: Question\na: Answer`;
+      const result = guessMarkdownCards(md);
+      expect(result!.notes).toHaveLength(1);
+    });
+  });
+
+  describe('separator style', () => {
+    it('extracts cards separated by % and --- (ankdown)', () => {
+      const md = `What is the powerhouse of the cell?\n\n%\n\nThe mitochondria.\n\n---\n\nWhat does ATP stand for?\n\n%\n\nAdenosine triphosphate.`;
+      const result = guessMarkdownCards(md);
+      expect(result).not.toBeNull();
+      expect(result!.formatDetected).toBe('separator');
+      expect(result!.notes).toHaveLength(2);
+    });
+
+    it('extracts cards separated by --- only (Obsidian ruled style)', () => {
+      const md = `What is the powerhouse of the cell?\n\n---\n\nThe mitochondria.`;
+      const result = guessMarkdownCards(md);
+      expect(result).not.toBeNull();
+      expect(result!.formatDetected).toBe('separator');
+      expect(result!.notes).toHaveLength(1);
+    });
+
+    it('ignores front matter --- delimiters', () => {
+      const md = `---\ntitle: My Notes\n---\n\nSome random text with no cards.`;
+      expect(guessMarkdownCards(md)).toBeNull();
+    });
+  });
+
+  describe('inline double-colon style', () => {
+    it('extracts :: pairs', () => {
+      const md = `Photosynthesis::Process by which plants convert light to glucose\nMitosis::Cell division producing identical cells`;
+      const result = guessMarkdownCards(md);
+      expect(result).not.toBeNull();
+      expect(result!.formatDetected).toBe('inline-double-colon');
+      expect(result!.notes).toHaveLength(2);
+      expect(result!.notes[0].name).toContain('Photosynthesis');
+    });
+
+    it('ignores lines with URLs containing ://', () => {
+      const md = `https://example.com::not a card`;
+      expect(guessMarkdownCards(md)).toBeNull();
+    });
+  });
+
+  describe('priority order', () => {
+    it('prefers details-summary over heading-body when both present', () => {
+      const md = `## Heading\n\nBody text\n\n<details>\n<summary>Q</summary>\nA\n</details>`;
+      const result = guessMarkdownCards(md);
+      expect(result!.formatDetected).toBe('details-summary');
+    });
+
+    it('prefers heading-body over qa-labels when both present', () => {
+      const md = `## Question\n\nAnswer\n\nQ: Another\nA: One`;
+      const result = guessMarkdownCards(md);
+      expect(result!.formatDetected).toBe('heading-body');
+    });
+  });
+});

--- a/src/lib/parser/guessMarkdownCards.ts
+++ b/src/lib/parser/guessMarkdownCards.ts
@@ -1,0 +1,145 @@
+import Note from './Note';
+import { markdownToHTML } from '../markdown';
+
+function tryDetailsPattern(content: string): Note[] {
+  const regex =
+    /<details[^>]*>\s*<summary>([\s\S]*?)<\/summary>([\s\S]*?)<\/details>/gi;
+  const notes: Note[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) {
+    const front = match[1].trim();
+    const back = match[2].trim();
+    if (front && back) {
+      notes.push(new Note(front, markdownToHTML(back)));
+    }
+  }
+  return notes;
+}
+
+function tryHeadingPattern(content: string): Note[] {
+  const sections = content.split(/^##+ /m);
+  const notes: Note[] = [];
+  for (const section of sections.slice(1)) {
+    const newlineIdx = section.indexOf('\n');
+    if (newlineIdx === -1) continue;
+    const front = section.slice(0, newlineIdx).trim();
+    const back = section.slice(newlineIdx).trim();
+    if (front && back) {
+      notes.push(new Note(markdownToHTML(front), markdownToHTML(back)));
+    }
+  }
+  return notes;
+}
+
+function tryQALabelPattern(content: string): Note[] {
+  const lines = content.split('\n');
+  const notes: Note[] = [];
+  let front = '';
+  const backLines: string[] = [];
+
+  for (const line of lines) {
+    const qMatch = /^Q:\s*(.+)/i.exec(line);
+    const aMatch = /^A:\s*(.*)/i.exec(line);
+
+    if (qMatch) {
+      if (front && backLines.length > 0) {
+        notes.push(
+          new Note(
+            markdownToHTML(front),
+            markdownToHTML(backLines.join('\n').trim())
+          )
+        );
+      }
+      front = qMatch[1].trim();
+      backLines.length = 0;
+    } else if (aMatch && front) {
+      backLines.push(aMatch[1]);
+    } else if (front && backLines.length > 0 && line.trim()) {
+      backLines.push(line);
+    }
+  }
+
+  if (front && backLines.length > 0) {
+    notes.push(
+      new Note(
+        markdownToHTML(front),
+        markdownToHTML(backLines.join('\n').trim())
+      )
+    );
+  }
+  return notes;
+}
+
+function trySeparatorPattern(content: string): Note[] {
+  const body = content.replace(/^---\n[\s\S]+?\n---\n/, '');
+
+  if (body.includes('\n%\n')) {
+    const cards = body.split(/\n---\n/);
+    const notes: Note[] = [];
+    for (const card of cards) {
+      const parts = card.split(/\n%\n/);
+      if (parts.length >= 2) {
+        const front = parts[0].trim();
+        const back = parts[1].trim();
+        if (front && back) {
+          notes.push(new Note(markdownToHTML(front), markdownToHTML(back)));
+        }
+      }
+    }
+    return notes;
+  }
+
+  const pairs = body.split(/\n\n---\n\n/);
+  if (pairs.length < 2) return [];
+
+  const notes: Note[] = [];
+  for (let i = 0; i + 1 < pairs.length; i += 2) {
+    const front = pairs[i].trim();
+    const back = pairs[i + 1].trim();
+    if (front && back) {
+      notes.push(new Note(markdownToHTML(front), markdownToHTML(back)));
+    }
+  }
+  return notes;
+}
+
+function tryInlineDoubleColonPattern(content: string): Note[] {
+  const lines = content.split('\n');
+  const notes: Note[] = [];
+  for (const line of lines) {
+    const idx = line.indexOf('::');
+    if (idx === -1) continue;
+    const front = line.slice(0, idx).trim();
+    const back = line.slice(idx + 2).trim();
+    if (front && back && !front.startsWith('#') && !front.includes('://')) {
+      notes.push(new Note(markdownToHTML(front), markdownToHTML(back)));
+    }
+  }
+  return notes;
+}
+
+export interface MarkdownHeuristicResult {
+  notes: Note[];
+  formatDetected: string;
+}
+
+export function guessMarkdownCards(
+  content: string
+): MarkdownHeuristicResult | null {
+  const patterns: Array<{ name: string; fn: (c: string) => Note[] }> = [
+    { name: 'details-summary', fn: tryDetailsPattern },
+    { name: 'heading-body', fn: tryHeadingPattern },
+    { name: 'qa-labels', fn: tryQALabelPattern },
+    { name: 'separator', fn: trySeparatorPattern },
+    { name: 'inline-double-colon', fn: tryInlineDoubleColonPattern },
+  ];
+
+  for (const { name, fn } of patterns) {
+    const notes = fn(content);
+    if (notes.length > 0) {
+      return { notes, formatDetected: name };
+    }
+  }
+
+  return null;
+}

--- a/src/lib/parser/guessMarkdownCards.ts
+++ b/src/lib/parser/guessMarkdownCards.ts
@@ -70,23 +70,26 @@ function tryQALabelPattern(content: string): Note[] {
   return notes;
 }
 
+function parseAnkdownCards(body: string): Note[] {
+  const notes: Note[] = [];
+  for (const card of body.split(/\n---\n/)) {
+    const parts = card.split(/\n%\n/);
+    if (parts.length >= 2) {
+      const front = parts[0].trim();
+      const back = parts[1].trim();
+      if (front && back) {
+        notes.push(new Note(markdownToHTML(front), markdownToHTML(back)));
+      }
+    }
+  }
+  return notes;
+}
+
 function trySeparatorPattern(content: string): Note[] {
   const body = content.replace(/^---\n[\s\S]+?\n---\n/, '');
 
   if (body.includes('\n%\n')) {
-    const cards = body.split(/\n---\n/);
-    const notes: Note[] = [];
-    for (const card of cards) {
-      const parts = card.split(/\n%\n/);
-      if (parts.length >= 2) {
-        const front = parts[0].trim();
-        const back = parts[1].trim();
-        if (front && back) {
-          notes.push(new Note(markdownToHTML(front), markdownToHTML(back)));
-        }
-      }
-    }
-    return notes;
+    return parseAnkdownCards(body);
   }
 
   const pairs = body.split(/\n\n---\n\n/);

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -231,7 +231,7 @@ class UploadService {
     paying: boolean
   ) {
     const useCase = new GeneratePackagesUseCase();
-    const { packages } = await useCase.execute(
+    const { packages, warnings } = await useCase.execute(
       paying,
       req.files as UploadedFile[],
       settings,
@@ -253,10 +253,15 @@ class UploadService {
       res.set('Content-Type', 'application/apkg');
       res.set('Content-Length', plen.toString());
       res.set('X-Card-Count', totalCards.toString());
-      res.set(
-        'Access-Control-Expose-Headers',
-        'File-Name, X-Card-Count'
-      );
+      const exposedHeaders = ['File-Name', 'X-Card-Count'];
+      if (warnings?.includes('markdown-heuristic')) {
+        res.set(
+          'X-Warning',
+          'Your Markdown file was processed using heuristic detection. For reliable results, use the nested bullet format or enable Claude AI in settings.'
+        );
+        exposedHeaders.push('X-Warning');
+      }
+      res.set('Access-Control-Expose-Headers', exposedHeaders.join(', '));
       first.name = toText(first.name);
       try {
         res.set('File-Name', encodeURIComponent(first.name));

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -8,10 +8,11 @@ import Workspace from '../../lib/parser/WorkSpace';
 
 export interface PackageResult {
   packages: Package[];
+  warnings?: string[];
 }
 
 type ProgressMessage = { type: 'progress'; step: string };
-type ResultMessage = { type: 'result'; packages: Package[] };
+type ResultMessage = { type: 'result'; packages: Package[]; warnings?: string[] };
 type ErrorMessage = { type: 'error'; message: string };
 type WorkerMessage = ProgressMessage | ResultMessage | ErrorMessage;
 
@@ -41,7 +42,7 @@ class GeneratePackagesUseCase {
         } else if (msg.type === 'error') {
           reject(new Error(msg.message));
         } else {
-          resolve({ packages: msg.packages });
+          resolve({ packages: msg.packages, warnings: msg.warnings });
         }
       });
       worker.on('error', (error) => reject(error));

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -32,6 +32,8 @@ export const getPackagesFromZip = async (
   const supportedFileNames = fileNames.filter(isZipContentFileSupported);
   const effectiveSettings = enableMarkdownForMarkdownUploads(fileNames, settings);
 
+  const warnings: string[] = [];
+
   if (effectiveSettings.claudeAIFlashcards && paying && fileNames.length > 0) {
     const rootName = fileNames[0];
     const deck = await PrepareDeck({
@@ -45,9 +47,10 @@ export const getPackagesFromZip = async (
 
     if (deck) {
       packages.push(new Package(deck.name, deck.cardCount ?? 0));
+      if (deck.warning) warnings.push(deck.warning);
     }
 
-    return { packages };
+    return { packages, warnings };
   }
 
   let cardCount = 0;
@@ -63,6 +66,7 @@ export const getPackagesFromZip = async (
 
     if (deck) {
       packages.push(new Package(deck.name, deck.cardCount ?? 0));
+      if (deck.warning) warnings.push(deck.warning);
       cardCount += deck.deck.reduce((acc, d) => acc + d.cards.length, 0);
 
       checkFlashcardsLimits({
@@ -78,5 +82,5 @@ export const getPackagesFromZip = async (
     });
   }
 
-  return { packages };
+  return { packages, warnings };
 };

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -45,6 +45,11 @@ function getFileContents(file: UploadedFile): Buffer {
 /**
  * Process a single file and return packages
  */
+interface FileResult {
+  packages: Package[];
+  warnings: string[];
+}
+
 async function processFile(
   file: UploadedFile,
   fileContents: Buffer,
@@ -52,12 +57,12 @@ async function processFile(
   settings: CardOption,
   workspace: Workspace,
   onProgress: (step: string) => void
-): Promise<Package[]> {
+): Promise<FileResult> {
   const packages: Package[] = [];
+  const warnings: string[] = [];
   const filename = file.originalname;
   const key = file.key;
 
-  // Check if it's a valid single file
   const allowImageQuizHtmlToAnki =
     paying && settings.imageQuizHtmlToAnki && isImageFile(filename);
   const isValidSingleFile =
@@ -78,26 +83,27 @@ async function processFile(
 
     if (d) {
       packages.push(new Package(d.name, d.cardCount ?? 0));
+      if (d.warning) warnings.push(d.warning);
     }
-  }
-  // Check if it's a compressed file
-  else if (isCompressedFile(filename) || isCompressedFile(key)) {
-    const { packages: extraPackages } = await getPackagesFromZip(
+  } else if (isCompressedFile(filename) || isCompressedFile(key)) {
+    const result = await getPackagesFromZip(
       fileContents,
       paying,
       settings,
       workspace,
       onProgress
     );
-    packages.push(...extraPackages);
+    packages.push(...result.packages);
+    if (result.warnings) warnings.push(...result.warnings);
   }
 
-  return packages;
+  return { packages, warnings };
 }
 
 async function doGenerationWork(data: GenerationData) {
   const { paying, files, settings, workspace } = data;
   let packages: Package[] = [];
+  const warnings: string[] = [];
 
   const onProgress = (step: string) => {
     parentPort?.postMessage({ type: 'progress', step });
@@ -105,7 +111,7 @@ async function doGenerationWork(data: GenerationData) {
 
   for (const file of files) {
     const fileContents = getFileContents(file);
-    const filePackages = await processFile(
+    const result = await processFile(
       file,
       fileContents,
       paying,
@@ -113,10 +119,11 @@ async function doGenerationWork(data: GenerationData) {
       workspace,
       onProgress
     );
-    packages = packages.concat(filePackages);
+    packages = packages.concat(result.packages);
+    warnings.push(...result.warnings);
   }
 
-  return { type: 'result', packages };
+  return { type: 'result', packages, warnings };
 }
 
 doGenerationWork(workerData.data)


### PR DESCRIPTION
## Summary

- Adds `guessMarkdownCards` which tries 5 patterns in priority order: `<details>`/`<summary>` (Notion export), `## heading + body` (markdown-anki-decks), `Q:`/`A:` labels (Obsidian-to-Anki), `---` separator (ankdown/Obsidian ruled), `::` inline (RemNote/Obsidian)
- When `handleNestedBulletPointsInMarkdown` produces zero cards, `DeckParser` falls back to the heuristic automatically — this covers Notion Markdown exports which don't use nested bullets
- On heuristic success, server sets `X-Warning` response header so the client can inform the user

## Context

Notion Markdown exports don't use the nested bullet format the existing parser expects. `enableMarkdownForMarkdownUploads` force-enables `nestedBulletPoints` for zip uploads containing `.md` files, but the parser finds no structure → 0 cards → "server rejected the upload" error. This fallback covers the common Markdown formats used across Anki tooling.

## Test plan

- [ ] 17 unit tests in `guessMarkdownCards.test.ts` cover all 5 patterns and priority ordering
- [ ] Upload a Notion Markdown export (.zip with .md files) — should produce cards and set `X-Warning`
- [ ] Upload a markdown-anki-decks file (`## Question\n\nAnswer`) — should produce cards
- [ ] Upload with `nestedBulletPoints` enabled — existing behaviour unchanged
- [ ] Upload with `claudeAIFlashcards` enabled — Claude path unchanged

> **Note:** Merge this before the companion web PR ([2anki/web](https://github.com/2anki/web)) which reads the `X-Warning` header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)