### PR TITLE
feat(ankify): transparent session URL recovery

### DIFF
--- a/migrations/20260512000000_ankify_session_tokens_drop_unique_active.js
+++ b/migrations/20260512000000_ankify_session_tokens_drop_unique_active.js
@@ -1,0 +1,12 @@
+exports.up = async function (knex) {
+  await knex.raw(
+    'DROP INDEX IF EXISTS ankify_session_tokens_one_active_per_client'
+  );
+};
+
+exports.down = async function (knex) {
+  await knex.raw(
+    'CREATE UNIQUE INDEX ankify_session_tokens_one_active_per_client ' +
+      'ON ankify_session_tokens(ankify_client_id) WHERE revoked_at IS NULL'
+  );
+};

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -519,8 +519,8 @@ const AnkifyRouter = () => {
    * @swagger
    * /api/ankify/clients/{id}/reissue-session:
    *   post:
-   *     summary: Mint a fresh session URL, invalidating the prior one
-   *     description: Allowlisted endpoint. Returns the active client with a fresh session_url containing a new 256-bit token. Any prior session URL is revoked immediately.
+   *     summary: Mint a fresh session URL
+   *     description: Allowlisted endpoint. Returns the active client with a fresh session_url containing a new 256-bit token. Prior tokens for the same client remain valid until their natural 8h TTL — open noVNC tabs survive a reissue. Tokens are revoked when the client is stopped or respun.
    *     tags: [Ankify]
    */
   router.post(

--- a/src/routes/AnkifySessionProxyRouter.test.ts
+++ b/src/routes/AnkifySessionProxyRouter.test.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import http from 'node:http';
+import { AddressInfo } from 'node:net';
 
 const capturedOptions: { value: Record<string, unknown> | null } = {
   value: null,
@@ -27,6 +28,45 @@ const makeFakeValidate = (port: number) =>
   ({
     execute: async () => ({ ok: true as const, novnc_port: port }),
   }) as unknown as ValidateAnkifySessionTokenUseCase;
+
+const makeRejectingValidate = (reason = 'invalid_session_token') =>
+  ({
+    execute: async () => ({ ok: false as const, status: 401 as const, reason }),
+  }) as unknown as ValidateAnkifySessionTokenUseCase;
+
+const requestViaListen = (
+  app: express.Express,
+  attach: (server: http.Server) => void,
+  path: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> =>
+  new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    attach(server);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      const req = http.request(
+        { host: '127.0.0.1', port, path, method: 'GET', headers },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c: Buffer) => chunks.push(c));
+          res.on('end', () => {
+            server.close();
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              body: Buffer.concat(chunks).toString('utf8'),
+            });
+          });
+        }
+      );
+      req.on('error', (err) => {
+        server.close();
+        reject(err);
+      });
+      req.end();
+    });
+  });
 
 describe('attachAnkifySessionProxy', () => {
   beforeEach(() => {
@@ -73,5 +113,35 @@ describe('attachAnkifySessionProxy', () => {
       54321
     );
     expect(socket.destroy).not.toHaveBeenCalled();
+  });
+
+  test('HTML GETs that fail validation get a 302 to /ankify so the user lands somewhere useful', async () => {
+    const app = express();
+    const validate = makeRejectingValidate('invalid_session_token');
+    const result = await requestViaListen(
+      app,
+      (server) => attachAnkifySessionProxy(app, server, validate),
+      `/v/${VALID_TOKEN}/vnc.html`,
+      { Accept: 'text/html,application/xhtml+xml' }
+    );
+
+    expect(result.status).toBe(302);
+    expect(result.headers.location).toBe(
+      '/ankify?session_expired=1&reason=invalid_session_token'
+    );
+  });
+
+  test('non-HTML requests still get the JSON 401 (websockify, fetch, etc.)', async () => {
+    const app = express();
+    const validate = makeRejectingValidate('invalid_session_token');
+    const result = await requestViaListen(
+      app,
+      (server) => attachAnkifySessionProxy(app, server, validate),
+      `/v/${VALID_TOKEN}/websockify`,
+      { Accept: 'application/json' }
+    );
+
+    expect(result.status).toBe(401);
+    expect(result.body).toBe(JSON.stringify({ message: 'invalid_session_token' }));
   });
 });

--- a/src/routes/AnkifySessionProxyRouter.ts
+++ b/src/routes/AnkifySessionProxyRouter.ts
@@ -59,6 +59,11 @@ export const attachAnkifySessionProxy = (
       cookieToken,
     });
     if (!result.ok) {
+      const accept = req.headers.accept ?? '';
+      if (req.method === 'GET' && accept.includes('text/html')) {
+        res.redirect(302, `/ankify?session_expired=1&reason=${result.reason}`);
+        return;
+      }
       res.status(result.status).json({ message: result.reason });
       return;
     }

--- a/src/services/ankify/RacService.test.ts
+++ b/src/services/ankify/RacService.test.ts
@@ -227,7 +227,11 @@ describe('RacService.provision', () => {
     const { client, created } = await service.provision(42);
 
     expect(created).toBe(false);
-    expect(client).toEqual({ ...existing, session_url: null });
+    expect(client).toEqual({
+      ...existing,
+      session_url: null,
+      has_active_session: false,
+    });
     expect(docker.listContainers).not.toHaveBeenCalled();
     expect(docker.createContainer).not.toHaveBeenCalled();
     expect(repo.create).not.toHaveBeenCalled();
@@ -393,6 +397,59 @@ describe('RacService.list', () => {
     expect(result).toHaveLength(0);
   });
 
+  test('has_active_session reflects whether a non-expired token exists for the client', async () => {
+    const live: AnkifyClient = {
+      id: 13,
+      owner: 7,
+      container_id: 'container-live-13',
+      container_name: 'sleepy_curie',
+      anki_port: 20000,
+      vnc_port: 0,
+      novnc_port: 22000,
+      anki_connect_api_key: null,
+      status: 'active' as const,
+      created_at: new Date(),
+      last_active_at: new Date(),
+    };
+    const repo = makeRepo({ listByOwner: jest.fn(async () => [live]) });
+    const tokens = makeTokens();
+    tokens.store.rows.push({
+      id: 100,
+      ankify_client_id: 13,
+      owner: 7,
+      token_hash: 'abc',
+      expires_at: new Date(Date.now() + 60 * 60 * 1000),
+      last_used_at: null,
+      revoked_at: null,
+      created_at: new Date(),
+    });
+    const { service } = makeService(repo, makeDocker(), tokens);
+
+    const [withToken] = await service.list(7);
+    expect(withToken.has_active_session).toBe(true);
+  });
+
+  test('has_active_session is false when no active token exists', async () => {
+    const live: AnkifyClient = {
+      id: 14,
+      owner: 7,
+      container_id: 'container-live-14',
+      container_name: null,
+      anki_port: 20000,
+      vnc_port: 0,
+      novnc_port: 22000,
+      anki_connect_api_key: null,
+      status: 'active' as const,
+      created_at: new Date(),
+      last_active_at: new Date(),
+    };
+    const repo = makeRepo({ listByOwner: jest.fn(async () => [live]) });
+    const { service } = makeService(repo);
+
+    const [noToken] = await service.list(7);
+    expect(noToken.has_active_session).toBe(false);
+  });
+
   test('non-404 inspect errors leave the row active (avoid false reconcile)', async () => {
     const live: AnkifyClient = {
       id: 11,
@@ -541,7 +598,7 @@ describe('RacService.resolveTokenForProxy', () => {
 });
 
 describe('RacService.reissueSessionUrl', () => {
-  test('revokes the prior token and mints a new one', async () => {
+  test('mints a new token without revoking the prior one (open noVNC tabs survive)', async () => {
     const repo = makeRepo();
     const { service, tokens } = makeService(repo);
 
@@ -568,20 +625,21 @@ describe('RacService.reissueSessionUrl', () => {
 
     expect(reissued).not.toBeNull();
     expect(reissued!.session_url).not.toBeNull();
+    expect(reissued!.has_active_session).toBe(true);
     const secondPlaintext = reissued!.session_url!.match(
       /[A-Za-z0-9_-]{43}/
     )![0];
     expect(secondPlaintext).not.toBe(firstPlaintext);
 
-    // Prior token row is now revoked; only the new one is active.
     const firstRow = tokens.store.rows.find(
       (r) => r.token_hash === hashToken(firstPlaintext)
     );
-    expect(firstRow!.revoked_at).not.toBeNull();
+    expect(firstRow!.revoked_at).toBeNull();
     const secondRow = tokens.store.rows.find(
       (r) => r.token_hash === hashToken(secondPlaintext)
     );
     expect(secondRow!.revoked_at).toBeNull();
+    expect(tokens.revokeByClientId).not.toHaveBeenCalled();
   });
 
   test('returns null when the client is not active', async () => {
@@ -784,6 +842,7 @@ describe('RacService — view shape passthrough', () => {
       created_at: new Date(),
       last_active_at: new Date(),
       session_url: null,
+      has_active_session: false,
     };
     expect(sample).toBeDefined();
   });

--- a/src/services/ankify/RacService.ts
+++ b/src/services/ankify/RacService.ts
@@ -75,6 +75,7 @@ export class NoAvailablePortError extends Error {
 
 export interface AnkifyClientView extends AnkifyClient {
   session_url: string | null;
+  has_active_session: boolean;
 }
 
 export interface ProvisionResult {
@@ -106,8 +107,9 @@ export class RacService {
         existing.id,
         existing.container_id
       );
+      const hasActive = await this.hasActiveSession(existing.id);
       return {
-        client: { ...existing, session_url: null },
+        client: { ...existing, session_url: null, has_active_session: hasActive },
         created: false,
       };
     }
@@ -217,7 +219,7 @@ export class RacService {
     const sessionUrl = await this.mintSessionUrl(client);
 
     return {
-      client: { ...client, session_url: sessionUrl },
+      client: { ...client, session_url: sessionUrl, has_active_session: true },
       created: true,
     };
   }
@@ -264,7 +266,7 @@ export class RacService {
     const sessionUrl = await this.mintSessionUrl(client);
 
     return {
-      client: { ...client, session_url: sessionUrl },
+      client: { ...client, session_url: sessionUrl, has_active_session: true },
       created: true,
     };
   }
@@ -294,13 +296,22 @@ export class RacService {
     const reconciled: AnkifyClientView[] = [];
     for (const client of clients) {
       if (client.status !== 'active') {
-        reconciled.push({ ...client, session_url: null });
+        reconciled.push({
+          ...client,
+          session_url: null,
+          has_active_session: false,
+        });
         continue;
       }
       try {
         const container = this.docker.getContainer(client.container_id);
         await container.inspect();
-        reconciled.push({ ...client, session_url: null });
+        const hasActive = await this.hasActiveSession(client.id);
+        reconciled.push({
+          ...client,
+          session_url: null,
+          has_active_session: hasActive,
+        });
       } catch (error) {
         const statusCode = (error as { statusCode?: number }).statusCode;
         if (statusCode === 404) {
@@ -310,7 +321,12 @@ export class RacService {
             `[ankify] reconcile skipped for container ${client.container_id}:`,
             (error as Error).message ?? error
           );
-          reconciled.push({ ...client, session_url: null });
+          const hasActive = await this.hasActiveSession(client.id);
+          reconciled.push({
+            ...client,
+            session_url: null,
+            has_active_session: hasActive,
+          });
         }
       }
     }
@@ -326,7 +342,12 @@ export class RacService {
       return null;
     }
     const sessionUrl = await this.mintSessionUrl(client);
-    return { ...client, session_url: sessionUrl };
+    return { ...client, session_url: sessionUrl, has_active_session: true };
+  }
+
+  private async hasActiveSession(clientId: number): Promise<boolean> {
+    const row = await this.tokens.findActiveByClientId(clientId);
+    return row != null;
   }
 
   async stop(id: number, owner: number): Promise<void> {
@@ -382,7 +403,6 @@ export class RacService {
   }
 
   private async mintSessionUrl(client: AnkifyClient): Promise<string> {
-    await this.tokens.revokeByClientId(client.id);
     const plaintext = generateTokenPlaintext();
     const tokenHash = hashToken(plaintext);
     const expiresAt = new Date(

--- a/web/src/lib/interfaces/AnkifyClient.ts
+++ b/web/src/lib/interfaces/AnkifyClient.ts
@@ -12,6 +12,7 @@ interface AnkifyClient {
   created_at: string | null;
   last_active_at: string | null;
   session_url?: string | null;
+  has_active_session?: boolean;
 }
 
 export default AnkifyClient;

--- a/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.test.tsx
@@ -260,3 +260,115 @@ describe('AnkifyPage workspace home', () => {
     expect(screen.queryByText(/your anki is ready/i)).not.toBeInTheDocument();
   });
 });
+
+const SESSION_URL_PREFIX = 'ankify_session_url:';
+
+describe('Ankify session URL — transparent recovery', () => {
+  beforeEach(() => {
+    globalThis.localStorage?.setItem(ANKI_WEB_ACK_KEY, 'true');
+    globalThis.localStorage?.removeItem(`${SESSION_URL_PREFIX}1`);
+  });
+
+  afterEach(() => {
+    globalThis.localStorage?.removeItem(ANKI_WEB_ACK_KEY);
+    globalThis.localStorage?.removeItem(`${SESSION_URL_PREFIX}1`);
+  });
+
+  const makeStatefulBackend = (initialHasActive: boolean) => {
+    const state = { hasActive: initialHasActive };
+    const reissue = vi.fn(async (id: number) => {
+      state.hasActive = true;
+      return {
+        ...sampleClient({ id }),
+        session_url: `https://2anki.net/v/FRESH/vnc.html`,
+        has_active_session: true,
+      };
+    });
+    const list = vi.fn(async () => [
+      sampleClient({ has_active_session: state.hasActive }),
+    ]);
+    const backend = makeBackend({
+      listAnkifyClients: list,
+      checkAnkifyActiveClientReady: vi.fn(async () => ({ ready: true })),
+      checkAnkifyAnkiWebStatus: vi.fn(async () => ({
+        status: 'linked' as const,
+      })),
+      reissueAnkifySessionUrl: reissue,
+    });
+    return { backend, reissue, list };
+  };
+
+  test('auto-mints a session URL on mount when none is cached and the container is ready', async () => {
+    const { backend, reissue } = makeStatefulBackend(false);
+
+    renderAt('/ankify', backend);
+
+    await waitFor(() => expect(reissue).toHaveBeenCalledWith(1));
+    await waitFor(() =>
+      expect(
+        globalThis.localStorage?.getItem(`${SESSION_URL_PREFIX}1`)
+      ).toBe('https://2anki.net/v/FRESH/vnc.html')
+    );
+  });
+
+  test('clears a stale cached URL when the server reports has_active_session=false', async () => {
+    globalThis.localStorage?.setItem(
+      `${SESSION_URL_PREFIX}1`,
+      'https://2anki.net/v/STALE/vnc.html'
+    );
+    const { backend, reissue } = makeStatefulBackend(false);
+
+    renderAt('/ankify', backend);
+
+    await waitFor(() => expect(reissue).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(
+        globalThis.localStorage?.getItem(`${SESSION_URL_PREFIX}1`)
+      ).toBe('https://2anki.net/v/FRESH/vnc.html')
+    );
+  });
+
+  test('honours ?session_expired=1 by clearing the cache and re-minting', async () => {
+    globalThis.localStorage?.setItem(
+      `${SESSION_URL_PREFIX}1`,
+      'https://2anki.net/v/STALE/vnc.html'
+    );
+    const { backend, reissue } = makeStatefulBackend(true);
+
+    renderAt('/ankify?session_expired=1&reason=invalid_session_token', backend);
+
+    await waitFor(() => expect(reissue).toHaveBeenCalledWith(1));
+    await waitFor(() =>
+      expect(
+        globalThis.localStorage?.getItem(`${SESSION_URL_PREFIX}1`)
+      ).toBe('https://2anki.net/v/FRESH/vnc.html')
+    );
+  });
+
+  test('does not show "Get a new link" anywhere in the workspace bar', async () => {
+    const backend = makeBackend({
+      listAnkifyClients: vi.fn(async () => [
+        sampleClient({ has_active_session: true }),
+      ]),
+      checkAnkifyActiveClientReady: vi.fn(async () => ({ ready: true })),
+      checkAnkifyAnkiWebStatus: vi.fn(async () => ({
+        status: 'linked' as const,
+      })),
+    });
+    globalThis.localStorage?.setItem(
+      `${SESSION_URL_PREFIX}1`,
+      'https://2anki.net/v/CACHED/vnc.html'
+    );
+
+    renderAt('/ankify', backend);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('link', { name: /open anki/i })
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('button', { name: /get a new link/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifySetupPage.tsx
@@ -138,6 +138,39 @@ export default function AnkifySetupPage({ backend }: Props) {
     },
   });
 
+  useEffect(() => {
+    if (activeClient == null) return;
+    if (
+      activeClient.has_active_session === false &&
+      readCachedSessionUrl(activeClient.id) != null
+    ) {
+      writeCachedSessionUrl(activeClient.id, null);
+    }
+  }, [activeClient?.id, activeClient?.has_active_session]);
+
+  const reissueMutate = reissueSession.mutate;
+  const reissueIsPending = reissueSession.isPending;
+  useEffect(() => {
+    if (activeClient == null) return;
+    if (!containerReady) return;
+    if (reissueIsPending) return;
+    if (activeClient.session_url != null) return;
+    if (
+      activeClient.has_active_session !== false &&
+      readCachedSessionUrl(activeClient.id) != null
+    ) {
+      return;
+    }
+    reissueMutate(activeClient.id);
+  }, [
+    activeClient?.id,
+    activeClient?.has_active_session,
+    activeClient?.session_url,
+    containerReady,
+    reissueIsPending,
+    reissueMutate,
+  ]);
+
   const acknowledgeAnkiWebSignIn = () => {
     setSignedInAcknowledged(true);
     try {
@@ -188,8 +221,11 @@ export default function AnkifySetupPage({ backend }: Props) {
     );
   }
 
-  const ankiUrlFor = (client: AnkifyClient): string | null =>
-    client.session_url ?? readCachedSessionUrl(client.id);
+  const ankiUrlFor = (client: AnkifyClient): string | null => {
+    if (client.session_url != null) return client.session_url;
+    if (client.has_active_session === false) return null;
+    return readCachedSessionUrl(client.id);
+  };
 
   const renderStartAnkiStep = () => (
     <section className={styles.setupActiveStep}>
@@ -305,10 +341,9 @@ export default function AnkifySetupPage({ backend }: Props) {
             <button
               type="button"
               className={`${sharedStyles.btnSecondary} ${styles.inlineButton}`}
-              onClick={() => reissueSession.mutate(client.id)}
-              disabled={reissueSession.isPending}
+              disabled
             >
-              {reissueSession.isPending ? 'Working…' : 'Get a new link'}
+              Opening…
             </button>
           ) : (
             <a

--- a/web/src/pages/AnkifyPage/components/WorkspaceBar.tsx
+++ b/web/src/pages/AnkifyPage/components/WorkspaceBar.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import sharedStyles from '../../../styles/shared.module.css';
@@ -54,6 +54,8 @@ export default function WorkspaceBar({
 }: Props) {
   const api = backend ?? get2ankiApi();
   const queryClient = useQueryClient();
+  const location = useLocation();
+  const navigate = useNavigate();
   const [confirmShutdown, setConfirmShutdown] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -138,12 +140,52 @@ export default function WorkspaceBar({
     return undefined;
   }, [menuOpen]);
 
+  const cachedSessionUrl =
+    activeClient == null ? null : readCachedSessionUrl(activeClient.id);
+  const serverHasActive = activeClient?.has_active_session !== false;
+  const sessionUrl =
+    activeClient?.session_url ?? (serverHasActive ? cachedSessionUrl : null);
+
+  useEffect(() => {
+    if (activeClient == null) return;
+    if (activeClient.has_active_session === false && cachedSessionUrl != null) {
+      writeCachedSessionUrl(activeClient.id, null);
+    }
+  }, [activeClient?.id, activeClient?.has_active_session, cachedSessionUrl]);
+
+  useEffect(() => {
+    if (activeClient == null) return;
+    const params = new URLSearchParams(location.search);
+    if (params.get('session_expired') !== '1') return;
+    writeCachedSessionUrl(activeClient.id, null);
+    params.delete('session_expired');
+    params.delete('reason');
+    const next = params.toString();
+    navigate(
+      { pathname: location.pathname, search: next.length > 0 ? `?${next}` : '' },
+      { replace: true }
+    );
+  }, [activeClient?.id, location.search, location.pathname, navigate]);
+
+  const reissueMutate = reissueSession.mutate;
+  const reissueIsPending = reissueSession.isPending;
+  useEffect(() => {
+    if (activeClient == null) return;
+    if (!containerReady) return;
+    if (sessionUrl != null) return;
+    if (reissueIsPending) return;
+    reissueMutate(activeClient.id);
+  }, [
+    activeClient?.id,
+    containerReady,
+    sessionUrl,
+    reissueIsPending,
+    reissueMutate,
+  ]);
+
   if (activeClient == null) {
     return null;
   }
-
-  const sessionUrl =
-    activeClient.session_url ?? readCachedSessionUrl(activeClient.id);
 
   let statusContent: ReactNode;
   if (!containerReady) {
@@ -190,10 +232,9 @@ export default function WorkspaceBar({
           <button
             type="button"
             className={`${sharedStyles.btnPrimary} ${styles.inlineButton}`}
-            onClick={() => reissueSession.mutate(activeClient.id)}
-            disabled={reissueSession.isPending}
+            disabled
           >
-            {reissueSession.isPending ? 'Working…' : 'Get a new link'}
+            Opening…
           </button>
         ) : (
           <a


### PR DESCRIPTION
## Summary

- Customer-visible: the **\"Get a new link\"** button is gone, **\"Open Anki\"** just works. Stale tokens, expired sessions, and reissues from other tabs now recover silently.
- Two concrete root causes addressed:
  1. **Cached URL outlives the 8h TTL.** Frontend cached the URL in localStorage and had no way to know it had gone stale. List response now carries `has_active_session`; the page auto-mints when the cache is invalid.
  2. **Reissue revokes in-flight tokens.** \`mintSessionUrl\` used to revoke any active row, killing open noVNC tabs. Dropped the unique-active partial index + the revoke step; tokens now coexist until the natural 8h TTL.
- Safety net for bookmarked/refreshed noVNC tabs: HTML \`GET /v/<token>/*\` failures 302 to \`/ankify?session_expired=1\` instead of dumping JSON. The page clears the stale cache and auto-mints on mount.

## What changed

- **DB migration**: drop \`ankify_session_tokens_one_active_per_client\` partial unique index.
- **Service**: \`RacService.mintSessionUrl\` no longer calls \`revokeByClientId\`; \`list()\` populates \`has_active_session\` from \`tokens.findActiveByClientId\`.
- **Route**: \`AnkifySessionProxyRouter.authMiddleware\` redirects HTML GETs on validation failure; non-HTML callers (websockify, fetch) still get JSON 401.
- **Frontend**: \`WorkspaceBar\` + \`AnkifySetupPage\` drop the button, auto-mint on mount, clear stale cache when \`has_active_session === false\`, honour \`?session_expired=1\`.

## Diagnosis (from prod, today)

User clicked Open Anki and got \`{\"message\":\"invalid_session_token\"}\`. The URL token hashed to row id=20, which had expired naturally at 17:38 (8h TTL from morning provision). Token id=21 (still valid) had been minted later from a different tab/device. localStorage in the offending browser was never refreshed because nothing told the frontend the cached URL was dead.

## Test plan

- [x] \`/check\` (server tsc + web typecheck + web vitest + web lint) — all green locally
- [x] Manual: provision Ankify, hit Open Anki — works
- [x] Manual: wait until cached URL expires (or hand-revoke in DB), refresh \`/ankify\` — page auto-mints, Open Anki link shows fresh URL, no button click required
- [x] Manual: with two tabs open, click Restart in one — the other can still Open Anki via newly minted URL
- [x] Manual: navigate to a stale \`/v/<token>/vnc.html\` directly — 302s to \`/ankify\`, lands on a working Open Anki

## Notes

- Touches auth-adjacent code (session token lifecycle). Run \`/security-review\` before merge.
- Migration is reversible; rollback re-adds the unique partial index.
- Stripe / payments untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)