### PR TITLE
fix(jobs): classify and humanise Python conversion errors (#2100)

### DIFF
--- a/Documentation/specs/2100-python-error-humanise.md
+++ b/Documentation/specs/2100-python-error-humanise.md
@@ -1,0 +1,85 @@
+# Spec: Humanise Python conversion errors (#2100)
+
+**Outcome**: First-time users who hit a Python crash see a clear next step instead of "Technical error Error: Python script exited with code 1...". Target: cut the 73% never-return rate among Python-crash users in half within 60 days.
+**Goal alignment**: ~5% of new signups bounce at this exact error today; recovering even half is worth ~6K retained users per 100K signups against the 300K goal.
+**Branch**: `fix/humanise-python-conversion-errors`
+**PR title**: `fix(jobs): classify and humanise Python conversion errors (#2100)`
+
+## Problem
+
+- `buildPythonExitError` emits `Python script exited with code N: <raw stderr>`.
+- `jobFailureReasonFromError` prefixes `Technical error ` and stores it in `jobs.job_reason_failure`.
+- `web/src/pages/DownloadsPage/components/ListJobs/index.tsx:42` renders that string verbatim. No code change needed in `web/` — same field, cleaner content.
+
+## Layered scope
+
+`src/lib/anki/CardGenerator.ts` (caller, untouched) → `src/lib/anki/buildPythonExitError.ts` (classify) → `src/usecases/jobs/jobFailureReason.ts` (no prefix) → `jobs.job_reason_failure` (existing column) → existing web display surface.
+
+## Classified crash modes
+
+Classifier lives in `buildPythonExitError.ts`. Match against `stderr || stdout` (trimmed). First match wins. All messages use plain English; no "Python", "script", "code", "stderr".
+
+| # | Detection (case-sensitive substring unless noted) | User-facing message (paste verbatim) |
+|---|---|---|
+| 1 | `UserWarning: Field contained the following invalid HTML tags` | `Something on this page — usually a pasted embed or copied-in web content — has formatting we can't read. Open the page in Notion, remove or simplify that block, and convert again.` |
+| 2 | `Unsupported 'data_source'!` (also matches `Unsupported "data_source"`) | `This Notion database uses a view we don't support yet. Convert the parent page, or switch the database to a different view and try again.` |
+| 3 | `MemoryError` OR `Killed` (whole-line match) OR exit code `137` | `This page is too large for us to convert in one go. Split it into smaller pages — or convert it section by section — and try again.` |
+| 4 | empty output (current `(no output)` branch) OR no other classifier matched | `Something went wrong on our end converting this page. Email support@2anki.net with job ID <JOB_ID> and we'll take a look.` |
+
+Notes:
+- Modes 3 and the generic fallback are additions beyond the issue body; tests already cover the empty-stream and `code: null` paths, and `Killed`/`MemoryError` is a known shape on the prod box for very large Notion pages — worth claiming now while we're in the file.
+- The `<JOB_ID>` placeholder must be filled in by `jobFailureReasonFromError`'s caller path. See "Code changes" below.
+
+## Code changes
+
+- **`src/lib/anki/buildPythonExitError.ts`**
+  - Export a `PythonCrashKind` union: `'invalid-markup' | 'unsupported-data-source' | 'too-large' | 'unknown'`.
+  - Export a new `PythonExitError extends Error` carrying `{ kind: PythonCrashKind, rawOutput: string, code: number | null }`.
+  - `buildPythonExitError` returns `PythonExitError`. `message` is the human string (without job ID — generic fallback uses placeholder `__JOB_ID__` to be filled later, OR accept `jobId?: string` param; pick the param approach so the message is final at construction time).
+  - Update `CardGenerator.ts` call site to pass `jobId` through. `jobId` is already in scope of `performConversion.ts` (`id` param) — pass it down to `CardGenerator.generate` (one new param).
+
+- **`src/usecases/jobs/jobFailureReason.ts`**
+  - Drop the `'Technical error '` prefix.
+  - If `error instanceof PythonExitError`, return `error.message` directly.
+  - Keep `EmptyDeckError` branch as-is.
+  - Final fallback for unknown errors becomes the generic mode-4 message; accept an optional `jobId` arg.
+
+- **`src/lib/storage/jobs/helpers/performConversion.ts`**
+  - Pass `id` (job id) into `jobFailureReasonFromError(error, id)`.
+  - On `PythonExitError`, log raw output server-side: `console.error('[conversion] python crash', { jobId: id, kind: error.kind, code: error.code, rawOutput: error.rawOutput })`. Use `console.error` to match the existing `[UploadService]` pattern (line 219 of `services/UploadService.ts`); the observability sink is HTTP-only and does not fit job-internal events.
+
+- **`web/`**: no change. Same string field renders the cleaner copy.
+
+## Tests
+
+`src/lib/anki/buildPythonExitError.test.ts` — replace existing tests; the old "contains 'Python script exited with code'" assertions now contradict the contract. Add:
+- `classifies invalid HTML tag warnings as invalid-markup and tells the user to simplify the offending block`
+- `classifies Unsupported 'data_source'! as unsupported-data-source`
+- `classifies MemoryError / Killed / exit code 137 as too-large`
+- `falls back to unknown kind with job ID and support email when output is empty`
+- `falls back to unknown kind when stderr does not match any classifier`
+- `never includes the words "Python", "script", or "exited" in the user-facing message` (regex assertion across all branches)
+- `retains the raw output on the error for server-side logging`
+
+`src/usecases/jobs/jobFailureReason.test.ts` — replace the "Technical error Error: boom" test. Add:
+- `returns the EmptyDeckError reason unchanged`
+- `returns the PythonExitError message verbatim (no "Technical error" prefix)`
+- `returns the generic fallback with job ID for an unknown error`
+- `never produces a string starting with "Technical error"` (regex across all branches)
+
+## Voice rules applied
+
+- 1-2 sentences, plain English, recovery hint at the end.
+- Generic fallback is the only message that mentions support; the others are self-serve.
+
+## Open questions
+
+- None blocking. Mode 3 (too-large) is a judgment call; if no `Killed` / `MemoryError` evidence exists in the wild, drop it and keep modes 1, 2, 4 — the spec still ships.
+
+## Out of scope (explicit)
+
+- Changes to `2anki/create_deck` (Python repo).
+- Retry button / retry affordance on the downloads page.
+- Moving Python in-process or rewriting the converter.
+- Schema changes to `jobs` (no new columns; raw output stays in stdout/stderr logs).
+- Backfilling old `job_reason_failure` rows.

--- a/src/lib/anki/CardGenerator.ts
+++ b/src/lib/anki/CardGenerator.ts
@@ -60,8 +60,11 @@ function PYTHON(): string {
 class CardGenerator {
   currentDirectory: string;
 
-  constructor(workspace: string) {
+  jobId?: string;
+
+  constructor(workspace: string, jobId?: string) {
     this.currentDirectory = workspace;
+    this.jobId = jobId;
   }
 
   run() {
@@ -74,6 +77,7 @@ class CardGenerator {
       templateDirectory,
     ];
     console.log('execFile', path.basename(PYTHON()), createDeckScriptPathARGS.length, 'args');
+    const jobId = this.jobId;
     return new Promise((resolve, reject) => {
       const process = spawn(PYTHON(), createDeckScriptPathARGS, {
         cwd: this.currentDirectory,
@@ -102,6 +106,7 @@ class CardGenerator {
               code,
               stdout: stdoutData.join(''),
               stderr: stderrData.join(''),
+              jobId,
             })
           );
         }

--- a/src/lib/anki/buildPythonExitError.test.ts
+++ b/src/lib/anki/buildPythonExitError.test.ts
@@ -1,43 +1,146 @@
-import { buildPythonExitError } from './buildPythonExitError';
+import { buildPythonExitError, PythonExitError } from './buildPythonExitError';
 
 describe('buildPythonExitError', () => {
-  test('uses stderr when present', () => {
+  it("classifies invalid HTML tag warnings as invalid-markup and tells the user to simplify the offending block", () => {
     const error = buildPythonExitError({
       code: 1,
-      stdout: 'progress output\n',
-      stderr: 'Traceback (most recent call last):\n  ...\nValueError: bad deck\n',
-    });
-    expect(error.message).toContain('Python script exited with code 1');
-    expect(error.message).toContain('ValueError: bad deck');
-  });
-
-  test('falls back to stdout when stderr is empty', () => {
-    const error = buildPythonExitError({
-      code: 1,
-      stdout: 'fatal: missing template\n',
-      stderr: '',
-    });
-    expect(error.message).toContain('Python script exited with code 1');
-    expect(error.message).toContain('fatal: missing template');
-  });
-
-  test('uses a placeholder when both streams are empty', () => {
-    const error = buildPythonExitError({
-      code: 2,
       stdout: '',
-      stderr: '   \n',
+      stderr:
+        "UserWarning: Field contained the following invalid HTML tags and was cleaned. Please check the field for errors.\n  warnings.warn(",
+      jobId: 'job-123',
     });
-    expect(error.message).toContain('Python script exited with code 2');
-    expect(error.message).toContain('(no output)');
+    expect(error).toBeInstanceOf(PythonExitError);
+    expect(error.kind).toBe('invalid-markup');
+    expect(error.message).toBe(
+      "Something on this page — usually a pasted embed or copied-in web content — has formatting we can't read. Open the page in Notion, remove or simplify that block, and convert again."
+    );
   });
 
-  test('handles null exit code', () => {
+  it("classifies Unsupported 'data_source'! as unsupported-data-source", () => {
     const error = buildPythonExitError({
+      code: 1,
+      stdout: '',
+      stderr: "RuntimeError: Unsupported 'data_source'!",
+      jobId: 'job-123',
+    });
+    expect(error.kind).toBe('unsupported-data-source');
+    expect(error.message).toBe(
+      "This Notion database uses a view we don't support yet. Convert the parent page, or switch the database to a different view and try again."
+    );
+  });
+
+  it('also matches the double-quoted variant of Unsupported "data_source"', () => {
+    const error = buildPythonExitError({
+      code: 1,
+      stdout: '',
+      stderr: 'RuntimeError: Unsupported "data_source"!',
+      jobId: 'job-123',
+    });
+    expect(error.kind).toBe('unsupported-data-source');
+  });
+
+  it('classifies MemoryError / Killed / exit code 137 as too-large', () => {
+    const memoryErrorCase = buildPythonExitError({
+      code: 1,
+      stdout: '',
+      stderr: 'MemoryError',
+      jobId: 'job-1',
+    });
+    expect(memoryErrorCase.kind).toBe('too-large');
+    expect(memoryErrorCase.message).toBe(
+      'This page is too large for us to convert in one go. Split it into smaller pages — or convert it section by section — and try again.'
+    );
+
+    const killedLineCase = buildPythonExitError({
       code: null,
       stdout: '',
-      stderr: 'killed by signal',
+      stderr: 'some prefix\nKilled\n',
+      jobId: 'job-2',
     });
-    expect(error.message).toContain('Python script exited with code null');
-    expect(error.message).toContain('killed by signal');
+    expect(killedLineCase.kind).toBe('too-large');
+
+    const exit137Case = buildPythonExitError({
+      code: 137,
+      stdout: '',
+      stderr: 'no helpful message',
+      jobId: 'job-3',
+    });
+    expect(exit137Case.kind).toBe('too-large');
+  });
+
+  it('falls back to unknown kind with job ID and support email when output is empty', () => {
+    const error = buildPythonExitError({
+      code: 1,
+      stdout: '',
+      stderr: '   \n',
+      jobId: 'job-abc',
+    });
+    expect(error.kind).toBe('unknown');
+    expect(error.message).toBe(
+      "Something went wrong on our end converting this page. Email support@2anki.net with job ID job-abc and we'll take a look."
+    );
+  });
+
+  it('falls back to unknown kind when stderr does not match any classifier', () => {
+    const error = buildPythonExitError({
+      code: 1,
+      stdout: 'progress output',
+      stderr: 'Traceback (most recent call last):\n  ValueError: weird thing',
+      jobId: 'job-xyz',
+    });
+    expect(error.kind).toBe('unknown');
+    expect(error.message).toContain('support@2anki.net');
+    expect(error.message).toContain('job-xyz');
+  });
+
+  it('never includes the words "Python", "script", or "exited" in the user-facing message', () => {
+    const samples = [
+      buildPythonExitError({
+        code: 1,
+        stdout: '',
+        stderr:
+          'UserWarning: Field contained the following invalid HTML tags',
+        jobId: 'j1',
+      }),
+      buildPythonExitError({
+        code: 1,
+        stdout: '',
+        stderr: "Unsupported 'data_source'!",
+        jobId: 'j2',
+      }),
+      buildPythonExitError({
+        code: 137,
+        stdout: '',
+        stderr: '',
+        jobId: 'j3',
+      }),
+      buildPythonExitError({
+        code: 1,
+        stdout: '',
+        stderr: '',
+        jobId: 'j4',
+      }),
+      buildPythonExitError({
+        code: 1,
+        stdout: '',
+        stderr: 'random traceback',
+        jobId: 'j5',
+      }),
+    ];
+    const forbidden = /python|script|exited/i;
+    for (const sample of samples) {
+      expect(sample.message).not.toMatch(forbidden);
+    }
+  });
+
+  it('retains the raw output on the error for server-side logging', () => {
+    const error = buildPythonExitError({
+      code: 1,
+      stdout: 'progress',
+      stderr: "Unsupported 'data_source'!",
+      jobId: 'job-keep-raw',
+    });
+    expect(error.rawOutput).toBe("Unsupported 'data_source'!");
+    expect(error.code).toBe(1);
   });
 });

--- a/src/lib/anki/buildPythonExitError.ts
+++ b/src/lib/anki/buildPythonExitError.ts
@@ -1,16 +1,117 @@
+export type PythonCrashKind =
+  | 'invalid-markup'
+  | 'unsupported-data-source'
+  | 'too-large'
+  | 'unknown';
+
 interface PythonExitInfo {
   code: number | null;
   stdout: string;
   stderr: string;
+  jobId?: string;
+}
+
+interface PythonExitErrorDetails {
+  kind: PythonCrashKind;
+  rawOutput: string;
+  code: number | null;
+}
+
+export class PythonExitError extends Error {
+  readonly kind: PythonCrashKind;
+  readonly rawOutput: string;
+  readonly code: number | null;
+
+  constructor(message: string, details: PythonExitErrorDetails) {
+    super(message);
+    this.name = 'PythonExitError';
+    this.kind = details.kind;
+    this.rawOutput = details.rawOutput;
+    this.code = details.code;
+  }
+}
+
+const INVALID_MARKUP_MESSAGE =
+  "Something on this page — usually a pasted embed or copied-in web content — has formatting we can't read. Open the page in Notion, remove or simplify that block, and convert again.";
+
+const UNSUPPORTED_DATA_SOURCE_MESSAGE =
+  "This Notion database uses a view we don't support yet. Convert the parent page, or switch the database to a different view and try again.";
+
+const TOO_LARGE_MESSAGE =
+  'This page is too large for us to convert in one go. Split it into smaller pages — or convert it section by section — and try again.';
+
+function genericMessage(jobId: string | undefined): string {
+  const idPart = jobId ?? 'unavailable';
+  return `Something went wrong on our end converting this page. Email support@2anki.net with job ID ${idPart} and we'll take a look.`;
+}
+
+function hasInvalidMarkupSignature(output: string): boolean {
+  return output.includes(
+    'UserWarning: Field contained the following invalid HTML tags'
+  );
+}
+
+function hasUnsupportedDataSourceSignature(output: string): boolean {
+  return (
+    output.includes("Unsupported 'data_source'!") ||
+    output.includes('Unsupported "data_source"')
+  );
+}
+
+function hasTooLargeSignature(output: string, code: number | null): boolean {
+  if (code === 137) {
+    return true;
+  }
+  if (output.includes('MemoryError')) {
+    return true;
+  }
+  return output.split('\n').some((line) => line.trim() === 'Killed');
+}
+
+function classify(
+  output: string,
+  code: number | null
+): Exclude<PythonCrashKind, 'unknown'> | null {
+  if (hasInvalidMarkupSignature(output)) {
+    return 'invalid-markup';
+  }
+  if (hasUnsupportedDataSourceSignature(output)) {
+    return 'unsupported-data-source';
+  }
+  if (hasTooLargeSignature(output, code)) {
+    return 'too-large';
+  }
+  return null;
+}
+
+function messageFor(kind: PythonCrashKind, jobId: string | undefined): string {
+  if (kind === 'invalid-markup') {
+    return INVALID_MARKUP_MESSAGE;
+  }
+  if (kind === 'unsupported-data-source') {
+    return UNSUPPORTED_DATA_SOURCE_MESSAGE;
+  }
+  if (kind === 'too-large') {
+    return TOO_LARGE_MESSAGE;
+  }
+  return genericMessage(jobId);
 }
 
 export function buildPythonExitError({
   code,
   stdout,
   stderr,
-}: PythonExitInfo): Error {
+  jobId,
+}: PythonExitInfo): PythonExitError {
   const trimmedStderr = stderr.trim();
   const trimmedStdout = stdout.trim();
-  const output = trimmedStderr || trimmedStdout || '(no output)';
-  return new Error(`Python script exited with code ${code}: ${output}`);
+  const rawOutput = trimmedStderr || trimmedStdout;
+  const kind: PythonCrashKind = rawOutput
+    ? (classify(rawOutput, code) ?? 'unknown')
+    : 'unknown';
+  return new PythonExitError(messageFor(kind, jobId), {
+    kind,
+    rawOutput,
+    code,
+  });
 }

--- a/src/lib/anki/buildPythonExitError.ts
+++ b/src/lib/anki/buildPythonExitError.ts
@@ -40,9 +40,8 @@ const UNSUPPORTED_DATA_SOURCE_MESSAGE =
 const TOO_LARGE_MESSAGE =
   'This page is too large for us to convert in one go. Split it into smaller pages — or convert it section by section — and try again.';
 
-function genericMessage(jobId: string | undefined): string {
-  const idPart = jobId ?? 'unavailable';
-  return `Something went wrong on our end converting this page. Email support@2anki.net with job ID ${idPart} and we'll take a look.`;
+function genericMessage(jobId = 'unavailable'): string {
+  return `Something went wrong on our end converting this page. Email support@2anki.net with job ID ${jobId} and we'll take a look.`;
 }
 
 function hasInvalidMarkupSignature(output: string): boolean {

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -17,6 +17,7 @@ import { BuildDeckForJobUseCase } from '../../../../usecases/jobs/BuildDeckForJo
 import { CompleteJobUseCase } from '../../../../usecases/jobs/CompleteJobUseCase';
 import { NotifyUserUseCase } from '../../../../usecases/jobs/NotifyUserUseCase';
 import { jobFailureReasonFromError } from '../../../../usecases/jobs/jobFailureReason';
+import { PythonExitError } from '../../../anki/buildPythonExitError';
 
 interface ConversionRequest {
   title: string;
@@ -137,8 +138,16 @@ export default async function performConversion(
     const completeJob = new CompleteJobUseCase(jobRepository);
     await completeJob.execute(id, owner);
   } catch (error) {
+    if (error instanceof PythonExitError) {
+      console.error('[conversion] python crash', {
+        jobId: id,
+        kind: error.kind,
+        code: error.code,
+        rawOutput: error.rawOutput,
+      });
+    }
     const failedJob = new SetJobFailedUseCase(jobRepository);
-    await failedJob.execute(id, owner, jobFailureReasonFromError(error));
+    await failedJob.execute(id, owner, jobFailureReasonFromError(error, id));
 
     if (waitingResponse) {
       res?.status(400).send('conversion failed.');

--- a/src/usecases/jobs/BuildDeckForJobUseCase.ts
+++ b/src/usecases/jobs/BuildDeckForJobUseCase.ts
@@ -55,7 +55,7 @@ export class BuildDeckForJobUseCase {
     }
 
     exporter.configure(filteredDecks);
-    const gen = new CardGenerator(ws.location);
+    const gen = new CardGenerator(ws.location, id);
     const payload = (await gen.run()) as string;
     const apkg = fs.readFileSync(payload);
     const filename = toText(

--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -1,3 +1,4 @@
+import { buildPythonExitError } from '../../lib/anki/buildPythonExitError';
 import { EmptyDeckError } from './EmptyDeckError';
 import {
   EMPTY_DECK_FAILURE_REASON,
@@ -5,14 +6,57 @@ import {
 } from './jobFailureReason';
 
 describe('jobFailureReasonFromError', () => {
-  it('returns the friendly reason for EmptyDeckError', () => {
-    const reason = jobFailureReasonFromError(new EmptyDeckError());
+  it('returns the EmptyDeckError reason unchanged', () => {
+    const reason = jobFailureReasonFromError(new EmptyDeckError(), 'job-1');
     expect(reason).toBe(EMPTY_DECK_FAILURE_REASON);
-    expect(reason).not.toMatch(/^Technical error /);
   });
 
-  it('returns the technical fallback for any other error', () => {
-    const reason = jobFailureReasonFromError(new Error('boom'));
-    expect(reason).toBe('Technical error Error: boom');
+  it('returns the PythonExitError message verbatim (no "Technical error" prefix)', () => {
+    const pythonError = buildPythonExitError({
+      code: 1,
+      stdout: '',
+      stderr: "Unsupported 'data_source'!",
+      jobId: 'job-py',
+    });
+    const reason = jobFailureReasonFromError(pythonError, 'job-py');
+    expect(reason).toBe(pythonError.message);
+    expect(reason).not.toMatch(/^Technical error/);
+  });
+
+  it('returns the generic fallback with job ID for an unknown error', () => {
+    const reason = jobFailureReasonFromError(new Error('boom'), 'job-xyz');
+    expect(reason).toBe(
+      "Something went wrong on our end converting this page. Email support@2anki.net with job ID job-xyz and we'll take a look."
+    );
+  });
+
+  it('never produces a string starting with "Technical error"', () => {
+    const reasons = [
+      jobFailureReasonFromError(new EmptyDeckError(), 'j1'),
+      jobFailureReasonFromError(
+        buildPythonExitError({
+          code: 1,
+          stdout: '',
+          stderr: 'UserWarning: Field contained the following invalid HTML tags',
+          jobId: 'j2',
+        }),
+        'j2'
+      ),
+      jobFailureReasonFromError(
+        buildPythonExitError({
+          code: 137,
+          stdout: '',
+          stderr: '',
+          jobId: 'j3',
+        }),
+        'j3'
+      ),
+      jobFailureReasonFromError(new Error('mystery'), 'j4'),
+      jobFailureReasonFromError('string error', 'j5'),
+      jobFailureReasonFromError(undefined, 'j6'),
+    ];
+    for (const reason of reasons) {
+      expect(reason).not.toMatch(/^Technical error/);
+    }
   });
 });

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -1,11 +1,23 @@
+import { PythonExitError } from '../../lib/anki/buildPythonExitError';
 import { EmptyDeckError } from './EmptyDeckError';
 
 export const EMPTY_DECK_FAILURE_REASON =
   "No cards in this deck yet. 2anki turns Notion toggle blocks (the little triangles you click to expand) into flashcards — the toggle title becomes the question, what's inside becomes the answer. We didn't find any in this page. Open the page in Notion, wrap your key terms in toggles, then convert again. See examples: /documentation/help/common-problems#could-not-create-a-deck-using-your-file-and-rules";
 
-export function jobFailureReasonFromError(error: unknown): string {
+function genericFailureReason(jobId: string | undefined): string {
+  const idPart = jobId ?? 'unavailable';
+  return `Something went wrong on our end converting this page. Email support@2anki.net with job ID ${idPart} and we'll take a look.`;
+}
+
+export function jobFailureReasonFromError(
+  error: unknown,
+  jobId?: string
+): string {
   if (error instanceof EmptyDeckError) {
     return EMPTY_DECK_FAILURE_REASON;
   }
-  return 'Technical error ' + error;
+  if (error instanceof PythonExitError) {
+    return error.message;
+  }
+  return genericFailureReason(jobId);
 }

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -4,9 +4,8 @@ import { EmptyDeckError } from './EmptyDeckError';
 export const EMPTY_DECK_FAILURE_REASON =
   "No cards in this deck yet. 2anki turns Notion toggle blocks (the little triangles you click to expand) into flashcards — the toggle title becomes the question, what's inside becomes the answer. We didn't find any in this page. Open the page in Notion, wrap your key terms in toggles, then convert again. See examples: /documentation/help/common-problems#could-not-create-a-deck-using-your-file-and-rules";
 
-function genericFailureReason(jobId: string | undefined): string {
-  const idPart = jobId ?? 'unavailable';
-  return `Something went wrong on our end converting this page. Email support@2anki.net with job ID ${idPart} and we'll take a look.`;
+function genericFailureReason(jobId = 'unavailable'): string {
+  return `Something went wrong on our end converting this page. Email support@2anki.net with job ID ${jobId} and we'll take a look.`;
 }
 
 export function jobFailureReasonFromError(


### PR DESCRIPTION
## Summary

- Classify Python conversion crashes into invalid-markup / unsupported-data-source / too-large / unknown
- Replace "Technical error Error: Python script exited with code 1: ..." with plain-English copy + recovery hint
- Capture raw Python output in structured server-side log keyed by job id (no schema change)

Closes #2100. Spec: `Documentation/specs/2100-python-error-humanise.md`.

## Test plan

- [ ] `pnpm test src/lib/anki/buildPythonExitError.test.ts` — all classifier branches green
- [ ] `pnpm test src/usecases/jobs/jobFailureReason.test.ts` — PythonExitError flows through verbatim, no "Technical error" prefix anywhere
- [ ] Manual: convert a Notion page with pasted HTML embeds, confirm message reads "Some of your Notion content has..."
- [ ] Manual: trigger the empty-output path, confirm message contains job ID + support@2anki.net

🤖 Generated with [Claude Code](https://claude.com/claude-code)