### PR TITLE
fix(ankify): time out Step 1 after 45s with a Try again action

### DIFF
--- a/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
@@ -96,6 +96,31 @@ describe('AnkifySetupPage', () => {
     );
     expect(screen.queryByText(/beta/i)).not.toBeInTheDocument();
   });
+
+  test('shows a timeout fallback once Anki has been starting too long', async () => {
+    const stale = sampleClient({
+      created_at: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const respin = vi.fn(async () => sampleClient({ id: 2 }));
+    const backend = makeBackend({
+      listAnkifyClients: vi.fn(async () => [stale]),
+      checkAnkifyActiveClientReady: vi.fn(async () => ({
+        ready: false,
+        reason: 'unreachable' as const,
+      })),
+      respinAnkifyClient: respin,
+    });
+
+    renderAt('/ankify/setup', backend);
+
+    const tryAgain = await screen.findByRole('button', { name: /try again/i });
+    expect(
+      screen.getByText(/anki is taking longer than expected/i)
+    ).toBeInTheDocument();
+
+    tryAgain.click();
+    await waitFor(() => expect(respin).toHaveBeenCalledTimes(1));
+  });
 });
 
 describe('AnkifyPage workspace home', () => {

--- a/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
@@ -10,8 +10,10 @@ import AnkifyClient from '../../lib/interfaces/AnkifyClient';
 import { Skeleton } from '../../components/Skeleton/Skeleton';
 
 const QUERY_KEY = ['ankify-clients'];
+const READINESS_QUERY_KEY = ['ankify-active-ready'];
 const ANKI_WEB_ACK_KEY = 'ankify_anki_web_acknowledged';
 const SESSION_URL_PREFIX = 'ankify_session_url:';
+const STARTING_TIMEOUT_MS = 45_000;
 
 const sessionUrlKey = (clientId: number) => `${SESSION_URL_PREFIX}${clientId}`;
 
@@ -62,10 +64,12 @@ export default function AnkifySetupPage({ backend }: Props) {
   const activeClient = (data ?? []).find((c) => c.status === 'active');
   const hasActiveClient = activeClient != null;
 
+  const [startingTimedOut, setStartingTimedOut] = useState(false);
+
   const readiness = useQuery({
-    queryKey: ['ankify-active-ready'],
+    queryKey: READINESS_QUERY_KEY,
     queryFn: () => api.checkAnkifyActiveClientReady(),
-    enabled: hasActiveClient,
+    enabled: hasActiveClient && !startingTimedOut,
     refetchInterval: (query) =>
       (query.state.data as { ready?: boolean } | undefined)?.ready === true
         ? false
@@ -73,6 +77,36 @@ export default function AnkifySetupPage({ backend }: Props) {
   });
 
   const containerReady = readiness.data?.ready === true;
+
+  useEffect(() => {
+    if (!hasActiveClient || containerReady) {
+      setStartingTimedOut(false);
+      return;
+    }
+    const startedAt =
+      activeClient?.created_at != null
+        ? new Date(activeClient.created_at).getTime()
+        : Date.now();
+    const remaining = startedAt + STARTING_TIMEOUT_MS - Date.now();
+    if (remaining <= 0) {
+      setStartingTimedOut(true);
+      return;
+    }
+    const timer = setTimeout(() => setStartingTimedOut(true), remaining);
+    return () => clearTimeout(timer);
+  }, [hasActiveClient, containerReady, activeClient?.created_at]);
+
+  const respin = useMutation({
+    mutationFn: () => api.respinAnkifyClient(),
+    onSuccess: (client) => {
+      if (client.session_url != null) {
+        writeCachedSessionUrl(client.id, client.session_url);
+      }
+      setStartingTimedOut(false);
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: READINESS_QUERY_KEY });
+    },
+  });
 
   const ankiWebStatus = useQuery({
     queryKey: ['ankify-anki-web-status'],
@@ -208,16 +242,49 @@ export default function AnkifySetupPage({ backend }: Props) {
     <section className={styles.setupActiveStep}>
       <p className={styles.setupActiveStepLabel}>Step 1 of 2</p>
       <h2 className={styles.setupActiveStepTitle}>Start Anki</h2>
-      <div
-        className={styles.setupActiveStepActions}
-        role="status"
-        aria-live="polite"
-      >
-        <Skeleton width="11rem" height="2.25rem" radius="0.4rem" />
-        <p className={styles.setupActiveStepHint}>
-          Starting Anki — usually 5 to 15 seconds.
-        </p>
-      </div>
+      {startingTimedOut ? (
+        <>
+          <div className={styles.provisionErrorBlock} role="alert">
+            <p className={styles.provisionErrorTitle}>
+              Anki is taking longer than expected.
+            </p>
+            <p className={styles.provisionErrorBody}>
+              Most retries succeed. If it keeps failing, email
+              hello@2anki.net.
+            </p>
+          </div>
+          <div className={styles.setupActiveStepActions}>
+            <button
+              type="button"
+              className={`${sharedStyles.btnPrimary} ${styles.inlineButton}`}
+              onClick={() => respin.mutate()}
+              disabled={respin.isPending}
+            >
+              {respin.isPending ? 'Restarting…' : 'Try again'}
+            </button>
+          </div>
+          {respin.error && (
+            <p
+              className={styles.provisionErrorBody}
+              role="alert"
+              aria-live="polite"
+            >
+              {(respin.error as Error).message}
+            </p>
+          )}
+        </>
+      ) : (
+        <div
+          className={styles.setupActiveStepActions}
+          role="status"
+          aria-live="polite"
+        >
+          <Skeleton width="11rem" height="2.25rem" radius="0.4rem" />
+          <p className={styles.setupActiveStepHint}>
+            Starting Anki — usually 5 to 15 seconds.
+          </p>
+        </div>
+      )}
     </section>
   );
 


### PR DESCRIPTION
## Summary
- The Ankify setup UI sat on *Step 1 of 2 — Starting Anki — usually 5 to 15 seconds.* indefinitely whenever the readiness probe never flipped to `ready` (e.g. the case Al hit on 2anki.net today, where the container booted but `apiKey` templating silently failed and AnkiConnect rejected every probe).
- Once the active client has been alive for 45s without becoming ready, the page now shows a timeout message and a **Try again** button that calls `respinAnkifyClient()`. While timed out, readiness polling pauses so we stop hammering the backend.
- 45s = 3× the documented worst-case start time, leaves headroom for a slow cold boot, fails fast on truly broken containers.

## Notes
- The container-side fix is in remote-anki-client#15. This PR makes the UI graceful even when something else goes wrong (Docker disruption, port collision, image regression).

## Test plan
- [x] `pnpm --filter 2anki-web exec vitest run src/pages/AnkifyPage` — all 6 tests pass, including the new timeout-fallback test
- [x] `pnpm --filter 2anki-web typecheck` — clean
- [ ] Visual check on a fresh provision: page advances to Step 2 within ~15s
- [ ] Visual check on a stuck provision (e.g. force a misconfigured container): timeout fallback appears at ~45s, **Try again** spins up a fresh client and the page recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)