### PR TITLE
chore(claude): allow agent writes for tests, edits, and specs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,20 @@
   },
   "permissions": {
     "allow": [
-      "Bash(git commit *)"
+      "Bash(git commit *)",
+
+      "Write(src/**/*.test.ts)",
+      "Write(web/src/**/*.test.ts)",
+      "Write(web/src/**/*.test.tsx)",
+
+      "Edit(src/**)",
+      "Edit(web/src/**)",
+      "Edit(web/public/**)",
+
+      "Write(Documentation/specs/*.md)",
+      "Edit(Documentation/specs/*.md)",
+      "Write(Documentation/ankify/*.md)",
+      "Edit(Documentation/ankify/*.md)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

- Subagents (engineer / pm / designer) have `Write` and `Edit` in their tool frontmatter but `.claude/settings.json` had no matching `allow` rules — so every file write fell through to the auto-mode classifier, which denied things like colocated `*.test.tsx` files and `Documentation/specs/*.md` drafts.
- This change adds tight, path-scoped allow patterns so legitimate trio work doesn't stall on permission prompts.

## What's allowed now

| Pattern | Scope |
|---|---|
| `Write(src/**/*.test.ts)` | Server Jest tests only — not new prod files |
| `Write(web/src/**/*.test.ts(x))` | Web Vitest tests only — not new prod files |
| `Edit(src/**)`, `Edit(web/src/**)`, `Edit(web/public/**)` | Editing existing source / asset files |
| `Write/Edit(Documentation/specs/*.md)` | PM/designer specs |
| `Write/Edit(Documentation/ankify/*.md)` | Existing ankify-feature docs convention |

## What still prompts

- `Write(src/**)` — new non-test files. Adding a new module is a design call worth a confirmation.
- Anything under `.claude/`, `.github/`, repo-root `*.md`, `package.json`, `pnpm-lock.yaml`, etc. — load-bearing or political files.
- `Write` to other `Documentation/` subtrees and to `Documentation/*.md` at the top level.

## Why this is safe

- New file creation is gated to test paths and a couple of docs subtrees — agents can't drop arbitrary files anywhere in the tree.
- The pre-write secret-scan hook (`pre-write-secret-scan.py`) still runs on every Write/Edit, so credentials still get blocked.
- The classifier and `safety.py` still gate Bash, including destructive git operations — none of that is touched.

## Test plan

- [ ] Open this PR's diff and read the patterns; check none are broader than intended.
- [ ] Next time you run `/spec` or `/implement`, observe whether the trio drafts a spec or test file without a permission prompt.
- [ ] Confirm `Write(.claude/settings.json)` and `Write(package.json)` still prompt.
- [ ] Confirm a new non-test file under `src/` (e.g. `src/foo.ts`) still prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)