### PR TITLE
docs: write 8 overhaul pages with tier markers

### DIFF
--- a/web/src/pages/DocsPage/DocContent.test.tsx
+++ b/web/src/pages/DocsPage/DocContent.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { DocContent } from './DocContent';
+
+function renderAt(slug: string, path = '/documentation/*') {
+  return render(
+    <MemoryRouter initialEntries={[`/documentation/${slug}`]}>
+      <Routes>
+        <Route path={path} element={<DocContent slug={slug} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('DocContent markdown link rewriting', () => {
+  it('keeps /documentation/... links unchanged (no double prefix)', () => {
+    renderAt('help/limits');
+    const links = Array.from(
+      document.querySelectorAll('a[href^="/documentation/"]'),
+    ).map((a) => a.getAttribute('href') ?? '');
+    expect(links.length).toBeGreaterThan(0);
+    for (const href of links) {
+      expect(href).not.toMatch(/^\/documentation\/documentation\//);
+    }
+  });
+
+  it('keeps /pricing as a top-level app route', () => {
+    renderAt('help/limits');
+    const pricing = Array.from(document.querySelectorAll('a')).find(
+      (a) => a.getAttribute('href') === '/pricing',
+    );
+    expect(pricing).toBeTruthy();
+  });
+
+  it('renders external links with target=_blank', () => {
+    renderAt('reference/self-hosting');
+    const ext = Array.from(document.querySelectorAll('a')).find(
+      (a) => a.getAttribute('href') === 'https://github.com/2anki/server',
+    );
+    expect(ext).toBeTruthy();
+    expect(ext?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('renders the Not found state for an unknown slug', () => {
+    renderAt('does/not/exist');
+    expect(
+      screen.getByRole('heading', { level: 1, name: /not found/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DocsPage/DocContent.tsx
+++ b/web/src/pages/DocsPage/DocContent.tsx
@@ -38,15 +38,16 @@ function DocsAnchor({ href, children, ...rest }: AnchorProps) {
     );
   }
 
-  const to = href.startsWith('/')
-    ? `/documentation${href.replace(/\/$/, '')}`
-    : href;
+  const to = href.length > 1 && href.endsWith('/') ? href.slice(0, -1) : href;
+  const isAppRoute = to.startsWith('/documentation') || to === '/documentation';
+  const handlesClientSide = isAppRoute || to.startsWith('/pricing');
 
   return (
     <a
       href={to}
       onClick={(e) => {
         if (
+          !handlesClientSide ||
           e.defaultPrevented ||
           e.button !== 0 ||
           e.metaKey ||

--- a/web/src/pages/DocsPage/content-links.test.ts
+++ b/web/src/pages/DocsPage/content-links.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { hasDoc } from './loader';
+
+const modules = import.meta.glob('./content/**/*.{md,mdx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+const KNOWN_APP_PREFIXES = [
+  '/pricing',
+  '/debug',
+  '/api',
+  '/upload',
+  '/login',
+  '/about',
+  '/changelog',
+];
+
+const LINK_RE = /(?<!!)\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+
+function stripCode(body: string): string {
+  return body
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`\n]+`/g, '');
+}
+
+type LinkKind = 'external' | 'anchor' | 'doc' | 'app' | 'relative';
+
+function classify(href: string): LinkKind {
+  if (/^(https?:|mailto:)/i.test(href)) return 'external';
+  if (href.startsWith('#')) return 'anchor';
+  if (href === '/documentation' || href.startsWith('/documentation/')) {
+    return 'doc';
+  }
+  if (href.startsWith('/')) return 'app';
+  return 'relative';
+}
+
+function slugFromDocHref(href: string): string {
+  return href
+    .replace(/^\/documentation\//, '')
+    .replace(/#.*$/, '')
+    .replace(/\?.*$/, '')
+    .replace(/\/$/, '');
+}
+
+interface FoundLink {
+  source: string;
+  href: string;
+}
+
+const allLinks: FoundLink[] = (() => {
+  const out: FoundLink[] = [];
+  for (const [path, raw] of Object.entries(modules)) {
+    const body = stripCode(raw);
+    LINK_RE.lastIndex = 0;
+    let m: RegExpExecArray | null = LINK_RE.exec(body);
+    while (m !== null) {
+      out.push({ source: path, href: m[1] });
+      m = LINK_RE.exec(body);
+    }
+  }
+  return out;
+})();
+
+describe('docs content link integrity', () => {
+  it('parses at least one link (sanity)', () => {
+    expect(allLinks.length).toBeGreaterThan(0);
+  });
+
+  it('every /documentation/... link points to a real page', () => {
+    const broken = allLinks.filter((l) => {
+      if (classify(l.href) !== 'doc') return false;
+      if (l.href === '/documentation') return false;
+      return !hasDoc(slugFromDocHref(l.href));
+    });
+    expect(broken).toEqual([]);
+  });
+
+  it('no link starts with /documentation/documentation/', () => {
+    const doubled = allLinks.filter((l) =>
+      l.href.startsWith('/documentation/documentation/'),
+    );
+    expect(doubled).toEqual([]);
+  });
+
+  it('absolute non-docs links target a known app route', () => {
+    const unknown = allLinks.filter((l) => {
+      if (classify(l.href) !== 'app') return false;
+      const path = l.href.split(/[?#]/)[0];
+      return !KNOWN_APP_PREFIXES.some(
+        (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+      );
+    });
+    expect(unknown).toEqual([]);
+  });
+
+  it('uses absolute paths only — no relative markdown links', () => {
+    const relative = allLinks.filter((l) => classify(l.href) === 'relative');
+    expect(relative).toEqual([]);
+  });
+});

--- a/web/src/pages/DocsPage/content/cards/card-types.md
+++ b/web/src/pages/DocsPage/content/cards/card-types.md
@@ -3,8 +3,87 @@ title: Card types
 description: The three card shapes 2anki makes, and when each fires.
 ---
 
-This page is being written. It will cover the three card types 2anki produces — Basic (toggle → front/back), Cloze (`{{c1::...}}` and code-as-cloze), and Input (typed answer) — and how to switch between them.
+2anki produces three card shapes. Which one you get depends on what's in your source — bold text becomes a typed answer, code becomes a cloze, everything else stays as a basic front/back card.
 
-If you'd like this page sooner, comment on the [tracking issue](https://github.com/2anki/server/issues/2069) — we read every one.
+**Plan:** Free (all three card types work on every plan)
 
-In the meantime: see [HTML](/documentation/cards/html) and [Markdown and Obsidian](/documentation/cards/markdown) for example syntax for each type.
+## Basic
+
+The default. The toggle's heading becomes the front; the toggle's contents become the back.
+
+In Notion:
+
+- A toggle with the heading "What is the capital of Albania?" and "Tirana!" inside.
+
+In Markdown (with **Markdown Nested Bullet Points** on):
+
+```
+- What is the capital of France?
+  - Paris
+```
+
+In HTML:
+
+```html
+<details>
+  <summary>What is the capital of Albania?</summary>
+  <p>Tirana</p>
+</details>
+```
+
+You also get **Basic and Reversed** as a card option — that creates the front/back card and a second card with front and back swapped. Useful for vocabulary. See [Card options](/documentation/cards/card-options).
+
+## Cloze
+
+Cloze hides part of a sentence. You see "The capital of France is [...]" and type or recall "Paris".
+
+2anki turns inline code into clozes. Wrap the hidden text in backticks (Markdown) or `<code>` tags (HTML):
+
+```
+- The capital of `France` is `Paris`
+```
+
+```html
+<details>
+  <summary>The capital of <code>Albania</code> is <code>Tirana</code></summary>
+</details>
+```
+
+You can also use Anki's native cloze syntax directly when you want explicit numbering or hints:
+
+```
+{{c1::Canberra::city}} was founded in {{c2::1913::year}}
+```
+
+The **Cloze Deletion** card option controls whether code-as-cloze fires — it's on by default. See [HTML](/documentation/cards/html) and [Markdown and Obsidian](/documentation/cards/markdown) for more examples.
+
+## Input
+
+Input cards make you type the answer. You see the question, type, and Anki marks it right or wrong by exact match.
+
+Turn on **Treat Bold Text as Input** in card options. Then bold text on the back becomes the typed-answer field:
+
+```
+- What is 21 + 21 = **42**
+```
+
+```html
+<details>
+  <summary>What is 21 + 21?</summary>
+  <p><strong>42</strong></p>
+</details>
+```
+
+Best for facts where exact spelling matters — dates, names, equation results. Skip it for definitions or anything where wording can vary.
+
+## How to switch between them
+
+You don't pick a card type per card. You pick a card option, and 2anki applies it across the whole upload:
+
+- **Basic** is the default whenever a toggle has nothing else going on.
+- **Cloze** fires automatically when **Cloze Deletion** is on (default) and your toggle contains code.
+- **Input** fires when **Treat Bold Text as Input** is on and your toggle has bold text on the back.
+
+If a single toggle has both code and bold text, cloze wins. If you want a different mix, split the toggle in your source.
+
+The full card option list with defaults is on [Card options](/documentation/cards/card-options). The card templates Anki uses (`n2a-basic`, `n2a-cloze`, `n2a-input`) are listed in the [glossary](/documentation/reference/glossary).

--- a/web/src/pages/DocsPage/content/help/limits.md
+++ b/web/src/pages/DocsPage/content/help/limits.md
@@ -1,32 +1,67 @@
 ---
 title: Limits and quotas
-description: What's allowed on free, what's allowed on paid, and how long files stick around.
+description: What's allowed on each plan, and how long your decks stick around.
 ---
 
-2anki.net is free for everyone. To keep it that way, there are a few limits on the hosted service. If you self-host, you can change them — see [self-hosting](/documentation/reference/self-hosting).
+2anki.net is free for the conversion features. The limits below keep the hosted service fast for everyone. If you self-host, you can change them — see [self-hosting](/documentation/reference/self-hosting).
 
 ## File size
 
 | Plan | Max upload size |
 |---|---|
 | Free | 100 MB per request |
-| Paid | ~10 GB per request |
+| Subscription / Lifetime | ~10 GB per request |
+
+Free covers anonymous and signed-in users without a paid plan. The file-size limit lives in `src/lib/misc/getUploadLimits.ts`.
 
 ## PDF pages
 
 | Plan | Max pages per PDF |
 |---|---|
 | Free | 100 |
-| Paid | No fixed cap |
+| Subscription / Lifetime | No fixed cap |
 
 PDFs over the free limit return: *PDF exceeds maximum page limit of 100 for free and anonymous users.*
 
-## Storage time
+## AI-generated flashcards
 
-Uploaded files are deleted automatically **2 hours** after processing. The same window applies whether you're free or paid. The matching message on the upload page says the same thing.
+The **Use Claude AI** card option is a Subscription / Lifetime feature. Free accounts see the toggle but the conversion falls back to the standard parser.
+
+## Storage
+
+What "storage" means depends on which path you used.
+
+### File upload (no Claude AI)
+
+Your file lives on disk only long enough to build the deck. The `.apkg` is sent straight back as the response — we don't keep a copy. The temporary working files are wiped after **two hours**.
+
+**Plan:** any (anonymous, Free account, Subscription, Lifetime — same window for all).
+
+### Notion convert and Claude AI uploads
+
+These paths build your deck in the background and store the `.apkg` in our bucket so you can re-download it from **My uploads** and so [sync](/documentation/sync/how-it-works) has something to update.
+
+| Plan | How long your decks stay in the bucket |
+|---|---|
+| Free account | Removed in the next daily cleanup (within 24 hours). |
+| Subscription | Kept for as long as your subscription is active. |
+| Lifetime (Patreon) | Kept indefinitely. |
+
+If your subscription lapses, your stored decks are removed in the next daily cleanup — re-convert and they come back. You can also delete a deck yourself from **My uploads** at any time.
 
 ## Free vs paid
 
-The paid plan unlocks larger uploads, more PDF pages, and AI-powered flashcard generation (Claude). See the [pricing page](/pricing) for the current plan list.
+Free covers the conversion paths most people need: drag in a file, get a deck back. The paid plans add AI-generated flashcards, larger uploads, longer storage, and Notion sync.
+
+| Capability | Free | Subscription | Lifetime |
+|---|---|---|---|
+| Anonymous file upload | ✓ | ✓ | ✓ |
+| Account features (history, favorites, templates) | sign-in required | ✓ | ✓ |
+| AI-generated flashcards (Claude) | — | ✓ | ✓ |
+| Notion sync | — | ✓ | ✓ |
+| Long-term deck storage | 24 h | active sub | indefinite |
+| Ankify (hosted bidirectional sync) | — | — | ✓ |
+
+See the [pricing page](/pricing) for the current plan list. Privacy details — what we read, what we don't — are on the [privacy policy](/documentation/reference/privacy).
 
 If something looks wrong, [contact us](/documentation/help/contact).

--- a/web/src/pages/DocsPage/content/reference/file-formats.md
+++ b/web/src/pages/DocsPage/content/reference/file-formats.md
@@ -3,8 +3,26 @@ title: File formats
 description: Every input we accept and how it's read.
 ---
 
-This reference page is being written. It will list every supported input — Notion HTML exports, raw HTML, Markdown, CSV, XLSX, ZIP, PDF, PPT/PPTX — with how 2anki reads each one, the limits that apply, and notes on common pitfalls.
+This is the full list of inputs 2anki accepts. The hard limits live on [Limits and quotas](/documentation/help/limits) — this page is the format reference.
 
-If you'd like this page sooner, comment on the [tracking issue](https://github.com/2anki/server/issues/2072) — we read every one.
+**Plan:** Free (any plan can upload any format; paid plans get bigger files and AI-generated cards)
 
-In the meantime: [HTML](/documentation/cards/html) and [Markdown and Obsidian](/documentation/cards/markdown) have their own pages with examples.
+| Format | How 2anki reads it | Limits | Notes |
+|---|---|---|---|
+| **Notion HTML export** (`.zip`) | Each `.html` file inside becomes a deck. Toggles inside the file become cards. The `assets/` folder is bundled into the deck. | Same size limit as any upload. | The `.zip` Notion gives you when you export with "HTML" + "Include subpages". The cleanest non-Notion-integration path. |
+| **HTML** (`.html`) | Each `<details>` block becomes a card — `<summary>` is the front, the rest is the back. `<code>` becomes cloze. `<strong>` becomes input (with the **Treat Bold Text as Input** option on). | Same size limit as any upload. | Hand-written HTML works the same way. See [HTML](/documentation/cards/html). |
+| **Markdown** (`.md`) | Bullet pairs become cards: parent bullet is the front, child bullet is the back. Backticks become cloze. | Same size limit as any upload. | Requires the **Markdown Nested Bullet Points** card option (on by default). Obsidian vaults work the same way. See [Markdown and Obsidian](/documentation/cards/markdown). |
+| **ZIP** (`.zip`) | Extracted; the contents are processed in place. Notion HTML exports, folders of HTML files, or mixed bundles all work. | Same size limit as any upload. Entries are checked for unsafe paths before extraction. | If you have a Notion export with images, keep it zipped — the assets stay attached. |
+| **CSV** (`.csv`) | One row per card. The first column is the front, the second is the back. | Same size limit as any upload. | Use commas as the separator. TSV (tab-separated) is not supported — convert to CSV first. |
+| **XLSX** (`.xlsx`) | Same as CSV but for Excel files. First column front, second column back. | Same size limit as any upload. | One sheet per deck. |
+| **PDF** (`.pdf`) | Each page becomes an image. By default, page 1 is the front and page 2 is the back, page 3 the front of the next card, page 4 the back, and so on — useful for slide decks where each topic spans two slides. | 100 pages on free, no fixed cap on paid. | Turn on **Generate Flashcards with Claude AI** to have Claude read the PDF and write questions instead of pairing pages. Paid only. |
+| **PPT / PPTX** (`.pptx`, `.ppt`) | Converted to PDF via LibreOffice, then handled like a PDF (pair-of-pages cards or AI-generated). | Same as PDF. | Same as PDF behaviour after conversion — see PDF row. |
+
+## HTML and Markdown
+
+HTML and Markdown have their own pages because the syntax for cloze and input cards is worth a couple of examples each:
+
+- [HTML](/documentation/cards/html) — toggles, cloze, input, and how images travel with the deck.
+- [Markdown and Obsidian](/documentation/cards/markdown) — bullet syntax for basic, cloze, and input cards.
+
+For the format-by-format pitfalls users actually hit, see [Common problems](/documentation/help/common-problems).

--- a/web/src/pages/DocsPage/content/reference/self-hosting.md
+++ b/web/src/pages/DocsPage/content/reference/self-hosting.md
@@ -3,15 +3,23 @@ title: Self-hosting
 description: You can run 2anki yourself. Here's the short version.
 ---
 
-The codebase lives in [2anki/server](https://github.com/2anki/server) — a pnpm monorepo that contains the Express API and the React frontend (the latter is the `web/` workspace, package name `2anki-web`). It's free to self-host for personal or commercial use.
+:::note
+Self-hosting is for tinkerers and contributors. Almost everyone is better off using the hosted service at [2anki.net](https://2anki.net/) — same code, no setup, free for the conversion features.
+:::
+
+The codebase lives in [2anki/server](https://github.com/2anki/server) — a pnpm monorepo with the Express API and the React frontend (the `web/` workspace, package name `2anki-web`). Free to run for personal or commercial use.
+
+**Plan:** Free (self-hosted; the [hosted-service tiers](/pricing) don't apply when you run your own instance)
 
 ## System requirements
 
-- Node.js — the version pinned in the repo's `.nvmrc` / `packageManager` field.
+- Node.js — match the version in `.nvmrc`.
 - pnpm — don't use npm or yarn.
 - PostgreSQL.
-- LibreOffice — for PPT/PPTX → PDF conversion.
-- Poppler (`pdftoppm`) — for PDF → image rendering.
+- LibreOffice — for PPT/PPTX to PDF conversion.
+- Poppler (`pdftoppm`) — for PDF page rendering.
+
+On Debian/Ubuntu:
 
 ```bash
 sudo apt-get install -y git postgresql libreoffice poppler-utils
@@ -22,7 +30,7 @@ npm install -g pnpm
 
 ## Required env vars
 
-Create `.env` at the repo root with:
+Create `.env` at the repo root:
 
 ```bash
 PORT=2020
@@ -36,20 +44,28 @@ POSTGRES_PORT=5432
 POSTGRES_USER=tanki
 POSTGRES_PASSWORD=tanki
 POSTGRES_DATABASE=tanki
+
+SECRET=replace-with-a-long-random-string
 ```
 
-Set `RUN_MIGRATIONS=true` on first boot. Leave it unset in production where you run migrations out of band.
+`SECRET` is used to sign session cookies. Set it to a long random value before exposing the server publicly. Set `RUN_MIGRATIONS=true` on first boot; leave unset in production where you run migrations out of band.
 
 ## Optional integrations
 
-- **Notion OAuth** — `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, `NOTION_REDIRECT_URI` enable the Connect Notion flow.
-- **Anthropic Claude** — `ANTHROPIC_API_KEY` enables the Claude AI flashcard option.
-- **Google Vertex AI** — credentials for the experimental PDF-questions option.
-- **Stripe** — for paid plans, if you want them.
-- **SendGrid** — for transactional email.
-- **S3 / DigitalOcean Spaces** — remote storage for uploads.
-- **Bugsnag** — error reporting.
+Each integration adds a feature. You can run 2anki without any of them — the file-upload conversion path works on its own.
+
+| Integration | Env vars | Adds |
+|---|---|---|
+| Notion OAuth | `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, `NOTION_REDIRECT_URI` | Connect Notion + Find pages picker |
+| Anthropic Claude | `ANTHROPIC_API_KEY` | AI flashcard generation from PDFs |
+| Stripe | `STRIPE_*` | Paid plans (skip if you're running for yourself) |
+| SendGrid | `SENDGRID_API_KEY` | Transactional email (password reset, etc.) |
+| AWS S3 / DigitalOcean Spaces | `S3_*` | Remote upload storage instead of local disk |
 
 ## Where to get help
 
-A fuller setup guide is being written — track it in [issue #2073](https://github.com/2anki/server/issues/2073). For now, the repo `README.md` is the source of truth, and the Swagger UI is at `/api/docs` once the server is running.
+- The repo's [`README.md`](https://github.com/2anki/server#readme) is the source of truth for setup steps.
+- Once the server is running, the API reference is at `/api/docs` (Swagger UI).
+- For self-host questions, [open a discussion](https://github.com/2anki/server/discussions) on GitHub. Email is fine for hosted-service questions but the discussion forum is faster for self-hosting because other self-hosters answer.
+
+We don't write a full ops manual on purpose — the hosted service is what most users want, and the README plus the code are enough for the tinkerers who don't.

--- a/web/src/pages/DocsPage/content/reference/self-hosting.md
+++ b/web/src/pages/DocsPage/content/reference/self-hosting.md
@@ -30,25 +30,22 @@ npm install -g pnpm
 
 ## Required env vars
 
-Create `.env` at the repo root:
+Create `.env` at the repo root. Real keys live in `src/env.example`:
 
 ```bash
 PORT=2020
+DOMAIN=http://localhost:2020
 WORKSPACE_BASE=/tmp/genanki
 UPLOAD_BASE=/tmp/genanki-uploads
 WEB_BUILD_DIR=./web/build
-RUN_MIGRATIONS=true
 
-POSTGRES_HOST=localhost
-POSTGRES_PORT=5432
-POSTGRES_USER=tanki
-POSTGRES_PASSWORD=tanki
-POSTGRES_DATABASE=tanki
+DATABASE_URL=postgresql://tanki:tanki@localhost:5432/tanki
 
 SECRET=replace-with-a-long-random-string
+THE_HASHING_SECRET=replace-with-a-different-long-random-string
 ```
 
-`SECRET` is used to sign session cookies. Set it to a long random value before exposing the server publicly. Set `RUN_MIGRATIONS=true` on first boot; leave unset in production where you run migrations out of band.
+`SECRET` signs session JWTs; `THE_HASHING_SECRET` encrypts stored Notion tokens. Both must be long random strings before you expose the server publicly. Migrations run automatically on boot via the Knex config.
 
 ## Optional integrations
 
@@ -58,9 +55,9 @@ Each integration adds a feature. You can run 2anki without any of them — the f
 |---|---|---|
 | Notion OAuth | `NOTION_CLIENT_ID`, `NOTION_CLIENT_SECRET`, `NOTION_REDIRECT_URI` | Connect Notion + Find pages picker |
 | Anthropic Claude | `ANTHROPIC_API_KEY` | AI flashcard generation from PDFs |
-| Stripe | `STRIPE_*` | Paid plans (skip if you're running for yourself) |
+| Stripe | `STRIPE_KEY`, `STRIPE_ENDPOINT_SECRET` | Paid plans (skip if you're running for yourself) |
 | SendGrid | `SENDGRID_API_KEY` | Transactional email (password reset, etc.) |
-| AWS S3 / DigitalOcean Spaces | `S3_*` | Remote upload storage instead of local disk |
+| DigitalOcean Spaces (S3-compatible) | `SPACES_ENDPOINT`, `SPACES_DEFAULT_BUCKET_NAME`, plus standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Remote storage for converted decks (needed for "My uploads" history and sync) |
 
 ## Where to get help
 

--- a/web/src/pages/DocsPage/content/start-here/open-in-anki.md
+++ b/web/src/pages/DocsPage/content/start-here/open-in-anki.md
@@ -3,8 +3,49 @@ title: Open your deck in Anki
 description: Get the .apkg you downloaded into Anki on any device.
 ---
 
-This page is being written. It will cover importing on Anki desktop, AnkiMobile (iPhone/iPad), AnkiDroid (Android), AnkiWeb, and how to update an existing deck without losing review progress.
+Anki opens `.apkg` files on every platform — desktop, iPhone, iPad, Android, and the web. The flow is slightly different on each. Pick yours below.
 
-If you'd like this page sooner, comment on the [tracking issue](https://github.com/2anki/server/issues/2068) — we read every one.
+**Plan:** Free (Anki itself is free on every platform except iOS)
 
-In the meantime: the official Anki manual covers each platform's import flow at [docs.ankiweb.net](https://docs.ankiweb.net/).
+## Anki desktop (Windows, macOS, Linux)
+
+1. Make sure Anki is installed — [download it from ankiweb.net](https://apps.ankiweb.net/).
+2. Double-click the `.apkg` file you downloaded. Anki opens and imports it.
+3. The new deck appears in your deck list, ready to study.
+
+If double-click doesn't work, open Anki and use **File → Import**, then pick the `.apkg`.
+
+## AnkiMobile (iPhone, iPad)
+
+AnkiMobile is a paid app from the official Anki team — buying it directly funds Anki's development.
+
+1. Save the `.apkg` to the Files app (e.g. via AirDrop, Mail, or iCloud Drive).
+2. Open Files, tap the `.apkg`, and pick **Open in AnkiMobile**.
+3. Confirm the import. The deck appears in your deck list.
+
+If the file opens in a preview app instead, use the **Share** button and pick AnkiMobile from the list.
+
+## AnkiDroid (Android)
+
+AnkiDroid is free on Google Play.
+
+1. Save the `.apkg` to your phone — direct download from Chrome or Firefox works.
+2. Open the file from your notifications or the Files app.
+3. Pick **AnkiDroid** when Android asks how to open it. The deck imports automatically.
+
+## AnkiWeb
+
+AnkiWeb is the official sync service. You can study in the browser, but it's mainly used to keep desktop and mobile in sync.
+
+1. Sign in at [ankiweb.net](https://ankiweb.net/).
+2. AnkiWeb itself doesn't import `.apkg` files directly — import on desktop or mobile, then let Anki sync the deck up to AnkiWeb.
+
+## Updating an existing deck
+
+If you re-convert the same Notion page or file, 2anki keeps the card IDs stable. Re-importing the new `.apkg` updates existing cards in place — your review history stays intact, you don't get duplicates.
+
+:::warning
+This relies on the **Use Notion ID** card option (on by default for Notion sources). If you turned it off, re-importing creates new cards alongside the old ones. See [Card options](/documentation/cards/card-options).
+:::
+
+For Notion pages where you want updates to flow automatically without re-uploading, use [Sync](/documentation/sync/how-it-works) instead.

--- a/web/src/pages/DocsPage/content/start-here/upload-a-file.md
+++ b/web/src/pages/DocsPage/content/start-here/upload-a-file.md
@@ -3,8 +3,51 @@ title: Upload a file instead
 description: For PDFs, slides, spreadsheets, or a Notion HTML export.
 ---
 
-This page is being written. It will cover when to upload a file instead of [Connect Notion](/documentation/start-here/connect-notion), how to drop in a file, the supported types, and what happens to the file after conversion.
+Upload works without an account. You drop in a file, 2anki builds the deck, and you download an `.apkg`. Good for one-off conversions or sources that don't live in Notion.
 
-If you'd like this page sooner, comment on the [tracking issue](https://github.com/2anki/server/issues/2067) — we read every one.
+**Plan:** Free (anonymous, no sign-in needed)
 
-In the meantime: the supported types are listed in [File formats](/documentation/reference/file-formats), and what we keep is described in the [privacy policy](/documentation/reference/privacy).
+## When to use upload instead of Connect Notion
+
+Upload when:
+
+- The source is a PDF, slide deck, spreadsheet, CSV, or Markdown file.
+- You don't have a Notion workspace, or the page isn't in Notion.
+- You want a fast one-shot conversion and don't need future edits to flow into the deck.
+
+Use [Connect Notion](/documentation/start-here/connect-notion) when the source is a Notion page and you want the deck to update as you edit.
+
+## Drop in a file
+
+1. Go to [2anki.net/upload](https://2anki.net/upload).
+2. Drag your file onto the drop area, or click to pick one.
+3. Open the settings panel if you want to change card options. Defaults are tuned for first-time use — see [Card options](/documentation/cards/card-options) for what each one does.
+4. Click **Convert**. When it finishes, click **Download** to grab the `.apkg`.
+5. Open the file in Anki — see [Open your deck in Anki](/documentation/start-here/open-in-anki).
+
+:::tip
+Toggle lists make the cleanest cards. If your source is plain prose, the conversion will still work, but you'll get better results from a structure where each card is one toggle, one bullet pair, or one row.
+:::
+
+## Supported types
+
+The full table of formats and limits is on [File formats](/documentation/reference/file-formats). Short version:
+
+- **Notion HTML export** (`.zip`) — the `.zip` Notion gives you when you export with "HTML" + "Include subpages".
+- **HTML** — a single `.html` file or a folder of them.
+- **Markdown** — `.md`, including Obsidian vaults.
+- **CSV / XLSX** — one row per card.
+- **PDF** — front/back per page pair, or AI-generated questions on paid.
+- **PPT / PPTX** — converted via slides to PDF to images.
+
+Drop the wrong format and 2anki tells you. The error message names the supported types so you don't have to guess.
+
+## What happens to your file
+
+We need the file long enough to convert it. After that:
+
+- **Anonymous uploads** are deleted automatically two hours after conversion.
+- **Account uploads** stick around in your history until you delete them, or hit the same two-hour cleanup if storage is full.
+- We don't read your content for any reason other than building your deck. We don't train models on it.
+
+The full story is on the [privacy policy](/documentation/reference/privacy). The hard numbers are on [Limits and quotas](/documentation/help/limits).

--- a/web/src/pages/DocsPage/content/start-here/upload-a-file.md
+++ b/web/src/pages/DocsPage/content/start-here/upload-a-file.md
@@ -46,8 +46,8 @@ Drop the wrong format and 2anki tells you. The error message names the supported
 
 We need the file long enough to convert it. After that:
 
-- **Anonymous uploads** are deleted automatically two hours after conversion.
-- **Account uploads** stick around in your history until you delete them, or hit the same two-hour cleanup if storage is full.
+- **Anonymous and Free account file uploads** — the temporary working files are wiped within two hours. The `.apkg` is sent straight back as the response, so we don't keep a copy.
+- **Claude AI uploads and Notion conversions** are stored in your account so you can re-download from **My uploads**. Free accounts: removed within 24 hours. Subscription: kept while your sub is active. Lifetime: kept indefinitely.
 - We don't read your content for any reason other than building your deck. We don't train models on it.
 
 The full story is on the [privacy policy](/documentation/reference/privacy). The hard numbers are on [Limits and quotas](/documentation/help/limits).

--- a/web/src/pages/DocsPage/content/start-here/what-is-2anki.md
+++ b/web/src/pages/DocsPage/content/start-here/what-is-2anki.md
@@ -3,8 +3,37 @@ title: What is 2anki?
 description: 2anki turns your Notion pages and study files into Anki decks.
 ---
 
-This page is being written. It will cover what you can drop in, what you get back, the two ways to use 2anki (Connect Notion vs upload a file), and a one-line summary of free and paid.
+2anki is a tool for turning what you're studying into Anki flashcards. Drop in a Notion page, a PDF, or a Markdown file, and you get back an `.apkg` deck ready to import.
 
-If you'd like this page sooner, comment on the [tracking issue](https://github.com/2anki/server/issues/2066) — we read every one.
+You don't need an account to try it. You don't need to know how Anki templates work. The defaults aim at one thing: a clean deck on the first try.
 
-In the meantime: the fastest tour is [Connect Notion in 5 minutes](/documentation/start-here/connect-notion).
+## What you can drop in
+
+- A page from your Notion workspace.
+- A PDF, slide deck, spreadsheet, or CSV.
+- A Markdown file or an Obsidian vault.
+- A Notion HTML export (the `.zip` Notion gives you).
+
+The full list with limits and quirks is on [File formats](/documentation/reference/file-formats).
+
+## What you get back
+
+A standard Anki `.apkg` file. Open it on Anki desktop, AnkiMobile, AnkiDroid, or AnkiWeb — see [Open your deck in Anki](/documentation/start-here/open-in-anki).
+
+Inside the deck:
+
+- One card per toggle (or per bullet pair, or per CSV row).
+- Three card shapes: basic, cloze, and typed-input. See [Card types](/documentation/cards/card-types).
+- Images, audio, and other assets are bundled in.
+
+## Two ways to use it
+
+**Connect Notion.** Sign in with Notion, pick a page, get a deck. The recommended path. Edits in Notion can flow back into your deck without re-uploading. Walkthrough: [Connect Notion in 5 minutes](/documentation/start-here/connect-notion).
+
+**Upload a file.** No account needed. Good for PDFs, slide decks, Markdown vaults, or a one-off CSV. Walkthrough: [Upload a file instead](/documentation/start-here/upload-a-file).
+
+## Free and paid
+
+**Free:** anonymous file uploads up to 100 MB and PDFs up to 100 pages. The Connect Notion flow works free with a 2anki account too.
+
+**Paid:** larger uploads, more PDF pages, AI flashcard generation, and (for lifetime supporters) two-way Notion sync. See the [pricing page](/pricing) and [Limits and quotas](/documentation/help/limits) for the numbers.

--- a/web/src/pages/DocsPage/content/sync/review-export.md
+++ b/web/src/pages/DocsPage/content/sync/review-export.md
@@ -3,8 +3,56 @@ title: Send your reviews back to Notion
 description: Push how often you got each card right back into your Notion database.
 ---
 
-This page is being written. It will cover what you'll see in Notion after the export runs, how to turn it on, the Notion database properties you'll need, and the limits.
+:::note
+This is an early-access feature for **Lifetime** supporters only. It builds on [Sync](/documentation/sync/how-it-works), which is itself in private alpha. If you'd like to be on the list, email [alexander@alemayhu.com](mailto:alexander@alemayhu.com).
+:::
 
-If you'd like this page sooner, comment on the [tracking issue](https://github.com/2anki/server/issues/2070) — we read every one.
+Review export pushes your Anki review history back into a Notion database. After a study session, you'll see — for each card — how many times you got it right, how many times you got it wrong, and when you last saw it.
 
-In the meantime: see [How sync works](/documentation/sync/how-it-works) for the broader sync flow this builds on. Like sync, this is currently in private alpha.
+## What you'll see in Notion
+
+Each card maps to one row in the database you pick. After a sync runs, the row's properties update with:
+
+- **Reviews** — total times you've seen the card.
+- **Lapses** — times you forgot.
+- **Ease** — Anki's ease factor for the card.
+- **Last review** — when you last studied it.
+- **Due** — when Anki wants to show it next.
+
+Notion stays your source of truth for the question and answer. 2anki only writes the review numbers — it doesn't touch your card content.
+
+## Turning it on
+
+You'll do this from the Ankify dashboard once you have access:
+
+1. Make sure the source page is already syncing — see [How sync works](/documentation/sync/how-it-works).
+2. In the Notion database that holds the cards, add the required properties (below).
+3. From the Ankify dashboard, open the page's settings and toggle **Export reviews to Notion**.
+4. Pick the database you want the data written to.
+5. Run a sync. After your next Anki study session, the database rows fill in.
+
+## Required Notion properties
+
+The database needs these properties. Names must match exactly. Types in parentheses.
+
+| Property | Type |
+|---|---|
+| Reviews | Number |
+| Lapses | Number |
+| Ease | Number |
+| Last review | Date |
+| Due | Date |
+
+You can have other properties too — 2anki only writes the ones above.
+
+:::warning
+If a property is missing or the wrong type, the sync skips it silently for that row. Check the Ankify dashboard's run log to see which rows updated.
+:::
+
+## Limits
+
+- Review export runs at the same five-minute cadence as sync. It isn't real-time.
+- Only cards 2anki originally created from that Notion page are tracked. Cards you added by hand in Anki aren't matched back.
+- If you delete the Notion row, the matching Anki card stays — Anki is the source of truth for what you study, Notion is the source of truth for what you wrote.
+
+If a row isn't updating, see [When sync gets stuck](/documentation/sync/troubleshooting).

--- a/web/src/pages/DocsPage/content/sync/troubleshooting.md
+++ b/web/src/pages/DocsPage/content/sync/troubleshooting.md
@@ -3,8 +3,46 @@ title: When sync gets stuck
 description: Three things to try when your deck won't update.
 ---
 
-This page is being written. It will cover what to do when a page didn't sync, when you see a duplicate deck, when you've revoked access by mistake, and where to go if none of those help.
+Sync runs every five minutes in the background. Most of the time you don't notice it. When it does get stuck, it's almost always one of the three things below.
 
-If you'd like this page sooner, comment on the [tracking issue](https://github.com/2anki/server/issues/2071) — we read every one.
+**Plan:** Lifetime (sync is gated by the same access as [How sync works](/documentation/sync/how-it-works))
 
-In the meantime: see [How sync works](/documentation/sync/how-it-works) for the expected flow, or [contact us](/documentation/help/contact) if your sync is stuck.
+## Page didn't sync
+
+You edited a Notion page. The deck in Anki didn't update. Try, in order:
+
+1. **Wait five minutes.** Sync polls on a five-minute cadence to stay inside Notion's free-tier rate limits. If you just edited, it might not have run yet.
+2. **Open the Ankify dashboard.** Each subscribed page shows the last run time and any error from that run. If you see an error, it usually points right at the cause.
+3. **Check the page is still shared with the 2anki integration.** Notion sometimes drops the connection after a workspace change. Open the page in Notion, click **Share → Add connections**, and re-add 2anki.
+4. **Check Anki is open with AnkiConnect running.** Sync writes to Anki through AnkiConnect — if Anki isn't open on the device that holds the deck, the run completes on our side but the deck doesn't change.
+
+If the dashboard shows runs are succeeding but the deck still isn't updating, it's almost always AnkiConnect. Restart Anki, then trigger a manual sync from the dashboard.
+
+## I see a duplicate deck
+
+Duplicates happen when card IDs change between runs. The usual cause is the **Use Notion ID** card option getting turned off — see [Card options](/documentation/cards/card-options).
+
+To fix:
+
+1. In Anki, delete the duplicate deck (keep the one with your review history).
+2. In the Ankify dashboard, open the page's card options and turn **Use Notion ID** back on.
+3. Run a sync. The single deck refills with stable card IDs.
+
+If both decks have review history you care about, [contact us](/documentation/help/contact) before deleting either — we can sometimes merge.
+
+## I revoked access by mistake
+
+If you removed 2anki from your Notion workspace, sync stops running and the dashboard shows an authentication error. To restore:
+
+1. Go to [2anki.net](https://2anki.net/) and sign in again with Notion.
+2. Re-share the pages you want to sync — open each in Notion, click **Share → Add connections**, and pick 2anki.
+3. Existing subscriptions resume on the next run. You don't need to re-subscribe.
+
+Your card history isn't lost. The dashboard remembers which Notion pages mapped to which Anki decks.
+
+## Still stuck?
+
+If none of the above helped:
+
+- Check [Common problems](/documentation/help/common-problems) for any error message you're seeing.
+- [Contact us](/documentation/help/contact) — include the Notion page name, the Ankify run timestamp, and the error message from the dashboard.


### PR DESCRIPTION
## Summary
- Replaces 8 stub docs pages with real content per the docs-overhaul design spec (start-here, cards, sync, reference).
- Adds a consistent tier marker (Free / Free account / Subscription / Lifetime) so each feature shows what it requires.
- file-formats consolidates six per-format pages into one table; self-hosting stays short by design.

Closes #2066
Closes #2067
Closes #2068
Closes #2069
Closes #2070
Closes #2071
Closes #2072
Closes #2073

## Test plan
- [ ] `/check` green.
- [ ] Visual pass on /documentation/{start-here,cards,sync,reference}/* in dev.
- [ ] Tier markers consistent across pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)