### PR TITLE
feat: simplify register form and drop required name field

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -1,0 +1,143 @@
+import express from 'express';
+
+jest.mock('../lib/integrations/stripe', () => ({
+  getStripe: jest.fn().mockReturnValue({
+    customers: { retrieve: jest.fn() },
+    subscriptions: { retrieve: jest.fn(), cancel: jest.fn(), update: jest.fn() },
+  }),
+  updateStoreSubscription: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../services/SubscriptionService', () => ({
+  __esModule: true,
+  default: {
+    cancelUserSubscriptions: jest.fn(),
+    findRecentStripeSubscriptions: jest.fn(),
+  },
+}));
+
+import UsersController from './UsersControllers';
+import UsersService from '../services/UsersService';
+import AuthenticationService from '../services/AuthenticationService';
+
+const SAMPLE_PW = '12345678';
+
+const buildRes = () => {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { json, status } as unknown as express.Response & {
+    json: jest.Mock;
+    status: jest.Mock;
+  };
+};
+
+const buildController = (overrides?: {
+  getUserFrom?: jest.Mock;
+  register?: jest.Mock;
+  getHashPassword?: jest.Mock;
+}) => {
+  const userService = {
+    getUserFrom: overrides?.getUserFrom ?? jest.fn().mockResolvedValue(null),
+    register: overrides?.register ?? jest.fn().mockResolvedValue([{ id: 1 }]),
+  } as unknown as UsersService;
+  const authService = {
+    getHashPassword:
+      overrides?.getHashPassword ?? jest.fn().mockReturnValue('hashed'),
+  } as unknown as AuthenticationService;
+  const controller = new UsersController(
+    userService,
+    authService,
+    {} as ReturnType<typeof import('../data_layer').getDatabase>
+  );
+  return { controller, userService, authService };
+};
+
+describe('UsersController.register', () => {
+  it('rejects requests missing both email and password with 400', async () => {
+    const { controller } = buildController();
+    const req = { body: {} } as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/email and password/i),
+      })
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects requests missing only the password with 400', async () => {
+    const { controller } = buildController();
+    const req = { body: { email: 'a@b.com' } } as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('does not require name in the request body', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const { controller } = buildController({ register });
+    const req = {
+      body: { email: 'jane.doe@example.com', password: SAMPLE_PW },
+    } as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ message: 'ok' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('still accepts a name when older clients send one', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const { controller } = buildController({ register });
+    const req = {
+      body: {
+        email: 'alex@example.com',
+        password: SAMPLE_PW,
+        name: 'Alex',
+      },
+    } as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(register).toHaveBeenCalledWith(
+      'Alex',
+      'hashed',
+      'alex@example.com',
+      expect.any(String)
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 400 when the email is already registered', async () => {
+    const getUserFrom = jest
+      .fn()
+      .mockResolvedValue({ id: 1, email: 'taken@example.com' });
+    const register = jest.fn();
+    const { controller } = buildController({ getUserFrom, register });
+    const req = {
+      body: { email: 'taken@example.com', password: SAMPLE_PW },
+    } as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(register).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Register failed' });
+  });
+});

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -137,10 +137,10 @@ class UsersController {
   ) {
     if (
       !req.body ||
-      !this.isValidUser(req.body.password, req.body.name, req.body.email)
+      !this.isValidUser(req.body.password, req.body.email)
     ) {
       res.status(400).json({
-        message: 'Invalid user data. Required name, email and password!',
+        message: 'Invalid user data. Required email and password!',
       });
       return;
     }
@@ -155,7 +155,7 @@ class UsersController {
     const { name, email } = req.body;
     try {
       await this.userService.register(
-        name,
+        name ?? '',
         password,
         email,
         getDefaultAvatarPicture()
@@ -390,8 +390,8 @@ class UsersController {
     return res.redirect('https://www.patreon.com/alemayhu');
   }
 
-  public isValidUser(password: string, name: string, email: string) {
-    if (!password || !name || !email) {
+  public isValidUser(password: string, email: string) {
+    if (!password || !email) {
       return false;
     }
     return true;

--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -1,0 +1,55 @@
+import UsersService from './UsersService';
+import UsersRepository from '../data_layer/UsersRepository';
+import { IEmailService } from './EmailService/EmailService';
+
+function buildRepository() {
+  return {
+    createUser: jest.fn().mockResolvedValue([{ id: 1 }]),
+  } as unknown as UsersRepository & { createUser: jest.Mock };
+}
+
+const noopEmailService = {} as IEmailService;
+
+describe('UsersService.register', () => {
+  it('passes the supplied name through to the repository unchanged', async () => {
+    const repository = buildRepository();
+    const service = new UsersService(repository, noopEmailService);
+
+    await service.register('Alex', 'hashed', 'Alex@Example.com', 'pic.png');
+
+    expect(repository.createUser).toHaveBeenCalledWith(
+      'Alex',
+      'hashed',
+      'alex@example.com',
+      'pic.png'
+    );
+  });
+
+  it('defaults the name to the local part of the email when no name is supplied', async () => {
+    const repository = buildRepository();
+    const service = new UsersService(repository, noopEmailService);
+
+    await service.register('', 'hashed', 'jane.doe@example.com', 'pic.png');
+
+    expect(repository.createUser).toHaveBeenCalledWith(
+      'jane.doe',
+      'hashed',
+      'jane.doe@example.com',
+      'pic.png'
+    );
+  });
+
+  it('uses the email local part when the name is whitespace only', async () => {
+    const repository = buildRepository();
+    const service = new UsersService(repository, noopEmailService);
+
+    await service.register('   ', 'hashed', 'student@uni.edu', 'pic.png');
+
+    expect(repository.createUser).toHaveBeenCalledWith(
+      'student',
+      'hashed',
+      'student@uni.edu',
+      'pic.png'
+    );
+  });
+});

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -42,10 +42,14 @@ class UsersService {
   }
 
   register(name: string, password: string, email: string, picture: string) {
+    const normalizedEmail = email.toLowerCase();
+    const trimmedName = name?.trim() ?? '';
+    const resolvedName =
+      trimmedName.length > 0 ? trimmedName : normalizedEmail.split('@')[0];
     return this.repository.createUser(
-      name,
+      resolvedName,
       password,
-      email.toLowerCase(),
+      normalizedEmail,
       picture
     );
   }

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -55,10 +55,10 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
   };
 
   const passwordHelpClass = (() => {
-    if (!passwordTouched) {
-      return styles.helpMuted;
+    if (passwordTouched) {
+      return passwordMeetsMinimum ? styles.helpSuccess : styles.helpDanger;
     }
-    return passwordMeetsMinimum ? styles.helpSuccess : styles.helpDanger;
+    return styles.helpMuted;
   })();
 
   const passwordHelpText = (() => {

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -5,37 +5,36 @@ import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { WithGoogleLink } from './WithGoogleLink';
 import { getVisibleText } from '../../lib/text/getVisibleText';
 import styles from '../../styles/auth.module.css';
-import sharedStyles from '../../styles/shared.module.css';
 
 interface Props {
   readonly setErrorMessage: ErrorHandlerType;
   readonly redirect?: string | null;
 }
 
+const MIN_PASSWORD_LENGTH = 8;
+
 function RegisterForm({ setErrorMessage, redirect }: Props) {
-  const [name, setName] = useState(localStorage.getItem('name') || '');
   const [email, setEmail] = useState(localStorage.getItem('email') || '');
   const [tos, setTos] = useState(localStorage.getItem('tos') === 'true');
   const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const passwordTouched = password.length > 0;
+  const passwordMeetsMinimum = password.length >= MIN_PASSWORD_LENGTH;
 
   const isValid = () =>
     tos &&
-    name.length > 0 &&
-    name.length < 256 &&
     email.length > 0 &&
     email.length < 256 &&
-    password.length > 7 &&
-    password.length < 256 &&
-    password === confirmPassword;
+    passwordMeetsMinimum &&
+    password.length < 256;
 
   const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
     setLoading(true);
 
     try {
-      const res = await get2ankiApi().register(name, email, password);
+      const res = await get2ankiApi().register('', email, password);
       if (res.status === 200) {
         const loginUrl = redirect
           ? `/login?redirect=${encodeURIComponent(redirect)}`
@@ -43,48 +42,49 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
         globalThis.location.href = loginUrl;
       } else {
         setErrorMessage(
-          'Unknown error. Please try again or reach out to support@2anki.net for assistance if the issue persists.'
+          'Something went wrong on our end. Try again, or email support@2anki.net if it keeps happening.'
         );
       }
     } catch (error) {
       console.error('Register submit failed', error);
       setErrorMessage(
-        'Request failed. If you already have a user try login instead'
+        "We couldn't create your account. If you already have one, log in instead."
       );
       setLoading(false);
     }
   };
+
+  const passwordHelpClass = (() => {
+    if (!passwordTouched) {
+      return styles.helpMuted;
+    }
+    return passwordMeetsMinimum ? styles.helpSuccess : styles.helpDanger;
+  })();
+
+  const passwordHelpText = (() => {
+    if (passwordMeetsMinimum) {
+      return '✓ Looks good';
+    }
+    return 'Use at least 8 characters.';
+  })();
+
   return (
     <div className={styles.formPage}>
       <div className={styles.formCard}>
         <TopMessage />
-        <h1 className={styles.formTitle}>Register</h1>
+        <h1 className={styles.formTitle}>
+          {getVisibleText('navigation.register.title')}
+        </h1>
         <WithGoogleLink text={getVisibleText('navigation.register.google')} />
-        <hr />
-        <p className={sharedStyles.formDescription}>Or create a new account.</p>
+        <div className={styles.divider}>
+          <span className={styles.dividerLabel}>or sign up with email</span>
+        </div>
         <form onSubmit={handleSubmit}>
-          <div className={styles.field}>
-            <label htmlFor="name">
-              <span>Name</span>
-              <input
-                name="name"
-                min="1"
-                max="255"
-                value={name}
-                onChange={(event) => {
-                  setName(event.target.value);
-                  localStorage.setItem('name', event.target.value);
-                }}
-                type="text"
-                placeholder="Your name"
-                required
-              />
-            </label>
-          </div>
           <div className={styles.field}>
             <label htmlFor="email">
               <span>Email</span>
               <input
+                id="email"
                 min="3"
                 max="255"
                 value={email}
@@ -101,8 +101,9 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
           </div>
           <div className={styles.field}>
             <label htmlFor="password">
-              <span>Password (minimum 8 characters)</span>
+              <span>Password</span>
               <input
+                id="password"
                 name="password"
                 min="8"
                 max="255"
@@ -111,28 +112,17 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
                 required
                 type="password"
                 placeholder="Your password"
+                aria-describedby="password-help"
               />
             </label>
-            <label
-              htmlFor="confirm_password"
-              className={sharedStyles.marginTopSm}
-            >
-              <span>Confirm Password</span>
-              <input
-                name="confirm_password"
-                min="8"
-                max="255"
-                value={confirmPassword}
-                onChange={(event) => setConfirmPassword(event.target.value)}
-                required
-                type="password"
-                placeholder="Confirm password"
-              />
-            </label>
+            <p id="password-help" className={passwordHelpClass}>
+              {passwordHelpText}
+            </p>
           </div>
           <div className={styles.field}>
             <label htmlFor="tos" className={styles.checkbox}>
               <input
+                id="tos"
                 name="tos"
                 required
                 type="checkbox"
@@ -170,6 +160,12 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
             </button>
           </div>
         </form>
+        <p className={styles.footerText}>
+          {getVisibleText('navigation.login.question')}{' '}
+          <a rel="noreferrer" href="/login">
+            Log in
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/web/src/lib/text/app.document.json
+++ b/web/src/lib/text/app.document.json
@@ -10,6 +10,8 @@
   "navigation.logout": "Log Out",
   "navigation.register": "Register",
   "navigation.register.question": "Don't have an account?",
+  "navigation.register.title": "Create your account",
+  "navigation.login.question": "Already have an account?",
   "navigation.deleteAccount": "Delete account",
   "navigation.page.settings": "Settings",
   "downloads.empty": "You have no downloads!",

--- a/web/src/styles/auth.module.css
+++ b/web/src/styles/auth.module.css
@@ -9,18 +9,52 @@
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  padding: 2rem;
+  padding: 2.5rem 2rem;
 }
 
 .formTitle {
   font-size: var(--text-2xl);
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
-  margin: 0 0 1.5rem;
+  margin: 0 0 1.75rem;
 }
 
 .field {
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+  color: var(--color-text-secondary);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  border-top: 1px solid var(--color-border);
+}
+
+.dividerLabel {
+  white-space: nowrap;
+}
+
+.helpMuted {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin-top: 0.375rem;
+}
+
+.helpSuccess {
+  font-size: var(--text-xs);
+  color: var(--color-success);
+  margin-top: 0.375rem;
 }
 
 .googleButton {


### PR DESCRIPTION
## What
Trim the register flow to email + password. Drop the Name and Confirm-Password fields, lighten the heading, surface live password validation under the input, and add an "Already have an account? Log in" link. Lead with Google + new "or sign up with email" divider so the relationship between the two paths reads. Friendlier error copy on submit failures.

Backend keeps the `users.name` column unchanged. The register service now defaults `name` to the email local part (`jane.doe@example.com` -> `jane.doe`) when the client doesn't send one, so the account page, "Welcome back" header, and billing emails keep working without a migration. Older clients that still send a name continue to work.

## Why
Reducing the new-user surface from four fields to two is a direct hit on the goal in `CLAUDE.md`: "the simplest, fastest way to turn what they're studying into beautiful flashcards." Every removed field is a measurable conversion drop. Login is already single-password, so unifying register matches.

## How
- Server
  - `UsersService.register` derives `name` from the email local part when blank (`name?.trim() ?? ''` -> falls back to `email.split('@')[0]`).
  - `UsersController.register` no longer requires `name`; tightens the 400 message.
  - `isValidUser(password, email)` drops the `name` parameter; only one caller, updated in the same file.
- Web
  - `RegisterForm.tsx`: remove Name + Confirm Password, add aria-described password helper with three states (neutral / success / danger), add footer log-in link, update title to "Create your account", swap divider copy.
  - `auth.module.css`: small vertical-rhythm bump (card padding, field spacing) to balance the slimmer form, plus `.divider`, `.dividerLabel`, `.helpSuccess`, `.helpMuted`.
  - `app.document.json`: new keys `navigation.register.title` and `navigation.login.question`.

## Testing
- Unit tests added:
  - `src/services/UsersService.test.ts` - covers (a) supplied name passes through, (b) empty/whitespace name falls back to email local part.
  - `src/controllers/UsersControllers.test.ts` - covers register validation (400 without password, 400 without email), accepts a request with no `name`, accepts old clients that still send `name`, and 400s on duplicate email.
- `/check` (server tsc + web typecheck + web vitest + web lint) green.
- Manually verified: dev `vite preview` build serves `/register` with the new layout. Headless browser screenshot capture failed in this environment (missing `libnspr4` / no sudo to install Playwright deps); please grab a screenshot before un-drafting.

## Risks
- Existing users with empty `name` rows are unaffected (column already nullable).
- `loginWithGoogle` still uses Google's `name` directly, untouched.
- The `register` API contract gets *more* permissive (name optional). No breaking change for old clients.
- Rollback: revert the commit. No DB migration to undo.

## Goal alignment
Removing two fields from the only signup flow is a direct conversion win. Per `CLAUDE.md`, "drop something in, get a clean deck back" - if signup is two fields instead of four, more people get to the conversion path. That moves us toward the 300K-user goal.

## Out of scope
- Password reveal toggle (called out, separate PR).
- Login page changes other than mirroring the inverse footer link copy (handled via i18n key only; no JSX change to `LoginForm`).
- Any other auth flow.