### PR TITLE
fix(ci): keep workflow files as-ours in dependabot sync

### DIFF
--- a/.github/workflows/dependabot-sync-from-main.yml
+++ b/.github/workflows/dependabot-sync-from-main.yml
@@ -55,6 +55,13 @@ jobs:
                 git checkout --ours "$f"
                 git add "$f"
                 ;;
+              .github/workflows/*)
+                # GITHUB_TOKEN lacks `workflows` permission to push
+                # workflow changes — keep ours, main's version arrives
+                # via the merge-back PR
+                git checkout --ours "$f"
+                git add "$f"
+                ;;
               *.yml|*.yaml)
                 git checkout --theirs "$f"
                 git add "$f"


### PR DESCRIPTION
## Summary
- Fixes the `dependabot-sync-from-main` workflow failing with `refusing to allow a GitHub App to create or update workflow without workflows permission`
- Adds a `.github/workflows/*` case before the generic `*.yml` catch-all so workflow file conflicts resolve as "ours" (keep dependabot-updates version) instead of "theirs" (main's version)
- The `GITHUB_TOKEN` can't be granted `workflows` permission, so pushing workflow changes from this job will always fail — main's workflow changes arrive via the merge-back PR instead

## Test plan
- [ ] Re-run the sync workflow after merge and confirm it no longer fails on workflow file conflicts
- [ ] Verify non-workflow YAML conflicts still resolve as theirs (main wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)