### PR TITLE
feat: job success tracking, scanner hardening, pricing bullet

### DIFF
--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -45,7 +45,7 @@ class JobRepository {
       .update({ status: 'interrupted', last_edited_time: new Date() });
   }
 
-  private static readonly TERMINAL_STATUSES = ['done', 'failed', 'cancelled', 'interrupted'];
+  static readonly TERMINAL_STATUSES = ['done', 'failed', 'cancelled', 'interrupted'];
 
   async updateJobStatus(
     id: string,

--- a/src/routes/middleware/rejectScannerProbes.test.ts
+++ b/src/routes/middleware/rejectScannerProbes.test.ts
@@ -1,0 +1,53 @@
+import { Request, Response, NextFunction } from 'express';
+import rejectScannerProbes from './rejectScannerProbes';
+
+function mockReqRes(method: string, path: string) {
+  const req = { method, path } as Request;
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    end: jest.fn(),
+  } as unknown as Response;
+  const next = jest.fn() as NextFunction;
+  return { req, res, next };
+}
+
+describe('rejectScannerProbes', () => {
+  it.each([
+    '/phpinfo.php',
+    '/mysql/.env',
+    '/admin/test.asp',
+    '/old/config.bak',
+    '/.htaccess',
+    '/dump.sql',
+  ])('returns 404 for %s', (path) => {
+    const { req, res, next } = mockReqRes('GET', path);
+    rejectScannerProbes(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.end).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    '/login',
+    '/downloads',
+    '/notion-to-anki',
+    '/api/users/me',
+    '/assets/app.js',
+    '/index.html',
+  ])('passes through for %s', (path) => {
+    const { req, res, next } = mockReqRes('GET', path);
+    rejectScannerProbes(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('passes through POST requests even with probe extensions', () => {
+    const { req, res, next } = mockReqRes('POST', '/test.php');
+    rejectScannerProbes(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/middleware/rejectScannerProbes.ts
+++ b/src/routes/middleware/rejectScannerProbes.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+
+const PROBE_EXTENSIONS =
+  /\.(php|env|asp|aspx|jsp|cgi|bak|old|save|sql|htaccess|htpasswd)$/i;
+
+export default function rejectScannerProbes(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  if (req.method === 'GET' && PROBE_EXTENSIONS.test(req.path)) {
+    res.status(404).end();
+    return;
+  }
+  next();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import {
 } from './routes/AnkifySessionProxyRouter';
 import templatesRouter from './routes/TemplatesRouter';
 import defaultRouter from './routes/DefaultRouter';
+import rejectScannerProbes from './routes/middleware/rejectScannerProbes';
 import webhookRouter from './routes/WebhookRouter';
 import ankifyWebhookRouter from './routes/AnkifyWebhookRouter';
 import swaggerRouter from './routes/SwaggerRouter';
@@ -100,6 +101,7 @@ const serve = async () => {
   app.use(templatesRouter());
   app.use(opsRouter());
 
+  app.use(rejectScannerProbes);
   // Note: this has to be the last router
   app.use(defaultRouter());
 

--- a/src/usecases/jobs/CheckJobLimitUseCase.test.ts
+++ b/src/usecases/jobs/CheckJobLimitUseCase.test.ts
@@ -1,0 +1,49 @@
+import { CheckJobLimitUseCase } from './CheckJobLimitUseCase';
+import JobRepository from '../../data_layer/JobRepository';
+
+describe('CheckJobLimitUseCase', () => {
+  it('counts only active jobs toward the limit', async () => {
+    const jobRepository = {
+      getJobsByOwner: jest.fn().mockResolvedValue([
+        { status: 'started' },
+        { status: 'done' },
+        { status: 'failed' },
+      ]),
+    } as unknown as JobRepository;
+
+    const useCase = new CheckJobLimitUseCase(jobRepository);
+    const result = await useCase.execute({ owner: 'user-a', maxJobs: 1 });
+
+    expect(result).toBe(true);
+  });
+
+  it('blocks when active jobs exceed the limit', async () => {
+    const jobRepository = {
+      getJobsByOwner: jest.fn().mockResolvedValue([
+        { status: 'started' },
+        { status: 'step1' },
+      ]),
+    } as unknown as JobRepository;
+
+    const useCase = new CheckJobLimitUseCase(jobRepository);
+    const result = await useCase.execute({ owner: 'user-a', maxJobs: 1 });
+
+    expect(result).toBe(false);
+  });
+
+  it('ignores all terminal statuses', async () => {
+    const jobRepository = {
+      getJobsByOwner: jest.fn().mockResolvedValue([
+        { status: 'done' },
+        { status: 'failed' },
+        { status: 'cancelled' },
+        { status: 'interrupted' },
+      ]),
+    } as unknown as JobRepository;
+
+    const useCase = new CheckJobLimitUseCase(jobRepository);
+    const result = await useCase.execute({ owner: 'user-a', maxJobs: 1 });
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/usecases/jobs/CheckJobLimitUseCase.ts
+++ b/src/usecases/jobs/CheckJobLimitUseCase.ts
@@ -12,7 +12,10 @@ export class CheckJobLimitUseCase {
     const { owner, maxJobs } = input;
 
     const jobs = await this.jobRepository.getJobsByOwner(owner);
+    const activeJobs = jobs.filter(
+      (j) => !JobRepository.TERMINAL_STATUSES.includes(j.status)
+    );
 
-    return jobs.length <= maxJobs;
+    return activeJobs.length <= maxJobs;
   }
 }

--- a/src/usecases/jobs/CompleteJobUseCase.test.ts
+++ b/src/usecases/jobs/CompleteJobUseCase.test.ts
@@ -1,0 +1,66 @@
+import { CompleteJobUseCase } from './CompleteJobUseCase';
+import JobRepository from '../../data_layer/JobRepository';
+
+describe('CompleteJobUseCase', () => {
+  it('marks the job as done instead of deleting it', async () => {
+    const updatedJob = {
+      id: 1,
+      object_id: 'page-1',
+      owner: 'user-a',
+      status: 'done',
+    };
+
+    const jobRepository = {
+      findJobById: jest.fn().mockResolvedValue({
+        id: 1,
+        object_id: 'page-1',
+        owner: 'user-a',
+        status: 'started',
+      }),
+      updateJobStatus: jest.fn().mockResolvedValue(updatedJob),
+      deleteJob: jest.fn(),
+    } as unknown as JobRepository;
+
+    const useCase = new CompleteJobUseCase(jobRepository);
+    const result = await useCase.execute('page-1', 'user-a');
+
+    expect(jobRepository.updateJobStatus).toHaveBeenCalledWith(
+      'page-1',
+      'user-a',
+      'done'
+    );
+    expect(jobRepository.deleteJob).not.toHaveBeenCalled();
+    expect(result).toEqual(updatedJob);
+  });
+
+  it('returns the job unchanged when already cancelled', async () => {
+    const cancelledJob = {
+      id: 1,
+      object_id: 'page-1',
+      owner: 'user-a',
+      status: 'cancelled',
+    };
+
+    const jobRepository = {
+      findJobById: jest.fn().mockResolvedValue(cancelledJob),
+      updateJobStatus: jest.fn(),
+    } as unknown as JobRepository;
+
+    const useCase = new CompleteJobUseCase(jobRepository);
+    const result = await useCase.execute('page-1', 'user-a');
+
+    expect(jobRepository.updateJobStatus).not.toHaveBeenCalled();
+    expect(result).toEqual(cancelledJob);
+  });
+
+  it('throws when the job does not exist', async () => {
+    const jobRepository = {
+      findJobById: jest.fn().mockResolvedValue(null),
+    } as unknown as JobRepository;
+
+    const useCase = new CompleteJobUseCase(jobRepository);
+    await expect(useCase.execute('missing', 'user-a')).rejects.toThrow(
+      'Job not found'
+    );
+  });
+});

--- a/src/usecases/jobs/CompleteJobUseCase.ts
+++ b/src/usecases/jobs/CompleteJobUseCase.ts
@@ -1,9 +1,10 @@
 import JobRepository from '../../data_layer/JobRepository';
+import Jobs from '../../data_layer/public/Jobs';
 
 export class CompleteJobUseCase {
   constructor(private readonly jobRepository: JobRepository) {}
 
-  async execute(jobId: string, owner: string): Promise<number> {
+  async execute(jobId: string, owner: string): Promise<Jobs> {
     const job = await this.jobRepository.findJobById(jobId, owner);
 
     if (!job) {
@@ -14,6 +15,6 @@ export class CompleteJobUseCase {
       return job;
     }
 
-    return this.jobRepository.deleteJob(job.id, owner);
+    return this.jobRepository.updateJobStatus(jobId, owner, 'done');
   }
 }

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -27,6 +27,13 @@ const renderAt = (path: string) =>
     </MemoryRouter>
   );
 
+describe('PricingPage Unlimited benefits', () => {
+  it('lists parallel conversions as a benefit', () => {
+    const { getByText } = renderAt('/pricing');
+    expect(getByText('Run multiple conversions at once')).toBeInTheDocument();
+  });
+});
+
 describe('PricingPage paywall telemetry', () => {
   beforeEach(() => {
     (globalThis as AnalyticsGlobals).hj = vi.fn();

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -95,6 +95,7 @@ export default function PricingPage({
           title="Unlimited"
           benefits={[
             'Unlimited flashcards',
+            'Run multiple conversions at once',
             'PDFs and large Notion exports',
             'Cancel anytime',
           ]}


### PR DESCRIPTION
## Summary

- **Conversion success tracking**: `CompleteJobUseCase` now marks jobs as `done` instead of deleting them. The `jobs` table finally records successes alongside failures, enabling conversion success rate measurement — the W19 retro's biggest data gap. `CheckJobLimitUseCase` updated to only count active jobs so done rows don't block free-tier users.
- **Scanner probe hardening**: `rejectScannerProbes` middleware returns 404 for `.php`, `.env`, `.asp`, `.bak`, `.sql`, etc. before the SPA catch-all serves `index.html` to vulnerability scanners (observed ~60 probe requests returning 200 in today's deploy logs).
- **Pricing bullet**: "Run multiple conversions at once" added to the Unlimited tier's benefits list — designer follow-up from #2106 since the paywall CTA now mentions the one-at-a-time limit.

## Test plan

- [x] `CompleteJobUseCase.test.ts` — marks done, skips cancelled, throws on missing
- [x] `CheckJobLimitUseCase.test.ts` — counts only active jobs, ignores all terminal statuses
- [x] `rejectScannerProbes.test.ts` — blocks .php/.env/.bak, passes legitimate paths, ignores POST
- [x] `PricingPage.test.tsx` — new bullet appears in rendered output
- [x] Full server suite (712 tests), full web suite (193 tests), tsc + biome lint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)