### PR TITLE
fix(ankify): drop ws:true to stop racing our manual upgrade handler

### DIFF
--- a/src/routes/AnkifySessionProxyRouter.test.ts
+++ b/src/routes/AnkifySessionProxyRouter.test.ts
@@ -1,0 +1,77 @@
+import express from 'express';
+import http from 'node:http';
+
+const capturedOptions: { value: Record<string, unknown> | null } = {
+  value: null,
+};
+
+jest.mock('http-proxy-middleware', () => {
+  const middleware = Object.assign(
+    jest.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+    { upgrade: jest.fn() }
+  );
+  return {
+    createProxyMiddleware: jest.fn((options: Record<string, unknown>) => {
+      capturedOptions.value = options;
+      return middleware;
+    }),
+  };
+});
+
+import { attachAnkifySessionProxy } from './AnkifySessionProxyRouter';
+import { ValidateAnkifySessionTokenUseCase } from '../usecases/ankify/ValidateAnkifySessionTokenUseCase';
+
+const VALID_TOKEN = 'A'.repeat(43);
+
+const makeFakeValidate = (port: number) =>
+  ({
+    execute: async () => ({ ok: true as const, novnc_port: port }),
+  }) as unknown as ValidateAnkifySessionTokenUseCase;
+
+describe('attachAnkifySessionProxy', () => {
+  beforeEach(() => {
+    capturedOptions.value = null;
+  });
+
+  test('does not pass ws:true to the proxy (would race with our upgrade handler)', () => {
+    const app = express();
+    const server = http.createServer(app);
+    attachAnkifySessionProxy(app, server, makeFakeValidate(54321));
+
+    expect(capturedOptions.value).not.toBeNull();
+    expect(capturedOptions.value?.ws).not.toBe(true);
+  });
+
+  test('registers exactly one upgrade handler on the http server', () => {
+    const app = express();
+    const server = http.createServer(app);
+    attachAnkifySessionProxy(app, server, makeFakeValidate(54321));
+
+    expect(server.listenerCount('upgrade')).toBe(1);
+  });
+
+  test('upgrade handler validates and forwards to proxy.upgrade with port set', async () => {
+    const app = express();
+    const server = http.createServer(app);
+    attachAnkifySessionProxy(app, server, makeFakeValidate(54321));
+
+    const upgradeListeners = server.listeners(
+      'upgrade'
+    ) as ((req: http.IncomingMessage, socket: unknown, head: Buffer) => Promise<void>)[];
+    const ourHandler = upgradeListeners[0];
+
+    const req = {
+      url: `/v/${VALID_TOKEN}/websockify`,
+      headers: { cookie: 'token=abc' },
+    } as unknown as http.IncomingMessage;
+    const socket = { destroy: jest.fn() };
+    const head = Buffer.alloc(0);
+
+    await ourHandler(req, socket, head);
+
+    expect((req as unknown as { __ankifyNovncPort: number }).__ankifyNovncPort).toBe(
+      54321
+    );
+    expect(socket.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/AnkifySessionProxyRouter.ts
+++ b/src/routes/AnkifySessionProxyRouter.ts
@@ -47,7 +47,6 @@ export const attachAnkifySessionProxy = (
       return `http://127.0.0.1:${port}`;
     },
     changeOrigin: true,
-    ws: true,
     logger: console,
   });
 


### PR DESCRIPTION
## Summary

- Fixes the websockify connection failure visible at `https://2anki.net/v/<token>/vnc.html` (browser reports `WebSocket connection failed` + `code 1006`).
- Root cause: `ws: true` in `createProxyMiddleware` makes http-proxy-middleware v4 lazily subscribe its own `upgrade` listener to the http server the first time HTTP traffic flows through. We already register our own validation-aware upgrade listener — so two listeners ended up running per WS request. Ours awaits validation before setting the per-request port; the internal one runs concurrently, sees `req[PORT_KEY]` undefined, and proxies to `http://127.0.0.1:0` → ECONNREFUSED. Visible in pm2 logs as `[HPM] Error occurred while proxying request 2anki.net/v/<token>/websockify to undefined [ECONNREFUSED]`.
- Fix: drop `ws: true`. With `wsInternalSubscribed` staying false, our handler is the sole upgrade listener and `proxy.upgrade(...)` (which we still call after validating) actually proxies. New `AnkifySessionProxyRouter.test.ts` pins this down: asserts `ws !== true`, exactly one upgrade listener, and that the handler sets the port before calling the proxy.

## Test plan

- [x] `pnpm test -- src/routes/AnkifySessionProxyRouter.test.ts` — 3/3 green.
- [x] `tsc --noEmit` — clean.
- [ ] Prod smoke: visit a fresh `/v/<token>/vnc.html`, confirm noVNC reaches the desktop (no 1006 error in browser console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)