### PR TITLE
fix(jobs): show friendly empty-deck failure instead of Python crash

### DIFF
--- a/create_deck/create_deck.py
+++ b/create_deck/create_deck.py
@@ -38,7 +38,8 @@ if __name__ == "__main__":
             decks = []
 
             if len(data) == 0:
-                raise ValueError("No cards were generated. The page may be empty or contain no supported toggle lists.")
+                print('No cards generated; exiting cleanly')
+                sys.exit(0)
 
             # Model / Template stuff
             mt = data[0].get("settings", {})

--- a/create_deck/helpers/test_get_template.py
+++ b/create_deck/helpers/test_get_template.py
@@ -14,6 +14,7 @@ from . import get_template
 
 
 def test_get_template_path_resolves_to_existing_dir():
+    """The resolved template path points at a real directory on disk."""
     resolved = os.path.realpath(get_template.get_template_path())
     assert os.path.isdir(resolved), f"template dir not found: {resolved}"
 
@@ -22,6 +23,7 @@ def test_get_template_path_resolves_to_existing_dir():
     "file_name", ["n2a-basic.json", "n2a-cloze.json", "n2a-input.json"]
 )
 def test_bundled_template_loads(file_name):
+    """Each bundled template JSON loads as a dict with a non-empty name."""
     template = get_template.get_template(file_name)
     assert isinstance(template, dict)
     assert template.get("name")

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -16,6 +16,7 @@ import { SetJobFailedUseCase } from '../../../../usecases/jobs/SetJobFailedUseCa
 import { BuildDeckForJobUseCase } from '../../../../usecases/jobs/BuildDeckForJobUseCase';
 import { CompleteJobUseCase } from '../../../../usecases/jobs/CompleteJobUseCase';
 import { NotifyUserUseCase } from '../../../../usecases/jobs/NotifyUserUseCase';
+import { jobFailureReasonFromError } from '../../../../usecases/jobs/jobFailureReason';
 
 interface ConversionRequest {
   title: string;
@@ -119,6 +120,7 @@ export default async function performConversion(
       storage,
       id,
       owner,
+      type,
     });
 
     const notifyUser = new NotifyUserUseCase(jobRepository);
@@ -136,9 +138,8 @@ export default async function performConversion(
     await completeJob.execute(id, owner);
   } catch (error) {
     const failedJob = new SetJobFailedUseCase(jobRepository);
-    await failedJob.execute(id, owner, 'Technical error ' + error);
+    await failedJob.execute(id, owner, jobFailureReasonFromError(error));
 
-    // The User is still waiting and has not received a response yet
     if (waitingResponse) {
       res?.status(400).send('conversion failed.');
     }

--- a/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
+++ b/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
@@ -1,0 +1,61 @@
+import { BuildDeckForJobUseCase } from './BuildDeckForJobUseCase';
+import { EmptyDeckError } from './EmptyDeckError';
+import JobRepository from '../../data_layer/JobRepository';
+import Deck from '../../lib/parser/Deck';
+import CustomExporter from '../../lib/parser/exporters/CustomExporter';
+import BlockHandler from '../../services/NotionService/BlockHandler/BlockHandler';
+import Workspace from '../../lib/parser/WorkSpace';
+import StorageHandler from '../../lib/storage/StorageHandler';
+import CardOption from '../../lib/parser/Settings';
+import CardGenerator from '../../lib/anki/CardGenerator';
+
+jest.mock('../../lib/anki/CardGenerator');
+jest.mock('../../data_layer', () => ({
+  getDatabase: jest.fn(),
+}));
+
+describe('BuildDeckForJobUseCase', () => {
+  const jobRepository = {
+    updateJobStatus: jest.fn().mockResolvedValue(undefined),
+  } as unknown as JobRepository;
+
+  const exporter = {
+    configure: jest.fn(),
+  } as unknown as CustomExporter;
+
+  const bl = { firstPageTitle: 'Title' } as unknown as BlockHandler;
+  const ws = { location: '/tmp/ws' } as unknown as Workspace;
+  const storage = {
+    uniqify: jest.fn(),
+    uploadFile: jest.fn(),
+  } as unknown as StorageHandler;
+  const settings = { deckName: 'Deck' } as unknown as CardOption;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('throws EmptyDeckError when every deck has zero cards and never invokes CardGenerator', async () => {
+    const useCase = new BuildDeckForJobUseCase(jobRepository);
+    const decks: Deck[] = [
+      { cards: [] } as unknown as Deck,
+      { cards: [] } as unknown as Deck,
+    ];
+
+    await expect(
+      useCase.execute({
+        bl,
+        exporter,
+        decks,
+        ws,
+        settings,
+        storage,
+        id: 'job-1',
+        owner: 'owner-1',
+      })
+    ).rejects.toBeInstanceOf(EmptyDeckError);
+
+    expect(CardGenerator).not.toHaveBeenCalled();
+    expect(exporter.configure).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/jobs/BuildDeckForJobUseCase.ts
+++ b/src/usecases/jobs/BuildDeckForJobUseCase.ts
@@ -15,6 +15,7 @@ import {
 } from '../../lib/anki/format';
 import { FileSizeInMegaBytes } from '../../lib/misc/file';
 import { getDatabase } from '../../data_layer';
+import { EmptyDeckError } from './EmptyDeckError';
 
 interface BuildDeckForJobUseCaseOutput {
   size: number;
@@ -31,6 +32,7 @@ interface BuildDeckForJobUseCaseInput {
   storage: StorageHandler;
   id: string;
   owner: string;
+  type?: string;
 }
 
 export class BuildDeckForJobUseCase {
@@ -39,12 +41,18 @@ export class BuildDeckForJobUseCase {
   async execute(
     input: BuildDeckForJobUseCaseInput
   ): Promise<BuildDeckForJobUseCaseOutput> {
-    const { bl, exporter, decks, ws, settings, storage, id, owner } = input;
+    const { bl, exporter, decks, ws, settings, storage, id, owner, type } =
+      input;
     await this.jobRepository.updateJobStatus(id, owner, 'step3_building_deck', '');
 
     const filteredDecks = decks.filter(
       (deck) => deck.cards && deck.cards.length > 0
     );
+
+    if (filteredDecks.length === 0) {
+      console.log('conversion.zero_cards', { id, owner, type });
+      throw new EmptyDeckError();
+    }
 
     exporter.configure(filteredDecks);
     const gen = new CardGenerator(ws.location);

--- a/src/usecases/jobs/EmptyDeckError.test.ts
+++ b/src/usecases/jobs/EmptyDeckError.test.ts
@@ -1,0 +1,22 @@
+import { EmptyDeckError } from './EmptyDeckError';
+
+describe('EmptyDeckError', () => {
+  it('is an Error subclass with the EmptyDeckError name', () => {
+    const error = new EmptyDeckError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(EmptyDeckError);
+    expect(error.name).toBe('EmptyDeckError');
+  });
+
+  it('survives an instanceof check after being thrown and caught', () => {
+    let caught: unknown;
+    try {
+      throw new EmptyDeckError();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(EmptyDeckError);
+  });
+});

--- a/src/usecases/jobs/EmptyDeckError.ts
+++ b/src/usecases/jobs/EmptyDeckError.ts
@@ -1,0 +1,6 @@
+export class EmptyDeckError extends Error {
+  constructor() {
+    super();
+    this.name = 'EmptyDeckError';
+  }
+}

--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -1,0 +1,18 @@
+import { EmptyDeckError } from './EmptyDeckError';
+import {
+  EMPTY_DECK_FAILURE_REASON,
+  jobFailureReasonFromError,
+} from './jobFailureReason';
+
+describe('jobFailureReasonFromError', () => {
+  it('returns the friendly reason for EmptyDeckError', () => {
+    const reason = jobFailureReasonFromError(new EmptyDeckError());
+    expect(reason).toBe(EMPTY_DECK_FAILURE_REASON);
+    expect(reason).not.toMatch(/^Technical error /);
+  });
+
+  it('returns the technical fallback for any other error', () => {
+    const reason = jobFailureReasonFromError(new Error('boom'));
+    expect(reason).toBe('Technical error Error: boom');
+  });
+});

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -1,0 +1,11 @@
+import { EmptyDeckError } from './EmptyDeckError';
+
+export const EMPTY_DECK_FAILURE_REASON =
+  "No cards in this deck yet. 2anki turns Notion toggle blocks (the little triangles you click to expand) into flashcards — the toggle title becomes the question, what's inside becomes the answer. We didn't find any in this page. Open the page in Notion, wrap your key terms in toggles, then convert again. See examples: /documentation/help/common-problems#could-not-create-a-deck-using-your-file-and-rules";
+
+export function jobFailureReasonFromError(error: unknown): string {
+  if (error instanceof EmptyDeckError) {
+    return EMPTY_DECK_FAILURE_REASON;
+  }
+  return 'Technical error ' + error;
+}

--- a/web/src/pages/UploadPage/components/DownloadButton.tsx
+++ b/web/src/pages/UploadPage/components/DownloadButton.tsx
@@ -39,13 +39,15 @@ function DownloadButton(props: Readonly<Props>) {
       {isReady && isEmptyDeck && (
         <div className={sharedStyles.alertDanger}>
           <p>
-            <strong>Your deck was created but contains no cards.</strong>{' '}
-            Check that your Notion page uses toggle blocks, or adjust your
-            conversion rules and try again.
-          </p>
-          <p className={sharedStyles.smallDescription}>
-            You can still download the empty deck below if you want to inspect
-            it.
+            No cards in this deck yet. 2anki turns Notion toggle blocks (the
+            little triangles you click to expand) into flashcards — the toggle
+            title becomes the question, what&apos;s inside becomes the answer.
+            We didn&apos;t find any in this page. Open the page in Notion, wrap
+            your key terms in toggles, then convert again.{' '}
+            <a href="/documentation/help/common-problems#could-not-create-a-deck-using-your-file-and-rules">
+              See examples
+            </a>
+            .
           </p>
         </div>
       )}


### PR DESCRIPTION
## What
When a Notion page yields no toggles, the conversion pipeline now fails fast with a friendly, actionable explanation instead of crashing the Python process and showing the user a raw traceback.

## Why
Last night a user converted a 19-block Notion page with zero toggle blocks. Path B in the trace:

1. `BuildDeckForJobUseCase` filtered every deck out (zero cards each).
2. The empty deck list still reached `create_deck.py`, which `raise ValueError(...)`.
3. The Python wrapper called `send_error_email`, paging Alexander.
4. The job's `job_reason_failure` got the raw `'Technical error ' + error` string, which the Downloads table rendered as a multi-line Python traceback.

Prod log evidence: `~/.pm2/logs/server-out__2026-05-10_00-00-00.log` lines 60-95.

## How
Four code surfaces:

1. **`src/usecases/jobs/BuildDeckForJobUseCase.ts`** — after the existing card-count filter, throws a new typed `EmptyDeckError` (defined alongside in `EmptyDeckError.ts`) before configuring the exporter or invoking `CardGenerator`. Logs `conversion.zero_cards` with `{ id, owner, type }` as a grep-able marker for now (PM is repaving metrics next week).
2. **`src/lib/storage/jobs/helpers/performConversion.ts`** — catch block branches via the new `jobFailureReasonFromError` helper: friendly copy for `EmptyDeckError`, existing `'Technical error ' + error` fallback otherwise. Helper extracted into `src/usecases/jobs/jobFailureReason.ts` so the copy is unit-testable without standing up the full conversion pipeline.
3. **`create_deck/create_deck.py`** — defense in depth: the `len(data) == 0` branch now `print('No cards generated; exiting cleanly')` + `sys.exit(0)` instead of `raise ValueError`. We never page again if a regression in step 1 lets an empty deck reach Python.
4. **`web/src/pages/UploadPage/components/DownloadButton.tsx`** — sync upload path now shows the same one-paragraph copy as the async Notion path, with a real `<a>` to `/documentation/help/common-problems#could-not-create-a-deck-using-your-file-and-rules`. The "Download empty deck" button is unchanged.

## Testing
- Unit tests added:
  - `BuildDeckForJobUseCase.test.ts` — `EmptyDeckError` is thrown when every deck has zero cards; `CardGenerator` and `exporter.configure` are never invoked.
  - `jobFailureReason.test.ts` — `EmptyDeckError` produces the friendly reason string; other errors keep the `Technical error ` prefix.
  - `EmptyDeckError.test.ts` — error class shape + survives instanceof across throw/catch.
- `pnpm tsc --noEmit`, `pnpm --filter 2anki-web typecheck`, `pnpm --filter 2anki-web test`, `pnpm --filter 2anki-web lint` all green.
- Per spec: no test added for the Python script (out of scope).

## Risks
- Behavior change in the failure reason string. Existing failed jobs are unaffected (we only set the reason on new failures). Frontend still renders the reason as text — the deep-link in the Downloads cell is plain text by design for v1.
- Tiny new branch in `performConversion`'s catch block; everything else unchanged.
- Rollback: revert the commit; behavior reverts to the Python crash + traceback.

## Goal alignment
Direct removal of a user-facing error that leaves people stuck. The friendly copy tells them exactly what to do (wrap key terms in toggles) and links to examples. Reduces support load on Alexander and converts a "what went wrong" abandonment into a recoverable flow — both feed the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)