### PR TITLE
docs(limits): rename Ankify entry to Hosted Anki

### DIFF
--- a/web/src/pages/DocsPage/content/help/limits.md
+++ b/web/src/pages/DocsPage/content/help/limits.md
@@ -60,7 +60,7 @@ Free covers the conversion paths most people need: drag in a file, get a deck ba
 | AI-generated flashcards (Claude) | — | ✓ | ✓ |
 | Notion sync | — | ✓ | ✓ |
 | Long-term deck storage | 24 h | active sub | indefinite |
-| Ankify (hosted bidirectional sync) | — | — | ✓ |
+| Hosted Anki | — | — | ✓ |
 
 See the [pricing page](/pricing) for the current plan list. Privacy details — what we read, what we don't — are on the [privacy policy](/documentation/reference/privacy).
 


### PR DESCRIPTION
## Summary
- One-line rename in the help/limits capability table: "Ankify (hosted bidirectional sync)" → "Hosted Anki".
- Sync pages still say "Ankify" because that's the in-app surface name today; happy to chase that in a follow-up if we want a full rename.

## Test plan
- [ ] Visual check on /documentation/help/limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)