### PR TITLE
fix: dedent Notion nested bullet content so images render in Anki

### DIFF
--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -109,6 +109,27 @@ export class DeckParser {
       if (this.payload.every((d) => d.cards.length === 0)) {
         const heuristic = guessMarkdownCards(contentsStr ?? '');
         if (heuristic) {
+          for (const note of heuristic.notes) {
+            const dom = cheerio.load(note.back, { xmlMode: true });
+            const media: string[] = [];
+            dom('img').each((_i, elem) => {
+              const src = dom(elem).attr('src');
+              if (src && isImageFileEmbedable(src)) {
+                const newName = embedFile({
+                  exporter: this.customExporter,
+                  files: this.files,
+                  filePath: decodeURIComponent(src),
+                  workspace: this.workspace,
+                });
+                if (newName) {
+                  dom(elem).attr('src', newName);
+                  media.push(newName);
+                }
+              }
+            });
+            note.back = dom.html() ?? note.back;
+            note.media = media;
+          }
           const deck = new Deck(
             this.settings.deckName ?? getTitleFromMarkdown(contentsStr) ?? name,
             heuristic.notes,

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -26,7 +26,7 @@ import {
 } from '../storage/checks';
 import { getFileContents } from './getFileContents';
 import { handleNestedBulletPointsInMarkdown } from './handleNestedBulletPointsInMarkdown';
-import { guessMarkdownCards } from './guessMarkdownCards';
+import { guessMarkdownCards, MarkdownHeuristicResult } from './guessMarkdownCards';
 import { getTitleFromMarkdown } from './getTitleFromMarkdown';
 import { checkFlashcardsLimits } from '../User/checkFlashcardsLimits';
 import { extractStyles } from './extractStyles';
@@ -109,23 +109,7 @@ export class DeckParser {
       if (this.payload.every((d) => d.cards.length === 0)) {
         const heuristic = guessMarkdownCards(contentsStr ?? '');
         if (heuristic) {
-          for (const note of heuristic.notes) {
-            const { html: newName, media: namMedia } = this.embedImagesInHtml(note.name);
-            const { html: newBack, media: backMedia } = this.embedImagesInHtml(note.back);
-            note.name = newName;
-            note.back = newBack;
-            note.media = [...namMedia, ...backMedia];
-          }
-          const deck = new Deck(
-            this.settings.deckName ?? getTitleFromMarkdown(contentsStr) ?? name,
-            heuristic.notes,
-            '',
-            '',
-            get16DigitRandomId(),
-            this.settings
-          );
-          this.payload = [deck];
-          this.usedHeuristic = true;
+          this.applyHeuristic(heuristic, contentsStr, name);
         }
       }
     } else if (isHTMLFile(name)) {
@@ -190,6 +174,26 @@ export class DeckParser {
   removeNestedTogglesNewFormat(input: string): string {
     const result = this.cleanupEmptyElements(input, true);
     return result.trim();
+  }
+
+  private applyHeuristic(heuristic: MarkdownHeuristicResult, contentsStr: string | undefined, name: string) {
+    for (const note of heuristic.notes) {
+      const { html: newName, media: namMedia } = this.embedImagesInHtml(note.name);
+      const { html: newBack, media: backMedia } = this.embedImagesInHtml(note.back);
+      note.name = newName;
+      note.back = newBack;
+      note.media = [...namMedia, ...backMedia];
+    }
+    const deck = new Deck(
+      this.settings.deckName ?? getTitleFromMarkdown(contentsStr) ?? name,
+      heuristic.notes,
+      '',
+      '',
+      get16DigitRandomId(),
+      this.settings
+    );
+    this.payload = [deck];
+    this.usedHeuristic = true;
   }
 
   private embedImagesInHtml(html: string): { html: string; media: string[] } {

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -110,24 +110,28 @@ export class DeckParser {
         const heuristic = guessMarkdownCards(contentsStr ?? '');
         if (heuristic) {
           for (const note of heuristic.notes) {
-            const dom = cheerio.load(note.back, { xmlMode: true });
             const media: string[] = [];
-            dom('img').each((_i, elem) => {
-              const src = dom(elem).attr('src');
-              if (src && isImageFileEmbedable(src)) {
-                const newName = embedFile({
-                  exporter: this.customExporter,
-                  files: this.files,
-                  filePath: decodeURIComponent(src),
-                  workspace: this.workspace,
-                });
-                if (newName) {
-                  dom(elem).attr('src', newName);
-                  media.push(newName);
+            const embedImagesInHtml = (html: string): string => {
+              const dom = cheerio.load(html, { xmlMode: true });
+              dom('img').each((_i, elem) => {
+                const src = dom(elem).attr('src');
+                if (src && isImageFileEmbedable(src)) {
+                  const newName = embedFile({
+                    exporter: this.customExporter,
+                    files: this.files,
+                    filePath: decodeURIComponent(src),
+                    workspace: this.workspace,
+                  });
+                  if (newName) {
+                    dom(elem).attr('src', newName);
+                    media.push(newName);
+                  }
                 }
-              }
-            });
-            note.back = dom.html() ?? note.back;
+              });
+              return dom.html() ?? html;
+            };
+            note.name = embedImagesInHtml(note.name);
+            note.back = embedImagesInHtml(note.back);
             note.media = media;
           }
           const deck = new Deck(

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -110,29 +110,11 @@ export class DeckParser {
         const heuristic = guessMarkdownCards(contentsStr ?? '');
         if (heuristic) {
           for (const note of heuristic.notes) {
-            const media: string[] = [];
-            const embedImagesInHtml = (html: string): string => {
-              const dom = cheerio.load(html, { xmlMode: true });
-              dom('img').each((_i, elem) => {
-                const src = dom(elem).attr('src');
-                if (src && isImageFileEmbedable(src)) {
-                  const newName = embedFile({
-                    exporter: this.customExporter,
-                    files: this.files,
-                    filePath: decodeURIComponent(src),
-                    workspace: this.workspace,
-                  });
-                  if (newName) {
-                    dom(elem).attr('src', newName);
-                    media.push(newName);
-                  }
-                }
-              });
-              return dom.html() ?? html;
-            };
-            note.name = embedImagesInHtml(note.name);
-            note.back = embedImagesInHtml(note.back);
-            note.media = media;
+            const { html: newName, media: namMedia } = this.embedImagesInHtml(note.name);
+            const { html: newBack, media: backMedia } = this.embedImagesInHtml(note.back);
+            note.name = newName;
+            note.back = newBack;
+            note.media = [...namMedia, ...backMedia];
           }
           const deck = new Deck(
             this.settings.deckName ?? getTitleFromMarkdown(contentsStr) ?? name,
@@ -208,6 +190,27 @@ export class DeckParser {
   removeNestedTogglesNewFormat(input: string): string {
     const result = this.cleanupEmptyElements(input, true);
     return result.trim();
+  }
+
+  private embedImagesInHtml(html: string): { html: string; media: string[] } {
+    const dom = cheerio.load(html, { xmlMode: true });
+    const media: string[] = [];
+    dom('img').each((_i, elem) => {
+      const src = dom(elem).attr('src');
+      if (src && isImageFileEmbedable(src)) {
+        const newName = embedFile({
+          exporter: this.customExporter,
+          files: this.files,
+          filePath: decodeURIComponent(src),
+          workspace: this.workspace,
+        });
+        if (newName) {
+          dom(elem).attr('src', newName);
+          media.push(newName);
+        }
+      }
+    });
+    return { html: dom.html() ?? html, media };
   }
 
   private preserveSummaryContent(html: string): string {

--- a/src/lib/parser/guessMarkdownCards.test.ts
+++ b/src/lib/parser/guessMarkdownCards.test.ts
@@ -16,7 +16,7 @@ describe('guessMarkdownCards', () => {
       expect(result).not.toBeNull();
       expect(result!.formatDetected).toBe('details-summary');
       expect(result!.notes).toHaveLength(1);
-      expect(result!.notes[0].name).toBe('What is the capital of France?');
+      expect(result!.notes[0].name).toContain('What is the capital of France?');
       expect(result!.notes[0].back).toContain('Paris');
     });
 

--- a/src/lib/parser/guessMarkdownCards.ts
+++ b/src/lib/parser/guessMarkdownCards.ts
@@ -10,7 +10,7 @@ function tryDetailsPattern(content: string): Note[] {
     const front = match[1].trim();
     const back = match[2].trim();
     if (front && back) {
-      notes.push(new Note(front, markdownToHTML(back)));
+      notes.push(new Note(markdownToHTML(front), markdownToHTML(back)));
     }
   }
   return notes;

--- a/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
+++ b/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
@@ -13,6 +13,15 @@ import Workspace from './WorkSpace';
 
 import { File } from '../zip/zip';
 
+function dedent(text: string): string {
+  const lines = text.split('\n');
+  const nonEmptyLines = lines.filter((l) => l.trim().length > 0);
+  if (nonEmptyLines.length === 0) return text;
+  const minIndent = Math.min(...nonEmptyLines.map((l) => l.match(/^[ \t]*/)?.[0].length ?? 0));
+  if (minIndent === 0) return text;
+  return lines.map((l) => l.slice(minIndent)).join('\n');
+}
+
 const BULLET_POINT_REGEX = /^-/;
 
 interface HandleNestedBulletPointsInMarkdownInput {
@@ -63,7 +72,7 @@ export const handleNestedBulletPointsInMarkdown = (
     }
 
     if (BULLET_POINT_REGEX.exec(line) && isCreating) {
-      const convertedBack = markdownToHTML(currentBack, trimWhitespace);
+      const convertedBack = markdownToHTML(dedent(currentBack), trimWhitespace);
       const dom = cheerio.load(convertedBack, {
         xmlMode: true,
       });
@@ -109,7 +118,7 @@ export const handleNestedBulletPointsInMarkdown = (
 
   // Ensure the last card is processed
   if (currentBack !== '' || currentFront !== '') {
-    const convertedBack = markdownToHTML(currentBack, trimWhitespace);
+    const convertedBack = markdownToHTML(dedent(currentBack), trimWhitespace);
     const dom = cheerio.load(convertedBack, {
       xmlMode: true,
     });

--- a/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
+++ b/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
@@ -17,7 +17,7 @@ function dedent(text: string): string {
   const lines = text.split('\n');
   const nonEmptyLines = lines.filter((l) => l.trim().length > 0);
   if (nonEmptyLines.length === 0) return text;
-  const minIndent = Math.min(...nonEmptyLines.map((l) => l.match(/^[ \t]*/)?.[0].length ?? 0));
+  const minIndent = Math.min(...nonEmptyLines.map((l) => /^[ \t]*/.exec(l)?.[0].length ?? 0));
   if (minIndent === 0) return text;
   return lines.map((l) => l.slice(minIndent)).join('\n');
 }

--- a/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
+++ b/src/lib/parser/handleNestedBulletPointsInMarkdown.ts
@@ -22,6 +22,38 @@ function dedent(text: string): string {
   return lines.map((l) => l.slice(minIndent)).join('\n');
 }
 
+function buildNoteFromBack(
+  front: string,
+  rawBack: string,
+  exporter: CustomExporter,
+  files: File[],
+  workspace: Workspace
+): Note {
+  const convertedBack = markdownToHTML(dedent(rawBack), true);
+  const dom = cheerio.load(convertedBack, { xmlMode: true });
+  const media: string[] = [];
+
+  dom('img').each((_i, elem) => {
+    const src = dom(elem).attr('src');
+    if (src && isImageFileEmbedable(src)) {
+      const newName = embedFile({
+        exporter,
+        files,
+        filePath: decodeURIComponent(src),
+        workspace,
+      });
+      if (newName) {
+        dom(elem).attr('src', newName);
+        media.push(newName);
+      }
+    }
+  });
+
+  const note = new Note(front, dom.html() || '');
+  note.media = media;
+  return note;
+}
+
 const BULLET_POINT_REGEX = /^-/;
 
 interface HandleNestedBulletPointsInMarkdownInput {
@@ -59,12 +91,10 @@ export const handleNestedBulletPointsInMarkdown = (
 
   decks.push(deck);
 
-  // Parse the markdown content
   const lines = contents?.split('\n') ?? [];
   let isCreating = false;
   let currentFront = '';
   let currentBack = '';
-  const trimWhitespace = true;
 
   for (const line of lines) {
     if (line.trim().length === 0) {
@@ -72,36 +102,7 @@ export const handleNestedBulletPointsInMarkdown = (
     }
 
     if (BULLET_POINT_REGEX.exec(line) && isCreating) {
-      const convertedBack = markdownToHTML(dedent(currentBack), trimWhitespace);
-      const dom = cheerio.load(convertedBack, {
-        xmlMode: true,
-      });
-      const images = dom('img');
-      const media: string[] = [];
-
-      images.each((_i, elem) => {
-        const src = dom(elem).attr('src');
-        if (src && isImageFileEmbedable(src)) {
-          const decodedSrc = decodeURIComponent(src);
-          const newName = embedFile({
-            exporter: exporter,
-            files: files,
-            filePath: decodedSrc,
-            workspace: workspace,
-          });
-          if (newName) {
-            dom(elem).attr('src', newName);
-            media.push(newName);
-          }
-        }
-      });
-
-      const note = new Note(
-        currentFront,
-        dom.html() || ''
-      );
-      note.media = media;
-      deck.cards.push(note);
+      deck.cards.push(buildNoteFromBack(currentFront, currentBack, exporter, files, workspace));
       isCreating = false;
       currentFront = '';
       currentBack = '';
@@ -109,45 +110,15 @@ export const handleNestedBulletPointsInMarkdown = (
 
     if (BULLET_POINT_REGEX.exec(line) && !isCreating) {
       isCreating = true;
-      currentFront = markdownToHTML(line, trimWhitespace);
+      currentFront = markdownToHTML(line, true);
       currentBack = '';
     } else if (isCreating) {
       currentBack += line + '\n';
     }
   }
 
-  // Ensure the last card is processed
   if (currentBack !== '' || currentFront !== '') {
-    const convertedBack = markdownToHTML(dedent(currentBack), trimWhitespace);
-    const dom = cheerio.load(convertedBack, {
-      xmlMode: true,
-    });
-    const images = dom('img');
-    const media: string[] = [];
-
-    images.each((_i, elem) => {
-      const src = dom(elem).attr('src');
-      if (src && isImageFileEmbedable(src)) {
-        const decodedSrc = decodeURIComponent(src);
-        const newName = embedFile({
-          exporter,
-          files: files,
-          filePath: decodedSrc,
-          workspace,
-        });
-        if (newName) {
-          dom(elem).attr('src', newName);
-          media.push(newName);
-        }
-      }
-    });
-
-    const note = new Note(
-      currentFront,
-      dom.html() || ''
-    );
-    note.media = media;
-    deck.cards.push(note);
+    deck.cards.push(buildNoteFromBack(currentFront, currentBack, exporter, files, workspace));
   }
 
   return decks;


### PR DESCRIPTION
## Summary

- Notion markdown exports indent all card back content by 4+ spaces. Showdown treats 4-space indented lines as code blocks, so `![](file.png)` was rendered as `<code>` text instead of an `<img>` tag — causing images to show as literal text in Anki.
- Added `dedent()` to strip the minimum shared indentation from back content before passing to `markdownToHTML`, so Notion-exported images now render correctly.
- Also embed images found in `note.name` (card front) in the heuristic markdown path — previously only `note.back` was processed.
- Call `markdownToHTML` on the `<details>/<summary>` front field consistently with all other patterns.

## Test plan

- [ ] Upload a Notion markdown export ZIP with images referenced in nested bullets — images should appear in Anki cards
- [ ] Verify existing nested bullet cards without images still generate correctly
- [ ] All parser tests pass (`pnpm test src/lib/parser/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)