### PR TITLE
fix(ankify): register session proxy before SPA catch-all

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,7 @@ function registerSignalHandlers(server: http.Server) {
 const serve = async () => {
   const templateDir = path.join(__dirname, 'templates');
   const app = express();
+  const server = http.createServer(app);
 
   app.use(webhookRouter());
   app.use(ankifyWebhookRouter());
@@ -71,6 +72,10 @@ const serve = async () => {
   app.use(morgan('combined') as RequestHandler);
 
   const ankifySessionValidate = buildAnkifySessionProxyDeps();
+  // Must run before defaultRouter()'s catch-all (which serves index.html
+  // for anything not under /api), otherwise /v/<token>/* gets shadowed
+  // by the SPA and users see a 404 instead of their Ankify session.
+  attachAnkifySessionProxy(app, server, ankifySessionValidate);
 
   app.use('/templates', express.static(templateDir));
   app.use(express.static(BUILD_DIR));
@@ -113,10 +118,9 @@ const serve = async () => {
   process.chdir(cwd);
   process.env.SECRET ||= 'victory';
   const port = process.env.PORT || 2020;
-  const server = app.listen(port, () => {
+  server.listen(port, () => {
     console.info(`🟢 Running on http://localhost:${port}`);
   });
-  attachAnkifySessionProxy(app, server, ankifySessionValidate);
   registerSignalHandlers(server);
 
   const database = getDatabase();


### PR DESCRIPTION
## Summary
- Production session URLs like `https://2anki.net/v/<43-char-token>/vnc.html` were returning the React SPA's 404 page instead of proxying to the user's Ankify container.
- Root cause: `attachAnkifySessionProxy()` was called *after* `app.listen()`, well past the point where `defaultRouter()`'s catch-all regex (`/^\/(?!api).*/` → `index.html`) had already been registered. Express handlers run in registration order, so every `/v/...` request hit the SPA fallback first.
- Fix: create the `http.Server` up front, register the session proxy right after `cookieParser` / `morgan` and before any of the API routers or the SPA catch-all. Switch `app.listen()` → `server.listen()`.
- Added a one-line `// Must run before defaultRouter()…` comment to keep this from regressing on a future refactor — non-obvious invariant, justifies the comment per CLAUDE.md.

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [ ] After deploy: `https://2anki.net/v/<token>/vnc.html` opens noVNC (was: SPA 404)
- [ ] After deploy: WebSocket upgrade still works (the proxy's `httpServer.on('upgrade', …)` registration is unchanged; only the express-side handler was moved)
- [ ] Spot-check unrelated routes (a Notion page, `/api/upload/jobs`, `/downloads`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)