### PR TITLE
docs(specs): commit docs-overhaul audit and design

### DIFF
--- a/Documentation/specs/docs-overhaul-audit.md
+++ b/Documentation/specs/docs-overhaul-audit.md
@@ -1,0 +1,130 @@
+# Docs Overhaul — Audit Report
+
+Audit date: 2026-05-09. Scope: every file under `web/src/pages/DocsPage/content/`. Verdicts cross-checked against `src/routes/`, `src/lib/`, `src/controllers/`, `README.md`, `ROADMAP.md`, recent git log.
+
+## 1. User-perspective summary
+
+A new user landing on `/documentation` today sees a hero CTA pointing at "Getting started", a WIP banner asking them to file issues on GitHub, and a sidebar grouped Guides / Features / Troubleshooting / Advanced / Links / Misc. The first guide they read tells them flashcards are made by exporting Notion to HTML and uploading the zip — accurate but stale. **The core failure is that the docs describe the 2022-era product**: HTML/CSV/Markdown uploads with a Notion *export* flow. There is **zero documentation** of the actual current happy path — the direct Notion integration with the Find-pages picker, nested decks per page, page icons, and (for paying users) Claude AI generation and the Ankify two-way sync. A new user who connected their Notion will not find a single page that explains what just happened. Worst single offender: the FAQ, which reads like a 2020 personal blog and answers questions nobody is asking.
+
+## 2. Per-file verdict table
+
+| File | Verdict | Why |
+|---|---|---|
+| `index.mdx` | KEEP | Tiny landing hero, still correct. Designer can restyle later. |
+| `guides/introduction.md` | REWRITE | Lists supported inputs reasonably but still frames the product as a Notion-export converter. Doesn't mention the direct Notion integration, Ankify, or AI generation. |
+| `guides/getting-started.mdx` | REWRITE | Walks through Notion HTML export — that is no longer the recommended path. The current happy path is "connect Notion, pick a page, get a deck". |
+| `features/notion-support.md` | REWRITE | Block-support list is plausibly still right but says nothing about the *integration* (OAuth, Find-pages picker, sync). Most users hit this page expecting that. |
+| `features/markdown.md` | KEEP | Matches the `markdown-nested-bullet-points` card option in `supportedOptions.ts`. Has a typo in the description ("Markdonw") to fix. |
+| `features/html.md` | KEEP | Matches `treatBoldAsInput` and cloze-from-`<code>` behaviour in `DeckParser.ts`. Still accurate. |
+| `features/zip.md` | KEEP | Behaviour matches; cross-links are good. |
+| `features/csv.md` | KEEP | Format matches. |
+| `features/xlsx.md` | KEEP | Matches. |
+| `features/tsv.md` | DELETE | Page exists only to say TSV isn't supported. Remove the file and the sidebar entry; redirect to CSV. Don't waste a slot in the IA on "this format we don't support". |
+| `features/pdf.md` | REWRITE | Page-pairing description matches `convertPDFToImages.ts` and the 100-page limit is real, but the AI section conflates Claude with Vertex AI. Code has *both* `claude-ai-flashcards` and `vertex-ai-pdf-questions` as separate card options — the doc shows neither flag name and only mentions Claude. |
+| `features/ppt.md` | KEEP | LibreOffice→PDF→images pipeline is real. Short and accurate. |
+| `troubleshooting/common-problems.md` | REWRITE | Two problems covered. Both still relevant but tonally inconsistent with the rest, and there's an unmatched `]` after a video link. Should grow to 5–8 real problems pulled from support email, not stay at 2. |
+| `troubleshooting/bug-report.md` | KEEP | Template is fine. The `/debug` page link works. |
+| `troubleshooting/contact.md` | KEEP | Three sentences, accurate. |
+| `troubleshooting/faq.md` | REWRITE | Half the entries are personal-blog content ("How do I become a successful developer?"). The actually-useful ones (cloze, input cards, images on front) are buried. Cut to product-only Q&A. |
+| `troubleshooting/limits.md` | REWRITE | Numbers are mostly right (100 MB free / ~10 GB paid match `getUploadLimits.ts`; PDF 100 pages matches `convertPDFToImages.ts`; 2 hour cleanup matches `CLEANUP_AGE_SECONDS = 7200`). But the **"21 files"**, **"100 flashcards per deck"**, **"2,100 files"**, and **"no concurrent job limit"** claims have **no backing in the code I searched**. Either remove them or have engineer verify. The `/upload` UI also tells users files are deleted after 24 hours, contradicting this page's 2-hour claim — pick one and fix the UI. |
+| `advanced/self-hosting.md` | REWRITE | Mostly correct (port 2020, LibreOffice, Poppler, Knex migrations, `WEB_BUILD_DIR`). Mentions only `NOTION_*` and `ANTHROPIC_API_KEY` as optional integrations — actual codebase also needs Stripe, SendGrid, Vertex AI, Bugsnag, Dropbox, Google Drive, Docker (for Ankify RAC). Two-repo split is described but the monorepo lives at `2anki/server` with `web/` as a workspace — needs engineer to confirm whether the standalone `2anki/web` repo is still the deployment target. |
+| `advanced/terminology.md` | MERGE | Three short paragraphs that overlap with `advanced/domain.md`. Merge into one glossary page. |
+| `advanced/domain.md` | MERGE | Better-written glossary than `terminology.md`. Keep this one's content, merge `terminology.md` into it, name the result "Glossary". |
+| `advanced/napi.md` | KEEP | Correctly says the API is private, points at Swagger at `/api/docs`. Holds up. |
+| `advanced/domain.md` (Domain ≠ DNS) | (covered above) | Note: title "Domain" is confusing — reads like DNS docs. Rename to "Glossary" when merging. |
+| `advanced/strategy.md` | DELETE | Reads like an internal roadmap from a year ago ("v1", "v2"). User-facing docs should not contain strategy notes. The roadmap belongs in `ROADMAP.md` (which exists). |
+| `links/anki.md` | KEEP | Three official links, accurate. |
+| `links/community.md` | KEEP | Subreddit + AnkiDroid + awesome-anki. Trim formatting (loose H3s) but content is fine. |
+| `links/youtube.md` | DELETE | Three random YouTube channels with no clear connection to 2anki. Doesn't help a new user; doesn't help retention. The frontmatter description is literally "x". |
+| `links/support.md` | REWRITE | Mixes "support the project financially" (sponsorship) with "request support" (help). Confusingly named. Move sponsorship CTAs into the footer or a dedicated `/support-the-project` page; remove from docs IA. |
+| `misc/privacy-policy.md` | MISSING-CONTEXT | Lists Hotjar and Google Analytics — both are present in `web/index.html`. Lists ChatGPT — I found **no OpenAI/ChatGPT usage** in `src/`; only Anthropic Claude and Google Vertex AI. Engineer must confirm whether ChatGPT processing was removed and whether Vertex AI should be added. Service list also missing: Stripe, SendGrid, Anthropic, Google Vertex AI, possibly Cloudflare. |
+| `misc/terms-of-service.md` | MISSING-CONTEXT | Refers to a Notion-hosted privacy policy URL that is *different* from the in-product privacy policy. Legal text — defer to Alexander, not engineering. Do not rewrite without his sign-off. |
+
+## 3. Gaps
+
+What new users are looking for and **cannot find today**:
+
+1. **"How do I sync my Notion deck after I edit a page?"** — Ankify and the Notion subscription/webhook flow are completely undocumented despite being the recent product focus (last 30+ commits).
+2. **"What note types do I get and what do they look like?"** — `n2a-basic`, `n2a-cloze`, `n2a-input` namespaced templates exist, are seeded into Anki, and the welcome banner mentions them, but no doc page explains them.
+3. **"Why did my upload fail?"** — common-problems covers 2 issues. Real failure modes (PDF over 100 pages on free, file too big, empty file, accidentally uploading an `.apkg`, Notion permission missing) all have specific server error messages that should be searchable in the docs.
+4. **"What's the difference between uploading a file and connecting Notion?"** — never explained. The site has both `/upload` and `/ankify` routes; docs talk only about upload.
+5. **"What does each Card Option do?"** — there are ~20 options in `supportedOptions.ts` (cherry, avocado, strikethrough tags, max-one-toggle, etc.). The descriptions live in code only. A reference page would cut a huge support-email category.
+6. **"How do I get my deck into Anki on iPhone / Android / AnkiWeb?"** — no platform-specific import instructions.
+7. **"What happens to my files? When are they deleted?"** — privacy policy mentions it weakly; users want a one-liner.
+8. **"What do I get if I subscribe?"** — limits page lists paid perks but there is no honest "free vs paid" comparison page that links to `/pricing`.
+9. **"Pricing"** — no docs entry at all.
+10. **"How do I export my Anki review data back to Notion?"** — `ExportReviewDataToNotionUseCase` exists; users have no way to discover it.
+
+## 4. Top 5 priorities
+
+Ordered. Each priority states what to ship, why now, and effort.
+
+1. **Rewrite `getting-started.mdx` around the Notion integration, not the HTML export.** Effort: M. The current page actively pushes users down a slower, more error-prone path. The fastest path to "drop something in, get a clean deck back" is `Connect Notion → pick a page → download deck`. Every new user hits this page; getting it right is the single highest-leverage doc change toward the 300K-user goal because the export-then-zip flow is where most first-time users currently fail. Keep the HTML/zip path as an "advanced upload" footnote.
+2. **Write a new `features/ankify.md` (or `guides/sync-with-notion.md`) covering the sync flow.** Effort: M. The product team has spent the last weeks on Find-pages caching, nested decks, page icons, sync mappings, conflict resolution. Zero of it is documented. This is the feature most likely to convert free→paid because it's the one thing competitors don't do. Without a doc, users won't discover it.
+3. **Create a `features/card-options.md` reference page.** Effort: S. Pull the descriptions straight from `src/controllers/CardOptionsController/supportedOptions.ts` (already user-facing). Trim the FAQ entries this replaces. This single page collapses a large bucket of support email and reduces churn from "I don't understand why my cards look wrong".
+4. **Slim and correct `troubleshooting/limits.md` + `misc/privacy-policy.md`.** Effort: S. Limits page makes claims with no code backing (file count caps, deck card caps); privacy lists ChatGPT which appears unused, and is missing Stripe, SendGrid, Anthropic, Vertex AI. These are the two pages where being wrong actively damages trust. Quality over completeness — drop unverifiable numbers, list only confirmed processors.
+5. **Rewrite `troubleshooting/common-problems.md` into a real "When it fails, do this" page.** Effort: S–M. Pull the actual error strings from `getUploadValidationError.ts`, `convertPDFToImages.ts`, the Notion permission errors, the Claude-quota errors. Make each a searchable heading. This is the page Google indexes from support queries — getting it right reduces both churn and inbound email volume.
+
+## 5. What NOT to write
+
+Scope discipline. These exist in the product but should stay undocumented:
+
+- **The HTTP API surface beyond `napi.md`.** Already private; documenting endpoints invites integration work we can't support yet.
+- **Webhook internals (`/webhook`, `AnkifyWebhookRouter`).** Internal infrastructure; users do not call these.
+- **Self-hosting beyond a "yes you can, here's the repo, here are the env vars" page.** Self-hosters are <0.1% of users; we should not maintain a full ops manual. The current self-hosting page is borderline too detailed already.
+- **Strategy / roadmap / "where we're heading".** Belongs in `ROADMAP.md`, not in user docs.
+- **Per-card-option deep dives.** One reference page (priority 3) is enough — do not write a separate page per option.
+- **Notion block-by-block compatibility matrix.** The current `notion-support.md` table is fine as one page; do not expand into per-block guides.
+- **Vertex AI vs Claude AI comparisons.** Pick one (Claude, since it's the primary AI feature) and document it. Do not document the experimental Vertex AI PDF-questions option until it's promoted.
+- **The `/debug` page beyond a single sentence in the bug-report doc.** It's already there; don't escalate it to its own page.
+- **Cherry / avocado / strikethrough-tags edge-case options.** Mention in the card-options reference, do not give them tutorial pages.
+
+## 6. Sidebar / IA recommendation
+
+**Current shape** (Guides / Features / Troubleshooting / Advanced / Links / Misc) is organised by *content type*, not by *user task*. A new user reading top-to-bottom learns Notion HTML export before they learn that connecting Notion is even an option. Reorganise around the user's job, not ours.
+
+**Recommended structure** (one option, recommended):
+
+```
+Start here
+  - What is 2anki.net?              (was guides/introduction)
+  - Connect Notion (5 min)          (NEW — replaces getting-started top half)
+  - Upload a file (alt path)        (NEW — getting-started bottom half + zip/html essentials)
+
+Make better cards
+  - Card options reference          (NEW — priority 3 above)
+  - Cloze, basic, input, reversed   (consolidates html.md examples)
+  - Notion blocks supported         (was features/notion-support, trimmed)
+  - Markdown / Obsidian             (was features/markdown)
+
+Sync with Notion (paid)
+  - How sync works                  (NEW — Ankify overview)
+  - Two-way review export           (NEW)
+  - Resolving conflicts             (NEW)
+
+When it fails
+  - Common problems                 (rewritten)
+  - Bug report template
+  - Limits & quotas
+  - Contact
+
+Reference
+  - Glossary                        (merge of domain + terminology)
+  - File formats                    (csv, xlsx, html, zip, pdf, ppt — short table not separate pages)
+  - Self-hosting (advanced)
+  - API access
+  - Privacy policy
+  - Terms of service
+
+Links
+  - Anki (official apps + manual)
+  - Community
+```
+
+Three structural moves the Designer will care about:
+
+- **Merge eight feature pages into one "File formats" reference table.** Right now CSV, XLSX, TSV, PPT, PDF, ZIP each get their own page despite most being 5 lines. A table with format / how it's parsed / limits / link is denser and more useful. Exception: keep HTML and Markdown as separate pages because they have meaningful examples.
+- **Promote "Sync with Notion" to a top-level group.** It's the paid feature and the moat. Hiding it under "Features" buries it.
+- **Drop "Misc" as a category.** Privacy/Terms go under Reference. YouTube link page goes away. "Strategy" page goes away.
+
+The Designer should treat the labels above as drafts; the IA shape is the load-bearing part.

--- a/Documentation/specs/docs-overhaul-design.md
+++ b/Documentation/specs/docs-overhaul-design.md
@@ -1,0 +1,399 @@
+# Docs Overhaul — Design Spec
+
+Author: Designer. Date: 2026-05-09. Inputs: `docs-overhaul-audit.md`, current `web/src/pages/DocsPage/`.
+
+This document is the brief the Engineer writes content and code against. Read it once, ship from it.
+
+---
+
+## 1. Final IA
+
+The sidebar tree, in order. Group labels are user-facing.
+
+```
+Start here
+  - What is 2anki?                       (start-here/what-is-2anki)
+  - Connect Notion in 5 minutes          (start-here/connect-notion)
+  - Upload a file instead                (start-here/upload-a-file)
+  - Open your deck in Anki               (start-here/open-in-anki)
+
+Make better cards
+  - Card options                         (cards/card-options)
+  - Card types (basic, cloze, input)     (cards/card-types)
+  - Notion blocks we support             (cards/notion-blocks)
+  - Markdown and Obsidian                (cards/markdown)
+  - HTML                                 (cards/html)
+
+Sync with Notion
+  - How sync works                       (sync/how-it-works)
+  - Send your reviews back to Notion     (sync/review-export)
+  - When sync gets stuck                 (sync/troubleshooting)
+
+When something breaks
+  - Common problems                      (help/common-problems)
+  - Limits and quotas                    (help/limits)
+  - Report a bug                         (help/bug-report)
+  - Contact us                           (help/contact)
+
+Reference
+  - Glossary                             (reference/glossary)
+  - File formats                         (reference/file-formats)
+  - Self-hosting                         (reference/self-hosting)
+  - API access                           (reference/api)
+  - Privacy policy                       (reference/privacy)
+  - Terms of service                     (reference/terms)
+
+Links
+  - Official Anki                        (external: https://apps.ankiweb.net/)
+  - Community                            (links/community)
+```
+
+Reasoning: groups are jobs ("Start here", "When something breaks"), not content types ("Guides", "Misc"); a first-time user can read top-to-bottom and reach a working deck without backtracking, and the paid feature (sync) gets its own visible group instead of being buried under "Features".
+
+Slug renames break old links — Engineer adds redirects from old slugs in `loader.ts` (small map; one line each).
+
+---
+
+## 2. Per-page structure
+
+Skeletons are tight on purpose. If the Engineer needs more than what's listed, the page is doing too much and should be split.
+
+### Start here
+
+**`start-here/what-is-2anki`**
+- H1: What is 2anki?
+- Summary: 2anki turns your Notion pages and study files into Anki decks.
+- Sections: What you can drop in · What you get back · Two ways to use it (connect Notion vs upload a file) · Free and paid in one sentence each
+
+**`start-here/connect-notion`** (the load-bearing page — most users land here)
+- H1: Connect Notion in 5 minutes
+- Summary: From signing in to your first deck downloaded.
+- Sections: Step 1 — Sign in with Notion · Step 2 — Pick a page · Step 3 — Download your deck · Step 4 — Open it in Anki · What if a page won't show up?
+- Each step gets one screenshot. No long prose.
+
+**`start-here/upload-a-file`**
+- H1: Upload a file instead
+- Summary: For PDFs, slides, spreadsheets, or a Notion HTML export.
+- Sections: When to use upload instead of Connect Notion · Drop in a file · Supported types (link to File formats) · What happens to your file (link to Privacy)
+
+**`start-here/open-in-anki`**
+- H1: Open your deck in Anki
+- Summary: Get the `.apkg` you downloaded into Anki on any device.
+- Sections: Anki desktop · AnkiMobile (iPhone/iPad) · AnkiDroid (Android) · AnkiWeb · Updating an existing deck
+
+### Make better cards
+
+**`cards/card-options`**
+- H1: Card options
+- Summary: Every checkbox on the upload screen, what it does, and when to turn it on.
+- Sections: How to set options · Reference table (option name, plain-language description, default, example before/after)
+- Engineer pulls names and descriptions from `src/controllers/CardOptionsController/supportedOptions.ts`. One row per option. No per-option pages.
+
+**`cards/card-types`**
+- H1: Card types
+- Summary: The three card shapes 2anki makes, and when each fires.
+- Sections: Basic (toggle → front/back) · Cloze (`{{c1::...}}` and code-as-cloze) · Input (typed answer) · How to switch between them
+
+**`cards/notion-blocks`**
+- H1: Notion blocks we support
+- Summary: What works, what's ignored, what's coming.
+- Sections: Supported (table) · Partial support · Not yet supported · Tips for clean cards
+
+**`cards/markdown`**
+- H1: Markdown and Obsidian
+- Summary: Use a Markdown file or Obsidian vault as the source.
+- Sections: How nesting becomes cards · Front/back syntax · Cloze syntax · Limits
+
+**`cards/html`**
+- H1: HTML
+- Summary: How 2anki reads an HTML page or a zipped Notion HTML export.
+- Sections: Toggle blocks become cards · Bold-as-input · Code-as-cloze · Images and assets
+
+### Sync with Notion
+
+**`sync/how-it-works`**
+- H1: How sync works
+- Summary: Edit a Notion page, get the updated deck — without re-uploading.
+- Sections: What sync does · Setting up sync on a page · How updates flow (Notion → 2anki → Anki) · Free vs paid
+
+**`sync/review-export`**
+- H1: Send your reviews back to Notion
+- Summary: Push how often you got each card right back into your Notion database.
+- Sections: What you'll see in Notion · Turning it on · Required Notion properties · Limits
+
+**`sync/troubleshooting`**
+- H1: When sync gets stuck
+- Summary: Three things to try when your deck won't update.
+- Sections: Page didn't sync · I see a duplicate deck · I revoked access by mistake · Still stuck? (links to contact)
+
+### When something breaks
+
+**`help/common-problems`**
+- H1: Common problems
+- Summary: The errors users actually hit, with the fix on the same page.
+- Sections: One H2 per error, each with — What you saw · Why it happened · How to fix it. Engineer pulls the exact strings from `getUploadValidationError.ts`, `convertPDFToImages.ts`, Notion permission errors, Claude quota errors. Aim for 6–8 entries.
+
+**`help/limits`**
+- H1: Limits and quotas
+- Summary: What's allowed on free, what's allowed on paid, and how long files stick around.
+- Sections: File size · PDF pages · Storage time · Free vs paid (link to /pricing). Engineer drops every number that isn't backed by code.
+
+**`help/bug-report`**
+- H1: Report a bug
+- Summary: A short template that gets you a fast reply.
+- Sections: Before you report (one-line checklist) · Template (copy-paste block) · Where to send it · The `/debug` page
+
+**`help/contact`**
+- H1: Contact us
+- Summary: Three ways to reach a human.
+- Sections: Email · GitHub · Discord/community
+
+### Reference
+
+**`reference/glossary`** (merged from `domain` + `terminology`)
+- H1: Glossary
+- Summary: Words 2anki and Anki use, in plain language.
+- Sections: One alphabetical definition list. No subheadings.
+
+**`reference/file-formats`** (replaces six pages)
+- H1: File formats
+- Summary: Every input we accept and how it's read.
+- Sections: One table — Format · How 2anki reads it · Limits · Notes. Below the table, two short subsections that *do* need prose: HTML and Markdown link out to their own pages.
+
+**`reference/self-hosting`**
+- H1: Self-hosting
+- Summary: You can run 2anki yourself. Here's the short version.
+- Sections: Repo and license · System requirements · Required env vars · Optional integrations · Where to get help
+
+**`reference/api`**
+- H1: API access
+- Summary: There's no public API yet.
+- Sections: One paragraph. Link to Swagger at `/api/docs` for self-hosters.
+
+**`reference/privacy`** — content rewrite owned by Alexander, not Engineer. Keep the page; mark `MISSING-CONTEXT` from the audit on the spec but don't touch copy.
+
+**`reference/terms`** — same. Defer to Alexander.
+
+### Links
+
+**`links/community`**
+- H1: Community
+- Summary: Where Anki users hang out.
+- Sections: Subreddit · AnkiDroid · awesome-anki
+
+---
+
+## 3. DocsHome (`index.mdx`) layout
+
+Replace the current centered hero. The landing page should answer "what now?" in three seconds.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                                                                  │
+│   2anki documentation                                            │
+│   The simplest way to turn what you're studying into Anki cards. │
+│                                                                  │
+│   [ Connect Notion in 5 min → ]   [ Upload a file ]              │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Start here                                                      │
+│  ┌────────────────────┐  ┌────────────────────┐                  │
+│  │ What is 2anki?     │  │ Connect Notion     │                  │
+│  │ A 60-second tour.  │  │ The fastest path.  │                  │
+│  └────────────────────┘  └────────────────────┘                  │
+│  ┌────────────────────┐  ┌────────────────────┐                  │
+│  │ Upload a file      │  │ Open in Anki       │                  │
+│  │ PDFs, slides, CSV. │  │ Desktop and mobile.│                  │
+│  └────────────────────┘  └────────────────────┘                  │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Popular pages                                                   │
+│  • Card options reference                                        │
+│  • Common problems                                               │
+│  • How sync works                                                │
+│  • Limits and quotas                                             │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Stuck? Email alexander@alemayhu.com or open an issue on GitHub. │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Decisions:
+
+- Drop the mascot from the landing page. It's charming on the marketing site; on a docs landing it costs ~180px of vertical space before the user sees a single link. Keep it for `/` and `/about`, not here.
+- Primary CTA is **"Connect Notion in 5 min →"** linking to `/documentation/start-here/connect-notion`. Secondary is **"Upload a file"** linking to `/documentation/start-here/upload-a-file`. No third action.
+- The four "Start here" cards are the four pages of the Start here group. Each card: title + one-line summary, full card is the click target, no icon.
+- "Popular pages" is a hand-curated four-link list, not analytics-driven. Update when content lands.
+
+**Recommendation: rewrite `DocsHome.tsx`.** The current file is 30 lines of MDX-frontmatter shape (`hero`, `actions`) that aren't actually parsed — it's deceiving. Replace with a simple TSX component that renders the structure above using existing `shared.module.css` tokens. `index.mdx` stays as the slug-zero entry and contains only the Popular pages list as Markdown so it's editable without touching code; the hero and cards live in `DocsHome.tsx`.
+
+---
+
+## 4. Sidebar UX
+
+One design, no toggles.
+
+- **Groups stay flat and always expanded.** Collapsible groups add a click and hide content from people scanning. The IA is short enough (six groups, ~25 leaves) to not need it.
+- **Sticky on desktop.** Already sticky — keep.
+- **Active-item highlight stays.** Already there.
+- **Add: section indicator.** When the user is inside a group, that group's label gets a subtle left border (`border-left: 2px solid var(--color-primary)`, only on the active group's items) to anchor the user.
+- **Mobile: full-screen drawer, not inline expand.** Current "Menu" button toggles an inline panel above content — fine but feels cramped on 375px. Replace with a slide-in drawer from the left, full height, with a close button. Triggered by the same button. Body scroll-locked while open.
+- **No search bar.** Out of scope per constraints, and the IA is small enough that scanning works.
+- **No "on this page" / table-of-contents rail on the right.** Pages are short by design (skeletons above). If a page grows past ~5 H2s, that's a sign to split it.
+
+---
+
+## 5. Page template / content components
+
+Invest in a small set. Each is worth the engineering only because it shows up across many pages.
+
+Keep:
+- Headings, paragraphs, lists, tables, blockquote, inline code, fenced code blocks, images. All already styled.
+- Edit-on-GitHub link (already exists, keep).
+- Prev/next pager (already exists, keep — fix labels to be human, not slug-cased).
+
+Add:
+1. **Callouts** — `:::note`, `:::tip`, `:::warning` rendered as a styled box with an icon-free coloured left border. Three variants, no more. Use a `remark-directive` plugin or a small custom remark transform; do not invent MDX components per callout type.
+2. **Step blocks** — for the "Connect Notion in 5 min" page and the bug-report template. Render an `<ol>` with bigger numbers and more padding. Implement as plain HTML/Markdown via a `class="steps"` wrapper that the Engineer applies in MDX.
+3. **Code block copy button** — small "Copy" button top-right of every `<pre>`. One file, ~20 lines. High value for env-var blocks and bug-report templates.
+4. **Screenshot frame** — images already get a border + radius. Add `figure` + optional `figcaption` support so screenshots can have a caption without extra components. Use the standard Markdown image-with-title syntax.
+
+Reject:
+- Tabs (e.g. macOS / Windows / Linux). Audit shows almost no place needs them; when one does, two H3s do the job.
+- Accordions. `<details>` is already styled; that's enough.
+- Embedded video player. Link out to YouTube; don't iframe.
+- Per-page TOC component. See sidebar section.
+
+---
+
+## 6. Visual style
+
+Stay inside `shared.module.css` tokens. No new colour primitives.
+
+- **Type scale:** keep current. H1 `text-4xl`, H2 `text-2xl` with bottom border, H3 `text-xl`, body `text-base`, leading `relaxed`. The current scale is already Stripe-class.
+- **Measure:** keep `max-width: 760px` on `.article`. Don't widen — long lines hurt scan.
+- **Spacing rhythm:** tighten H2 top margin from `2rem` to `2.5rem` so sections breathe. H3 stays at `2rem`. Paragraph bottom margin stays at `1rem`.
+- **Links:** keep underlined-blue. The understated underline is correct for docs; don't switch to hover-only underlines.
+- **Callout colours:**
+  - note → `var(--color-primary-light)` bg, `var(--color-primary)` left border
+  - tip → `var(--color-success-light)` bg, `var(--color-success)` left border
+  - warning → `var(--color-warning-light)` bg, `var(--color-warning)` left border
+- **Code:** keep dark `pre` block. Add a 1px `var(--color-border)` to `pre` so it sits on light backgrounds with the same weight as cards.
+- **WipBanner:** keep, but soften copy and shrink. New copy:
+  > These docs are being rewritten. If something looks wrong, [open an issue](…) — we read every one.
+
+  Drop the "WIP" pill (the badge feels alarming). Keep the warning palette but reduce padding to `0.5rem 0.875rem` and font to `text-sm`. Banner sits above the article header on every doc page including the home.
+
+---
+
+## 7. Component changes
+
+Concrete file-level guidance.
+
+### `sidebar.ts`
+New shape: same `SidebarGroup` / `SidebarItem` types, just new contents. Example entry to make the renames concrete:
+
+```ts
+{
+  label: 'Start here',
+  items: [
+    { label: 'What is 2anki?', slug: 'start-here/what-is-2anki' },
+    { label: 'Connect Notion in 5 minutes', slug: 'start-here/connect-notion' },
+    { label: 'Upload a file instead', slug: 'start-here/upload-a-file' },
+    { label: 'Open your deck in Anki', slug: 'start-here/open-in-anki' },
+  ],
+},
+```
+
+Plus a new `redirects` map alongside the export, like `{ 'guides/getting-started': 'start-here/connect-notion', 'features/csv': 'reference/file-formats', ... }`. `loader.ts` consults it when a slug misses.
+
+### `DocsPage.tsx`
+- Replace inline mobile menu toggle with a portal-rendered drawer (existing `useState` is fine; add body scroll lock when `menuOpen`).
+- No layout grid changes.
+
+### `DocsSidebar.tsx`
+- Add active-group detection: walk `sidebar` to find which group contains the current slug, pass an `activeGroup` flag into the group render to apply the left-border class.
+- Add drawer-mode props (`isDrawer: boolean`, `onClose: () => void`) so the same component renders in both desktop sidebar and mobile drawer. Don't fork.
+
+### `DocsHome.tsx`
+- Rewrite. New JSX: hero (h1 + tagline + two buttons), Start here cards grid (4 cards, `columns2`), Popular pages list (rendered from `index.mdx` body via the existing markdown pipeline — pass MDX body in as children), footer line.
+- Reuse `shared.module.css` tokens: `btnPrimary`, `btnSecondary`, `card`, `columns2`.
+
+### `DocContent.tsx`
+- Add `remark-directive` + a small custom transform for `:::note`, `:::tip`, `:::warning` → `<aside class="callout callout-note">…</aside>`.
+- Add a `CodeBlock` component slot for `pre > code` rendering with a copy button. Keep ReactMarkdown's `components` map small — one entry for `pre`.
+- Pager labels: pull from `frontmatter.title` rather than the sidebar `label` if both exist, so frontmatter is the source of truth.
+- "Last updated" line: skip. Git timestamps surprise users; the edit-on-GitHub link is enough.
+
+### `DocsPage.module.css`
+Add:
+- `.callout`, `.calloutNote`, `.calloutTip`, `.calloutWarning`
+- `.steps` (numbered list with larger numerals)
+- `.codeWrapper`, `.copyButton` (positioned top-right of `.markdown pre`)
+- `.figure`, `.figcaption`
+- `.sidebarGroupActive` (left border on active group's item list)
+- `.drawer`, `.drawerOpen`, `.drawerBackdrop` (replace inline mobile sidebar styles)
+- `.homeCard`, `.homeCardTitle`, `.homeCardDesc`, `.homeGrid`, `.popularList`
+
+Change:
+- `.wipBanner` — reduced padding/font, drop `.wipLabel` styling (component drops the pill).
+- `.markdown h2` — top margin to `2.5rem`.
+- `.markdown pre` — add `1px solid var(--color-border)`.
+
+Remove:
+- `.hero*` classes (move to a new `.docsHomeHero` set since the layout is different).
+- `.heroImage` — landing image is gone.
+
+### New components
+- `Callout.tsx` — renders `<aside>` with variant class. ~15 lines.
+- `CodeBlock.tsx` — wraps `<pre>` with a copy button. ~30 lines.
+- `DocsDrawer.tsx` — mobile drawer wrapping `DocsSidebar`. ~40 lines including focus trap and body scroll lock.
+
+That's three small components total. No more.
+
+---
+
+## 8. Voice and tone
+
+Write to one reader: a student or knowledge worker, not a developer. Address them as **you**. Use **we** for 2anki when something is on us ("we couldn't read this page"). Sentences are short — usually under 20 words; aim for fewer commas, more periods. Lead with the user's verb ("Pick a page", not "The user selects a page"). Use second person for every instruction ("Click Download", "Paste your link"). Skip hedging words ("simply", "just", "easily") — they sound condescending and add nothing. Use examples over prose for anything mechanical (a code block, a screenshot, a copy-pasteable template); use prose only for *why* something exists. Never use "render", "parse", "endpoint", "instance", "payload", or "schema" in user-facing text — if one of those is the only honest word, explain it inline. Keep contractions ("it's", "you'll") — they read warmer without losing precision. One exclamation point per page maximum, and probably zero.
+
+---
+
+## 9. Out of scope (intentionally not designed)
+
+So the Engineer doesn't add these back:
+
+- **Search bar.** Per constraints. The IA is small; scanning works.
+- **i18n / localized docs.** Per constraints. Voice spec assumes English-only for now.
+- **Versioned docs.** No `v1` / `v2` toggle; we ship one current version.
+- **Analytics events on doc pages.** Per constraints. Don't instrument.
+- **A separate `/changelog` page in the docs IA.** Already lives elsewhere; don't duplicate.
+- **Per-card-option page.** One reference page only. The audit explicitly rejects per-option deep dives.
+- **Per-Notion-block tutorial pages.** One support matrix table. Don't expand.
+- **Vertex AI documentation.** Document Claude AI only (`features/pdf` rewrite mentions "AI flashcards" generically; no Vertex page).
+- **YouTube links page.** Audit deletes it; don't reintroduce.
+- **Sponsorship / "support the project" page in docs.** Belongs in the global footer, not the docs IA.
+- **`/debug` as its own page.** One sentence in the bug-report page.
+- **Light/dark mode toggle for docs.** The site doesn't have one yet; docs don't get one alone.
+- **Comment threads / "was this helpful" voting.** No infra for it; out of scope.
+- **TOC rail / "On this page".** Pages are short. If one grows long, split it.
+- **MDX interactive widgets.** Per constraints — Markdown/MDX content only, no React-only blocks beyond the small set in section 5.
+
+---
+
+## Hand-off checklist for the Engineer
+
+1. Update `sidebar.ts` to the IA in section 1, including the redirects map.
+2. Update `loader.ts` to honour redirects on miss.
+3. Move/rename content files to match new slugs; create new files as empty stubs first so routing works.
+4. Rewrite `DocsHome.tsx` per section 3.
+5. Add `Callout.tsx`, `CodeBlock.tsx`, `DocsDrawer.tsx`.
+6. Wire callout directive through ReactMarkdown.
+7. Apply CSS deltas in section 7.
+8. Soften `WipBanner` copy and styles per section 6.
+9. Write content against the skeletons in section 2, in the voice from section 8.
+10. Manual pass on 375px viewport. Drawer opens, no horizontal scroll, hero CTAs stack.


### PR DESCRIPTION
## Summary
- Adds the two planning artifacts from the docs overhaul (PR #2090): the audit and the design spec.
- Untracked in the working tree until now; committing them keeps the planning history with the code.

## Test plan
- N/A — Markdown under `Documentation/specs/`, no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)