### PR TITLE
chore: always use npx tsx when suggesting to run TS scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 
 - Use conventional commit prefixes (e.g. fix:, feat:, chore:, refactor:, test:, docs:)
 - Suggest a branch name before starting any code changes
+- Always rebase on origin/main before creating a new branch or opening a PR
 
 ## General
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@
 - Run tests with `pnpm test` scoped to the current test file
 - If test output is truncated, rerun without coverage for full output
 - When tests fail, provide the specific error message
+- When suggesting to run a TypeScript script manually, always use `npx tsx <script>` — never `ts-node`
 
 ## Database schema types
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,6 @@
 - Run tests with `pnpm test` scoped to the current test file
 - If test output is truncated, rerun without coverage for full output
 - When tests fail, provide the specific error message
-- When suggesting to run a TypeScript script manually, always use `npx tsx <script>` — never `ts-node`
 
 ## Database schema types
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## Running scripts
+
+- Always use `npx tsx <script>` to run TypeScript scripts — never `ts-node`


### PR DESCRIPTION
Adds a rule to CLAUDE.md so Claude always suggests `npx tsx` instead of `npx ts-node` when recommending how to run TypeScript scripts manually. `tsx` is already installed and used for `dev`, and is faster since it skips type-checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)