### PR TITLE
fix(web/ankify): drop untitled pages and DB rows from parent picker

### DIFF
--- a/web/src/lib/backend/Backend.test.ts
+++ b/web/src/lib/backend/Backend.test.ts
@@ -96,6 +96,64 @@ describe('Backend', () => {
     });
   });
 
+  describe('search', () => {
+    beforeEach(() => {
+      vi.mocked(api.get).mockResolvedValue(
+        createMockResponse(200, true, '', { results: [] })
+      );
+    });
+
+    it('drops entries with empty titles and exposes parent on the rest', async () => {
+      vi.mocked(api.post).mockResolvedValue(
+        createMockResponse(200, true, '', {
+          results: [
+            {
+              id: 'page-named',
+              object: 'page',
+              url: 'https://www.notion.so/page-named',
+              parent: { type: 'page_id', page_id: 'parent-1' },
+              properties: {
+                title: {
+                  id: 'title',
+                  type: 'title',
+                  title: [{ plain_text: 'Real page' }],
+                },
+              },
+            },
+            {
+              id: 'page-untitled',
+              object: 'page',
+              url: 'https://www.notion.so/page-untitled',
+              parent: { type: 'page_id', page_id: 'parent-1' },
+              properties: {
+                title: { id: 'title', type: 'title', title: [] },
+              },
+            },
+            {
+              id: 'db-row',
+              object: 'page',
+              url: 'https://www.notion.so/db-row',
+              parent: { type: 'database_id', database_id: 'db-1' },
+              properties: {
+                Name: {
+                  id: 'name',
+                  type: 'title',
+                  title: [{ plain_text: 'Card 1' }],
+                },
+              },
+            },
+          ],
+        })
+      );
+
+      const results = await backend.search('anything');
+
+      expect(results.map((r) => r.id)).toEqual(['page-named', 'db-row']);
+      expect(results[0].parent).toEqual({ type: 'page_id' });
+      expect(results[1].parent).toEqual({ type: 'database_id' });
+    });
+  });
+
   describe('restartClaudeJob', () => {
     it('should call post with the correct URL and empty payload', async () => {
       const mockResponse = createMockResponse(202, true);

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -130,14 +130,20 @@ export class Backend {
     }
 
     if (data?.results) {
-      return data.results.map((p: NotionDatabase | NotionPage) => ({
-        object: p.object,
-        title: getNotionObjectTitle(p, { emoji: false }),
-        icon: getObjectIcon(p as ObjectIcon),
-        url: getResourceUrl(p),
-        id: p.id,
-        isFavorite: favorites.some((f) => f.id === p.id),
-      }));
+      return data.results
+        .map((p: NotionDatabase | NotionPage) => {
+          const parentType = (p as { parent?: { type?: string } }).parent?.type;
+          return {
+            object: p.object,
+            title: getNotionObjectTitle(p, { emoji: false }) ?? '',
+            icon: getObjectIcon(p as ObjectIcon),
+            url: getResourceUrl(p),
+            id: p.id,
+            isFavorite: favorites.some((f) => f.id === p.id),
+            parent: parentType != null ? { type: parentType } : undefined,
+          };
+        })
+        .filter((entry: NotionObject) => entry.title.trim().length > 0);
     }
     return [];
   }

--- a/web/src/lib/interfaces/NotionObject.ts
+++ b/web/src/lib/interfaces/NotionObject.ts
@@ -6,6 +6,7 @@ interface NotionObject {
   id: string;
   data?: Response;
   isFavorite?: boolean;
+  parent?: { type: string };
 }
 
 export default NotionObject;

--- a/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
@@ -77,10 +77,12 @@ export default function NotionPagePicker({
       )}
 
       {(() => {
-        const visible = results.filter(
-          (entry) =>
-            entry.object === 'page' && entry.title.trim().length > 0
-        );
+        const visible = results.filter((entry) => {
+          if (entry.object !== 'page') return false;
+          if (entry.title.trim().length === 0) return false;
+          const parentType = entry.parent?.type;
+          return parentType !== 'database_id' && parentType !== 'data_source_id';
+        });
 
         if (!loading && error == null && visible.length === 0) {
           if (query.trim().length > 0) {

--- a/web/src/pages/AnkifyPage/components/TrackerParentPicker.tsx
+++ b/web/src/pages/AnkifyPage/components/TrackerParentPicker.tsx
@@ -54,10 +54,14 @@ export default function TrackerParentPicker({
 
     const handleSearchResults = (data: NotionObject[]) => {
       if (cancelled) return;
-      const pagesOnly = data.filter((entry) => entry.object === 'page');
-      setResults(pagesOnly);
+      const containerPages = data.filter((entry) => {
+        if (entry.object !== 'page') return false;
+        const parentType = entry.parent?.type;
+        return parentType !== 'database_id' && parentType !== 'data_source_id';
+      });
+      setResults(containerPages);
       setLoading(false);
-      setSelectedId((current) => pickNextSelectedId(current, pagesOnly));
+      setSelectedId((current) => pickNextSelectedId(current, containerPages));
     };
 
     const handleSearchError = (err: Error) => {


### PR DESCRIPTION
## Summary

The "Where should we put it?" picker on `/ankify/history` was rendering a wall of blank rows and `Card 1`/`Page 1`-style entries — Notion search returns database rows as `object: "page"` with `parent.type: "database_id"`, and the picker had no filter for either case.

- `Backend.search()` now drops entries whose computed title (via `getNotionObjectTitle`) is empty, and exposes `parent.type` on `NotionObject` so callers can tell a real container page from a database row. The empty-title filter helps any future picker without re-implementing the rule.
- `TrackerParentPicker` additionally drops pages whose parent is `database_id` / `data_source_id`. You can't put a tracker database under a database row, so they shouldn't be candidates.

## Followup (separate PR)

Investigation found a related but distinct issue: for users whose 100 most-recently-edited Notion items are all database rows (true on the test account), the empty-query Notion search returns no top-level titled pages, and `NotionPagePicker` on `/ankify` correctly shows "No pages yet." Real fix is server-side: paginate or use Notion's `filter: { property: "object", value: "page" }` and skip DB rows so the response surfaces the user's actual top-level pages. Will follow up.

## Test plan

- [x] `pnpm --filter 2anki-web test -- src/lib/backend/Backend.test.ts --run` — 38/38 green, including new `Backend > search > drops entries with empty titles and exposes parent on the rest`.
- [x] `pnpm --filter 2anki-web typecheck` — clean.
- [x] Server `tsc --noEmit` — clean.
- [ ] Prod smoke: open `/ankify/history`, confirm parent picker no longer shows blank rows or `Card N` / `Page N` database-row entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)