### PR TITLE
perf(ankify): two-tier cache for Find-pages picker (<200ms warm)

### DIFF
--- a/Documentation/specs/ankify-find-pages-cache.md
+++ b/Documentation/specs/ankify-find-pages-cache.md
@@ -1,0 +1,98 @@
+# Spec: Cache "Find pages" results to fix slow Ankify picker
+
+**Goal**: Make the "Find pages" picker on `/ankify` open instantly on repeat use, without changing the cold-start cost or the result set.
+
+**Goal alignment**: The picker is the first thing a returning user touches when adding a new deck. Today it stalls 4–8s on heavy-database accounts, every single open. A short-TTL server-side cache turns the second open (and every keystroke-debounced re-fetch) into a sub-50ms response — directly serving the "simplest, fastest" mission and unblocking deck creation, the top-of-funnel action toward 300K users.
+
+## Problem (verified)
+
+The Ankify "Find pages" picker (`web/src/pages/AnkifyPage/components/NotionPagePicker.tsx`) calls `POST /api/notion/top-level-pages` on every mount and on every debounced keystroke. The server handler, `NotionAPIWrapper.searchTopLevelPages` at `src/services/NotionService/NotionAPIWrapper.ts:243`, paginates Notion's `search` endpoint up to **20 times** (200 items each) to collect 50 useful top-level pages.
+
+The cost is structural: Notion has no "list workspace pages" API. `search` returns objects sorted by `last_edited_time desc`, which on heavy-database accounts is dominated by database rows. The recent commit `d434d93b` ("bump top-level page search to 20 paginated calls") documents this directly:
+
+> Probed prod: 5 pages of Notion search (500 results) returned 0 useful entries on the test account because the most recently edited 500 items are all rows from one active database. Real top-level pages start showing up around page 6+.
+
+Twenty sequential Notion calls × ~200–400ms each = **4–8s** per request on heavy-DB accounts. Nothing is cached, so the cost is paid on every mount, every navigation back to `/ankify`, and after every debounced keystroke clears the input.
+
+**Why `/notion` (`SearchPage`) feels faster**: it defaults to `query='anki'` (`web/src/pages/SearchPage/helpers/useSearchQuery.tsx:30`). With a non-empty query, Notion does server-side fuzzy matching and returns a small targeted slice in **one** API call. Same workspace, same code path — different default query.
+
+## User-facing change
+
+None visible. The picker behaves identically. First open is unchanged. Subsequent opens within 60s render the previous result list immediately instead of showing "Looking up your pages…" for several seconds.
+
+## Server-side change
+
+Add an in-memory per-owner cache for `searchTopLevelPages` results, keyed by `${owner}:${query.trim().toLowerCase()}`, TTL 60s.
+
+```
+NotionService.searchTopLevelPages(query, owner)
+  ├── cacheKey = `${owner}:${query.toLowerCase().trim()}`
+  ├── if (cache hit && !expired) return cached
+  ├── result = client.searchTopLevelPages(...)
+  ├── cache.set(cacheKey, result, ttl=60s)
+  └── return result
+
++ NotionService.disconnect(owner) calls cache.invalidateOwner(owner)
+```
+
+### Files to touch
+
+- `src/services/NotionService/topLevelPagesCache.ts` (new): a small module exporting `get(key)`, `set(key, value, ttlMs)`, `invalidateOwner(owner)`. Backed by a `Map<string, { value, expiresAt }>` at module scope. ~40 LOC.
+- `src/services/NotionService/NotionService.ts:77`: wrap `searchTopLevelPages` with cache lookup/populate.
+- `src/services/NotionService/NotionService.ts:155` (`disconnect`): call `invalidateOwner` so a re-connected account doesn't see another user's cached pages on the same process. (Multi-tenant safety.)
+- `src/services/NotionService/topLevelPagesCache.test.ts` (new): unit test for hit/miss/expiry/invalidateOwner.
+
+No frontend changes. No new endpoints. No DB migration. No schema change.
+
+## Why 60s and not longer / shorter
+
+- **Long enough** to cover the realistic re-open pattern (open picker → realize you want a different page → close → reopen).
+- **Short enough** that a user adding a new top-level page in Notion sees it within a minute without needing manual invalidation.
+- Process-local TTL is sufficient: a stale read from another pm2 worker is no worse than today (a fresh fetch). No need for Redis or a shared store.
+
+## Cache key normalisation
+
+Lowercase + trim the query so `"My Page"` and `"my page "` share an entry. Owner is part of the key so cross-tenant leakage is impossible. Don't cache empty-query and non-empty-query under the same key — they're different Notion calls with different result shapes.
+
+## Acceptance criteria
+
+- [ ] Two consecutive `POST /api/notion/top-level-pages` requests with the same body from the same authenticated user issue **one** Notion API call (verified via mocked `notion.search` call count in unit test).
+- [ ] A third request 61s later issues a fresh Notion call.
+- [ ] Disconnecting Notion (`POST /api/notion/disconnect`) drops the cached entries for that owner; the next picker open does a fresh fetch.
+- [ ] Two different users hitting the endpoint do not share cache entries (owner is part of the key).
+- [ ] No change to the JSON shape returned to the FE — `NotionPagePicker.tsx` does not need to be touched.
+- [ ] Existing `NotionAPIWrapper.searchTopLevelPages` tests still pass unchanged.
+- [ ] New `topLevelPagesCache.test.ts` covers: hit, miss, expiry, `invalidateOwner` clears only that owner's keys.
+
+## Out of scope (next iteration)
+
+- **Streaming results** (SSE) so the first batch shows in ~500ms even on cold start. Defer until we measure whether the cache alone is enough.
+- **Persistent DB cache** (`notion_top_level_pages` table) — only worth it if process-local cache misses turn out to be common.
+- **Force-refresh button** in the picker UI — add only if users complain about staleness within the 60s window.
+- **Client-side `sessionStorage` cache** — redundant once the server cache exists; revisit if pm2 worker hashing causes uneven hit rates.
+- **Reducing `maxPages` from 20** — `d434d93b` already tuned this; don't relitigate without new prod data.
+- **Notion-side filter improvements** — Notion's `search` API has no parent-type filter, so this is a dead end without their API changing.
+
+## Risks and mitigation
+
+- **Stale data within 60s**: a user who just created a new page in Notion won't see it for up to a minute. Acceptable — the picker has no "this list is fresh as of HH:MM:SS" affordance today, and the alternative is the current 4–8s wait.
+- **Memory growth**: bounded by `(number of active users in last 60s) × (number of distinct queries per user)`. At our scale this is tiny — a few MB worst case. If we ever need to bound it harder, swap to an LRU; not needed today.
+- **pm2 cluster split**: each worker has its own Map. A user pinned to worker A who later hits worker B pays one fresh fetch. No correctness issue. Sticky sessions or a shared store can come later if hit-rate telemetry warrants it.
+- **Test isolation**: cache lives at module scope. Tests must reset it between cases (export a `__resetForTests` helper or use `vi.resetModules`).
+
+## Commit message guidance
+
+Use `perf(ankify):` prefix. Reference the root cause from `d434d93b` so the chain of fixes is traceable. Example body:
+
+> Find-pages picker calls `searchTopLevelPages` on every mount and every
+> debounced keystroke. On heavy-DB accounts each call does up to 20
+> sequential Notion search pages (~4–8s) because top-level pages are
+> buried under DB rows in `last_edited_time` order — see d434d93b.
+>
+> Add a per-owner in-memory cache (60s TTL) so repeat opens hit the
+> cache instead of Notion. Cold start is unchanged. Cache is dropped
+> when the user disconnects Notion.
+>
+> Future scope (deferred, not in this PR): streaming/SSE for cold-start
+> latency, and a persistent cache if process-local hit rate proves
+> insufficient.

--- a/Documentation/specs/ankify-find-pages-cache.md
+++ b/Documentation/specs/ankify-find-pages-cache.md
@@ -1,8 +1,8 @@
 # Spec: Cache "Find pages" results to fix slow Ankify picker
 
-**Goal**: Make the "Find pages" picker on `/ankify` open instantly on repeat use, without changing the cold-start cost or the result set.
+**Goal**: First batch of results in the `/ankify` "Find pages" picker shows in **<200ms** for the empty-query case (initial mount) across all account sizes — including heavy-database accounts where today it stalls 4–8s.
 
-**Goal alignment**: The picker is the first thing a returning user touches when adding a new deck. Today it stalls 4–8s on heavy-database accounts, every single open. A short-TTL server-side cache turns the second open (and every keystroke-debounced re-fetch) into a sub-50ms response — directly serving the "simplest, fastest" mission and unblocking deck creation, the top-of-funnel action toward 300K users.
+**Goal alignment**: The picker is the first thing a returning user touches when adding a new deck. A sub-200ms first paint serves the "simplest, fastest" mission directly and unblocks deck creation, the top-of-funnel action toward 300K users.
 
 ## Problem (verified)
 
@@ -14,85 +14,135 @@ The cost is structural: Notion has no "list workspace pages" API. `search` retur
 
 Twenty sequential Notion calls × ~200–400ms each = **4–8s** per request on heavy-DB accounts. Nothing is cached, so the cost is paid on every mount, every navigation back to `/ankify`, and after every debounced keystroke clears the input.
 
-**Why `/notion` (`SearchPage`) feels faster**: it defaults to `query='anki'` (`web/src/pages/SearchPage/helpers/useSearchQuery.tsx:30`). With a non-empty query, Notion does server-side fuzzy matching and returns a small targeted slice in **one** API call. Same workspace, same code path — different default query.
+**Why `/notion` (`SearchPage`) feels faster**: it defaults to `query='anki'` (`web/src/pages/SearchPage/helpers/useSearchQuery.tsx:30`). With a non-empty query, Notion does server-side fuzzy matching and returns a small targeted slice in **one** API call. An empty-query `/notion` would be just as slow — same code path, different default query. So `/notion` is a useful diagnostic, not a benchmark we can match without changing where the data comes from.
+
+## Why <200ms requires not calling Notion in the hot path
+
+Each `notion.search` call is ~200–400ms round-trip. On heavy-DB accounts the *first* call returns zero useful entries — useful pages don't appear until page 6+. Streaming/SSE doesn't help because there's nothing to stream in the first 200ms. Notion's `search` is cursor-only, so calls can't be parallelised. The only way to reliably hit <200ms is to read from a local cache that was populated out-of-band.
+
+This spec therefore has two tiers, intended to land **together** in one PR:
+
+- **Tier 1** — in-memory per-process cache (60s TTL) for repeat-open and debounced-keystroke wins.
+- **Tier 2** — persistent DB cache + stale-while-revalidate, populated by the existing Ankify poll job, for cold-start and cross-process wins.
+
+Reads check Tier 1 → Tier 2 → live Notion in that order. Writes populate both tiers.
 
 ## User-facing change
 
-None visible. The picker behaves identically. First open is unchanged. Subsequent opens within 60s render the previous result list immediately instead of showing "Looking up your pages…" for several seconds.
+None visible. The picker behaves identically; it just renders results in <200ms instead of 4–8s.
 
 ## Server-side change
 
-Add an in-memory per-owner cache for `searchTopLevelPages` results, keyed by `${owner}:${query.trim().toLowerCase()}`, TTL 60s.
+### Tier 1 — in-memory cache
+
+Per-owner in-memory cache keyed by `${owner}:${query.trim().toLowerCase()}`, TTL 60s. Lives at module scope in `src/services/NotionService/topLevelPagesCache.ts`. Backed by a `Map<string, { value, expiresAt }>`. Invalidated when the user disconnects Notion.
+
+### Tier 2 — persistent DB cache + stale-while-revalidate
+
+New table `notion_top_level_pages`:
 
 ```
-NotionService.searchTopLevelPages(query, owner)
-  ├── cacheKey = `${owner}:${query.toLowerCase().trim()}`
-  ├── if (cache hit && !expired) return cached
-  ├── result = client.searchTopLevelPages(...)
-  ├── cache.set(cacheKey, result, ttl=60s)
-  └── return result
-
-+ NotionService.disconnect(owner) calls cache.invalidateOwner(owner)
+notion_top_level_pages
+  owner            integer  not null  references users(id) on delete cascade
+  notion_page_id   text     not null
+  title            text     not null
+  icon             jsonb    null
+  url              text     null
+  parent_type      text     not null
+  last_edited_time timestamptz not null
+  cached_at        timestamptz not null default now()
+  primary key (owner, notion_page_id)
+  index (owner, cached_at)
 ```
+
+Stored only for the empty-query case (the slow path). Typed queries continue to hit Notion live — they're already fast because Notion filters server-side, and persisting per-query results would explode the table.
+
+**Read path** (empty query):
+1. Tier 1 hit → return.
+2. Tier 2 rows for owner exist → return them immediately. If the newest `cached_at` is older than 5 min, fire-and-forget a background refresh (don't await).
+3. Tier 2 empty (first time ever) → live fetch, populate both tiers, return.
+
+**Read path** (typed query): Tier 1 → live Notion (unchanged). No Tier 2 involvement.
+
+**Write path** (background refresh):
+- Triggered by the existing **5-min Ankify poll job** that already runs per owner (`scheduleAnkifyPolling.ts` and friends — confirm exact entry point during implementation).
+- Calls `client.searchTopLevelPages('')`, replaces all rows for that owner in a single transaction (`delete where owner = ? ; insert ...`).
+- Also triggered once on Notion connect, off the request path, so the user's first picker open is already warm.
+
+**Invalidation**:
+- `NotionService.disconnect(owner)` deletes Tier 2 rows and calls `Tier 1 invalidateOwner`. (FK `on delete cascade` from `users` covers account deletion.)
 
 ### Files to touch
 
-- `src/services/NotionService/topLevelPagesCache.ts` (new): a small module exporting `get(key)`, `set(key, value, ttlMs)`, `invalidateOwner(owner)`. Backed by a `Map<string, { value, expiresAt }>` at module scope. ~40 LOC.
-- `src/services/NotionService/NotionService.ts:77`: wrap `searchTopLevelPages` with cache lookup/populate.
-- `src/services/NotionService/NotionService.ts:155` (`disconnect`): call `invalidateOwner` so a re-connected account doesn't see another user's cached pages on the same process. (Multi-tenant safety.)
-- `src/services/NotionService/topLevelPagesCache.test.ts` (new): unit test for hit/miss/expiry/invalidateOwner.
+- `src/services/NotionService/topLevelPagesCache.ts` *(new, ~40 LOC)* — Tier 1 module: `get`, `set`, `invalidateOwner`, `__resetForTests`.
+- `migrations/<timestamp>_create_notion_top_level_pages.ts` *(new)* — Tier 2 table per schema above.
+- `src/data_layer/NotionTopLevelPagesRepository.ts` *(new, ~80 LOC)* — `getByOwner(owner)`, `replaceForOwner(owner, rows)`, `deleteByOwner(owner)`, `newestCachedAt(owner)`.
+- `src/services/NotionService/NotionService.ts:77` — wrap `searchTopLevelPages` with the two-tier read path described above. Empty-query branch reads Tier 2; non-empty branch only uses Tier 1.
+- `src/services/NotionService/NotionService.ts:155` (`disconnect`) — delete Tier 2 rows; call Tier 1 `invalidateOwner`.
+- Notion connect handler (`NotionController.connect` at `src/controllers/NotionController.ts:93` or its downstream `connectToNotion` use case) — fire-and-forget initial Tier 2 warm.
+- Ankify poll job entry point — add a per-owner Tier 2 refresh step. (Identify exact file during implementation; do not rewire scheduler shape.)
+- Tests:
+  - `topLevelPagesCache.test.ts` *(new)* — hit/miss/expiry/invalidateOwner.
+  - `NotionTopLevelPagesRepository.test.ts` *(new)* — round-trip, replaceForOwner is atomic, deleteByOwner.
+  - `NotionService.searchTopLevelPages.test.ts` *(new or extended)* — read path priority (Tier 1 > Tier 2 > live), stale-while-revalidate fires non-blocking refresh, typed queries skip Tier 2.
 
-No frontend changes. No new endpoints. No DB migration. No schema change.
+No frontend changes. No new endpoints.
 
-## Why 60s and not longer / shorter
+## Why 60s (Tier 1) and 5 min (Tier 2)
 
-- **Long enough** to cover the realistic re-open pattern (open picker → realize you want a different page → close → reopen).
-- **Short enough** that a user adding a new top-level page in Notion sees it within a minute without needing manual invalidation.
-- Process-local TTL is sufficient: a stale read from another pm2 worker is no worse than today (a fresh fetch). No need for Redis or a shared store.
-
-## Cache key normalisation
-
-Lowercase + trim the query so `"My Page"` and `"my page "` share an entry. Owner is part of the key so cross-tenant leakage is impossible. Don't cache empty-query and non-empty-query under the same key — they're different Notion calls with different result shapes.
+- **Tier 1 / 60s**: covers re-open patterns and debounced keystroke flutter without holding stale data long.
+- **Tier 2 / 5 min stale window**: matches the Ankify poll cadence, so refresh costs are amortised onto an existing job. User sees stale list instantly while refresh runs in the background — staleness is invisible.
+- Both are tunable via constants; revisit only if telemetry says so.
 
 ## Acceptance criteria
 
-- [ ] Two consecutive `POST /api/notion/top-level-pages` requests with the same body from the same authenticated user issue **one** Notion API call (verified via mocked `notion.search` call count in unit test).
-- [ ] A third request 61s later issues a fresh Notion call.
-- [ ] Disconnecting Notion (`POST /api/notion/disconnect`) drops the cached entries for that owner; the next picker open does a fresh fetch.
-- [ ] Two different users hitting the endpoint do not share cache entries (owner is part of the key).
-- [ ] No change to the JSON shape returned to the FE — `NotionPagePicker.tsx` does not need to be touched.
-- [ ] Existing `NotionAPIWrapper.searchTopLevelPages` tests still pass unchanged.
-- [ ] New `topLevelPagesCache.test.ts` covers: hit, miss, expiry, `invalidateOwner` clears only that owner's keys.
+- [ ] **Cold first open**: a user with no Tier 2 rows sees results within the live-fetch latency (unavoidable). Subsequent opens within 5 min read from Tier 2 in <50ms server time.
+- [ ] **Warm open** (after Notion connect-time pre-warm or at least one prior fetch): `POST /api/notion/top-level-pages` with empty query returns in <200ms end-to-end on a heavy-DB account.
+- [ ] **Stale-while-revalidate**: when Tier 2's newest `cached_at` is >5 min old, the response returns immediately with cached rows AND a background refresh runs (verified via mocked clock + spy on `client.searchTopLevelPages`).
+- [ ] **Typed queries skip Tier 2** — verified by asserting Tier 2 read is not invoked for `query !== ''`.
+- [ ] **Disconnect drops Tier 2** — `NotionService.disconnect(owner)` removes all rows for that owner and clears Tier 1.
+- [ ] **Cross-tenant isolation** — two users hitting the endpoint cannot see each other's cached pages.
+- [ ] **No FE change** — `NotionPagePicker.tsx` is untouched; JSON response shape is identical.
+- [ ] **Existing `NotionAPIWrapper.searchTopLevelPages` tests pass unchanged.**
+- [ ] **New tests** cover Tier 1 (`topLevelPagesCache.test.ts`), repository round-trip (`NotionTopLevelPagesRepository.test.ts`), and read-path priority + stale-while-revalidate behaviour (`NotionService.searchTopLevelPages.test.ts`).
+- [ ] **Connect pre-warm** is fire-and-forget — the connect flow does not await it, and a failed warm does not break connect.
+- [ ] **Poll-job refresh** runs per owner on the existing 5-min cadence and uses `replaceForOwner` so the table never has duplicates or partial state.
 
 ## Out of scope (next iteration)
 
-- **Streaming results** (SSE) so the first batch shows in ~500ms even on cold start. Defer until we measure whether the cache alone is enough.
-- **Persistent DB cache** (`notion_top_level_pages` table) — only worth it if process-local cache misses turn out to be common.
-- **Force-refresh button** in the picker UI — add only if users complain about staleness within the 60s window.
-- **Client-side `sessionStorage` cache** — redundant once the server cache exists; revisit if pm2 worker hashing causes uneven hit rates.
-- **Reducing `maxPages` from 20** — `d434d93b` already tuned this; don't relitigate without new prod data.
-- **Notion-side filter improvements** — Notion's `search` API has no parent-type filter, so this is a dead end without their API changing.
+- **Streaming results (SSE)**: not needed — Tier 2 makes the cold path moot.
+- **Cross-process / Redis cache**: Tier 2 is in Postgres, which is already shared across pm2 workers.
+- **Force-refresh button** in the picker UI — only if users complain about staleness within 5 min.
+- **Client-side `sessionStorage` cache** — redundant.
+- **Reducing `maxPages` from 20** — `d434d93b` already tuned this; don't relitigate.
+- **Notion webhook subscription** for instant invalidation — interesting follow-up; defer until we measure whether 5-min staleness is a real complaint.
+- **Persisting typed-query results** — explosion of cache space for marginal benefit; Notion already handles typed queries fast.
+- **Retiring `/notion`'s `SearchPage`** — separate roadmap item.
 
 ## Risks and mitigation
 
-- **Stale data within 60s**: a user who just created a new page in Notion won't see it for up to a minute. Acceptable — the picker has no "this list is fresh as of HH:MM:SS" affordance today, and the alternative is the current 4–8s wait.
-- **Memory growth**: bounded by `(number of active users in last 60s) × (number of distinct queries per user)`. At our scale this is tiny — a few MB worst case. If we ever need to bound it harder, swap to an LRU; not needed today.
-- **pm2 cluster split**: each worker has its own Map. A user pinned to worker A who later hits worker B pays one fresh fetch. No correctness issue. Sticky sessions or a shared store can come later if hit-rate telemetry warrants it.
-- **Test isolation**: cache lives at module scope. Tests must reset it between cases (export a `__resetForTests` helper or use `vi.resetModules`).
+- **Stale data within 5 min**: a user who just created a page in Notion won't see it for up to 5 min. Acceptable — the picker has no freshness affordance today, and the alternative is the current 4–8s wait. Future Notion-webhook follow-up would close this.
+- **Migration risk**: new table only, no schema change to existing tables, no backfill required (table starts empty; populated lazily). Rollback = drop the table.
+- **Background refresh failures**: a thrown error inside the fire-and-forget refresh must not crash the request or the poll job. Wrap in try/catch with `console.error`. Existing `withRetry` already covers Notion API flakiness.
+- **Poll-job amplification**: adding a Notion call per owner per 5 min is non-trivial at scale. Mitigation: only refresh owners with an active Notion connection (already a precondition for the poll job) and skip if `newestCachedAt` is fresher than 5 min (e.g., a recent live fetch already populated it).
+- **Memory growth (Tier 1)**: bounded by active users × distinct queries in last 60s. Tiny at our scale; swap to LRU only if it ever matters.
+- **Test isolation (Tier 1)**: cache lives at module scope. Export a `__resetForTests` helper or use `vi.resetModules` between cases.
+- **Disconnect race**: a refresh in flight when the user disconnects could re-populate rows after the delete. Mitigation: refresh writer checks the user still has a Notion token before writing, or wraps the write in a transaction that re-reads the token first. Cheap and correct.
 
 ## Commit message guidance
 
-Use `perf(ankify):` prefix. Reference the root cause from `d434d93b` so the chain of fixes is traceable. Example body:
+Use `perf(ankify):` prefix. Reference `d434d93b` for the root cause. Example body:
 
 > Find-pages picker calls `searchTopLevelPages` on every mount and every
 > debounced keystroke. On heavy-DB accounts each call does up to 20
 > sequential Notion search pages (~4–8s) because top-level pages are
 > buried under DB rows in `last_edited_time` order — see d434d93b.
 >
-> Add a per-owner in-memory cache (60s TTL) so repeat opens hit the
-> cache instead of Notion. Cold start is unchanged. Cache is dropped
-> when the user disconnects Notion.
+> Add a two-tier cache: in-memory per-process (60s TTL) for repeat-open
+> wins, plus a persistent `notion_top_level_pages` table refreshed by
+> the existing 5-min Ankify poll job for cold-start wins. Reads are
+> stale-while-revalidate, so the picker renders <200ms across account
+> sizes and a background refresh closes the staleness gap silently.
 >
-> Future scope (deferred, not in this PR): streaming/SSE for cold-start
-> latency, and a persistent cache if process-local hit rate proves
-> insufficient.
+> Future scope (deferred): Notion webhook subscriptions for instant
+> invalidation, and a force-refresh affordance in the picker UI.

--- a/Documentation/specs/ankify-find-pages-cache.md
+++ b/Documentation/specs/ankify-find-pages-cache.md
@@ -59,15 +59,22 @@ Stored only for the empty-query case (the slow path). Typed queries continue to 
 
 **Read path** (empty query):
 1. Tier 1 hit → return.
-2. Tier 2 rows for owner exist → return them immediately. If the newest `cached_at` is older than 5 min, fire-and-forget a background refresh (don't await).
+2. Tier 2 rows for owner exist → return them immediately. If the newest `cached_at` is older than 5 min, schedule a background refresh via the dedup gate below (don't await).
 3. Tier 2 empty (first time ever) → live fetch, populate both tiers, return.
 
 **Read path** (typed query): Tier 1 → live Notion (unchanged). No Tier 2 involvement.
 
 **Write path** (background refresh):
-- Triggered by the existing **5-min Ankify poll job** that already runs per owner (`scheduleAnkifyPolling.ts` and friends — confirm exact entry point during implementation).
-- Calls `client.searchTopLevelPages('')`, replaces all rows for that owner in a single transaction (`delete where owner = ? ; insert ...`).
-- Also triggered once on Notion connect, off the request path, so the user's first picker open is already warm.
+- Triggered by the existing **5-min Ankify poll job** that already runs per owner (`scheduleAnkifyPolling.ts` and friends — confirm exact entry point during implementation), and by stale-while-revalidate reads.
+- Calls `client.searchTopLevelPages('')` and replaces all rows for that owner. The replace + token check happens in **one** SQL transaction (see disconnect-race mitigation below) — the prior `delete; insert` framing was misleading because those two statements alone don't close the race.
+- Also triggered once on Notion connect, off the request path. **This is best-effort**: the warm runs in the background and is not awaited, so a user who opens the picker faster than the warm completes will still hit the cold path. The acceptance criteria treat that case as "cold first open" by design — do not make the warm synchronous to "fix" it.
+
+**Concurrent refresh dedup**:
+- Module-scoped `Set<owner>` of in-flight refreshes. Before scheduling a refresh, `if (inFlight.has(owner)) return`. On completion (success or failure, in `finally`), `inFlight.delete(owner)`.
+- This matters because with a 5-min staleness threshold and a 5-min poll cadence, *most* picker opens between polls will see stale data and try to schedule a refresh. Without dedup, N concurrent picker opens by the same user fan out to N concurrent Notion sweeps (each up to 20 calls). With dedup, the second through Nth opens see "refresh already running" and no-op.
+- Process-local is sufficient for the same reason Tier 1 is: cross-process duplication of refreshes is bounded by pm2 worker count and harmless.
+
+**Expected behaviour** (not a bug): with the schedule above, almost every picker open between two poll cycles will trigger one background refresh per owner per process. Responses stay instant because they read from the existing rows; the dedup gate keeps the Notion fan-out bounded. If telemetry later shows this overshoots Notion rate limits, the cheapest knob is bumping the staleness threshold above the poll cadence (e.g. 10 min stale window vs 5 min poll).
 
 **Invalidation**:
 - `NotionService.disconnect(owner)` deletes Tier 2 rows and calls `Tier 1 invalidateOwner`. (FK `on delete cascade` from `users` covers account deletion.)
@@ -76,7 +83,8 @@ Stored only for the empty-query case (the slow path). Typed queries continue to 
 
 - `src/services/NotionService/topLevelPagesCache.ts` *(new, ~40 LOC)* — Tier 1 module: `get`, `set`, `invalidateOwner`, `__resetForTests`.
 - `migrations/<timestamp>_create_notion_top_level_pages.ts` *(new)* — Tier 2 table per schema above.
-- `src/data_layer/NotionTopLevelPagesRepository.ts` *(new, ~80 LOC)* — `getByOwner(owner)`, `replaceForOwner(owner, rows)`, `deleteByOwner(owner)`, `newestCachedAt(owner)`.
+- `src/data_layer/NotionTopLevelPagesRepository.ts` *(new, ~80 LOC)* — `getByOwner(owner)`, `replaceForOwnerIfTokenStillValid(owner, rows)` (single transaction: re-reads the Notion token, no-ops if absent, otherwise deletes + bulk-inserts atomically), `deleteByOwner(owner)`, `newestCachedAt(owner)`.
+  - **Icon shape**: Notion's `icon` field has multiple shapes (`{type:'emoji', emoji}`, `{type:'external', external:{url}}`, `{type:'file', file:{url}}`, or `null`). `NotionAPIWrapper.searchTopLevelPages` returns the raw object straight from the SDK. The repository persists the raw shape as `jsonb`; the existing `getObjectIcon` helper on the FE already handles all variants, so no normalisation is needed. Implementer just needs to know the column accepts `null` and any of the three shapes.
 - `src/services/NotionService/NotionService.ts:77` — wrap `searchTopLevelPages` with the two-tier read path described above. Empty-query branch reads Tier 2; non-empty branch only uses Tier 1.
 - `src/services/NotionService/NotionService.ts:155` (`disconnect`) — delete Tier 2 rows; call Tier 1 `invalidateOwner`.
 - Notion connect handler (`NotionController.connect` at `src/controllers/NotionController.ts:93` or its downstream `connectToNotion` use case) — fire-and-forget initial Tier 2 warm.
@@ -99,14 +107,15 @@ No frontend changes. No new endpoints.
 - [ ] **Cold first open**: a user with no Tier 2 rows sees results within the live-fetch latency (unavoidable). Subsequent opens within 5 min read from Tier 2 in <50ms server time.
 - [ ] **Warm open** (after Notion connect-time pre-warm or at least one prior fetch): `POST /api/notion/top-level-pages` with empty query returns in <200ms end-to-end on a heavy-DB account.
 - [ ] **Stale-while-revalidate**: when Tier 2's newest `cached_at` is >5 min old, the response returns immediately with cached rows AND a background refresh runs (verified via mocked clock + spy on `client.searchTopLevelPages`).
+- [ ] **Concurrent-refresh dedup**: 5 simultaneous stale reads for the same owner trigger exactly **one** background refresh — verified by spying on `client.searchTopLevelPages` while five `searchTopLevelPages('', owner)` calls run concurrently.
 - [ ] **Typed queries skip Tier 2** — verified by asserting Tier 2 read is not invoked for `query !== ''`.
 - [ ] **Disconnect drops Tier 2** — `NotionService.disconnect(owner)` removes all rows for that owner and clears Tier 1.
 - [ ] **Cross-tenant isolation** — two users hitting the endpoint cannot see each other's cached pages.
 - [ ] **No FE change** — `NotionPagePicker.tsx` is untouched; JSON response shape is identical.
 - [ ] **Existing `NotionAPIWrapper.searchTopLevelPages` tests pass unchanged.**
 - [ ] **New tests** cover Tier 1 (`topLevelPagesCache.test.ts`), repository round-trip (`NotionTopLevelPagesRepository.test.ts`), and read-path priority + stale-while-revalidate behaviour (`NotionService.searchTopLevelPages.test.ts`).
-- [ ] **Connect pre-warm** is fire-and-forget — the connect flow does not await it, and a failed warm does not break connect.
-- [ ] **Poll-job refresh** runs per owner on the existing 5-min cadence and uses `replaceForOwner` so the table never has duplicates or partial state.
+- [ ] **Connect pre-warm** is fire-and-forget — the connect flow does not await it, and a failed warm does not break connect. (A user who opens the picker before the warm finishes correctly falls through to the cold path; the warm is best-effort, not a guarantee.)
+- [ ] **Poll-job refresh** runs per owner on the existing 5-min cadence and uses `replaceForOwnerIfTokenStillValid` so the table never has duplicates or partial state.
 
 ## Out of scope (next iteration)
 
@@ -127,7 +136,7 @@ No frontend changes. No new endpoints.
 - **Poll-job amplification**: adding a Notion call per owner per 5 min is non-trivial at scale. Mitigation: only refresh owners with an active Notion connection (already a precondition for the poll job) and skip if `newestCachedAt` is fresher than 5 min (e.g., a recent live fetch already populated it).
 - **Memory growth (Tier 1)**: bounded by active users × distinct queries in last 60s. Tiny at our scale; swap to LRU only if it ever matters.
 - **Test isolation (Tier 1)**: cache lives at module scope. Export a `__resetForTests` helper or use `vi.resetModules` between cases.
-- **Disconnect race**: a refresh in flight when the user disconnects could re-populate rows after the delete. Mitigation: refresh writer checks the user still has a Notion token before writing, or wraps the write in a transaction that re-reads the token first. Cheap and correct.
+- **Disconnect race**: a refresh in flight when the user disconnects could re-populate rows after the delete. Mitigation: the refresh writer's `replaceForOwnerIfTokenStillValid` runs as a single transaction — re-reads the Notion token row inside the transaction, no-ops if the token is absent, otherwise performs the delete + bulk-insert. A pre-write token check outside a transaction is TOCTOU and does not close the race; do not use that variant.
 
 ## Commit message guidance
 

--- a/migrations/20260509000001_notion_top_level_pages.js
+++ b/migrations/20260509000001_notion_top_level_pages.js
@@ -1,0 +1,18 @@
+exports.up = function (knex) {
+  return knex.schema.createTable('notion_top_level_pages', function (table) {
+    table.integer('owner').notNullable();
+    table.string('notion_page_id').notNullable();
+    table.text('title').notNullable();
+    table.jsonb('icon').nullable();
+    table.text('url').nullable();
+    table.text('parent_type').notNullable();
+    table.timestamp('last_edited_time').nullable();
+    table.timestamp('cached_at').notNullable().defaultTo(knex.fn.now());
+    table.primary(['owner', 'notion_page_id']);
+    table.index(['owner', 'cached_at']);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTable('notion_top_level_pages');
+};

--- a/src/data_layer/NotionTopLevelPagesRepository.test.ts
+++ b/src/data_layer/NotionTopLevelPagesRepository.test.ts
@@ -1,0 +1,171 @@
+import { NotionTopLevelPagesRepository } from "./NotionTopLevelPagesRepository";
+
+interface FakeRow {
+	owner: number;
+	notion_page_id: string;
+	title: string;
+	icon: unknown;
+	url: string | null;
+	parent_type: string;
+	last_edited_time: Date | null;
+	cached_at: Date;
+}
+
+function makeFakeKnex(
+	initial: {
+		pages?: FakeRow[];
+		tokens?: { owner: number; token: string }[];
+	} = {},
+) {
+	const pages: FakeRow[] = [...(initial.pages ?? [])];
+	const tokens = [...(initial.tokens ?? [])];
+	const calls: string[] = [];
+
+	const queryBuilder = (rows: FakeRow[], filter: Partial<FakeRow>) => {
+		const matches = (r: FakeRow) =>
+			Object.entries(filter).every(([k, v]) => (r as never)[k] === v);
+
+		return {
+			del: () => {
+				const before = rows.length;
+				for (let i = rows.length - 1; i >= 0; i--) {
+					if (matches(rows[i])) rows.splice(i, 1);
+				}
+				return Promise.resolve(before - rows.length);
+			},
+			orderBy: () => ({
+				select: () => Promise.resolve(rows.filter(matches)),
+			}),
+			first: () => Promise.resolve(rows.find(matches) ?? undefined),
+		};
+	};
+
+	const tableHandler = (tableName: string) => {
+		if (tableName === "notion_top_level_pages") {
+			return {
+				where: (filter: Partial<FakeRow>) => queryBuilder(pages, filter),
+				insert: (rows: FakeRow[]) => {
+					calls.push(`insert ${rows.length}`);
+					pages.push(...rows);
+					return Promise.resolve(rows.length);
+				},
+				max: () => ({
+					where: (filter: Partial<FakeRow>) => ({
+						first: () => {
+							const filtered = pages.filter((r) =>
+								Object.entries(filter).every(([k, v]) => (r as never)[k] === v),
+							);
+							if (filtered.length === 0) return Promise.resolve({ max: null });
+							const max = filtered
+								.map((r) => r.cached_at)
+								.reduce((a, b) => (a > b ? a : b));
+							return Promise.resolve({ max });
+						},
+					}),
+				}),
+			};
+		}
+		if (tableName === "notion_tokens") {
+			return {
+				where: (filter: { owner: number }) => ({
+					first: () =>
+						Promise.resolve(
+							tokens.find((t) => t.owner === filter.owner) ?? undefined,
+						),
+				}),
+			};
+		}
+		throw new Error(`unexpected table: ${tableName}`);
+	};
+
+	const fn = ((tableName: string) => tableHandler(tableName)) as never;
+	(
+		fn as unknown as {
+			transaction: <T>(cb: (trx: unknown) => Promise<T>) => Promise<T>;
+		}
+	).transaction = (cb) => cb(fn);
+
+	return { db: fn, pages, tokens, calls };
+}
+
+describe("NotionTopLevelPagesRepository", () => {
+	const sampleRow = (owner: number, id: string): FakeRow => ({
+		owner,
+		notion_page_id: id,
+		title: `T-${id}`,
+		icon: null,
+		url: `https://notion.so/${id}`,
+		parent_type: "workspace",
+		last_edited_time: new Date("2026-05-01"),
+		cached_at: new Date(),
+	});
+
+	it("getByOwner returns all rows for that owner only", async () => {
+		const fixture = makeFakeKnex({
+			pages: [sampleRow(1, "a"), sampleRow(1, "b"), sampleRow(2, "c")],
+		});
+		const repo = new NotionTopLevelPagesRepository(fixture.db);
+		const rows = await repo.getByOwner(1);
+		expect(rows.map((r) => r.notion_page_id).sort()).toEqual(["a", "b"]);
+	});
+
+	it("newestCachedAt returns the latest cached_at for that owner", async () => {
+		const old = sampleRow(1, "a");
+		old.cached_at = new Date("2026-01-01");
+		const fresh = sampleRow(1, "b");
+		fresh.cached_at = new Date("2026-05-01");
+		const fixture = makeFakeKnex({ pages: [old, fresh] });
+		const repo = new NotionTopLevelPagesRepository(fixture.db);
+		const result = await repo.newestCachedAt(1);
+		expect(result?.toISOString()).toEqual(fresh.cached_at.toISOString());
+	});
+
+	it("newestCachedAt returns null for an owner with no rows", async () => {
+		const fixture = makeFakeKnex();
+		const repo = new NotionTopLevelPagesRepository(fixture.db);
+		expect(await repo.newestCachedAt(99)).toBeNull();
+	});
+
+	it("replaceForOwnerIfTokenStillValid replaces all rows when the token exists", async () => {
+		const fixture = makeFakeKnex({
+			pages: [
+				sampleRow(1, "old-1"),
+				sampleRow(1, "old-2"),
+				sampleRow(2, "other"),
+			],
+			tokens: [{ owner: 1, token: "t" }],
+		});
+		const repo = new NotionTopLevelPagesRepository(fixture.db);
+		await repo.replaceForOwnerIfTokenStillValid(1, [
+			sampleRow(1, "new-1"),
+			sampleRow(1, "new-2"),
+		]);
+		expect(
+			fixture.pages
+				.filter((p) => p.owner === 1)
+				.map((p) => p.notion_page_id)
+				.sort(),
+		).toEqual(["new-1", "new-2"]);
+		expect(fixture.pages.find((p) => p.owner === 2)).toBeDefined();
+	});
+
+	it("replaceForOwnerIfTokenStillValid no-ops when the token has been revoked", async () => {
+		const fixture = makeFakeKnex({
+			pages: [sampleRow(1, "old-1")],
+			tokens: [],
+		});
+		const repo = new NotionTopLevelPagesRepository(fixture.db);
+		await repo.replaceForOwnerIfTokenStillValid(1, [sampleRow(1, "new-1")]);
+		expect(fixture.pages.map((p) => p.notion_page_id)).toEqual(["old-1"]);
+		expect(fixture.calls.find((c) => c.startsWith("insert"))).toBeUndefined();
+	});
+
+	it("deleteByOwner removes only that owner", async () => {
+		const fixture = makeFakeKnex({
+			pages: [sampleRow(1, "a"), sampleRow(2, "b")],
+		});
+		const repo = new NotionTopLevelPagesRepository(fixture.db);
+		await repo.deleteByOwner(1);
+		expect(fixture.pages.map((p) => p.notion_page_id)).toEqual(["b"]);
+	});
+});

--- a/src/data_layer/NotionTopLevelPagesRepository.ts
+++ b/src/data_layer/NotionTopLevelPagesRepository.ts
@@ -1,0 +1,72 @@
+import type { Knex } from "knex";
+
+export interface NotionTopLevelPageRow {
+	owner: number;
+	notion_page_id: string;
+	title: string;
+	icon: unknown;
+	url: string | null;
+	parent_type: string;
+	last_edited_time: Date | null;
+	cached_at: Date;
+}
+
+export interface INotionTopLevelPagesRepository {
+	getByOwner(owner: number): Promise<NotionTopLevelPageRow[]>;
+	newestCachedAt(owner: number): Promise<Date | null>;
+	replaceForOwnerIfTokenStillValid(
+		owner: number,
+		rows: NotionTopLevelPageRow[],
+	): Promise<boolean>;
+	deleteByOwner(owner: number): Promise<number>;
+}
+
+export class NotionTopLevelPagesRepository
+	implements INotionTopLevelPagesRepository
+{
+	private readonly tableName = "notion_top_level_pages";
+
+	private readonly tokenTable = "notion_tokens";
+
+	constructor(private readonly database: Knex) {}
+
+	getByOwner(owner: number): Promise<NotionTopLevelPageRow[]> {
+		return this.database(this.tableName)
+			.where({ owner })
+			.orderBy("title", "asc")
+			.select<NotionTopLevelPageRow[]>("*");
+	}
+
+	async newestCachedAt(owner: number): Promise<Date | null> {
+		const row = await this.database(this.tableName)
+			.max("cached_at as max")
+			.where({ owner })
+			.first();
+		const max = (row as { max?: Date | string | null } | undefined)?.max;
+		if (max == null) return null;
+		return max instanceof Date ? max : new Date(max);
+	}
+
+	async replaceForOwnerIfTokenStillValid(
+		owner: number,
+		rows: NotionTopLevelPageRow[],
+	): Promise<boolean> {
+		return this.database.transaction(async (trx) => {
+			const token = await trx(this.tokenTable).where({ owner }).first();
+			if (token == null) {
+				return false;
+			}
+			await trx(this.tableName).where({ owner }).del();
+			if (rows.length > 0) {
+				await trx(this.tableName).insert(rows);
+			}
+			return true;
+		});
+	}
+
+	deleteByOwner(owner: number): Promise<number> {
+		return this.database(this.tableName).where({ owner }).del();
+	}
+}
+
+export default NotionTopLevelPagesRepository;

--- a/src/data_layer/index.ts
+++ b/src/data_layer/index.ts
@@ -21,6 +21,11 @@ import { AnkifySyncLogsRepository } from './ankify/AnkifySyncLogsRepository';
 import { ankiConnectFactory } from '../services/ankify/buildAnkiConnectClient';
 import { notionBlockChildrenFetcherFactory } from '../services/ankify/notionBlockChildrenFetcher';
 import NotionRepository from './NotionRespository';
+import NotionTopLevelPagesRepository from './NotionTopLevelPagesRepository';
+import {
+  NotionService,
+  TOP_LEVEL_PAGES_STALE_AFTER_MS,
+} from '../services/NotionService/NotionService';
 import { Client as NotionClient } from '@notionhq/client';
 import { setAnkifyExportScheduler } from '../lib/ankify/scheduler/instance';
 import Docker from 'dockerode';
@@ -225,7 +230,23 @@ export const setupDatabase = async (database: Knex) => {
           };
         }
       );
-      scheduleAnkifyPolling(subscriptionsRepo, syncUseCase);
+      const topLevelPagesRepo = new NotionTopLevelPagesRepository(database);
+      const notionServiceForRefresh = new NotionService(
+        notionRepo,
+        topLevelPagesRepo
+      );
+      scheduleAnkifyPolling(subscriptionsRepo, syncUseCase, {
+        refreshTopLevelPagesForOwner: async (owner) => {
+          const newest = await topLevelPagesRepo.newestCachedAt(owner);
+          if (
+            newest &&
+            Date.now() - newest.getTime() < TOP_LEVEL_PAGES_STALE_AFTER_MS
+          ) {
+            return;
+          }
+          await notionServiceForRefresh.refreshTopLevelPagesCache(owner);
+        },
+      });
       console.info('Ankify polling worker scheduled');
     }
 

--- a/src/lib/ankify/jobs/scheduleAnkifyPolling.ts
+++ b/src/lib/ankify/jobs/scheduleAnkifyPolling.ts
@@ -6,9 +6,13 @@ export const ANKIFY_POLLING_INTERVAL_MS = 5 * 60 * 1000;
 export const scheduleAnkifyPolling = (
   subscriptions: AnkifyNotionSubscriptionsRepositoryInterface,
   useCase: SyncNotionPageToRacUseCase,
-  options: { intervalMs?: number } = {}
+  options: {
+    intervalMs?: number;
+    refreshTopLevelPagesForOwner?: (owner: number) => Promise<void> | void;
+  } = {}
 ): NodeJS.Timeout => {
   const intervalMs = options.intervalMs ?? ANKIFY_POLLING_INTERVAL_MS;
+  const refreshTopLevelPagesForOwner = options.refreshTopLevelPagesForOwner;
 
   const tick = async () => {
     let active: Awaited<ReturnType<typeof subscriptions.listEnabled>>;
@@ -18,6 +22,7 @@ export const scheduleAnkifyPolling = (
       console.error('[ankify-polling] failed to list subscriptions', error);
       return;
     }
+    const seenOwners = new Set<number>();
     for (const sub of active) {
       try {
         await useCase.execute({
@@ -30,6 +35,17 @@ export const scheduleAnkifyPolling = (
           `[ankify-polling] sync failed for subscription ${sub.id}`,
           error
         );
+      }
+      if (refreshTopLevelPagesForOwner && !seenOwners.has(sub.owner)) {
+        seenOwners.add(sub.owner);
+        try {
+          await refreshTopLevelPagesForOwner(sub.owner);
+        } catch (error) {
+          console.error(
+            `[ankify-polling] top-level pages refresh failed for owner ${sub.owner}`,
+            error
+          );
+        }
       }
     }
   };

--- a/src/routes/NotionRouter.ts
+++ b/src/routes/NotionRouter.ts
@@ -4,14 +4,19 @@ import RequireAuthentication from './middleware/RequireAuthentication';
 import RequirePaying from './middleware/RequirePaying';
 import NotionController from '../controllers/NotionController';
 import NotionRepository from '../data_layer/NotionRespository';
+import NotionTopLevelPagesRepository from '../data_layer/NotionTopLevelPagesRepository';
 import NotionService from '../services/NotionService';
 import { getDatabase } from '../data_layer';
 
 const NotionRouter = () => {
   const router = express.Router();
 
-  const repository = new NotionRepository(getDatabase());
-  const controller = new NotionController(new NotionService(repository));
+  const database = getDatabase();
+  const repository = new NotionRepository(database);
+  const topLevelPagesRepository = new NotionTopLevelPagesRepository(database);
+  const controller = new NotionController(
+    new NotionService(repository, topLevelPagesRepository)
+  );
 
   /**
    * Endpoint for establishing a connection to Notion. We need a token for this.

--- a/src/services/NotionService/NotionService.searchTopLevelPages.test.ts
+++ b/src/services/NotionService/NotionService.searchTopLevelPages.test.ts
@@ -1,0 +1,226 @@
+import { NotionService } from "./NotionService";
+import { __resetTopLevelPagesCacheForTests } from "./topLevelPagesCache";
+import { __resetTopLevelPagesRefreshGateForTests } from "./topLevelPagesRefreshGate";
+
+const liveResults = [
+	{
+		id: "p1",
+		object: "page" as const,
+		url: "https://notion.so/p1",
+		icon: { type: "emoji", emoji: "📓" },
+		title: "Top page 1",
+		parent: { type: "workspace" },
+	},
+	{
+		id: "p2",
+		object: "page" as const,
+		url: "https://notion.so/p2",
+		icon: null,
+		title: "Top page 2",
+		parent: { type: "workspace" },
+	},
+];
+
+function makeFakeApi() {
+	const calls: string[] = [];
+	const api = {
+		searchTopLevelPages: jest.fn(async (query: string) => {
+			calls.push(`live:${query}`);
+			return { results: liveResults };
+		}),
+	};
+	return { api, calls };
+}
+
+function makeFakeRepo(initial: { rows?: typeof rowsLike } = {}) {
+	let rows: typeof rowsLike = initial.rows ?? [];
+	const calls: string[] = [];
+	return {
+		calls,
+		rows: () => rows,
+		getByOwner: jest.fn(async () => {
+			calls.push("getByOwner");
+			return rows;
+		}),
+		newestCachedAt: jest.fn(async () => {
+			calls.push("newestCachedAt");
+			if (rows.length === 0) return null;
+			return rows.map((r) => r.cached_at).reduce((a, b) => (a > b ? a : b));
+		}),
+		replaceForOwnerIfTokenStillValid: jest.fn(
+			async (_owner: number, next: typeof rowsLike) => {
+				calls.push("replace");
+				rows = next;
+				return true;
+			},
+		),
+		deleteByOwner: jest.fn(async () => {
+			calls.push("delete");
+			const before = rows.length;
+			rows = [];
+			return before;
+		}),
+	};
+}
+
+const rowsLike: Array<{
+	owner: number;
+	notion_page_id: string;
+	title: string;
+	icon: unknown;
+	url: string | null;
+	parent_type: string;
+	last_edited_time: Date | null;
+	cached_at: Date;
+}> = [];
+
+function makeService(opts: {
+	api: ReturnType<typeof makeFakeApi>["api"] | null;
+	repo: ReturnType<typeof makeFakeRepo>;
+}) {
+	const fakeNotionRepo = {
+		getNotionData: jest.fn(),
+		saveNotionToken: jest.fn(),
+		getNotionToken: jest.fn(),
+		deleteBlocksByOwner: jest.fn(),
+		deleteNotionData: jest.fn(),
+	};
+	const service = new NotionService(
+		fakeNotionRepo as never,
+		opts.repo as never,
+	);
+	service.tryGetNotionAPI = jest.fn(async () => opts.api as never) as never;
+	service.getNotionAPI = jest.fn(async () => {
+		if (opts.api == null) throw new Error("Unauthorized");
+		return opts.api as never;
+	}) as never;
+	return service;
+}
+
+describe("NotionService.searchTopLevelPages two-tier read path", () => {
+	beforeEach(() => {
+		__resetTopLevelPagesCacheForTests();
+		__resetTopLevelPagesRefreshGateForTests();
+	});
+
+	it("Tier 1 hit short-circuits Tier 2 and live", async () => {
+		const fakeApi = makeFakeApi();
+		const repo = makeFakeRepo();
+		const service = makeService({ api: fakeApi.api, repo });
+
+		await service.searchTopLevelPages("", 1);
+		await service.searchTopLevelPages("", 1);
+
+		expect(fakeApi.api.searchTopLevelPages).toHaveBeenCalledTimes(1);
+		expect(repo.getByOwner).toHaveBeenCalledTimes(1);
+	});
+
+	it("Tier 2 hit (fresh) does not call live and does not refresh", async () => {
+		const fakeApi = makeFakeApi();
+		const fresh = new Date();
+		const repo = makeFakeRepo({
+			rows: [
+				{
+					owner: 1,
+					notion_page_id: "p1",
+					title: "Top page 1",
+					icon: null,
+					url: "https://notion.so/p1",
+					parent_type: "workspace",
+					last_edited_time: null,
+					cached_at: fresh,
+				},
+			],
+		});
+		const service = makeService({ api: fakeApi.api, repo });
+
+		const result = await service.searchTopLevelPages("", 1);
+
+		expect(result.results.map((r) => r.id)).toEqual(["p1"]);
+		expect(fakeApi.api.searchTopLevelPages).not.toHaveBeenCalled();
+		expect(repo.replaceForOwnerIfTokenStillValid).not.toHaveBeenCalled();
+	});
+
+	it("stale Tier 2 returns immediately and fires a background refresh", async () => {
+		const fakeApi = makeFakeApi();
+		const stale = new Date(Date.now() - 10 * 60 * 1000);
+		const repo = makeFakeRepo({
+			rows: [
+				{
+					owner: 1,
+					notion_page_id: "old",
+					title: "Old",
+					icon: null,
+					url: null,
+					parent_type: "workspace",
+					last_edited_time: null,
+					cached_at: stale,
+				},
+			],
+		});
+		const service = makeService({ api: fakeApi.api, repo });
+
+		const result = await service.searchTopLevelPages("", 1);
+		expect(result.results.map((r) => r.id)).toEqual(["old"]);
+
+		await new Promise((r) => setImmediate(r));
+		await new Promise((r) => setImmediate(r));
+
+		expect(fakeApi.api.searchTopLevelPages).toHaveBeenCalledTimes(1);
+		expect(repo.replaceForOwnerIfTokenStillValid).toHaveBeenCalledTimes(1);
+	});
+
+	it("5 simultaneous stale reads trigger exactly one background refresh", async () => {
+		const fakeApi = makeFakeApi();
+		const stale = new Date(Date.now() - 10 * 60 * 1000);
+		const repo = makeFakeRepo({
+			rows: [
+				{
+					owner: 1,
+					notion_page_id: "old",
+					title: "Old",
+					icon: null,
+					url: null,
+					parent_type: "workspace",
+					last_edited_time: null,
+					cached_at: stale,
+				},
+			],
+		});
+		const service = makeService({ api: fakeApi.api, repo });
+
+		await Promise.all(
+			Array.from({ length: 5 }, () => service.searchTopLevelPages("", 1)),
+		);
+
+		await new Promise((r) => setImmediate(r));
+		await new Promise((r) => setImmediate(r));
+
+		expect(fakeApi.api.searchTopLevelPages).toHaveBeenCalledTimes(1);
+	});
+
+	it("typed query bypasses Tier 2 entirely", async () => {
+		const fakeApi = makeFakeApi();
+		const repo = makeFakeRepo();
+		const service = makeService({ api: fakeApi.api, repo });
+
+		await service.searchTopLevelPages("foo", 1);
+
+		expect(fakeApi.api.searchTopLevelPages).toHaveBeenCalledTimes(1);
+		expect(fakeApi.api.searchTopLevelPages).toHaveBeenCalledWith("foo", {});
+		expect(repo.getByOwner).not.toHaveBeenCalled();
+		expect(repo.replaceForOwnerIfTokenStillValid).not.toHaveBeenCalled();
+	});
+
+	it("cold Tier 2 (no rows) falls through to live and persists results", async () => {
+		const fakeApi = makeFakeApi();
+		const repo = makeFakeRepo();
+		const service = makeService({ api: fakeApi.api, repo });
+
+		const result = await service.searchTopLevelPages("", 1);
+
+		expect(result.results.map((r) => r.id)).toEqual(["p1", "p2"]);
+		expect(fakeApi.api.searchTopLevelPages).toHaveBeenCalledTimes(1);
+		expect(repo.replaceForOwnerIfTokenStillValid).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/services/NotionService/NotionService.ts
+++ b/src/services/NotionService/NotionService.ts
@@ -46,8 +46,8 @@ export class NotionService {
   redirectURI: string;
 
   constructor(
-    private notionRepository: INotionRepository,
-    private topLevelPagesRepository?: INotionTopLevelPagesRepository
+    private readonly notionRepository: INotionRepository,
+    private readonly topLevelPagesRepository?: INotionTopLevelPagesRepository
   ) {
     this.clientId = process.env.NOTION_CLIENT_ID!;
     this.clientSecret = process.env.NOTION_CLIENT_SECRET!;
@@ -151,9 +151,9 @@ export class NotionService {
     const rows = await this.topLevelPagesRepository.getByOwner(owner);
     if (rows.length === 0) return null;
 
-    const newest = rows
-      .map((r) => new Date(r.cached_at).getTime())
-      .reduce((a, b) => (a > b ? a : b));
+    const newest = Math.max(
+      ...rows.map((r) => new Date(r.cached_at).getTime())
+    );
     const isStale = Date.now() - newest > TOP_LEVEL_PAGES_STALE_AFTER_MS;
 
     if (isStale) {

--- a/src/services/NotionService/NotionService.ts
+++ b/src/services/NotionService/NotionService.ts
@@ -2,14 +2,40 @@ import { APIErrorCode } from '@notionhq/client';
 import axios from 'axios';
 
 import { INotionRepository } from '../../data_layer/NotionRespository';
+import {
+  INotionTopLevelPagesRepository,
+  NotionTopLevelPageRow,
+} from '../../data_layer/NotionTopLevelPagesRepository';
 import hashToken from '../../lib/misc/hashToken';
 import NotionAPIWrapper from './NotionAPIWrapper';
 import { getNotionId } from './getNotionId';
+import {
+  getTopLevelPagesCache,
+  invalidateTopLevelPagesForOwner,
+  setTopLevelPagesCache,
+} from './topLevelPagesCache';
+import {
+  releaseRefresh,
+  tryClaimRefresh,
+} from './topLevelPagesRefreshGate';
 
 export interface NotionLinkInfo {
   link: string;
   isConnected: boolean;
   workspace: string | null;
+}
+
+export const TOP_LEVEL_PAGES_STALE_AFTER_MS = 5 * 60 * 1000;
+
+interface TopLevelPagesResult {
+  results: Array<{
+    id: string;
+    object: 'page';
+    url: string | null;
+    icon: unknown;
+    title: string;
+    parent: { type: string };
+  }>;
 }
 
 export class NotionService {
@@ -19,7 +45,10 @@ export class NotionService {
 
   redirectURI: string;
 
-  constructor(private notionRepository: INotionRepository) {
+  constructor(
+    private notionRepository: INotionRepository,
+    private topLevelPagesRepository?: INotionTopLevelPagesRepository
+  ) {
     this.clientId = process.env.NOTION_CLIENT_ID!;
     this.clientSecret = process.env.NOTION_CLIENT_SECRET!;
     this.redirectURI = process.env.NOTION_REDIRECT_URI!;
@@ -76,16 +105,118 @@ export class NotionService {
 
   async searchTopLevelPages(
     query: string,
-    owner: string,
+    owner: string | number,
     opts: { maxResults?: number; maxPages?: number } = {}
-  ) {
-    const client = await this.getNotionAPI(owner);
-    return client.searchTopLevelPages(query, opts);
+  ): Promise<TopLevelPagesResult> {
+    const ownerId = typeof owner === 'number' ? owner : Number(owner);
+    const normalisedQuery = query.trim();
+
+    const cached = getTopLevelPagesCache<TopLevelPagesResult>(
+      ownerId,
+      normalisedQuery
+    );
+    if (cached) return cached;
+
+    if (normalisedQuery === '' && this.topLevelPagesRepository) {
+      const tier2 = await this.tier2Read(ownerId);
+      if (tier2) {
+        setTopLevelPagesCache(ownerId, normalisedQuery, tier2);
+        return tier2;
+      }
+    }
+
+    const client = await this.getNotionAPI(String(owner));
+    const live = await client.searchTopLevelPages(query, opts);
+
+    setTopLevelPagesCache(ownerId, normalisedQuery, live);
+
+    if (normalisedQuery === '' && this.topLevelPagesRepository) {
+      try {
+        await this.topLevelPagesRepository.replaceForOwnerIfTokenStillValid(
+          ownerId,
+          live.results.map((r) => toRow(ownerId, r))
+        );
+      } catch (error) {
+        console.error('[notion] tier2 cold-fill failed', error);
+      }
+    }
+
+    return live;
+  }
+
+  private async tier2Read(
+    owner: number
+  ): Promise<TopLevelPagesResult | null> {
+    if (!this.topLevelPagesRepository) return null;
+    const rows = await this.topLevelPagesRepository.getByOwner(owner);
+    if (rows.length === 0) return null;
+
+    const newest = rows
+      .map((r) => new Date(r.cached_at).getTime())
+      .reduce((a, b) => (a > b ? a : b));
+    const isStale = Date.now() - newest > TOP_LEVEL_PAGES_STALE_AFTER_MS;
+
+    if (isStale) {
+      this.scheduleBackgroundRefresh(owner);
+    }
+
+    return {
+      results: rows.map((r) => ({
+        id: r.notion_page_id,
+        object: 'page' as const,
+        url: r.url,
+        icon: r.icon,
+        title: r.title,
+        parent: { type: r.parent_type },
+      })),
+    };
+  }
+
+  private scheduleBackgroundRefresh(owner: number): void {
+    if (!tryClaimRefresh(owner)) return;
+    void this.runRefresh(owner).finally(() => releaseRefresh(owner));
+  }
+
+  private async runRefresh(owner: number): Promise<void> {
+    if (!this.topLevelPagesRepository) return;
+    try {
+      const client = await this.tryGetNotionAPI(String(owner));
+      if (!client) return;
+      const live = await client.searchTopLevelPages('');
+      const wrote =
+        await this.topLevelPagesRepository.replaceForOwnerIfTokenStillValid(
+          owner,
+          live.results.map((r) => toRow(owner, r))
+        );
+      if (wrote) {
+        invalidateTopLevelPagesForOwner(owner);
+      }
+    } catch (error) {
+      console.error('[notion] tier2 refresh failed', error);
+    }
+  }
+
+  refreshTopLevelPagesCache(owner: number): Promise<void> {
+    return new Promise((resolve) => {
+      if (!tryClaimRefresh(owner)) {
+        resolve();
+        return;
+      }
+      this.runRefresh(owner).finally(() => {
+        releaseRefresh(owner);
+        resolve();
+      });
+    });
   }
 
   async connectToNotion(authorizationCode: string, owner: number) {
     const accessData = await this.getAccessData(authorizationCode.toString());
     await this.notionRepository.saveNotionToken(owner, accessData, hashToken);
+    if (this.topLevelPagesRepository) {
+      void this.refreshTopLevelPagesCache(owner).catch((error) => {
+        console.error('[notion] connect-time pre-warm failed', error);
+      });
+    }
   }
 
   async getNotionLinkInfo(owner: number): Promise<NotionLinkInfo> {
@@ -152,7 +283,37 @@ export class NotionService {
     return this.clientId;
   }
 
-  disconnect(owner: number) {
+  async disconnect(owner: number) {
+    invalidateTopLevelPagesForOwner(owner);
+    if (this.topLevelPagesRepository) {
+      try {
+        await this.topLevelPagesRepository.deleteByOwner(owner);
+      } catch (error) {
+        console.error('[notion] tier2 disconnect cleanup failed', error);
+      }
+    }
     return this.notionRepository.deleteNotionData(owner);
   }
+}
+
+function toRow(
+  owner: number,
+  page: {
+    id: string;
+    title: string;
+    icon: unknown;
+    url: string | null;
+    parent: { type: string };
+  }
+): NotionTopLevelPageRow {
+  return {
+    owner,
+    notion_page_id: page.id,
+    title: page.title,
+    icon: page.icon ?? null,
+    url: page.url,
+    parent_type: page.parent.type,
+    last_edited_time: null,
+    cached_at: new Date(),
+  };
 }

--- a/src/services/NotionService/topLevelPagesCache.test.ts
+++ b/src/services/NotionService/topLevelPagesCache.test.ts
@@ -1,0 +1,57 @@
+import {
+	__resetTopLevelPagesCacheForTests,
+	getTopLevelPagesCache,
+	invalidateTopLevelPagesForOwner,
+	setTopLevelPagesCache,
+	TOP_LEVEL_PAGES_CACHE_TTL_MS,
+} from "./topLevelPagesCache";
+
+const VALUE = { results: [{ id: "p1" } as never] };
+
+describe("topLevelPagesCache", () => {
+	beforeEach(() => {
+		__resetTopLevelPagesCacheForTests();
+	});
+
+	it("returns undefined on miss", () => {
+		expect(getTopLevelPagesCache(1, "")).toBeUndefined();
+	});
+
+	it("returns the stored value within the TTL", () => {
+		setTopLevelPagesCache(1, "", VALUE);
+		expect(getTopLevelPagesCache(1, "")).toEqual(VALUE);
+	});
+
+	it("expires entries after the TTL", () => {
+		jest.useFakeTimers();
+		try {
+			setTopLevelPagesCache(1, "", VALUE);
+			jest.advanceTimersByTime(TOP_LEVEL_PAGES_CACHE_TTL_MS + 1);
+			expect(getTopLevelPagesCache(1, "")).toBeUndefined();
+		} finally {
+			jest.useRealTimers();
+		}
+	});
+
+	it("normalises queries (trim + lowercase)", () => {
+		setTopLevelPagesCache(1, "My Page", VALUE);
+		expect(getTopLevelPagesCache(1, "  my page  ")).toEqual(VALUE);
+	});
+
+	it("isolates by owner", () => {
+		setTopLevelPagesCache(1, "", VALUE);
+		expect(getTopLevelPagesCache(2, "")).toBeUndefined();
+	});
+
+	it("invalidateTopLevelPagesForOwner clears only that owner", () => {
+		setTopLevelPagesCache(1, "", VALUE);
+		setTopLevelPagesCache(1, "foo", VALUE);
+		setTopLevelPagesCache(2, "", VALUE);
+
+		invalidateTopLevelPagesForOwner(1);
+
+		expect(getTopLevelPagesCache(1, "")).toBeUndefined();
+		expect(getTopLevelPagesCache(1, "foo")).toBeUndefined();
+		expect(getTopLevelPagesCache(2, "")).toEqual(VALUE);
+	});
+});

--- a/src/services/NotionService/topLevelPagesCache.ts
+++ b/src/services/NotionService/topLevelPagesCache.ts
@@ -1,0 +1,51 @@
+export const TOP_LEVEL_PAGES_CACHE_TTL_MS = 60 * 1000;
+
+interface CacheEntry<T> {
+	value: T;
+	expiresAt: number;
+	owner: number;
+}
+
+const store = new Map<string, CacheEntry<unknown>>();
+
+function buildKey(owner: number, query: string): string {
+	return `${owner}:${query.trim().toLowerCase()}`;
+}
+
+export function getTopLevelPagesCache<T>(
+	owner: number,
+	query: string,
+): T | undefined {
+	const key = buildKey(owner, query);
+	const entry = store.get(key);
+	if (!entry) return undefined;
+	if (entry.expiresAt <= Date.now()) {
+		store.delete(key);
+		return undefined;
+	}
+	return entry.value as T;
+}
+
+export function setTopLevelPagesCache<T>(
+	owner: number,
+	query: string,
+	value: T,
+): void {
+	store.set(buildKey(owner, query), {
+		value,
+		expiresAt: Date.now() + TOP_LEVEL_PAGES_CACHE_TTL_MS,
+		owner,
+	});
+}
+
+export function invalidateTopLevelPagesForOwner(owner: number): void {
+	for (const [key, entry] of store) {
+		if (entry.owner === owner) {
+			store.delete(key);
+		}
+	}
+}
+
+export function __resetTopLevelPagesCacheForTests(): void {
+	store.clear();
+}

--- a/src/services/NotionService/topLevelPagesRefreshGate.ts
+++ b/src/services/NotionService/topLevelPagesRefreshGate.ts
@@ -1,0 +1,15 @@
+const inFlight = new Set<number>();
+
+export function tryClaimRefresh(owner: number): boolean {
+	if (inFlight.has(owner)) return false;
+	inFlight.add(owner);
+	return true;
+}
+
+export function releaseRefresh(owner: number): void {
+	inFlight.delete(owner);
+}
+
+export function __resetTopLevelPagesRefreshGateForTests(): void {
+	inFlight.clear();
+}


### PR DESCRIPTION
## Summary

Find-pages picker on `/ankify` stalls 4–8s on heavy-DB accounts every open because `searchTopLevelPages` does up to 20 sequential Notion search pages with nothing cached (root cause documented in d434d93b). This PR adds a two-tier cache so warm opens render in <200ms while cold opens stay bounded by Notion latency.

- **Tier 1**: in-memory per-owner cache, 60s TTL — eliminates repeat-open and debounced-keystroke cost.
- **Tier 2**: persistent `notion_top_level_pages` table, refreshed by the existing 5-min Ankify poll job and pre-warmed on Notion connect — eliminates cold-start cost for warm picker opens.

Reads check Tier 1 → Tier 2 → live Notion. Stale Tier 2 (>5 min old) returns immediately and fires a deduped background refresh — N concurrent stale reads trigger exactly 1 sweep, not N. Typed queries skip Tier 2 entirely (Notion already filters server-side; persisting per-query results would explode the table). Disconnect drops both tiers; the refresh writer's single-transaction `replaceForOwnerIfTokenStillValid` closes the disconnect race.

Spec: [`Documentation/specs/ankify-find-pages-cache.md`](https://github.com/2anki/server/blob/perf/ankify-find-pages-cache/Documentation/specs/ankify-find-pages-cache.md). No FE changes. JSON shape is unchanged.

## What changed

- `src/services/NotionService/topLevelPagesCache.ts` — Tier 1 cache (~50 LOC).
- `src/services/NotionService/topLevelPagesRefreshGate.ts` — `Set<owner>` dedup gate.
- `migrations/20260509000001_notion_top_level_pages.js` — Tier 2 table.
- `src/data_layer/NotionTopLevelPagesRepository.ts` — `getByOwner`, `newestCachedAt`, `replaceForOwnerIfTokenStillValid` (single tx, token re-check inside), `deleteByOwner`.
- `src/services/NotionService/NotionService.ts` — two-tier read path, `runRefresh`, `refreshTopLevelPagesCache`, connect pre-warm (best-effort), disconnect cleanup.
- `src/routes/NotionRouter.ts` — passes the new repo into `NotionService`.
- `src/lib/ankify/jobs/scheduleAnkifyPolling.ts` — optional `refreshTopLevelPagesForOwner(owner)` callback, called once per unique owner per tick.
- `src/data_layer/index.ts` — wires the poll-job callback with a freshness short-circuit (skip if `newestCachedAt` < 5 min old).

## Test plan

- [x] `pnpm jest src/services/NotionService src/data_layer/NotionTopLevelPagesRepository.test.ts src/lib/ankify/jobs src/controllers` → 28 suites, 150 tests, all pass.
- [x] `pnpm tsc --noEmit` → clean.
- [x] New tests cover: Tier 1 (hit/miss/expiry/normalised key/cross-tenant/invalidateOwner); repository (round-trip, atomic replace, token-revoked no-op, deleteByOwner); two-tier read path (Tier 1 short-circuit, fresh Tier 2, stale SWR fires 1 refresh, **5 concurrent stale reads → 1 refresh**, typed query bypasses Tier 2, cold Tier 2 falls through to live and persists).
- [ ] Reviewer sanity-check: open the picker on staging (heavy-DB account), then close + reopen → second open should be visibly instant.
- [ ] Reviewer sanity-check: disconnect Notion, confirm Tier 2 rows are dropped and the next picker open does a fresh fetch.
- [ ] Out-of-scope (deferred): SSE streaming, Notion webhook subscriptions for instant invalidation, force-refresh affordance in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)