### PR TITLE
feat(ankify): add a Restart Anki action on Step 2

### DIFF
--- a/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
@@ -97,6 +97,26 @@ describe('AnkifySetupPage', () => {
     expect(screen.queryByText(/beta/i)).not.toBeInTheDocument();
   });
 
+  test('Step 2 offers a Restart Anki action that respins the client', async () => {
+    const respin = vi.fn(async () => sampleClient({ id: 99 }));
+    const backend = makeBackend({
+      listAnkifyClients: vi.fn(async () => [sampleClient()]),
+      checkAnkifyActiveClientReady: vi.fn(async () => ({ ready: true })),
+      checkAnkifyAnkiWebStatus: vi.fn(async () => ({
+        status: 'unlinked' as const,
+      })),
+      respinAnkifyClient: respin,
+    });
+
+    renderAt('/ankify/setup', backend);
+
+    const restart = await screen.findByRole('button', {
+      name: /restart anki/i,
+    });
+    restart.click();
+    await waitFor(() => expect(respin).toHaveBeenCalledTimes(1));
+  });
+
   test('shows a timeout fallback once Anki has been starting too long', async () => {
     const stale = sampleClient({
       created_at: new Date(Date.now() - 60_000).toISOString(),

--- a/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
@@ -359,6 +359,25 @@ export default function AnkifySetupPage({ backend }: Props) {
             We'll move on automatically once AnkiWeb is linked.
           </p>
         )}
+        <p className={styles.setupActiveStepHint}>
+          Stuck?{' '}
+          <button
+            type="button"
+            className={styles.btnLink}
+            onClick={() => respin.mutate()}
+            disabled={respin.isPending}
+          >
+            {respin.isPending ? 'Restarting…' : 'Restart Anki'}
+          </button>
+        </p>
+        {respin.error && (
+          <div
+            role="alert"
+            className={`${sharedStyles.alertDanger} ${styles.signInAlert}`}
+          >
+            We couldn't restart Anki. {(respin.error as Error).message}
+          </div>
+        )}
       </section>
     );
   };


### PR DESCRIPTION
## Summary
- If the AnkiWeb sign-in keeps failing on Step 2, users had no way to recover. Adds a subtle "Stuck? **Restart Anki**" link below the existing verify alerts that calls `respinAnkifyClient()` — tears down the current container and provisions a fresh one. The component already had the `respin` mutation wired up (added with the Step 1 timeout fix).
- Uses the existing `.btnLink` style — text-link weight, intentionally less prominent than the primary "I've signed in" CTA so it doesn't compete with the happy path.

## Test plan
- [x] `pnpm --filter 2anki-web exec vitest run src/pages/AnkifyPage` — 7/7 pass, including a new test that clicks Restart Anki and asserts `respinAnkifyClient` is called
- [x] `pnpm --filter 2anki-web typecheck` — clean
- [ ] Visual: on `/ankify/setup` with an active+ready client and `unlinked` AnkiWeb status, the link reads *Stuck? Restart Anki*. Clicking it tears down the current container and the page returns to Step 1 (Starting Anki…) momentarily before flipping to Step 2 with a fresh session URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)