### PR TITLE
fix(ankify): seed namespaced note types and add welcome banner

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -26,7 +26,7 @@ describe('AnkiConnectClient', () => {
 
     const id = await client.addNote({
       deckName: 'My Deck',
-      modelName: 'Basic',
+      modelName: 'TestModel',
       fields: { Front: 'q', Back: 'a' },
       tags: ['notion-sync'],
     });
@@ -41,7 +41,7 @@ describe('AnkiConnectClient', () => {
       params: {
         note: {
           deckName: 'My Deck',
-          modelName: 'Basic',
+          modelName: 'TestModel',
           fields: { Front: 'q', Back: 'a' },
           tags: ['notion-sync'],
         },
@@ -110,6 +110,49 @@ describe('AnkiConnectClient', () => {
 
     const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
     expect(body).not.toHaveProperty('key');
+  });
+
+  test('createModel posts the createModel action with css/cardTemplates payload', async () => {
+    const fetchImpl = makeFetch({
+      result: { id: 1700000000000 },
+      error: null,
+    });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    await client.createModel({
+      modelName: 'Ankify Basic',
+      inOrderFields: ['Front', 'Back'],
+      css: '.card { color: black; }',
+      isCloze: false,
+      cardTemplates: [
+        {
+          Name: 'Card 1',
+          Front: '{{Front}}',
+          Back: '{{FrontSide}}<hr id="answer">{{Back}}',
+        },
+      ],
+    });
+
+    const body = JSON.parse(
+      (fetchImpl as jest.Mock).mock.calls[0][1].body
+    );
+    expect(body).toEqual({
+      action: 'createModel',
+      version: 6,
+      params: {
+        modelName: 'Ankify Basic',
+        inOrderFields: ['Front', 'Back'],
+        css: '.card { color: black; }',
+        isCloze: false,
+        cardTemplates: [
+          {
+            Name: 'Card 1',
+            Front: '{{Front}}',
+            Back: '{{FrontSide}}<hr id="answer">{{Back}}',
+          },
+        ],
+      },
+    });
   });
 
   test('throws AnkiConnectUnreachableError when fetch rejects', async () => {

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -87,6 +87,10 @@ export class AnkiConnectClient {
     return this.invoke('modelFieldNames', { modelName });
   }
 
+  async createModel(params: AnkiConnectCreateModelParams): Promise<unknown> {
+    return this.invoke('createModel', params as unknown as Record<string, unknown>);
+  }
+
   async getNumCardsReviewedByDay(): Promise<Array<[string, number]>> {
     return this.invoke('getNumCardsReviewedByDay');
   }
@@ -165,6 +169,20 @@ export class AnkiConnectClient {
     }
     return body.result;
   }
+}
+
+export interface AnkiConnectCardTemplate {
+  Name: string;
+  Front: string;
+  Back: string;
+}
+
+export interface AnkiConnectCreateModelParams {
+  modelName: string;
+  inOrderFields: string[];
+  css: string;
+  isCloze?: boolean;
+  cardTemplates: AnkiConnectCardTemplate[];
 }
 
 export interface AnkiNoteInfo {

--- a/src/services/ankify/ankifyModels.ts
+++ b/src/services/ankify/ankifyModels.ts
@@ -1,0 +1,69 @@
+import { AnkiConnectCreateModelParams } from './AnkiConnectClient';
+
+export const ANKIFY_BASIC_MODEL = 'Ankify Basic';
+export const ANKIFY_CLOZE_MODEL = 'Ankify Cloze';
+
+export const ANKIFY_BASIC_FIELDS = ['Front', 'Back'] as const;
+export const ANKIFY_CLOZE_FIELDS = ['Text', 'Back Extra'] as const;
+
+const ANKIFY_CARD_STYLING = `
+html, body { text-align: center; }
+
+.card {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+    "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
+  color: black;
+  background-color: white;
+  border: lightgray 1px solid;
+  padding: 16px;
+  border-radius: 8px;
+  margin: 16px;
+  width: 80%;
+  display: inline-block;
+}
+
+.card:hover {
+  box-shadow: 0 0 8px #ccc;
+  border: 1px solid #fff;
+}
+
+.front-text-pre { font-size: 1.5rem; }
+.front-text-post { color: gray; font-size: 1rem; }
+.back-text { font-size: 1.5rem; text-align: left; }
+.extra { color: gray; }
+
+hr { border: none; border-bottom: 1px solid rgba(55, 53, 47, 0.18); }
+
+.cloze {
+  font-weight: bold;
+  color: #2563eb;
+}
+`.trim();
+
+export const ankifyBasicCreateModelParams = (): AnkiConnectCreateModelParams => ({
+  modelName: ANKIFY_BASIC_MODEL,
+  inOrderFields: [...ANKIFY_BASIC_FIELDS],
+  css: ANKIFY_CARD_STYLING,
+  isCloze: false,
+  cardTemplates: [
+    {
+      Name: 'Card 1',
+      Front: '<span class="front-text-pre">{{Front}}</span>',
+      Back: '<span class="front-text-post">{{Front}}</span><hr id="answer"><span class="back-text">{{Back}}</span>',
+    },
+  ],
+});
+
+export const ankifyClozeCreateModelParams = (): AnkiConnectCreateModelParams => ({
+  modelName: ANKIFY_CLOZE_MODEL,
+  inOrderFields: [...ANKIFY_CLOZE_FIELDS],
+  css: ANKIFY_CARD_STYLING,
+  isCloze: true,
+  cardTemplates: [
+    {
+      Name: 'Cloze',
+      Front: '{{cloze:Text}}',
+      Back: '{{cloze:Text}}<br><span class="extra">{{Back Extra}}</span>',
+    },
+  ],
+});

--- a/src/services/ankify/ensureAnkifyModels.test.ts
+++ b/src/services/ankify/ensureAnkifyModels.test.ts
@@ -1,0 +1,75 @@
+import { ensureAnkifyModels } from './ensureAnkifyModels';
+import {
+  ANKIFY_BASIC_MODEL,
+  ANKIFY_CLOZE_MODEL,
+} from './ankifyModels';
+import { AnkiConnectClient } from './AnkiConnectClient';
+
+const makeStub = (modelNames: string[]) => {
+  const stub = {
+    modelNames: jest.fn(async () => modelNames),
+    createModel: jest.fn(async () => ({ id: 1 })),
+  };
+  return stub as unknown as AnkiConnectClient & typeof stub;
+};
+
+describe('ensureAnkifyModels', () => {
+  test('creates both Ankify models when AnkiConnect has neither', async () => {
+    const ac = makeStub([
+      'Kaishi 1.5k',
+      'JlabNote',
+      'PrettyYomitan',
+    ]);
+    const cache = new Set<string>();
+
+    await ensureAnkifyModels(ac, cache);
+
+    expect(ac.createModel).toHaveBeenCalledTimes(2);
+    const created = (ac.createModel as jest.Mock).mock.calls.map(
+      (args) => (args[0] as { modelName: string }).modelName
+    );
+    expect(created).toEqual(
+      expect.arrayContaining([ANKIFY_BASIC_MODEL, ANKIFY_CLOZE_MODEL])
+    );
+    expect(cache.has(ANKIFY_BASIC_MODEL)).toBe(true);
+    expect(cache.has(ANKIFY_CLOZE_MODEL)).toBe(true);
+  });
+
+  test('skips creation entirely when both models already exist', async () => {
+    const ac = makeStub([ANKIFY_BASIC_MODEL, ANKIFY_CLOZE_MODEL, 'Other']);
+    const cache = new Set<string>();
+
+    await ensureAnkifyModels(ac, cache);
+
+    expect(ac.createModel).not.toHaveBeenCalled();
+    expect(cache.has(ANKIFY_BASIC_MODEL)).toBe(true);
+    expect(cache.has(ANKIFY_CLOZE_MODEL)).toBe(true);
+  });
+
+  test('a second call with the same cache makes no AnkiConnect round-trip', async () => {
+    const ac = makeStub([]);
+    const cache = new Set<string>();
+
+    await ensureAnkifyModels(ac, cache);
+    (ac.modelNames as jest.Mock).mockClear();
+    (ac.createModel as jest.Mock).mockClear();
+
+    await ensureAnkifyModels(ac, cache);
+
+    expect(ac.modelNames).not.toHaveBeenCalled();
+    expect(ac.createModel).not.toHaveBeenCalled();
+  });
+
+  test('treats createModel "already exists" failure as success (race-safe)', async () => {
+    const ac = makeStub([]);
+    (ac.createModel as jest.Mock).mockRejectedValueOnce(
+      new Error('Model name already exists')
+    );
+    const cache = new Set<string>();
+
+    await ensureAnkifyModels(ac, cache);
+
+    expect(cache.has(ANKIFY_BASIC_MODEL)).toBe(true);
+    expect(cache.has(ANKIFY_CLOZE_MODEL)).toBe(true);
+  });
+});

--- a/src/services/ankify/ensureAnkifyModels.ts
+++ b/src/services/ankify/ensureAnkifyModels.ts
@@ -1,0 +1,49 @@
+import { AnkiConnectClient } from './AnkiConnectClient';
+import {
+  ANKIFY_BASIC_MODEL,
+  ANKIFY_CLOZE_MODEL,
+  ankifyBasicCreateModelParams,
+  ankifyClozeCreateModelParams,
+} from './ankifyModels';
+
+const ALREADY_EXISTS_PATTERN = /already\s+exists/i;
+
+const isAlreadyExistsError = (error: unknown): boolean =>
+  error instanceof Error && ALREADY_EXISTS_PATTERN.test(error.message);
+
+const ensureSingleModel = async (
+  ac: AnkiConnectClient,
+  cache: Set<string>,
+  params: ReturnType<typeof ankifyBasicCreateModelParams>
+): Promise<void> => {
+  if (cache.has(params.modelName)) {
+    return;
+  }
+  try {
+    await ac.createModel(params);
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) {
+      throw error;
+    }
+  }
+  cache.add(params.modelName);
+};
+
+export const ensureAnkifyModels = async (
+  ac: AnkiConnectClient,
+  cache: Set<string>
+): Promise<void> => {
+  if (cache.has(ANKIFY_BASIC_MODEL) && cache.has(ANKIFY_CLOZE_MODEL)) {
+    return;
+  }
+
+  const existing = new Set(await ac.modelNames());
+  for (const name of existing) {
+    if (name === ANKIFY_BASIC_MODEL || name === ANKIFY_CLOZE_MODEL) {
+      cache.add(name);
+    }
+  }
+
+  await ensureSingleModel(ac, cache, ankifyBasicCreateModelParams());
+  await ensureSingleModel(ac, cache, ankifyClozeCreateModelParams());
+};

--- a/src/usecases/ankify/SendUploadToRacUseCase.test.ts
+++ b/src/usecases/ankify/SendUploadToRacUseCase.test.ts
@@ -70,6 +70,8 @@ const makeAnkiConnectStub = () => {
     addNote: jest.fn(async (_n: unknown) => 9_876_543_210),
     updateNoteFields: jest.fn(async (_id: number, _f: unknown) => null),
     sync: jest.fn(async () => null),
+    modelNames: jest.fn(async () => [] as string[]),
+    createModel: jest.fn(async (_p: unknown) => ({ id: 1 })),
   };
   return stub as unknown as AnkiConnectClient & typeof stub;
 };
@@ -141,7 +143,7 @@ describe('SendUploadToRacUseCase', () => {
     expect(ac.addNote).toHaveBeenCalledWith(
       expect.objectContaining({
         deckName: 'Imported::Subdeck',
-        modelName: 'Basic',
+        modelName: 'Ankify Basic',
         fields: { Front: 'front text', Back: 'back text' },
       })
     );
@@ -269,13 +271,69 @@ describe('SendUploadToRacUseCase', () => {
 
     expect(ac.addNote).toHaveBeenCalledWith(
       expect.objectContaining({
-        modelName: 'Cloze',
+        modelName: 'Ankify Cloze',
         fields: expect.objectContaining({
           Text: 'Capital of {{c1::France}} is Paris.',
           'Back Extra': 'extra',
         }),
       })
     );
+  });
+
+  test('seeds Ankify note types once even with multiple notes across decks', async () => {
+    const { clients, mappings, uploads } = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SendUploadToRacUseCase(
+      clients,
+      mappings,
+      uploads,
+      async () => Buffer.from('fake'),
+      () =>
+        buildCollection({
+          notes: new Map([
+            [
+              100,
+              {
+                id: 100,
+                mid: 1,
+                tags: '',
+                fields: ['front-a', 'back-a'],
+                guid: 'guid-a',
+              },
+            ],
+            [
+              101,
+              {
+                id: 101,
+                mid: 1,
+                tags: '',
+                fields: ['Capital of {{c1::France}}', 'extra'],
+                guid: 'guid-c',
+              },
+            ],
+          ]),
+          decks: new Map([
+            [10, { id: 10, name: 'DeckOne' }],
+            [11, { id: 11, name: 'DeckTwo' }],
+          ]),
+          cards: [
+            { id: 1, nid: 100, did: 10, ord: 0 },
+            { id: 2, nid: 101, did: 11, ord: 0 },
+          ],
+        }),
+      () => ac
+    );
+
+    await useCase.execute({ uploadId: 7, owner: 42 });
+
+    expect(ac.modelNames).toHaveBeenCalledTimes(1);
+    const created = (ac.createModel as jest.Mock).mock.calls.map(
+      (args) => (args[0] as { modelName: string }).modelName
+    );
+    expect(created).toEqual(
+      expect.arrayContaining(['Ankify Basic', 'Ankify Cloze'])
+    );
+    expect(created).toHaveLength(2);
   });
 
   test('NoActiveAnkifyClientError when the user has no provisioned client', async () => {

--- a/src/usecases/ankify/SendUploadToRacUseCase.ts
+++ b/src/usecases/ankify/SendUploadToRacUseCase.ts
@@ -13,6 +13,11 @@ import {
   AnkiConnectNote,
   AnkiConnectUnreachableError,
 } from '../../services/ankify/AnkiConnectClient';
+import {
+  ANKIFY_BASIC_MODEL,
+  ANKIFY_CLOZE_MODEL,
+} from '../../services/ankify/ankifyModels';
+import { ensureAnkifyModels } from '../../services/ankify/ensureAnkifyModels';
 import { NormalizedCollection, Note } from '../../services/ApkgPreviewService/types';
 
 export class NoActiveAnkifyClientError extends Error {
@@ -71,7 +76,7 @@ const buildAnkiConnectNoteFromApkgNote = (input: {
   if (isClozeField(input.fields[0])) {
     return {
       deckName: input.deckName,
-      modelName: 'Cloze',
+      modelName: ANKIFY_CLOZE_MODEL,
       fields: {
         Text: input.fields[0] ?? '',
         'Back Extra': input.fields[1] ?? '',
@@ -82,7 +87,7 @@ const buildAnkiConnectNoteFromApkgNote = (input: {
   }
   return {
     deckName: input.deckName,
-    modelName: 'Basic',
+    modelName: ANKIFY_BASIC_MODEL,
     fields: {
       Front: input.fields[0] ?? '',
       Back: input.fields[1] ?? '',
@@ -112,6 +117,8 @@ interface SendUploadToRacInput {
 }
 
 export class SendUploadToRacUseCase {
+  private readonly modelCacheByClient = new Map<number, Set<string>>();
+
   constructor(
     private readonly clients: AnkifyClientsRepositoryInterface,
     private readonly mappings: AnkifySyncMappingsRepositoryInterface,
@@ -121,6 +128,15 @@ export class SendUploadToRacUseCase {
     private readonly ankiConnect: AnkiConnectFactory,
     private readonly logs?: AnkifySyncLogsRepositoryInterface
   ) {}
+
+  private modelCache(clientId: number): Set<string> {
+    let cache = this.modelCacheByClient.get(clientId);
+    if (cache == null) {
+      cache = new Set<string>();
+      this.modelCacheByClient.set(clientId, cache);
+    }
+    return cache;
+  }
 
   async execute(input: SendUploadToRacInput): Promise<SendUploadToRacResult> {
     const upload = await this.uploads.findByIdAndOwner(
@@ -155,6 +171,8 @@ export class SendUploadToRacUseCase {
       ankiWebSync: 'skipped',
       ankiWebSyncError: null,
     };
+
+    await ensureAnkifyModels(ac, this.modelCache(client.id));
 
     for (const [noteId, note] of collection.notes) {
       await this.processNote({

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -10,6 +10,13 @@ import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/a
 import { AnkifySyncLogsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncLogsRepository';
 import { INotionRepository } from '../../data_layer/NotionRespository';
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
+import { WalkedNotionFlashcard } from '../../services/ankify/notionPageWalker';
+
+jest.mock('../../services/ankify/notionPageWalker', () => ({
+  walkNotionPageForFlashcards: jest.fn(),
+}));
+
+import { walkNotionPageForFlashcards } from '../../services/ankify/notionPageWalker';
 
 const sampleClient = (): AnkifyClient => ({
   id: 1,
@@ -42,6 +49,13 @@ const sampleSubscription = (
   created_at: new Date(),
   updated_at: new Date(),
   ...overrides,
+});
+
+const sampleCard = (): WalkedNotionFlashcard => ({
+  notion_block_id: 'block-1',
+  front: 'Front text',
+  back: 'Back text',
+  notion_last_edited_at: new Date(),
 });
 
 const makeClients = (): jest.Mocked<AnkifyClientsRepositoryInterface> =>
@@ -109,9 +123,25 @@ const makeAnkiConnectStub = () =>
     notesInfo: jest.fn(async () => []),
     updateNoteFields: jest.fn(async () => null),
     sync: jest.fn(async () => null),
+    modelNames: jest.fn(async () => [] as string[]),
+    createModel: jest.fn(async (_p: unknown) => ({ id: 1 })),
   } as unknown as AnkiConnectClient & { [k: string]: jest.Mock });
 
+const makeRepos = () => ({
+  clients: makeClients(),
+  mappings: makeMappings(),
+  conflicts: makeConflicts(),
+  subscriptions: makeSubscriptionsRepo(),
+  logs: makeLogs(),
+  notionRepo: makeNotionRepo(),
+});
+
 describe('SyncNotionPageToRacUseCase', () => {
+  beforeEach(() => {
+    (walkNotionPageForFlashcards as jest.Mock).mockReset();
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([]);
+  });
+
   test('persists icon returned by the page-meta fetcher on upsert', async () => {
     const clients = makeClients();
     const mappings = makeMappings();
@@ -191,5 +221,110 @@ describe('SyncNotionPageToRacUseCase', () => {
         notion_page_icon: 'https://example.com/icon.png',
       })
     );
+  });
+
+  test('addNote uses the Ankify Basic model name', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([sampleCard()]);
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.addNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelName: 'Ankify Basic',
+        fields: { Front: 'Front text', Back: 'Back text' },
+      })
+    );
+  });
+
+  test('seeds Ankify note types before the first addNote call', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([sampleCard()]);
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const callOrder: string[] = [];
+    (ac.createModel as jest.Mock).mockImplementation(async () => {
+      callOrder.push('createModel');
+      return { id: 1 };
+    });
+    (ac.addNote as jest.Mock).mockImplementation(async () => {
+      callOrder.push('addNote');
+      return 7_777_777;
+    });
+
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.modelNames).toHaveBeenCalled();
+    const createdNames = (ac.createModel as jest.Mock).mock.calls.map(
+      (args) => (args[0] as { modelName: string }).modelName
+    );
+    expect(createdNames).toEqual(
+      expect.arrayContaining(['Ankify Basic', 'Ankify Cloze'])
+    );
+    expect(callOrder.indexOf('createModel')).toBeLessThan(
+      callOrder.indexOf('addNote')
+    );
+  });
+
+  test('a second sync for the same client reuses the cache and skips modelNames', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([sampleCard()]);
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+    (ac.modelNames as jest.Mock).mockClear();
+    (ac.createModel as jest.Mock).mockClear();
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'polling',
+    });
+
+    expect(ac.modelNames).not.toHaveBeenCalled();
+    expect(ac.createModel).not.toHaveBeenCalled();
   });
 });

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -10,6 +10,8 @@ import {
   AnkifySyncMapping,
 } from '../../entities/ankify';
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
+import { ANKIFY_BASIC_MODEL } from '../../services/ankify/ankifyModels';
+import { ensureAnkifyModels } from '../../services/ankify/ensureAnkifyModels';
 import {
   walkNotionPageForFlashcards,
   NotionBlockChildrenFetcher,
@@ -67,6 +69,8 @@ const BACK_FIELD_BASIC = 'Back';
 const DECK_NAME_FALLBACK = 'Notion Sync';
 
 export class SyncNotionPageToRacUseCase {
+  private readonly modelCacheByClient = new Map<number, Set<string>>();
+
   constructor(
     private readonly clients: AnkifyClientsRepositoryInterface,
     private readonly mappings: AnkifySyncMappingsRepositoryInterface,
@@ -78,6 +82,15 @@ export class SyncNotionPageToRacUseCase {
     private readonly notionFetcher: NotionFetcherFactory,
     private readonly notionPageMeta?: NotionPageMetaFetcher
   ) {}
+
+  private modelCache(clientId: number): Set<string> {
+    let cache = this.modelCacheByClient.get(clientId);
+    if (cache == null) {
+      cache = new Set<string>();
+      this.modelCacheByClient.set(clientId, cache);
+    }
+    return cache;
+  }
 
   async execute(input: SyncNotionPageInput): Promise<SyncNotionPageResult> {
     const client = await this.clients.findActiveByOwner(input.owner);
@@ -183,6 +196,7 @@ export class SyncNotionPageToRacUseCase {
       client.anki_connect_api_key
     );
     await ac.createDeck(DECK_NAME_FALLBACK);
+    await ensureAnkifyModels(ac, this.modelCache(client.id));
 
     for (const card of cards) {
       await this.processCard({ card, client, subscription, ac, input, result });
@@ -208,7 +222,7 @@ export class SyncNotionPageToRacUseCase {
       if (existing == null) {
         const ankiNoteId = await ac.addNote({
           deckName: DECK_NAME_FALLBACK,
-          modelName: 'Basic',
+          modelName: ANKIFY_BASIC_MODEL,
           fields: {
             [FRONT_FIELD_BASIC]: card.front,
             [BACK_FIELD_BASIC]: card.back,

--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -906,6 +906,10 @@
   letter-spacing: var(--tracking-tight);
 }
 
+.welcomeBanner {
+  margin-bottom: 1.25rem;
+}
+
 .conflictsBanner {
   display: flex;
   align-items: center;

--- a/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
@@ -144,13 +144,17 @@ describe('AnkifySetupPage', () => {
   });
 });
 
+const ANKIFY_WELCOME_KEY = 'ankify_welcome_seen';
+
 describe('AnkifyPage workspace home', () => {
   beforeEach(() => {
     globalThis.localStorage?.setItem(ANKI_WEB_ACK_KEY, 'true');
+    globalThis.localStorage?.removeItem(ANKIFY_WELCOME_KEY);
   });
 
   afterEach(() => {
     globalThis.localStorage?.removeItem(ANKI_WEB_ACK_KEY);
+    globalThis.localStorage?.removeItem(ANKIFY_WELCOME_KEY);
   });
 
   test('renders the Ankify title and Decks heading when setup is complete', async () => {
@@ -194,5 +198,65 @@ describe('AnkifyPage workspace home', () => {
       ).toBeInTheDocument()
     );
     expect(screen.queryByText(/^beta$/i)).not.toBeInTheDocument();
+  });
+
+  test('shows the welcome banner once on first arrival and remembers dismissal', async () => {
+    const backend = makeBackend({
+      listAnkifyClients: vi.fn(async () => [sampleClient()]),
+      checkAnkifyActiveClientReady: vi.fn(async () => ({ ready: true })),
+      checkAnkifyAnkiWebStatus: vi.fn(async () => ({
+        status: 'linked' as const,
+      })),
+    });
+
+    const { unmount } = renderAt('/ankify', backend);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/your anki is ready/i)
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.getByText(/ankify basic and ankify cloze/i)
+    ).toBeInTheDocument();
+
+    const dismiss = screen.getByRole('button', { name: /got it/i });
+    dismiss.click();
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/your anki is ready/i)
+      ).not.toBeInTheDocument()
+    );
+
+    unmount();
+    renderAt('/ankify', backend);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: /^ankify$/i, level: 1 })
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/your anki is ready/i)).not.toBeInTheDocument();
+  });
+
+  test('does not show the welcome banner once it has been seen', async () => {
+    globalThis.localStorage?.setItem(ANKIFY_WELCOME_KEY, 'true');
+    const backend = makeBackend({
+      listAnkifyClients: vi.fn(async () => [sampleClient()]),
+      checkAnkifyActiveClientReady: vi.fn(async () => ({ ready: true })),
+      checkAnkifyAnkiWebStatus: vi.fn(async () => ({
+        status: 'linked' as const,
+      })),
+    });
+
+    renderAt('/ankify', backend);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: /^ankify$/i, level: 1 })
+      ).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/your anki is ready/i)).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/AnkifyPage/AnkifyPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.tsx
@@ -13,6 +13,7 @@ import ConflictsModal from './components/ConflictsModal';
 
 const QUERY_KEY = ['ankify-clients'];
 const ANKI_WEB_ACK_KEY = 'ankify_anki_web_acknowledged';
+const ANKIFY_WELCOME_SEEN_KEY = 'ankify_welcome_seen';
 const TRACKER_LOCAL_KEY = 'ankify-export-database-id';
 const TRACKER_TITLE_LOCAL_KEY = 'ankify-export-database-title';
 const TRACKER_URL_LOCAL_KEY = 'ankify-export-database-url';
@@ -33,6 +34,14 @@ const readSignedInAcknowledged = (): boolean => {
   }
 };
 
+const readWelcomeSeen = (): boolean => {
+  try {
+    return globalThis.localStorage?.getItem(ANKIFY_WELCOME_SEEN_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
 interface AnkifyPageProps {
   backend?: Backend;
 }
@@ -41,6 +50,14 @@ export default function AnkifyPage({ backend }: Readonly<AnkifyPageProps>) {
   const api = backend ?? get2ankiApi();
   const navigate = useNavigate();
   const [conflictsOpen, setConflictsOpen] = useState(false);
+  const [welcomeOpen, setWelcomeOpen] = useState<boolean>(() => !readWelcomeSeen());
+
+  const dismissWelcome = () => {
+    setWelcomeOpen(false);
+    try {
+      globalThis.localStorage?.setItem(ANKIFY_WELCOME_SEEN_KEY, 'true');
+    } catch {}
+  };
 
   const { data, isLoading } = useQuery<AnkifyClient[]>({
     queryKey: QUERY_KEY,
@@ -85,6 +102,27 @@ export default function AnkifyPage({ backend }: Readonly<AnkifyPageProps>) {
     <main className={sharedStyles.page}>
       <WorkspaceBar backend={backend} />
       <h1 className={styles.workspaceTitle}>Ankify</h1>
+
+      {welcomeOpen && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={`${sharedStyles.alertSuccess} ${styles.welcomeBanner}`}
+        >
+          <span>
+            Your Anki is ready. We added two note types — Ankify Basic and
+            Ankify Cloze — so your synced cards always look right. You can
+            edit them anytime in Anki.
+          </span>
+          <button
+            type="button"
+            className={sharedStyles.btnSecondary}
+            onClick={dismissWelcome}
+          >
+            Got it
+          </button>
+        </div>
+      )}
 
       {conflictCount > 0 && (
         <output className={styles.conflictsBanner}>

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
@@ -243,6 +243,28 @@ describe('NotionSubscriptions sync copy', () => {
     expect(img.src).toBe('https://example.com/icon.png');
   });
 
+  test('shows "Preparing your first sync" for a brand new subscription with no last_synced_at', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 1,
+          notion_page_id: 'a'.repeat(32),
+          last_synced_at: null,
+          last_polled_at: null,
+          last_error: null,
+        }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/preparing your first sync/i)
+      ).toBeInTheDocument()
+    );
+  });
+
   test('error line takes precedence over next-export line', async () => {
     const matchingId = 'a'.repeat(32);
     const backend = makeBackend({

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -407,14 +407,28 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                 nextExportLabel
               );
               const relative = formatRelativeTime(sub.last_synced_at);
-              const lastSyncedDisplay =
-                relative == null ? (
-                  <span className={styles.muted}>Not yet</span>
-                ) : (
-                  <span title={sub.last_synced_at ?? undefined}>
-                    updated {relative}
+              const isPreparingFirstSync =
+                sub.last_synced_at == null &&
+                sub.last_polled_at == null &&
+                sub.last_error == null;
+              let lastSyncedDisplay: ReactNode;
+              if (isPreparingFirstSync) {
+                lastSyncedDisplay = (
+                  <span className={styles.muted}>
+                    Preparing your first sync — usually under a minute.
                   </span>
                 );
+              } else if (relative == null) {
+                lastSyncedDisplay = (
+                  <span className={styles.muted}>Not yet</span>
+                );
+              } else {
+                lastSyncedDisplay = (
+                  <span title={sub.last_synced_at ?? undefined}>
+                    Last sync: {relative}
+                  </span>
+                );
+              }
               const iconValue = sub.notion_page_icon ?? '';
               return (
                 <li key={sub.id} className={styles.decksItem}>


### PR DESCRIPTION
## Summary
- Switch sync to namespaced note types (`Ankify Basic` / `Ankify Cloze`) and seed them lazily via AnkiConnect's `createModel` before the first `addNote`, so users whose AnkiWeb collections don't ship Anki's defaults stop getting `model was not found: Basic` errors.
- Add a one-shot welcome banner on the workspace home explaining the new note types, persisted in `localStorage`.
- Replace "updated {relative}" / "Not yet" with a friendlier `Preparing your first sync — usually under a minute.` while a subscription has no `last_polled_at`, then `Last sync: {relative}` once it has run.

## What
Until now, both `SyncNotionPageToRacUseCase` and `SendUploadToRacUseCase` hardcoded `modelName: 'Basic'` / `'Cloze'`, assuming AnkiConnect's collection had Anki's default note types. When a user's AnkiWeb collection synced down without them (e.g. Japanese-study collections that ship custom types only), every `addNote` failed with `model was not found: Basic` and the user saw repeated polling errors with zero cards delivered.

This PR introduces a single source of truth (`src/services/ankify/ankifyModels.ts`) for the canonical Ankify note-type names plus their `createModel` payloads, and a small `ensureAnkifyModels` helper that runs once per sync (cached per client per process). Both use cases call the helper before the first `addNote`. CSS/templates are derived from `src/templates/n2a-basic.json` so cards still render with our branded styling.

## Why
4 enabled `ankify_notion_subscriptions` poll every 5 minutes for our allowlisted user with `status=error` on every run. Without this fix Ankify is unusable for anyone whose AnkiWeb collection is missing the stock note types. The 4 stuck subscriptions auto-recover on the next polling tick once this ships — no migration or force-resync endpoint needed.

## How
- `src/services/ankify/ankifyModels.ts` — exports `ANKIFY_BASIC_MODEL`, `ANKIFY_CLOZE_MODEL`, in-order field arrays, and the `createModel` params (with branded CSS/templates).
- `AnkiConnectClient.createModel(params)` — thin wrapper over the existing `invoke` pattern.
- `ensureAnkifyModels(ac, cache)` — checks the cache first, then `modelNames`, then creates only what's missing. Treats "already exists" errors as success for race-safety.
- Both use cases keep a per-instance `Map<clientId, Set<string>>` so a hot process pays one `modelNames` round-trip per fresh container.
- Web: welcome banner uses the existing `alertSuccess` styling (no toast lib added). Subscription rows render the new "preparing" copy when `last_synced_at == null && last_polled_at == null && last_error == null`.

Card-count copy was intentionally left out — exposing it would have required a join across `ankify_sync_mappings` in the list-subscriptions endpoint. Shipping this first; counts can land in a follow-up if the empty-state copy needs more punch.

## Testing
- Server: 8 new/updated assertions across `AnkiConnectClient.test.ts`, `ensureAnkifyModels.test.ts`, `SendUploadToRacUseCase.test.ts`, and a new `SyncNotionPageToRacUseCase.test.ts` (4 cases). All 69 ankify-scoped tests pass.
- Web: 4 new assertions across `AnkifyPage.test.tsx` and `NotionSubscriptions.test.tsx`. All 49 web tests pass; `pnpm typecheck` and `pnpm lint` are clean.
- The 14 pre-existing failures in `parseCollection.test.ts` / `DeckParser.test.ts` are environment issues (`genanki` Python module + better-sqlite3 fixture) unrelated to this change — confirmed by stashing the diff and rerunning.
- Manually verified: greppable check `modelName: 'Basic'|'Cloze'` returns nothing under `src/services/ankify/` and `src/usecases/ankify/`.

## Risks
- AnkiConnect's `createModel` is well-documented but if a user has manually created models named `Ankify Basic` / `Ankify Cloze` with different field shapes, the existing-model check still treats those as valid and we'll write notes against them. Acceptable — users who intentionally created models with these names own that decision.
- Rollback: revert both commits; existing subscriptions go back to silent error state but no data is lost (mappings table untouched).

## Goal alignment
Directly unblocks Ankify for users whose AnkiWeb collections don't ship Anki's default note types — a known blocker that turns sync into a silent failure mode. Without this, the whole product is invisible to a meaningful slice of the 300K-user target audience (Japanese-study and custom-collection users in particular).

## Notes
- Alexander's 4 stuck subscriptions auto-recover on the next 5-minute polling tick once this deploys; no force-resync needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)