### PR TITLE
feat(ankify): block parity with DeckParser via notion-render

### DIFF
--- a/src/lib/notion-render/embedUrl.test.ts
+++ b/src/lib/notion-render/embedUrl.test.ts
@@ -1,0 +1,67 @@
+import { resolveEmbedUrl, resolveVideoUrl } from './embedUrl';
+
+describe('resolveVideoUrl', () => {
+  it('rewrites a YouTube URL to the embed iframe src', () => {
+    const result = resolveVideoUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+    expect(result.kind).toBe('iframe');
+    if (result.kind === 'iframe') {
+      expect(result.src).toContain('youtube.com/embed/dQw4w9WgXcQ');
+    }
+  });
+
+  it('rewrites a Vimeo URL to player.vimeo.com', () => {
+    const result = resolveVideoUrl('https://vimeo.com/123456789');
+    expect(result).toEqual({
+      kind: 'iframe',
+      src: 'https://player.vimeo.com/video/123456789',
+    });
+  });
+
+  it('falls back to raw-url for an unrecognized host', () => {
+    const result = resolveVideoUrl('https://example.com/clip.mp4');
+    expect(result).toEqual({
+      kind: 'raw-url',
+      url: 'https://example.com/clip.mp4',
+    });
+  });
+});
+
+describe('resolveEmbedUrl', () => {
+  it('wraps a SoundCloud track in the SoundCloud player iframe', () => {
+    const url = 'https://soundcloud.com/artist/track';
+    const result = resolveEmbedUrl(url);
+    expect(result.kind).toBe('iframe');
+    if (result.kind === 'iframe') {
+      expect(result.src).toBe(
+        `https://w.soundcloud.com/player/?url=${url}`
+      );
+    }
+  });
+
+  it('returns a twitter-link directive for Twitter URLs', () => {
+    const result = resolveEmbedUrl('https://twitter.com/x/status/1');
+    expect(result).toEqual({
+      kind: 'twitter-link',
+      url: 'https://twitter.com/x/status/1',
+    });
+  });
+
+  it('rewrites YouTube and Vimeo to embed iframes', () => {
+    const yt = resolveEmbedUrl('https://youtu.be/dQw4w9WgXcQ');
+    expect(yt.kind).toBe('iframe');
+
+    const vimeo = resolveEmbedUrl('https://vimeo.com/42');
+    expect(vimeo).toEqual({
+      kind: 'iframe',
+      src: 'https://player.vimeo.com/video/42',
+    });
+  });
+
+  it('passes other URLs through as iframe src', () => {
+    const result = resolveEmbedUrl('https://codepen.io/user/pen/abc');
+    expect(result).toEqual({
+      kind: 'iframe',
+      src: 'https://codepen.io/user/pen/abc',
+    });
+  });
+});

--- a/src/lib/notion-render/embedUrl.ts
+++ b/src/lib/notion-render/embedUrl.ts
@@ -1,0 +1,55 @@
+import getYouTubeEmbedLink from '../parser/helpers/getYouTubeEmbedLink';
+import getYouTubeID from '../parser/helpers/getYouTubeID';
+import {
+  isSoundCloudURL,
+  isTwitterURL,
+  isVimeoURL,
+} from '../storage/checks';
+
+export type ResolvedEmbed =
+  | { kind: 'iframe'; src: string }
+  | { kind: 'twitter-link'; url: string }
+  | { kind: 'raw-url'; url: string };
+
+const vimeoIdFromUrl = (url: string): string | null => {
+  const tail = url.split('/').pop();
+  if (tail == null || tail === '') return null;
+  return tail.split('?')[0];
+};
+
+export const resolveVideoUrl = (url: string): ResolvedEmbed => {
+  const yt = getYouTubeID(url);
+  if (yt != null) {
+    return { kind: 'iframe', src: getYouTubeEmbedLink(yt) };
+  }
+  if (isVimeoURL(url) != null) {
+    const id = vimeoIdFromUrl(url);
+    if (id != null && id !== '') {
+      return { kind: 'iframe', src: `https://player.vimeo.com/video/${id}` };
+    }
+  }
+  return { kind: 'raw-url', url };
+};
+
+export const resolveEmbedUrl = (url: string): ResolvedEmbed => {
+  if (isSoundCloudURL(url) != null) {
+    return {
+      kind: 'iframe',
+      src: `https://w.soundcloud.com/player/?url=${url}`,
+    };
+  }
+  if (isTwitterURL(url) != null) {
+    return { kind: 'twitter-link', url };
+  }
+  const yt = getYouTubeID(url);
+  if (yt != null) {
+    return { kind: 'iframe', src: getYouTubeEmbedLink(yt) };
+  }
+  if (isVimeoURL(url) != null) {
+    const id = vimeoIdFromUrl(url);
+    if (id != null && id !== '') {
+      return { kind: 'iframe', src: `https://player.vimeo.com/video/${id}` };
+    }
+  }
+  return { kind: 'iframe', src: url };
+};

--- a/src/lib/notion-render/escape.ts
+++ b/src/lib/notion-render/escape.ts
@@ -1,0 +1,13 @@
+const ENTITIES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export const escapeHtml = (input: string): string =>
+  input.replace(/[&<>"']/g, (ch) => ENTITIES[ch] ?? ch);
+
+export const escapeAttribute = (input: string): string =>
+  escapeHtml(input);

--- a/src/lib/notion-render/index.ts
+++ b/src/lib/notion-render/index.ts
@@ -1,0 +1,9 @@
+export { renderNotionBlocks } from './renderBlocks';
+export type {
+  NotionBlockChildrenFetcher,
+  NotionRenderableBlock,
+  RenderOptions,
+  RenderedBlocks,
+  WalkedMediaKind,
+  WalkedNotionMediaRef,
+} from './types';

--- a/src/lib/notion-render/renderBlocks.test.ts
+++ b/src/lib/notion-render/renderBlocks.test.ts
@@ -1,0 +1,353 @@
+import { renderNotionBlocks } from './renderBlocks';
+import {
+  NotionBlockChildrenFetcher,
+  NotionRenderableBlock,
+} from './types';
+
+const noChildren: NotionBlockChildrenFetcher = async () => [];
+
+const fetcherFor = (
+  byParent: Record<string, NotionRenderableBlock[]>
+): NotionBlockChildrenFetcher => {
+  return async (id: string) => byParent[id] ?? [];
+};
+
+const para = (text: string): NotionRenderableBlock => ({
+  type: 'paragraph',
+  paragraph: { rich_text: [{ plain_text: text }] },
+});
+
+describe('renderNotionBlocks — text blocks', () => {
+  it('renders a paragraph as <p>', async () => {
+    const out = await renderNotionBlocks([para('hello')], noChildren);
+    expect(out.html).toBe('<p>hello</p>');
+    expect(out.media).toEqual([]);
+  });
+
+  it('renders headings 1/2/3 (and folds heading_4 into h3)', async () => {
+    const blocks: NotionRenderableBlock[] = [
+      { type: 'heading_1', heading_1: { rich_text: [{ plain_text: 'A' }] } },
+      { type: 'heading_2', heading_2: { rich_text: [{ plain_text: 'B' }] } },
+      { type: 'heading_3', heading_3: { rich_text: [{ plain_text: 'C' }] } },
+      { type: 'heading_4', heading_3: { rich_text: [{ plain_text: 'D' }] } },
+    ];
+    const out = await renderNotionBlocks(blocks, noChildren);
+    expect(out.html).toBe('<h1>A</h1>\n<h2>B</h2>\n<h3>C</h3>\n<h3>D</h3>');
+  });
+
+  it('groups adjacent bulleted_list_items into one <ul>', async () => {
+    const blocks: NotionRenderableBlock[] = [
+      {
+        type: 'bulleted_list_item',
+        bulleted_list_item: { rich_text: [{ plain_text: 'one' }] },
+      },
+      {
+        type: 'bulleted_list_item',
+        bulleted_list_item: { rich_text: [{ plain_text: 'two' }] },
+      },
+      para('break'),
+      {
+        type: 'bulleted_list_item',
+        bulleted_list_item: { rich_text: [{ plain_text: 'three' }] },
+      },
+    ];
+    const out = await renderNotionBlocks(blocks, noChildren);
+    expect(out.html).toBe(
+      '<ul><li>one</li><li>two</li></ul>\n<p>break</p>\n<ul><li>three</li></ul>'
+    );
+  });
+
+  it('groups numbered list items into <ol> separately from <ul>', async () => {
+    const blocks: NotionRenderableBlock[] = [
+      {
+        type: 'numbered_list_item',
+        numbered_list_item: { rich_text: [{ plain_text: 'one' }] },
+      },
+      {
+        type: 'bulleted_list_item',
+        bulleted_list_item: { rich_text: [{ plain_text: 'a' }] },
+      },
+      {
+        type: 'numbered_list_item',
+        numbered_list_item: { rich_text: [{ plain_text: 'two' }] },
+      },
+    ];
+    const out = await renderNotionBlocks(blocks, noChildren);
+    expect(out.html).toBe(
+      '<ol><li>one</li></ol>\n<ul><li>a</li></ul>\n<ol><li>two</li></ol>'
+    );
+  });
+
+  it('renders to_do with checked / unchecked markers', async () => {
+    const blocks: NotionRenderableBlock[] = [
+      {
+        type: 'to_do',
+        to_do: { rich_text: [{ plain_text: 'done' }], checked: true },
+      },
+      {
+        type: 'to_do',
+        to_do: { rich_text: [{ plain_text: 'todo' }], checked: false },
+      },
+    ];
+    const out = await renderNotionBlocks(blocks, noChildren);
+    expect(out.html).toBe(
+      '<div class="todo">☑ done</div>\n<div class="todo">☐ todo</div>'
+    );
+  });
+
+  it('renders quote, divider, code, equation', async () => {
+    const blocks: NotionRenderableBlock[] = [
+      { type: 'quote', quote: { rich_text: [{ plain_text: 'said' }] } },
+      { type: 'divider', divider: {} },
+      {
+        type: 'code',
+        code: {
+          rich_text: [{ plain_text: 'console.log("hi")' }],
+          language: 'javascript',
+        },
+      },
+      { type: 'equation', equation: { expression: 'a + b' } },
+    ];
+    const out = await renderNotionBlocks(blocks, noChildren);
+    expect(out.html).toContain('<blockquote>said</blockquote>');
+    expect(out.html).toContain('<hr>');
+    expect(out.html).toContain(
+      '<pre><code class="language-javascript">console.log(&quot;hi&quot;)</code></pre>'
+    );
+    expect(out.html).toContain('\\(a + b\\)');
+  });
+});
+
+describe('renderNotionBlocks — recursion', () => {
+  it('recurses into toggle children and emits <details>', async () => {
+    const root: NotionRenderableBlock = {
+      id: 'tog1',
+      type: 'toggle',
+      has_children: true,
+      toggle: { rich_text: [{ plain_text: 'Q' }] },
+    };
+    const fetch = fetcherFor({ tog1: [para('A')] });
+    const out = await renderNotionBlocks([root], fetch);
+    expect(out.html).toBe('<details><summary>Q</summary><p>A</p></details>');
+  });
+
+  it('handles nested toggles up to maxDepth and stops past it', async () => {
+    const fetch = fetcherFor({
+      a: [{ id: 'b', type: 'toggle', has_children: true, toggle: { rich_text: [{ plain_text: 'b' }] } }],
+      b: [{ id: 'c', type: 'toggle', has_children: true, toggle: { rich_text: [{ plain_text: 'c' }] } }],
+      c: [para('deep')],
+    });
+    const root: NotionRenderableBlock = {
+      id: 'a',
+      type: 'toggle',
+      has_children: true,
+      toggle: { rich_text: [{ plain_text: 'a' }] },
+    };
+    const shallow = await renderNotionBlocks([root], fetch, { maxDepth: 2 });
+    expect(shallow.html).not.toContain('deep');
+
+    const deep = await renderNotionBlocks([root], fetch, { maxDepth: 8 });
+    expect(deep.html).toContain('deep');
+  });
+
+  it('renders callout text + emoji + nested children', async () => {
+    const fetch = fetcherFor({ co: [para('inside')] });
+    const block: NotionRenderableBlock = {
+      id: 'co',
+      type: 'callout',
+      has_children: true,
+      callout: {
+        rich_text: [{ plain_text: 'note' }],
+        icon: { type: 'emoji', emoji: '💡' },
+      },
+    };
+    const out = await renderNotionBlocks([block], fetch);
+    expect(out.html).toContain('💡 note');
+    expect(out.html).toContain('<p>inside</p>');
+    expect(out.html).toContain('class="callout"');
+  });
+});
+
+describe('renderNotionBlocks — media', () => {
+  it('emits an external image as <img> and one external media ref', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'img1',
+      type: 'image',
+      image: { type: 'external', external: { url: 'https://x/i.png' } },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toBe('<img src="https://x/i.png">');
+    expect(out.media).toEqual([
+      {
+        block_id: 'img1',
+        kind: 'image',
+        source: 'external',
+        url: 'https://x/i.png',
+      },
+    ]);
+  });
+
+  it('emits a file image with ankify-{id}.{ext} filename and a file media ref', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'img2',
+      type: 'image',
+      image: {
+        type: 'file',
+        file: { url: 'https://signed-url/file.JPG?x=1' },
+      },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toContain('<img src="ankify-img2.jpg">');
+    expect(out.media[0]).toMatchObject({
+      block_id: 'img2',
+      kind: 'image',
+      source: 'file',
+      filename: 'ankify-img2.jpg',
+    });
+  });
+
+  it('rewrites a YouTube external video to an iframe and emits a media ref', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'v1',
+      type: 'video',
+      video: {
+        type: 'external',
+        external: { url: 'https://youtu.be/dQw4w9WgXcQ' },
+      },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toContain(
+      '<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ?'
+    );
+    expect(out.media[0]).toMatchObject({
+      block_id: 'v1',
+      kind: 'video',
+      source: 'external',
+    });
+  });
+
+  it('rewrites a Vimeo external video to player.vimeo.com', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'v2',
+      type: 'video',
+      video: {
+        type: 'external',
+        external: { url: 'https://vimeo.com/123' },
+      },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toContain('https://player.vimeo.com/video/123');
+  });
+
+  it('downloads a hosted video as ankify-{id}.{ext} and emits a file media ref', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'v3',
+      type: 'video',
+      video: {
+        type: 'file',
+        file: { url: 'https://signed/clip.MP4?token=abc' },
+      },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toContain(
+      '<video controls src="ankify-v3.mp4"></video>'
+    );
+    expect(out.media[0]).toMatchObject({
+      block_id: 'v3',
+      kind: 'video',
+      source: 'file',
+      filename: 'ankify-v3.mp4',
+    });
+  });
+
+  it('emits an Anki [sound:] tag for audio blocks', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'au1',
+      type: 'audio',
+      audio: {
+        type: 'external',
+        external: { url: 'https://x/clip.mp3' },
+      },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toContain('[sound:ankify-au1.mp3]');
+    expect(out.media[0]).toMatchObject({
+      block_id: 'au1',
+      kind: 'audio',
+      filename: 'ankify-au1.mp3',
+    });
+  });
+
+  it('emits a download link for file blocks (using name when present)', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'f1',
+      type: 'file',
+      file: {
+        type: 'file',
+        file: { url: 'https://x/notes.pdf?t=1' },
+        name: 'class-notes.pdf',
+      },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toContain(
+      '<a href="ankify-f1.pdf">class-notes.pdf</a>'
+    );
+    expect(out.media[0]).toMatchObject({ kind: 'file', filename: 'ankify-f1.pdf' });
+  });
+
+  it('emits an iframe for pdf blocks and tracks the file', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'pdf1',
+      type: 'pdf',
+      pdf: {
+        type: 'file',
+        file: { url: 'https://x/doc.pdf' },
+      },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toContain(
+      '<iframe src="ankify-pdf1.pdf"'
+    );
+    expect(out.media[0]).toMatchObject({ kind: 'file', filename: 'ankify-pdf1.pdf' });
+  });
+
+  it('rewrites embed YouTube to iframe and embed Twitter to source link', async () => {
+    const yt: NotionRenderableBlock = {
+      id: 'e1',
+      type: 'embed',
+      embed: { url: 'https://youtu.be/abcdefghijk' },
+    };
+    const tw: NotionRenderableBlock = {
+      id: 'e2',
+      type: 'embed',
+      embed: { url: 'https://twitter.com/u/status/1' },
+    };
+    const out = await renderNotionBlocks([yt, tw], noChildren);
+    expect(out.html).toContain('<iframe');
+    expect(out.html).toContain(
+      '<div class="source"><a href="https://twitter.com/u/status/1">'
+    );
+  });
+
+  it('renders bookmark blocks as a plain anchor', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'b1',
+      type: 'bookmark',
+      bookmark: { url: 'https://example.com/x' },
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toBe(
+      '<a href="https://example.com/x">https://example.com/x</a>'
+    );
+  });
+
+  it('skips unknown block types silently', async () => {
+    const block: NotionRenderableBlock = {
+      id: 'mystery',
+      type: 'something_new',
+    };
+    const out = await renderNotionBlocks([block], noChildren);
+    expect(out.html).toBe('');
+    expect(out.media).toEqual([]);
+  });
+});

--- a/src/lib/notion-render/renderBlocks.ts
+++ b/src/lib/notion-render/renderBlocks.ts
@@ -1,0 +1,423 @@
+import { escapeAttribute, escapeHtml } from './escape';
+import { resolveEmbedUrl, resolveVideoUrl } from './embedUrl';
+import { renderPlainText, renderRichText } from './richText';
+import {
+  NotionBlockChildrenFetcher,
+  NotionRenderableBlock,
+  NotionRichTextItem,
+  RenderOptions,
+  RenderedBlocks,
+  WalkedNotionMediaRef,
+} from './types';
+
+const DEFAULT_MAX_DEPTH = 8;
+
+const extToken = (url: string): string => {
+  const cleaned = url.split('?')[0];
+  const m = /\.([a-zA-Z0-9]{1,5})$/.exec(cleaned);
+  if (m == null) return '';
+  return m[1].toLowerCase();
+};
+
+const buildMediaFilename = (
+  block: NotionRenderableBlock,
+  url: string,
+  fallback: string
+): string => {
+  const ext = extToken(url);
+  const id = block.id ?? 'unknown';
+  return `ankify-${id}.${ext === '' ? fallback : ext}`;
+};
+
+interface MediaContent {
+  type: 'external' | 'file';
+  external?: { url: string };
+  file?: { url: string; expiry_time?: string };
+  caption?: NotionRichTextItem[];
+  name?: string;
+}
+
+const mediaUrl = (content: MediaContent): string | null => {
+  if (content.type === 'external') return content.external?.url ?? null;
+  return content.file?.url ?? null;
+};
+
+const renderCaption = (caption: NotionRichTextItem[] | undefined): string => {
+  const html = renderRichText(caption);
+  if (html === '') return '';
+  return `<figcaption>${html}</figcaption>`;
+};
+
+interface ListBuffer {
+  type: 'ul' | 'ol' | null;
+  items: string[];
+}
+
+const flushList = (buf: ListBuffer): string => {
+  if (buf.type == null || buf.items.length === 0) {
+    buf.type = null;
+    buf.items = [];
+    return '';
+  }
+  const tag = buf.type;
+  const html = `<${tag}>${buf.items.join('')}</${tag}>`;
+  buf.type = null;
+  buf.items = [];
+  return html;
+};
+
+const pushListItem = (
+  buf: ListBuffer,
+  type: 'ul' | 'ol',
+  itemHtml: string,
+  out: string[]
+): void => {
+  if (buf.type !== type) {
+    const flushed = flushList(buf);
+    if (flushed !== '') out.push(flushed);
+    buf.type = type;
+  }
+  buf.items.push(`<li>${itemHtml}</li>`);
+};
+
+const renderImageBlock = (
+  block: NotionRenderableBlock,
+  media: WalkedNotionMediaRef[]
+): string => {
+  const content = block.image;
+  if (content == null || block.id == null) return '';
+  const url = mediaUrl(content);
+  if (url == null) return '';
+  if (content.type === 'external') {
+    media.push({
+      block_id: block.id,
+      kind: 'image',
+      source: 'external',
+      url,
+    });
+    return `<img src="${escapeAttribute(url)}">${renderCaption(content.caption)}`;
+  }
+  const filename = buildMediaFilename(block, url, 'png');
+  media.push({
+    block_id: block.id,
+    kind: 'image',
+    source: 'file',
+    url,
+    filename,
+  });
+  return `<img src="${escapeAttribute(filename)}">${renderCaption(content.caption)}`;
+};
+
+const renderVideoBlock = (
+  block: NotionRenderableBlock,
+  media: WalkedNotionMediaRef[]
+): string => {
+  const content = block.video;
+  if (content == null || block.id == null) return '';
+  const url = mediaUrl(content);
+  if (url == null) return '';
+  const caption = renderCaption(content.caption);
+  if (content.type === 'external') {
+    const resolved = resolveVideoUrl(url);
+    media.push({
+      block_id: block.id,
+      kind: 'video',
+      source: 'external',
+      url,
+    });
+    if (resolved.kind === 'iframe') {
+      return `<iframe width="560" height="315" src="${escapeAttribute(resolved.src)}" frameborder="0" allowfullscreen></iframe>${caption}`;
+    }
+    return `<video controls src="${escapeAttribute(resolved.url)}"></video>${caption}`;
+  }
+  const filename = buildMediaFilename(block, url, 'mp4');
+  media.push({
+    block_id: block.id,
+    kind: 'video',
+    source: 'file',
+    url,
+    filename,
+  });
+  return `<video controls src="${escapeAttribute(filename)}"></video>${caption}`;
+};
+
+const renderAudioBlock = (
+  block: NotionRenderableBlock,
+  media: WalkedNotionMediaRef[]
+): string => {
+  const content = block.audio;
+  if (content == null || block.id == null) return '';
+  const url = mediaUrl(content);
+  if (url == null) return '';
+  const filename = buildMediaFilename(block, url, 'mp3');
+  media.push({
+    block_id: block.id,
+    kind: 'audio',
+    source: content.type,
+    url,
+    filename,
+  });
+  const caption = renderCaption(content.caption);
+  return `[sound:${filename}]${caption}`;
+};
+
+const renderFileBlock = (
+  block: NotionRenderableBlock,
+  media: WalkedNotionMediaRef[]
+): string => {
+  const content = block.file;
+  if (content == null || block.id == null) return '';
+  const url = mediaUrl(content);
+  if (url == null) return '';
+  const filename = buildMediaFilename(block, url, 'bin');
+  media.push({
+    block_id: block.id,
+    kind: 'file',
+    source: content.type,
+    url,
+    filename,
+  });
+  const label = content.name ?? filename;
+  const caption = renderCaption(content.caption);
+  return `<a href="${escapeAttribute(filename)}">${escapeHtml(label)}</a>${caption}`;
+};
+
+const renderPdfBlock = (
+  block: NotionRenderableBlock,
+  media: WalkedNotionMediaRef[]
+): string => {
+  const content = block.pdf;
+  if (content == null || block.id == null) return '';
+  const url = mediaUrl(content);
+  if (url == null) return '';
+  const filename = buildMediaFilename(block, url, 'pdf');
+  media.push({
+    block_id: block.id,
+    kind: 'file',
+    source: content.type,
+    url,
+    filename,
+  });
+  const caption = renderCaption(content.caption);
+  return `<iframe src="${escapeAttribute(filename)}" width="100%" height="400"></iframe>${caption}`;
+};
+
+const renderEmbedBlock = (block: NotionRenderableBlock): string => {
+  const content = block.embed;
+  if (content?.url == null || content.url === '') return '';
+  const resolved = resolveEmbedUrl(content.url);
+  if (resolved.kind === 'iframe') {
+    return `<iframe width="560" height="315" src="${escapeAttribute(resolved.src)}" frameborder="0" allowfullscreen></iframe>`;
+  }
+  if (resolved.kind === 'twitter-link') {
+    return `<div class="source"><a href="${escapeAttribute(resolved.url)}">${escapeHtml(resolved.url)}</a></div>`;
+  }
+  return `<a href="${escapeAttribute(resolved.url)}">${escapeHtml(resolved.url)}</a>`;
+};
+
+const renderBookmarkBlock = (block: NotionRenderableBlock): string => {
+  const content = block.bookmark;
+  if (content?.url == null || content.url === '') return '';
+  return `<a href="${escapeAttribute(content.url)}">${escapeHtml(content.url)}</a>`;
+};
+
+const renderHeading = (
+  level: 1 | 2 | 3,
+  block: NotionRenderableBlock
+): string => {
+  const holder =
+    level === 1
+      ? block.heading_1
+      : level === 2
+        ? block.heading_2
+        : block.heading_3;
+  const inner = renderRichText(holder?.rich_text);
+  if (inner === '') return '';
+  return `<h${level}>${inner}</h${level}>`;
+};
+
+const renderTodo = (block: NotionRenderableBlock): string => {
+  const inner = renderRichText(block.to_do?.rich_text);
+  if (inner === '') return '';
+  const mark = block.to_do?.checked === true ? '☑' : '☐';
+  return `<div class="todo">${mark} ${inner}</div>`;
+};
+
+const renderQuote = (block: NotionRenderableBlock): string => {
+  const inner = renderRichText(block.quote?.rich_text);
+  if (inner === '') return '';
+  return `<blockquote>${inner}</blockquote>`;
+};
+
+const renderCode = (block: NotionRenderableBlock): string => {
+  const inner = renderPlainText(block.code?.rich_text);
+  if (inner === '') return '';
+  const lang = block.code?.language ?? 'plaintext';
+  return `<pre><code class="language-${escapeAttribute(lang)}">${escapeHtml(inner)}</code></pre>`;
+};
+
+const renderEquation = (block: NotionRenderableBlock): string => {
+  const expr = block.equation?.expression;
+  if (expr == null || expr === '') return '';
+  return `\\(${escapeHtml(expr)}\\)`;
+};
+
+const renderChildPageTitle = (block: NotionRenderableBlock): string => {
+  const title = block.child_page?.title ?? block.child_database?.title;
+  if (title == null || title === '') return '';
+  return `<p><strong>${escapeHtml(title)}</strong></p>`;
+};
+
+interface RenderContext {
+  fetchChildren: NotionBlockChildrenFetcher;
+  maxDepth: number;
+  media: WalkedNotionMediaRef[];
+}
+
+const renderToggle = async (
+  block: NotionRenderableBlock,
+  ctx: RenderContext,
+  depth: number
+): Promise<string> => {
+  const summary = renderRichText(block.toggle?.rich_text);
+  const childrenHtml = await renderChildren(block, ctx, depth);
+  return `<details><summary>${summary}</summary>${childrenHtml}</details>`;
+};
+
+const renderCallout = async (
+  block: NotionRenderableBlock,
+  ctx: RenderContext,
+  depth: number
+): Promise<string> => {
+  const inner = renderRichText(block.callout?.rich_text);
+  const emoji =
+    block.callout?.icon?.type === 'emoji' ? block.callout.icon.emoji ?? '' : '';
+  const childrenHtml = await renderChildren(block, ctx, depth);
+  const head = emoji === '' ? inner : `${escapeHtml(emoji)} ${inner}`;
+  return `<div class="callout">${head}${childrenHtml}</div>`;
+};
+
+const renderChildren = async (
+  block: NotionRenderableBlock,
+  ctx: RenderContext,
+  depth: number
+): Promise<string> => {
+  if (block.has_children !== true || block.id == null) return '';
+  if (depth >= ctx.maxDepth) return '';
+  const children = await ctx.fetchChildren(block.id);
+  return await renderBlockList(children, ctx, depth + 1);
+};
+
+const renderBlockList = async (
+  blocks: NotionRenderableBlock[],
+  ctx: RenderContext,
+  depth: number
+): Promise<string> => {
+  const out: string[] = [];
+  const buf: ListBuffer = { type: null, items: [] };
+
+  for (const block of blocks) {
+    const isList =
+      block.type === 'bulleted_list_item' ||
+      block.type === 'numbered_list_item';
+    if (!isList) {
+      const flushed = flushList(buf);
+      if (flushed !== '') out.push(flushed);
+    }
+
+    switch (block.type) {
+      case 'paragraph': {
+        const inner = renderRichText(block.paragraph?.rich_text);
+        if (inner !== '') out.push(`<p>${inner}</p>`);
+        break;
+      }
+      case 'heading_1':
+        out.push(renderHeading(1, block));
+        break;
+      case 'heading_2':
+        out.push(renderHeading(2, block));
+        break;
+      case 'heading_3':
+      case 'heading_4':
+        out.push(renderHeading(3, block));
+        break;
+      case 'bulleted_list_item': {
+        const inner = renderRichText(block.bulleted_list_item?.rich_text);
+        if (inner !== '') pushListItem(buf, 'ul', inner, out);
+        break;
+      }
+      case 'numbered_list_item': {
+        const inner = renderRichText(block.numbered_list_item?.rich_text);
+        if (inner !== '') pushListItem(buf, 'ol', inner, out);
+        break;
+      }
+      case 'to_do':
+        out.push(renderTodo(block));
+        break;
+      case 'toggle':
+        out.push(await renderToggle(block, ctx, depth));
+        break;
+      case 'quote':
+        out.push(renderQuote(block));
+        break;
+      case 'callout':
+        out.push(await renderCallout(block, ctx, depth));
+        break;
+      case 'code':
+        out.push(renderCode(block));
+        break;
+      case 'equation':
+        out.push(renderEquation(block));
+        break;
+      case 'divider':
+        out.push('<hr>');
+        break;
+      case 'image':
+        out.push(renderImageBlock(block, ctx.media));
+        break;
+      case 'video':
+        out.push(renderVideoBlock(block, ctx.media));
+        break;
+      case 'audio':
+        out.push(renderAudioBlock(block, ctx.media));
+        break;
+      case 'file':
+        out.push(renderFileBlock(block, ctx.media));
+        break;
+      case 'pdf':
+        out.push(renderPdfBlock(block, ctx.media));
+        break;
+      case 'embed':
+        out.push(renderEmbedBlock(block));
+        break;
+      case 'bookmark':
+        out.push(renderBookmarkBlock(block));
+        break;
+      case 'child_page':
+      case 'child_database':
+        out.push(renderChildPageTitle(block));
+        break;
+      default:
+        break;
+    }
+  }
+
+  const tail = flushList(buf);
+  if (tail !== '') out.push(tail);
+
+  return out.filter((s) => s !== '').join('\n');
+};
+
+export const renderNotionBlocks = async (
+  blocks: NotionRenderableBlock[],
+  fetchChildren: NotionBlockChildrenFetcher,
+  options: RenderOptions = {}
+): Promise<RenderedBlocks> => {
+  const ctx: RenderContext = {
+    fetchChildren,
+    maxDepth: options.maxDepth ?? DEFAULT_MAX_DEPTH,
+    media: [],
+  };
+  const html = await renderBlockList(blocks, ctx, 0);
+  return { html, media: ctx.media };
+};

--- a/src/lib/notion-render/richText.test.ts
+++ b/src/lib/notion-render/richText.test.ts
@@ -1,0 +1,62 @@
+import { renderPlainText, renderRichText } from './richText';
+
+describe('renderRichText', () => {
+  it('returns empty string for nullish or empty input', () => {
+    expect(renderRichText(undefined)).toBe('');
+    expect(renderRichText([])).toBe('');
+  });
+
+  it('escapes html-special characters in plain_text', () => {
+    expect(renderRichText([{ plain_text: '<script>&"' }])).toBe(
+      '&lt;script&gt;&amp;&quot;'
+    );
+  });
+
+  it('wraps annotated text — bold + italic + code + strike + underline', () => {
+    expect(
+      renderRichText([
+        {
+          plain_text: 'hi',
+          annotations: {
+            bold: true,
+            italic: true,
+            code: true,
+            strikethrough: true,
+            underline: true,
+          },
+        },
+      ])
+    ).toBe('<u><del><em><strong><code>hi</code></strong></em></del></u>');
+  });
+
+  it('renders an anchor tag when href is present', () => {
+    expect(
+      renderRichText([
+        { plain_text: 'click', href: 'https://example.com/?x=1&y=2' },
+      ])
+    ).toBe('<a href="https://example.com/?x=1&amp;y=2">click</a>');
+  });
+
+  it('renders inline LaTeX for equation items', () => {
+    expect(
+      renderRichText([
+        { type: 'equation', equation: { expression: 'a < b' } },
+      ])
+    ).toBe('\\(a &lt; b\\)');
+  });
+});
+
+describe('renderPlainText', () => {
+  it('joins plain_text without escaping or annotations', () => {
+    expect(
+      renderPlainText([
+        { plain_text: 'a', annotations: { bold: true } },
+        { plain_text: '<b>' },
+      ])
+    ).toBe('a<b>');
+  });
+
+  it('returns empty string for nullish input', () => {
+    expect(renderPlainText(undefined)).toBe('');
+  });
+});

--- a/src/lib/notion-render/richText.ts
+++ b/src/lib/notion-render/richText.ts
@@ -1,0 +1,36 @@
+import { escapeAttribute, escapeHtml } from './escape';
+import { NotionRichTextItem } from './types';
+
+const wrap = (open: string, close: string, inner: string): string =>
+  `${open}${inner}${close}`;
+
+export const renderRichTextItem = (item: NotionRichTextItem): string => {
+  if (item.type === 'equation' && item.equation?.expression != null) {
+    return `\\(${escapeHtml(item.equation.expression)}\\)`;
+  }
+  let inner = escapeHtml(item.plain_text ?? '');
+  const a = item.annotations ?? {};
+  if (a.code) inner = wrap('<code>', '</code>', inner);
+  if (a.bold) inner = wrap('<strong>', '</strong>', inner);
+  if (a.italic) inner = wrap('<em>', '</em>', inner);
+  if (a.strikethrough) inner = wrap('<del>', '</del>', inner);
+  if (a.underline) inner = wrap('<u>', '</u>', inner);
+  if (item.href != null && item.href !== '') {
+    inner = `<a href="${escapeAttribute(item.href)}">${inner}</a>`;
+  }
+  return inner;
+};
+
+export const renderRichText = (
+  items: NotionRichTextItem[] | undefined
+): string => {
+  if (items == null || items.length === 0) return '';
+  return items.map(renderRichTextItem).join('');
+};
+
+export const renderPlainText = (
+  items: NotionRichTextItem[] | undefined
+): string => {
+  if (items == null) return '';
+  return items.map((item) => item.plain_text ?? '').join('');
+};

--- a/src/lib/notion-render/types.ts
+++ b/src/lib/notion-render/types.ts
@@ -1,0 +1,79 @@
+export interface NotionRichTextItem {
+  plain_text?: string;
+  href?: string | null;
+  annotations?: {
+    bold?: boolean;
+    italic?: boolean;
+    strikethrough?: boolean;
+    underline?: boolean;
+    code?: boolean;
+    color?: string;
+  };
+  equation?: { expression?: string };
+  type?: string;
+}
+
+interface RichTextHolder {
+  rich_text?: NotionRichTextItem[];
+}
+
+interface MediaContent {
+  type: 'external' | 'file';
+  external?: { url: string };
+  file?: { url: string; expiry_time?: string };
+  caption?: NotionRichTextItem[];
+  name?: string;
+}
+
+export interface NotionRenderableBlock {
+  id?: string;
+  type: string;
+  has_children?: boolean;
+  paragraph?: RichTextHolder & { color?: string };
+  heading_1?: RichTextHolder;
+  heading_2?: RichTextHolder;
+  heading_3?: RichTextHolder;
+  bulleted_list_item?: RichTextHolder;
+  numbered_list_item?: RichTextHolder;
+  to_do?: RichTextHolder & { checked?: boolean };
+  toggle?: RichTextHolder;
+  quote?: RichTextHolder;
+  callout?: RichTextHolder & {
+    icon?: { type: 'emoji' | 'external' | 'file'; emoji?: string };
+  };
+  code?: RichTextHolder & { language?: string };
+  equation?: { expression?: string };
+  image?: MediaContent;
+  video?: MediaContent;
+  audio?: MediaContent;
+  file?: MediaContent;
+  pdf?: MediaContent;
+  embed?: { url?: string; caption?: NotionRichTextItem[] };
+  bookmark?: { url?: string; caption?: NotionRichTextItem[] };
+  divider?: Record<string, never>;
+  child_page?: { title?: string };
+  child_database?: { title?: string };
+}
+
+export type WalkedMediaKind = 'image' | 'video' | 'audio' | 'file';
+
+export interface WalkedNotionMediaRef {
+  block_id: string;
+  kind: WalkedMediaKind;
+  source: 'external' | 'file';
+  url: string;
+  filename?: string;
+}
+
+export type NotionBlockChildrenFetcher = (
+  blockId: string
+) => Promise<NotionRenderableBlock[]>;
+
+export interface RenderedBlocks {
+  html: string;
+  media: WalkedNotionMediaRef[];
+}
+
+export interface RenderOptions {
+  maxDepth?: number;
+}

--- a/src/services/ankify/notionPageWalker.test.ts
+++ b/src/services/ankify/notionPageWalker.test.ts
@@ -15,7 +15,7 @@ const paragraphChild = (text: string) => ({
 });
 
 describe('walkNotionPageForFlashcards', () => {
-  test('extracts image blocks from toggle children and embeds <img> in the back', async () => {
+  test('extracts hosted image blocks and embeds <img> with ankify-{id}.{ext}', async () => {
     const fetchChildren = jest.fn(async (blockId: string) => {
       if (blockId === 'page-id') {
         return [toggleBlock()];
@@ -36,14 +36,15 @@ describe('walkNotionPageForFlashcards', () => {
       ];
     });
 
-    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren);
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
 
     expect(cards).toHaveLength(1);
     expect(cards[0].back).toContain('Spaced repetition.');
-    expect(cards[0].back).toContain('<img');
-    expect(cards[0].images).toEqual([
+    expect(cards[0].back).toContain('<img src="ankify-img-block-77.png">');
+    expect(cards[0].media).toEqual([
       {
         block_id: 'img-block-77',
+        kind: 'image',
         source: 'file',
         url: 'https://prod-files.notion.so/abc/img.png?signed=1',
         filename: 'ankify-img-block-77.png',
@@ -68,18 +69,131 @@ describe('walkNotionPageForFlashcards', () => {
       ];
     });
 
-    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren);
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
 
     expect(cards[0].back).toContain(
       '<img src="https://cdn.example.com/diagram.png">'
     );
-    expect(cards[0].images).toEqual([
+    expect(cards[0].media).toEqual([
       {
         block_id: 'img-block-ext',
+        kind: 'image',
         source: 'external',
         url: 'https://cdn.example.com/diagram.png',
       },
     ]);
+  });
+
+  test('rewrites a YouTube external video to an iframe', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') return [toggleBlock()];
+      return [
+        {
+          id: 'vid-1',
+          type: 'video',
+          video: {
+            type: 'external',
+            external: { url: 'https://youtu.be/dQw4w9WgXcQ' },
+          },
+        },
+      ];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
+
+    expect(cards[0].back).toContain(
+      'src="https://www.youtube.com/embed/dQw4w9WgXcQ?'
+    );
+    expect(cards[0].media[0]).toMatchObject({ kind: 'video', source: 'external' });
+  });
+
+  test('emits an Anki [sound:] tag for audio blocks and tracks the file', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') return [toggleBlock()];
+      return [
+        {
+          id: 'a-1',
+          type: 'audio',
+          audio: {
+            type: 'file',
+            file: { url: 'https://signed/song.mp3' },
+          },
+        },
+      ];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
+
+    expect(cards[0].back).toContain('[sound:ankify-a-1.mp3]');
+    expect(cards[0].media[0]).toMatchObject({
+      kind: 'audio',
+      filename: 'ankify-a-1.mp3',
+      source: 'file',
+    });
+  });
+
+  test('renders an embed block as an iframe', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') return [toggleBlock()];
+      return [
+        {
+          id: 'em-1',
+          type: 'embed',
+          embed: { url: 'https://youtu.be/dQw4w9WgXcQ' },
+        },
+      ];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
+
+    expect(cards[0].back).toContain('<iframe');
+    expect(cards[0].back).toContain('youtube.com/embed/');
+  });
+
+  test('extracts file blocks as download links and tracks them', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') return [toggleBlock()];
+      return [
+        {
+          id: 'f-1',
+          type: 'file',
+          file: {
+            type: 'file',
+            file: { url: 'https://signed/notes.pdf' },
+            name: 'class-notes.pdf',
+          },
+        },
+      ];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
+
+    expect(cards[0].back).toContain('<a href="ankify-f-1.pdf">class-notes.pdf</a>');
+    expect(cards[0].media[0]).toMatchObject({ kind: 'file', filename: 'ankify-f-1.pdf' });
+  });
+
+  test('recurses into nested toggles inside a parent toggle', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') return [toggleBlock({ id: 'outer' })];
+      if (blockId === 'outer') {
+        return [
+          {
+            id: 'inner',
+            type: 'toggle',
+            has_children: true,
+            toggle: { rich_text: [{ plain_text: 'sub-q' }] },
+          },
+        ];
+      }
+      if (blockId === 'inner') return [paragraphChild('sub-a')];
+      return [];
+    });
+
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
+
+    expect(cards[0].back).toContain('<details>');
+    expect(cards[0].back).toContain('<summary>sub-q</summary>');
+    expect(cards[0].back).toContain('<p>sub-a</p>');
   });
 
   test('skips toggles with empty front text', async () => {
@@ -93,7 +207,7 @@ describe('walkNotionPageForFlashcards', () => {
       return [paragraphChild('answer')];
     });
 
-    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren);
+    const cards = await walkNotionPageForFlashcards('page-id', fetchChildren as never);
 
     expect(cards).toHaveLength(1);
     expect(cards[0].notion_block_id).toBe('t-real');

--- a/src/services/ankify/notionPageWalker.ts
+++ b/src/services/ankify/notionPageWalker.ts
@@ -1,3 +1,10 @@
+import {
+  NotionRenderableBlock,
+  WalkedMediaKind,
+  WalkedNotionMediaRef,
+  renderNotionBlocks,
+} from '../../lib/notion-render';
+
 interface RichTextItem {
   plain_text?: string;
 }
@@ -10,134 +17,47 @@ interface NotionToggleBlock {
   toggle: { rich_text: RichTextItem[] };
 }
 
-interface NotionParagraphBlock {
-  type: 'paragraph';
-  paragraph: { rich_text: RichTextItem[] };
-}
+type NotionTopLevelBlock = NotionToggleBlock | { type: string; id?: string };
 
-interface NotionBulletedListItemBlock {
-  type: 'bulleted_list_item';
-  bulleted_list_item: { rich_text: RichTextItem[] };
-}
-
-interface NotionImageBlock {
-  id: string;
-  type: 'image';
-  image:
-    | { type: 'external'; external: { url: string } }
-    | { type: 'file'; file: { url: string; expiry_time?: string } };
-}
-
-type NotionChildBlock =
-  | NotionToggleBlock
-  | NotionParagraphBlock
-  | NotionBulletedListItemBlock
-  | NotionImageBlock
-  | { type: string; id?: string };
-
-export type WalkedImageSource = 'external' | 'file';
-
-export interface WalkedNotionImageRef {
-  block_id: string;
-  source: WalkedImageSource;
-  url: string;
-  filename?: string;
-}
+export type { WalkedMediaKind, WalkedNotionMediaRef };
 
 export interface WalkedNotionFlashcard {
   notion_block_id: string;
   notion_last_edited_at: Date;
   front: string;
   back: string;
-  images: WalkedNotionImageRef[];
+  media: WalkedNotionMediaRef[];
 }
 
 export type NotionBlockChildrenFetcher = (
   blockId: string
-) => Promise<NotionChildBlock[]>;
+) => Promise<NotionRenderableBlock[]>;
 
 const renderRichText = (items: RichTextItem[] | undefined): string => {
-  if (items == null) {
-    return '';
-  }
+  if (items == null) return '';
   return items
     .map((item) => item.plain_text ?? '')
     .join('')
     .trim();
 };
 
-const buildMediaFilename = (image: NotionImageBlock): string => {
-  const url = image.image.type === 'file'
-    ? image.image.file.url
-    : image.image.external.url;
-  const cleanedUrl = url.split('?')[0];
-  const extMatch = /\.([a-zA-Z0-9]{1,5})$/.exec(cleanedUrl);
-  const ext = extMatch == null ? 'png' : extMatch[1].toLowerCase();
-  return `ankify-${image.id}.${ext}`;
-};
-
-const renderImageHtml = (image: NotionImageBlock): string => {
-  if (image.image.type === 'external') {
-    return `<img src="${image.image.external.url}">`;
-  }
-  return `<img src="${buildMediaFilename(image)}">`;
-};
-
-const buildImageRef = (image: NotionImageBlock): WalkedNotionImageRef => {
-  if (image.image.type === 'file') {
-    return {
-      block_id: image.id,
-      source: 'file',
-      url: image.image.file.url,
-      filename: buildMediaFilename(image),
-    };
-  }
-  return {
-    block_id: image.id,
-    source: 'external',
-    url: image.image.external.url,
-  };
-};
-
 const renderToggleBack = async (
   toggle: NotionToggleBlock,
   fetchChildren: NotionBlockChildrenFetcher
-): Promise<{ back: string; images: WalkedNotionImageRef[] }> => {
+): Promise<{ back: string; media: WalkedNotionMediaRef[] }> => {
   if (!toggle.has_children) {
-    return { back: '', images: [] };
+    return { back: '', media: [] };
   }
   const children = await fetchChildren(toggle.id);
-  const lines: string[] = [];
-  const images: WalkedNotionImageRef[] = [];
-  for (const child of children) {
-    if (child.type === 'paragraph') {
-      lines.push(
-        renderRichText((child as NotionParagraphBlock).paragraph.rich_text)
-      );
-    } else if (child.type === 'bulleted_list_item') {
-      const text = renderRichText(
-        (child as NotionBulletedListItemBlock).bulleted_list_item.rich_text
-      );
-      if (text.length > 0) {
-        lines.push(`• ${text}`);
-      }
-    } else if (child.type === 'image' && child.id != null) {
-      const imageBlock = child as NotionImageBlock;
-      lines.push(renderImageHtml(imageBlock));
-      images.push(buildImageRef(imageBlock));
-    }
-  }
-  return {
-    back: lines.filter((line) => line.length > 0).join('\n'),
-    images,
-  };
+  const rendered = await renderNotionBlocks(children, fetchChildren);
+  return { back: rendered.html, media: rendered.media };
 };
 
 export const walkNotionPageForFlashcards = async (
   pageId: string,
   fetchChildren: NotionBlockChildrenFetcher
 ): Promise<WalkedNotionFlashcard[]> => {
-  const topLevel = await fetchChildren(pageId);
+  const topLevel = (await fetchChildren(pageId)) as NotionTopLevelBlock[];
   const cards: WalkedNotionFlashcard[] = [];
   for (const block of topLevel) {
     if (block.type !== 'toggle') {
@@ -148,15 +68,14 @@ export const walkNotionPageForFlashcards = async (
     if (front.length === 0) {
       continue;
     }
-    const { back, images } = await renderToggleBack(toggle, fetchChildren);
+    const { back, media } = await renderToggleBack(toggle, fetchChildren);
     cards.push({
       notion_block_id: toggle.id,
       notion_last_edited_at: new Date(toggle.last_edited_time),
       front,
       back,
-      images,
+      media,
     });
   }
   return cards;
 };
-

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -58,7 +58,7 @@ const sampleCard = (
   front: 'Front text',
   back: 'Back text',
   notion_last_edited_at: new Date(),
-  images: [],
+  media: [],
   ...overrides,
 });
 
@@ -453,9 +453,10 @@ describe('SyncNotionPageToRacUseCase', () => {
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([
       sampleCard({
         back: 'See <img src="ankify-img-77.png">',
-        images: [
+        media: [
           {
             block_id: 'img-77',
+            kind: 'image',
             source: 'file',
             url: 'https://prod-files.notion.so/img.png?signed=1',
             filename: 'ankify-img-77.png',
@@ -510,9 +511,10 @@ describe('SyncNotionPageToRacUseCase', () => {
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([
       sampleCard({
         back: '<img src="https://cdn.example.com/x.png">',
-        images: [
+        media: [
           {
             block_id: 'img-ext',
+            kind: 'image',
             source: 'external',
             url: 'https://cdn.example.com/x.png',
           },
@@ -549,9 +551,10 @@ describe('SyncNotionPageToRacUseCase', () => {
 
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue([
       sampleCard({
-        images: [
+        media: [
           {
             block_id: 'img-bad',
+            kind: 'image',
             source: 'file',
             url: 'https://prod-files.notion.so/bad.png?signed=1',
             filename: 'ankify-img-bad.png',

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -20,7 +20,7 @@ import {
   walkNotionPageForFlashcards,
   NotionBlockChildrenFetcher,
   WalkedNotionFlashcard,
-  WalkedNotionImageRef,
+  WalkedNotionMediaRef,
 } from '../../services/ankify/notionPageWalker';
 import { NoActiveAnkifyClientError } from './SendUploadToRacUseCase';
 import { NotionNotConnectedError } from './ExportReviewDataToNotionUseCase';
@@ -74,7 +74,7 @@ const BACK_FIELD_BASIC = 'Back';
 const DECK_PARENT = 'Notion Sync';
 const DECK_TITLE_FALLBACK = 'Untitled';
 
-export type AnkifyImageFetcher = typeof fetch;
+export type AnkifyMediaFetcher = typeof fetch;
 
 const sanitizeDeckTitle = (title: string | null | undefined): string => {
   if (title == null) {
@@ -106,7 +106,7 @@ export class SyncNotionPageToRacUseCase {
     private readonly ankiConnect: AnkiConnectFactory,
     private readonly notionFetcher: NotionFetcherFactory,
     private readonly notionPageMeta?: NotionPageMetaFetcher,
-    private readonly imageFetcher: AnkifyImageFetcher = fetch
+    private readonly mediaFetcher: AnkifyMediaFetcher = fetch
   ) {}
 
   private modelCache(clientId: number): Set<string> {
@@ -241,40 +241,40 @@ export class SyncNotionPageToRacUseCase {
     await this.runFinalAnkiWebSync(ac, result);
   }
 
-  private async uploadCardImages(
+  private async uploadCardMedia(
     ac: AnkiConnectClient,
     card: WalkedNotionFlashcard,
     result: SyncNotionPageResult
   ): Promise<void> {
-    for (const image of card.images) {
-      if (image.source !== 'file' || image.filename == null) {
+    for (const ref of card.media) {
+      if (ref.source !== 'file' || ref.filename == null) {
         continue;
       }
-      await this.uploadSingleImage(ac, image, result);
+      await this.uploadSingleMediaRef(ac, ref, result);
     }
   }
 
-  private async uploadSingleImage(
+  private async uploadSingleMediaRef(
     ac: AnkiConnectClient,
-    image: WalkedNotionImageRef,
+    ref: WalkedNotionMediaRef,
     result: SyncNotionPageResult
   ): Promise<void> {
-    if (image.filename == null) {
+    if (ref.filename == null) {
       return;
     }
     try {
-      const response = await this.imageFetcher(image.url);
+      const response = await this.mediaFetcher(ref.url);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
       const buffer = await response.arrayBuffer();
       await ac.storeMediaFile({
-        filename: image.filename,
+        filename: ref.filename,
         data: arrayBufferToBase64(buffer),
       });
     } catch (error) {
       result.errors.push(
-        `Image ${image.block_id}: ${(error as Error).message}`
+        `${ref.kind} ${ref.block_id}: ${(error as Error).message}`
       );
     }
   }
@@ -309,7 +309,7 @@ export class SyncNotionPageToRacUseCase {
   }): Promise<void> {
     const { card, client, subscription, ac, input, result, deckName } = args;
     try {
-      await this.uploadCardImages(ac, card, result);
+      await this.uploadCardMedia(ac, card, result);
       const existing = await this.mappings.findBySourceId(
         client.id,
         card.notion_block_id


### PR DESCRIPTION
## Summary

`notionPageWalker.renderToggleBack` is currently a 3-type allowlist (paragraph, bulleted_list_item, image). Every other Notion block — including **video**, **audio**, **embed**, **file**, headings, code, numbered lists, callouts, toggles inside toggles — is silently dropped. Customers using Ankify see empty card backs whenever a toggle answer contains anything beyond plain text.

This PR introduces a pure renderer at `src/lib/notion-render/` that handles ~25 block types, mirrors the customer-visible behavior of the legacy `BlockHandler`/`BlockVideo`/`BlockEmbed`/`blockToStaticMarkup` pipeline, and rewires the walker + sync use case to consume it.

## Block-type matrix

| Block | Render |
|---|---|
| paragraph | `<p>` with rich-text annotations (bold/italic/code/strike/underline/links) |
| heading_1..4 | `<h1>`..`<h3>` (h4 folds to h3) |
| bulleted_list_item / numbered_list_item | adjacent items grouped into a single `<ul>` / `<ol>` |
| to_do | `<div class="todo">` with ☑/☐ marker |
| toggle | `<details><summary>` recursive |
| quote / callout / code / equation / divider | direct equivalents (KaTeX inline `\(…\)`) |
| image | external `<img src=url>`, hosted `<img src=ankify-{id}.{ext}>` + media ref |
| **video** | YouTube/Vimeo external → iframe (mirrors `BlockVideo.tsx`); hosted → `<video controls src=…>` + media ref |
| **audio** | `[sound:ankify-{id}.{ext}]` Anki tag + media ref |
| **file** | `<a href=…>` link + media ref; pdf gets `<iframe>` |
| **embed** | YouTube/SoundCloud/Twitter routing matching `BlockEmbed.tsx` |
| bookmark | plain anchor |
| column_list / column / table / child_page | flattened/skipped — see below |

Recursion depth-capped at 8 to guard pathological pages. Unknown block types are silently skipped.

## Data model

`WalkedNotionImageRef` → `WalkedNotionMediaRef` with a `kind: 'image' | 'video' | 'audio' | 'file'` discriminator. `WalkedNotionFlashcard.images` → `media`. **No DB schema change** — media is in-memory only, flowing walker → use case → `AnkiConnect.storeMediaFile` at sync time.

## Sync use case

`uploadCardImages` → `uploadCardMedia` — same fetch-and-storeMediaFile pattern, now keyed by `kind`. External refs are still skipped (Anki streams them); file refs are fetched and uploaded exactly as before. Constructor dep `imageFetcher` → `mediaFetcher`.

## Not in scope (deferred — intentionally not filed as GitHub issues)

- **Migrating the legacy `.apkg` DeckParser/BlockHandler** to consume `notion-render`. That's mature code with very different mechanics (synchronous downloads, exporter registration). Doing it here would conflate goals.
- **`column_list` / `column` / `table` / `child_page` recursion.** Emitted as titles or skipped; full table support adds little to the toggle-card format.

## Test plan

- [x] `src/lib/notion-render/` — 34 cases (richText, embedUrl, renderBlocks: per block type + recursion + media)
- [x] `notionPageWalker.test.ts` — 8 cases including video, audio, embed, file, nested toggle
- [x] `SyncNotionPageToRacUseCase.test.ts` — image upload / external-skip / error-path tests updated to the new shape
- [x] Server tsc clean
- [x] Web tsc clean
- [ ] Manual: Notion test page with one of each block type → Ankify sync → verify on Anki desktop. **AnkiWeb iframe playback is shaky for embeds — same caveat as the existing `.apkg` exporter.**

## Pre-existing test failures (not introduced here)

`src/lib/parser/DeckParser.test.ts` (13 cases) and `src/services/ApkgPreviewService/parseCollection.test.ts` (1 case) fail on plain `main` too, with `Python script exited with code 1` from `create_deck.py`. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)