### PR TITLE
feat(ops): cancellation reasons + comments in Business tab

### DIFF
--- a/src/data_layer/CancellationFeedbackRepository.test.ts
+++ b/src/data_layer/CancellationFeedbackRepository.test.ts
@@ -1,0 +1,105 @@
+import { InMemoryCancellationFeedbackRepository } from './CancellationFeedbackRepository';
+
+describe('InMemoryCancellationFeedbackRepository', () => {
+  describe('countByReason', () => {
+    it('groups rows by reason and orders by count desc', async () => {
+      const repo = new InMemoryCancellationFeedbackRepository();
+      const now = new Date('2026-05-09T12:00:00Z');
+      repo.insert({ reason: 'Too expensive', created_at: now });
+      repo.insert({ reason: 'Too expensive', created_at: now });
+      repo.insert({ reason: 'Too expensive', created_at: now });
+      repo.insert({ reason: "I don't use it enough", created_at: now });
+      repo.insert({ reason: 'Other', comment: 'wat', created_at: now });
+
+      const result = await repo.countByReason(
+        new Date('2026-01-01T00:00:00Z')
+      );
+
+      expect(result).toEqual([
+        { reason: 'Too expensive', count: 3 },
+        { reason: "I don't use it enough", count: 1 },
+        { reason: 'Other', count: 1 },
+      ]);
+    });
+
+    it('excludes rows older than the since cutoff', async () => {
+      const repo = new InMemoryCancellationFeedbackRepository();
+      repo.insert({
+        reason: 'Too expensive',
+        created_at: new Date('2026-01-01T00:00:00Z'),
+      });
+      repo.insert({
+        reason: 'Too expensive',
+        created_at: new Date('2026-05-01T00:00:00Z'),
+      });
+
+      const result = await repo.countByReason(
+        new Date('2026-04-01T00:00:00Z')
+      );
+
+      expect(result).toEqual([{ reason: 'Too expensive', count: 1 }]);
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      const repo = new InMemoryCancellationFeedbackRepository();
+
+      const result = await repo.countByReason(new Date('2026-01-01T00:00:00Z'));
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('recentComments', () => {
+    it('returns only rows with non-empty comment, newest first, capped to limit', async () => {
+      const repo = new InMemoryCancellationFeedbackRepository();
+      repo.insert({
+        reason: 'Other',
+        comment: 'first',
+        created_at: new Date('2026-05-01T00:00:00Z'),
+      });
+      repo.insert({
+        reason: 'Other',
+        comment: 'second',
+        created_at: new Date('2026-05-05T00:00:00Z'),
+      });
+      repo.insert({
+        reason: 'Other',
+        comment: 'third',
+        created_at: new Date('2026-05-09T00:00:00Z'),
+      });
+      repo.insert({
+        reason: 'Too expensive',
+        created_at: new Date('2026-05-09T00:00:00Z'),
+      });
+      repo.insert({
+        reason: 'Other',
+        comment: '',
+        created_at: new Date('2026-05-09T00:00:00Z'),
+      });
+
+      const result = await repo.recentComments(2);
+
+      expect(result).toEqual([
+        {
+          reason: 'Other',
+          comment: 'third',
+          created_at: '2026-05-09T00:00:00.000Z',
+        },
+        {
+          reason: 'Other',
+          comment: 'second',
+          created_at: '2026-05-05T00:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('returns an empty array when no rows have a comment', async () => {
+      const repo = new InMemoryCancellationFeedbackRepository();
+      repo.insert({ reason: 'Too expensive' });
+
+      const result = await repo.recentComments(20);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/data_layer/CancellationFeedbackRepository.ts
+++ b/src/data_layer/CancellationFeedbackRepository.ts
@@ -1,0 +1,121 @@
+import type { Knex } from 'knex';
+
+export interface CancellationReasonCount {
+  reason: string;
+  count: number;
+}
+
+export interface CancellationCommentEntry {
+  reason: string;
+  comment: string;
+  created_at: string;
+}
+
+export interface ICancellationFeedbackRepository {
+  countByReason(since: Date): Promise<CancellationReasonCount[]>;
+  recentComments(limit: number): Promise<CancellationCommentEntry[]>;
+}
+
+interface ReasonRow {
+  reason: string;
+  count: string | number;
+}
+
+interface CommentRow {
+  reason: string;
+  comment: string;
+  created_at: Date | string;
+}
+
+const toIso = (value: Date | string): string =>
+  typeof value === 'string' ? value : value.toISOString();
+
+export class CancellationFeedbackRepository
+  implements ICancellationFeedbackRepository
+{
+  private readonly table = 'cancellation_feedback';
+
+  constructor(private readonly database: Knex) {}
+
+  async countByReason(since: Date): Promise<CancellationReasonCount[]> {
+    const rows = await this.database(this.table)
+      .select('reason')
+      .count<ReasonRow[]>('* as count')
+      .where('created_at', '>=', since)
+      .groupBy('reason')
+      .orderBy('count', 'desc');
+    return rows.map((row) => ({
+      reason: row.reason,
+      count: Number(row.count),
+    }));
+  }
+
+  async recentComments(limit: number): Promise<CancellationCommentEntry[]> {
+    const rows = await this.database<CommentRow>(this.table)
+      .select('reason', 'comment', 'created_at')
+      .whereNotNull('comment')
+      .andWhere('comment', '!=', '')
+      .orderBy('created_at', 'desc')
+      .limit(limit);
+    return rows.map((row) => ({
+      reason: row.reason,
+      comment: row.comment,
+      created_at: toIso(row.created_at),
+    }));
+  }
+}
+
+export class InMemoryCancellationFeedbackRepository
+  implements ICancellationFeedbackRepository
+{
+  private readonly rows: Array<{
+    reason: string;
+    comment: string | null;
+    created_at: Date;
+  }> = [];
+
+  insert(row: {
+    reason: string;
+    comment?: string | null;
+    created_at?: Date;
+  }): void {
+    this.rows.push({
+      reason: row.reason,
+      comment: row.comment ?? null,
+      created_at: row.created_at ?? new Date(),
+    });
+  }
+
+  async countByReason(since: Date): Promise<CancellationReasonCount[]> {
+    const counts = new Map<string, number>();
+    for (const row of this.rows) {
+      if (row.created_at >= since) {
+        counts.set(row.reason, (counts.get(row.reason) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([reason, count]) => ({ reason, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  async recentComments(limit: number): Promise<CancellationCommentEntry[]> {
+    return this.rows
+      .filter(
+        (r): r is { reason: string; comment: string; created_at: Date } =>
+          r.comment != null && r.comment !== ''
+      )
+      .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+      .slice(0, limit)
+      .map((r) => ({
+        reason: r.reason,
+        comment: r.comment,
+        created_at: r.created_at.toISOString(),
+      }));
+  }
+
+  clear(): void {
+    this.rows.length = 0;
+  }
+}
+
+export default CancellationFeedbackRepository;

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -7,6 +7,7 @@ import { ObservabilityRepository } from '../data_layer/ObservabilityRepository';
 import { ObservabilityQueryService } from '../services/observability/ObservabilityQueryService';
 import { BusinessMetricsService } from '../services/ops/BusinessMetricsService';
 import { BusinessMetricsCacheRepository } from '../data_layer/BusinessMetricsCacheRepository';
+import { CancellationFeedbackRepository } from '../data_layer/CancellationFeedbackRepository';
 import { getDatabase } from '../data_layer';
 import RequireOpsAccess from './middleware/RequireOpsAccess';
 
@@ -18,6 +19,7 @@ const OpsRouter = () => {
 
   const businessMetricsService = new BusinessMetricsService({
     cacheRepository: new BusinessMetricsCacheRepository(database),
+    cancellationRepository: new CancellationFeedbackRepository(database),
   });
 
   const controller = new OpsController(

--- a/src/services/ops/BusinessMetricsService.test.ts
+++ b/src/services/ops/BusinessMetricsService.test.ts
@@ -7,6 +7,7 @@ import {
   BusinessMetricsResponse,
 } from './BusinessMetricsService';
 import { InMemoryBusinessMetricsCacheRepository } from '../../data_layer/BusinessMetricsCacheRepository';
+import { InMemoryCancellationFeedbackRepository } from '../../data_layer/CancellationFeedbackRepository';
 
 interface FakeSubscriptionItem {
   price: {
@@ -486,6 +487,101 @@ describe('BusinessMetricsService', () => {
       expect(stripe.invoices.list).toHaveBeenCalledTimes(1);
       expect(second.mrr_timeseries).toEqual(first.mrr_timeseries);
       expect(second.failed_payments_weekly).toEqual(first.failed_payments_weekly);
+    });
+  });
+
+  describe('cancellation feedback', () => {
+    it('returns top reasons (last 90 days) and recent comments from the repo', async () => {
+      const stripe = buildFakeStripe({});
+      const cancellationRepo = new InMemoryCancellationFeedbackRepository();
+      const inWindow = new Date(NOW_MS - 5 * SECONDS_PER_DAY * 1000);
+      const tooOld = new Date(NOW_MS - 100 * SECONDS_PER_DAY * 1000);
+
+      cancellationRepo.insert({ reason: 'Too expensive', created_at: inWindow });
+      cancellationRepo.insert({ reason: 'Too expensive', created_at: inWindow });
+      cancellationRepo.insert({
+        reason: "I don't use it enough",
+        created_at: inWindow,
+      });
+      cancellationRepo.insert({
+        reason: 'Other',
+        comment: 'missed Anki shared decks',
+        created_at: inWindow,
+      });
+      cancellationRepo.insert({
+        reason: 'Too expensive',
+        created_at: tooOld,
+      });
+
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+        cancellationRepository: cancellationRepo,
+      });
+
+      const result = await service.getMetrics();
+
+      expect(result.cancellation_reasons_top).toEqual([
+        { reason: 'Too expensive', count: 2 },
+        { reason: "I don't use it enough", count: 1 },
+        { reason: 'Other', count: 1 },
+      ]);
+      expect(result.cancellation_comments_recent).toEqual([
+        {
+          reason: 'Other',
+          comment: 'missed Anki shared decks',
+          created_at: inWindow.toISOString(),
+        },
+      ]);
+    });
+
+    it('caches cancellation metrics within the TTL', async () => {
+      const stripe = buildFakeStripe({});
+      const cancellationRepo = new InMemoryCancellationFeedbackRepository();
+      cancellationRepo.insert({
+        reason: 'Too expensive',
+        created_at: new Date(NOW_MS - 1000),
+      });
+      const countSpy = jest.spyOn(cancellationRepo, 'countByReason');
+      const commentsSpy = jest.spyOn(cancellationRepo, 'recentComments');
+
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+        cancellationRepository: cancellationRepo,
+      });
+
+      await service.getMetrics();
+      jest.advanceTimersByTime(10 * 60 * 1000);
+      await service.getMetrics();
+
+      expect(countSpy).toHaveBeenCalledTimes(1);
+      expect(commentsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a per-metric error and returns null when the repo throws', async () => {
+      const stripe = buildFakeStripe({});
+      const cancellationRepo: InMemoryCancellationFeedbackRepository =
+        new InMemoryCancellationFeedbackRepository();
+      jest
+        .spyOn(cancellationRepo, 'countByReason')
+        .mockRejectedValueOnce(new Error('db down'));
+
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+        cancellationRepository: cancellationRepo,
+      });
+
+      const result = await service.getMetrics();
+
+      expect(result.cancellation_reasons_top).toBeNull();
+      expect(result.cancellation_comments_recent).toEqual([]);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            metric: 'cancellation_reasons_top',
+            message: 'db down',
+          }),
+        ])
+      );
     });
   });
 });

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -7,6 +7,12 @@ import {
   IBusinessMetricsCacheRepository,
   InMemoryBusinessMetricsCacheRepository,
 } from '../../data_layer/BusinessMetricsCacheRepository';
+import {
+  CancellationCommentEntry,
+  CancellationReasonCount,
+  ICancellationFeedbackRepository,
+  InMemoryCancellationFeedbackRepository,
+} from '../../data_layer/CancellationFeedbackRepository';
 
 export type BusinessMetricKey =
   | 'mrr_usd'
@@ -18,7 +24,9 @@ export type BusinessMetricKey =
   | 'mrr_timeseries'
   | 'active_subs_timeseries'
   | 'conversions_vs_churn_weekly'
-  | 'failed_payments_weekly';
+  | 'failed_payments_weekly'
+  | 'cancellation_reasons_top'
+  | 'cancellation_comments_recent';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -57,17 +65,22 @@ export interface BusinessMetricsResponse {
   active_subs_timeseries: ActiveSubsTimeseriesPoint[] | null;
   conversions_vs_churn_weekly: ConversionsChurnWeekPoint[] | null;
   failed_payments_weekly: FailedPaymentsWeekPoint[] | null;
+  cancellation_reasons_top: CancellationReasonCount[] | null;
+  cancellation_comments_recent: CancellationCommentEntry[] | null;
   as_of: string;
   cache_age_seconds: number;
   errors?: BusinessMetricError[];
 }
 
 export const BUSINESS_METRICS_CACHE_TTL_MS = 15 * 60 * 1000;
+export const CANCELLATION_REASONS_LOOKBACK_DAYS = 90;
+export const CANCELLATION_COMMENTS_LIMIT = 20;
 
 interface BusinessMetricsServiceDeps {
   stripeFactory?: () => Stripe;
   cacheTtlMs?: number;
   cacheRepository?: IBusinessMetricsCacheRepository;
+  cancellationRepository?: ICancellationFeedbackRepository;
 }
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
@@ -105,6 +118,8 @@ export class BusinessMetricsService {
 
   private readonly cacheRepository: IBusinessMetricsCacheRepository;
 
+  private readonly cancellationRepository: ICancellationFeedbackRepository;
+
   private allSubsPromise: Promise<NormalizedSubscription[]> | null = null;
 
   private invoicesPromise: Promise<NormalizedInvoice[]> | null = null;
@@ -114,6 +129,9 @@ export class BusinessMetricsService {
     this.cacheTtlMs = deps.cacheTtlMs ?? BUSINESS_METRICS_CACHE_TTL_MS;
     this.cacheRepository =
       deps.cacheRepository ?? new InMemoryBusinessMetricsCacheRepository();
+    this.cancellationRepository =
+      deps.cancellationRepository ??
+      new InMemoryCancellationFeedbackRepository();
   }
 
   async getMetrics(): Promise<BusinessMetricsResponse> {
@@ -169,6 +187,23 @@ export class BusinessMetricsService {
         key: 'failed_payments_weekly',
         fetch: invoiceDerived((i) => computeFailedPaymentsWeekly(i, now)),
       },
+      {
+        key: 'cancellation_reasons_top',
+        fetch: () =>
+          this.cancellationRepository.countByReason(
+            new Date(
+              now.getTime() -
+                CANCELLATION_REASONS_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
+            )
+          ),
+      },
+      {
+        key: 'cancellation_comments_recent',
+        fetch: () =>
+          this.cancellationRepository.recentComments(
+            CANCELLATION_COMMENTS_LIMIT
+          ),
+      },
     ];
 
     const usedEntries: BusinessMetricsCacheEntry[] = [];
@@ -223,6 +258,12 @@ export class BusinessMetricsService {
       failed_payments_weekly: valueByKey.get('failed_payments_weekly') as
         | FailedPaymentsWeekPoint[]
         | null,
+      cancellation_reasons_top: valueByKey.get('cancellation_reasons_top') as
+        | CancellationReasonCount[]
+        | null,
+      cancellation_comments_recent: valueByKey.get(
+        'cancellation_comments_recent'
+      ) as CancellationCommentEntry[] | null,
       as_of: now.toISOString(),
       cache_age_seconds: cacheAgeSeconds,
     };

--- a/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
+++ b/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
@@ -17,6 +17,8 @@ describe('GetBusinessMetricsUseCase', () => {
       active_subs_timeseries: [],
       conversions_vs_churn_weekly: [],
       failed_payments_weekly: [],
+      cancellation_reasons_top: [],
+      cancellation_comments_recent: [],
       as_of: '2026-05-09T14:32:07.000Z',
       cache_age_seconds: 412,
     };

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import BusinessTab from './BusinessTab';
 import { BusinessMetricsResponse } from './businessTypes';
@@ -46,6 +46,18 @@ const buildSampleMetrics = (
     week: `2026-02-${String((i % 28) + 1).padStart(2, '0')}`,
     count: i % 4,
   })),
+  cancellation_reasons_top: [
+    { reason: 'Too expensive', count: 7 },
+    { reason: "I don't use it enough", count: 4 },
+    { reason: 'Other', count: 1 },
+  ],
+  cancellation_comments_recent: [
+    {
+      reason: 'Other',
+      comment: 'I missed Anki shared decks',
+      created_at: '2026-05-08T11:00:00.000Z',
+    },
+  ],
   as_of: '2026-05-09T14:32:07.000Z',
   cache_age_seconds: 412,
   ...overrides,
@@ -73,9 +85,7 @@ describe('BusinessTab', () => {
 
     renderTab();
 
-    await waitFor(() =>
-      expect(screen.getByText('$4,820')).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByText('$4,820')).toBeInTheDocument());
     expect(screen.getByText('MRR')).toBeInTheDocument();
     expect(screen.getByText('$312')).toBeInTheDocument();
     expect(screen.getByText('Net new MRR (MTD)')).toBeInTheDocument();
@@ -94,7 +104,7 @@ describe('BusinessTab', () => {
     );
   });
 
-  test('renders all four chart panel titles', async () => {
+  test('renders all chart panel titles', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
@@ -110,9 +120,17 @@ describe('BusinessTab', () => {
     expect(
       screen.getByText('Active paying subs, last 90 days')
     ).toBeInTheDocument();
-    expect(screen.getByText('New vs churned, last 12 weeks')).toBeInTheDocument();
+    expect(
+      screen.getByText('New vs churned, last 12 weeks')
+    ).toBeInTheDocument();
     expect(
       screen.getByText('Failed payments, last 12 weeks')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Why users cancel, last 90 days')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Recent cancellation comments')
     ).toBeInTheDocument();
   });
 
@@ -127,6 +145,8 @@ describe('BusinessTab', () => {
           active_subs_timeseries: [],
           conversions_vs_churn_weekly: [],
           failed_payments_weekly: [],
+          cancellation_reasons_top: [],
+          cancellation_comments_recent: [],
         }),
     });
 
@@ -136,10 +156,31 @@ describe('BusinessTab', () => {
       expect(screen.getByText('No MRR history yet.')).toBeInTheDocument()
     );
     expect(screen.getByText('No active-subs history yet.')).toBeInTheDocument();
-    expect(screen.getByText('No subscription movements yet.')).toBeInTheDocument();
+    expect(
+      screen.getByText('No subscription movements yet.')
+    ).toBeInTheDocument();
     expect(
       screen.getByText('No failed payments in this window.')
     ).toBeInTheDocument();
+    expect(
+      screen.getByText('No cancellations recorded yet.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('No free-text comments yet.')).toBeInTheDocument();
+  });
+
+  test('renders cancellation comment text from the response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => buildSampleMetrics(),
+    });
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(screen.getByText('I missed Anki shared decks')).toBeInTheDocument()
+    );
   });
 
   test('shows the alert banner when the request fails', async () => {
@@ -170,9 +211,7 @@ describe('BusinessTab', () => {
 
     const { container } = renderTab();
 
-    await waitFor(() =>
-      expect(screen.getByText('$4,820')).toBeInTheDocument()
-    );
+    await waitFor(() => expect(screen.getByText('$4,820')).toBeInTheDocument());
     expect(container.querySelector('pre')).toBeNull();
   });
 });

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import sharedStyles from '../../styles/shared.module.css';
-import styles from './OpsPage.module.css';
-import { BusinessMetricsResponse } from './businessTypes';
 import {
   formatCacheAge,
   formatClockShort,
@@ -10,11 +8,15 @@ import {
   formatPercentOneDecimal,
   formatUsd,
 } from './businessHelpers';
-import ChartPanel from './charts/ChartPanel';
-import MrrTimeseriesChart from './charts/MrrTimeseriesChart';
+import { BusinessMetricsResponse } from './businessTypes';
 import ActiveSubsTimeseriesChart from './charts/ActiveSubsTimeseriesChart';
+import CancellationCommentsList from './charts/CancellationCommentsList';
+import CancellationReasonsChart from './charts/CancellationReasonsChart';
+import ChartPanel from './charts/ChartPanel';
 import ConversionsChurnChart from './charts/ConversionsChurnChart';
 import FailedPaymentsWeeklyChart from './charts/FailedPaymentsWeeklyChart';
+import MrrTimeseriesChart from './charts/MrrTimeseriesChart';
+import styles from './OpsPage.module.css';
 import { useBusinessMetrics } from './useBusinessMetrics';
 
 interface MetricCardProps {
@@ -52,9 +54,8 @@ const buildMrrFootnote = (
 
 export default function BusinessTab() {
   const { data, error, isLoading } = useBusinessMetrics();
-  const [lastSnapshot, setLastSnapshot] = useState<BusinessMetricsResponse | null>(
-    null
-  );
+  const [lastSnapshot, setLastSnapshot] =
+    useState<BusinessMetricsResponse | null>(null);
 
   useEffect(() => {
     if (data != null) {
@@ -78,8 +79,8 @@ export default function BusinessTab() {
     <>
       {error != null && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
-          /api/ops/business/metrics failed: {error.message}. Last good data shown
-          below.
+          /api/ops/business/metrics failed: {error.message}. Last good data
+          shown below.
         </div>
       )}
 
@@ -166,6 +167,29 @@ export default function BusinessTab() {
         >
           <FailedPaymentsWeeklyChart
             points={visible?.failed_payments_weekly ?? []}
+          />
+        </ChartPanel>
+
+        <ChartPanel
+          title="Why users cancel, last 90 days"
+          isLoading={showInitialSkeleton}
+          isEmpty={(visible?.cancellation_reasons_top?.length ?? 0) === 0}
+          emptyText="No cancellations recorded yet."
+        >
+          <CancellationReasonsChart
+            points={visible?.cancellation_reasons_top ?? []}
+          />
+        </ChartPanel>
+
+        <ChartPanel
+          title="Recent cancellation comments"
+          subtitle="Latest free-text feedback from the cancel survey"
+          isLoading={showInitialSkeleton}
+          isEmpty={(visible?.cancellation_comments_recent?.length ?? 0) === 0}
+          emptyText="No free-text comments yet."
+        >
+          <CancellationCommentsList
+            points={visible?.cancellation_comments_recent ?? []}
           />
         </ChartPanel>
       </div>

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -253,3 +253,51 @@
 .refreshButton {
   font-family: inherit;
 }
+
+.commentList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.commentItem {
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.75rem;
+  background: var(--color-bg-secondary);
+}
+
+.commentMeta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.commentReason {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+}
+
+.commentDate {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.commentBody {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/web/src/pages/OpsPage/businessTypes.ts
+++ b/web/src/pages/OpsPage/businessTypes.ts
@@ -8,7 +8,9 @@ export type BusinessMetricKey =
   | 'mrr_timeseries'
   | 'active_subs_timeseries'
   | 'conversions_vs_churn_weekly'
-  | 'failed_payments_weekly';
+  | 'failed_payments_weekly'
+  | 'cancellation_reasons_top'
+  | 'cancellation_comments_recent';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -36,6 +38,17 @@ export interface FailedPaymentsWeekPoint {
   count: number;
 }
 
+export interface CancellationReasonPoint {
+  reason: string;
+  count: number;
+}
+
+export interface CancellationCommentPoint {
+  reason: string;
+  comment: string;
+  created_at: string;
+}
+
 export interface BusinessMetricsResponse {
   mrr_usd: number | null;
   net_new_mrr_mtd_usd: number | null;
@@ -47,6 +60,8 @@ export interface BusinessMetricsResponse {
   active_subs_timeseries: ActiveSubsTimeseriesPoint[] | null;
   conversions_vs_churn_weekly: ConversionsChurnWeekPoint[] | null;
   failed_payments_weekly: FailedPaymentsWeekPoint[] | null;
+  cancellation_reasons_top: CancellationReasonPoint[] | null;
+  cancellation_comments_recent: CancellationCommentPoint[] | null;
   as_of: string;
   cache_age_seconds: number;
   errors?: BusinessMetricError[];

--- a/web/src/pages/OpsPage/charts/CancellationCommentsList.tsx
+++ b/web/src/pages/OpsPage/charts/CancellationCommentsList.tsx
@@ -1,0 +1,36 @@
+import { CancellationCommentPoint } from '../businessTypes';
+import styles from '../OpsPage.module.css';
+
+interface CancellationCommentsListProps {
+  points: CancellationCommentPoint[];
+}
+
+const formatDate = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  });
+};
+
+export default function CancellationCommentsList({
+  points,
+}: Readonly<CancellationCommentsListProps>) {
+  return (
+    <ul className={styles.commentList}>
+      {points.map((point, idx) => (
+        <li key={`${point.created_at}-${idx}`} className={styles.commentItem}>
+          <div className={styles.commentMeta}>
+            <span className={styles.commentReason}>{point.reason}</span>
+            <span className={styles.commentDate}>
+              {formatDate(point.created_at)}
+            </span>
+          </div>
+          <p className={styles.commentBody}>{point.comment}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/pages/OpsPage/charts/CancellationReasonsChart.tsx
+++ b/web/src/pages/OpsPage/charts/CancellationReasonsChart.tsx
@@ -1,0 +1,83 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipContentProps,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { CancellationReasonPoint } from '../businessTypes';
+import TimeSeriesTooltipShell, {
+  TimeSeriesTooltipRow,
+} from './TimeSeriesTooltipShell';
+import {
+  AXIS_STROKE,
+  AXIS_TICK_STYLE,
+  GRID_STROKE,
+  SERIES_RED,
+  TOOLTIP_CURSOR_FILL,
+} from './timeSeriesChartHelpers';
+
+interface CancellationReasonsChartProps {
+  points: CancellationReasonPoint[];
+}
+
+interface ReasonRow {
+  reason: string;
+  count: number;
+}
+
+const buildRows = (points: CancellationReasonPoint[]): ReasonRow[] =>
+  points.map((point) => ({ reason: point.reason, count: point.count }));
+
+function ReasonsTooltip({ active, payload }: TooltipContentProps) {
+  if (!active || payload == null || payload.length === 0) return null;
+  const row = payload[0].payload as ReasonRow;
+  return (
+    <TimeSeriesTooltipShell title={row.reason}>
+      <TimeSeriesTooltipRow
+        label="cancels"
+        value={row.count.toLocaleString()}
+      />
+    </TimeSeriesTooltipShell>
+  );
+}
+
+const HORIZONTAL_MARGIN = {
+  top: 8,
+  right: 16,
+  left: 0,
+  bottom: 0,
+} as const;
+
+export default function CancellationReasonsChart({
+  points,
+}: Readonly<CancellationReasonsChartProps>) {
+  const data = buildRows(points);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} layout="vertical" margin={HORIZONTAL_MARGIN}>
+        <CartesianGrid stroke={GRID_STROKE} horizontal={false} />
+        <XAxis
+          type="number"
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          allowDecimals={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="reason"
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          width={140}
+        />
+        <Tooltip content={ReasonsTooltip} cursor={TOOLTIP_CURSOR_FILL} />
+        <Bar dataKey="count" fill={SERIES_RED} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary

The cancel-subscription survey has been writing to `cancellation_feedback` since it shipped, but nothing reads from it. The Business tab shows churn *count*; this PR shows churn *reasons* — and surfaces the free-text comments users leave on "Other".

## What's added

- **`CancellationFeedbackRepository`** (knex) + `InMemory` variant for tests.
  - `countByReason(since)` — groups rows by reason, orders by count desc.
  - `recentComments(limit)` — newest first, filters out empty comments.
- **`BusinessMetricsService`** picks up two new keyed metrics:
  - `cancellation_reasons_top` — last 90 days.
  - `cancellation_comments_recent` — latest 20 with non-empty comment.
  - Both flow through the existing 15-min cache (`business_metrics_cache`) and the same per-metric error reporting as the rest.
- **`BusinessTab`** gets two new `ChartPanel`s:
  - "Why users cancel, last 90 days" — horizontal Recharts bar.
  - "Recent cancellation comments" — scrollable list with reason badge + date.

## Privacy

`owner` (user id) is **never** exposed to the dashboard. The endpoint is already gated to `alexander@alemayhu.com` via `RequireOpsAccess`, but there is no need to surface the FK either way.

## Test plan

- [x] Server tsc clean
- [x] Web tsc clean
- [x] `BusinessMetricsService.test.ts` — 3 new cases (returns rows, caches, surfaces per-metric error)
- [x] `CancellationFeedbackRepository.test.ts` — 5 cases on the InMemory variant
- [x] `BusinessTab.test.tsx` — extended with new panel titles, empty-state copy, and a comment-text assertion
- [x] Biome clean on touched files
- [ ] Manual: deploy, hit `/ops/business`, confirm reasons + comments render against real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)