### PR TITLE
chore: tighten push safety and skip git-commit prompts

### DIFF
--- a/.claude/hooks/safety.py
+++ b/.claude/hooks/safety.py
@@ -3,7 +3,8 @@
 PreToolUse safety hook: blocks foot-gun shell commands.
 
 Currently blocks:
-  * git push --force / -f / +ref to main or master
+  * git push to main or master (force or not)
+  * bare `git push` with no remote+branch — forces explicit branch name
   * git reset --hard when there are uncommitted changes
   * rm -rf against /, ~, $HOME, or parent directories
 
@@ -33,18 +34,30 @@ def deny(reason):
 
 
 PROTECTED_BRANCH = re.compile(r"\b(main|master)\b")
-FORCE_FLAG = re.compile(r"(?:--force(?:-with-lease)?|(?:^|\s)-f(?:\s|$))")
-PLUS_REF = re.compile(r"\s\+(?:main|master)\b")
+GIT_PUSH = re.compile(r"\bgit\s+push\b")
 
 
-def is_force_push_to_protected(cmd):
-    if "git push" not in cmd:
+def push_args(cmd):
+    if not GIT_PUSH.search(cmd):
+        return None
+    after = GIT_PUSH.split(cmd, 1)[1]
+    after = re.split(r"[;&|]", after, 1)[0]
+    return after
+
+
+def is_push_to_protected(cmd):
+    after = push_args(cmd)
+    if after is None:
         return False
-    has_force = bool(FORCE_FLAG.search(cmd))
-    has_plus = bool(PLUS_REF.search(cmd))
-    if not (has_force or has_plus):
+    return bool(PROTECTED_BRANCH.search(after))
+
+
+def is_bare_push(cmd):
+    after = push_args(cmd)
+    if after is None:
         return False
-    return bool(PROTECTED_BRANCH.search(cmd))
+    non_flags = [t for t in after.split() if not t.startswith("-")]
+    return len(non_flags) < 2
 
 
 def has_uncommitted_changes():
@@ -93,10 +106,17 @@ def main():
 
     cmd = data.get("tool_input", {}).get("command", "")
 
-    if is_force_push_to_protected(cmd):
+    if is_push_to_protected(cmd):
         deny(
-            "Refusing force-push to main/master — rewrites shared history.\n"
+            "Refusing to push to main/master — push to a feature branch and open a PR.\n"
             "If you genuinely need this, prefix with CLAUDE_SKIP_SAFETY=1."
+        )
+
+    if is_bare_push(cmd):
+        deny(
+            "Refusing bare `git push` — always specify the remote and branch explicitly\n"
+            "(e.g. `git push origin <branch-name>`) so we never push to main by accident.\n"
+            "Bypass with CLAUDE_SKIP_SAFETY=1 if intentional."
         )
 
     if is_reset_hard_with_uncommitted(cmd):

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(git commit *)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Express/TypeScript server that converts Notion pages and file uploads into Anki 
 - Use conventional commit prefixes (e.g. fix:, feat:, chore:, refactor:, test:, docs:)
 - Suggest a branch name before starting any code changes
 - Always rebase on origin/main before creating a new branch or opening a PR
+- When a unit of work is done, ship it without asking: commit, push the branch (always `git push -u origin <branch>` — never bare `git push`, never to main), then open a draft PR with `gh pr create --draft`. The safety hook in `.claude/hooks/safety.py` blocks pushes to main and bare `git push` as a backstop.
 
 ## General
 


### PR DESCRIPTION
## Summary

- Allow `Bash(git commit *)` in committed `.claude/settings.json` — no more permission prompt on every commit. Commit content is still vetted by `check-commit-message.py`.
- Replace the narrow "force-push to main" guard in `.claude/hooks/safety.py` with two broader checks: deny any push whose args mention `main`/`master` (covers `-u`, `HEAD:main`, refspecs, force or not) and deny bare `git push` (forces explicit `origin <branch>`). `CLAUDE_SKIP_SAFETY=1` still bypasses for the rare legitimate case.
- Document the resulting end-of-task flow in CLAUDE.md: ship without asking — commit, push branch with `-u`, open a draft PR.

## Test plan

- [x] Pipe-tested `safety.py` against 11 push variants (`origin main`, `-u origin main`, `HEAD:main`, bare push, `--tags`, `origin` only, force variants, normal feature pushes, `git commit`) — each returns the expected allow/deny.
- [x] Settings JSON parses cleanly with `Bash(git commit *)` present.
- [ ] Reviewer: skim the new CLAUDE.md bullet under `## Git` and confirm the workflow matches expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
