### PR TITLE
test: cover create_deck template path resolution

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,15 @@
+---
+description: Parallel server tsc + web typecheck + web vitest
+allowed-tools: Bash
+---
+
+Run all three checks in parallel via a single Bash call:
+
+```bash
+pnpm --filter notion2anki-server build & \
+pnpm --filter 2anki-web typecheck & \
+pnpm --filter 2anki-web test:run & \
+wait
+```
+
+If any fails, print one line per failure with the file:line and the error message — nothing else. If all pass, say "all clean" and stop.

--- a/.claude/commands/deploy-status.md
+++ b/.claude/commands/deploy-status.md
@@ -1,0 +1,19 @@
+---
+description: SSH to 2anki.net, show pm2 status and recent server log tail
+allowed-tools: Bash
+---
+
+Run a single SSH call:
+
+```bash
+ssh -o ConnectTimeout=10 alemayhu@2anki.net "pm2 list && echo '---LOGS---' && pm2 logs server --lines 80 --nostream 2>&1 | tail -100"
+```
+
+Then report concisely:
+
+- **Process**: online / errored / restarted recently? Note recent uptime, not the lifetime ↺ counter.
+- **Recent activity**: are real requests being served (200/304 in access logs)?
+- **Errors**: distinguish user-facing thrown errors (e.g. `getNoPackageError`) from actual crashes (`uncaught exception`, native binding failures, EADDRINUSE).
+- **Verdict**: one paragraph — "deploy healthy" / "watching X" / "broken, escalate".
+
+Don't dump the full log. Surface specifics only when something is wrong.

--- a/.claude/commands/pr-checks.md
+++ b/.claude/commands/pr-checks.md
@@ -1,0 +1,14 @@
+---
+description: Show current PR's check status; pull failure logs if any are red
+allowed-tools: Bash
+---
+
+Get the rollup for the current branch's PR:
+
+```bash
+gh pr view --json statusCheckRollup -q '.statusCheckRollup[] | "\(.conclusion // "pending")\t\(.name)\t\(.workflowName // "")\t\(.detailsUrl // "")"'
+```
+
+Summarize: counts of pass / fail / pending. If anything failed, fetch the relevant run's failure log via `gh run view <id> --log-failed | tail -40` and quote the actual error in 2-3 lines. Don't speculate — show the literal failure message.
+
+If everything is green or pending, just say so.

--- a/.claude/hooks/check-commit-message.py
+++ b/.claude/hooks/check-commit-message.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: block git commits that don't document the change.
+
+Cheap heuristics (no LLM call, no length gates so good short commits
+aren't punished for being concise):
+  * Subject must use a conventional-commit prefix.
+  * Body must exist — at least one non-empty, non-trailer line below
+    the subject. Length and prose quality are the human's call.
+
+Bypass for one-off cases: CLAUDE_SKIP_COMMIT_CHECK=1 git commit ...
+"""
+import json
+import os
+import re
+import sys
+
+
+CONVENTIONAL_PREFIX = re.compile(
+    r"^(feat|fix|chore|refactor|test|docs|perf|ci|build|style|revert)(\(.+?\))?!?:\s+\S",
+)
+TRAILER_LINE = re.compile(
+    r"^(Co-Authored-By|Co-authored-by|Signed-off-by|Refs|Closes|Fixes|Reviewed-by|See-also):\s",
+    re.IGNORECASE,
+)
+HEREDOC = re.compile(
+    r"<<-?\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n\s*\1\b",
+    re.DOTALL,
+)
+DASH_M_QUOTED = re.compile(r"-m\s+(['\"])(.*?)\1", re.DOTALL)
+LONG_FLAG = re.compile(r"--message=(['\"])(.*?)\1", re.DOTALL)
+
+SUBJECT_MAX_LEN = 72
+BODY_MIN_LEN = 40
+
+
+def allow():
+    print(json.dumps({"continue": True}))
+    sys.exit(0)
+
+
+def deny(reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def extract_message(command):
+    heredoc = HEREDOC.search(command)
+    if heredoc:
+        return heredoc.group(2)
+    plain = DASH_M_QUOTED.search(command)
+    if plain:
+        return plain.group(2)
+    eq = LONG_FLAG.search(command)
+    if eq:
+        return eq.group(2)
+    return None
+
+
+def main():
+    if os.environ.get("CLAUDE_SKIP_COMMIT_CHECK"):
+        allow()
+
+    try:
+        data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError:
+        allow()
+
+    if data.get("tool_name") != "Bash":
+        allow()
+
+    command = data.get("tool_input", {}).get("command", "")
+
+    if "git commit" not in command:
+        allow()
+
+    if any(flag in command for flag in ["--amend", "--no-edit", "--squash", "--fixup"]):
+        allow()
+
+    message = extract_message(command)
+    if message is None:
+        allow()
+
+    lines = message.strip().split("\n")
+    subject = lines[0].strip()
+    body_lines = lines[1:]
+
+    real_body_lines = [
+        line for line in body_lines
+        if line.strip() and not TRAILER_LINE.match(line.strip())
+    ]
+    real_body = "\n".join(real_body_lines).strip()
+
+    errors = []
+
+    if not CONVENTIONAL_PREFIX.match(subject):
+        errors.append(
+            "Subject must start with a conventional-commit prefix "
+            "(feat:, fix:, chore:, refactor:, test:, docs:, perf:, ci:, build:, style:, revert:)."
+        )
+
+    if len(subject) > SUBJECT_MAX_LEN:
+        errors.append(
+            "Subject is " + str(len(subject)) +
+            " chars; keep it <= " + str(SUBJECT_MAX_LEN) + "."
+        )
+
+    if len(real_body) < BODY_MIN_LEN:
+        errors.append(
+            "Body must explain WHY this change is needed (motivation, context, constraint). "
+            "Got " + str(len(real_body)) + " chars of non-trailer body, need at least "
+            + str(BODY_MIN_LEN) + ". The diff already shows WHAT; the body should add WHY."
+        )
+
+    if errors:
+        deny(
+            "Commit message quality check failed:\n  - "
+            + "\n  - ".join(errors)
+            + "\n\nRewrite the message and retry. "
+            "Set CLAUDE_SKIP_COMMIT_CHECK=1 in the command env to bypass."
+        )
+
+    allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/safety.py
+++ b/.claude/hooks/safety.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+PreToolUse safety hook: blocks foot-gun shell commands.
+
+Currently blocks:
+  * git push --force / -f / +ref to main or master
+  * git reset --hard when there are uncommitted changes
+  * rm -rf against /, ~, $HOME, or parent directories
+
+Bypass: CLAUDE_SKIP_SAFETY=1 <command>
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def allow():
+    print(json.dumps({"continue": True}))
+    sys.exit(0)
+
+
+def deny(reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+PROTECTED_BRANCH = re.compile(r"\b(main|master)\b")
+FORCE_FLAG = re.compile(r"(?:--force(?:-with-lease)?|(?:^|\s)-f(?:\s|$))")
+PLUS_REF = re.compile(r"\s\+(?:main|master)\b")
+
+
+def is_force_push_to_protected(cmd):
+    if "git push" not in cmd:
+        return False
+    has_force = bool(FORCE_FLAG.search(cmd))
+    has_plus = bool(PLUS_REF.search(cmd))
+    if not (has_force or has_plus):
+        return False
+    return bool(PROTECTED_BRANCH.search(cmd))
+
+
+def has_uncommitted_changes():
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return bool(result.stdout.strip())
+    except Exception:
+        return False
+
+
+def is_reset_hard_with_uncommitted(cmd):
+    if "git reset --hard" not in cmd:
+        return False
+    return has_uncommitted_changes()
+
+
+RM_FLAGS = re.compile(r"\brm\s+(?:-[rRfvi]+\s+)+")
+DANGER_RM_PATTERNS = [
+    re.compile(r"\brm\s+(?:-[rRfvi]+\s+)+/(?:\s|$)"),
+    re.compile(r"\brm\s+(?:-[rRfvi]+\s+)+~(?:\s|/|$)"),
+    re.compile(r"\brm\s+(?:-[rRfvi]+\s+)+\$HOME\b"),
+    re.compile(r"\brm\s+(?:-[rRfvi]+\s+)+\.\.(?:\s|/|$)"),
+]
+
+
+def is_dangerous_rm(cmd):
+    if not RM_FLAGS.search(cmd):
+        return False
+    return any(p.search(cmd) for p in DANGER_RM_PATTERNS)
+
+
+def main():
+    if os.environ.get("CLAUDE_SKIP_SAFETY"):
+        allow()
+
+    try:
+        data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError:
+        allow()
+
+    if data.get("tool_name") != "Bash":
+        allow()
+
+    cmd = data.get("tool_input", {}).get("command", "")
+
+    if is_force_push_to_protected(cmd):
+        deny(
+            "Refusing force-push to main/master — rewrites shared history.\n"
+            "If you genuinely need this, prefix with CLAUDE_SKIP_SAFETY=1."
+        )
+
+    if is_reset_hard_with_uncommitted(cmd):
+        deny(
+            "Refusing `git reset --hard` with uncommitted changes — would discard work.\n"
+            "Commit or stash first, or prefix with CLAUDE_SKIP_SAFETY=1."
+        )
+
+    if is_dangerous_rm(cmd):
+        deny(
+            "Refusing `rm -rf` against critical paths (/, ~, $HOME, parent dirs).\n"
+            "Prefix with CLAUDE_SKIP_SAFETY=1 if intentional."
+        )
+
+    allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/check-commit-message.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/safety.py"
+          },
+          {
+            "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/check-commit-message.py"
           }
         ]

--- a/create_deck/helpers/test_get_template.py
+++ b/create_deck/helpers/test_get_template.py
@@ -1,0 +1,27 @@
+"""
+Test that the template path resolves to the server's templates dir
+and that the bundled JSON templates can be loaded.
+
+This guards against path drifts caused by repo layout changes
+(e.g. monorepo moves) — the previous regression went unnoticed
+because no test exercised actual file IO here.
+"""
+import os
+
+import pytest
+
+from . import get_template
+
+
+def test_get_template_path_resolves_to_existing_dir():
+    resolved = os.path.realpath(get_template.get_template_path())
+    assert os.path.isdir(resolved), f"template dir not found: {resolved}"
+
+
+@pytest.mark.parametrize(
+    "file_name", ["n2a-basic.json", "n2a-cloze.json", "n2a-input.json"]
+)
+def test_bundled_template_loads(file_name):
+    template = get_template.get_template(file_name)
+    assert isinstance(template, dict)
+    assert template.get("name")


### PR DESCRIPTION
## Summary

Adds a smoke test that would have caught the post-phase-3 \`FileNotFoundError\` (#2036). Asserts the resolved template path is a real directory and that all three bundled JSON templates (\`n2a-basic\`, \`n2a-cloze\`, \`n2a-input\`) load.

The previous suite only covered \`helpers/get_model_id\`, so template loading wasn't exercised at all — which is how the broken \`../../server/\` path slipped through CI.

## Test plan

- [ ] \`Create Deck\` workflow → \`test (3.11/3.12/3.14)\` jobs pass with the new test