### PR TITLE
fix(ankify): coerce bigint note ids to number in repository reads

### DIFF
--- a/src/data_layer/ankify/AnkifySyncConflictsRepository.test.ts
+++ b/src/data_layer/ankify/AnkifySyncConflictsRepository.test.ts
@@ -1,0 +1,64 @@
+import { AnkifySyncConflict } from '../../entities/ankify';
+import { AnkifySyncConflictsRepository } from './AnkifySyncConflictsRepository';
+
+const stringNoteIdRow = {
+  id: 1,
+  owner: 1,
+  ankify_client_id: 17,
+  subscription_id: 10,
+  source_id: 'block-1',
+  anki_note_id: '1778341400653',
+  kind: 'both_edited',
+  notion_last_edited_at: new Date(),
+  anki_modified_at: '1778400000000',
+  notion_snapshot: { front: 'a', back: 'b' },
+  anki_snapshot: { front: 'c', back: 'd' },
+  status: 'pending',
+  resolution: null,
+  created_at: new Date(),
+  resolved_at: null,
+};
+
+function buildKnex(rowToReturn: unknown, rowsToReturn: unknown[] = []) {
+  const orderBy = jest.fn().mockReturnValue({
+    andWhere: jest.fn().mockReturnThis(),
+    then: (resolve: (rows: unknown[]) => unknown) =>
+      Promise.resolve(rowsToReturn).then(resolve),
+  });
+  const first = jest.fn().mockResolvedValue(rowToReturn);
+  const where = jest.fn().mockReturnValue({ first, orderBy });
+  const select = jest.fn().mockReturnValue({ where });
+  return jest.fn().mockReturnValue({ select });
+}
+
+describe('AnkifySyncConflictsRepository — bigint coercion', () => {
+  test('findById returns anki_note_id and anki_modified_at as numbers', async () => {
+    const knex = buildKnex(stringNoteIdRow);
+    const repo = new AnkifySyncConflictsRepository(knex as never);
+
+    const row = (await repo.findById(1, 1)) as AnkifySyncConflict;
+
+    expect(typeof row.anki_note_id).toBe('number');
+    expect(row.anki_note_id).toBe(1778341400653);
+    expect(typeof row.anki_modified_at).toBe('number');
+    expect(row.anki_modified_at).toBe(1778400000000);
+  });
+
+  test('findById preserves null anki_modified_at', async () => {
+    const knex = buildKnex({ ...stringNoteIdRow, anki_modified_at: null });
+    const repo = new AnkifySyncConflictsRepository(knex as never);
+
+    const row = (await repo.findById(1, 1)) as AnkifySyncConflict;
+
+    expect(row.anki_modified_at).toBeNull();
+  });
+
+  test('findById returns null untouched when no row exists', async () => {
+    const knex = buildKnex(undefined);
+    const repo = new AnkifySyncConflictsRepository(knex as never);
+
+    const row = await repo.findById(1, 1);
+
+    expect(row).toBeNull();
+  });
+});

--- a/src/data_layer/ankify/AnkifySyncConflictsRepository.ts
+++ b/src/data_layer/ankify/AnkifySyncConflictsRepository.ts
@@ -8,6 +8,14 @@ import {
 
 const TABLE = 'ankify_sync_conflicts';
 
+const fromRow = (row: AnkifySyncConflict): AnkifySyncConflict => ({
+  ...row,
+  anki_note_id: Number(row.anki_note_id),
+  anki_modified_at: row.anki_modified_at == null
+    ? null
+    : Number(row.anki_modified_at),
+});
+
 export interface AnkifySyncConflictsRepositoryInterface {
   recordOrFindPending(
     input: NewAnkifySyncConflict
@@ -45,7 +53,7 @@ export class AnkifySyncConflictsRepository
       })
       .first();
     if (existing != null) {
-      return existing;
+      return fromRow(existing);
     }
     const [row] = await this.database<AnkifySyncConflict>(TABLE)
       .insert({
@@ -66,10 +74,10 @@ export class AnkifySyncConflictsRepository
         status: 'pending',
       })
       .returning('*');
-    return row;
+    return fromRow(row);
   }
 
-  listByOwner(
+  async listByOwner(
     owner: number,
     options: { status?: string } = {}
   ): Promise<AnkifySyncConflict[]> {
@@ -80,7 +88,8 @@ export class AnkifySyncConflictsRepository
     if (options.status != null) {
       query.andWhere({ status: options.status });
     }
-    return query;
+    const rows = await query;
+    return rows.map(fromRow);
   }
 
   async findById(
@@ -91,7 +100,7 @@ export class AnkifySyncConflictsRepository
       .select('*')
       .where({ id, owner })
       .first();
-    return row ?? null;
+    return row == null ? null : fromRow(row);
   }
 
   async resolve(

--- a/src/data_layer/ankify/AnkifySyncMappingsRepository.test.ts
+++ b/src/data_layer/ankify/AnkifySyncMappingsRepository.test.ts
@@ -1,0 +1,67 @@
+import { AnkifySyncMapping } from '../../entities/ankify';
+import { AnkifySyncMappingsRepository } from './AnkifySyncMappingsRepository';
+
+const stringNoteIdRow = {
+  id: 43,
+  ankify_client_id: 17,
+  source_id: 'block-1',
+  source_type: 'notion_block',
+  anki_note_id: '1778341400653',
+  deck_name: 'Notion Sync::Hva og når skal vi spise?',
+  last_synced_at: new Date(),
+};
+
+function buildKnex(rowToReturn: unknown) {
+  const first = jest.fn().mockResolvedValue(rowToReturn);
+  const orderBy = jest.fn().mockReturnValue(Promise.resolve([rowToReturn]));
+  const select = jest.fn().mockReturnValue({
+    where: jest.fn().mockReturnValue({ first, orderBy }),
+  });
+  const tableBuilder = { select };
+  return jest.fn().mockReturnValue(tableBuilder);
+}
+
+describe('AnkifySyncMappingsRepository — bigint coercion', () => {
+  test('findBySourceId returns anki_note_id as a number even when pg yields a bigint string', async () => {
+    const knex = buildKnex(stringNoteIdRow);
+    const repo = new AnkifySyncMappingsRepository(knex as never);
+
+    const row = (await repo.findBySourceId(17, 'block-1')) as AnkifySyncMapping;
+
+    expect(row).not.toBeNull();
+    expect(typeof row.anki_note_id).toBe('number');
+    expect(row.anki_note_id).toBe(1778341400653);
+  });
+
+  test('findByAnkiNoteId returns anki_note_id as a number', async () => {
+    const knex = buildKnex(stringNoteIdRow);
+    const repo = new AnkifySyncMappingsRepository(knex as never);
+
+    const row = (await repo.findByAnkiNoteId(
+      17,
+      1778341400653
+    )) as AnkifySyncMapping;
+
+    expect(typeof row.anki_note_id).toBe('number');
+    expect(row.anki_note_id).toBe(1778341400653);
+  });
+
+  test('listByClient maps every row through the coercion', async () => {
+    const knex = buildKnex(stringNoteIdRow);
+    const repo = new AnkifySyncMappingsRepository(knex as never);
+
+    const rows = await repo.listByClient(17);
+
+    expect(rows).toHaveLength(1);
+    expect(typeof rows[0].anki_note_id).toBe('number');
+  });
+
+  test('findBySourceId returns null untouched when no row exists', async () => {
+    const knex = buildKnex(undefined);
+    const repo = new AnkifySyncMappingsRepository(knex as never);
+
+    const row = await repo.findBySourceId(17, 'missing');
+
+    expect(row).toBeNull();
+  });
+});

--- a/src/data_layer/ankify/AnkifySyncMappingsRepository.ts
+++ b/src/data_layer/ankify/AnkifySyncMappingsRepository.ts
@@ -7,6 +7,11 @@ import {
 
 const TABLE = 'ankify_sync_mappings';
 
+const fromRow = (row: AnkifySyncMapping): AnkifySyncMapping => ({
+  ...row,
+  anki_note_id: Number(row.anki_note_id),
+});
+
 export interface AnkifySyncMappingsRepositoryInterface {
   findBySourceId(
     ankifyClientId: number,
@@ -37,7 +42,7 @@ export class AnkifySyncMappingsRepository
       .select('*')
       .where({ ankify_client_id: ankifyClientId, source_id: sourceId })
       .first();
-    return row ?? null;
+    return row == null ? null : fromRow(row);
   }
 
   async upsert(input: NewAnkifySyncMapping): Promise<AnkifySyncMapping> {
@@ -57,14 +62,15 @@ export class AnkifySyncMappingsRepository
         last_synced_at: this.database.fn.now() as unknown as Date,
       })
       .returning('*');
-    return row;
+    return fromRow(row);
   }
 
-  listByClient(ankifyClientId: number): Promise<AnkifySyncMapping[]> {
-    return this.database<AnkifySyncMapping>(TABLE)
+  async listByClient(ankifyClientId: number): Promise<AnkifySyncMapping[]> {
+    const rows = await this.database<AnkifySyncMapping>(TABLE)
       .select('*')
       .where({ ankify_client_id: ankifyClientId })
       .orderBy('last_synced_at', 'desc');
+    return rows.map(fromRow);
   }
 
   async findByAnkiNoteId(
@@ -75,7 +81,7 @@ export class AnkifySyncMappingsRepository
       .select('*')
       .where({ ankify_client_id: ankifyClientId, anki_note_id: ankiNoteId })
       .first();
-    return row ?? null;
+    return row == null ? null : fromRow(row);
   }
 
   async deleteByAnkiNoteId(


### PR DESCRIPTION
## Summary

- node-postgres returns `bigint` columns as **strings**, so `anki_note_id` was flowing into AnkiConnect as `"1778318862219"` instead of `1778318862219`. The Python addon rejected every call with `'str' object cannot be interpreted as an integer`.
- Effect on prod: 12+ already-mapped notes for owner=1 errored on every poll inside `reconcileExistingCard` (`SyncNotionPageToRacUseCase.ts:375`). Notion edits never propagated to Anki and conflict detection was silently dead.
- Fix: coerce at the `data_layer/` seam so entities stay typed honestly. Same fix applied to `AnkifySyncConflictsRepository.anki_modified_at`.

Anki note ids are ms timestamps (~1.7e12), well below `Number.MAX_SAFE_INTEGER` (~9e15), so `Number()` is safe.

## Diagnosis trail

`ankify_sync_logs` payloads on prod made the bug obvious — every dispatch logged `created/updated/conflicts/unchanged: 0` plus a per-block error string from AnkiConnect. The pg-bigint-as-string default is the only thing that would produce that exact Python message.

## Test plan

- [x] `pnpm test src/data_layer/ankify/AnkifySyncMappingsRepository.test.ts` — failing tests assert `typeof anki_note_id === 'number'` for `findBySourceId`, `findByAnkiNoteId`, `listByClient`; pass after the fix.
- [x] `pnpm test src/data_layer/ankify/AnkifySyncConflictsRepository.test.ts` — same shape for conflicts repo, plus `null` preservation for `anki_modified_at`.
- [x] `pnpm test src/usecases/ankify/` `src/data_layer/ankify/` — 50 / 50 still green.
- [x] `pnpm tsc --noEmit` — clean.
- [ ] After merge: tail prod logs and confirm `ankify_sync_logs.payload->>'errors'` is empty for owner=1 polls.

## Out of scope (follow-ups noted in commit)

- Some pre-fix mappings live under the bare `Notion Sync` deck instead of `Notion Sync::<title>` — needs a `changeDeck` call inside `reconcileExistingCard`. Separate PR.
- `persistSyncLog` paints any-block-error as a whole-run `status='error'`; `partial` would be more honest now that reconcile actually does something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)