### PR TITLE
feat(ankify): add "Update now" menu item to bypass 5-min polling

### DIFF
--- a/src/controllers/AnkifyController.ts
+++ b/src/controllers/AnkifyController.ts
@@ -29,6 +29,11 @@ import { CheckAnkiWebStatusUseCase } from '../usecases/ankify/CheckAnkiWebStatus
 import ReissueAnkifySessionUrlUseCase from '../usecases/ankify/ReissueAnkifySessionUrlUseCase';
 import { ValidateAnkifySessionTokenUseCase } from '../usecases/ankify/ValidateAnkifySessionTokenUseCase';
 import { SyncNotionPageToRacUseCase } from '../usecases/ankify/SyncNotionPageToRacUseCase';
+import {
+  RefreshAnkifySubscriptionUseCase,
+  RefreshCooldownError,
+  SubscriptionNotFoundError,
+} from '../usecases/ankify/RefreshAnkifySubscriptionUseCase';
 import { ListNotionSubscriptionsUseCase } from '../usecases/ankify/ListNotionSubscriptionsUseCase';
 import { DeleteNotionSubscriptionUseCase } from '../usecases/ankify/DeleteNotionSubscriptionUseCase';
 import { ListConflictsUseCase } from '../usecases/ankify/ListConflictsUseCase';
@@ -58,6 +63,7 @@ class AnkifyController {
     private readonly syncNotionPageUseCase: SyncNotionPageToRacUseCase,
     private readonly listSubscriptionsUseCase: ListNotionSubscriptionsUseCase,
     private readonly deleteSubscriptionUseCase: DeleteNotionSubscriptionUseCase,
+    private readonly refreshSubscriptionUseCase: RefreshAnkifySubscriptionUseCase,
     private readonly listConflictsUseCase: ListConflictsUseCase,
     private readonly resolveConflictUseCase: ResolveConflictUseCase,
     private readonly listNotionDatabasesUseCase: ListNotionDatabasesUseCase,
@@ -372,6 +378,62 @@ class AnkifyController {
     }
     await this.deleteSubscriptionUseCase.execute(id, owner);
     res.status(204).send();
+  }
+
+  async refreshSubscription(req: Request, res: Response) {
+    const owner = res.locals.owner as number;
+    const id = Number.parseInt(req.params.id, 10);
+    if (!Number.isFinite(id)) {
+      res.status(400).json({ message: 'Invalid subscription id' });
+      return;
+    }
+    try {
+      const result = await this.refreshSubscriptionUseCase.execute({
+        id,
+        owner,
+      });
+      res.status(200).json({
+        subscription: result.subscription,
+        created: result.created,
+        updated: result.updated,
+        conflicts: result.conflicts,
+        unchanged: result.unchanged,
+        errors: result.errors,
+        anki_web_sync: result.ankiWebSync,
+        anki_web_sync_error: result.ankiWebSyncError,
+      });
+    } catch (error) {
+      if (error instanceof SubscriptionNotFoundError) {
+        res.status(404).json({ message: 'Subscription not found' });
+        return;
+      }
+      if (error instanceof RefreshCooldownError) {
+        res
+          .status(429)
+          .set('Retry-After', String(error.retryAfterSeconds))
+          .json({
+            message: error.message,
+            retry_after_seconds: error.retryAfterSeconds,
+          });
+        return;
+      }
+      if (error instanceof NoActiveAnkifyClientError) {
+        res.status(409).json({
+          message:
+            'No active Ankify client. Provision one before refreshing.',
+        });
+        return;
+      }
+      if (error instanceof NotionNotConnectedError) {
+        res.status(409).json({ message: 'Notion is not connected' });
+        return;
+      }
+      if (error instanceof AnkiConnectUnreachableError) {
+        res.status(503).json({ message: 'AnkiConnect is unreachable.' });
+        return;
+      }
+      throw error;
+    }
   }
 
   async listConflicts(req: Request, res: Response) {

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -23,6 +23,7 @@ import { AnkifySyncLogsRepository } from '../data_layer/ankify/AnkifySyncLogsRep
 import { AnkifyNotionSubscriptionsRepository } from '../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import { AnkifySyncConflictsRepository } from '../data_layer/ankify/AnkifySyncConflictsRepository';
 import { SyncNotionPageToRacUseCase } from '../usecases/ankify/SyncNotionPageToRacUseCase';
+import { RefreshAnkifySubscriptionUseCase } from '../usecases/ankify/RefreshAnkifySubscriptionUseCase';
 import { ListNotionSubscriptionsUseCase } from '../usecases/ankify/ListNotionSubscriptionsUseCase';
 import { DeleteNotionSubscriptionUseCase } from '../usecases/ankify/DeleteNotionSubscriptionUseCase';
 import { ListConflictsUseCase } from '../usecases/ankify/ListConflictsUseCase';
@@ -328,6 +329,18 @@ const AnkifyRouter = () => {
     return Buffer.isBuffer(body) ? body : Buffer.from(body as Uint8Array);
   };
 
+  const syncNotionPageUseCase = new SyncNotionPageToRacUseCase(
+    repo,
+    mappings,
+    conflictsRepo,
+    subscriptionsRepo,
+    logsRepo,
+    new NotionRepository(db),
+    ankiConnectFactory,
+    notionBlockChildrenFetcherFactory,
+    buildNotionPageMetaFetcher
+  );
+
   const controller = new AnkifyController(
     new ProvisionAnkifyClientUseCase(rac),
     new ListAnkifyClientsUseCase(rac),
@@ -352,19 +365,13 @@ const AnkifyRouter = () => {
     new GetExportScheduleUseCase(schedulesRepo),
     new DeleteExportScheduleUseCase(schedulesRepo, getAnkifyExportScheduler),
     new ListSyncLogsUseCase(logsRepo),
-    new SyncNotionPageToRacUseCase(
-      repo,
-      mappings,
-      conflictsRepo,
-      subscriptionsRepo,
-      logsRepo,
-      new NotionRepository(db),
-      ankiConnectFactory,
-      notionBlockChildrenFetcherFactory,
-      buildNotionPageMetaFetcher
-    ),
+    syncNotionPageUseCase,
     new ListNotionSubscriptionsUseCase(subscriptionsRepo),
     new DeleteNotionSubscriptionUseCase(subscriptionsRepo),
+    new RefreshAnkifySubscriptionUseCase(
+      subscriptionsRepo,
+      syncNotionPageUseCase
+    ),
     new ListConflictsUseCase(conflictsRepo),
     new ResolveConflictUseCase(
       repo,
@@ -656,6 +663,39 @@ const AnkifyRouter = () => {
     '/api/ankify/subscriptions/:id',
     RequireAnkifyAccess,
     (req, res) => controller.deleteSubscription(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ankify/subscriptions/{id}/refresh:
+   *   post:
+   *     summary: Manually pull a subscribed Notion page right now
+   *     description: Allowlisted endpoint. Re-runs the Notion → hosted Anki pull for the given subscription, bypassing the 5-minute polling cycle. Per-subscription 30-second cooldown enforced server-side; returns 429 with Retry-After when on cooldown.
+   *     tags: [Ankify]
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: integer
+   *     responses:
+   *       200:
+   *         description: Refresh result (created/updated/conflicts/unchanged)
+   *       400:
+   *         description: Invalid subscription id
+   *       404:
+   *         description: Subscription not found for this user
+   *       409:
+   *         description: No active Ankify client or Notion not connected
+   *       429:
+   *         description: Cooldown — wait Retry-After seconds and try again
+   *       503:
+   *         description: AnkiConnect unreachable
+   */
+  router.post(
+    '/api/ankify/subscriptions/:id/refresh',
+    RequireAnkifyAccess,
+    (req, res) => controller.refreshSubscription(req, res)
   );
 
   /**

--- a/src/usecases/ankify/RefreshAnkifySubscriptionUseCase.test.ts
+++ b/src/usecases/ankify/RefreshAnkifySubscriptionUseCase.test.ts
@@ -1,0 +1,192 @@
+import {
+  RefreshAnkifySubscriptionUseCase,
+  RefreshCooldownError,
+  SubscriptionNotFoundError,
+} from './RefreshAnkifySubscriptionUseCase';
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import { SyncNotionPageToRacUseCase } from './SyncNotionPageToRacUseCase';
+import { AnkifyNotionSubscription } from '../../entities/ankify';
+
+const sampleSubscription = (
+  overrides: Partial<AnkifyNotionSubscription> = {}
+): AnkifyNotionSubscription => ({
+  id: 7,
+  owner: 42,
+  ankify_client_id: 1,
+  notion_page_id: 'page-abc',
+  notion_page_title: 'My Notes',
+  notion_page_url: 'https://notion.so/page-abc',
+  notion_page_icon: '📓',
+  enabled: true,
+  last_polled_at: null,
+  last_synced_at: null,
+  last_error: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+  ...overrides,
+});
+
+const makeSubscriptionsRepo = (
+  subscription: AnkifyNotionSubscription | null
+): jest.Mocked<AnkifyNotionSubscriptionsRepositoryInterface> =>
+  ({
+    upsert: jest.fn(),
+    listByOwner: jest.fn(),
+    listEnabled: jest.fn(),
+    findByPageId: jest.fn(),
+    findById: jest.fn(async () => subscription),
+    setEnabled: jest.fn(),
+    deleteById: jest.fn(),
+    recordPoll: jest.fn(),
+  } as unknown as jest.Mocked<AnkifyNotionSubscriptionsRepositoryInterface>);
+
+const makeSyncUseCase = (): jest.Mocked<
+  Pick<SyncNotionPageToRacUseCase, 'execute'>
+> => ({
+  execute: jest.fn(async (_input) => ({
+    client: {} as never,
+    subscription: sampleSubscription(),
+    created: 2,
+    updated: 1,
+    conflicts: 0,
+    unchanged: 5,
+    errors: [],
+    ankiWebSync: 'synced' as const,
+    ankiWebSyncError: null,
+  })),
+});
+
+describe('RefreshAnkifySubscriptionUseCase', () => {
+  it('throws SubscriptionNotFoundError when the subscription does not exist for that owner', async () => {
+    const subs = makeSubscriptionsRepo(null);
+    const sync = makeSyncUseCase();
+    const useCase = new RefreshAnkifySubscriptionUseCase(
+      subs,
+      sync as unknown as SyncNotionPageToRacUseCase
+    );
+
+    await expect(useCase.execute({ id: 7, owner: 42 })).rejects.toBeInstanceOf(
+      SubscriptionNotFoundError
+    );
+    expect(subs.findById).toHaveBeenCalledWith(7, 42);
+    expect(sync.execute).not.toHaveBeenCalled();
+  });
+
+  it('delegates to the sync use case with the stored Notion page fields and trigger=manual', async () => {
+    const subscription = sampleSubscription({ id: 7, owner: 42 });
+    const subs = makeSubscriptionsRepo(subscription);
+    const sync = makeSyncUseCase();
+    const useCase = new RefreshAnkifySubscriptionUseCase(
+      subs,
+      sync as unknown as SyncNotionPageToRacUseCase
+    );
+
+    const result = await useCase.execute({
+      id: 7,
+      owner: 42,
+      ankiConnectHost: 'localhost',
+    });
+
+    expect(sync.execute).toHaveBeenCalledWith({
+      owner: 42,
+      notionPageId: 'page-abc',
+      notionPageTitle: 'My Notes',
+      notionPageUrl: 'https://notion.so/page-abc',
+      notionPageIcon: '📓',
+      trigger: 'manual',
+      ankiConnectHost: 'localhost',
+    });
+    expect(result.created).toBe(2);
+  });
+
+  it('throws RefreshCooldownError on a second call inside the cooldown window', async () => {
+    const subscription = sampleSubscription();
+    const subs = makeSubscriptionsRepo(subscription);
+    const sync = makeSyncUseCase();
+    let now = 1_000_000;
+    const useCase = new RefreshAnkifySubscriptionUseCase(
+      subs,
+      sync as unknown as SyncNotionPageToRacUseCase,
+      30_000,
+      () => now
+    );
+
+    await useCase.execute({ id: 7, owner: 42 });
+    now += 5_000;
+
+    await expect(useCase.execute({ id: 7, owner: 42 })).rejects.toMatchObject({
+      name: 'RefreshCooldownError',
+      retryAfterSeconds: 25,
+    });
+    expect(sync.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a second call once the cooldown has elapsed', async () => {
+    const subscription = sampleSubscription();
+    const subs = makeSubscriptionsRepo(subscription);
+    const sync = makeSyncUseCase();
+    let now = 1_000_000;
+    const useCase = new RefreshAnkifySubscriptionUseCase(
+      subs,
+      sync as unknown as SyncNotionPageToRacUseCase,
+      30_000,
+      () => now
+    );
+
+    await useCase.execute({ id: 7, owner: 42 });
+    now += 30_000;
+    await useCase.execute({ id: 7, owner: 42 });
+
+    expect(sync.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('records the cooldown stamp before the underlying sync runs so spam during a long sync is blocked', async () => {
+    const subscription = sampleSubscription();
+    const subs = makeSubscriptionsRepo(subscription);
+    const release: { fn: (() => void) | null } = { fn: null };
+    const slowSync = {
+      execute: jest.fn(
+        (_input) =>
+          new Promise<{
+            client: never;
+            subscription: AnkifyNotionSubscription;
+            created: number;
+            updated: number;
+            conflicts: number;
+            unchanged: number;
+            errors: string[];
+            ankiWebSync: 'synced' | 'failed' | 'skipped';
+            ankiWebSyncError: string | null;
+          }>((resolve) => {
+            release.fn = () =>
+              resolve({
+                client: {} as never,
+                subscription,
+                created: 0,
+                updated: 0,
+                conflicts: 0,
+                unchanged: 0,
+                errors: [],
+                ankiWebSync: 'skipped',
+                ankiWebSyncError: null,
+              });
+          })
+      ),
+    };
+    const useCase = new RefreshAnkifySubscriptionUseCase(
+      subs,
+      slowSync as unknown as SyncNotionPageToRacUseCase,
+      30_000
+    );
+
+    const inflight = useCase.execute({ id: 7, owner: 42 });
+    await Promise.resolve();
+
+    await expect(useCase.execute({ id: 7, owner: 42 })).rejects.toBeInstanceOf(
+      RefreshCooldownError
+    );
+
+    release.fn?.();
+    await inflight;
+  });
+});

--- a/src/usecases/ankify/RefreshAnkifySubscriptionUseCase.ts
+++ b/src/usecases/ankify/RefreshAnkifySubscriptionUseCase.ts
@@ -1,0 +1,71 @@
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import {
+  SyncNotionPageResult,
+  SyncNotionPageToRacUseCase,
+} from './SyncNotionPageToRacUseCase';
+
+export class SubscriptionNotFoundError extends Error {
+  constructor() {
+    super('Subscription not found');
+    this.name = 'SubscriptionNotFoundError';
+  }
+}
+
+export class RefreshCooldownError extends Error {
+  constructor(public readonly retryAfterSeconds: number) {
+    super(`Refresh on cooldown — retry in ${retryAfterSeconds}s`);
+    this.name = 'RefreshCooldownError';
+  }
+}
+
+export interface RefreshAnkifySubscriptionInput {
+  id: number;
+  owner: number;
+  ankiConnectHost?: string;
+}
+
+const DEFAULT_COOLDOWN_MS = 30_000;
+
+export class RefreshAnkifySubscriptionUseCase {
+  private readonly lastRunAtBySubscription = new Map<number, number>();
+
+  constructor(
+    private readonly subscriptions: AnkifyNotionSubscriptionsRepositoryInterface,
+    private readonly syncNotionPageUseCase: SyncNotionPageToRacUseCase,
+    private readonly cooldownMs: number = DEFAULT_COOLDOWN_MS,
+    private readonly now: () => number = () => Date.now()
+  ) {}
+
+  async execute(
+    input: RefreshAnkifySubscriptionInput
+  ): Promise<SyncNotionPageResult> {
+    const subscription = await this.subscriptions.findById(input.id, input.owner);
+    if (subscription == null) {
+      throw new SubscriptionNotFoundError();
+    }
+
+    const startedAt = this.now();
+    const previous = this.lastRunAtBySubscription.get(subscription.id);
+    if (previous != null) {
+      const elapsedMs = startedAt - previous;
+      if (elapsedMs < this.cooldownMs) {
+        const retryAfterSeconds = Math.max(
+          1,
+          Math.ceil((this.cooldownMs - elapsedMs) / 1000)
+        );
+        throw new RefreshCooldownError(retryAfterSeconds);
+      }
+    }
+    this.lastRunAtBySubscription.set(subscription.id, startedAt);
+
+    return this.syncNotionPageUseCase.execute({
+      owner: input.owner,
+      notionPageId: subscription.notion_page_id,
+      notionPageTitle: subscription.notion_page_title,
+      notionPageUrl: subscription.notion_page_url,
+      notionPageIcon: subscription.notion_page_icon,
+      trigger: 'manual',
+      ankiConnectHost: input.ankiConnectHost,
+    });
+  }
+}

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -29,6 +29,8 @@ export class TrackerSchemaError extends Error {
   }
 }
 
+export type AnkiWebSyncStatus = 'synced' | 'failed' | 'skipped';
+
 export class Backend {
   public baseURL = '/api/';
 
@@ -438,7 +440,7 @@ export class Backend {
     conflicts: number;
     unchanged: number;
     errors: string[];
-    anki_web_sync: 'synced' | 'failed' | 'skipped';
+    anki_web_sync: AnkiWebSyncStatus;
     anki_web_sync_error: string | null;
   }> {
     const response = await post(`${this.baseURL}ankify/subscriptions`, {
@@ -471,7 +473,7 @@ export class Backend {
     conflicts: number;
     unchanged: number;
     errors: string[];
-    anki_web_sync: 'synced' | 'failed' | 'skipped';
+    anki_web_sync: AnkiWebSyncStatus;
     anki_web_sync_error: string | null;
   }> {
     const response = await post(
@@ -614,7 +616,7 @@ export class Backend {
     created: number;
     updated: number;
     errors: string[];
-    anki_web_sync: 'synced' | 'failed' | 'skipped';
+    anki_web_sync: AnkiWebSyncStatus;
     anki_web_sync_error: string | null;
   }> {
     const response = await post(`${this.baseURL}ankify/dispatch`, {

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -465,6 +465,36 @@ export class Backend {
     }
   }
 
+  async refreshAnkifySubscription(id: number): Promise<{
+    created: number;
+    updated: number;
+    conflicts: number;
+    unchanged: number;
+    errors: string[];
+    anki_web_sync: 'synced' | 'failed' | 'skipped';
+    anki_web_sync_error: string | null;
+  }> {
+    const response = await post(
+      `${this.baseURL}ankify/subscriptions/${id}/refresh`,
+      {}
+    );
+    if (!response.ok) {
+      const body = await response
+        .json()
+        .catch(() => ({ message: response.statusText }));
+      const error = new Error(body.message ?? 'Failed to update deck') as Error & {
+        status?: number;
+        retryAfterSeconds?: number;
+      };
+      error.status = response.status;
+      if (typeof body.retry_after_seconds === 'number') {
+        error.retryAfterSeconds = body.retry_after_seconds;
+      }
+      throw error;
+    }
+    return response.json();
+  }
+
   async listAnkifyConflicts(): Promise<
     Array<{
       id: number;

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -262,6 +262,211 @@ describe('NotionSubscriptions sync copy', () => {
       expect(
         screen.getByText(/preparing your first sync/i)
       ).toBeInTheDocument()
+    );
+  });
+
+  test('kebab menu shows "Update now" with a per-deck aria-label, above "Stop"', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({ id: 11, notion_page_id: 'a'.repeat(32) }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    const kebab = await screen.findByRole('button', {
+      name: /options for my deck/i,
+    });
+    fireEvent.click(kebab);
+
+    const updateItem = await screen.findByRole('menuitem', {
+      name: /update my deck now/i,
+    });
+    const stopItem = screen.getByRole('menuitem', { name: /^stop$/i });
+    expect(updateItem).toBeInTheDocument();
+    expect(stopItem).toBeInTheDocument();
+    expect(updateItem.compareDocumentPosition(stopItem)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+  });
+
+  test('clicking "Update now" calls refreshAnkifySubscription with the row id and shows a success flash', async () => {
+    const refresh = vi.fn(async (_id: number) => ({
+      created: 3,
+      updated: 1,
+      conflicts: 0,
+      unchanged: 5,
+      errors: [],
+      anki_web_sync: 'synced' as const,
+      anki_web_sync_error: null,
+    }));
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({ id: 11, notion_page_id: 'a'.repeat(32) }),
+      ]),
+      refreshAnkifySubscription: refresh,
+    });
+
+    renderSubs(backend);
+
+    const kebab = await screen.findByRole('button', {
+      name: /options for my deck/i,
+    });
+    fireEvent.click(kebab);
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: /update my deck now/i })
+    );
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledWith(11));
+    expect(
+      await screen.findByText(/updated · 3 new, 1 changed/i)
+    ).toBeInTheDocument();
+  });
+
+  test('a refresh that returns no changes shows "Already up to date"', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({ id: 12, notion_page_id: 'b'.repeat(32) }),
+      ]),
+      refreshAnkifySubscription: vi.fn(async () => ({
+        created: 0,
+        updated: 0,
+        conflicts: 0,
+        unchanged: 9,
+        errors: [],
+        anki_web_sync: 'skipped' as const,
+        anki_web_sync_error: null,
+      })),
+    });
+
+    renderSubs(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /options for my deck/i })
+    );
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: /update my deck now/i })
+    );
+
+    expect(
+      await screen.findByText(/already up to date/i)
+    ).toBeInTheDocument();
+  });
+
+  test('a 429 cooldown error renders inline retry guidance', async () => {
+    const cooldownError = Object.assign(new Error('cooldown'), {
+      status: 429,
+      retryAfterSeconds: 22,
+    });
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({ id: 13, notion_page_id: 'c'.repeat(32) }),
+      ]),
+      refreshAnkifySubscription: vi.fn(async () => {
+        throw cooldownError;
+      }),
+    });
+
+    renderSubs(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /options for my deck/i })
+    );
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: /update my deck now/i })
+    );
+
+    expect(
+      await screen.findByText(/try again in 22s/i)
+    ).toBeInTheDocument();
+  });
+
+  test('a refresh that produced conflicts points the user at the banner above', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({ id: 14, notion_page_id: 'd'.repeat(32) }),
+      ]),
+      refreshAnkifySubscription: vi.fn(async () => ({
+        created: 0,
+        updated: 0,
+        conflicts: 2,
+        unchanged: 1,
+        errors: [],
+        anki_web_sync: 'skipped' as const,
+        anki_web_sync_error: null,
+      })),
+    });
+
+    renderSubs(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /options for my deck/i })
+    );
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: /update my deck now/i })
+    );
+
+    expect(
+      await screen.findByText(/needs a decision — see banner above/i)
+    ).toBeInTheDocument();
+  });
+
+  test('the row shows "Updating now…" while the refresh is in flight', async () => {
+    let resolveRefresh: (value: {
+      created: number;
+      updated: number;
+      conflicts: number;
+      unchanged: number;
+      errors: string[];
+      anki_web_sync: 'synced' | 'failed' | 'skipped';
+      anki_web_sync_error: string | null;
+    }) => void = () => undefined;
+    const refresh = vi.fn(
+      () =>
+        new Promise<{
+          created: number;
+          updated: number;
+          conflicts: number;
+          unchanged: number;
+          errors: string[];
+          anki_web_sync: 'synced' | 'failed' | 'skipped';
+          anki_web_sync_error: string | null;
+        }>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({ id: 15, notion_page_id: 'e'.repeat(32) }),
+      ]),
+      refreshAnkifySubscription: refresh,
+    });
+
+    renderSubs(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /options for my deck/i })
+    );
+    fireEvent.click(
+      await screen.findByRole('menuitem', { name: /update my deck now/i })
+    );
+
+    expect(await screen.findByText(/updating now…/i)).toBeInTheDocument();
+
+    await act(async () => {
+      resolveRefresh({
+        created: 1,
+        updated: 0,
+        conflicts: 0,
+        unchanged: 0,
+        errors: [],
+        anki_web_sync: 'synced',
+        anki_web_sync_error: null,
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText(/updating now…/i)).not.toBeInTheDocument()
     );
   });
 

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { formatDistanceToNow } from 'date-fns';
 
@@ -60,7 +60,60 @@ const formatScheduleTime = (
 };
 
 const SUBSCRIPTIONS_KEY = ['ankify-subscriptions'];
+const CONFLICTS_KEY = ['ankify-conflicts'];
 const SEARCH_THRESHOLD = 10;
+const FLASH_DURATION_MS = 4_000;
+
+interface RowFlash {
+  kind: 'success' | 'error' | 'conflict';
+  text: string;
+}
+
+const buildSuccessFlash = (result: {
+  created: number;
+  updated: number;
+  conflicts: number;
+}): RowFlash => {
+  if (result.conflicts > 0) {
+    return {
+      kind: 'conflict',
+      text: 'Needs a decision — see banner above',
+    };
+  }
+  if (result.created + result.updated === 0) {
+    return { kind: 'success', text: 'Already up to date' };
+  }
+  const cardWord = result.created === 1 ? 'card' : 'cards';
+  if (result.updated === 0) {
+    return {
+      kind: 'success',
+      text: `Updated · ${result.created} new ${cardWord}`,
+    };
+  }
+  if (result.created === 0) {
+    return {
+      kind: 'success',
+      text: `Updated · ${result.updated} changed`,
+    };
+  }
+  return {
+    kind: 'success',
+    text: `Updated · ${result.created} new, ${result.updated} changed`,
+  };
+};
+
+const errorFlashFor = (error: Error & {
+  status?: number;
+  retryAfterSeconds?: number;
+}): RowFlash => {
+  if (error.status === 429 && error.retryAfterSeconds != null) {
+    return {
+      kind: 'error',
+      text: `Try again in ${error.retryAfterSeconds}s`,
+    };
+  }
+  return { kind: 'error', text: "Couldn't update. Try again in a moment." };
+};
 
 const extractNotionId = (input: string): string => {
   const trimmed = input.trim();
@@ -103,6 +156,72 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
   const [search, setSearch] = useState('');
   const [openMenuId, setOpenMenuId] = useState<number | null>(null);
   const menuContainerRef = useRef<HTMLUListElement | null>(null);
+  const [refreshingIds, setRefreshingIds] = useState<Set<number>>(
+    () => new Set()
+  );
+  const [flashByRow, setFlashByRow] = useState<Record<number, RowFlash>>({});
+  const flashTimers = useRef<Map<number, ReturnType<typeof setTimeout>>>(
+    new Map()
+  );
+
+  useEffect(
+    () => () => {
+      flashTimers.current.forEach((handle) => clearTimeout(handle));
+      flashTimers.current.clear();
+    },
+    []
+  );
+
+  const showFlash = useCallback((id: number, flash: RowFlash) => {
+    setFlashByRow((prev) => ({ ...prev, [id]: flash }));
+    const previousTimer = flashTimers.current.get(id);
+    if (previousTimer != null) clearTimeout(previousTimer);
+    const handle = setTimeout(() => {
+      flashTimers.current.delete(id);
+      setFlashByRow((prev) => {
+        const { [id]: _omit, ...rest } = prev;
+        return rest;
+      });
+    }, FLASH_DURATION_MS);
+    flashTimers.current.set(id, handle);
+  }, []);
+
+  const handleRefresh = useCallback(
+    async (id: number) => {
+      setOpenMenuId(null);
+      setRefreshingIds((prev) => {
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+      setFlashByRow((prev) => {
+        const { [id]: _omit, ...rest } = prev;
+        return rest;
+      });
+      const previousTimer = flashTimers.current.get(id);
+      if (previousTimer != null) {
+        clearTimeout(previousTimer);
+        flashTimers.current.delete(id);
+      }
+      try {
+        const result = await api.refreshAnkifySubscription(id);
+        showFlash(id, buildSuccessFlash(result));
+        queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY });
+        if (result.conflicts > 0) {
+          queryClient.invalidateQueries({ queryKey: CONFLICTS_KEY });
+        }
+      } catch (error) {
+        showFlash(id, errorFlashFor(error as Error));
+      } finally {
+        setRefreshingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }
+    },
+    [api, queryClient, showFlash]
+  );
 
   const subs = useQuery({
     queryKey: SUBSCRIPTIONS_KEY,
@@ -392,10 +511,14 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                 sub.notion_page_title?.trim().length
                   ? sub.notion_page_title
                   : 'Untitled page';
-              const isUpdatingThisRow =
+              const isSubscribingThisRow =
                 subscribe.isPending &&
                 pendingId != null &&
                 normalizeId(pendingId) === normalizeId(sub.notion_page_id);
+              const isRefreshingThisRow = refreshingIds.has(sub.id);
+              const isUpdatingThisRow =
+                isSubscribingThisRow || isRefreshingThisRow;
+              const flash = flashByRow[sub.id] ?? null;
               const nextExportLabel =
                 schedule?.enabled === true &&
                 normalizeId(schedule.database_id) ===
@@ -452,12 +575,24 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                     )}
                     {secondLine}
                   </span>
-                  <span className={styles.decksItemTime}>
-                    {isUpdatingThisRow ? (
-                      <span aria-live="polite">Updating now…</span>
-                    ) : (
-                      lastSyncedDisplay
-                    )}
+                  <span className={styles.decksItemTime} aria-live="polite">
+                    {(() => {
+                      if (isUpdatingThisRow) return <span>Updating now…</span>;
+                      if (flash != null) {
+                        return (
+                          <span
+                            className={
+                              flash.kind === 'success'
+                                ? styles.muted
+                                : styles.decksItemError
+                            }
+                          >
+                            {flash.text}
+                          </span>
+                        );
+                      }
+                      return lastSyncedDisplay;
+                    })()}
                   </span>
                   <div className={styles.decksItemRowMenu}>
                     <button
@@ -476,6 +611,16 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                     </button>
                     {openMenuId === sub.id && (
                       <div role="menu" className={styles.decksItemMenu}>
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className={styles.decksItemMenuItem}
+                          aria-label={`Update ${displayTitle} now`}
+                          onClick={() => handleRefresh(sub.id)}
+                          disabled={isUpdatingThisRow}
+                        >
+                          Update now
+                        </button>
                         <button
                           type="button"
                           role="menuitem"


### PR DESCRIPTION
## Summary
- New kebab item on each Decks-tab row triggers an immediate Notion → hosted Anki pull, so users (and Al while testing) don't have to wait up to 5 minutes for the next poll.
- Backend: `POST /api/ankify/subscriptions/:id/refresh` reuses `SyncNotionPageToRacUseCase` with `trigger='manual'` and enforces a 30s per-subscription cooldown (in-memory `Map`, returns `429` + `Retry-After`).
- Frontend: kebab item labeled **"Update now"** above **"Stop"**; row swaps timestamp for in-flight `Updating now…`, then a 4s flash showing what happened (`Updated · 3 new, 1 changed` / `Already up to date` / `Needs a decision — see banner above` / error). Conflicts banner above re-fetches automatically.

## What's deliberately not in v1
- Global "Refresh all" — premature; one row at a time is the actual job-to-be-done for both testing and the impatient-user case.
- Per-page polling-interval picker — settings creep; manual button is the answer.
- Cross-restart cooldown persistence — solo-Alex scale, in-memory map is fine.

## Copy
- House style respected: no new "sync" word in any user copy. New strings: "Update now", "Updating now…" (reused), "Updated · N new, M changed", "Already up to date", "Needs a decision — see banner above", "Couldn't update. Try again in a moment.", "Try again in Xs".

## Test plan
- [ ] `pnpm test src/usecases/ankify/RefreshAnkifySubscriptionUseCase.test.ts` — 5 tests cover not-found, delegation w/ `trigger='manual'`, cooldown error w/ retry seconds, post-cooldown allowed, stamp-before-run blocks spam during in-flight sync.
- [ ] `cd web && pnpm test -- --run NotionSubscriptions.test` — 6 new tests: menu item presence + ordering, success flash, "Already up to date", 429 retry text, conflicts copy, in-flight `Updating now…`.
- [ ] Manual smoke on prod: open `/ankify`, click kebab on a row → "Update now" → see "Updating now…" → see flash → confirm `last_synced_at` advanced.
- [ ] Manual smoke on cooldown: click "Update now" twice in quick succession → second click within 30s shows "Try again in Xs".
- [ ] Manual smoke on conflict path: edit the same toggle in Notion + Anki, "Update now" → row shows "Needs a decision — see banner above", banner appears at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)