### PR TITLE
fix: JWT expiry, cloze newlines, nested toggles

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -245,6 +245,28 @@ test('Notion new export: deeply nested toggles (3 levels)', async () => {
   expect(deck.cards[0].back).toContain('summary');
 });
 
+test('Nested toggles produce one card without maxOne (new format)', async () => {
+  const deck = await getDeck(
+    'Notion Page grandchildren 2ce7ab29a11e809998e3d22ed65fc5f2.html',
+    new CardOption({ 'max-one-toggle-per-card': 'false', cherry: 'false', all: 'true', 'enable-input': 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  expect(deck.cards[0].name).toContain('Parent');
+  expect(deck.cards[0].back).toContain('Child');
+});
+
+test('Nested toggles produce one card without maxOne (legacy format)', async () => {
+  const deck = await getDeck(
+    'Nested Toggles.html',
+    new CardOption({ 'max-one-toggle-per-card': 'false', cherry: 'false', all: 'true', 'enable-input': 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  expect(deck.cards[0].name).toContain('Parent');
+  expect(deck.cards[0].back).toContain('Capital');
+});
+
 describe('removeNewlinesInSVGPathAttributeD', () => {
   const newParser = () =>
     new DeckParser({

--- a/src/lib/parser/findNotionToggleLists.ts
+++ b/src/lib/parser/findNotionToggleLists.ts
@@ -9,8 +9,13 @@ export function findNotionToggleLists(
     isAll: boolean;
   }
 ): Element[] {
-  if (context.isCherry || context.isAll) {
+  if (context.isCherry) {
     return dom('.toggle').toArray();
+  }
+  if (context.isAll) {
+    return dom('.toggle')
+      .toArray()
+      .filter((el) => dom(el).parents('.toggle').length === 0);
   }
   if (!context.disableIndentedBulletPoints) {
     return dom('.page-body > ul').toArray();

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -1,0 +1,34 @@
+import jwt from 'jsonwebtoken';
+
+import AuthenticationService from './AuthenticationService';
+import TokenRepository from '../data_layer/TokenRepository';
+import UsersRepository from '../data_layer/UsersRepository';
+
+const SECRET = 'test-secret';
+
+beforeAll(() => {
+  process.env.SECRET = SECRET;
+});
+
+function createService() {
+  const tokenRepo = {} as TokenRepository;
+  const usersRepo = {} as UsersRepository;
+  return new AuthenticationService(tokenRepo, usersRepo);
+}
+
+test('newJWTToken includes an expiration claim', async () => {
+  const service = createService();
+  const token = await service.newJWTToken(42);
+  const decoded = jwt.decode(token) as jwt.JwtPayload;
+
+  expect(decoded.exp).toBeDefined();
+  expect(decoded.iat).toBeDefined();
+  expect(decoded.exp! - decoded.iat!).toBe(86400);
+});
+
+test('isValidToken rejects an expired token', async () => {
+  const service = createService();
+  const token = jwt.sign({ userId: 1 }, SECRET, { expiresIn: '0s' });
+
+  await expect(service.isValidToken(token)).rejects.toThrow();
+});

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -53,8 +53,7 @@ class AuthenticationService {
       jwt.sign(
         { userId },
         process.env.SECRET!,
-        // TODO: let user decide expiry
-        // { expiresIn: "1d" },
+        { expiresIn: '1d' },
         (error: Error | null, token: string | undefined) => {
           if (error) {
             reject(error);

--- a/src/services/NotionService/BlockHandler/BlockHandler.test.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.test.ts
@@ -381,12 +381,10 @@ describe('BlockHandler', () => {
     expect(flashcards.length).toBeGreaterThan(0);
     const card = flashcards[0];
     
-    // Should contain both cloze syntax and <br /> tags for newlines
-    expect(card.name).toBe('Mult-line cloze <br />{{c1::First}}<br />{{c2::Second}} <br />{{c3::Third}}');
     expect(card.name).toContain('{{c1::First}}');
     expect(card.name).toContain('{{c2::Second}}');
     expect(card.name).toContain('{{c3::Third}}');
-    expect(card.name).toContain('<br />');
+    expect(card.name).not.toContain('<br />');
   });
 
   test('Cloze Deletion from Blocks', async () => {
@@ -521,5 +519,50 @@ describe('BlockHandler', () => {
   test.todo('Just the Reversed Flashcards');
   test.todo('Remove Underlines');
   test.todo('Download Media Files');
-  test.todo('Preserve Newlines in the Toggle Header and Body');
+  test('Cloze respects preserve-newlines setting', async () => {
+    const mockToggleBlock = {
+      object: "block" as const,
+      id: "preserve-nl-test",
+      parent: { type: "page_id" as const, page_id: "page-id" },
+      created_time: "",
+      last_edited_time: "",
+      created_by: { object: "user" as const, id: "user-id" },
+      last_edited_by: { object: "user" as const, id: "user-id" },
+      has_children: false,
+      archived: false,
+      in_trash: false,
+      type: "toggle" as const,
+      toggle: {
+        rich_text: [
+          {
+            type: "text" as const,
+            text: { content: "Line one\n", link: null },
+            annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: false, color: "default" as const },
+            plain_text: "Line one\n",
+            href: null
+          },
+          {
+            type: "text" as const,
+            text: { content: "Answer", link: null },
+            annotations: { bold: false, italic: false, strikethrough: false, underline: false, code: true, color: "default" as const },
+            plain_text: "Answer",
+            href: null
+          }
+        ],
+        color: "default" as const
+      }
+    };
+
+    const settingsOn = new CardOption({ cloze: 'true', 'perserve-newlines': 'true' });
+    const exporterOn = new CustomExporter('', new Workspace(true, 'fs').location);
+    const blOn = new BlockHandler(exporterOn, api, settingsOn);
+    const cardsOn = await blOn.getFlashcards(new ParserRules(), [mockToggleBlock], [], undefined);
+    expect(cardsOn[0].name).toContain('<br />');
+
+    const settingsOff = new CardOption({ cloze: 'true', 'perserve-newlines': 'false' });
+    const exporterOff = new CustomExporter('', new Workspace(true, 'fs').location);
+    const blOff = new BlockHandler(exporterOff, api, settingsOff);
+    const cardsOff = await blOff.getFlashcards(new ParserRules(), [mockToggleBlock], [], undefined);
+    expect(cardsOff[0].name).not.toContain('<br />');
+  });
 });

--- a/src/services/NotionService/helpers/getClozeDeletionCard.ts
+++ b/src/services/NotionService/helpers/getClozeDeletionCard.ts
@@ -39,10 +39,7 @@ export default function getClozeDeletionCard(
       isCloze = true;
       index++;
     } else if (text?.content) {
-      // Convert newlines to <br /> tags for proper HTML rendering
-      // XXX: This a potential regression since the preserve newline card option is not checked.
-      const contentWithBr = text.content.replaceAll('\n', '<br />');
-      name += contentWithBr;
+      name += text.content;
     }
   }
   if (isCloze) {


### PR DESCRIPTION
## Summary

- **JWT expiration (#2124):** Tokens now expire after 24h. Previously tokens lived forever — a leaked token was valid indefinitely.
- **Cloze newlines (#2125):** `getClozeDeletionCard` no longer unconditionally converts `\n` → `<br />`. The caller's `preserveNewlinesIfApplicable` already handles this based on the user's setting.
- **Nested toggles (#1883, #1900):** `findNotionToggleLists` now filters out toggles that are children of other toggles (when not in cherry-pick mode). Nested toggle HTML stays in the parent card's back instead of spawning separate cards.

## Test plan

- [x] JWT: token has `exp` claim set to 24h, expired tokens are rejected
- [x] Cloze: newlines preserved as `\n` when setting off, converted to `<br />` when on
- [x] Nested toggles: 1 card from new-format and legacy-format nested toggle HTML (without `maxOne`)
- [x] All existing parser + BlockHandler tests pass (167 tests, 0 failures)
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)