### PR TITLE
feat(ops): cache business metrics in database

### DIFF
--- a/migrations/20260511000000_business_metrics_cache.js
+++ b/migrations/20260511000000_business_metrics_cache.js
@@ -1,0 +1,13 @@
+exports.up = async function (knex) {
+  await knex.schema.createTable('business_metrics_cache', function (table) {
+    table.string('metric_key', 64).primary();
+    table.jsonb('value').notNullable();
+    table.timestamp('cached_at', { useTz: true }).notNullable();
+    table.timestamp('expires_at', { useTz: true }).notNullable();
+    table.index(['expires_at'], 'business_metrics_cache_expires_at_idx');
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.dropTableIfExists('business_metrics_cache');
+};

--- a/src/data_layer/BusinessMetricsCacheRepository.ts
+++ b/src/data_layer/BusinessMetricsCacheRepository.ts
@@ -1,0 +1,81 @@
+import type { Knex } from 'knex';
+
+import type { BusinessMetricKey } from '../services/ops/BusinessMetricsService';
+
+export interface BusinessMetricsCacheEntry {
+  key: BusinessMetricKey;
+  value: unknown;
+  cachedAt: Date;
+  expiresAt: Date;
+}
+
+export interface IBusinessMetricsCacheRepository {
+  loadAll(): Promise<BusinessMetricsCacheEntry[]>;
+  upsertMany(entries: BusinessMetricsCacheEntry[]): Promise<void>;
+}
+
+interface BusinessMetricsCacheRow {
+  metric_key: string;
+  value: unknown;
+  cached_at: Date | string;
+  expires_at: Date | string;
+}
+
+export class BusinessMetricsCacheRepository
+  implements IBusinessMetricsCacheRepository
+{
+  private readonly table = 'business_metrics_cache';
+
+  constructor(private readonly database: Knex) {}
+
+  async loadAll(): Promise<BusinessMetricsCacheEntry[]> {
+    const rows = await this.database<BusinessMetricsCacheRow>(this.table).select(
+      'metric_key',
+      'value',
+      'cached_at',
+      'expires_at'
+    );
+    return rows.map((row) => ({
+      key: row.metric_key as BusinessMetricKey,
+      value: row.value,
+      cachedAt: new Date(row.cached_at),
+      expiresAt: new Date(row.expires_at),
+    }));
+  }
+
+  async upsertMany(entries: BusinessMetricsCacheEntry[]): Promise<void> {
+    if (entries.length === 0) return;
+    const rows = entries.map((entry) => ({
+      metric_key: entry.key,
+      value: JSON.stringify(entry.value),
+      cached_at: entry.cachedAt,
+      expires_at: entry.expiresAt,
+    }));
+    await this.database(this.table)
+      .insert(rows)
+      .onConflict('metric_key')
+      .merge();
+  }
+}
+
+export class InMemoryBusinessMetricsCacheRepository
+  implements IBusinessMetricsCacheRepository
+{
+  private readonly entries = new Map<BusinessMetricKey, BusinessMetricsCacheEntry>();
+
+  async loadAll(): Promise<BusinessMetricsCacheEntry[]> {
+    return Array.from(this.entries.values()).map((entry) => ({ ...entry }));
+  }
+
+  async upsertMany(entries: BusinessMetricsCacheEntry[]): Promise<void> {
+    for (const entry of entries) {
+      this.entries.set(entry.key, { ...entry });
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+export default BusinessMetricsCacheRepository;

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -6,6 +6,7 @@ import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUse
 import { ObservabilityRepository } from '../data_layer/ObservabilityRepository';
 import { ObservabilityQueryService } from '../services/observability/ObservabilityQueryService';
 import { BusinessMetricsService } from '../services/ops/BusinessMetricsService';
+import { BusinessMetricsCacheRepository } from '../data_layer/BusinessMetricsCacheRepository';
 import { getDatabase } from '../data_layer';
 import RequireOpsAccess from './middleware/RequireOpsAccess';
 
@@ -15,7 +16,9 @@ const OpsRouter = () => {
   const repo = new ObservabilityRepository(database);
   const queryService = new ObservabilityQueryService(repo);
 
-  const businessMetricsService = new BusinessMetricsService();
+  const businessMetricsService = new BusinessMetricsService({
+    cacheRepository: new BusinessMetricsCacheRepository(database),
+  });
 
   const controller = new OpsController(
     new GetOpsMetricsUseCase(queryService),

--- a/src/services/ops/BusinessMetricsService.test.ts
+++ b/src/services/ops/BusinessMetricsService.test.ts
@@ -6,6 +6,7 @@ import {
   BusinessMetricsService,
   BusinessMetricsResponse,
 } from './BusinessMetricsService';
+import { InMemoryBusinessMetricsCacheRepository } from '../../data_layer/BusinessMetricsCacheRepository';
 
 interface FakeSubscriptionItem {
   price: {
@@ -173,6 +174,30 @@ describe('BusinessMetricsService', () => {
     expect(stripe.subscriptions.list).toHaveBeenCalledTimes(1);
     expect(stripe.invoices.list).toHaveBeenCalledTimes(1);
     expect(second.cache_age_seconds).toBe(10 * 60);
+  });
+
+  it('reuses a shared cache repository across service instances (survives restart)', async () => {
+    const stripe = buildFakeStripe({
+      allSubs: [sub('sub_1', [monthly(1000)], { created: daysAgoEpoch(60) })],
+    });
+    const sharedCache = new InMemoryBusinessMetricsCacheRepository();
+
+    const first = new BusinessMetricsService({
+      stripeFactory: () => stripe as never,
+      cacheRepository: sharedCache,
+    });
+    await first.getMetrics();
+
+    const second = new BusinessMetricsService({
+      stripeFactory: () => stripe as never,
+      cacheRepository: sharedCache,
+    });
+    const result = await second.getMetrics();
+
+    expect(stripe.subscriptions.list).toHaveBeenCalledTimes(1);
+    expect(stripe.invoices.list).toHaveBeenCalledTimes(1);
+    expect(result.mrr_usd).toBeCloseTo(10, 5);
+    expect(result.cache_age_seconds).toBe(0);
   });
 
   it('refetches metrics after cache expires', async () => {

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -2,6 +2,11 @@ import type { Stripe } from 'stripe';
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 
 import { getStripe } from '../../lib/integrations/stripe';
+import {
+  BusinessMetricsCacheEntry,
+  IBusinessMetricsCacheRepository,
+  InMemoryBusinessMetricsCacheRepository,
+} from '../../data_layer/BusinessMetricsCacheRepository';
 
 export type BusinessMetricKey =
   | 'mrr_usd'
@@ -57,17 +62,12 @@ export interface BusinessMetricsResponse {
   errors?: BusinessMetricError[];
 }
 
-interface CacheEntry<T> {
-  value: T;
-  expiresAt: number;
-  cachedAt: number;
-}
-
 export const BUSINESS_METRICS_CACHE_TTL_MS = 15 * 60 * 1000;
 
 interface BusinessMetricsServiceDeps {
   stripeFactory?: () => Stripe;
   cacheTtlMs?: number;
+  cacheRepository?: IBusinessMetricsCacheRepository;
 }
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
@@ -103,7 +103,7 @@ export class BusinessMetricsService {
 
   private readonly cacheTtlMs: number;
 
-  private readonly cache = new Map<BusinessMetricKey, CacheEntry<unknown>>();
+  private readonly cacheRepository: IBusinessMetricsCacheRepository;
 
   private allSubsPromise: Promise<NormalizedSubscription[]> | null = null;
 
@@ -112,6 +112,8 @@ export class BusinessMetricsService {
   constructor(deps: BusinessMetricsServiceDeps = {}) {
     this.stripeFactory = deps.stripeFactory ?? (() => getStripe());
     this.cacheTtlMs = deps.cacheTtlMs ?? BUSINESS_METRICS_CACHE_TTL_MS;
+    this.cacheRepository =
+      deps.cacheRepository ?? new InMemoryBusinessMetricsCacheRepository();
   }
 
   async getMetrics(): Promise<BusinessMetricsResponse> {
@@ -120,6 +122,8 @@ export class BusinessMetricsService {
 
     this.allSubsPromise = null;
     this.invoicesPromise = null;
+
+    const cachedByKey = await this.loadCacheMap();
 
     const subDerived = (computer: (subs: NormalizedSubscription[]) => unknown) =>
       async () => computer(await this.loadAllSubs());
@@ -167,23 +171,36 @@ export class BusinessMetricsService {
       },
     ];
 
+    const usedEntries: BusinessMetricsCacheEntry[] = [];
+    const freshEntries: BusinessMetricsCacheEntry[] = [];
+
     const settled = await Promise.all(
       tasks.map(({ key, fetch }) =>
-        this.resolveMetric(key, fetch, now).catch((error: unknown) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          errors.push({ metric: key, message });
-          return null;
-        })
+        this.resolveMetric(key, fetch, now, cachedByKey, usedEntries, freshEntries).catch(
+          (error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            errors.push({ metric: key, message });
+            return null;
+          }
+        )
       )
     );
+
+    if (freshEntries.length > 0) {
+      try {
+        await this.cacheRepository.upsertMany(freshEntries);
+      } catch (error) {
+        console.error('[ops] business metrics cache upsert failed', error);
+      }
+    }
 
     const valueByKey = new Map<BusinessMetricKey, unknown>();
     tasks.forEach(({ key }, idx) => {
       valueByKey.set(key, settled[idx]);
     });
 
-    const cacheAgeSeconds = this.cacheAgeSeconds(now);
+    const cacheAgeSeconds = computeCacheAgeSeconds(usedEntries, now);
 
     const response: BusinessMetricsResponse = {
       mrr_usd: valueByKey.get('mrr_usd') as number | null,
@@ -217,32 +234,44 @@ export class BusinessMetricsService {
     return response;
   }
 
+  private async loadCacheMap(): Promise<
+    Map<BusinessMetricKey, BusinessMetricsCacheEntry>
+  > {
+    const map = new Map<BusinessMetricKey, BusinessMetricsCacheEntry>();
+    try {
+      const rows = await this.cacheRepository.loadAll();
+      for (const row of rows) {
+        map.set(row.key, row);
+      }
+    } catch (error) {
+      console.error('[ops] business metrics cache load failed', error);
+    }
+    return map;
+  }
+
   private async resolveMetric(
     key: BusinessMetricKey,
     fetcher: () => Promise<unknown>,
-    now: Date
+    now: Date,
+    cachedByKey: Map<BusinessMetricKey, BusinessMetricsCacheEntry>,
+    usedEntries: BusinessMetricsCacheEntry[],
+    freshEntries: BusinessMetricsCacheEntry[]
   ): Promise<unknown> {
-    const existing = this.cache.get(key);
-    if (existing != null && existing.expiresAt > now.getTime()) {
+    const existing = cachedByKey.get(key);
+    if (existing != null && existing.expiresAt.getTime() > now.getTime()) {
+      usedEntries.push(existing);
       return existing.value;
     }
     const value = await fetcher();
-    this.cache.set(key, {
+    const entry: BusinessMetricsCacheEntry = {
+      key,
       value,
-      cachedAt: now.getTime(),
-      expiresAt: now.getTime() + this.cacheTtlMs,
-    });
+      cachedAt: now,
+      expiresAt: new Date(now.getTime() + this.cacheTtlMs),
+    };
+    usedEntries.push(entry);
+    freshEntries.push(entry);
     return value;
-  }
-
-  private cacheAgeSeconds(now: Date): number {
-    let oldest = now.getTime();
-    for (const entry of this.cache.values()) {
-      if (entry.cachedAt < oldest) {
-        oldest = entry.cachedAt;
-      }
-    }
-    return Math.max(0, Math.floor((now.getTime() - oldest) / 1000));
   }
 
   private loadAllSubs(): Promise<NormalizedSubscription[]> {
@@ -303,6 +332,19 @@ export class BusinessMetricsService {
     return result;
   }
 }
+
+const computeCacheAgeSeconds = (
+  entries: BusinessMetricsCacheEntry[],
+  now: Date
+): number => {
+  if (entries.length === 0) return 0;
+  let oldest = now.getTime();
+  for (const entry of entries) {
+    const t = entry.cachedAt.getTime();
+    if (t < oldest) oldest = t;
+  }
+  return Math.max(0, Math.floor((now.getTime() - oldest) / 1000));
+};
 
 const normalizeSubscription = (
   sub: StripeTypes.Subscription


### PR DESCRIPTION
## Summary

The `/ops` business panel walked Stripe on every cold cache. With the in-memory `Map`, that's every process restart (and any future second worker). Move the 15-min cache into a `business_metrics_cache` table so it survives restarts and is shared across instances.

- **migration** `20260511000000_business_metrics_cache.js` — `metric_key` PK, `value` JSONB, `cached_at`, `expires_at`
- **`BusinessMetricsCacheRepository`** — Knex `loadAll` + bulk `upsert(... onConflict('metric_key').merge())`. Includes an `InMemoryBusinessMetricsCacheRepository` for unit tests so no live DB is needed.
- **`BusinessMetricsService`** — drops the internal `Map`. Now does one `loadAll()` per request, falls back to Stripe only for expired keys, then `upsertMany`s the fresh values. TTL stays at 15 min, `cache_age_seconds` semantics preserved.
- **`OpsRouter`** — wires the DB-backed repo via the existing `database` instance.

The Stripe-walk dedup (`allSubsPromise` / `invoicesPromise` within a single `getMetrics()` call) is unchanged.

## Test plan

- [x] `pnpm test src/services/ops/BusinessMetricsService.test.ts` — 15 pass (14 existing + 1 new "survives restart" test using a shared cache repo across two service instances)
- [x] `pnpm test src/controllers/OpsController.test.ts src/routes/OpsRouter.test.ts src/usecases/ops/` — 11 pass
- [x] `tsc --noEmit` clean
- [ ] After deploy: hit `/api/ops/business/metrics`, restart the server, hit it again — second hit should return immediately and `stripe_subscriptions_list` outbound count stays flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)