### PR TITLE
fix(seo): add /upload to sitemap

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -6,6 +6,11 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://2anki.net/upload</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/pricing</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>


### PR DESCRIPTION
## Summary
- GSC search performance shows `/upload` pulling **184 clicks (+77% WoW)** as a standalone indexed page — Google found it via crawl, not via the sitemap shipped in #2103.
- Add it explicitly so future re-crawls treat it as a primary page.
- Priority 0.9, weekly — same as the four landing pages (conversion page, not navigation).

## Test plan
- [ ] CI green
- [ ] After deploy: `curl https://2anki.net/sitemap.xml` lists `/upload`
- [ ] GSC sitemap re-fetch shows 8 discovered pages (was 7)