### PR TITLE
feat(ankify): clarify next-sync copy on the deck list

### DIFF
--- a/Documentation/specs/ankify-next-sync-copy.md
+++ b/Documentation/specs/ankify-next-sync-copy.md
@@ -1,0 +1,64 @@
+# Spec: Ankify "next sync" copy clarification
+
+**Goal**: Stop the "when's the next sync?" question by making the polling cadence and (when relevant) the per-database daily export visible on `/ankify`, without new DB columns or per-deck schedule UI.
+
+**Goal alignment**: Trust in freshness keeps Ankify users active week-over-week — directly feeds retention curve toward the 300K-user target in `CLAUDE.md`.
+
+## User-facing change
+
+1. **Page-level helper, rendered once under the "Decks" heading** (not per card). Muted/small text, exact copy:
+
+   > Checks Notion for changes every 5 minutes.
+
+2. **Per-card line 2**, rendered only when there's something deck-specific to say. Rules, in order:
+   - If `last_error != null` on the subscription → `Last check failed — we'll try again soon`
+   - Else if a daily export schedule is enabled and its `database_id` equals this subscription's `notion_page_id` → `Next export at HH:MM` where `HH:MM` is the user's configured `time_of_day`, formatted in their browser locale's clock style (12h vs 24h via `Intl.DateTimeFormat`, using the schedule's `timezone`).
+   - Else → render nothing (no filler).
+
+   Line 1 (`updated <relative>`) stays as-is.
+
+## Files to touch
+
+- `web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx` (around line 300–365): add the page-level helper above the `<ul className={styles.decksList}>`; replace the existing `last_error` red paragraph with the new "line 2" rules described above.
+- `web/src/pages/AnkifyPage/AnkifyPage.tsx`: fetch the user's export schedule alongside subscriptions and pass `schedule` down to `NotionSubscriptions` (use existing `GET /api/ankify/exports/schedule` via `get2ankiApi()`; add a thin client method if missing).
+- `web/src/styles/...` or component-scoped CSS module: small muted-text helper class if one isn't already available.
+
+No backend changes. No new columns. No new endpoints.
+
+## Data: have vs need (verified)
+
+- `GET /api/ankify/subscriptions` already returns `last_error`, `last_synced_at`, `last_polled_at`, `notion_page_id`, `notion_page_title`, `notion_page_url`. **Sufficient for the error branch.**
+- `GET /api/ankify/exports/schedule` already returns `{ database_id, time_of_day, timezone, enabled }` (per-owner, single row). **Sufficient for the next-export branch.** No new endpoint needed; just call it from the page once.
+- Caveat: the schedule is keyed by `database_id`, while subscriptions are keyed by `notion_page_id`. The "Next export at HH:MM" line will only appear on a subscription whose `notion_page_id === schedule.database_id` and `schedule.enabled === true`. This is the correct (narrow) match — flag in PR description so reviewers don't expect it on every card.
+
+## User story
+
+As an Ankify user, I want to see how often my decks check Notion and when my next daily export will run so that I trust my flashcards are fresh without asking support.
+
+## Acceptance criteria
+
+- [ ] The "Checks Notion for changes every 5 minutes." helper renders exactly once on the Decks tab, above the deck list.
+- [ ] A subscription with `last_error == null` and no matching enabled schedule renders only the existing `updated <relative>` line — no second line.
+- [ ] A subscription with `last_error != null` renders `Last check failed — we'll try again soon` as line 2 (replacing the current "Notion couldn't reach this page" copy).
+- [ ] A subscription whose `notion_page_id` matches an enabled schedule's `database_id` renders `Next export at <localized HH:MM>` as line 2.
+- [ ] When both conditions are true, the error line wins (last-error takes precedence).
+- [ ] Vitest unit tests cover the three line-2 branches (none / error / next-export) and assert the page-helper renders once regardless of deck count.
+- [ ] No new API endpoints added; no DB migrations.
+
+## Open questions
+
+- Confirm with designer: does line 2 share the same muted/small style as the page-level helper, or should the error variant carry a subtle warning tint (current code uses `styles.decksItemError`)? Default to keeping the existing error styling unless designer says otherwise.
+
+## Out of scope (next iteration)
+
+- Per-deck sync interval controls.
+- Adding a `next_run_at` column to `ankify_notion_subscriptions`.
+- Refactoring `scheduleAnkifyPolling.ts` or `AnkifyExportScheduler`.
+- Surfacing detailed `last_error` messages to users.
+- Live countdown timers.
+
+## Commit message guidance
+
+Use `fix(ankify):` or `feat(ankify):` prefix. In the body, explicitly note that broader sync-failure visibility and per-deck error surfacing are deferred future scope so the thread isn't lost — e.g.:
+
+> Future scope (deferred, not in this PR): a fuller error-visibility audit — surfacing actionable `last_error` detail to users and a per-deck retry CTA — would be the natural follow-up if support volume around silent sync failures persists.

--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -946,6 +946,12 @@
   margin: 0;
 }
 
+.decksHelper {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0 0 0.5rem;
+}
+
 .decksList {
   list-style: none;
   margin: 0;

--- a/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
@@ -53,6 +53,7 @@ const makeBackend = (overrides: Partial<Backend> = {}): Backend =>
     reissueAnkifySessionUrl: vi.fn(),
     listAnkifySubscriptions: vi.fn(async () => []),
     listAnkifyConflicts: vi.fn(async () => []),
+    getAnkifyExportSchedule: vi.fn(async () => null),
     checkAnkifyActiveClientReady: vi.fn(async () => ({ ready: false })),
     checkAnkifyAnkiWebStatus: vi.fn(async () => ({
       status: 'unlinked' as const,

--- a/web/src/pages/AnkifyPage/AnkifyPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.tsx
@@ -53,6 +53,11 @@ export default function AnkifyPage({ backend }: Readonly<AnkifyPageProps>) {
     refetchInterval: 30_000,
   });
 
+  const exportSchedule = useQuery({
+    queryKey: ['ankify-export-schedule'],
+    queryFn: () => api.getAnkifyExportSchedule(),
+  });
+
   const hasActiveClient = data?.some((c) => c.status === 'active') ?? false;
   const signedInAcknowledged = readSignedInAcknowledged();
 
@@ -102,7 +107,10 @@ export default function AnkifyPage({ backend }: Readonly<AnkifyPageProps>) {
         backend={backend}
       />
 
-      <NotionSubscriptions backend={backend} />
+      <NotionSubscriptions
+        backend={backend}
+        schedule={exportSchedule.data ?? null}
+      />
 
       <div className={styles.historyFooter}>
         {hasTracker ? (

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import NotionSubscriptions from './NotionSubscriptions';
+import { Backend } from '../../../lib/backend/Backend';
+
+type Subscription = Awaited<ReturnType<Backend['listAnkifySubscriptions']>>[number];
+type Schedule = Awaited<ReturnType<Backend['getAnkifyExportSchedule']>>;
+
+const sampleSubscription = (overrides: Partial<Subscription> = {}): Subscription => ({
+  id: 1,
+  notion_page_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  notion_page_title: 'My deck',
+  notion_page_url: 'https://notion.so/My-deck',
+  enabled: true,
+  last_polled_at: null,
+  last_synced_at: new Date().toISOString(),
+  last_error: null,
+  ...overrides,
+});
+
+const sampleSchedule = (overrides: Partial<NonNullable<Schedule>> = {}): Schedule => ({
+  id: 10,
+  owner: 42,
+  database_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  time_of_day: '09:15',
+  timezone: 'UTC',
+  date_range_days: null,
+  enabled: true,
+  last_run_at: null,
+  ...overrides,
+});
+
+const makeBackend = (overrides: Partial<Backend> = {}): Backend =>
+  ({
+    listAnkifySubscriptions: vi.fn(async () => []),
+    deleteAnkifySubscription: vi.fn(),
+    subscribeAnkifyNotionPage: vi.fn(),
+    searchTopLevelPages: vi.fn(async () => []),
+    ...overrides,
+  } as unknown as Backend);
+
+const renderSubs = (
+  backend: Backend,
+  schedule: Schedule = null,
+) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NotionSubscriptions backend={backend} schedule={schedule} />
+    </QueryClientProvider>
+  );
+};
+
+describe('NotionSubscriptions sync copy', () => {
+  test('renders the page-level helper exactly once above the deck list', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({ id: 1, notion_page_id: 'a'.repeat(32) }),
+        sampleSubscription({ id: 2, notion_page_id: 'b'.repeat(32) }),
+        sampleSubscription({ id: 3, notion_page_id: 'c'.repeat(32) }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    await waitFor(() => {
+      const matches = screen.getAllByText(/checks notion for changes every 5 minutes\./i);
+      expect(matches).toHaveLength(1);
+    });
+  });
+
+  test('does not render the helper when there are no decks', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => []),
+    });
+
+    renderSubs(backend);
+
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText(/search your notion pages/i)
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText(/checks notion for changes every 5 minutes\./i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders no second line when last_error is null and no schedule matches', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: 'a'.repeat(32),
+          last_error: null,
+        }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    await waitFor(() =>
+      expect(screen.getByText('My deck')).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText(/last check failed/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/next export at/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders the error line when last_error is set', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: 'a'.repeat(32),
+          last_error: 'boom',
+        }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/last check failed — we'll try again soon/i)
+      ).toBeInTheDocument()
+    );
+  });
+
+  test('renders next-export line when schedule matches and is enabled', async () => {
+    const matchingId = 'a'.repeat(32);
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: matchingId,
+          last_error: null,
+        }),
+      ]),
+    });
+
+    renderSubs(
+      backend,
+      sampleSchedule({ database_id: matchingId, time_of_day: '09:15', enabled: true })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(/^next export at /i)).toBeInTheDocument()
+    );
+  });
+
+  test('does not render next-export line when schedule is disabled', async () => {
+    const matchingId = 'a'.repeat(32);
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: matchingId,
+          last_error: null,
+        }),
+      ]),
+    });
+
+    renderSubs(
+      backend,
+      sampleSchedule({ database_id: matchingId, enabled: false })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('My deck')).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/next export at/i)).not.toBeInTheDocument();
+  });
+
+  test('does not render next-export line when schedule database_id does not match', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: 'a'.repeat(32),
+          last_error: null,
+        }),
+      ]),
+    });
+
+    renderSubs(
+      backend,
+      sampleSchedule({ database_id: 'b'.repeat(32), enabled: true })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('My deck')).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/next export at/i)).not.toBeInTheDocument();
+  });
+
+  test('error line takes precedence over next-export line', async () => {
+    const matchingId = 'a'.repeat(32);
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: matchingId,
+          last_error: 'boom',
+        }),
+      ]),
+    });
+
+    renderSubs(
+      backend,
+      sampleSchedule({ database_id: matchingId, enabled: true })
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/last check failed — we'll try again soon/i)
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/next export at/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
 
@@ -71,6 +71,27 @@ const extractNotionId = (input: string): string => {
 };
 
 const normalizeId = (id: string): string => id.replaceAll('-', '').toLowerCase();
+
+const renderSecondLine = (
+  lastError: string | null | undefined,
+  nextExportLabel: string | null
+): ReactNode => {
+  if (lastError != null) {
+    return (
+      <p className={styles.decksItemError}>
+        Last check failed — we'll try again soon
+      </p>
+    );
+  }
+  if (nextExportLabel != null) {
+    return (
+      <p className={styles.decksItemError}>
+        Next export at {nextExportLabel}
+      </p>
+    );
+  }
+  return null;
+};
 
 export default function NotionSubscriptions({ backend, schedule }: Props) {
   const api = backend ?? get2ankiApi();
@@ -365,15 +386,16 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                 subscribe.isPending &&
                 pendingId != null &&
                 normalizeId(pendingId) === normalizeId(sub.notion_page_id);
-              const matchesSchedule =
-                schedule != null &&
-                schedule.enabled === true &&
-                normalizeId(schedule.database_id) ===
-                  normalizeId(sub.notion_page_id);
               const nextExportLabel =
-                matchesSchedule && schedule != null
+                schedule?.enabled === true &&
+                normalizeId(schedule.database_id) ===
+                  normalizeId(sub.notion_page_id)
                   ? formatScheduleTime(schedule.time_of_day, schedule.timezone)
                   : null;
+              const secondLine = renderSecondLine(
+                sub.last_error,
+                nextExportLabel
+              );
               const relative = formatRelativeTime(sub.last_synced_at);
               const lastSyncedDisplay =
                 relative == null ? (
@@ -398,15 +420,7 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                     ) : (
                       displayTitle
                     )}
-                    {sub.last_error != null ? (
-                      <p className={styles.decksItemError}>
-                        Last check failed — we'll try again soon
-                      </p>
-                    ) : nextExportLabel != null ? (
-                      <p className={styles.decksItemError}>
-                        Next export at {nextExportLabel}
-                      </p>
-                    ) : null}
+                    {secondLine}
                   </span>
                   <span className={styles.decksItemTime}>
                     {isUpdatingThisRow ? (

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -16,9 +16,47 @@ const formatRelativeTime = (iso: string | null | undefined): string | null => {
   return formatDistanceToNow(parsed, { addSuffix: true });
 };
 
+type Schedule = Awaited<ReturnType<Backend['getAnkifyExportSchedule']>>;
+
 interface Props {
   readonly backend?: Backend;
+  readonly schedule?: Schedule;
 }
+
+const formatScheduleTime = (
+  timeOfDay: string,
+  timezone: string
+): string | null => {
+  const match = /^(\d{2}):(\d{2})$/.exec(timeOfDay);
+  if (match == null) return null;
+  const targetHours = Number(match[1]);
+  const targetMinutes = Number(match[2]);
+  const sample = new Date();
+  sample.setUTCHours(targetHours, targetMinutes, 0, 0);
+  const probe = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  const parts = Object.fromEntries(
+    probe
+      .formatToParts(sample)
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, part.value])
+  );
+  const seenHours = Number(parts.hour);
+  const seenMinutes = Number(parts.minute);
+  if (Number.isNaN(seenHours) || Number.isNaN(seenMinutes)) return null;
+  const diffMinutes =
+    targetHours * 60 + targetMinutes - (seenHours * 60 + seenMinutes);
+  const adjusted = new Date(sample.getTime() + diffMinutes * 60_000);
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: timezone,
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(adjusted);
+};
 
 const SUBSCRIPTIONS_KEY = ['ankify-subscriptions'];
 const SEARCH_THRESHOLD = 10;
@@ -34,7 +72,7 @@ const extractNotionId = (input: string): string => {
 
 const normalizeId = (id: string): string => id.replaceAll('-', '').toLowerCase();
 
-export default function NotionSubscriptions({ backend }: Props) {
+export default function NotionSubscriptions({ backend, schedule }: Props) {
   const api = backend ?? get2ankiApi();
   const queryClient = useQueryClient();
   const [advancedInput, setAdvancedInput] = useState('');
@@ -314,6 +352,9 @@ export default function NotionSubscriptions({ backend }: Props) {
               />
             </div>
           )}
+          <p className={styles.decksHelper}>
+            Checks Notion for changes every 5 minutes.
+          </p>
           <ul className={styles.decksList} ref={menuContainerRef}>
             {filteredSubscriptions.map((sub) => {
               const displayTitle =
@@ -324,6 +365,15 @@ export default function NotionSubscriptions({ backend }: Props) {
                 subscribe.isPending &&
                 pendingId != null &&
                 normalizeId(pendingId) === normalizeId(sub.notion_page_id);
+              const matchesSchedule =
+                schedule != null &&
+                schedule.enabled === true &&
+                normalizeId(schedule.database_id) ===
+                  normalizeId(sub.notion_page_id);
+              const nextExportLabel =
+                matchesSchedule && schedule != null
+                  ? formatScheduleTime(schedule.time_of_day, schedule.timezone)
+                  : null;
               const relative = formatRelativeTime(sub.last_synced_at);
               const lastSyncedDisplay =
                 relative == null ? (
@@ -348,11 +398,15 @@ export default function NotionSubscriptions({ backend }: Props) {
                     ) : (
                       displayTitle
                     )}
-                    {sub.last_error != null && (
+                    {sub.last_error != null ? (
                       <p className={styles.decksItemError}>
-                        Notion couldn't reach this page
+                        Last check failed — we'll try again soon
                       </p>
-                    )}
+                    ) : nextExportLabel != null ? (
+                      <p className={styles.decksItemError}>
+                        Next export at {nextExportLabel}
+                      </p>
+                    ) : null}
                   </span>
                   <span className={styles.decksItemTime}>
                     {isUpdatingThisRow ? (


### PR DESCRIPTION
## What
Replaces the per-card "Notion couldn't reach this page" copy and adds:

- A page-level helper rendered once above the deck list: **"Checks Notion for changes every 5 minutes."**
- A per-card line 2 with three branches:
  - `last_error != null` → **"Last check failed — we'll try again soon"**
  - else, schedule matches and is enabled → **"Next export at HH:MM"** (formatted in browser locale's clock style, in the schedule's timezone)
  - else → nothing

Last-error wins over next-export.

## Why
Trust in freshness keeps Ankify users active week-over-week. Closes the recurring "when's the next sync?" support thread without new endpoints, columns, or scheduler changes. Spec at `Documentation/specs/ankify-next-sync-copy.md`.

## How
- `AnkifyPage` fetches `getAnkifyExportSchedule()` (existing client method) and passes the result down to `NotionSubscriptions` as a prop.
- The next-export line is keyed by `subscription.notion_page_id === schedule.database_id` AND `schedule.enabled === true`. The schedule is one-per-owner, so this only appears on the matching card — flagged here so reviewers don't expect it on every row.
- `formatScheduleTime(timeOfDay, timezone)` builds an instant whose wall-time in `timezone` is HH:MM, then formats it via `Intl.DateTimeFormat(undefined, { hour, minute, timeZone })` so 12h vs 24h follows the browser locale.

## Testing
- New: `web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx` — covers all three line-2 branches, the disabled-schedule and unmatched-database_id cases, the precedence rule (error wins), and asserts the page-level helper renders exactly once across multi-deck lists.
- `pnpm test` (web): 46/46 pass
- `pnpm typecheck` (web) + `pnpm tsc --noEmit` (server): clean
- `pnpm lint` (web/biome): clean

## Risks
Cosmetic copy + one extra GET on `/ankify`. Rollback is a revert.

## Goal alignment
Reduces a repeated support friction point on the conversion-of-flow happy path. Quiet trust signal that makes the workflow feel obvious — directly feeds the retention curve toward the 300K-user goal.

## Future scope (deferred)
A fuller error-visibility audit — surfacing actionable `last_error` detail to users and a per-deck retry CTA — would be the natural follow-up if support volume around silent sync failures persists.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>