### PR TITLE
fix: resolve create_deck template path in monorepo

### DIFF
--- a/create_deck/helpers/get_template.py
+++ b/create_deck/helpers/get_template.py
@@ -10,7 +10,7 @@ def get_template_path():
     helper to find path to the server's template directory
     :return:
     """
-    return os.path.dirname(__file__) + "/../../server/src/templates/"
+    return os.path.dirname(__file__) + "/../../src/templates/"
 
 
 def get_template(path):


### PR DESCRIPTION
## Summary

Hotfix for a regression introduced by Phase 3 (#2035). Deck generation has been failing in production since the merge with:

```
FileNotFoundError: '/home/alemayhu/src/github.com/2anki/2anki.net/create_deck/helpers/../../server/src/templates/n2a-basic.json'
```

\`create_deck/helpers/get_template.py\` was hardcoding \`../../server/src/templates/\`, which made sense in the legacy sibling layout but resolves to a non-existent path inside the monorepo. Changed to \`../../src/templates/\` so it climbs out of \`create_deck/helpers/\` to the monorepo root and into the server's existing template dir.

Pytest didn't catch this because no test exercises actual template file loading.

## Verify

After merge, watch \`pm2 logs server\` while triggering an upload — should see no \`FileNotFoundError\`.