### PR TITLE
feat(ankify): nest synced decks per page, refresh styling, support Notion images

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -155,6 +155,69 @@ describe('AnkiConnectClient', () => {
     });
   });
 
+  test('updateModelStyling posts the updateModelStyling action with model.css payload', async () => {
+    const fetchImpl = makeFetch({ result: null, error: null });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    await client.updateModelStyling({
+      name: 'Ankify Basic',
+      css: '.card { color: red; }',
+    });
+
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'updateModelStyling',
+      version: 6,
+      params: {
+        model: { name: 'Ankify Basic', css: '.card { color: red; }' },
+      },
+    });
+  });
+
+  test('updateModelTemplates posts the updateModelTemplates action with templates payload', async () => {
+    const fetchImpl = makeFetch({ result: null, error: null });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    await client.updateModelTemplates({
+      name: 'Ankify Basic',
+      templates: {
+        'Card 1': { Front: '{{Front}}', Back: '{{Back}}' },
+      },
+    });
+
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'updateModelTemplates',
+      version: 6,
+      params: {
+        model: {
+          name: 'Ankify Basic',
+          templates: {
+            'Card 1': { Front: '{{Front}}', Back: '{{Back}}' },
+          },
+        },
+      },
+    });
+  });
+
+  test('storeMediaFile posts the storeMediaFile action with filename + base64 data', async () => {
+    const fetchImpl = makeFetch({ result: 'ankify-x.png', error: null });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const stored = await client.storeMediaFile({
+      filename: 'ankify-x.png',
+      data: 'UEFTREFUQQ==',
+    });
+
+    expect(stored).toBe('ankify-x.png');
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'storeMediaFile',
+      version: 6,
+      params: { filename: 'ankify-x.png', data: 'UEFTREFUQQ==' },
+    });
+  });
+
   test('throws AnkiConnectUnreachableError when fetch rejects', async () => {
     const fetchImpl = jest.fn(async () => {
       throw new Error('connect ECONNREFUSED');

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -91,6 +91,18 @@ export class AnkiConnectClient {
     return this.invoke('createModel', params as unknown as Record<string, unknown>);
   }
 
+  async updateModelStyling(params: AnkiConnectUpdateStylingParams): Promise<null> {
+    return this.invoke('updateModelStyling', { model: params });
+  }
+
+  async updateModelTemplates(params: AnkiConnectUpdateTemplatesParams): Promise<null> {
+    return this.invoke('updateModelTemplates', { model: params });
+  }
+
+  async storeMediaFile(params: AnkiConnectStoreMediaFileParams): Promise<string> {
+    return this.invoke('storeMediaFile', params as unknown as Record<string, unknown>);
+  }
+
   async getNumCardsReviewedByDay(): Promise<Array<[string, number]>> {
     return this.invoke('getNumCardsReviewedByDay');
   }
@@ -183,6 +195,26 @@ export interface AnkiConnectCreateModelParams {
   css: string;
   isCloze?: boolean;
   cardTemplates: AnkiConnectCardTemplate[];
+}
+
+export interface AnkiConnectUpdateStylingParams {
+  name: string;
+  css: string;
+}
+
+export interface AnkiConnectTemplateBody {
+  Front: string;
+  Back: string;
+}
+
+export interface AnkiConnectUpdateTemplatesParams {
+  name: string;
+  templates: Record<string, AnkiConnectTemplateBody>;
+}
+
+export interface AnkiConnectStoreMediaFileParams {
+  filename: string;
+  data: string;
 }
 
 export interface AnkiNoteInfo {

--- a/src/services/ankify/ankifyModels.ts
+++ b/src/services/ankify/ankifyModels.ts
@@ -1,3 +1,4 @@
+import { NOTION_STYLE } from '../../templates/helper';
 import { AnkiConnectCreateModelParams } from './AnkiConnectClient';
 
 export const ANKIFY_BASIC_MODEL = 'Ankify Basic';
@@ -6,39 +7,76 @@ export const ANKIFY_CLOZE_MODEL = 'Ankify Cloze';
 export const ANKIFY_BASIC_FIELDS = ['Front', 'Back'] as const;
 export const ANKIFY_CLOZE_FIELDS = ['Text', 'Back Extra'] as const;
 
-const ANKIFY_CARD_STYLING = `
-html, body { text-align: center; }
-
+const ANKIFY_CARD_OVERRIDES = `
 .card {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
-    "Apple Color Emoji", Arial, sans-serif, "Segoe UI Emoji", "Segoe UI Symbol";
-  color: black;
-  background-color: white;
-  border: lightgray 1px solid;
-  padding: 16px;
-  border-radius: 8px;
-  margin: 16px;
-  width: 80%;
-  display: inline-block;
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  font-size: 18px;
+  line-height: 1.5;
+  color: rgb(55, 53, 47);
+  background-color: rgb(255, 255, 255);
+  text-align: left;
+  padding: 32px 24px;
+  max-width: 720px;
+  margin: 0 auto;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-.card:hover {
-  box-shadow: 0 0 8px #ccc;
-  border: 1px solid #fff;
+.nightMode.card,
+.night_mode .card {
+  color: rgba(255, 255, 255, 0.9);
+  background-color: rgb(25, 25, 25);
 }
 
-.front-text-pre { font-size: 1.5rem; }
-.front-text-post { color: gray; font-size: 1rem; }
-.back-text { font-size: 1.5rem; text-align: left; }
-.extra { color: gray; }
+.front-text-pre {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+  text-align: center;
+  margin-bottom: 0.25em;
+}
 
-hr { border: none; border-bottom: 1px solid rgba(55, 53, 47, 0.18); }
+.front-text-post {
+  display: block;
+  font-size: 1rem;
+  font-weight: 500;
+  color: rgba(55, 53, 47, 0.65);
+  text-align: center;
+  letter-spacing: -0.005em;
+}
+
+.back-text { display: block; }
+
+.extra {
+  display: block;
+  margin-top: 1em;
+  color: rgba(55, 53, 47, 0.6);
+  font-size: 0.9em;
+}
+
+hr#answer {
+  border: none;
+  border-top: 1px solid rgba(55, 53, 47, 0.16);
+  margin: 1.5em 0;
+}
+
+mark { background: rgba(255, 212, 0, 0.25); color: inherit; padding: 0 2px; border-radius: 2px; }
 
 .cloze {
-  font-weight: bold;
-  color: #2563eb;
+  font-weight: 600;
+  color: rgb(11, 110, 153);
+}
+.nightMode .cloze, .night_mode .cloze { color: rgb(82, 156, 202); }
+
+@media (max-width: 480px) {
+  .card { padding: 20px 16px; font-size: 17px; }
+  .front-text-pre { font-size: 1.3rem; }
 }
 `.trim();
+
+const ANKIFY_CARD_STYLING = `${NOTION_STYLE}\n\n${ANKIFY_CARD_OVERRIDES}`;
 
 export const ankifyBasicCreateModelParams = (): AnkiConnectCreateModelParams => ({
   modelName: ANKIFY_BASIC_MODEL,
@@ -63,7 +101,7 @@ export const ankifyClozeCreateModelParams = (): AnkiConnectCreateModelParams => 
     {
       Name: 'Cloze',
       Front: '{{cloze:Text}}',
-      Back: '{{cloze:Text}}<br><span class="extra">{{Back Extra}}</span>',
+      Back: '{{cloze:Text}}<hr id="answer"><span class="extra">{{Back Extra}}</span>',
     },
   ],
 });

--- a/src/services/ankify/notionPageWalker.test.ts
+++ b/src/services/ankify/notionPageWalker.test.ts
@@ -1,0 +1,101 @@
+import { walkNotionPageForFlashcards } from './notionPageWalker';
+
+const toggleBlock = (overrides: Record<string, unknown> = {}) => ({
+  id: 'toggle-1',
+  type: 'toggle',
+  has_children: true,
+  last_edited_time: '2026-05-09T12:00:00.000Z',
+  toggle: { rich_text: [{ plain_text: 'What is Anki?' }] },
+  ...overrides,
+});
+
+const paragraphChild = (text: string) => ({
+  type: 'paragraph',
+  paragraph: { rich_text: [{ plain_text: text }] },
+});
+
+describe('walkNotionPageForFlashcards', () => {
+  test('extracts image blocks from toggle children and embeds <img> in the back', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') {
+        return [toggleBlock()];
+      }
+      return [
+        paragraphChild('Spaced repetition.'),
+        {
+          id: 'img-block-77',
+          type: 'image',
+          image: {
+            type: 'file',
+            file: {
+              url: 'https://prod-files.notion.so/abc/img.png?signed=1',
+              expiry_time: '2026-05-09T13:00:00.000Z',
+            },
+          },
+        },
+      ];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].back).toContain('Spaced repetition.');
+    expect(cards[0].back).toContain('<img');
+    expect(cards[0].images).toEqual([
+      {
+        block_id: 'img-block-77',
+        source: 'file',
+        url: 'https://prod-files.notion.so/abc/img.png?signed=1',
+        filename: 'ankify-img-block-77.png',
+      },
+    ]);
+  });
+
+  test('keeps external-hosted image URLs as-is in the back HTML', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') {
+        return [toggleBlock()];
+      }
+      return [
+        {
+          id: 'img-block-ext',
+          type: 'image',
+          image: {
+            type: 'external',
+            external: { url: 'https://cdn.example.com/diagram.png' },
+          },
+        },
+      ];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren);
+
+    expect(cards[0].back).toContain(
+      '<img src="https://cdn.example.com/diagram.png">'
+    );
+    expect(cards[0].images).toEqual([
+      {
+        block_id: 'img-block-ext',
+        source: 'external',
+        url: 'https://cdn.example.com/diagram.png',
+      },
+    ]);
+  });
+
+  test('skips toggles with empty front text', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') {
+        return [
+          toggleBlock({ id: 't-empty', toggle: { rich_text: [] } }),
+          toggleBlock({ id: 't-real' }),
+        ];
+      }
+      return [paragraphChild('answer')];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].notion_block_id).toBe('t-real');
+  });
+});

--- a/src/services/ankify/notionPageWalker.ts
+++ b/src/services/ankify/notionPageWalker.ts
@@ -20,17 +20,36 @@ interface NotionBulletedListItemBlock {
   bulleted_list_item: { rich_text: RichTextItem[] };
 }
 
+interface NotionImageBlock {
+  id: string;
+  type: 'image';
+  image:
+    | { type: 'external'; external: { url: string } }
+    | { type: 'file'; file: { url: string; expiry_time?: string } };
+}
+
 type NotionChildBlock =
   | NotionToggleBlock
   | NotionParagraphBlock
   | NotionBulletedListItemBlock
-  | { type: string };
+  | NotionImageBlock
+  | { type: string; id?: string };
+
+export type WalkedImageSource = 'external' | 'file';
+
+export interface WalkedNotionImageRef {
+  block_id: string;
+  source: WalkedImageSource;
+  url: string;
+  filename?: string;
+}
 
 export interface WalkedNotionFlashcard {
   notion_block_id: string;
   notion_last_edited_at: Date;
   front: string;
   back: string;
+  images: WalkedNotionImageRef[];
 }
 
 export type NotionBlockChildrenFetcher = (
@@ -47,15 +66,49 @@ const renderRichText = (items: RichTextItem[] | undefined): string => {
     .trim();
 };
 
-const renderChildAsBackText = async (
+const buildMediaFilename = (image: NotionImageBlock): string => {
+  const url = image.image.type === 'file'
+    ? image.image.file.url
+    : image.image.external.url;
+  const cleanedUrl = url.split('?')[0];
+  const extMatch = /\.([a-zA-Z0-9]{1,5})$/.exec(cleanedUrl);
+  const ext = extMatch == null ? 'png' : extMatch[1].toLowerCase();
+  return `ankify-${image.id}.${ext}`;
+};
+
+const renderImageHtml = (image: NotionImageBlock): string => {
+  if (image.image.type === 'external') {
+    return `<img src="${image.image.external.url}">`;
+  }
+  return `<img src="${buildMediaFilename(image)}">`;
+};
+
+const buildImageRef = (image: NotionImageBlock): WalkedNotionImageRef => {
+  if (image.image.type === 'file') {
+    return {
+      block_id: image.id,
+      source: 'file',
+      url: image.image.file.url,
+      filename: buildMediaFilename(image),
+    };
+  }
+  return {
+    block_id: image.id,
+    source: 'external',
+    url: image.image.external.url,
+  };
+};
+
+const renderToggleBack = async (
   toggle: NotionToggleBlock,
   fetchChildren: NotionBlockChildrenFetcher
-): Promise<string> => {
+): Promise<{ back: string; images: WalkedNotionImageRef[] }> => {
   if (!toggle.has_children) {
-    return '';
+    return { back: '', images: [] };
   }
   const children = await fetchChildren(toggle.id);
   const lines: string[] = [];
+  const images: WalkedNotionImageRef[] = [];
   for (const child of children) {
     if (child.type === 'paragraph') {
       lines.push(
@@ -68,9 +121,16 @@ const renderChildAsBackText = async (
       if (text.length > 0) {
         lines.push(`• ${text}`);
       }
+    } else if (child.type === 'image' && child.id != null) {
+      const imageBlock = child as NotionImageBlock;
+      lines.push(renderImageHtml(imageBlock));
+      images.push(buildImageRef(imageBlock));
     }
   }
-  return lines.filter((line) => line.length > 0).join('\n');
+  return {
+    back: lines.filter((line) => line.length > 0).join('\n'),
+    images,
+  };
 };
 
 export const walkNotionPageForFlashcards = async (
@@ -88,13 +148,15 @@ export const walkNotionPageForFlashcards = async (
     if (front.length === 0) {
       continue;
     }
-    const back = await renderChildAsBackText(toggle, fetchChildren);
+    const { back, images } = await renderToggleBack(toggle, fetchChildren);
     cards.push({
       notion_block_id: toggle.id,
       notion_last_edited_at: new Date(toggle.last_edited_time),
       front,
       back,
+      images,
     });
   }
   return cards;
 };
+

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -51,11 +51,15 @@ const sampleSubscription = (
   ...overrides,
 });
 
-const sampleCard = (): WalkedNotionFlashcard => ({
+const sampleCard = (
+  overrides: Partial<WalkedNotionFlashcard> = {}
+): WalkedNotionFlashcard => ({
   notion_block_id: 'block-1',
   front: 'Front text',
   back: 'Back text',
   notion_last_edited_at: new Date(),
+  images: [],
+  ...overrides,
 });
 
 const makeClients = (): jest.Mocked<AnkifyClientsRepositoryInterface> =>
@@ -125,6 +129,9 @@ const makeAnkiConnectStub = () =>
     sync: jest.fn(async () => null),
     modelNames: jest.fn(async () => [] as string[]),
     createModel: jest.fn(async (_p: unknown) => ({ id: 1 })),
+    updateModelStyling: jest.fn(async () => null),
+    updateModelTemplates: jest.fn(async () => null),
+    storeMediaFile: jest.fn(async () => 'stored.png'),
   } as unknown as AnkiConnectClient & { [k: string]: jest.Mock });
 
 const makeRepos = () => ({
@@ -293,6 +300,290 @@ describe('SyncNotionPageToRacUseCase', () => {
     expect(callOrder.indexOf('createModel')).toBeLessThan(
       callOrder.indexOf('addNote')
     );
+  });
+
+  test('addNote uses a per-page deck name nested under "Notion Sync"', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([sampleCard()]);
+    const repos = makeRepos();
+    repos.subscriptions = makeSubscriptionsRepo(
+      sampleSubscription({ notion_page_title: 'Algebra Basics' })
+    );
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      () => async () => ({
+        title: 'Algebra Basics',
+        url: null,
+        icon: null,
+      })
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.createDeck).toHaveBeenCalledWith('Notion Sync::Algebra Basics');
+    expect(ac.addNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deckName: 'Notion Sync::Algebra Basics',
+      })
+    );
+    expect(repos.mappings.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deck_name: 'Notion Sync::Algebra Basics',
+      })
+    );
+  });
+
+  test('falls back to "Notion Sync::Untitled" when the page title is null', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([sampleCard()]);
+    const repos = makeRepos();
+    repos.subscriptions = makeSubscriptionsRepo(
+      sampleSubscription({ notion_page_title: null })
+    );
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.createDeck).toHaveBeenCalledWith('Notion Sync::Untitled');
+    expect(ac.addNote).toHaveBeenCalledWith(
+      expect.objectContaining({ deckName: 'Notion Sync::Untitled' })
+    );
+  });
+
+  test('strips "::" from titles so users cannot accidentally nest deeper', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([sampleCard()]);
+    const repos = makeRepos();
+    repos.subscriptions = makeSubscriptionsRepo(
+      sampleSubscription({ notion_page_title: '  Quick::Tricks  ' })
+    );
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.createDeck).toHaveBeenCalledWith('Notion Sync::QuickTricks');
+  });
+
+  test('refreshes model styling and templates after ensuring models exist', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([sampleCard()]);
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.updateModelStyling).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Ankify Basic',
+        css: expect.stringContaining('.card'),
+      })
+    );
+    expect(ac.updateModelTemplates).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Ankify Basic',
+        templates: expect.objectContaining({
+          'Card 1': expect.objectContaining({
+            Front: expect.stringContaining('{{Front}}'),
+            Back: expect.stringContaining('{{Back}}'),
+          }),
+        }),
+      })
+    );
+  });
+
+  test('downloads Notion file images and pushes them to media before addNote', async () => {
+    const sampleFetcher = jest.fn(async (url: string) => ({
+      ok: true,
+      arrayBuffer: async () => {
+        expect(url).toBe('https://prod-files.notion.so/img.png?signed=1');
+        return new TextEncoder().encode('PNGDATA').buffer as ArrayBuffer;
+      },
+    })) as unknown as typeof fetch;
+
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([
+      sampleCard({
+        back: 'See <img src="ankify-img-77.png">',
+        images: [
+          {
+            block_id: 'img-77',
+            source: 'file',
+            url: 'https://prod-files.notion.so/img.png?signed=1',
+            filename: 'ankify-img-77.png',
+          },
+        ],
+      }),
+    ]);
+
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const callOrder: string[] = [];
+    (ac.storeMediaFile as jest.Mock).mockImplementation(async () => {
+      callOrder.push('storeMediaFile');
+      return 'ankify-img-77.png';
+    });
+    (ac.addNote as jest.Mock).mockImplementation(async () => {
+      callOrder.push('addNote');
+      return 12345;
+    });
+
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      sampleFetcher
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.storeMediaFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filename: 'ankify-img-77.png',
+        data: expect.any(String),
+      })
+    );
+    expect(callOrder.indexOf('storeMediaFile')).toBeLessThan(
+      callOrder.indexOf('addNote')
+    );
+  });
+
+  test('skips storeMediaFile for external-hosted images and still proceeds', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([
+      sampleCard({
+        back: '<img src="https://cdn.example.com/x.png">',
+        images: [
+          {
+            block_id: 'img-ext',
+            source: 'external',
+            url: 'https://cdn.example.com/x.png',
+          },
+        ],
+      }),
+    ]);
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.storeMediaFile).not.toHaveBeenCalled();
+    expect(ac.addNote).toHaveBeenCalled();
+  });
+
+  test('records sync_logs error but does not fail when image download fails', async () => {
+    const failingFetch = jest.fn(async () => {
+      throw new Error('network down');
+    }) as unknown as typeof fetch;
+
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([
+      sampleCard({
+        images: [
+          {
+            block_id: 'img-bad',
+            source: 'file',
+            url: 'https://prod-files.notion.so/bad.png?signed=1',
+            filename: 'ankify-img-bad.png',
+          },
+        ],
+      }),
+    ]);
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      failingFetch
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.storeMediaFile).not.toHaveBeenCalled();
+    expect(ac.addNote).toHaveBeenCalled();
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toMatch(/img-bad/);
   });
 
   test('a second sync for the same client reuses the cache and skips modelNames', async () => {

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -10,12 +10,17 @@ import {
   AnkifySyncMapping,
 } from '../../entities/ankify';
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
-import { ANKIFY_BASIC_MODEL } from '../../services/ankify/ankifyModels';
+import {
+  ANKIFY_BASIC_MODEL,
+  ankifyBasicCreateModelParams,
+  ankifyClozeCreateModelParams,
+} from '../../services/ankify/ankifyModels';
 import { ensureAnkifyModels } from '../../services/ankify/ensureAnkifyModels';
 import {
   walkNotionPageForFlashcards,
   NotionBlockChildrenFetcher,
   WalkedNotionFlashcard,
+  WalkedNotionImageRef,
 } from '../../services/ankify/notionPageWalker';
 import { NoActiveAnkifyClientError } from './SendUploadToRacUseCase';
 import { NotionNotConnectedError } from './ExportReviewDataToNotionUseCase';
@@ -66,7 +71,27 @@ export type NotionFetcherFactory = (token: string) => NotionBlockChildrenFetcher
 
 const FRONT_FIELD_BASIC = 'Front';
 const BACK_FIELD_BASIC = 'Back';
-const DECK_NAME_FALLBACK = 'Notion Sync';
+const DECK_PARENT = 'Notion Sync';
+const DECK_TITLE_FALLBACK = 'Untitled';
+
+export type AnkifyImageFetcher = typeof fetch;
+
+const sanitizeDeckTitle = (title: string | null | undefined): string => {
+  if (title == null) {
+    return DECK_TITLE_FALLBACK;
+  }
+  const cleaned = title.split('::').join('').trim();
+  if (cleaned.length === 0) {
+    return DECK_TITLE_FALLBACK;
+  }
+  return cleaned;
+};
+
+const buildDeckName = (title: string | null | undefined): string =>
+  `${DECK_PARENT}::${sanitizeDeckTitle(title)}`;
+
+const arrayBufferToBase64 = (buffer: ArrayBuffer): string =>
+  Buffer.from(buffer).toString('base64');
 
 export class SyncNotionPageToRacUseCase {
   private readonly modelCacheByClient = new Map<number, Set<string>>();
@@ -80,7 +105,8 @@ export class SyncNotionPageToRacUseCase {
     private readonly notionRepo: INotionRepository,
     private readonly ankiConnect: AnkiConnectFactory,
     private readonly notionFetcher: NotionFetcherFactory,
-    private readonly notionPageMeta?: NotionPageMetaFetcher
+    private readonly notionPageMeta?: NotionPageMetaFetcher,
+    private readonly imageFetcher: AnkifyImageFetcher = fetch
   ) {}
 
   private modelCache(clientId: number): Set<string> {
@@ -195,14 +221,81 @@ export class SyncNotionPageToRacUseCase {
       client.anki_port,
       client.anki_connect_api_key
     );
-    await ac.createDeck(DECK_NAME_FALLBACK);
+    const deckName = buildDeckName(subscription.notion_page_title);
+    await ac.createDeck(deckName);
     await ensureAnkifyModels(ac, this.modelCache(client.id));
+    await this.refreshAnkifyModelStyling(ac);
 
     for (const card of cards) {
-      await this.processCard({ card, client, subscription, ac, input, result });
+      await this.processCard({
+        card,
+        client,
+        subscription,
+        ac,
+        input,
+        result,
+        deckName,
+      });
     }
 
     await this.runFinalAnkiWebSync(ac, result);
+  }
+
+  private async uploadCardImages(
+    ac: AnkiConnectClient,
+    card: WalkedNotionFlashcard,
+    result: SyncNotionPageResult
+  ): Promise<void> {
+    for (const image of card.images) {
+      if (image.source !== 'file' || image.filename == null) {
+        continue;
+      }
+      await this.uploadSingleImage(ac, image, result);
+    }
+  }
+
+  private async uploadSingleImage(
+    ac: AnkiConnectClient,
+    image: WalkedNotionImageRef,
+    result: SyncNotionPageResult
+  ): Promise<void> {
+    if (image.filename == null) {
+      return;
+    }
+    try {
+      const response = await this.imageFetcher(image.url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const buffer = await response.arrayBuffer();
+      await ac.storeMediaFile({
+        filename: image.filename,
+        data: arrayBufferToBase64(buffer),
+      });
+    } catch (error) {
+      result.errors.push(
+        `Image ${image.block_id}: ${(error as Error).message}`
+      );
+    }
+  }
+
+  private async refreshAnkifyModelStyling(ac: AnkiConnectClient): Promise<void> {
+    const basic = ankifyBasicCreateModelParams();
+    const cloze = ankifyClozeCreateModelParams();
+    await ac.updateModelStyling({ name: basic.modelName, css: basic.css });
+    await ac.updateModelStyling({ name: cloze.modelName, css: cloze.css });
+    await ac.updateModelTemplates({
+      name: basic.modelName,
+      templates: Object.fromEntries(
+        basic.cardTemplates.map((t) => [t.Name, { Front: t.Front, Back: t.Back }])
+      ),
+    });
+    await ac.updateModelTemplates({
+      name: cloze.modelName,
+      templates: Object.fromEntries(
+        cloze.cardTemplates.map((t) => [t.Name, { Front: t.Front, Back: t.Back }])
+      ),
+    });
   }
 
   private async processCard(args: {
@@ -212,16 +305,18 @@ export class SyncNotionPageToRacUseCase {
     ac: AnkiConnectClient;
     input: SyncNotionPageInput;
     result: SyncNotionPageResult;
+    deckName: string;
   }): Promise<void> {
-    const { card, client, subscription, ac, input, result } = args;
+    const { card, client, subscription, ac, input, result, deckName } = args;
     try {
+      await this.uploadCardImages(ac, card, result);
       const existing = await this.mappings.findBySourceId(
         client.id,
         card.notion_block_id
       );
       if (existing == null) {
         const ankiNoteId = await ac.addNote({
-          deckName: DECK_NAME_FALLBACK,
+          deckName,
           modelName: ANKIFY_BASIC_MODEL,
           fields: {
             [FRONT_FIELD_BASIC]: card.front,
@@ -235,7 +330,7 @@ export class SyncNotionPageToRacUseCase {
           source_id: card.notion_block_id,
           source_type: 'notion_block',
           anki_note_id: ankiNoteId,
-          deck_name: DECK_NAME_FALLBACK,
+          deck_name: deckName,
         });
         result.created += 1;
         return;


### PR DESCRIPTION
## Summary

Three pre-existing gaps surfaced once polling started actually producing cards (PR #2063 yesterday). All three addressed in one PR because they share a code path and a deploy:

- **Per-page nested decks.** `Notion Sync::<page-title>` instead of one flat `Notion Sync`. Anki auto-creates the parent. Sanitises `::` out of titles, falls back to `Untitled`.
- **Styling refresh on every sync.** Always pushes canonical CSS + templates via `updateModelStyling` / `updateModelTemplates` after `ensureAnkifyModels`. Cheap, idempotent, self-heals desktop Anki installs that pulled an empty-CSS variant of the model from AnkiWeb during earlier sync attempts.
- **Notion images.** Walker now picks up `image`-type children of toggles. `external` URLs are referenced directly; `file` URLs are downloaded and pushed to AnkiConnect via `storeMediaFile` with a stable `ankify-<blockId>.<ext>` filename so they survive the Notion signed-URL expiry.

## Why

Al's first real polling tick today created 42 cards across 4 subscriptions. In desktop Anki he saw: one giant flat deck, no styling, no images. After this:

- New cards land in `Notion Sync::<page>` per subscription — students keep the page-level hierarchy in Anki.
- `ensureAnkifyModels` no longer relies on the model's first-create being authoritative; the canonical CSS is repushed every sync.
- Toggles with images actually render the image, not a paragraph hole.

Direct path to the 300K-user goal: Ankify's whole pitch is "study Notion in Anki without thinking about it." Decks that are organised, styled, and visually complete are the ship-stopper for keeping users.

## How

- `SyncNotionPageToRacUseCase`:
  - `buildDeckName(title)` derives `Notion Sync::<sanitized>` (strip `::`, trim, fallback `Untitled`); used at `createDeck`, `addNote.deckName`, and `mappings.upsert.deck_name`.
  - `refreshAnkifyModelStyling` runs after `ensureAnkifyModels` and pushes CSS + templates for both `Ankify Basic` and `Ankify Cloze`.
  - `uploadCardImages` runs before each `addNote`. File-type images are fetched, base64-encoded, and sent to `storeMediaFile`. Download failures push to `result.errors` (which already flows to `sync_logs`), the card still gets added.
  - New optional `imageFetcher: typeof fetch` constructor param; defaults to `fetch`. Test-only injection point.
- `notionPageWalker`:
  - Adds `WalkedNotionImageRef` (`{block_id, source, url, filename?}`) to `WalkedNotionFlashcard`.
  - Recognises `image` children: emits `<img src="...">` in the back text and tracks the ref. `file` images get a deterministic filename; `external` images keep their URL.
- `AnkiConnectClient`: adds `updateModelStyling`, `updateModelTemplates`, `storeMediaFile` methods + matching `*Params` interfaces.

## Testing

- Unit tests added:
  - [x] Walker: extracts file-type image, embeds `<img>`, returns ref with derived filename
  - [x] Walker: keeps external image URL as-is, no filename
  - [x] Walker: skips empty-front toggles (regression)
  - [x] AnkiConnectClient: `updateModelStyling`, `updateModelTemplates`, `storeMediaFile` send the right action + params shape
  - [x] Use case: `addNote` deck name nested under `Notion Sync::<title>`
  - [x] Use case: falls back to `Untitled` when title is null
  - [x] Use case: strips `::` from titles
  - [x] Use case: `updateModelStyling` + `updateModelTemplates` invoked after model ensure
  - [x] Use case: `storeMediaFile` called with base64 data **before** `addNote`
  - [x] Use case: external images skip `storeMediaFile`
  - [x] Use case: image download failure logs an error and still calls `addNote`
- Manually verified:
  - [x] Container's AnkiConnect `modelStyling` already returns full CSS — confirmed before shipping the styling refresh; we ship it because Al's desktop is downstream of AnkiWeb where an earlier empty-CSS variant of the model is the most plausible cause.
  - [ ] After deploy, Al confirms the next polling tick produces nested decks + styled cards + visible images.
- `pnpm build`, web typecheck, web vitest, web biome lint: all clean.
- Server-side `pnpm test src/services/ankify/ src/usecases/ankify/`: 84 passed, 0 failed.

## Risks

- AnkiConnect `updateModelTemplates` adds two extra round-trips per sync. Both calls are local container traffic so the cost is negligible vs. the Notion fetch.
- Image downloads happen synchronously in the walker loop. A 5-image card hits `fetch` 5 times in series. If this bites we move to a job queue, but for the typical 0–2 images per toggle it's fine.
- Risk of double-base64-encoding on retried syncs is nil — `storeMediaFile` is idempotent on (filename, content).

## Notes

- Existing 42 cards in Al's flat `Notion Sync` deck stay where they are. Their mappings match by `source_id` on the next poll, hit the `existing != null` branch, and reconcile via `updateNoteFields` — the deck is not changed for already-mapped cards. If Al wants a clean nested layout he can delete the 42 cards manually; the next poll re-creates them in the new structure.
- AnkiWeb sync still runs at the end of every successful sync; first nested-deck sync after this PR will push the new `Notion Sync::<page>` decks to AnkiWeb so desktop Anki sees them.
- Stale `.js` artefacts removed from the touched ankify files (Jest was resolving them ahead of `.ts`, masking the new tests).

## Goal alignment

Hits all three pillars: **simpler** (decks organised by page; users don't search a wall of cards), **faster** (styling and images render correctly the first time, no manual fix-up), **more beautiful** (the whole point of Ankify is the aesthetic). Direct contributor toward the 300K-user goal — flashcards that look broken are the fastest way to lose a free trial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)