### PR TITLE
fix(parser): strip SVG path newlines via regex, not cheerio

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -236,11 +236,69 @@ test('Notion new export: deeply nested toggles (3 levels)', async () => {
   );
 
   expect(deck.cards.length).toBe(1);
-  
+
   expect(deck.cards[0].name).toContain('Parent');
   expect(deck.cards[0].back).toContain('Grand child');
-  
+
   expect(deck.cards[0].back).toContain('Child');
   expect(deck.cards[0].back).toContain('details');
   expect(deck.cards[0].back).toContain('summary');
+});
+
+describe('removeNewlinesInSVGPathAttributeD', () => {
+  const newParser = () =>
+    new DeckParser({
+      name: 'svg-test',
+      settings: new CardOption({}),
+      files: [],
+      noLimits: false,
+      workspace: new Workspace(true, 'fs'),
+    });
+
+  it('strips newlines from a path d attribute', () => {
+    const input = '<svg><path d="M0,0\nL10,10\nL20,0"/></svg>';
+    expect(newParser().removeNewlinesInSVGPathAttributeD(input)).toBe(
+      '<svg><path d="M0,0L10,10L20,0"/></svg>'
+    );
+  });
+
+  it('trims leading and trailing whitespace inside d', () => {
+    const input = '<path d="\n  M0,0 L10,10  \n"/>';
+    expect(newParser().removeNewlinesInSVGPathAttributeD(input)).toBe(
+      '<path d="M0,0 L10,10"/>'
+    );
+  });
+
+  it('leaves d attributes on non-path elements untouched', () => {
+    const input = '<text d="\nignore me\n">hi</text>';
+    expect(newParser().removeNewlinesInSVGPathAttributeD(input)).toBe(input);
+  });
+
+  it('leaves sibling attributes on path untouched', () => {
+    const input =
+      '<path fill="red" d="M0,0\nL1,1" stroke="blue" stroke-width="2"/>';
+    expect(newParser().removeNewlinesInSVGPathAttributeD(input)).toBe(
+      '<path fill="red" d="M0,0L1,1" stroke="blue" stroke-width="2"/>'
+    );
+  });
+
+  it('handles single-quoted d attributes', () => {
+    const input = "<path d='M0,0\nL5,5'/>";
+    expect(newParser().removeNewlinesInSVGPathAttributeD(input)).toBe(
+      "<path d='M0,0L5,5'/>"
+    );
+  });
+
+  it('processes multiple path elements in one document', () => {
+    const input =
+      '<svg><path d="M0,0\nL1,1"/><path d="\nM2,2\nL3,3\n"/></svg>';
+    expect(newParser().removeNewlinesInSVGPathAttributeD(input)).toBe(
+      '<svg><path d="M0,0L1,1"/><path d="M2,2L3,3"/></svg>'
+    );
+  });
+
+  it('returns input unchanged when there are no path elements', () => {
+    const input = '<div><p>no svg here</p></div>';
+    expect(newParser().removeNewlinesInSVGPathAttributeD(input)).toBe(input);
+  });
 });

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -266,19 +266,15 @@ export class DeckParser {
     }
   }
 
+  // Avoids a full cheerio.load on the whole document. Paired with loadDOM,
+  // a DOM-based normalisation here meant the entire HTML was materialised as a
+  // cheerio tree twice in a row, which OOM'd 30–40 MB Notion exports.
   removeNewlinesInSVGPathAttributeD(html: string): string {
-    const dom = cheerio.load(html);
-    const pathElements = dom('path');
-
-    for (const pathElement of pathElements) {
-      if ('attribs' in pathElement && 'd' in pathElement.attribs) {
-        const dAttribute = pathElement.attribs.d;
-        const newDAttribute = dAttribute.replace(/\n/g, '').trim();
-        dom(pathElement).attr('d', newDAttribute);
-      }
-    }
-
-    return dom.html();
+    return html.replace(
+      /<path\b([^>]*?)\sd=(["'])([\s\S]*?)\2/gi,
+      (_match, prefix, quote, value) =>
+        `<path${prefix} d=${quote}${value.replace(/\n/g, '').trim()}${quote}`
+    );
   }
 
   getFirstHeadingText(dom: cheerio.CheerioAPI) {


### PR DESCRIPTION
## Summary
- `removeNewlinesInSVGPathAttributeD` was loading the entire HTML upload into cheerio just to strip `\n` from `d` attributes on `<path>` elements, then serialising back to a string. Its only caller (`loadDOM`) immediately re-loaded that string into a second cheerio tree — so every parse materialised the full document as a DOM **twice in a row** at the entry pipeline.
- On 30–40 MB Notion exports (heavy inline styles + deeply nested DOM, worse with base64-inlined images) this OOM'd the worker. Surfaced via support — a 38 MB export crashed with `JS heap out of memory` even though the prod worker has `--max-old-space-size=16384`.
- Swap the DOM walk for a regex against `<path … d="…" …>`. Same behaviour, no full-document DOM materialisation. Covered by 7 new unit tests; the rest of `DeckParser.test.ts` stays green (21 passing).

## Goal alignment
Roughly halves peak memory through the entry parsing pipeline on every HTML upload, which is the hot path for Notion HTML exports — directly serves the "drop something in, get a clean deck back" promise for the med-student / power-user cohort whose exports trip the existing ceiling.

## Follow-ups (deliberately out of scope)
- The surviving `cheerio.load` inside `loadDOM` (line 631) still operates on the full HTML. If post-deploy measurement shows 38 MB still OOMs, the next move is **per-toggle / per-heading chunking before full DOM materialisation**, not a Node heap bump (already at 16 GB on prod, confirmed via `pm2 prettylist`).
- No upload-time size warning yet. Worth revisiting only if chunking lands and we still hit a ceiling.

## Test plan
- [x] `pnpm test src/lib/parser/DeckParser.test.ts` — 21 passed, 0 failed (7 new tests for the regex + 14 existing integration tests unchanged)
- [x] `/check` — server tsc + web typecheck + web vitest (163) + web lint, all green
- [ ] After merge + deploy, ask Nathan (the support reporter) to retry his original 38 MB Notion export

🤖 Generated with [Claude Code](https://claude.com/claude-code)