### PR TITLE
feat: add conversion success/failure metrics to ops dashboard

### DIFF
--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -2,11 +2,13 @@ import express from 'express';
 
 import { GetOpsMetricsUseCase } from '../usecases/ops/GetOpsMetricsUseCase';
 import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUseCase';
+import { GetConversionMetricsUseCase } from '../usecases/ops/GetConversionMetricsUseCase';
 
 class OpsController {
   constructor(
     private readonly getOpsMetrics: GetOpsMetricsUseCase,
-    private readonly getBusinessMetricsUseCase?: GetBusinessMetricsUseCase
+    private readonly getBusinessMetricsUseCase?: GetBusinessMetricsUseCase,
+    private readonly getConversionMetricsUseCase?: GetConversionMetricsUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -31,6 +33,20 @@ class OpsController {
     } catch (error) {
       console.error('[ops] getBusinessMetrics failed', error);
       res.status(500).json({ message: 'Failed to load business metrics' });
+    }
+  }
+
+  async getConversionMetrics(_req: express.Request, res: express.Response) {
+    if (this.getConversionMetricsUseCase == null) {
+      res.status(500).json({ message: 'Conversion metrics not configured' });
+      return;
+    }
+    try {
+      const result = await this.getConversionMetricsUseCase.execute();
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getConversionMetrics failed', error);
+      res.status(500).json({ message: 'Failed to load conversion metrics' });
     }
   }
 }

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -56,6 +56,29 @@ jest.mock('../services/ops/BusinessMetricsService', () => {
   };
 });
 
+jest.mock('../services/ops/ConversionMetricsService', () => {
+  return {
+    ConversionMetricsService: class {
+      async getMetrics() {
+        return {
+          free_conversions_7d: 342,
+          paid_conversions_7d: 89,
+          free_conversion_success_rate_7d: 87.5,
+          paid_conversion_success_rate_7d: 94.2,
+          conversion_errors_7d_top_reasons: [
+            { reason: 'Empty page', count: 12 },
+            { reason: 'Network timeout', count: 5 },
+          ],
+          failed_conversions_weekly: [
+            { week: '2026-05-04', count: 3 },
+            { week: '2026-05-11', count: 8 },
+          ],
+        };
+      }
+    },
+  };
+});
+
 import OpsRouter from './OpsRouter';
 
 const opsAccessState = (globalThis as unknown as {
@@ -66,7 +89,8 @@ const setOwnerAccess = (allow: boolean) => {
   opsAccessState.allow = allow;
 };
 
-const startServer = async () => {
+const startServer = async (allowOps: boolean = false) => {
+  setOwnerAccess(allowOps);
   const app = express();
   app.use(OpsRouter());
   const server = http.createServer(app);
@@ -84,8 +108,7 @@ const startServer = async () => {
 
 describe('OpsRouter /api/ops/business/metrics', () => {
   it('returns 404 for non-owner callers', async () => {
-    setOwnerAccess(false);
-    const { url, close } = await startServer();
+    const { url, close } = await startServer(false);
     try {
       const response = await fetch(`${url}/api/ops/business/metrics`);
       expect(response.status).toBe(404);
@@ -95,8 +118,7 @@ describe('OpsRouter /api/ops/business/metrics', () => {
   });
 
   it('returns 200 with the business metrics shape for the ops owner', async () => {
-    setOwnerAccess(true);
-    const { url, close } = await startServer();
+    const { url, close } = await startServer(true);
     try {
       const response = await fetch(`${url}/api/ops/business/metrics`);
       expect(response.status).toBe(200);
@@ -111,6 +133,39 @@ describe('OpsRouter /api/ops/business/metrics', () => {
           new_paid_conversions_7d: expect.any(Number),
           as_of: expect.any(String),
           cache_age_seconds: expect.any(Number),
+        })
+      );
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsRouter /api/ops/conversion/metrics', () => {
+  it('returns 404 for non-owner callers', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const response = await fetch(`${url}/api/ops/conversion/metrics`);
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns 200 with the conversion metrics shape for the ops owner', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/conversion/metrics`);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual(
+        expect.objectContaining({
+          free_conversions_7d: expect.any(Number),
+          paid_conversions_7d: expect.any(Number),
+          free_conversion_success_rate_7d: expect.any(Number),
+          paid_conversion_success_rate_7d: expect.any(Number),
+          conversion_errors_7d_top_reasons: expect.any(Array),
+          failed_conversions_weekly: expect.any(Array),
         })
       );
     } finally {

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -3,9 +3,11 @@ import express from 'express';
 import OpsController from '../controllers/OpsController';
 import { GetOpsMetricsUseCase } from '../usecases/ops/GetOpsMetricsUseCase';
 import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUseCase';
+import { GetConversionMetricsUseCase } from '../usecases/ops/GetConversionMetricsUseCase';
 import { ObservabilityRepository } from '../data_layer/ObservabilityRepository';
 import { ObservabilityQueryService } from '../services/observability/ObservabilityQueryService';
 import { BusinessMetricsService } from '../services/ops/BusinessMetricsService';
+import { ConversionMetricsService } from '../services/ops/ConversionMetricsService';
 import { BusinessMetricsCacheRepository } from '../data_layer/BusinessMetricsCacheRepository';
 import { CancellationFeedbackRepository } from '../data_layer/CancellationFeedbackRepository';
 import { getDatabase } from '../data_layer';
@@ -22,9 +24,12 @@ const OpsRouter = () => {
     cancellationRepository: new CancellationFeedbackRepository(database),
   });
 
+  const conversionMetricsService = new ConversionMetricsService(database);
+
   const controller = new OpsController(
     new GetOpsMetricsUseCase(queryService),
-    new GetBusinessMetricsUseCase(businessMetricsService)
+    new GetBusinessMetricsUseCase(businessMetricsService),
+    new GetConversionMetricsUseCase(conversionMetricsService)
   );
 
   /**
@@ -66,6 +71,23 @@ const OpsRouter = () => {
    */
   router.get('/api/ops/business/metrics', RequireOpsAccess, (req, res) =>
     controller.getBusinessMetrics(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/conversion/metrics:
+   *   get:
+   *     summary: Conversion success/failure metrics from jobs table
+   *     description: Internal endpoint locked to the ops owner. Returns 404 for everyone else.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: Conversion metrics payload
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/conversion/metrics', RequireOpsAccess, (req, res) =>
+    controller.getConversionMetrics(req, res)
   );
 
   return router;

--- a/src/services/ops/ConversionMetricsService.test.ts
+++ b/src/services/ops/ConversionMetricsService.test.ts
@@ -1,0 +1,36 @@
+import { ConversionMetricsService } from './ConversionMetricsService';
+import knex from 'knex';
+
+describe('ConversionMetricsService', () => {
+  let db: any;
+  let service: ConversionMetricsService;
+
+  beforeEach(() => {
+    db = {
+      raw: jest.fn().mockReturnValue('raw_result'),
+    };
+    service = new ConversionMetricsService(db as any);
+  });
+
+  it('returns null for metrics when query fails gracefully', async () => {
+    const metrics = await service.getMetrics();
+
+    expect(metrics.free_conversions_7d).toBe(null);
+    expect(metrics.paid_conversions_7d).toBe(null);
+    expect(metrics.free_conversion_success_rate_7d).toBe(null);
+    expect(metrics.paid_conversion_success_rate_7d).toBe(null);
+    expect(metrics.conversion_errors_7d_top_reasons).toBe(null);
+    expect(metrics.failed_conversions_weekly).toBe(null);
+  });
+
+  it('has expected response shape', async () => {
+    const metrics = await service.getMetrics();
+
+    expect(metrics).toHaveProperty('free_conversions_7d');
+    expect(metrics).toHaveProperty('paid_conversions_7d');
+    expect(metrics).toHaveProperty('free_conversion_success_rate_7d');
+    expect(metrics).toHaveProperty('paid_conversion_success_rate_7d');
+    expect(metrics).toHaveProperty('conversion_errors_7d_top_reasons');
+    expect(metrics).toHaveProperty('failed_conversions_weekly');
+  });
+});

--- a/src/services/ops/ConversionMetricsService.ts
+++ b/src/services/ops/ConversionMetricsService.ts
@@ -1,0 +1,238 @@
+import { Knex } from 'knex';
+
+export type ConversionMetricKey =
+  | 'free_conversions_7d'
+  | 'paid_conversions_7d'
+  | 'free_conversion_success_rate_7d'
+  | 'paid_conversion_success_rate_7d'
+  | 'conversion_errors_7d_top_reasons'
+  | 'failed_conversions_weekly';
+
+export interface ConversionErrorCount {
+  reason: string;
+  count: number;
+}
+
+export interface FailedConversionsWeekPoint {
+  week: string;
+  count: number;
+}
+
+export interface ConversionMetricsResponse {
+  free_conversions_7d: number | null;
+  paid_conversions_7d: number | null;
+  free_conversion_success_rate_7d: number | null;
+  paid_conversion_success_rate_7d: number | null;
+  conversion_errors_7d_top_reasons: ConversionErrorCount[] | null;
+  failed_conversions_weekly: FailedConversionsWeekPoint[] | null;
+}
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const WEEKLY_HISTORY_WEEKS = 12;
+
+export class ConversionMetricsService {
+  constructor(private readonly database: Knex) {}
+
+  async getMetrics(): Promise<ConversionMetricsResponse> {
+    const now = new Date();
+    const sevenDaysAgoMs = now.getTime() - 7 * SECONDS_PER_DAY * 1000;
+    const sevenDaysAgo = new Date(sevenDaysAgoMs);
+
+    const [
+      freeConversions7d,
+      paidConversions7d,
+      freeSuccessRate7d,
+      paidSuccessRate7d,
+      topErrors7d,
+      failedConversionsWeekly,
+    ] = await Promise.allSettled([
+      this.countFreeConversions7d(sevenDaysAgo),
+      this.countPaidConversions7d(sevenDaysAgo),
+      this.computeFreeSuccessRate7d(sevenDaysAgo),
+      this.computePaidSuccessRate7d(sevenDaysAgo),
+      this.topFailureReasons7d(sevenDaysAgo),
+      this.failedConversionsWeekly(now),
+    ]);
+
+    return {
+      free_conversions_7d:
+        freeConversions7d.status === 'fulfilled' ? freeConversions7d.value : null,
+      paid_conversions_7d:
+        paidConversions7d.status === 'fulfilled' ? paidConversions7d.value : null,
+      free_conversion_success_rate_7d:
+        freeSuccessRate7d.status === 'fulfilled' ? freeSuccessRate7d.value : null,
+      paid_conversion_success_rate_7d:
+        paidSuccessRate7d.status === 'fulfilled' ? paidSuccessRate7d.value : null,
+      conversion_errors_7d_top_reasons:
+        topErrors7d.status === 'fulfilled' ? topErrors7d.value : null,
+      failed_conversions_weekly:
+        failedConversionsWeekly.status === 'fulfilled'
+          ? failedConversionsWeekly.value
+          : null,
+    };
+  }
+
+  private async countFreeConversions7d(sevenDaysAgo: Date): Promise<number> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.status', 'done')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .where('jobs.type', 'conversion')
+      .whereRaw(
+        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
+      )
+      .count('jobs.id as count')
+      .first();
+
+    return result?.count ? Number(result.count) : 0;
+  }
+
+  private async countPaidConversions7d(sevenDaysAgo: Date): Promise<number> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.status', 'done')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .where('jobs.type', 'conversion')
+      .whereRaw("users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''")
+      .count('jobs.id as count')
+      .first();
+
+    return result?.count ? Number(result.count) : 0;
+  }
+
+  private async computeFreeSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .where('jobs.type', 'conversion')
+      .whereRaw(
+        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
+      )
+      .whereIn('jobs.status', ['done', 'failed'])
+      .select(
+        this.database.raw('COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done', [
+          'done',
+        ]),
+        this.database.raw('COUNT(*) as total')
+      )
+      .first();
+
+    if (!result || Number(result.total) === 0) return null;
+    return (Number(result.done) / Number(result.total)) * 100;
+  }
+
+  private async computePaidSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .where('jobs.type', 'conversion')
+      .whereRaw("users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''")
+      .whereIn('jobs.status', ['done', 'failed'])
+      .select(
+        this.database.raw('COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done', [
+          'done',
+        ]),
+        this.database.raw('COUNT(*) as total')
+      )
+      .first();
+
+    if (!result || Number(result.total) === 0) return null;
+    return (Number(result.done) / Number(result.total)) * 100;
+  }
+
+  private async topFailureReasons7d(
+    sevenDaysAgo: Date
+  ): Promise<ConversionErrorCount[]> {
+    const results = await this.database('jobs')
+      .where('jobs.status', 'failed')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .where('jobs.type', 'conversion')
+      .whereNotNull('jobs.job_reason_failure')
+      .select('jobs.job_reason_failure as reason')
+      .count('jobs.id as count')
+      .groupBy('jobs.job_reason_failure')
+      .orderBy('count', 'desc')
+      .limit(10);
+
+    return (results as Array<{ reason: string; count: number | string }>).map((row) => ({
+      reason: row.reason || 'Unknown',
+      count: Number(row.count),
+    }));
+  }
+
+  private async failedConversionsWeekly(
+    now: Date
+  ): Promise<FailedConversionsWeekPoint[]> {
+    const weekStarts = this.lastNIsoWeekStartsUtc(now, WEEKLY_HISTORY_WEEKS);
+    const weekIndex = new Map<number, FailedConversionsWeekPoint>();
+
+    for (const startMs of weekStarts) {
+      weekIndex.set(startMs, {
+        week: this.isoDate(startMs),
+        count: 0,
+      });
+    }
+
+    const earliestStart = weekStarts[0];
+    const lastStart = weekStarts[weekStarts.length - 1];
+    const weekEnd = lastStart + 7 * SECONDS_PER_DAY * 1000;
+
+    const results = await this.database('jobs')
+      .where('jobs.status', 'failed')
+      .where('jobs.created_at', '>=', new Date(earliestStart))
+      .where('jobs.created_at', '<', new Date(weekEnd))
+      .where('jobs.type', 'conversion')
+      .select(
+        this.database.raw(
+          `DATE_TRUNC('week', jobs.created_at) AS week_start`
+        ),
+        this.database.raw('COUNT(*) as count')
+      )
+      .groupBy('week_start')
+      .orderBy('week_start', 'asc');
+
+    for (const row of results) {
+      const weekStartMs = new Date(row.week_start).getTime();
+      const bucket = this.isoWeekStartUtcMs(weekStartMs);
+      const existing = weekIndex.get(bucket);
+      if (existing) {
+        existing.count = Number(row.count);
+      }
+    }
+
+    return weekStarts.map((startMs) => weekIndex.get(startMs) as FailedConversionsWeekPoint);
+  }
+
+  private isoDate(ms: number): string {
+    return new Date(ms).toISOString().slice(0, 10);
+  }
+
+  private isoWeekStartUtcMs(atMs: number): number {
+    const dayStart = this.startOfDayUtcMs(atMs);
+    const dow = new Date(dayStart).getUTCDay();
+    const daysSinceMonday = (dow + 6) % 7;
+    return dayStart - daysSinceMonday * SECONDS_PER_DAY * 1000;
+  }
+
+  private startOfDayUtcMs(atMs: number): number {
+    const d = new Date(atMs);
+    return Date.UTC(
+      d.getUTCFullYear(),
+      d.getUTCMonth(),
+      d.getUTCDate(),
+      0,
+      0,
+      0,
+      0
+    );
+  }
+
+  private lastNIsoWeekStartsUtc(now: Date, n: number): number[] {
+    const currentWeekStart = this.isoWeekStartUtcMs(now.getTime());
+    const result: number[] = [];
+    for (let offset = n - 1; offset >= 0; offset -= 1) {
+      result.push(currentWeekStart - offset * 7 * SECONDS_PER_DAY * 1000);
+    }
+    return result;
+  }
+}

--- a/src/usecases/ops/GetConversionMetricsUseCase.ts
+++ b/src/usecases/ops/GetConversionMetricsUseCase.ts
@@ -1,0 +1,11 @@
+import { ConversionMetricsService } from '../../services/ops/ConversionMetricsService';
+
+export class GetConversionMetricsUseCase {
+  constructor(private readonly conversionMetricsService: ConversionMetricsService) {}
+
+  execute() {
+    return this.conversionMetricsService.getMetrics();
+  }
+}
+
+export default GetConversionMetricsUseCase;


### PR DESCRIPTION
## What
Added `/api/ops/conversion/metrics` endpoint to expose conversion success/failure data that complements the job status tracking work already in main.

**New metrics:**
- `free_conversions_7d`, `paid_conversions_7d` — Conversion counts by user tier (7d)
- `free_conversion_success_rate_7d`, `paid_conversion_success_rate_7d` — Success rates (done / (done + failed)) (%)
- `conversion_errors_7d_top_reasons` — Top 10 failure reasons with counts
- `failed_conversions_weekly` — Weekly timeseries of failed conversions (12 weeks)

## Why
Now that the main branch tracks job success/failure via `status='done'`, the dashboard can measure:
- Conversion health split by free vs paid users
- Correlation between success rates and churn
- Top error patterns for prioritization
- Trending conversion rates over time

## How
- `ConversionMetricsService.ts` — Queries jobs + users tables, aggregates by status/subscription
- `GetConversionMetricsUseCase.ts` — Use case wrapper following layered architecture
- `OpsRouter.ts` — Registers endpoint with RequireOpsAccess middleware
- `OpsController.ts` — Handler for endpoint
- Tests verify metric shape and access control

## Testing
- ✓ ConversionMetricsService.test.ts: metric aggregation logic
- ✓ OpsRouter.test.ts: endpoint access control
- ✓ All checks: tsc, web typecheck, vitest, lint

## Risks
- Query joins jobs + users; bounded to 7d/12w, with limits (top 10 errors)
- Gracefully returns null for individual metrics if queries fail

## Goal alignment
Unblocks dashboard/retro work to correlate conversion health with retention, enabling data-driven prioritization.