### PR TITLE
feat(ankify): link rows to source Notion page on Find pages

### DIFF
--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -291,6 +291,37 @@
   letter-spacing: var(--tracking-wider);
 }
 
+.pickerNotionLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  opacity: 0.7;
+  transition: opacity var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.pickerNotionLink:hover,
+.pickerNotionLink:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.pickerNotionLink img {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: block;
+}
+
+@media (max-width: 599px) {
+  .pickerType {
+    display: none;
+  }
+}
+
 .advancedDetails {
   margin-top: 1rem;
   border: 1px solid var(--color-border);

--- a/web/src/pages/AnkifyPage/components/NotionPagePicker.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionPagePicker.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+import NotionPagePicker from './NotionPagePicker';
+import { Backend } from '../../../lib/backend/Backend';
+import NotionObject from '../../../lib/interfaces/NotionObject';
+
+const samplePage = (overrides: Partial<NotionObject> = {}): NotionObject => ({
+  id: 'page-1',
+  object: 'page',
+  title: 'Slash commands',
+  url: 'https://www.notion.so/Slash-commands-abc123',
+  icon: '📘',
+  ...overrides,
+});
+
+const makeBackend = (pages: NotionObject[]): Backend =>
+  ({
+    searchTopLevelPages: vi.fn(async () => pages),
+  } as unknown as Backend);
+
+const renderPicker = (
+  backend: Backend,
+  onSelect: (id: string, page?: NotionObject) => void = vi.fn()
+) =>
+  render(
+    <NotionPagePicker
+      backend={backend}
+      onSelect={onSelect}
+      busyId={null}
+      selectLabel="Make this a deck"
+      busyLabel="Subscribing…"
+      subscribedLabel="Subscribed"
+    />
+  );
+
+describe('NotionPagePicker — link to source Notion page', () => {
+  test('renders an anchor to the page URL with target="_blank" and rel="noreferrer"', async () => {
+    const backend = makeBackend([samplePage()]);
+    renderPicker(backend);
+
+    const link = await screen.findByRole('link', {
+      name: /open slash commands in notion/i,
+    });
+    expect(link).toHaveAttribute('href', 'https://www.notion.so/Slash-commands-abc123');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  test('aria-label and title include the page title and "(new tab)"', async () => {
+    const backend = makeBackend([samplePage({ title: 'My study notes' })]);
+    renderPicker(backend);
+
+    const link = await screen.findByRole('link', {
+      name: /open my study notes in notion \(new tab\)/i,
+    });
+    expect(link).toHaveAttribute(
+      'title',
+      'Open My study notes in Notion (new tab)'
+    );
+  });
+
+  test('clicking the Notion link does not call onSelect', async () => {
+    const onSelect = vi.fn();
+    const backend = makeBackend([samplePage()]);
+    renderPicker(backend, onSelect);
+
+    const link = await screen.findByRole('link', {
+      name: /open slash commands in notion/i,
+    });
+    fireEvent.click(link);
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  test('renders no anchor when page.url is missing', async () => {
+    const backend = makeBackend([samplePage({ url: '' })]);
+    renderPicker(backend);
+
+    await waitFor(() =>
+      expect(screen.getByText('Slash commands')).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByRole('link', { name: /open slash commands in notion/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
@@ -118,6 +118,23 @@ export default function NotionPagePicker({
                     </span>
                     <span className={styles.pickerType}>{page.object}</span>
                   </div>
+                  {page.url && (
+                    <a
+                      href={page.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={styles.pickerNotionLink}
+                      aria-label={`Open ${page.title} in Notion (new tab)`}
+                      title={`Open ${page.title} in Notion (new tab)`}
+                    >
+                      <img
+                        src="/icons/Notion_app_logo.png"
+                        alt=""
+                        width="24"
+                        height="24"
+                      />
+                    </a>
+                  )}
                   <button
                     type="button"
                     className={`${sharedStyles.btnSmall} ${styles.inlineButton}`}


### PR DESCRIPTION
## Summary

- Add a Notion-logo icon link to each row in the Ankify **Find pages** picker, between the type chip and "Make this a deck", so users can verify the candidate page in a new tab before subscribing.
- Mirrors the `/notion` route's `ObjectAction` pattern (`web/src/pages/SearchPage/components/actions/ObjectAction.tsx`), but lighter — the picker has one primary CTA, not the multi-action `/notion` row.
- Hide the `PAGE` type chip on screens narrower than 600px so the new icon + button fit cleanly on mobile.

## Why

Today, rows show only icon + title + type + a single "Make this a deck" button. Notion lets multiple pages share a name, and the title gets ellipsed at narrow widths — there was no way to confirm which page was about to be subscribed to. The data was already there (`NotionObject.url`).

## Out of scope

- No row redesign beyond the additions above.
- No preview link or rules dots-menu (those live on `/notion`, intentionally not on the picker).
- No backend, route, or `Backend.ts` changes.

## Test plan

- [ ] On `/ankify`, switch to the **Find pages** tab and search for any page. Confirm the Notion icon appears between the `PAGE` chip and the action button.
- [ ] Click the icon — page opens in a new tab pointing at the right Notion URL; the row's "Make this a deck" button does **not** fire.
- [ ] Subscribe to a row — the Notion icon stays clickable while the button shows "Subscribing…" and afterwards when the row reads "Subscribed".
- [ ] Tab through the row with keyboard — order is title → Notion link → "Make this a deck"; both have visible focus rings.
- [ ] Resize the window below 600px — the `PAGE` chip disappears, the icon + button still fit on one line.
- [ ] `pnpm --filter 2anki-web test src/pages/AnkifyPage/components/NotionPagePicker.test.tsx` passes (4 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)