### PR TITLE
feat(ankify): paginated top-level page search for both Ankify pickers

### DIFF
--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -139,6 +139,40 @@ class NotionController {
     }
   }
 
+  async searchTopLevelPages(req: Request, res: Response) {
+    try {
+      const linkInfo = await this.service.getNotionLinkInfo(res.locals.owner);
+      if (!linkInfo.isConnected) {
+        const renewalLink = this.service.getNotionAuthorizationLink(
+          this.service.getClientId()
+        );
+        return res.status(401).json({
+          message: `Notion is not connected. Please connect your account <a href='${renewalLink}'>here</a>.`,
+        });
+      }
+
+      const query =
+        typeof req.body?.query === 'string' ? req.body.query : '';
+      const result = await this.service.searchTopLevelPages(
+        query,
+        getOwner(res)
+      );
+      res.json(result);
+    } catch (err) {
+      if (err instanceof APIResponseError) {
+        if (err.code === APIErrorCode.Unauthorized) {
+          const renewalLink = this.service.getNotionAuthorizationLink(
+            this.service.getClientId()
+          );
+          err.message += `You can renew it <a href='${renewalLink}'>here</a>.`;
+        }
+        sendErrorResponse(err, res);
+      } else {
+        sendErrorResponse(err, res);
+      }
+    }
+  }
+
   async getNotionLink(_req: Request, res: Response) {
     console.debug('/get-notion-link');
     const clientId = this.service.getClientId();

--- a/src/routes/NotionRouter.ts
+++ b/src/routes/NotionRouter.ts
@@ -84,6 +84,25 @@ const NotionRouter = () => {
 
   /**
    * @swagger
+   * /api/notion/top-level-pages:
+   *   post:
+   *     summary: Search Notion for top-level titled pages only
+   *     description: Excludes databases, database rows, and untitled pages. Paginates Notion's search until up to 50 useful entries are collected. Used by the Ankify "Find pages" and "Where should we put it?" pickers so users see real container pages instead of a wall of database rows.
+   *     tags: [Notion]
+   *     responses:
+   *       200:
+   *         description: Top-level pages
+   *       401:
+   *         description: Authentication required or Notion not connected
+   */
+  router.post(
+    '/api/notion/top-level-pages',
+    RequireAuthentication,
+    (req, res) => controller.searchTopLevelPages(req, res)
+  );
+
+  /**
+   * @swagger
    * /api/notion/get-notion-link:
    *   get:
    *     summary: Get Notion connection link

--- a/src/services/NotionService/NotionAPIWrapper.searchTopLevelPages.test.ts
+++ b/src/services/NotionService/NotionAPIWrapper.searchTopLevelPages.test.ts
@@ -1,0 +1,121 @@
+import NotionAPIWrapper from './NotionAPIWrapper';
+
+const PAGE_WITH_TITLE = (id: string, title: string) => ({
+  object: 'page',
+  id,
+  url: `https://www.notion.so/${id}`,
+  parent: { type: 'page_id', page_id: 'root' },
+  properties: {
+    title: { id: 'title', type: 'title', title: [{ plain_text: title }] },
+  },
+});
+
+const DB_ROW = (id: string) => ({
+  object: 'page',
+  id,
+  url: `https://www.notion.so/${id}`,
+  parent: { type: 'data_source_id', data_source_id: 'ds-1' },
+  properties: {
+    Name: { id: 'name', type: 'title', title: [{ plain_text: 'Card 1' }] },
+  },
+});
+
+const UNTITLED_TOP_LEVEL_PAGE = (id: string) => ({
+  object: 'page',
+  id,
+  url: `https://www.notion.so/${id}`,
+  parent: { type: 'page_id', page_id: 'root' },
+  properties: {
+    title: { id: 'title', type: 'title', title: [] },
+  },
+});
+
+const installSearchStub = (
+  wrapper: NotionAPIWrapper,
+  pages: ReadonlyArray<{ results: unknown[]; next_cursor: string | null }>
+) => {
+  let call = 0;
+  const search = jest.fn(async () => {
+    const page = pages[call] ?? { results: [], next_cursor: null };
+    call += 1;
+    return {
+      object: 'list',
+      type: 'page_or_database',
+      results: page.results,
+      has_more: page.next_cursor != null,
+      next_cursor: page.next_cursor,
+    };
+  });
+  (wrapper as unknown as { notion: { search: unknown } }).notion = {
+    search,
+  } as unknown as NotionAPIWrapper['notion' & keyof NotionAPIWrapper];
+  return search;
+};
+
+describe('NotionAPIWrapper.searchTopLevelPages', () => {
+  test('drops DB rows and untitled pages and keeps real titled top-level pages', async () => {
+    const wrapper = new NotionAPIWrapper('test-token', '1');
+    installSearchStub(wrapper, [
+      {
+        results: [
+          PAGE_WITH_TITLE('aaa', 'stats'),
+          DB_ROW('bbb'),
+          UNTITLED_TOP_LEVEL_PAGE('ccc'),
+          PAGE_WITH_TITLE('ddd', 'Regression testing'),
+        ],
+        next_cursor: null,
+      },
+    ]);
+
+    const result = await wrapper.searchTopLevelPages('');
+
+    expect(result.results.map((r) => r.id)).toEqual(['aaa', 'ddd']);
+    expect(result.results.map((r) => r.title)).toEqual([
+      'stats',
+      'Regression testing',
+    ]);
+  });
+
+  test('paginates until maxResults real pages are collected or maxPages reached', async () => {
+    const wrapper = new NotionAPIWrapper('test-token', '1');
+    const search = installSearchStub(wrapper, [
+      {
+        results: [DB_ROW('row-1'), DB_ROW('row-2'), DB_ROW('row-3')],
+        next_cursor: 'cur-2',
+      },
+      {
+        results: [PAGE_WITH_TITLE('p-1', 'Page 1'), DB_ROW('row-4')],
+        next_cursor: 'cur-3',
+      },
+      {
+        results: [PAGE_WITH_TITLE('p-2', 'Page 2')],
+        next_cursor: null,
+      },
+    ]);
+
+    const result = await wrapper.searchTopLevelPages('', {
+      maxResults: 2,
+      maxPages: 5,
+    });
+
+    expect(result.results.map((r) => r.id)).toEqual(['p-1', 'p-2']);
+    expect(search).toHaveBeenCalledTimes(3);
+  });
+
+  test('stops at maxPages even if more results are available', async () => {
+    const wrapper = new NotionAPIWrapper('test-token', '1');
+    const search = installSearchStub(wrapper, [
+      { results: [DB_ROW('a')], next_cursor: 'c1' },
+      { results: [DB_ROW('b')], next_cursor: 'c2' },
+      { results: [DB_ROW('c')], next_cursor: 'c3' },
+    ]);
+
+    const result = await wrapper.searchTopLevelPages('', {
+      maxResults: 50,
+      maxPages: 2,
+    });
+
+    expect(result.results).toEqual([]);
+    expect(search).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -240,6 +240,83 @@ class NotionAPIWrapper {
     return aggregated;
   }
 
+  async searchTopLevelPages(
+    query: string,
+    opts: { maxResults?: number; maxPages?: number } = {}
+  ): Promise<{
+    results: Array<{
+      id: string;
+      object: 'page';
+      url: string | null;
+      icon: unknown;
+      title: string;
+      parent: { type: string };
+    }>;
+  }> {
+    const maxResults = opts.maxResults ?? 50;
+    const maxPages = opts.maxPages ?? 5;
+    const collected: Array<{
+      id: string;
+      object: 'page';
+      url: string | null;
+      icon: unknown;
+      title: string;
+      parent: { type: string };
+    }> = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < maxPages; page++) {
+      const response: SearchResponse = await withRetry(
+        () =>
+          this.notion.search({
+            page_size: DEFAULT_PAGE_SIZE_LIMIT,
+            query,
+            filter: { value: 'page', property: 'object' },
+            sort: {
+              direction: 'descending',
+              timestamp: 'last_edited_time',
+            },
+            ...(cursor ? { start_cursor: cursor } : {}),
+          }),
+        { label: 'searchTopLevelPages' }
+      );
+      for (const entry of response.results) {
+        const e = entry as {
+          id: string;
+          object: string;
+          url?: string;
+          icon?: unknown;
+          parent?: { type?: string };
+        };
+        const parentType = e.parent?.type;
+        if (parentType === 'database_id' || parentType === 'data_source_id') {
+          continue;
+        }
+        const title = (
+          getNotionObjectTitle(entry as never, { emoji: false }) ?? ''
+        ).trim();
+        if (title.length === 0) {
+          continue;
+        }
+        collected.push({
+          id: e.id,
+          object: 'page',
+          url: e.url ?? null,
+          icon: e.icon,
+          title,
+          parent: { type: parentType ?? 'workspace' },
+        });
+        if (collected.length >= maxResults) {
+          return { results: collected };
+        }
+      }
+      if (!response.has_more || response.next_cursor == null) {
+        break;
+      }
+      cursor = response.next_cursor;
+    }
+    return { results: collected };
+  }
+
   async search(query: string, all?: boolean) {
     const searchLabel = uniqueTimerLabel(`search:${all}`);
     console.time(searchLabel);

--- a/src/services/NotionService/NotionService.ts
+++ b/src/services/NotionService/NotionService.ts
@@ -74,6 +74,15 @@ export class NotionService {
     return client.search(query);
   }
 
+  async searchTopLevelPages(
+    query: string,
+    owner: string,
+    opts: { maxResults?: number; maxPages?: number } = {}
+  ) {
+    const client = await this.getNotionAPI(owner);
+    return client.searchTopLevelPages(query, opts);
+  }
+
   async connectToNotion(authorizationCode: string, owner: number) {
     const accessData = await this.getAccessData(authorizationCode.toString());
     await this.notionRepository.saveNotionToken(owner, accessData, hashToken);

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -101,6 +101,38 @@ export class Backend {
     });
   }
 
+  async searchTopLevelPages(query: string): Promise<NotionObject[]> {
+    const favorites = await this.getFavorites();
+    const response = await post(`${this.baseURL}notion/top-level-pages`, {
+      query,
+    });
+    const data = await response.json();
+    if ('message' in data) {
+      throw new Error(data.message);
+    }
+    if (!data?.results) {
+      return [];
+    }
+    return data.results.map(
+      (p: {
+        id: string;
+        object: string;
+        title: string;
+        url: string | null;
+        icon?: unknown;
+        parent: { type: string };
+      }) => ({
+        object: p.object,
+        title: p.title,
+        icon: getObjectIcon(p as unknown as ObjectIcon),
+        url: p.url ?? '',
+        id: p.id,
+        isFavorite: favorites.some((f) => f.id === p.id),
+        parent: p.parent,
+      })
+    );
+  }
+
   async search(query: string): Promise<NotionObject[]> {
     const favorites = await this.getFavorites();
 

--- a/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
@@ -39,7 +39,7 @@ export default function NotionPagePicker({
 
     const timer = setTimeout(() => {
       backend
-        .search(query)
+        .searchTopLevelPages(query)
         .then((data) => {
           if (cancelled) return;
           setResults(data);
@@ -77,12 +77,7 @@ export default function NotionPagePicker({
       )}
 
       {(() => {
-        const visible = results.filter((entry) => {
-          if (entry.object !== 'page') return false;
-          if (entry.title.trim().length === 0) return false;
-          const parentType = entry.parent?.type;
-          return parentType !== 'database_id' && parentType !== 'data_source_id';
-        });
+        const visible = results;
 
         if (!loading && error == null && visible.length === 0) {
           if (query.trim().length > 0) {

--- a/web/src/pages/AnkifyPage/components/TrackerParentPicker.tsx
+++ b/web/src/pages/AnkifyPage/components/TrackerParentPicker.tsx
@@ -54,14 +54,9 @@ export default function TrackerParentPicker({
 
     const handleSearchResults = (data: NotionObject[]) => {
       if (cancelled) return;
-      const containerPages = data.filter((entry) => {
-        if (entry.object !== 'page') return false;
-        const parentType = entry.parent?.type;
-        return parentType !== 'database_id' && parentType !== 'data_source_id';
-      });
-      setResults(containerPages);
+      setResults(data);
       setLoading(false);
-      setSelectedId((current) => pickNextSelectedId(current, containerPages));
+      setSelectedId((current) => pickNextSelectedId(current, data));
     };
 
     const handleSearchError = (err: Error) => {
@@ -71,7 +66,10 @@ export default function TrackerParentPicker({
     };
 
     const timer = setTimeout(() => {
-      backend.search(query).then(handleSearchResults).catch(handleSearchError);
+      backend
+        .searchTopLevelPages(query)
+        .then(handleSearchResults)
+        .catch(handleSearchError);
     }, DEBOUNCE_MS);
 
     return () => {


### PR DESCRIPTION
## Summary

Empty-query Notion search returns the user's last-100-edited items sorted by `last_edited_time desc`. For an account whose recent activity is concentrated in one or two databases (verified on the prod test account), that's 100 database rows with empty titles — and the Ankify pickers end up showing "No pages yet" (Decks → Find pages) or a wall of blank rows (Study history parent picker).

This PR adds a server-side `POST /api/notion/top-level-pages` that:

- Asks Notion for `filter: { value: 'page', property: 'object' }` (drops databases entirely).
- Paginates up to 5 pages of results.
- Drops entries whose `parent.type` is `database_id` / `data_source_id`.
- Drops entries whose computed title (via `getNotionObjectTitle`) is empty.
- Returns up to 50 useful entries `{ id, object: 'page', title, url, icon, parent: { type } }`.

Both pickers (`NotionPagePicker`, `TrackerParentPicker`) now call `backend.searchTopLevelPages(query)` and skip their local filters; the server is the single source of truth for "is this a useful container page." `/api/notion/pages` is unchanged — `SearchPage` on `/notion` still needs the unfiltered raw results for the convert flow.

## Test plan

- [x] `pnpm test -- src/services/NotionService/NotionAPIWrapper.searchTopLevelPages.test.ts` — 3/3 green (drops DB rows + untitled, paginates until maxResults, stops at maxPages).
- [x] `pnpm test -- src/controllers` — 66/66.
- [x] `pnpm --filter 2anki-web test --run` — 38/38.
- [x] Server `tsc --noEmit` and web `tsc --noEmit` — clean.
- [ ] Prod smoke: open `/ankify` Decks → Find pages — actual top-level pages should appear (not "No pages yet"). Open `/ankify/history` parent picker — same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)