### PR TITLE
chore: drop pull_request triggers from server.yml and web.yml

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -5,10 +5,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'web/**'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'web/**'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -7,12 +7,6 @@ on:
       - '.github/workflows/web.yml'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
-  pull_request:
-    paths:
-      - 'web/**'
-      - '.github/workflows/web.yml'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

GitHub fires both \`push\` and \`pull_request\` events on every PR-branch push, so each workflow currently runs twice per push. Dropping the \`pull_request:\` block from both consolidated workflows — \`push\` alone covers PR branches, and main is already covered.

Halves CI cost (and queue time) on every PR push.

## Test plan

- [ ] Open any small PR after this lands → only one Server / Web run per push
- [ ] PR still gets the required status checks