### PR TITLE
feat(ankify): show Notion page icons in the decks list

### DIFF
--- a/migrations/20260509000000_ankify_subscription_page_icon.js
+++ b/migrations/20260509000000_ankify_subscription_page_icon.js
@@ -1,0 +1,17 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable(
+    'ankify_notion_subscriptions',
+    function (table) {
+      table.text('notion_page_icon').nullable();
+    }
+  );
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable(
+    'ankify_notion_subscriptions',
+    function (table) {
+      table.dropColumn('notion_page_icon');
+    }
+  );
+};

--- a/src/controllers/AnkifyController.ts
+++ b/src/controllers/AnkifyController.ts
@@ -309,6 +309,7 @@ class AnkifyController {
     }
     const rawTitle = req.body?.notion_page_title;
     const rawUrl = req.body?.notion_page_url;
+    const rawIcon = req.body?.notion_page_icon;
     const notionPageTitle =
       typeof rawTitle === 'string' && rawTitle.trim().length > 0
         ? rawTitle.trim()
@@ -317,12 +318,17 @@ class AnkifyController {
       typeof rawUrl === 'string' && rawUrl.trim().length > 0
         ? rawUrl.trim()
         : undefined;
+    const notionPageIcon =
+      typeof rawIcon === 'string' && rawIcon.trim().length > 0
+        ? rawIcon.trim()
+        : undefined;
     try {
       const result = await this.syncNotionPageUseCase.execute({
         owner,
         notionPageId,
         notionPageTitle,
         notionPageUrl,
+        notionPageIcon,
         trigger: 'manual',
       });
       res.status(200).json({

--- a/src/data_layer/ankify/AnkifyNotionSubscriptionsRepository.ts
+++ b/src/data_layer/ankify/AnkifyNotionSubscriptionsRepository.ts
@@ -56,6 +56,10 @@ export class AnkifyNotionSubscriptionsRepository
       insertPayload.notion_page_url = input.notion_page_url;
       mergePayload.notion_page_url = input.notion_page_url;
     }
+    if (input.notion_page_icon !== undefined) {
+      insertPayload.notion_page_icon = input.notion_page_icon;
+      mergePayload.notion_page_icon = input.notion_page_icon;
+    }
     const [row] = await this.database<AnkifyNotionSubscription>(TABLE)
       .insert(insertPayload)
       .onConflict(['owner', 'notion_page_id'])

--- a/src/data_layer/index.ts
+++ b/src/data_layer/index.ts
@@ -204,7 +204,24 @@ export const setupDatabase = async (database: Knex) => {
               }
             }
             const url = (page as { url?: string }).url ?? null;
-            return { title, url };
+            const rawIcon = (page as {
+              icon?:
+                | { type: 'emoji'; emoji: string }
+                | { type: 'external'; external: { url: string } }
+                | { type: 'file'; file: { url: string } }
+                | null;
+            }).icon;
+            let icon: string | null = null;
+            if (rawIcon != null) {
+              if (rawIcon.type === 'emoji') {
+                icon = rawIcon.emoji;
+              } else if (rawIcon.type === 'external') {
+                icon = rawIcon.external.url;
+              } else if (rawIcon.type === 'file') {
+                icon = rawIcon.file.url;
+              }
+            }
+            return { title, url, icon };
           };
         }
       );

--- a/src/entities/ankify.ts
+++ b/src/entities/ankify.ts
@@ -120,6 +120,7 @@ export interface AnkifyNotionSubscription {
   notion_page_id: string;
   notion_page_title: string | null;
   notion_page_url: string | null;
+  notion_page_icon: string | null;
   enabled: boolean;
   last_polled_at: Date | null;
   last_synced_at: Date | null;
@@ -134,6 +135,7 @@ export interface UpsertAnkifyNotionSubscription {
   notion_page_id: string;
   notion_page_title?: string | null;
   notion_page_url?: string | null;
+  notion_page_icon?: string | null;
   enabled: boolean;
 }
 

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -132,6 +132,27 @@ const extractNotionPageTitle = (
   return null;
 };
 
+type NotionPageIconBlock =
+  | { type: 'emoji'; emoji: string }
+  | { type: 'external'; external: { url: string } }
+  | { type: 'file'; file: { url: string } }
+  | null
+  | undefined;
+
+const extractNotionPageIcon = (icon: NotionPageIconBlock): string | null => {
+  if (icon == null) return null;
+  switch (icon.type) {
+    case 'emoji':
+      return icon.emoji;
+    case 'external':
+      return icon.external.url;
+    case 'file':
+      return icon.file.url;
+    default:
+      return null;
+  }
+};
+
 const buildNotionPageMetaFetcher =
   (token: string) =>
   async (notionPageId: string) => {
@@ -141,7 +162,10 @@ const buildNotionPageMetaFetcher =
       .properties ?? {};
     const title = extractNotionPageTitle(props);
     const url = (page as { url?: string }).url ?? null;
-    return { title, url };
+    const icon = extractNotionPageIcon(
+      (page as { icon?: NotionPageIconBlock }).icon
+    );
+    return { title, url, icon };
   };
 
 const buildNotionConflictResolver = (token: string) => {

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -1,0 +1,195 @@
+import { SyncNotionPageToRacUseCase } from './SyncNotionPageToRacUseCase';
+import {
+  AnkifyClient,
+  AnkifyNotionSubscription,
+} from '../../entities/ankify';
+import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
+import { AnkifySyncMappingsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncMappingsRepository';
+import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncConflictsRepository';
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import { AnkifySyncLogsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncLogsRepository';
+import { INotionRepository } from '../../data_layer/NotionRespository';
+import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
+
+const sampleClient = (): AnkifyClient => ({
+  id: 1,
+  owner: 42,
+  container_id: 'c',
+  container_name: null,
+  anki_port: 20000,
+  vnc_port: 21000,
+  novnc_port: 22000,
+  anki_connect_api_key: null,
+  status: 'active',
+  created_at: new Date(),
+  last_active_at: new Date(),
+});
+
+const sampleSubscription = (
+  overrides: Partial<AnkifyNotionSubscription> = {}
+): AnkifyNotionSubscription => ({
+  id: 1,
+  owner: 42,
+  ankify_client_id: 1,
+  notion_page_id: 'page-id',
+  notion_page_title: null,
+  notion_page_url: null,
+  notion_page_icon: null,
+  enabled: true,
+  last_polled_at: null,
+  last_synced_at: null,
+  last_error: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+  ...overrides,
+});
+
+const makeClients = (): jest.Mocked<AnkifyClientsRepositoryInterface> =>
+  ({
+    create: jest.fn(),
+    listByOwner: jest.fn(),
+    findActiveById: jest.fn(),
+    findActiveByOwner: jest.fn(async () => sampleClient()),
+    setStatus: jest.fn(),
+    touchLastActiveAt: jest.fn(),
+    reservedPorts: jest.fn(),
+    listIdleSince: jest.fn(),
+  } as unknown as jest.Mocked<AnkifyClientsRepositoryInterface>);
+
+const makeMappings = (): jest.Mocked<AnkifySyncMappingsRepositoryInterface> =>
+  ({
+    findBySourceId: jest.fn(async () => null),
+    upsert: jest.fn(),
+    listByClient: jest.fn(),
+    findByAnkiNoteId: jest.fn(),
+    deleteByAnkiNoteId: jest.fn(),
+  } as unknown as jest.Mocked<AnkifySyncMappingsRepositoryInterface>);
+
+const makeConflicts = (): jest.Mocked<AnkifySyncConflictsRepositoryInterface> =>
+  ({
+    hasPending: jest.fn(async () => false),
+    recordOrFindPending: jest.fn(),
+  } as unknown as jest.Mocked<AnkifySyncConflictsRepositoryInterface>);
+
+const makeSubscriptionsRepo = (
+  upsertResult: AnkifyNotionSubscription = sampleSubscription()
+): jest.Mocked<AnkifyNotionSubscriptionsRepositoryInterface> =>
+  ({
+    upsert: jest.fn(async () => upsertResult),
+    listByOwner: jest.fn(),
+    listEnabled: jest.fn(),
+    findByPageId: jest.fn(),
+    findById: jest.fn(),
+    setEnabled: jest.fn(),
+    deleteById: jest.fn(),
+    recordPoll: jest.fn(),
+  } as unknown as jest.Mocked<AnkifyNotionSubscriptionsRepositoryInterface>);
+
+const makeLogs = (): jest.Mocked<AnkifySyncLogsRepositoryInterface> =>
+  ({
+    log: jest.fn(async () => undefined),
+    listByOwner: jest.fn(),
+  } as unknown as jest.Mocked<AnkifySyncLogsRepositoryInterface>);
+
+const makeNotionRepo = (
+  token: string | null = 'notion-token'
+): jest.Mocked<INotionRepository> =>
+  ({
+    getNotionData: jest.fn(),
+    saveNotionToken: jest.fn(),
+    getNotionToken: jest.fn(async () => token),
+    deleteBlocksByOwner: jest.fn(),
+    deleteNotionData: jest.fn(),
+  } as unknown as jest.Mocked<INotionRepository>);
+
+const makeAnkiConnectStub = () =>
+  ({
+    createDeck: jest.fn(async () => 1),
+    addNote: jest.fn(async () => 7),
+    notesInfo: jest.fn(async () => []),
+    updateNoteFields: jest.fn(async () => null),
+    sync: jest.fn(async () => null),
+  } as unknown as AnkiConnectClient & { [k: string]: jest.Mock });
+
+describe('SyncNotionPageToRacUseCase', () => {
+  test('persists icon returned by the page-meta fetcher on upsert', async () => {
+    const clients = makeClients();
+    const mappings = makeMappings();
+    const conflicts = makeConflicts();
+    const subscriptions = makeSubscriptionsRepo();
+    const logs = makeLogs();
+    const notionRepo = makeNotionRepo();
+    const ac = makeAnkiConnectStub();
+
+    const useCase = new SyncNotionPageToRacUseCase(
+      clients,
+      mappings,
+      conflicts,
+      subscriptions,
+      logs,
+      notionRepo,
+      () => ac,
+      () => async () => [],
+      (_token: string) => async (_pageId: string) => ({
+        title: 'Algebra',
+        url: 'https://www.notion.so/algebra',
+        icon: '📘',
+      })
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(subscriptions.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notion_page_id: 'page-id',
+        notion_page_title: 'Algebra',
+        notion_page_url: 'https://www.notion.so/algebra',
+        notion_page_icon: '📘',
+      })
+    );
+  });
+
+  test('lazy-fills missing icon on subsequent sync when the meta fetcher returns one', async () => {
+    const clients = makeClients();
+    const mappings = makeMappings();
+    const conflicts = makeConflicts();
+    const subscriptions = makeSubscriptionsRepo(
+      sampleSubscription({ notion_page_icon: null })
+    );
+    const logs = makeLogs();
+    const notionRepo = makeNotionRepo();
+    const ac = makeAnkiConnectStub();
+
+    const useCase = new SyncNotionPageToRacUseCase(
+      clients,
+      mappings,
+      conflicts,
+      subscriptions,
+      logs,
+      notionRepo,
+      () => ac,
+      () => async () => [],
+      () => async () => ({
+        title: null,
+        url: null,
+        icon: 'https://example.com/icon.png',
+      })
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'polling',
+    });
+
+    expect(subscriptions.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notion_page_icon: 'https://example.com/icon.png',
+      })
+    );
+  });
+});

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -25,6 +25,7 @@ export interface SyncNotionPageInput {
   notionPageId: string;
   notionPageTitle?: string | null;
   notionPageUrl?: string | null;
+  notionPageIcon?: string | null;
   trigger: 'manual' | 'polling' | 'webhook';
   ankiConnectHost?: string;
 }
@@ -32,6 +33,7 @@ export interface SyncNotionPageInput {
 export interface NotionPageMeta {
   title: string | null;
   url: string | null;
+  icon: string | null;
 }
 
 export type NotionPageMetaFetcher = (
@@ -89,7 +91,10 @@ export class SyncNotionPageToRacUseCase {
       throw new NotionNotConnectedError();
     }
 
-    const { pageTitle, pageUrl } = await this.resolvePageMeta(token, input);
+    const { pageTitle, pageUrl, pageIcon } = await this.resolvePageMeta(
+      token,
+      input
+    );
 
     const subscription = await this.subscriptions.upsert({
       owner: input.owner,
@@ -97,6 +102,7 @@ export class SyncNotionPageToRacUseCase {
       notion_page_id: input.notionPageId,
       notion_page_title: pageTitle,
       notion_page_url: pageUrl,
+      notion_page_icon: pageIcon,
       enabled: true,
     });
 
@@ -138,20 +144,23 @@ export class SyncNotionPageToRacUseCase {
   ): Promise<{
     pageTitle: string | null | undefined;
     pageUrl: string | null | undefined;
+    pageIcon: string | null | undefined;
   }> {
     let pageTitle: string | null | undefined = input.notionPageTitle;
     let pageUrl: string | null | undefined = input.notionPageUrl;
+    let pageIcon: string | null | undefined = input.notionPageIcon;
     if (this.notionPageMeta == null) {
-      return { pageTitle, pageUrl };
+      return { pageTitle, pageUrl, pageIcon };
     }
     try {
       const meta = await this.notionPageMeta(token)(input.notionPageId);
       pageTitle = meta.title;
       pageUrl = meta.url;
+      pageIcon = meta.icon;
     } catch {
       // Notion API hiccup — keep whatever the input or DB already has.
     }
-    return { pageTitle, pageUrl };
+    return { pageTitle, pageUrl, pageIcon };
   }
 
   private async runSync(args: {

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -172,7 +172,7 @@ export class Backend {
             url: getResourceUrl(p),
             id: p.id,
             isFavorite: favorites.some((f) => f.id === p.id),
-            parent: parentType != null ? { type: parentType } : undefined,
+            parent: parentType == null ? undefined : { type: parentType },
           };
         })
         .filter((entry: NotionObject) => entry.title.trim().length > 0);

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -416,6 +416,7 @@ export class Backend {
       notion_page_id: string;
       notion_page_title: string | null;
       notion_page_url: string | null;
+      notion_page_icon: string | null;
       enabled: boolean;
       last_polled_at: string | null;
       last_synced_at: string | null;
@@ -430,6 +431,7 @@ export class Backend {
     notionPageId: string;
     notionPageTitle?: string | null;
     notionPageUrl?: string | null;
+    notionPageIcon?: string | null;
   }): Promise<{
     created: number;
     updated: number;
@@ -443,6 +445,7 @@ export class Backend {
       notion_page_id: input.notionPageId,
       notion_page_title: input.notionPageTitle,
       notion_page_url: input.notionPageUrl,
+      notion_page_icon: input.notionPageIcon,
     });
     if (!response.ok) {
       const error = await response

--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -972,6 +972,24 @@
   border-bottom: none;
 }
 
+.decksItemIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  font-size: var(--text-base);
+  line-height: 1;
+}
+
+.decksItemIcon img {
+  width: 1.5rem;
+  height: 1.5rem;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
+}
+
 .decksItemTitle {
   flex: 1;
   font-size: var(--text-sm);

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
@@ -14,6 +14,7 @@ const sampleSubscription = (overrides: Partial<Subscription> = {}): Subscription
   notion_page_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
   notion_page_title: 'My deck',
   notion_page_url: 'https://notion.so/My-deck',
+  notion_page_icon: null,
   enabled: true,
   last_polled_at: null,
   last_synced_at: new Date().toISOString(),
@@ -200,6 +201,46 @@ describe('NotionSubscriptions sync copy', () => {
       expect(screen.getByText('My deck')).toBeInTheDocument()
     );
     expect(screen.queryByText(/next export at/i)).not.toBeInTheDocument();
+  });
+
+  test('renders the page icon next to the title when present', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: 'a'.repeat(32),
+          notion_page_icon: '📘',
+        }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    await waitFor(() =>
+      expect(screen.getByText('My deck')).toBeInTheDocument()
+    );
+    expect(screen.getByText('📘')).toBeInTheDocument();
+  });
+
+  test('renders an image icon when notion_page_icon is a URL', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: 'a'.repeat(32),
+          notion_page_icon: 'https://example.com/icon.png',
+        }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    await waitFor(() =>
+      expect(screen.getByText('My deck')).toBeInTheDocument()
+    );
+    const img = screen.getByAltText('icon') as HTMLImageElement;
+    expect(img).toBeInTheDocument();
+    expect(img.src).toBe('https://example.com/icon.png');
   });
 
   test('error line takes precedence over next-export line', async () => {

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -8,6 +8,7 @@ import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import { Backend } from '../../../lib/backend/Backend';
 import NotionPagePicker from './NotionPagePicker';
 import DotsHorizontal from '../../../components/icons/DotsHorizontal';
+import { BlockIcon } from '../../SearchPage/components/BlockIcon';
 
 const formatRelativeTime = (iso: string | null | undefined): string | null => {
   if (iso == null || iso.length === 0) return null;
@@ -116,6 +117,7 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
     notionPageId: string;
     notionPageTitle?: string | null;
     notionPageUrl?: string | null;
+    notionPageIcon?: string | null;
   }
 
   const subscribe = useMutation({
@@ -124,6 +126,7 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
         notionPageId: args.notionPageId,
         notionPageTitle: args.notionPageTitle,
         notionPageUrl: args.notionPageUrl,
+        notionPageIcon: args.notionPageIcon,
       }),
     onMutate: async (args: SubscribeArgs) => {
       await queryClient.cancelQueries({ queryKey: SUBSCRIPTIONS_KEY });
@@ -135,6 +138,7 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
         notion_page_id: args.notionPageId,
         notion_page_title: args.notionPageTitle ?? null,
         notion_page_url: args.notionPageUrl ?? null,
+        notion_page_icon: args.notionPageIcon ?? null,
         enabled: true,
         last_polled_at: null,
         last_synced_at: null,
@@ -173,12 +177,18 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
       queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY }),
   });
 
-  const handlePick = (id: string, page?: { title?: string; url?: string }) => {
+  const handlePick = (
+    id: string,
+    page?: { title?: string; url?: string; icon?: string }
+  ) => {
     setPendingId(id);
+    const trimmedIcon =
+      page?.icon != null && page.icon.length > 0 ? page.icon : undefined;
     subscribe.mutate({
       notionPageId: id,
       notionPageTitle: page?.title ?? undefined,
       notionPageUrl: page?.url ?? undefined,
+      notionPageIcon: trimmedIcon,
     });
   };
 
@@ -405,8 +415,14 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                     updated {relative}
                   </span>
                 );
+              const iconValue = sub.notion_page_icon ?? '';
               return (
                 <li key={sub.id} className={styles.decksItem}>
+                  {iconValue.length > 0 && (
+                    <span className={styles.decksItemIcon} aria-hidden="true">
+                      <BlockIcon icon={iconValue} />
+                    </span>
+                  )}
                   <span className={styles.decksItemTitle} title={displayTitle}>
                     {sub.notion_page_url != null &&
                     sub.notion_page_url.length > 0 ? (


### PR DESCRIPTION
## What
Notion page icons (emoji or image) now show in the Ankify decks list, matching the picker.

## Why
On `/ankify`, the Decks tab listed subscribed Notion pages with title only. Users had no quick visual cue to tell their decks apart, even though the picker tab next to it shows icons. This closes that inconsistency.

## How
- New migration adds a nullable `notion_page_icon` text column on `ankify_notion_subscriptions`.
- `AnkifyNotionSubscription` entity, repository upsert, and use-case input all carry the new field.
- `buildNotionPageMetaFetcher` (and the dupe in `data_layer/index.ts`) extracts the icon from the Notion `pages.retrieve` response, normalizing emoji / external / file shapes into a single string — same shape the picker already uses via `getObjectIcon`.
- The frontend forwards the icon from the picker into the subscribe call and renders `<BlockIcon />` in front of the title with picker-matching spacing.
- Existing rows lazy-fill on the next polling tick: the sync use case already calls the meta fetcher every run, and the upsert now persists the icon alongside title and url. No backfill script.

## Testing
- New unit test: `src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts` covers (1) icon from meta fetcher → upsert payload on subscribe, (2) lazy-fill path during polling. Started failing for the right reason before implementation.
- New web tests in `NotionSubscriptions.test.tsx` cover emoji and URL icon rendering.
- `pnpm test src/usecases/ankify` — 27/27 pass.
- `pnpm --filter 2anki-web test` — 48/48 pass.
- `pnpm --filter 2anki-web typecheck` — clean.
- Server `pnpm tsc --noEmit` — only pre-existing dockerode/http-proxy-middleware errors (also present on `main`).

## Risks
- Migration is reversible (adds + drops a single nullable column).
- Notion API icon shape is `emoji | external | file | null`; unknown variants safely fall back to `null` in the extractor.
- No change to the polling cadence or AnkiConnect path.

## Goal alignment
Smaller / faster / more beautiful: glanceable icons in the decks list match what users already see in Notion, removing a visual mismatch that made the list feel less polished. No new conversion-hot-path work.