### PR TITLE
chore(claude): /dependabot-triage skill + pre-push typecheck hook

### DIFF
--- a/.claude/hooks/pre-push-typecheck.py
+++ b/.claude/hooks/pre-push-typecheck.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: run server `tsc --noEmit` before `git push` to a feature branch.
+
+Goal: stop pushing red branches that then fail GH Actions and chew CI minutes.
+Skips pushes to main/master (safety.py blocks those anyway). Skips when tsc
+would cost more than it saves (no .ts changes since the last push).
+
+Bypass: CLAUDE_SKIP_TYPECHECK=1 git push ...
+        CLAUDE_SKIP_SAFETY=1     git push ...   (also honored)
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+TIMEOUT_SECONDS = 120
+
+
+def allow():
+    print(json.dumps({"continue": True}))
+    sys.exit(0)
+
+
+def deny(reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+GIT_PUSH = re.compile(r"\bgit\s+push\b")
+PROTECTED_BRANCH = re.compile(r"\b(main|master)\b")
+
+
+def is_git_push(cmd):
+    return bool(GIT_PUSH.search(cmd))
+
+
+def push_targets_protected(cmd):
+    after = GIT_PUSH.split(cmd, 1)[1]
+    after = re.split(r"[;&|]", after, 1)[0]
+    return bool(PROTECTED_BRANCH.search(after))
+
+
+def has_ts_changes_against_origin():
+    """True if any tracked .ts/.tsx file differs from origin/main, or there are
+    uncommitted .ts/.tsx changes. False means tsc has nothing new to say."""
+    try:
+        committed = subprocess.run(
+            ["git", "diff", "--name-only", "origin/main...HEAD"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout
+        working = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout
+    except Exception:
+        return True  # err on the side of running tsc
+    files = (committed + "\n" + working).splitlines()
+    return any(f.endswith((".ts", ".tsx")) for f in files)
+
+
+def run_typecheck(project_dir):
+    try:
+        result = subprocess.run(
+            ["pnpm", "exec", "tsc", "--noEmit", "-p", "."],
+            cwd=project_dir,
+            capture_output=True, text=True, timeout=TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"[pre-push-typecheck] tsc exceeded {TIMEOUT_SECONDS}s; allowing push.\n"
+        )
+        return None
+    except FileNotFoundError:
+        sys.stderr.write("[pre-push-typecheck] pnpm not on PATH; allowing push.\n")
+        return None
+    if result.returncode == 0:
+        return True
+    return result.stdout or result.stderr or "(tsc produced no output)"
+
+
+def main():
+    if os.environ.get("CLAUDE_SKIP_TYPECHECK") or os.environ.get("CLAUDE_SKIP_SAFETY"):
+        allow()
+
+    try:
+        data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError:
+        allow()
+
+    if data.get("tool_name") != "Bash":
+        allow()
+
+    cmd = data.get("tool_input", {}).get("command", "")
+    if not is_git_push(cmd):
+        allow()
+
+    if push_targets_protected(cmd):
+        allow()  # safety.py owns this case
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+    if not has_ts_changes_against_origin():
+        allow()
+
+    sys.stderr.write("[pre-push-typecheck] running server tsc --noEmit...\n")
+    result = run_typecheck(project_dir)
+    if result is None or result is True:
+        allow()
+
+    head = "\n".join(result.splitlines()[:30])
+    deny(
+        "Refusing `git push` — server tsc --noEmit failed. First errors:\n\n"
+        f"{head}\n\n"
+        "Fix the type errors, or bypass with CLAUDE_SKIP_TYPECHECK=1 if pushing a WIP branch."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,10 @@
           {
             "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/check-merge-status.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/pre-push-typecheck.py"
           }
         ]
       },

--- a/.claude/skills/dependabot-triage.md
+++ b/.claude/skills/dependabot-triage.md
@@ -1,0 +1,62 @@
+---
+description: Classify open dependabot PRs, auto-merge safe greens, hold + comment on the rest
+allowed-tools: Bash
+model: sonnet
+---
+
+Triage open dependabot PRs against this repo's dependency rules (`.claude/rules/dependencies.md`). Goal: clear the queue without staring at every diff.
+
+## Process
+
+1. **List open dependabot PRs** with the data needed to classify each:
+
+   ```
+   gh pr list --search "author:app/dependabot is:open" --json number,title,headRefName,labels,statusCheckRollup,additions,deletions,url,body
+   ```
+
+2. **Classify each PR.** A PR is **needs-eyes** (do NOT auto-merge) if ANY of these are true:
+
+   - **Major bump** — title contains `from <X>.x.x to <Y>.x.x` where `Y > X`. Dependabot also labels these `version-update:semver-major`.
+   - **Pinned override** — touches a package listed in `pnpm.overrides` (`package.json`):
+     `path-to-regexp`, `picomatch`, `rollup`, `yaml`, `@types/express`, `@types/express-serve-static-core`. Bumping these can silently re-open a CVE we've worked around.
+   - **Built dependency** — touches anything in `pnpm.onlyBuiltDependencies` (currently `better-sqlite3`). Build-step deps need a manual smoke run.
+   - **Security-sensitive surface** — touches `bcryptjs`, `jsonwebtoken`, `sanitize-html`, `multer`, `express`, `stripe`, `@notionhq/client`, `@anthropic-ai/sdk`, `@sendgrid/mail`, `axios`, `knex`, or anything matching `node-*`. Even minors here get a manual look.
+   - **Checks not green** — `statusCheckRollup` has any entry with `conclusion` ∉ {`SUCCESS`, `NEUTRAL`, `SKIPPED`} (treat in-progress as not-green; come back later).
+
+   Otherwise it is **safe** — patch/minor on a non-sensitive dep with all checks green.
+
+3. **Auto-merge the safe ones.** For each safe PR:
+
+   ```
+   gh pr merge <number> --squash --auto --delete-branch
+   ```
+
+   `--auto` is safe alongside the `check-merge-status.py` hook: if anything red lands later, GitHub holds the merge.
+
+4. **Hold the needs-eyes ones with a one-line comment** linking the upstream changelog so the next reviewer can decide in 30 seconds:
+
+   ```
+   gh pr comment <number> --body "Held for manual review (<reason>). Changelog: <url>"
+   ```
+
+   The changelog URL is usually in the PR body under "Release notes" or "Commits" — extract the GitHub release link if present, otherwise the repo's releases page.
+
+5. **Print a summary**, grouped:
+
+   ```
+   Auto-merged (N):
+     - #<num> <title>
+   Held (M):
+     - #<num> <title> — <reason>
+   ```
+
+## Rules
+
+- **Never** bypass the queue with `gh pr merge --admin`. The check-merge-status hook is the gate.
+- **Never** rebase or push to the dependabot branch yourself — comment `@dependabot rebase` if needed; the bot owns the branch.
+- **Never** close a held PR without merging. The dependabot workflow expects merge or label, not close (`.claude/rules/dependencies.md`).
+- **Do not** read or edit `pnpm-lock.yaml` directly. If a held major needs lockfile attention, surface it for manual `pnpm install`.
+
+## When held majors pile up
+
+If five or more held PRs accumulate, surface the list to Al with the upgrade impact (transitive bloat via `pnpm why`, breaking-change notes from the changelog) so a batch decision can be made. Do not start auto-upgrading majors.


### PR DESCRIPTION
## Summary

Two highest-leverage gaps from the recent .claude/ tooling audit:

- **`/dependabot-triage`** — classifies open dependabot PRs as **safe** (auto-merge with `--squash --auto --delete-branch`) vs **needs-eyes** (`pnpm.overrides`, `onlyBuiltDependencies`, security-sensitive deps, majors, or non-green checks). Drops a one-line comment with the changelog link on held majors. Pair with `/loop` for a daily morning run — saves ~15 min/day of manual triage.
- **`pre-push-typecheck.py`** — runs `pnpm exec tsc --noEmit` before pushes to feature branches. Short-circuits when no `.ts`/`.tsx` files diverge from `origin/main`, so config-only branches push instantly. 120s timeout fails open. Bypass with `CLAUDE_SKIP_TYPECHECK=1` for WIP work. Pushes to protected branches still delegate to `safety.py`.

## Files

- `.claude/skills/dependabot-triage.md` — new skill (sonnet, Bash only)
- `.claude/hooks/pre-push-typecheck.py` — new hook
- `.claude/settings.json` — register the hook in the Bash PreToolUse chain after `check-merge-status.py`

## Test plan

- [x] Smoke-tested all 5 hook gating paths (non-Bash, non-push, protected branch, two bypass envs)
- [x] Verified TS-change short-circuit on this branch (no `.ts` diff vs `origin/main` → skips tsc)
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` confirms valid JSON
- [ ] Real-world: next push of a TS-touching branch should run tsc and gate correctly
- [ ] Real-world: `/dependabot-triage` against the live PR queue tomorrow morning

## Follow-up

`safety.py` false-fires when the literal phrase \`git push\` appears inside a `-m` commit body (regex matches the whole shell argv). Should anchor on argv[1] instead of substring-search the entire command. Worked around in this commit's message — separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)