### PR TITLE
chore: auto-open the dependabot-updates → main PR

### DIFF
--- a/.github/workflows/dependabot-open-merge-pr.yml
+++ b/.github/workflows/dependabot-open-merge-pr.yml
@@ -1,0 +1,50 @@
+name: Open dependabot-updates → main PR
+
+on:
+  push:
+    branches:
+      - dependabot-updates
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Skip when no diff vs main
+        id: diff
+        run: |
+          git fetch origin main
+          if git diff --quiet origin/main..HEAD; then
+            echo "no_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure PR exists
+        if: steps.diff.outputs.no_diff != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh pr list \
+            --base main \
+            --head dependabot-updates \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -n "$existing" ]; then
+            echo "PR #$existing already open."
+            exit 0
+          fi
+
+          gh pr create \
+            --base main \
+            --head dependabot-updates \
+            --title "chore(deps): consolidated dependency updates" \
+            --body "Auto-opened by .github/workflows/dependabot-open-merge-pr.yml. Merging this triggers one production deploy covering every dependabot bump merged into \`dependabot-updates\` since the last release."


### PR DESCRIPTION
## Summary
Follow-up to #2039. Removes the last manual step from the staging-branch flow by auto-opening the consolidated `dependabot-updates → main` PR whenever the staging branch moves.

## Behavior
- Triggers on push to `dependabot-updates` and via `workflow_dispatch`
- No-ops if `dependabot-updates` has no diff vs `main`
- No-ops if a PR is already open for that head/base pair
- Otherwise opens a draft-quality PR titled `chore(deps): consolidated dependency updates`

End state: dependabot PRs auto-merge into staging → this workflow keeps a single `dependabot-updates → main` PR open and current → you click merge when ready → one deploy.

## Test plan
- [ ] After merge, manually trigger the workflow via `workflow_dispatch` and confirm it either no-ops (if already up to date) or opens a fresh PR
- [ ] Push a trivial commit to `dependabot-updates` and confirm the workflow runs and the PR is created/exists
- [ ] Re-run with the PR already open and confirm it no-ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)