### PR TITLE
fix(ankify): use support@2anki.net in setup error copy

### DIFF
--- a/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
@@ -231,7 +231,7 @@ export default function AnkifySetupPage({ backend }: Props) {
           </p>
           <p className={styles.provisionErrorHint}>
             Try again — most starts work on the second go. If it keeps failing,
-            email hello@2anki.net.
+            email support@2anki.net.
           </p>
         </div>
       )}
@@ -250,7 +250,7 @@ export default function AnkifySetupPage({ backend }: Props) {
             </p>
             <p className={styles.provisionErrorBody}>
               Most retries succeed. If it keeps failing, email
-              hello@2anki.net.
+              support@2anki.net.
             </p>
           </div>
           <div className={styles.setupActiveStepActions}>


### PR DESCRIPTION
Two error states on AnkifySetupPage referenced `hello@2anki.net`, which isn't a real inbox. Replaced with `support@2anki.net`.