### PR TITLE
chore: catch SonarCloud smells locally via Biome lint

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,15 +1,18 @@
 ---
-description: Parallel server tsc + web typecheck + web vitest
+description: Parallel server tsc + web typecheck + web vitest + web lint
 allowed-tools: Bash
 ---
 
-Run all three checks in parallel via a single Bash call:
+Run all four checks in parallel via a single Bash call:
 
 ```bash
 pnpm --filter notion2anki-server build & \
 pnpm --filter 2anki-web typecheck & \
 pnpm --filter 2anki-web test:run & \
+pnpm --filter 2anki-web lint & \
 wait
 ```
 
 If any fails, print one line per failure with the file:line and the error message — nothing else. If all pass, say "all clean" and stop.
+
+The web `lint` step runs Biome with the rules that mirror SonarCloud findings (`useOptionalChain`, `noNestedTernary`, `noNegationElse`, `noUselessTernary`). Catching them locally avoids a CI round-trip after Sonar comments on a PR.

--- a/web/biome.json
+++ b/web/biome.json
@@ -17,6 +17,14 @@
                         "correctness": {
                                 "noUnusedLabels": "error",
                                 "useValidForDirection": "error"
+                        },
+                        "complexity": {
+                                "useOptionalChain": "error",
+                                "noUselessTernary": "error"
+                        },
+                        "style": {
+                                "noNestedTernary": "error",
+                                "noNegationElse": "error"
                         }
                 }
         },

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -172,7 +172,7 @@ export class Backend {
             url: getResourceUrl(p),
             id: p.id,
             isFavorite: favorites.some((f) => f.id === p.id),
-            parent: parentType != null ? { type: parentType } : undefined,
+            parent: parentType == null ? undefined : { type: parentType },
           };
         })
         .filter((entry: NotionObject) => entry.title.trim().length > 0);

--- a/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
@@ -84,9 +84,9 @@ export default function AnkifySetupPage({ backend }: Props) {
       return;
     }
     const startedAt =
-      activeClient?.created_at != null
-        ? new Date(activeClient.created_at).getTime()
-        : Date.now();
+      activeClient?.created_at == null
+        ? Date.now()
+        : new Date(activeClient.created_at).getTime();
     const remaining = startedAt + STARTING_TIMEOUT_MS - Date.now();
     if (remaining <= 0) {
       setStartingTimedOut(true);


### PR DESCRIPTION
## What
Tightens `web/biome.json` so `pnpm lint` (and the `/check` skill) catches the SonarCloud smells we keep tripping on after CI:

- `complexity/useOptionalChain` → Sonar S6582
- `style/noNestedTernary` → Sonar S3358
- `style/noNegationElse` → Sonar S2138 (negated condition + else)
- `complexity/noUselessTernary` → common companion

Adds `pnpm --filter 2anki-web lint` to the `/check` skill so the engineer agent's preflight runs lint alongside typecheck + tests + server build.

## Why
On the previous Ankify PR (#2059), SonarCloud flagged 4 smells *after* CI on a feature branch — costing one round-trip (push → CI → review → fix → push → CI → merge ≈ 4 min). Biome already had matching rules; they were just disabled by `recommended: false`. Enabling them moves that check from a 4-minute CI loop to a ~50ms local lint.

## How
- `web/biome.json` — added the four rules under `linter.rules.complexity` and `linter.rules.style`.
- `.claude/commands/check.md` — `/check` now runs lint in parallel with typecheck/test/build.
- Two pre-existing offenders auto-fixed by Biome's safe fix (inverting `!= null` ternaries) in `Backend.ts` and `AnkifySetupPage.tsx`.

## Testing
- `pnpm --filter 2anki-web test` — 46/46 pass
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- Verified: re-running the rules against PR #2059's pre-fix code would have flagged all 4 of Sonar's findings locally.

## Risks
Low. Adds errors-not-warnings on rules with safe auto-fixes; only two pre-existing violations across the whole web tree.

## Goal alignment
Tightens the inner loop so engineer-agent PRs ship without Sonar round-trips. Compounds: every future PR that would have hit these rules now skips a 4-minute cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)