### PR TITLE
feat: bring create_deck into the monorepo (phase 3)

### DIFF
--- a/.github/workflows/create_deck.yml
+++ b/.github/workflows/create_deck.yml
@@ -1,0 +1,53 @@
+name: Create Deck
+
+on:
+  push:
+    paths:
+      - 'create_deck/**'
+      - '.github/workflows/create_deck.yml'
+
+jobs:
+  lint:
+    name: lint (3.11)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: create_deck
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: create_deck/requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pylint
+      - name: Pylint
+        run: pylint *.py helpers
+
+  test:
+    name: test (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: create_deck
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.14']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: create_deck/requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r requirements.txt
+      - name: Pytest
+        run: pytest

--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -22,7 +22,6 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            CREATE_DECK_DIR=~/src/github.com/2anki/create_deck
             SERVER_DIR=~/src/github.com/2anki/2anki.net
 
             export NVM_DIR="$HOME/.nvm"
@@ -35,14 +34,11 @@ jobs:
 
             git -C ${SERVER_DIR} clean -fd
             git -C ${SERVER_DIR} stash
-
-            git -C ${CREATE_DECK_DIR} pull origin
-            git -C ${SERVER_DIR}      pull origin
-
+            git -C ${SERVER_DIR} pull origin
             git -C ${SERVER_DIR} clean -fd
 
             pnpm --dir ${SERVER_DIR} install --frozen-lockfile
-            pip install -r ${CREATE_DECK_DIR}/requirements.txt
+            pip install -r ${SERVER_DIR}/create_deck/requirements.txt
 
             pnpm --dir ${SERVER_DIR} run build
             pnpm --filter 2anki-web -C ${SERVER_DIR} build

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -5,6 +5,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'web/**'
+      - 'create_deck/**'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/create_deck/.gitignore
+++ b/create_deck/.gitignore
@@ -1,0 +1,133 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+# Pycharm
+.idea
+
+*.apkg

--- a/create_deck/.pylintrc
+++ b/create_deck/.pylintrc
@@ -1,0 +1,232 @@
+[MASTER]
+# Python version to analyze
+py-version=3.9
+
+# Number of processes to use
+jobs=1
+
+# Files and directories to ignore
+ignore=CVS
+ignore-patterns=^\.#
+
+# Enable persistent caching
+persistent=yes
+
+# Set the minimum score threshold
+fail-under=10
+
+# Load plugins (if any)
+load-plugins=
+
+# Allow loading of C extensions (set to 'yes' if needed)
+unsafe-load-any-extension=no
+
+[MESSAGES CONTROL]
+# Disable specific messages
+disable=
+    raw-checker-failed,
+    bad-inline-option,
+    locally-disabled,
+    file-ignored,
+    suppressed-message,
+    useless-suppression,
+    deprecated-pragma,
+    use-symbolic-message-instead,
+    import-error
+
+# Enable specific messages
+enable=c-extension-no-member
+
+[REPORTS]
+# Disable the full report
+reports=no
+
+# Activate the evaluation score
+score=yes
+
+# Evaluation formula
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+[FORMAT]
+# Maximum number of characters on a single line
+max-line-length=150
+
+# Indentation settings
+indent-string='    '
+indent-after-paren=4
+
+# Allow long lines for URLs
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# Single-line statements
+single-line-class-stmt=no
+single-line-if-stmt=no
+
+[DESIGN]
+# Maximum number of arguments for function/method
+max-args=5
+
+# Maximum number of attributes for a class
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement
+max-bool-expr=5
+
+# Maximum number of branches for function/method
+max-branches=12
+
+# Maximum number of locals for function/method
+max-locals=15
+
+# Maximum number of parents for a class
+max-parents=7
+
+# Maximum number of public methods for a class
+max-public-methods=20
+
+# Maximum number of return/yield statements in function/method
+max-returns=6
+
+# Maximum number of statements in function/method
+max-statements=50
+
+# Minimum number of public methods for a class
+min-public-methods=2
+
+[TYPECHECK]
+# List of members set dynamically and missed by pylint
+generated-members=
+
+# Ignore missing members when the owner is inferred to be None
+ignore-none=yes
+
+# Ignore on opaque inference
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show hints for missing members
+missing-member-hint=yes
+missing-member-hint-distance=1
+missing-member-max-choices=1
+
+# Regex pattern for mixin class names
+mixin-class-rgx=.*[Mm]ixin
+
+[VARIABLES]
+# Allow unused global variables
+allow-global-unused-variables=yes
+
+# Dummy variable regex
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Ignored argument names regex
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of additional builtins
+additional-builtins=
+
+[BASIC]
+# Naming styles
+variable-naming-style=snake_case
+function-naming-style=snake_case
+method-naming-style=snake_case
+class-naming-style=PascalCase
+const-naming-style=UPPER_CASE
+attr-naming-style=snake_case
+class-attribute-naming-style=any
+class-const-naming-style=UPPER_CASE
+module-naming-style=snake_case
+inlinevar-naming-style=any
+
+# Good and bad variable names
+good-names=i,j,k,ex,Run,_
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Include naming hint
+include-naming-hint=no
+
+# Minimum line length for functions/classes that require docstrings
+docstring-min-length=-1
+
+# Regular expression for functions/classes that do not require a docstring
+no-docstring-rgx=^_
+
+[IMPORTS]
+# Known third-party modules
+known-third-party=enchant
+
+# Allow wildcard imports from modules that define __all__
+allow-wildcard-with-all=no
+
+# Allow explicit reexports by alias from a package __init__
+allow-reexport-from-package=no
+
+[EXCEPTIONS]
+# Exceptions that will emit a warning when caught
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+[LOGGING]
+# Logging format style
+logging-format-style=old
+
+# Logging modules to check
+logging-modules=logging
+
+[REFACTORING]
+# Maximum number of nested blocks for function/method
+max-nested-blocks=5
+
+# Functions that never return
+never-returning-functions=sys.exit,argparse.parse_error
+
+[SIMILARITIES]
+# Ignore comments, docstrings, imports, and signatures in similarity computation
+ignore-comments=yes
+ignore-docstrings=yes
+ignore-imports=yes
+ignore-signatures=yes
+
+# Minimum lines number of a similarity
+min-similarity-lines=4
+
+[SPELLING]
+# Maximum number of spelling suggestions
+max-spelling-suggestions=4
+
+# Spelling dictionary name
+spelling-dict=
+
+# Spelling ignore words
+spelling-ignore-words=
+
+# Spelling ignore comment directives
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# Spelling private dictionary file
+spelling-private-dict-file=
+
+# Store unknown words to the private dictionary
+spelling-store-unknown-words=no
+
+[STRING]
+# Check for inconsistent quotes
+check-quote-consistency=no
+
+# Check for implicit string concatenation over line jumps
+check-str-concat-over-line-jumps=no
+
+[METHOD_ARGS]
+# Methods that require a timeout parameter
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+[MISCELLANEOUS]
+# Note tags to consider
+notes=FIXME,XXX,TODO

--- a/create_deck/.vscode/settings.json
+++ b/create_deck/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["Anki", "apkg", "genanki"]
+}

--- a/create_deck/CHECKS
+++ b/create_deck/CHECKS
@@ -1,0 +1,3 @@
+ATTEMPTS=3
+
+/checks create_deck

--- a/create_deck/LICENSE
+++ b/create_deck/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 2anki.net
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/create_deck/README.md
+++ b/create_deck/README.md
@@ -1,0 +1,220 @@
+# create_deck
+
+This module is responsible for creating Anki flashcards for 2anki.net.
+You can report issues in the [server](https://github.com/2anki/server/issues) repository.
+
+## Dependencies
+
+This project requires Python 3.x and the following main dependencies:
+- `genanki` - Core library for creating Anki packages
+- `pydantic` - Data validation and settings management
+- `ftfy` - Text encoding fixes for proper Unicode handling
+- `pylint` - Code linting (development)
+- `pytest` - Testing framework (development)
+- `mock` - Testing utilities (development)
+
+Install all dependencies with exact versions:
+```bash
+pip install -r requirements.txt
+```
+
+## API
+
+The current implementation is CLI driven. [create_deck](./create_deck.py) is to
+be executed with two arguments: absolute path to a JSON payload and template
+directory. Note that the working directory has to be the workspace directory (
+location of payload).
+
+Here is an example execution
+
+```bash
+$ cd /tmp/w/9dOax-Y1fhrsmZxPad5g5
+$ ./create_deck.py \
+    /tmp/w/9dOax-Y1fhrsmZxPad5g5/deck_info.json
+    /Users/scanf/src/github.com/2anki/server/src/templates/
+```
+
+Here is the workspace directory (stripped long filenames)
+As you can see above there are also media files in here. The APKG file is
+created based on the contents of deck_info.json.
+
+```
+/tmp/w/9dOax-Y1fhrsmZxPad5g5
+├── [...].png
+├── [...].apkg
+├── [...].jpg
+├── [...].png
+├── [...].jpg
+└── deck_info.json
+```
+
+### Template Options
+
+The application supports several template options that can be specified in the `settings.template` field:
+
+- `specialstyle` (default) - Uses custom.css styling
+- `nostyle` - No additional styling
+- `abhiyan` - Abhiyan template with custom front/back layouts
+- `alex_deluxe` - Alex Deluxe template with custom styling
+- `custom` - User-provided custom templates via n2aBasic, n2aCloze, n2aInput settings
+
+Each template can have different styling and HTML layouts for basic, cloze, and input card types.
+
+### JSON Structure
+
+Inside the deck_info.json is an array of decks.
+
+#### Deck
+
+The deck object consists of settings (object), name (string), cards (array),
+image (string), style (string):
+https://github.com/2anki/server/blob/main/src/lib/parser/Deck.ts
+
+```typescript
+class Deck {
+  name: string;
+  cards: Note[];
+  image: string | undefined;
+  style: string | null;
+  id: number;
+  settings: Settings | null;
+}
+```
+
+#### Note
+
+The note type here is not exactly the same as in Anki. It is a mix between
+flashcards, notes and other 2anki implementation details. create_deck will use
+this structure to generate the flashcards.
+
+https://github.com/2anki/server/blob/main/src/lib/parser/Note.ts
+
+```typescript
+class Note {
+  name: string;
+  back: string;
+  tags: string[];
+  cloze = false;
+  number = 0;
+  enableInput = false;
+  answer = '';
+  media: string[] = [];
+  notionId?: string;
+  notionLink?: string;
+}
+```
+
+#### Settings
+
+One of the powerful things with 2anki is the flexibility it provides. With the
+settings users can make new rules for what a flashcard is.
+
+https://github.com/2anki/server/blob/main/src/lib/parser/Settings.ts
+
+```typescript
+interface TemplateFile {
+  parent: string;
+  name: string;
+  front: string;
+  back: string;
+  styling: string;
+  storageKey: string;
+}
+
+export default class Settings {
+  readonly deckName: string | undefined;
+  readonly useInput: boolean;
+  readonly maxOne: boolean;
+  readonly noUnderline: boolean;
+  readonly isCherry: boolean;
+  readonly isAvocado: boolean;
+  readonly isAll: boolean;
+  readonly fontSize: string;
+  readonly isTextOnlyBack: boolean;
+  readonly toggleMode: string;
+  readonly isCloze: boolean;
+  readonly useTags: boolean;
+  readonly basicReversed: boolean;
+  readonly reversed: boolean;
+  readonly removeMP3Links: boolean;
+  readonly clozeModelName: string;
+  readonly basicModelName: string;
+  readonly inputModelName: string;
+  readonly clozeModelId: string;
+  readonly basicModelId: string;
+  readonly inputModelId: string;
+  readonly template: string;
+  readonly perserveNewLines: boolean;
+  readonly n2aCloze: TemplateFile | undefined;
+  readonly n2aBasic: TemplateFile | undefined;
+  readonly n2aInput: TemplateFile | undefined;
+  readonly useNotionId: boolean;
+  readonly addNotionLink: boolean;
+  readonly pageEmoji: string;
+  parentBlockId: string;
+}
+```
+
+## Error Handling
+
+The application includes production-ready error handling:
+- Automatic error email alerts in production environments
+- Comprehensive error logging with stack traces
+- Graceful handling of encoding issues and malformed data
+- Safe processing of surrogate characters in text fields
+```
+
+## Testing
+
+The project includes a test suite using pytest:
+
+```bash
+# Run all tests
+npm run test
+
+# Or use pytest directly
+pytest tests/
+```
+
+Test files include:
+- `tests/test_cards.py` - Tests for card processing and encoding
+- `tests/test_write_apkg.py` - Tests for APKG file creation
+- `helpers/test_*.py` - Unit tests for helper modules
+
+## Architecture
+
+The codebase is organized into several modules:
+
+- `create_deck.py` - Main entry point and orchestration
+- `helpers/` - Utility modules for specific functionality:
+  - `cards.py` - Card processing and text encoding
+  - `write_apkg.py` - APKG file generation
+  - `get_model*.py` - Anki model management
+  - `sanitize_tags.py` - Tag processing
+  - `read_template.py` - Template file handling
+- `backend/utils/` - Backend utilities (email alerts)
+- `tests/` - Test suite
+- `fixtures/` - Test data and examples
+
+## Docker Support
+
+**Note**: The current Dockerfile references a `main.py` file that doesn't exist, suggesting incomplete HTTP API implementation. The Docker configuration needs to be updated to match the current CLI-based architecture.
+
+## Roadmap
+
+### Completed
+- ✅ Production error handling and logging
+- ✅ Multiple template support
+- ✅ Comprehensive test suite
+- ✅ Modular architecture with helper modules
+
+### Near future
+- Refactor the code base to use Python best practices
+- Fix Docker configuration for proper containerization
+- Complete HTTP API implementation
+
+### Later
+- Image Occlusion support
+- Introduce progress/estimates on conversion jobs
+- Read directly from 2anki database
+- Optimize deck creation for large payloads and media files

--- a/create_deck/backend/utils/email_error_alert.py
+++ b/create_deck/backend/utils/email_error_alert.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import smtplib
+
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+ERROR_SENDER_EMAIL = os.getenv('ERROR_SENDER_EMAIL', 'noreply@2anki.net')
+ERROR_RECEIVER_EMAIL = os.getenv('ERROR_RECEIVER_EMAIL', 'alexander@alemayhu.com')
+
+def send_error_email(subject, error_message):
+    """
+    Send an error email with the given subject and message.
+    
+    Args:
+        subject (str): The subject line of the email
+        error_message (str): The error details to include in the email body
+    """
+    msg = MIMEMultipart()
+    msg['From'] = ERROR_SENDER_EMAIL
+    msg['To'] = ERROR_RECEIVER_EMAIL
+    msg['Subject'] = subject
+    msg.attach(MIMEText(error_message, 'plain'))
+
+    try:
+        with smtplib.SMTP('localhost') as server:
+            server.send_message(msg)
+    except smtplib.SMTPException as email_err:
+        print(f"Failed to send error email: {email_err}", file=sys.stderr)

--- a/create_deck/conftest.py
+++ b/create_deck/conftest.py
@@ -1,0 +1,9 @@
+"""
+This module configures the test environment for the project.
+"""
+
+import os
+import sys
+
+# Add the project root directory to Python path
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))

--- a/create_deck/create_deck.py
+++ b/create_deck/create_deck.py
@@ -1,0 +1,212 @@
+"""
+This file is a modification on one of the test files of genanki[0].
+It's used to create the APKG file from the JSON structure produced
+by the Notion to Anki parser.
+
+[0]: https://github.com/kerrickstaley/genanki
+"""
+
+import traceback
+import json
+import sys
+import os
+
+from genanki import Note
+from genanki.util import guid_for
+
+from helpers.cards import get_safe_value
+from helpers.get_model import get_model
+from helpers.get_model_id import get_model_id
+from helpers.read_template import read_template
+from helpers.sanitize_tags import sanitize_tags
+from helpers.write_apkg import _write_new_apkg
+from backend.utils.email_error_alert import send_error_email
+
+if __name__ == "__main__":
+    try:
+        if len(sys.argv) < 2:
+            raise IOError(
+                'missing payload arguments(data file, deck style, template dir)')
+        DATA_FILE = sys.argv[1]
+        TEMPLATE_DIR = sys.argv[2]
+
+        CLOZE_STYLE = read_template(TEMPLATE_DIR, "cloze_style.css", "", "")
+
+        with open(DATA_FILE, "r", encoding="utf-8") as json_file:
+            data = json.load(json_file)
+            media_files = []
+            decks = []
+
+            if len(data) == 0:
+                raise ValueError("No cards were generated. The page may be empty or contain no supported toggle lists.")
+
+            # Model / Template stuff
+            mt = data[0].get("settings", {})
+
+            STYLING = data[0].get('style', "") or ""
+
+            # Retreive template names for user or get the default ones
+            cloze_model_name = mt.get('clozeModelName', "n2a-cloze") or "n2a-cloze"
+            basic_model_name = mt.get('basicModelName', "n2a-basic") or "n2a-basic"
+            input_model_name = mt.get('inputModelName', "n2a-input") or "n2a-input"
+
+            # Set the model ids based on the template name
+            input_model_id = mt.get('inputModelId', get_model_id(input_model_name))
+            cloze_model_id = mt.get('clozeModelId', get_model_id(cloze_model_name))
+            basic_model_id = mt.get('basicModelId', get_model_id(basic_model_name))
+            template = mt.get('template', 'specialstyle')
+
+            FMT_CLOZE_QUESTION = FMT_CLOZE_ANSWER = None
+            FMT_INPUT_QUESTION = FMT_INPUT_ANSWER = None
+            FMT_QUESTION = FMT_ANSWER = None
+
+            # Respect user's choice of template
+            if template == 'specialstyle':
+                STYLING += read_template(TEMPLATE_DIR, "custom.css", "", "")
+            elif template == 'nostyle':
+                STYLING = ""
+            elif template == 'abhiyan':
+                STYLING = read_template(TEMPLATE_DIR, 'abhiyan.css', "", "")
+                CLOZE_STYLE = read_template(TEMPLATE_DIR,
+                                            "abhiyan_cloze_style.css", "", "")
+                FMT_CLOZE_QUESTION = read_template(TEMPLATE_DIR,
+                                                   "abhiyan_cloze_front.html",
+                                                   "", "")
+                FMT_CLOZE_ANSWER = read_template(TEMPLATE_DIR,
+                                                 "abhiyan_cloze_back.html",
+                                                 "", "")
+                FMT_QUESTION = read_template(TEMPLATE_DIR,
+                                             "abhiyan_basic_front.html", "",
+                                             "")
+                FMT_ANSWER = read_template(TEMPLATE_DIR, "abhiyan_basic_back.html",
+                                           "",
+                                           "")
+                FMT_INPUT_QUESTION = read_template(TEMPLATE_DIR,
+                                                   "abhiyan_input_front.html",
+                                                   "", "")
+                # Note: reusing the basic back, essentially the same.
+                FMT_INPUT_ANSWER = read_template(TEMPLATE_DIR,
+                                                 "abhiyan_basic_back.html",
+                                                 "",
+                                                 "")
+            elif template == 'alex_deluxe':
+                STYLING = read_template(TEMPLATE_DIR, 'alex_deluxe.css', "", "")
+                CLOZE_STYLE = read_template(TEMPLATE_DIR,
+                                            "alex_deluxe_cloze_style.css", "", "")
+                FMT_CLOZE_QUESTION = read_template(TEMPLATE_DIR,
+                                                   "alex_deluxe_cloze_front.html",
+                                                   "", "")
+                FMT_CLOZE_ANSWER = read_template(TEMPLATE_DIR,
+                                                 "alex_deluxe_cloze_back.html", "",
+                                                 "")
+                FMT_QUESTION = read_template(TEMPLATE_DIR,
+                                             "alex_deluxe_basic_front.html",
+                                             "", "")
+                FMT_ANSWER = read_template(TEMPLATE_DIR,
+                                           "alex_deluxe_basic_back.html",
+                                           "", "")
+                FMT_INPUT_QUESTION = read_template(TEMPLATE_DIR,
+                                                   "alex_deluxe_input_front.html",
+                                                   "", "")
+                FMT_INPUT_ANSWER = read_template(TEMPLATE_DIR,
+                                                 "alex_deluxe_input_back.html", "",
+                                                 "")
+            # else notionstyle
+            USE_CUSTOM_TEMPLATE = template == 'custom'
+            CLOZE_STYLE = CLOZE_STYLE + "\n" + STYLING
+            BASIC_STYLE = STYLING
+            BASIC_FRONT = FMT_QUESTION
+            BASIC_BACK = FMT_ANSWER
+            n2aBasic = mt.get("n2aBasic")
+            if n2aBasic and USE_CUSTOM_TEMPLATE:
+                BASIC_STYLE = n2aBasic["styling"]
+                BASIC_FRONT = n2aBasic["front"]
+                BASIC_BACK = n2aBasic["back"]
+
+            CLOZE_FRONT = FMT_CLOZE_QUESTION
+            CLOZE_BACK = FMT_CLOZE_ANSWER
+            n2aCloze = mt.get("n2aCloze")
+            if n2aCloze and USE_CUSTOM_TEMPLATE:
+                CLOZE_STYLE = n2aCloze["styling"]
+                CLOZE_FRONT = n2aCloze["front"]
+                CLOZE_BACK = n2aCloze["back"]
+
+            n2aInput = mt.get("n2aInput")
+            INPUT_FRONT = FMT_INPUT_QUESTION
+            INPUT_BACK = FMT_INPUT_ANSWER
+            INPUT_STYLE = STYLING
+            if n2aInput and USE_CUSTOM_TEMPLATE:
+                INPUT_STYLE = n2aInput["styling"]
+                INPUT_FRONT = n2aInput["front"]
+                INPUT_BACK = n2aInput["back"]
+
+            for deck in data:
+                cards = deck.get("cards", [])
+                notes = []
+                for card in cards:
+                    tags = sanitize_tags(card.get('tags', []))
+                    front = card.get("name", "")
+                    back = card.get("back", "")
+                    fields = [front, back, ",".join(card["media"])]
+                    model = get_model(("basic", basic_model_id, basic_model_name,
+                                       BASIC_STYLE, BASIC_FRONT, BASIC_BACK))
+                    if card.get('cloze', False) and "{{c" in front:
+                        model = get_model(
+                            ("cloze", cloze_model_id, cloze_model_name,
+                             CLOZE_STYLE, CLOZE_FRONT, CLOZE_BACK))
+                    elif card.get('enableInput', False) and card.get('answer',
+                                                                     False):
+                        model = get_model(
+                            ("input", input_model_id, input_model_name,
+                             INPUT_STYLE, INPUT_FRONT, INPUT_BACK))
+                        fields = [
+                            front.replace("{{type:Input}}", ""),
+                            back,
+                            card["answer"],
+                            ",".join(card["media"]),
+                        ]
+
+                    # Handle surrogates in the front and back
+                    fields[0] = get_safe_value(fields[0])
+                    fields[1] = get_safe_value(fields[1])
+
+                    # Cards marked with -1 number means they are breaking
+                    # compatability, treat them differently by using their
+                    # respective Notion Id.
+                    if card["number"] == -1 and "notionId" in card:
+                        card["number"] = card["notionId"]
+
+                    if mt.get("useNotionId") and "notionId" in card:
+                        guid = guid_for(card["notionId"])
+                        my_note = Note(model, fields=fields,
+                                       sort_field=card["number"], tags=tags,
+                                       guid=guid)
+                        notes.append(my_note)
+                    else:
+                        my_note = Note(model, fields=fields,
+                                       sort_field=card["number"], tags=tags)
+                        notes.append(my_note)
+                    media_files = media_files + card["media"]
+                decks.append(
+                    {
+                        "notes": notes,
+                        "id": deck["id"],
+                        "desc": "",
+                        "name": deck["name"],
+                    }
+                )
+
+        _write_new_apkg(decks, media_files)
+    except Exception as e:
+        if os.getenv('NODE_ENV') != 'production':
+            raise e
+        error_details = f"""
+Error: {str(e)}
+Traceback:
+{traceback.format_exc()}
+Environment:
+DATA_FILE: {DATA_FILE if 'DATA_FILE' in locals() else 'N/A'}
+TEMPLATE_DIR: {TEMPLATE_DIR if 'TEMPLATE_DIR' in locals() else 'N/A'}
+"""
+        send_error_email(f"[ERROR] [2anki.net] - {str(e)}", error_details)
+        raise

--- a/create_deck/fixtures/Table-crash-empty-back/deck_info.json
+++ b/create_deck/fixtures/Table-crash-empty-back/deck_info.json
@@ -1,0 +1,431 @@
+[
+  {
+    "settings": {
+      "useInput": false,
+      "maxOne": true,
+      "noUnderline": false,
+      "isCherry": false,
+      "isAvocado": false,
+      "isAll": true,
+      "isTextOnlyBack": false,
+      "toggleMode": "close_toggle",
+      "isCloze": true,
+      "useTags": false,
+      "basicReversed": false,
+      "reversed": false,
+      "removeMP3Links": true,
+      "perserveNewLines": true,
+      "clozeModelName": "n2a-cloze",
+      "basicModelName": "n2a-basic",
+      "inputModelName": "n2a-input",
+      "useNotionId": true,
+      "pageEmoji": "first_emoji"
+    },
+    "name": "Tasks",
+    "cards": [],
+    "image": "",
+    "style": "",
+    "id": 985717778173372
+  },
+  {
+    "settings": {
+      "useInput": false,
+      "maxOne": true,
+      "noUnderline": false,
+      "isCherry": false,
+      "isAvocado": false,
+      "isAll": true,
+      "isTextOnlyBack": false,
+      "toggleMode": "close_toggle",
+      "isCloze": true,
+      "useTags": false,
+      "basicReversed": false,
+      "reversed": false,
+      "removeMP3Links": true,
+      "perserveNewLines": true,
+      "clozeModelName": "n2a-cloze",
+      "basicModelName": "n2a-basic",
+      "inputModelName": "n2a-input",
+      "useNotionId": true,
+      "pageEmoji": "first_emoji"
+    },
+    "name": "Default",
+    "cards": [
+      {
+        "name": "Done",
+        "back": "Write project proposal Alexander Alemayhu \"November 27  2023\" \"This project proposal aims to achieve cross-functional alignment on investing in mobile performance in Q3. Goals include adding user stories and specific problem statements  while non-goals include getting leadership sign-off and synthesizing user research learnings. Next steps include gathering feedback from the mobile team and creating awareness in appropriate Slack channels with internal comms.\"\r",
+        "tags": [],
+        "cloze": false,
+        "number": 0,
+        "enableInput": false,
+        "answer": "",
+        "media": []
+      },
+      {
+        "name": "In progress",
+        "back": "Schedule kick-off meeting Alexander Alemayhu \"November 25  2023\" \"This task is in progress and involves scheduling a kick-off meeting for the performance project  preparing meeting materials in advance  and inviting all stakeholders to the meeting. Non-goals include brainstorming additional performance projects. The due date is April 26  2023  and the priority is medium. The task is tagged as \"\"Mobile\"\".\"\r",
+        "tags": [],
+        "cloze": false,
+        "number": 0,
+        "enableInput": false,
+        "answer": "",
+        "media": []
+      },
+      {
+        "name": "Not started",
+        "back": "Review research results Alexander Alemayhu \"December 9  2023\" \"This document outlines the goals and non-goals for a research task  which include understanding which product areas need more education and deprioritizing areas with high engagement. The next steps involve watching 10 interviews and sharing insights in Slack.\"",
+        "tags": [],
+        "cloze": false,
+        "number": 0,
+        "enableInput": false,
+        "answer": "",
+        "media": []
+      }
+    ],
+    "image": "",
+    "style": "",
+    "id": 6491246539023512
+  },
+  {
+    "settings": {
+      "useInput": false,
+      "maxOne": true,
+      "noUnderline": false,
+      "isCherry": false,
+      "isAvocado": false,
+      "isAll": true,
+      "isTextOnlyBack": false,
+      "toggleMode": "close_toggle",
+      "isCloze": true,
+      "useTags": false,
+      "basicReversed": false,
+      "reversed": false,
+      "removeMP3Links": true,
+      "perserveNewLines": true,
+      "clozeModelName": "n2a-cloze",
+      "basicModelName": "n2a-basic",
+      "inputModelName": "n2a-input",
+      "useNotionId": true,
+      "pageEmoji": "first_emoji"
+    },
+    "name": "Schedule kick-off meeting",
+    "cards": [
+      {
+        "cloze": false,
+        "number": 0,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Goals:Schedule kick-off meeting for the performance projectPrep meeting materials in advanceMeeting goal is to review the project proposal",
+        "back": "• Schedule kick-off meeting for the performance project\n• Prep meeting materials in advance\n• Meeting goal is to review the project proposal",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 1,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Schedule kick-off meeting for the performance project",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 2,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Prep meeting materials in advance",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 3,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Meeting goal is to review the project proposal",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 4,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Non-goals:Brainstorm additional performance projects",
+        "back": "• Brainstorm additional performance projects",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 5,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Brainstorm additional performance projects",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 6,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Next steps:Invite all stakeholders to the meetingPrepare meeting agenda",
+        "back": "• Invite all stakeholders to the meeting\n• Prepare meeting agenda",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 7,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Invite all stakeholders to the meeting",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 8,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Prepare meeting agenda",
+        "back": "",
+        "tags": []
+      }
+    ],
+    "image": "",
+    "style": "",
+    "id": 6755464455735693
+  },
+  {
+    "settings": {
+      "useInput": false,
+      "maxOne": true,
+      "noUnderline": false,
+      "isCherry": false,
+      "isAvocado": false,
+      "isAll": true,
+      "isTextOnlyBack": false,
+      "toggleMode": "close_toggle",
+      "isCloze": true,
+      "useTags": false,
+      "basicReversed": false,
+      "reversed": false,
+      "removeMP3Links": true,
+      "perserveNewLines": true,
+      "clozeModelName": "n2a-cloze",
+      "basicModelName": "n2a-basic",
+      "inputModelName": "n2a-input",
+      "useNotionId": true,
+      "pageEmoji": "first_emoji"
+    },
+    "name": "Write project proposal",
+    "cards": [
+      {
+        "cloze": false,
+        "number": 0,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Goals:Achieve cross-functional alignment on why and how we’re investing in mobile performance in Q3Include more user stories, specific problem statements, and be crisp about what’s not in scope for now",
+        "back": "• Achieve cross-functional alignment on why and how we’re investing in mobile performance in Q3\n• Include more user stories, specific problem statements, and be crisp about what’s not in scope for now",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 1,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Achieve cross-functional alignment on why and how we’re investing in mobile performance in Q3",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 2,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Include more user stories, specific problem statements, and be crisp about what’s not in scope for now",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 3,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Non-goals:Get explicit leadership sign-offSynthesize user research learnings (already captured in research team’s performance doc)",
+        "back": "• Get explicit leadership sign-off\n• Synthesize user research learnings (already captured in research team’s performance doc)",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 4,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Get explicit leadership sign-off",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 5,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Synthesize user research learnings (already captured in research team’s performance doc)",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 6,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Next steps:Gather feedback from mobile teamWork with internal comms to create awareness in the appropriate Slack channels",
+        "back": "• Gather feedback from mobile team\n• Work with internal comms to create awareness in the appropriate Slack channels",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 7,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Gather feedback from mobile team",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 8,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Work with internal comms to create awareness in the appropriate Slack channels",
+        "back": "",
+        "tags": []
+      }
+    ],
+    "image": "",
+    "style": "",
+    "id": 1727045048880724
+  },
+  {
+    "settings": {
+      "useInput": false,
+      "maxOne": true,
+      "noUnderline": false,
+      "isCherry": false,
+      "isAvocado": false,
+      "isAll": true,
+      "isTextOnlyBack": false,
+      "toggleMode": "close_toggle",
+      "isCloze": true,
+      "useTags": false,
+      "basicReversed": false,
+      "reversed": false,
+      "removeMP3Links": true,
+      "perserveNewLines": true,
+      "clozeModelName": "n2a-cloze",
+      "basicModelName": "n2a-basic",
+      "inputModelName": "n2a-input",
+      "useNotionId": true,
+      "pageEmoji": "first_emoji"
+    },
+    "name": "Review research results",
+    "cards": [
+      {
+        "cloze": false,
+        "number": 0,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Goals:Understand which product areas need most educationDeprioritize product areas that already see high engagement",
+        "back": "• Understand which product areas need most education\n• Deprioritize product areas that already see high engagement",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 1,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Understand which product areas need most education",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 2,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Deprioritize product areas that already see high engagement",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 3,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Non-goals:Recommend UI changes for core productRecommend changes to product roadmap",
+        "back": "• Recommend UI changes for core product\n• Recommend changes to product roadmap",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 4,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Recommend UI changes for core product",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 5,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Recommend changes to product roadmap",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 6,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Next steps:Watch all 10 interviews from research teamWrite up insights and share in Slack",
+        "back": "• Watch all 10 interviews from research team\n• Write up insights and share in Slack",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 7,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Watch all 10 interviews from research team",
+        "tags": []
+      },
+      {
+        "cloze": false,
+        "number": 8,
+        "enableInput": false,
+        "answer": "",
+        "media": [],
+        "name": "• Write up insights and share in Slack",
+        "back": "",
+        "tags": []
+      }
+    ],
+    "image": "",
+    "style": "",
+    "id": 2889819554538593
+  }
+]

--- a/create_deck/fixtures/Table-crash-empty-back/run.bash
+++ b/create_deck/fixtures/Table-crash-empty-back/run.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/bin/python3 ../../create_deck.py deck_info.json ~/src/github.com/2anki/server/src/templates/

--- a/create_deck/helpers/__init__.py
+++ b/create_deck/helpers/__init__.py
@@ -1,0 +1,3 @@
+"""
+This module contains helper functions for creating Anki decks.
+"""

--- a/create_deck/helpers/build_deck_description.py
+++ b/create_deck/helpers/build_deck_description.py
@@ -1,0 +1,8 @@
+"""
+Helper function to add image to the deck description.
+"""
+from .read_template import read_template
+
+
+def _build_deck_description(template_dir, image):
+    return read_template(template_dir, "deck_description.html", "%s", image)

--- a/create_deck/helpers/cards.py
+++ b/create_deck/helpers/cards.py
@@ -1,0 +1,26 @@
+"""
+Helper functions for working with the flashcards
+"""
+import sys
+import ftfy
+
+
+def get_safe_value(value):
+    """
+    Remove any surrogates in the value.  Handles non-string inputs gracefully.
+    :param value: The value to process.
+    :return: The processed value, or None if the input is invalid.
+    """
+    if isinstance(value, bytes):
+        try:
+            value = value.decode('utf-8') # Decode bytes to string, handling potential errors
+        except UnicodeDecodeError:
+            print("Warning: Could not decode bytes using utf-8. Returning empty string.", file=sys.stderr)
+            return ""
+    elif value is None:
+        return ""
+    elif not isinstance(value, str):
+        print(f"Warning: get_safe_value received unexpected input type: {type(value)}. Returning empty string.", file=sys.stderr)
+        return ""
+
+    return ftfy.fixes.fix_surrogates(value)

--- a/create_deck/helpers/get_model.py
+++ b/create_deck/helpers/get_model.py
@@ -1,0 +1,51 @@
+"""
+Retrieve the correct genanki model
+"""
+from genanki import Model
+
+from .get_template import get_template
+
+MODEL_INFO = {
+    "cloze": {
+        "file_name": "n2a-cloze.json",
+        "model_type": Model.CLOZE
+    },
+    "basic": {
+        "file_name": "n2a-basic.json",
+        "model_type": Model.FRONT_BACK
+    },
+    "input": {
+        "file_name": "n2a-input.json",
+        "model_type": Model.FRONT_BACK
+    }
+}
+
+
+def get_model(descriptor):
+    """
+    load the correct model based on type
+    :param descriptor:
+    :return:
+    """
+    model_type, model_id, name, css, qfmt, afmt = descriptor
+    model_info = MODEL_INFO[model_type]
+    template_file = get_template(model_info.get("file_name"))
+
+    if qfmt is None:
+        qfmt = template_file.get('front')
+    if afmt is None:
+        afmt = template_file.get('back')
+
+    return Model(
+        model_id, name,
+        fields=template_file.get("fields"),
+        templates=[
+            {
+                "name": name,
+                "qfmt": qfmt,
+                "afmt": afmt,
+            },
+        ],
+        css=css,
+        model_type=model_info.get("model_type"),
+    )

--- a/create_deck/helpers/get_model_id.py
+++ b/create_deck/helpers/get_model_id.py
@@ -1,0 +1,22 @@
+"""
+Helper for retrieving the model id for genanki.
+"""
+
+import hashlib
+
+
+def get_model_id(name):
+    """
+    Preserve the old ids for backwards compatibility.
+    :param name:
+    :return:
+    """
+    if name == "n2a-input":
+        return 6394002335189144856
+    if name == "n2a-cloze":
+        return 998877661
+    if name == "n2a-basic":
+        return 2020
+    # https://stackoverflow.com/questions/16008670/how-to-hash-a-string-into-8-digits
+    return abs(
+        int(hashlib.sha1(name.encode("utf-8")).hexdigest(), 16) % (10 ** 8))

--- a/create_deck/helpers/get_path_start.py
+++ b/create_deck/helpers/get_path_start.py
@@ -1,0 +1,10 @@
+"""
+add root suffix
+"""
+import sys
+
+
+def _path_start():
+    if sys.platform == "win32":
+        return "C:"
+    return "/"

--- a/create_deck/helpers/get_template.py
+++ b/create_deck/helpers/get_template.py
@@ -1,0 +1,24 @@
+"""
+Template files
+"""
+import json
+import os
+
+
+def get_template_path():
+    """
+    helper to find path to the server's template directory
+    :return:
+    """
+    return os.path.dirname(__file__) + "/../../server/src/templates/"
+
+
+def get_template(path):
+    """
+    read the template
+    :param path:
+    :return:
+    """
+    file_path = get_template_path() + path
+    with open(file_path, "r", encoding="utf-8") as file:
+        return json.loads(file.read())

--- a/create_deck/helpers/read_template.py
+++ b/create_deck/helpers/read_template.py
@@ -1,0 +1,20 @@
+"""
+Load template file
+"""
+from .get_path_start import _path_start
+
+
+def read_template(template_dir, path, fmt, value):
+    """
+    Read a file in the template directory.
+    :param template_dir: users template directory
+    :param path: file to read
+    :param fmt: variable to replace in file
+    :param value: value to use for replacement
+    :return:
+    """
+    file_path = path if path.startswith(_path_start()) else template_dir + path
+    with open(file_path, "r", encoding="utf-8") as file:
+        if fmt and value:
+            return file.read().replace(fmt, value)
+        return file.read()

--- a/create_deck/helpers/sanitize_tags.py
+++ b/create_deck/helpers/sanitize_tags.py
@@ -1,0 +1,14 @@
+"""
+Todo move this into a Tag class
+"""
+
+
+def sanitize_tags(tags):
+    """
+    Remove invalid characters from the tag.
+    :param tags:
+    :return:
+    """
+    if len(tags) == 0:
+        return tags
+    return [tag.replace(' ', '-') for tag in tags]

--- a/create_deck/helpers/test_get_model_id.py
+++ b/create_deck/helpers/test_get_model_id.py
@@ -1,0 +1,14 @@
+"""
+Test for get_model_id
+"""
+
+from . import get_model_id
+
+
+def test_get_model_id():
+    """
+    :return: nothing
+    """
+    assert get_model_id.get_model_id("n2a-input") == 6394002335189144856
+    assert get_model_id.get_model_id("n2a-cloze") == 998877661
+    assert get_model_id.get_model_id("n2a-basic") == 2020

--- a/create_deck/helpers/test_sanitize_tags.py
+++ b/create_deck/helpers/test_sanitize_tags.py
@@ -1,0 +1,12 @@
+"""
+Test tags
+"""
+from . import sanitize_tags
+
+
+def test_sanitize_tags():
+    """
+    Test that we handle empty space in the tag
+    :return:
+    """
+    assert sanitize_tags.sanitize_tags({'a  a'}) == ['a--a']

--- a/create_deck/helpers/write_apkg.py
+++ b/create_deck/helpers/write_apkg.py
@@ -1,0 +1,164 @@
+"""
+This module provides functionality to write a new Anki package file (.apkg) using provided deck payloads and media files.
+"""
+
+import os
+import sys
+import re
+import tempfile
+import uuid
+
+from genanki import Deck, Package
+
+def sanitize_filename(filename):
+    """
+    Sanitize the filename by removing any character that is not alphanumeric, a space, or a hyphen.
+    Replace spaces with hyphens. Ensures the result is safe for use as a filename.
+    """
+    # Remove path separators and other dangerous characters
+    sanitized = re.sub(
+        r'[^\w\s\-\U0001F600-\U0001F64F]', '', filename, flags=re.UNICODE
+    )
+    sanitized = sanitized.replace(' ', '-')
+    # Use basename to ensure no directory traversal is possible
+    return os.path.basename(sanitized)
+
+def create_decks(deck_payloads):
+    """
+    Create decks from the provided deck payloads.
+
+    Args:
+        deck_payloads (list): List of dictionaries containing deck information.
+
+    Returns:
+        tuple: A tuple containing the list of created decks and the ID of the first deck.
+    """
+    first_deck_id = ""
+    decks = []
+
+    for deck_payload in deck_payloads:
+        deck = Deck(
+            deck_id=deck_payload["id"],
+            name=deck_payload["name"],
+            description=deck_payload["desc"]
+        )
+
+        if not first_deck_id:
+            first_deck_id = str(deck_payload["id"])
+
+        for note in deck_payload["notes"]:
+            deck.add_note(note)
+
+        decks.append(deck)
+
+    return decks, first_deck_id
+
+def write_package_to_temp_file(package):
+    """
+    Write the package to a temporary file.
+
+    Args:
+        package (Package): The package to be written to a file.
+
+    Returns:
+        str: The path to the temporary file.
+    """
+    temp_filename = f"temp_apkg_{uuid.uuid4().hex}.apkg"
+    temp_path = os.path.join(tempfile.gettempdir(), temp_filename)
+
+    try:
+        package.write_to_file(temp_path)
+    except Exception as e:
+        print(f"Error writing to temporary file: {e}", file=sys.stderr)
+        raise
+
+    return temp_path
+
+def _validate_path_safety(name_str, id_str):
+    """Validate inputs for path traversal attempts."""
+    dangerous_patterns = ['..', '/', '\\', ':']
+    for pattern in dangerous_patterns:
+        if pattern in name_str or pattern in id_str:
+            raise ValueError("Path traversal attempt detected in filename")
+
+def _create_safe_filename(sanitized_name, first_deck_id):
+    """Create a safe filename from sanitized inputs."""
+    safe_name = os.path.basename(str(sanitized_name))
+    safe_deck_id = os.path.basename(str(first_deck_id))
+    base_filename = f'{safe_name}-{safe_deck_id}'
+
+    if len(base_filename) + len(".apkg") > 255:
+        base_filename = base_filename[:245] + "-trunc"
+
+    return os.path.basename(f"{base_filename}.apkg")
+
+def _verify_path_within_cwd(final_path, cwd):
+    """Verify the final path is within the current working directory."""
+    real_final_path = os.path.realpath(final_path)
+    real_cwd = os.path.realpath(cwd)
+
+    if not real_final_path.startswith(real_cwd + os.sep) and not real_final_path == real_cwd:
+        raise ValueError("Path traversal attempt detected in final path")
+
+def rename_temp_file(temp_path, sanitized_name, first_deck_id):
+    """
+    Rename the temporary file to a final filename.
+
+    Args:
+        temp_path (str): The path to the temporary file.
+        sanitized_name (str): The sanitized name for the final file.
+        first_deck_id (str): The ID of the first deck.
+
+    Returns:
+        str: The path to the final file.
+    """
+    name_str = str(sanitized_name)
+    id_str = str(first_deck_id)
+
+    _validate_path_safety(name_str, id_str)
+
+    final_filename = _create_safe_filename(sanitized_name, first_deck_id)
+    cwd = os.getcwd()
+    final_path = os.path.join(cwd, final_filename)
+
+    _verify_path_within_cwd(final_path, cwd)
+
+    try:
+        os.replace(temp_path, final_path)
+    except OSError as e:
+        if e.errno == 36:
+            fallback_filename = f"deck_{uuid.uuid4().hex[:8]}.apkg"
+            final_path = os.path.join(cwd, fallback_filename)
+            _verify_path_within_cwd(final_path, cwd)
+            os.replace(temp_path, final_path)
+        else:
+            raise ValueError("Failed to rename file") from e
+
+    return final_path
+
+def _write_new_apkg(deck_payloads, media_files):
+    """
+    Write a new Anki package file (.apkg) using provided deck payloads and media files.
+
+    Args:
+        deck_payloads (list): List of dictionaries containing deck information.
+        media_files (list): List of media files to be included in the package.
+    """
+    decks, first_deck_id = create_decks(deck_payloads)
+    package = Package(decks)
+    existing_media = [f for f in media_files if os.path.exists(f)]
+    if len(existing_media) < len(media_files):
+        missing = set(media_files) - set(existing_media)
+        print(f"Skipping {len(missing)} missing media file(s): {missing}", file=sys.stderr)
+    package.media_files = existing_media
+
+    sanitized_name = sanitize_filename(deck_payloads[0]["name"]) if deck_payloads else "default"
+    temp_path = write_package_to_temp_file(package)
+    final_path = rename_temp_file(temp_path, sanitized_name, first_deck_id)
+
+    # Handle Unicode characters properly for Windows console
+    try:
+        sys.stdout.write(final_path)
+    except UnicodeEncodeError:
+        # If Unicode encoding fails, encode to bytes and write to stdout buffer
+        sys.stdout.buffer.write(final_path.encode('utf-8'))

--- a/create_deck/requirements.txt
+++ b/create_deck/requirements.txt
@@ -1,0 +1,8 @@
+# make sure to update the alemayhu/base-image-n2a
+# and pull it in the live server: ssh root@2anki.net docker pull alemayhu/base-image-n2a
+genanki==0.13.1
+pydantic>=2.13.3,<3.0.0
+pylint>=4.0.5
+ftfy~=6.3.1
+pytest
+mock

--- a/create_deck/tests/test_cards.py
+++ b/create_deck/tests/test_cards.py
@@ -1,0 +1,20 @@
+import unittest
+from helpers.cards import get_safe_value
+
+class TestCards(unittest.TestCase):
+    def test_get_safe_value_string(self):
+        self.assertEqual(get_safe_value("This is a test string."), "This is a test string.")
+
+    def test_get_safe_value_bytes(self):
+        self.assertEqual(get_safe_value(b"This is a test string."), "This is a test string.")
+
+    def test_get_safe_value_none(self):
+        self.assertEqual(get_safe_value(None), "")
+
+    def test_get_safe_value_invalid_type(self):
+        self.assertEqual(get_safe_value(123), "")
+        self.assertEqual(get_safe_value([1,2,3]), "")
+        self.assertEqual(get_safe_value({'a':1}), "")
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/create_deck/tests/test_write_apkg.py
+++ b/create_deck/tests/test_write_apkg.py
@@ -1,0 +1,218 @@
+import os
+import tempfile
+from unittest import TestCase, mock
+from genanki import Note, Model
+
+from helpers.write_apkg import sanitize_filename, _write_new_apkg, rename_temp_file
+
+class TestWriteApkg(TestCase):
+    def setUp(self):
+        self.test_model = Model(
+            1607392319,
+            'Test Model',
+            [{'name': 'Question'}, {'name': 'Answer'}],
+            [{'name': 'Card 1', 'qfmt': '{{Question}}', 'afmt': '{{Answer}}'}]
+        )
+        
+    def test_sanitize_filename(self):
+        test_cases = [
+            ("Hello World!", "Hello-World"),
+            ("Test@#$%^&*", "Test"),
+            ("Space - Dash", "Space---Dash"),
+            ("emoji😀test", "emoji😀test"),
+            ("", "")
+        ]
+        
+        for input_name, expected in test_cases:
+            self.assertEqual(sanitize_filename(input_name), expected)
+
+    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_single_deck(self, mock_replace, mock_package):
+        note = Note(model=self.test_model, fields=['Q1', 'A1'])
+        deck_payload = {
+            "id": 1234567890,
+            "name": "Test Deck",
+            "desc": "Test Description",
+            "notes": [note]
+        }
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                _write_new_apkg([deck_payload], [])
+                
+                # Verify Package was created with correct deck
+                mock_package.assert_called_once()
+                created_deck = mock_package.call_args[0][0][0]
+                self.assertEqual(created_deck.name, "Test Deck")
+                self.assertEqual(str(created_deck.deck_id), "1234567890")
+                
+                # Verify file operations
+                mock_package.return_value.write_to_file.assert_called_once()
+                mock_replace.assert_called_once()
+
+    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_multiple_decks(self, mock_replace, mock_package):
+        note1 = Note(model=self.test_model, fields=['Q1', 'A1'])
+        note2 = Note(model=self.test_model, fields=['Q2', 'A2'])
+        
+        deck_payloads = [
+            {
+                "id": 1234567890,
+                "name": "Test Deck 1",
+                "desc": "Test Description 1",
+                "notes": [note1]
+            },
+            {
+                "id": 9876543210,
+                "name": "Test Deck 2",
+                "desc": "Test Description 2",
+                "notes": [note2]
+            }
+        ]
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                _write_new_apkg(deck_payloads, [])
+                
+                mock_package.assert_called_once()
+                created_decks = mock_package.call_args[0][0]
+                self.assertEqual(len(created_decks), 2)
+                self.assertEqual(created_decks[0].name, "Test Deck 1")
+                self.assertEqual(created_decks[1].name, "Test Deck 2")
+                
+                # Verify file operations
+                mock_package.return_value.write_to_file.assert_called_once()
+                mock_replace.assert_called_once()
+
+    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_with_media(self, mock_replace, mock_package):
+        note = Note(model=self.test_model, fields=['Q1', 'A1'])
+        deck_payload = {
+            "id": 1234567890,
+            "name": "Test Deck",
+            "desc": "Test Description",
+            "notes": [note]
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            img_path = os.path.join(tmpdir, 'test.jpg')
+            audio_path = os.path.join(tmpdir, 'audio.mp3')
+            open(img_path, 'w').close()
+            open(audio_path, 'w').close()
+            media_files = [img_path, audio_path]
+
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                _write_new_apkg([deck_payload], media_files)
+
+                mock_package.assert_called_once()
+                package_instance = mock_package.return_value
+                self.assertEqual(package_instance.media_files, media_files)
+                
+                # Verify file operations
+                mock_package.return_value.write_to_file.assert_called_once()
+                mock_replace.assert_called_once()
+
+    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_skips_missing_media(self, mock_replace, mock_package):
+        note = Note(model=self.test_model, fields=['Q1', 'A1'])
+        deck_payload = {
+            "id": 1234567890,
+            "name": "Test Deck",
+            "desc": "Test Description",
+            "notes": [note]
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing_path = os.path.join(tmpdir, 'exists.jpg')
+            open(existing_path, 'w').close()
+            media_files = [existing_path, 'image.png']
+
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                _write_new_apkg([deck_payload], media_files)
+
+                package_instance = mock_package.return_value
+                self.assertEqual(package_instance.media_files, [existing_path])
+
+    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.os.replace')
+    def test_write_new_apkg_empty_deck_list(self, mock_replace, mock_package):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                _write_new_apkg([], [])
+                
+                mock_package.assert_called_once()
+                mock_package.return_value.write_to_file.assert_called_once()
+                mock_replace.assert_called_once()
+                
+                # Verify the default name is used
+                _, dst = mock_replace.call_args[0]
+                self.assertIn("default-", dst)
+
+    def test_sanitize_filename_security(self):
+        """Test that sanitize_filename prevents path traversal attacks."""
+        dangerous_cases = [
+            ("../../../etc/passwd", "etcpasswd"),
+            ("..\\..\\windows\\system32", "windowssystem32"),
+            ("/etc/passwd", "etcpasswd"),
+            ("C:\\Windows\\System32", "CWindowsSystem32"),
+            ("./config/secrets", "configsecrets"),
+            ("../test", "test"),
+            ("test/../danger", "testdanger"),
+        ]
+        
+        for dangerous_input, expected_safe in dangerous_cases:
+            result = sanitize_filename(dangerous_input)
+            self.assertEqual(result, expected_safe, 
+                           f"Failed to sanitize '{dangerous_input}' properly")
+            # Ensure no path separators remain
+            self.assertNotIn('/', result)
+            self.assertNotIn('\\', result)
+            self.assertNotIn('..', result)
+
+    def test_rename_temp_file_security(self):
+        """Test that rename_temp_file prevents path traversal attacks."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a temporary file to rename
+            temp_file = os.path.join(tmpdir, "temp.apkg")
+            with open(temp_file, 'w') as f:
+                f.write("test content")
+            
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                # Test dangerous inputs that should be blocked
+                dangerous_cases = [
+                    ("../../../danger", "1234"),
+                    ("normal", "../../../etc/passwd"),
+                    ("../up", "../back"),
+                ]
+                
+                for dangerous_name, dangerous_id in dangerous_cases:
+                    with self.assertRaises(ValueError) as cm:
+                        rename_temp_file(temp_file, dangerous_name, dangerous_id)
+                    self.assertIn("Path traversal attempt detected", str(cm.exception))
+                
+                # Test that safe inputs work correctly
+                safe_result = rename_temp_file(temp_file, "safe_name", "1234")
+                expected_path = os.path.join(tmpdir, "safe_name-1234.apkg")
+                self.assertEqual(safe_result, expected_path)
+                self.assertTrue(os.path.exists(safe_result))
+
+    def test_rename_temp_file_basename_only(self):
+        """Test that rename_temp_file works with safe filenames."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_file = os.path.join(tmpdir, "temp.apkg")
+            with open(temp_file, 'w') as f:
+                f.write("test content")
+            
+            with mock.patch('os.getcwd', return_value=tmpdir):
+                # Test with safe inputs (no path separators)
+                result = rename_temp_file(temp_file, "safe_name", "safe_id")
+                expected_filename = "safe_name-safe_id.apkg"
+                self.assertTrue(result.endswith(expected_filename))
+                self.assertTrue(os.path.exists(result))
+                
+                # Verify the file is in the expected directory
+                self.assertEqual(os.path.dirname(result), tmpdir)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -40,8 +40,7 @@ export const ONE_HOUR = 60 * 60 * 1000;
 
 export const BUILD_DIR = path.join(__dirname, '../../web/build');
 
-export const CREATE_DECK_DIR =
-  process.env.CREATE_DECK_DIR || path.join(__dirname, '../../../create_deck/');
+export const CREATE_DECK_DIR = path.join(__dirname, '../../create_deck/');
 
 export const CREATE_DECK_SCRIPT_PATH = path.join(
   CREATE_DECK_DIR,


### PR DESCRIPTION
## Summary

Phase 3 of the monorepo migration. Imports [2anki/create_deck](https://github.com/2anki/create_deck) into \`create_deck/\` and rewires the deploy + Express path resolution accordingly.

- 31 tracked files from \`2anki/create_deck@origin/main\` copied
- Drop broken \`Dockerfile\` (referenced a non-existent \`main:app\`) and nested \`.github\`
- New \`create_deck.yml\` workflow runs pylint + pytest (Python 3.11/3.12/3.14 matrix), path-filtered to \`create_deck/**\`
- \`server.yml\` ignores \`create_deck/**\`
- \`src/lib/constants.ts\`: drop \`CREATE_DECK_DIR\` env override; relative path now resolves consistently in dev/CI/prod
- \`deploy.2anki.net.yml\`: drop the separate \`CREATE_DECK_DIR\` clone + pull. \`pip install\` runs against \`\${SERVER_DIR}/create_deck/requirements.txt\`. The deploy now manages a single repo

## Test plan

- [ ] \`Create Deck\` workflow fires and passes pylint + pytest matrix
- [ ] Server build (\`tsc -p .\`) clean (verified locally)
- [ ] Merge → first deploy:
  - [ ] pip install runs against the new path
  - [ ] Deck generation flow still works end-to-end (upload a Notion page, verify .apkg downloads)
- [ ] After a week of green deploys: archive \`2anki/create_deck\` repo

## Rollback

Revert this PR → next deploy goes back to the Phase 2 behavior. The legacy \`~/src/github.com/2anki/create_deck\` checkout is still on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)