### PR TITLE
feat: add deck-to-printable-PDF export

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "express-session": "^1.18.1",
     "fflate": "^0.8.0",
     "find-remove": "^5.0.0",
+    "fzstd": "^0.1.1",
     "get-notion-object-title": "^0.2.0",
     "html-to-text": "^10.0.0",
     "http-proxy-middleware": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "multer": "^2.0.1",
     "nodemailer": "^8.0.1",
     "pg": "^8.11.3",
+    "puppeteer": "^24.43.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "sanitize-html": "^2.17.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       find-remove:
         specifier: ^5.0.0
         version: 5.1.1
+      fzstd:
+        specifier: ^0.1.1
+        version: 0.1.1
       get-notion-object-title:
         specifier: ^0.2.0
         version: 0.2.9
@@ -4046,6 +4049,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fzstd@0.1.1:
+    resolution: {integrity: sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==}
 
   gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
@@ -11406,6 +11412,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fzstd@0.1.1: {}
 
   gaxios@6.7.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 1.4.9
       '@anthropic-ai/sdk':
         specifier: ^0.95.2
-        version: 0.95.2
+        version: 0.95.2(zod@3.25.76)
       '@google-cloud/vertexai':
         specifier: ^1.9.0
         version: 1.12.0
@@ -130,6 +130,9 @@ importers:
       pg:
         specifier: ^8.11.3
         version: 8.20.0
+      puppeteer:
+        specifier: ^24.43.1
+        version: 24.43.1(typescript@6.0.3)
       react:
         specifier: ^19.2.5
         version: 19.2.6
@@ -1828,6 +1831,11 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -2299,6 +2307,9 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
@@ -2854,6 +2865,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
@@ -2996,6 +3011,10 @@ packages:
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
     engines: {node: '>= 0.8'}
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -3210,6 +3229,11 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
   chrono-node@2.9.0:
     resolution: {integrity: sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3367,6 +3391,15 @@ packages:
       typescript:
         optional: true
 
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
@@ -3473,6 +3506,10 @@ packages:
     resolution: {integrity: sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==}
     engines: {node: '>= 14'}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   data-uri-utils@1.0.13:
     resolution: {integrity: sha512-AjIQGQHlTnjnw7w21Marztmku1lijIVA3QXvPPHTRVdMaASI1LeYB9X+HEkGCnKjn5OnHhUhucpdeC3rUpJR0g==}
     engines: {node: '>= 14'}
@@ -3565,6 +3602,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -3590,6 +3631,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
@@ -3768,6 +3812,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
@@ -3776,6 +3825,10 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
@@ -3861,6 +3914,11 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3888,6 +3946,9 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -4043,6 +4104,10 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   getopts@2.3.0:
     resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
@@ -4313,6 +4378,10 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ip-regex@4.3.0:
     resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
@@ -4924,6 +4993,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -5213,6 +5286,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -5276,6 +5352,10 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
@@ -5439,6 +5519,14 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -5678,6 +5766,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
@@ -5688,6 +5780,13 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -5709,6 +5808,15 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
+
+  puppeteer@24.43.1:
+    resolution: {integrity: sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
@@ -6137,12 +6245,24 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smartquotes@2.3.2:
     resolution: {integrity: sha512-0R6YJ5hLpDH4mZR7N5eZ12oCMLspvGOHL9A9SEm2e3b/CQmQidekW4SWSKEmor/3x6m3NCBBEqLzikcZC9VJNQ==}
     engines: {node: '>=4.0.0'}
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6357,6 +6477,9 @@ packages:
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -6554,6 +6677,9 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -6816,6 +6942,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -6969,6 +7098,9 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
   yauzl@3.3.0:
     resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
     engines: {node: '>=12'}
@@ -7001,6 +7133,9 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7012,10 +7147,12 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@anthropic-ai/sdk@0.95.2':
+  '@anthropic-ai/sdk@0.95.2(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 3.25.76
 
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
@@ -8895,6 +9032,21 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.8.0
+      tar-fs: 3.1.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -9453,6 +9605,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -10036,6 +10190,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -10205,6 +10363,8 @@ snapshots:
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
+
+  basic-ftp@5.3.1: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -10462,6 +10622,12 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
+
   chrono-node@2.9.0: {}
 
   ci-info@4.4.0: {}
@@ -10596,6 +10762,15 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  cosmiconfig@9.0.1(typescript@6.0.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 6.0.3
+
   cpu-features@0.0.10:
     dependencies:
       buildcheck: 0.0.7
@@ -10694,6 +10869,8 @@ snapshots:
 
   data-uri-to-buffer@5.0.1: {}
 
+  data-uri-to-buffer@6.0.2: {}
+
   data-uri-utils@1.0.13:
     dependencies:
       data-uri-to-buffer: 5.0.1
@@ -10764,6 +10941,12 @@ snapshots:
 
   defu@6.1.7: {}
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -10779,6 +10962,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  devtools-protocol@0.0.1608973: {}
 
   diff@4.0.4: {}
 
@@ -10966,9 +11151,19 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   esm@3.2.25: {}
 
   esprima@4.0.1: {}
+
+  estraverse@5.3.0: {}
 
   estree-util-is-identifier-name@3.0.0: {}
 
@@ -11090,6 +11285,16 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -11115,6 +11320,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -11275,6 +11484,14 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
 
   getopts@2.3.0: {}
 
@@ -11634,6 +11851,8 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ip-address@10.2.0: {}
 
   ip-regex@4.3.0: {}
 
@@ -12434,6 +12653,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -12954,6 +13175,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mitt@3.0.1: {}
+
   mkdirp-classic@0.5.3: {}
 
   morgan@1.10.1:
@@ -13000,6 +13223,8 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
+
+  netmask@2.1.1: {}
 
   no-case@3.0.4:
     dependencies:
@@ -13167,6 +13392,24 @@ snapshots:
       retry: 0.13.1
 
   p-try@2.2.0: {}
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@5.5.0)
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
 
   package-json-from-dist@1.0.1: {}
 
@@ -13404,6 +13647,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   property-information@7.1.0: {}
 
   protobufjs@7.5.5:
@@ -13426,6 +13671,21 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@5.5.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
   proxy-from-env@2.1.0: {}
 
   pstree.remy@1.1.8: {}
@@ -13440,6 +13700,40 @@ snapshots:
   punycode@1.3.2: {}
 
   punycode@2.3.1: {}
+
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3(supports-color@5.5.0)
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  puppeteer@24.43.1(typescript@6.0.3):
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      devtools-protocol: 0.0.1608973
+      puppeteer-core: 24.43.1
+      typed-query-selector: 2.12.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - typescript
+      - utf-8-validate
 
   pure-rand@7.0.1: {}
 
@@ -13972,12 +14266,27 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smart-buffer@4.2.0: {}
+
   smartquotes@2.3.2: {}
 
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@5.5.0)
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
 
@@ -14226,6 +14535,18 @@ snapshots:
       pump: 3.0.4
       tar-stream: 2.2.0
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.6.0
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -14417,6 +14738,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typed-query-selector@2.12.2: {}
 
   typedarray@0.0.6: {}
 
@@ -14670,6 +14993,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
@@ -14801,6 +15126,11 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
   yauzl@3.3.0:
     dependencies:
       buffer-crc32: 0.2.13
@@ -14834,5 +15164,7 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -3,6 +3,10 @@ import path from 'path';
 import StorageHandler from '../lib/storage/StorageHandler';
 import DownloadService from '../services/DownloadService';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
+import PdfRenderService from '../services/PdfRenderService';
+import ExportApkgToPdfUseCase, {
+  CardLimitExceededError,
+} from '../usecases/apkg/ExportApkgToPdfUseCase';
 import sendErrorResponse from '../lib/sendErrorResponse';
 
 const MEDIA_CONTENT_TYPES: Record<string, string> = {
@@ -53,7 +57,8 @@ function isApkg(key: string): boolean {
 class ApkgController {
   constructor(
     private readonly downloadService: DownloadService,
-    private readonly previewService: ApkgPreviewService
+    private readonly previewService: ApkgPreviewService,
+    private readonly pdfRenderService: PdfRenderService = new PdfRenderService()
   ) {}
 
   private async loadForKey(req: Request, res: Response) {
@@ -144,6 +149,56 @@ class ApkgController {
       console.info('APKG preview media failed');
       console.error(error);
       sendErrorResponse(error, res);
+    }
+  }
+
+  async exportPdf(req: Request, res: Response) {
+    try {
+      const file = req.file;
+      if (file == null) {
+        res.status(400).json({ message: 'No file uploaded.' });
+        return;
+      }
+      if (!isApkg(file.originalname)) {
+        res.status(400).json({ message: 'File must be an .apkg file.' });
+        return;
+      }
+      const fs = await import('fs/promises');
+      let fileBuffer: Buffer;
+      try {
+        fileBuffer = await fs.readFile(file.path);
+      } finally {
+        await fs.unlink(file.path).catch(() => {});
+      }
+      const useCase = new ExportApkgToPdfUseCase(
+        this.previewService,
+        this.pdfRenderService
+      );
+      const result = await useCase.execute(fileBuffer);
+      const safeName = file.originalname
+        .replace(/\.apkg$/i, '')
+        .replace(/[^\w\s.-]/g, '_');
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="${safeName}.pdf"`
+      );
+      res.send(result.pdf);
+    } catch (error) {
+      if (error instanceof CardLimitExceededError) {
+        res.status(400).json({ message: error.message });
+        return;
+      }
+      if (
+        error instanceof Error &&
+        (error.message.includes('No Anki collection') ||
+          error.message.includes('open failed'))
+      ) {
+        res.status(400).json({ message: 'Invalid .apkg file' });
+        return;
+      }
+      console.error(error);
+      res.status(500).json({ message: 'PDF generation failed.' });
     }
   }
 }

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -163,7 +163,7 @@ class ApkgController {
         res.status(400).json({ message: 'File must be an .apkg file.' });
         return;
       }
-      const fs = await import('fs/promises');
+      const fs = await import('node:fs/promises');
       let fileBuffer: Buffer;
       try {
         fileBuffer = await fs.readFile(file.path);

--- a/src/routes/ApkgRouter.ts
+++ b/src/routes/ApkgRouter.ts
@@ -3,6 +3,7 @@ import multer from 'multer';
 
 import RequireAuthentication from './middleware/RequireAuthentication';
 import RequireAllowedOrigin from './middleware/RequireAllowedOrigin';
+import { isPaying } from '../lib/isPaying';
 import ApkgController from '../controllers/ApkgController';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
 import DownloadService from '../services/DownloadService';
@@ -143,6 +144,13 @@ const ApkgRouter = () => {
   router.post(
     '/api/apkg/pdf',
     RequireAllowedOrigin,
+    RequireAuthentication,
+    (req, res, next) => {
+      if (isPaying(res.locals)) return next();
+      return res.status(403).json({
+        message: 'PDF export is available to subscribers and lifetime members.',
+      });
+    },
     pdfUpload.single('file'),
     (req, res) => controller.exportPdf(req, res)
   );

--- a/src/routes/ApkgRouter.ts
+++ b/src/routes/ApkgRouter.ts
@@ -1,6 +1,8 @@
 import express from 'express';
+import multer from 'multer';
 
 import RequireAuthentication from './middleware/RequireAuthentication';
+import RequireAllowedOrigin from './middleware/RequireAllowedOrigin';
 import ApkgController from '../controllers/ApkgController';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
 import DownloadService from '../services/DownloadService';
@@ -131,6 +133,18 @@ const ApkgRouter = () => {
     '/api/apkg/:key/media/:name',
     RequireAuthentication,
     (req, res) => controller.getMedia(req, res)
+  );
+
+  const pdfUpload = multer({
+    dest: process.env.UPLOAD_BASE ?? '/tmp',
+    limits: { fileSize: 100 * 1024 * 1024 },
+  });
+
+  router.post(
+    '/api/apkg/pdf',
+    RequireAllowedOrigin,
+    pdfUpload.single('file'),
+    (req, res) => controller.exportPdf(req, res)
   );
 
   return router;

--- a/src/services/ApkgPreviewService/extractApkg.test.ts
+++ b/src/services/ApkgPreviewService/extractApkg.test.ts
@@ -93,11 +93,19 @@ describe('extractApkg + parseCollection composition', () => {
     expect(() => parseCollection(apkg)).toThrow(/not a database/i);
   });
 
-  it('rejects zstd-compressed Anki 23.10+ archives with a clear message', async () => {
-    const apkg = await buildApkgZip(
-      'collection.anki21b',
-      Buffer.from('zstd-compressed-bytes-here')
-    );
-    await expect(extractApkg(apkg)).rejects.toThrow(/zstd-compressed/i);
+  it('decompresses zstd-compressed collection.anki21b archives', async () => {
+    const zlib = await import('zlib');
+    const { promisify } = await import('util');
+    const zstdCompress = promisify(zlib.zstdCompress);
+    const sqliteBuffer = buildLegacyCollectionBuffer();
+    const compressed = await zstdCompress(sqliteBuffer);
+    const apkg = await buildApkgZip('collection.anki21b', compressed);
+
+    const archive = await extractApkg(apkg);
+    const collection = parseCollection(archive.collectionBuffer);
+
+    expect(archive.collectionName).toBe('collection.anki21b');
+    expect(collection.notes.size).toBe(1);
+    expect(collection.notes.get(10)?.fields).toEqual(['hello', 'world']);
   });
 });

--- a/src/services/ApkgPreviewService/extractApkg.ts
+++ b/src/services/ApkgPreviewService/extractApkg.ts
@@ -1,6 +1,8 @@
 import { decompress as zstdDecompress } from 'fzstd';
 import yauzl from 'yauzl';
 
+import { readRepeatedSubmessages, readString } from './protobuf';
+
 export interface ApkgArchive {
   collectionBuffer: Buffer;
   collectionName: string;
@@ -93,86 +95,14 @@ function isZstdCompressed(buf: Buffer): boolean {
 
 function parseProtobufMediaManifest(buf: Buffer): Map<string, string> {
   const map = new Map<string, string>();
-  let entryIndex = 0;
-  let pos = 0;
-  while (pos < buf.length) {
-    let tag = 0;
-    let shift = 0;
-    while (pos < buf.length) {
-      const b = buf[pos++];
-      tag |= (b & 0x7f) << shift;
-      shift += 7;
-      if ((b & 0x80) === 0) break;
-    }
-    const wireType = tag & 7;
-    if (wireType === 2) {
-      let len = 0;
-      let lenShift = 0;
-      while (pos < buf.length) {
-        const b = buf[pos++];
-        len |= (b & 0x7f) << lenShift;
-        lenShift += 7;
-        if ((b & 0x80) === 0) break;
-      }
-      if ((tag >> 3) === 1) {
-        const sub = buf.subarray(pos, pos + len);
-        const name = readSubmessageString(sub, 1);
-        if (name) {
-          map.set(name, String(entryIndex));
-          entryIndex++;
-        }
-      }
-      pos += len;
-    } else if (wireType === 0) {
-      while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
-    } else if (wireType === 5) {
-      pos += 4;
-    } else if (wireType === 1) {
-      pos += 8;
-    } else {
-      break;
+  const entries = readRepeatedSubmessages(buf, 1);
+  for (let i = 0; i < entries.length; i++) {
+    const name = readString(entries[i], 1);
+    if (name) {
+      map.set(name, String(i));
     }
   }
   return map;
-}
-
-function readSubmessageString(buf: Buffer, fieldNumber: number): string {
-  const wantTag = (fieldNumber << 3) | 2;
-  let pos = 0;
-  while (pos < buf.length) {
-    let tag = 0;
-    let shift = 0;
-    while (pos < buf.length) {
-      const b = buf[pos++];
-      tag |= (b & 0x7f) << shift;
-      shift += 7;
-      if ((b & 0x80) === 0) break;
-    }
-    const wireType = tag & 7;
-    if (wireType === 2) {
-      let len = 0;
-      let lenShift = 0;
-      while (pos < buf.length) {
-        const b = buf[pos++];
-        len |= (b & 0x7f) << lenShift;
-        lenShift += 7;
-        if ((b & 0x80) === 0) break;
-      }
-      if (tag === wantTag) {
-        return buf.subarray(pos, pos + len).toString('utf8');
-      }
-      pos += len;
-    } else if (wireType === 0) {
-      while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
-    } else if (wireType === 5) {
-      pos += 4;
-    } else if (wireType === 1) {
-      pos += 8;
-    } else {
-      break;
-    }
-  }
-  return '';
 }
 
 export function parseMediaManifest(

--- a/src/services/ApkgPreviewService/extractApkg.ts
+++ b/src/services/ApkgPreviewService/extractApkg.ts
@@ -1,3 +1,4 @@
+import { decompress as zstdDecompress } from 'fzstd';
 import yauzl from 'yauzl';
 
 export interface ApkgArchive {
@@ -64,16 +65,14 @@ export async function extractApkg(bytes: Buffer): Promise<ApkgArchive> {
           reject(new Error('No Anki collection file found in archive'));
           return;
         }
+        let collectionBuffer = collections.get(name) as Buffer;
         if (name === 'collection.anki21b') {
-          reject(
-            new Error(
-              'This deck uses the zstd-compressed Anki 23.10+ format, which is not supported yet.'
-            )
+          collectionBuffer = Buffer.from(
+            zstdDecompress(new Uint8Array(collectionBuffer))
           );
-          return;
         }
         resolve({
-          collectionBuffer: collections.get(name) as Buffer,
+          collectionBuffer,
           collectionName: name,
           mediaManifestRaw,
           mediaEntries,
@@ -86,18 +85,112 @@ export async function extractApkg(bytes: Buffer): Promise<ApkgArchive> {
   });
 }
 
+const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd]);
+
+function isZstdCompressed(buf: Buffer): boolean {
+  return buf.length >= 4 && buf.subarray(0, 4).equals(ZSTD_MAGIC);
+}
+
+function parseProtobufMediaManifest(buf: Buffer): Map<string, string> {
+  const map = new Map<string, string>();
+  let entryIndex = 0;
+  let pos = 0;
+  while (pos < buf.length) {
+    let tag = 0;
+    let shift = 0;
+    while (pos < buf.length) {
+      const b = buf[pos++];
+      tag |= (b & 0x7f) << shift;
+      shift += 7;
+      if ((b & 0x80) === 0) break;
+    }
+    const wireType = tag & 7;
+    if (wireType === 2) {
+      let len = 0;
+      let lenShift = 0;
+      while (pos < buf.length) {
+        const b = buf[pos++];
+        len |= (b & 0x7f) << lenShift;
+        lenShift += 7;
+        if ((b & 0x80) === 0) break;
+      }
+      if ((tag >> 3) === 1) {
+        const sub = buf.subarray(pos, pos + len);
+        const name = readSubmessageString(sub, 1);
+        if (name) {
+          map.set(name, String(entryIndex));
+          entryIndex++;
+        }
+      }
+      pos += len;
+    } else if (wireType === 0) {
+      while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
+    } else if (wireType === 5) {
+      pos += 4;
+    } else if (wireType === 1) {
+      pos += 8;
+    } else {
+      break;
+    }
+  }
+  return map;
+}
+
+function readSubmessageString(buf: Buffer, fieldNumber: number): string {
+  const wantTag = (fieldNumber << 3) | 2;
+  let pos = 0;
+  while (pos < buf.length) {
+    let tag = 0;
+    let shift = 0;
+    while (pos < buf.length) {
+      const b = buf[pos++];
+      tag |= (b & 0x7f) << shift;
+      shift += 7;
+      if ((b & 0x80) === 0) break;
+    }
+    const wireType = tag & 7;
+    if (wireType === 2) {
+      let len = 0;
+      let lenShift = 0;
+      while (pos < buf.length) {
+        const b = buf[pos++];
+        len |= (b & 0x7f) << lenShift;
+        lenShift += 7;
+        if ((b & 0x80) === 0) break;
+      }
+      if (tag === wantTag) {
+        return buf.subarray(pos, pos + len).toString('utf8');
+      }
+      pos += len;
+    } else if (wireType === 0) {
+      while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
+    } else if (wireType === 5) {
+      pos += 4;
+    } else if (wireType === 1) {
+      pos += 8;
+    } else {
+      break;
+    }
+  }
+  return '';
+}
+
 export function parseMediaManifest(
   raw: Buffer | null
 ): Map<string, string> {
-  const map = new Map<string, string>();
-  if (!raw) return map;
+  if (!raw || raw.length === 0) return new Map();
+  let buf = raw;
+  if (isZstdCompressed(buf)) {
+    buf = Buffer.from(zstdDecompress(new Uint8Array(buf)));
+  }
   try {
-    const json = JSON.parse(raw.toString('utf8')) as Record<string, string>;
+    const json = JSON.parse(buf.toString('utf8')) as Record<string, string>;
+    const map = new Map<string, string>();
     for (const [archiveName, originalName] of Object.entries(json)) {
       map.set(originalName, archiveName);
     }
+    return map;
   } catch {
-    // Protobuf manifest not supported in slice 1; leave map empty.
+    return parseProtobufMediaManifest(buf);
   }
-  return map;
 }

--- a/src/services/ApkgPreviewService/parseCollection.ts
+++ b/src/services/ApkgPreviewService/parseCollection.ts
@@ -25,6 +25,19 @@ interface LegacyDeckJson {
   name: string;
 }
 
+function patchUnicaseCollation(buffer: Buffer): Buffer {
+  const UNICASE = Buffer.from('COLLATE unicase');
+  const REPLACE = Buffer.from('COLLATE BINARY ');
+  let pos = 0;
+  while (pos < buffer.length) {
+    const idx = buffer.indexOf(UNICASE, pos);
+    if (idx === -1) break;
+    REPLACE.copy(buffer, idx);
+    pos = idx + REPLACE.length;
+  }
+  return buffer;
+}
+
 function writeTempDb(buffer: Buffer): string {
   const tempPath = path.join(
     os.tmpdir(),
@@ -39,6 +52,9 @@ function openCollection(buffer: Buffer): {
   cleanup: () => void;
 } {
   const tempPath = writeTempDb(buffer);
+  const raw = fs.readFileSync(tempPath);
+  patchUnicaseCollation(raw);
+  fs.writeFileSync(tempPath, raw);
   const db = new Database(tempPath, { readonly: true, fileMustExist: true });
   return {
     db,
@@ -104,38 +120,100 @@ function loadLegacyDecks(db: Database.Database): Map<number, Deck> {
   return map;
 }
 
+function readProtobufString(buf: Buffer, fieldNumber: number): string {
+  const wantTag = (fieldNumber << 3) | 2;
+  let pos = 0;
+  while (pos < buf.length) {
+    let tag = 0;
+    let shift = 0;
+    while (pos < buf.length) {
+      const byte = buf[pos++];
+      tag |= (byte & 0x7f) << shift;
+      shift += 7;
+      if ((byte & 0x80) === 0) break;
+    }
+    const wireType = tag & 0x07;
+    if (wireType === 2) {
+      let len = 0;
+      let lenShift = 0;
+      while (pos < buf.length) {
+        const byte = buf[pos++];
+        len |= (byte & 0x7f) << lenShift;
+        lenShift += 7;
+        if ((byte & 0x80) === 0) break;
+      }
+      if (tag === wantTag) {
+        return buf.subarray(pos, pos + len).toString('utf8');
+      }
+      pos += len;
+    } else if (wireType === 0) {
+      while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
+    } else if (wireType === 5) {
+      pos += 4;
+    } else if (wireType === 1) {
+      pos += 8;
+    } else {
+      break;
+    }
+  }
+  return '';
+}
+
+function getTableColumns(db: Database.Database, table: string): Set<string> {
+  const rows = db
+    .prepare(`SELECT name FROM pragma_table_info('${table}')`)
+    .all() as Array<{ name: string }>;
+  return new Set(rows.map((r) => r.name));
+}
+
+function safeQueryAll<T>(
+  db: Database.Database,
+  table: string,
+  wantedCols: string[],
+  suffix: string
+): T[] {
+  const existing = getTableColumns(db, table);
+  const cols = wantedCols.filter((c) => existing.has(c));
+  if (cols.length === 0) return [];
+  return db.prepare(`SELECT ${cols.join(', ')} FROM ${table} ${suffix}`).all() as T[];
+}
+
 function loadModernNoteTypes(db: Database.Database): Map<number, NoteType> {
-  const noteTypeRows = db
-    .prepare('SELECT id, name, mtype, config FROM notetypes')
-    .all() as Array<{
+  const noteTypeRows = safeQueryAll<{
     id: number;
     name: string;
-    mtype: number;
-    config: Buffer;
-  }>;
-  const fieldRows = db
-    .prepare(
-      'SELECT ntid, name, ord FROM fields ORDER BY ntid, ord'
-    )
-    .all() as Array<{ ntid: number; name: string; ord: number }>;
-  const templateRows = db
-    .prepare(
-      'SELECT ntid, name, ord, config FROM templates ORDER BY ntid, ord'
-    )
-    .all() as Array<{
-    ntid: number;
-    name: string;
-    ord: number;
-    config: Buffer;
-  }>;
+    mtype?: number;
+    config?: Buffer;
+  }>(db, 'notetypes', ['id', 'name', 'mtype', 'config'], '');
+  const hasFieldsTable = hasTable(db, 'fields');
+  const hasTemplatesTable = hasTable(db, 'templates');
+
+  const fieldRows = hasFieldsTable
+    ? safeQueryAll<{ ntid: number; name: string; ord: number }>(
+        db,
+        'fields',
+        ['ntid', 'name', 'ord'],
+        'ORDER BY ntid, ord'
+      )
+    : [];
+  const templateRows = hasTemplatesTable
+    ? safeQueryAll<{ ntid: number; name: string; ord: number; config: Buffer }>(
+        db,
+        'templates',
+        ['ntid', 'name', 'ord', 'config'],
+        'ORDER BY ntid, ord'
+      )
+    : [];
 
   const map = new Map<number, NoteType>();
   for (const row of noteTypeRows) {
+    const cfg = row.config;
+    const css = cfg ? readProtobufString(cfg, 3) : '';
     map.set(row.id, {
       id: row.id,
       name: row.name,
-      type: row.mtype === 1 ? 1 : 0,
-      css: '',
+      type: (row.mtype ?? 0) === 1 ? 1 : 0,
+      css,
       fields: [],
       templates: [],
     });
@@ -144,14 +222,14 @@ function loadModernNoteTypes(db: Database.Database): Map<number, NoteType> {
     map.get(field.ntid)?.fields.push({ name: field.name, ord: field.ord });
   }
   for (const tmpl of templateRows) {
-    // The modern schema stores qfmt/afmt inside a protobuf-encoded `config`
-    // blob. We don't decode protobuf here yet; surface a clear gap instead
-    // of returning malformed templates.
+    const cfg = tmpl.config;
+    const qfmt = cfg ? readProtobufString(cfg, 1) : '';
+    const afmt = cfg ? readProtobufString(cfg, 2) : '';
     map.get(tmpl.ntid)?.templates.push({
       name: tmpl.name,
       ord: tmpl.ord,
-      qfmt: '',
-      afmt: '',
+      qfmt,
+      afmt,
     });
   }
   return map;

--- a/src/services/ApkgPreviewService/parseCollection.ts
+++ b/src/services/ApkgPreviewService/parseCollection.ts
@@ -3,6 +3,8 @@ import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+
+import { readString } from './protobuf';
 import {
   Card,
   Deck,
@@ -120,45 +122,6 @@ function loadLegacyDecks(db: Database.Database): Map<number, Deck> {
   return map;
 }
 
-function readProtobufString(buf: Buffer, fieldNumber: number): string {
-  const wantTag = (fieldNumber << 3) | 2;
-  let pos = 0;
-  while (pos < buf.length) {
-    let tag = 0;
-    let shift = 0;
-    while (pos < buf.length) {
-      const byte = buf[pos++];
-      tag |= (byte & 0x7f) << shift;
-      shift += 7;
-      if ((byte & 0x80) === 0) break;
-    }
-    const wireType = tag & 0x07;
-    if (wireType === 2) {
-      let len = 0;
-      let lenShift = 0;
-      while (pos < buf.length) {
-        const byte = buf[pos++];
-        len |= (byte & 0x7f) << lenShift;
-        lenShift += 7;
-        if ((byte & 0x80) === 0) break;
-      }
-      if (tag === wantTag) {
-        return buf.subarray(pos, pos + len).toString('utf8');
-      }
-      pos += len;
-    } else if (wireType === 0) {
-      while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
-    } else if (wireType === 5) {
-      pos += 4;
-    } else if (wireType === 1) {
-      pos += 8;
-    } else {
-      break;
-    }
-  }
-  return '';
-}
-
 function getTableColumns(db: Database.Database, table: string): Set<string> {
   const rows = db
     .prepare(`SELECT name FROM pragma_table_info('${table}')`)
@@ -208,7 +171,7 @@ function loadModernNoteTypes(db: Database.Database): Map<number, NoteType> {
   const map = new Map<number, NoteType>();
   for (const row of noteTypeRows) {
     const cfg = row.config;
-    const css = cfg ? readProtobufString(cfg, 3) : '';
+    const css = cfg ? readString(cfg, 3) : '';
     map.set(row.id, {
       id: row.id,
       name: row.name,
@@ -223,8 +186,8 @@ function loadModernNoteTypes(db: Database.Database): Map<number, NoteType> {
   }
   for (const tmpl of templateRows) {
     const cfg = tmpl.config;
-    const qfmt = cfg ? readProtobufString(cfg, 1) : '';
-    const afmt = cfg ? readProtobufString(cfg, 2) : '';
+    const qfmt = cfg ? readString(cfg, 1) : '';
+    const afmt = cfg ? readString(cfg, 2) : '';
     map.get(tmpl.ntid)?.templates.push({
       name: tmpl.name,
       ord: tmpl.ord,

--- a/src/services/ApkgPreviewService/protobuf.ts
+++ b/src/services/ApkgPreviewService/protobuf.ts
@@ -18,7 +18,9 @@ function readVarint(buf: Buffer, pos: number): [number, number] {
 
 function skipField(wireType: number, buf: Buffer, pos: number): number {
   if (wireType === 0) {
-    while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
+    while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {
+      /* varint continuation bytes */
+    }
     return pos;
   }
   if (wireType === 5) return pos + 4;

--- a/src/services/ApkgPreviewService/protobuf.ts
+++ b/src/services/ApkgPreviewService/protobuf.ts
@@ -1,0 +1,68 @@
+interface ProtoField {
+  fieldNumber: number;
+  wireType: number;
+  data: Buffer;
+}
+
+function readVarint(buf: Buffer, pos: number): [number, number] {
+  let value = 0;
+  let shift = 0;
+  while (pos < buf.length) {
+    const b = buf[pos++];
+    value |= (b & 0x7f) << shift;
+    shift += 7;
+    if ((b & 0x80) === 0) break;
+  }
+  return [value, pos];
+}
+
+function skipField(wireType: number, buf: Buffer, pos: number): number {
+  if (wireType === 0) {
+    while (pos < buf.length && (buf[pos++] & 0x80) !== 0) {}
+    return pos;
+  }
+  if (wireType === 5) return pos + 4;
+  if (wireType === 1) return pos + 8;
+  return buf.length;
+}
+
+export function* iterFields(buf: Buffer): Generator<ProtoField> {
+  let pos = 0;
+  while (pos < buf.length) {
+    let tag: number;
+    [tag, pos] = readVarint(buf, pos);
+    const fieldNumber = tag >> 3;
+    const wireType = tag & 7;
+    if (wireType === 2) {
+      let len: number;
+      [len, pos] = readVarint(buf, pos);
+      yield { fieldNumber, wireType, data: buf.subarray(pos, pos + len) };
+      pos += len;
+    } else {
+      yield { fieldNumber, wireType, data: Buffer.alloc(0) };
+      pos = skipField(wireType, buf, pos);
+    }
+  }
+}
+
+export function readString(buf: Buffer, fieldNumber: number): string {
+  for (const field of iterFields(buf)) {
+    if (field.fieldNumber === fieldNumber && field.wireType === 2) {
+      return field.data.toString('utf8');
+    }
+  }
+  return '';
+}
+
+export function readRepeatedSubmessages(
+  buf: Buffer,
+  fieldNumber: number
+): Buffer[] {
+  const results: Buffer[] = [];
+  for (const field of iterFields(buf)) {
+    if (field.fieldNumber === fieldNumber && field.wireType === 2) {
+      results.push(field.data);
+    }
+  }
+  return results;
+}

--- a/src/services/PdfRenderService.test.ts
+++ b/src/services/PdfRenderService.test.ts
@@ -1,0 +1,15 @@
+import PdfRenderService from './PdfRenderService';
+
+const PUPPETEER_AVAILABLE = process.env.PUPPETEER_AVAILABLE === 'true';
+
+(PUPPETEER_AVAILABLE ? describe : describe.skip)('PdfRenderService', () => {
+  it('renders simple HTML to a PDF buffer', async () => {
+    const service = new PdfRenderService();
+    const html = '<html><body><h1>Hello</h1></body></html>';
+    const pdf = await service.renderHtml(html);
+
+    expect(Buffer.isBuffer(pdf)).toBe(true);
+    expect(pdf.length).toBeGreaterThan(0);
+    expect(pdf.subarray(0, 5).toString()).toBe('%PDF-');
+  }, 30_000);
+});

--- a/src/services/PdfRenderService.ts
+++ b/src/services/PdfRenderService.ts
@@ -12,32 +12,21 @@ export default class PdfRenderService {
     try {
       const page = await browser.newPage();
       await page.setContent(html, { waitUntil: 'load' });
-      await page.evaluate(
-        (timeout) =>
-          new Promise<void>((resolve) => {
-            const start = Date.now();
-            const check = () => {
-              const mj = (globalThis as Record<string, unknown>).MathJax;
-              if (
-                mj &&
-                typeof mj === 'object' &&
-                'typesetPromise' in mj &&
-                typeof (mj as Record<string, unknown>).typesetPromise ===
-                  'function'
-              ) {
-                (mj as { typesetPromise: () => Promise<void> })
-                  .typesetPromise()
-                  .then(resolve)
-                  .catch(resolve);
-              } else if (Date.now() - start > timeout) {
-                resolve();
-              } else {
-                setTimeout(check, 200);
-              }
-            };
-            check();
-          }),
-        MATHJAX_SETTLE_MS
+      await page.waitForFunction(
+        `new Promise(function(resolve) {
+          var start = Date.now();
+          function check() {
+            if (window.MathJax && typeof window.MathJax.typesetPromise === 'function') {
+              window.MathJax.typesetPromise().then(function() { resolve(true); }).catch(function() { resolve(true); });
+            } else if (Date.now() - start > ${MATHJAX_SETTLE_MS}) {
+              resolve(true);
+            } else {
+              setTimeout(check, 200);
+            }
+          }
+          check();
+        })`,
+        { timeout: PDF_TIMEOUT_MS }
       );
       const pdf = await page.pdf({
         format: 'A4',

--- a/src/services/PdfRenderService.ts
+++ b/src/services/PdfRenderService.ts
@@ -1,0 +1,53 @@
+import puppeteer from 'puppeteer';
+
+const PDF_TIMEOUT_MS = 30_000;
+const MATHJAX_SETTLE_MS = 2_000;
+
+export default class PdfRenderService {
+  async renderHtml(html: string): Promise<Buffer> {
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    try {
+      const page = await browser.newPage();
+      await page.setContent(html, { waitUntil: 'load' });
+      await page.evaluate(
+        (timeout) =>
+          new Promise<void>((resolve) => {
+            const start = Date.now();
+            const check = () => {
+              const mj = (globalThis as Record<string, unknown>).MathJax;
+              if (
+                mj &&
+                typeof mj === 'object' &&
+                'typesetPromise' in mj &&
+                typeof (mj as Record<string, unknown>).typesetPromise ===
+                  'function'
+              ) {
+                (mj as { typesetPromise: () => Promise<void> })
+                  .typesetPromise()
+                  .then(resolve)
+                  .catch(resolve);
+              } else if (Date.now() - start > timeout) {
+                resolve();
+              } else {
+                setTimeout(check, 200);
+              }
+            };
+            check();
+          }),
+        MATHJAX_SETTLE_MS
+      );
+      const pdf = await page.pdf({
+        format: 'A4',
+        printBackground: true,
+        margin: { top: '1cm', right: '1cm', bottom: '1cm', left: '1cm' },
+        timeout: PDF_TIMEOUT_MS,
+      });
+      return Buffer.from(pdf);
+    } finally {
+      await browser.close();
+    }
+  }
+}

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.test.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.test.ts
@@ -1,0 +1,174 @@
+import ExportApkgToPdfUseCase, {
+  CardLimitExceededError,
+} from './ExportApkgToPdfUseCase';
+import ApkgPreviewService from '../../services/ApkgPreviewService/ApkgPreviewService';
+import PdfRenderService from '../../services/PdfRenderService';
+import { RenderedCard, PreviewMeta } from '../../services/ApkgPreviewService/types';
+import { ParsedApkg } from '../../services/ApkgPreviewService/ApkgPreviewService';
+
+function makeCard(id: number): RenderedCard {
+  return {
+    id,
+    ord: 0,
+    templateName: 'Basic',
+    deckName: 'Test Deck',
+    deckPath: ['Test Deck'],
+    noteTypeName: 'Basic',
+    css: '.card { color: black; }',
+    front: `<p>Question ${id}</p>`,
+    back: `<p>Answer ${id}</p>`,
+  };
+}
+
+function makeParsed(cardCount: number): ParsedApkg {
+  return {
+    collection: {
+      noteTypes: new Map(),
+      notes: new Map(),
+      decks: new Map([[1, { id: 1, name: 'Test Deck' }]]),
+      cards: Array.from({ length: cardCount }, (_, i) => ({
+        id: i + 1,
+        nid: i + 1,
+        did: 1,
+        ord: 0,
+      })),
+    },
+    mediaMap: new Map(),
+    mediaEntries: new Map(),
+    parsedAt: Date.now(),
+  };
+}
+
+function makeMeta(totalCards: number): PreviewMeta {
+  return {
+    totalCards,
+    decks: [{ id: 1, fullName: 'Test Deck', path: ['Test Deck'], cardCount: totalCards }],
+  };
+}
+
+describe('ExportApkgToPdfUseCase', () => {
+  let previewService: jest.Mocked<ApkgPreviewService>;
+  let pdfRenderService: jest.Mocked<PdfRenderService>;
+  let useCase: ExportApkgToPdfUseCase;
+
+  beforeEach(() => {
+    previewService = {
+      parse: jest.fn(),
+      getMeta: jest.fn(),
+      getCardsPage: jest.fn(),
+      getMediaEntry: jest.fn(),
+    } as unknown as jest.Mocked<ApkgPreviewService>;
+
+    pdfRenderService = {
+      renderHtml: jest.fn(),
+    } as unknown as jest.Mocked<PdfRenderService>;
+
+    useCase = new ExportApkgToPdfUseCase(previewService, pdfRenderService);
+  });
+
+  it('produces a PDF buffer for a valid apkg', async () => {
+    const parsed = makeParsed(3);
+    const cards = [makeCard(1), makeCard(2), makeCard(3)];
+    const pdfBuffer = Buffer.from('%PDF-fake');
+
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(3));
+    previewService.getCardsPage.mockReturnValueOnce({
+      cards,
+      nextCursor: null,
+      total: 3,
+    });
+    pdfRenderService.renderHtml.mockResolvedValue(pdfBuffer);
+
+    const result = await useCase.execute(Buffer.from('fake-apkg'));
+
+    expect(result.pdf).toBe(pdfBuffer);
+    expect(result.deckName).toBe('Test Deck');
+    expect(result.cardCount).toBe(3);
+    expect(pdfRenderService.renderHtml).toHaveBeenCalledTimes(1);
+    const htmlArg = pdfRenderService.renderHtml.mock.calls[0][0];
+    expect(htmlArg).toContain('Question 1');
+    expect(htmlArg).toContain('Answer 3');
+  });
+
+  it('throws CardLimitExceededError for decks over 500 cards', async () => {
+    const parsed = makeParsed(501);
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(501));
+
+    await expect(useCase.execute(Buffer.from('fake-apkg'))).rejects.toThrow(
+      CardLimitExceededError
+    );
+    await expect(useCase.execute(Buffer.from('fake-apkg'))).rejects.toThrow(
+      /501 cards/
+    );
+    expect(pdfRenderService.renderHtml).not.toHaveBeenCalled();
+  });
+
+  it('handles missing media gracefully', async () => {
+    const parsed = makeParsed(1);
+    const cardWithMissingImage = makeCard(1);
+    cardWithMissingImage.front = '<p>Q</p><img src="missing.png" />';
+    cardWithMissingImage.back = '<p>A</p>';
+
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(1));
+    previewService.getCardsPage.mockReturnValueOnce({
+      cards: [cardWithMissingImage],
+      nextCursor: null,
+      total: 1,
+    });
+    pdfRenderService.renderHtml.mockResolvedValue(Buffer.from('%PDF'));
+
+    const result = await useCase.execute(Buffer.from('fake-apkg'));
+
+    expect(result.pdf).toEqual(Buffer.from('%PDF'));
+    const htmlArg = pdfRenderService.renderHtml.mock.calls[0][0];
+    expect(htmlArg).not.toContain('missing.png');
+  });
+
+  it('replaces sound tokens with italic text', async () => {
+    const parsed = makeParsed(1);
+    const cardWithAudio = makeCard(1);
+    cardWithAudio.front = '<p>Listen: [sound:word.mp3]</p>';
+
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(1));
+    previewService.getCardsPage.mockReturnValueOnce({
+      cards: [cardWithAudio],
+      nextCursor: null,
+      total: 1,
+    });
+    pdfRenderService.renderHtml.mockResolvedValue(Buffer.from('%PDF'));
+
+    await useCase.execute(Buffer.from('fake-apkg'));
+
+    const htmlArg = pdfRenderService.renderHtml.mock.calls[0][0];
+    expect(htmlArg).toContain('<em>[audio: word.mp3]</em>');
+    expect(htmlArg).not.toContain('[sound:');
+  });
+
+  it('inlines media as base64 data URIs when available', async () => {
+    const parsed = makeParsed(1);
+    parsed.mediaMap.set('photo.png', '0');
+    parsed.mediaEntries.set('0', Buffer.from('fake-png-data'));
+
+    const cardWithImage = makeCard(1);
+    cardWithImage.front = '<img src="photo.png" />';
+
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(1));
+    previewService.getCardsPage.mockReturnValueOnce({
+      cards: [cardWithImage],
+      nextCursor: null,
+      total: 1,
+    });
+    pdfRenderService.renderHtml.mockResolvedValue(Buffer.from('%PDF'));
+
+    await useCase.execute(Buffer.from('fake-apkg'));
+
+    const htmlArg = pdfRenderService.renderHtml.mock.calls[0][0];
+    const expectedBase64 = Buffer.from('fake-png-data').toString('base64');
+    expect(htmlArg).toContain(`data:image/png;base64,${expectedBase64}`);
+  });
+});

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.ts
@@ -1,0 +1,201 @@
+import ApkgPreviewService, {
+  ParsedApkg,
+} from '../../services/ApkgPreviewService/ApkgPreviewService';
+import PdfRenderService from '../../services/PdfRenderService';
+import { RenderedCard } from '../../services/ApkgPreviewService/types';
+
+const MAX_CARDS = 500;
+
+const SOUND_TAG_REGEX = /\[sound:([^\]]+)\]/g;
+const AUDIO_EXTENSIONS = new Set([
+  'mp3', 'ogg', 'oga', 'wav', 'flac', 'm4a', 'aac', 'opus',
+]);
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov']);
+
+const IMAGE_MIME: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+};
+
+function extensionOf(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot === -1 ? '' : name.slice(dot + 1).toLowerCase();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function isAudioOrVideo(name: string): boolean {
+  const ext = extensionOf(name);
+  return AUDIO_EXTENSIONS.has(ext) || VIDEO_EXTENSIONS.has(ext);
+}
+
+function replaceSoundTokens(html: string): string {
+  return html.replace(SOUND_TAG_REGEX, (_match, name: string) => {
+    const trimmed = name.trim();
+    return `<em>[audio: ${escapeHtml(trimmed)}]</em>`;
+  });
+}
+
+function replaceMediaWithBase64(
+  html: string,
+  parsed: ParsedApkg
+): string {
+  const SRC_REGEX = /\b(src)="([^"]+)"/g;
+  return html.replace(SRC_REGEX, (_match, attr: string, value: string) => {
+    if (value.startsWith('data:') || /^https?:\/\//i.test(value)) {
+      return `${attr}="${value}"`;
+    }
+    const decoded = decodeURIComponent(value);
+    const nameOnly = decoded.split('/').pop() ?? decoded;
+
+    if (isAudioOrVideo(nameOnly)) {
+      return `${attr}=""`;
+    }
+
+    const archiveName = parsed.mediaMap.get(nameOnly);
+    if (archiveName == null) {
+      return `${attr}=""`;
+    }
+    const buffer = parsed.mediaEntries.get(archiveName);
+    if (buffer == null) {
+      return `${attr}=""`;
+    }
+    const ext = extensionOf(nameOnly);
+    const mime = IMAGE_MIME[ext] ?? 'application/octet-stream';
+    const dataUri = `data:${mime};base64,${buffer.toString('base64')}`;
+    return `${attr}="${dataUri}"`;
+  });
+}
+
+function replaceMissingMediaPlaceholders(html: string): string {
+  return html.replace(
+    /data-missing-media="([^"]+)"/g,
+    (_match, name: string) => {
+      if (isAudioOrVideo(name)) {
+        return '';
+      }
+      return '';
+    }
+  );
+}
+
+function processCardHtml(side: string, parsed: ParsedApkg): string {
+  let result = replaceSoundTokens(side);
+  result = replaceMediaWithBase64(result, parsed);
+  result = replaceMissingMediaPlaceholders(result);
+  return result;
+}
+
+function buildCardRow(card: RenderedCard, parsed: ParsedApkg): string {
+  const front = processCardHtml(card.front, parsed);
+  const back = processCardHtml(card.back, parsed);
+  return `<tr>
+    <td class="card-cell"><style scoped>${card.css}</style><div class="card-content">${front}</div></td>
+    <td class="card-cell"><style scoped>${card.css}</style><div class="card-content">${back}</div></td>
+  </tr>`;
+}
+
+function collectAllCards(
+  previewService: ApkgPreviewService,
+  parsed: ParsedApkg
+): RenderedCard[] {
+  const all: RenderedCard[] = [];
+  let cursor = 0;
+  const pageSize = 100;
+  const mediaBaseUrl = '';
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    const page = previewService.getCardsPage(parsed, cursor, pageSize, mediaBaseUrl);
+    all.push(...page.cards);
+    if (page.nextCursor == null) break;
+    cursor = page.nextCursor;
+  }
+  return all;
+}
+
+function buildHtml(deckName: string, cards: RenderedCard[], parsed: ParsedApkg): string {
+  const rows = cards.map((card) => buildCardRow(card, parsed)).join('\n');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>${escapeHtml(deckName)}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 0; }
+  h1 { font-size: 18px; margin: 16px 0 8px; }
+  table { width: 100%; border-collapse: collapse; table-layout: fixed; }
+  th { text-align: left; font-size: 12px; padding: 6px 10px; border-bottom: 2px solid #333; }
+  .card-cell { width: 50%; padding: 10px; border: 1px solid #ddd; vertical-align: top; word-wrap: break-word; overflow: hidden; }
+  .card-content { font-size: 13px; line-height: 1.5; }
+  .card-content img { max-width: 100%; height: auto; }
+  @media print { body { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }
+</style>
+<script>
+window.MathJax = {
+  tex: { inlineMath: [['\\\\(','\\\\)'], ['$','$']], displayMath: [['\\\\[','\\\\]'], ['$$','$$']] },
+  startup: { typeset: true }
+};
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" async></script>
+</head>
+<body>
+<h1>${escapeHtml(deckName)}</h1>
+<table>
+<thead><tr><th>Front</th><th>Back</th></tr></thead>
+<tbody>
+${rows}
+</tbody>
+</table>
+</body>
+</html>`;
+}
+
+export interface ExportApkgToPdfResult {
+  pdf: Buffer;
+  deckName: string;
+  cardCount: number;
+}
+
+export default class ExportApkgToPdfUseCase {
+  constructor(
+    private readonly previewService: ApkgPreviewService,
+    private readonly pdfRenderService: PdfRenderService
+  ) {}
+
+  async execute(fileBuffer: Buffer): Promise<ExportApkgToPdfResult> {
+    const cacheKey = `pdf-export:${Date.now()}`;
+    const parsed = await this.previewService.parse(cacheKey, fileBuffer);
+    const meta = this.previewService.getMeta(parsed);
+
+    if (meta.totalCards > MAX_CARDS) {
+      throw new CardLimitExceededError(meta.totalCards);
+    }
+
+    const cards = collectAllCards(this.previewService, parsed);
+    const deckName =
+      meta.decks.length > 0 ? meta.decks[0].fullName : 'Flashcards';
+    const html = buildHtml(deckName, cards, parsed);
+    const pdf = await this.pdfRenderService.renderHtml(html);
+    return { pdf, deckName, cardCount: cards.length };
+  }
+}
+
+export class CardLimitExceededError extends Error {
+  constructor(public readonly cardCount: number) {
+    super(
+      `This deck has ${cardCount} cards. PDF export supports up to ${MAX_CARDS} cards.`
+    );
+    this.name = 'CardLimitExceededError';
+  }
+}

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.ts
@@ -1,8 +1,11 @@
+import { decompress as zstdDecompress } from 'fzstd';
 import ApkgPreviewService, {
   ParsedApkg,
 } from '../../services/ApkgPreviewService/ApkgPreviewService';
 import PdfRenderService from '../../services/PdfRenderService';
 import { RenderedCard } from '../../services/ApkgPreviewService/types';
+
+const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd]);
 
 const MAX_CARDS = 500;
 
@@ -67,9 +70,12 @@ function replaceMediaWithBase64(
     if (archiveName == null) {
       return `${attr}=""`;
     }
-    const buffer = parsed.mediaEntries.get(archiveName);
+    let buffer = parsed.mediaEntries.get(archiveName);
     if (buffer == null) {
       return `${attr}=""`;
+    }
+    if (buffer.length >= 4 && buffer.subarray(0, 4).equals(ZSTD_MAGIC)) {
+      buffer = Buffer.from(zstdDecompress(new Uint8Array(buffer)));
     }
     const ext = extensionOf(nameOnly);
     const mime = IMAGE_MIME[ext] ?? 'application/octet-stream';
@@ -97,9 +103,15 @@ function processCardHtml(side: string, parsed: ParsedApkg): string {
   return result;
 }
 
+function stripFrontFromBack(back: string): string {
+  const hrIndex = back.search(/<hr\s*\/?>/i);
+  if (hrIndex === -1) return back;
+  return back.substring(hrIndex).replace(/<hr\s*\/?>/i, '');
+}
+
 function buildCardRow(card: RenderedCard, parsed: ParsedApkg): string {
   const front = processCardHtml(card.front, parsed);
-  const back = processCardHtml(card.back, parsed);
+  const back = processCardHtml(stripFrontFromBack(card.back), parsed);
   return `<tr>
     <td class="card-cell"><style scoped>${card.css}</style><div class="card-content">${front}</div></td>
     <td class="card-cell"><style scoped>${card.css}</style><div class="card-content">${back}</div></td>

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.ts
@@ -128,6 +128,14 @@ function collectAllCards(
   return all;
 }
 
+const MATHJAX_CONFIG = String.raw`<script>
+window.MathJax = {
+  tex: { inlineMath: [['\\(','\\)'], ['$','$']], displayMath: [['\\[','\\]'], ['$$','$$']] },
+  startup: { typeset: true }
+};
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" async></script>`;
+
 function buildHtml(deckName: string, cards: RenderedCard[], parsed: ParsedApkg): string {
   const rows = cards.map((card) => buildCardRow(card, parsed)).join('\n');
   return `<!DOCTYPE html>
@@ -145,13 +153,7 @@ function buildHtml(deckName: string, cards: RenderedCard[], parsed: ParsedApkg):
   .card-content img { max-width: 100%; height: auto; }
   @media print { body { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }
 </style>
-<script>
-window.MathJax = {
-  tex: { inlineMath: [['\\(','\\)'], ['$','$']], displayMath: [['\\[','\\]'], ['$$','$$']] },
-  startup: { typeset: true }
-};
-</script>
-<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" async></script>
+${MATHJAX_CONFIG}
 </head>
 <body>
 <h1>${escapeHtml(deckName)}</h1>

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.ts
@@ -85,15 +85,7 @@ function replaceMediaWithBase64(
 }
 
 function replaceMissingMediaPlaceholders(html: string): string {
-  return html.replace(
-    /data-missing-media="([^"]+)"/g,
-    (_match, name: string) => {
-      if (isAudioOrVideo(name)) {
-        return '';
-      }
-      return '';
-    }
-  );
+  return html.replace(/data-missing-media="[^"]+"/g, '');
 }
 
 function processCardHtml(side: string, parsed: ParsedApkg): string {
@@ -155,7 +147,7 @@ function buildHtml(deckName: string, cards: RenderedCard[], parsed: ParsedApkg):
 </style>
 <script>
 window.MathJax = {
-  tex: { inlineMath: [['\\\\(','\\\\)'], ['$','$']], displayMath: [['\\\\[','\\\\]'], ['$$','$$']] },
+  tex: { inlineMath: [['\\(','\\)'], ['$','$']], displayMath: [['\\[','\\]'], ['$$','$$']] },
   startup: { typeset: true }
 };
 </script>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,6 +52,7 @@ const MarkdownToAnki = lazy(
   () => import('./pages/LandingPage/MarkdownToAnki')
 );
 const PdfToAnki = lazy(() => import('./pages/LandingPage/PdfToAnki'));
+const PrintPage = lazy(() => import('./pages/PrintPage'));
 
 const queryClient = new QueryClient();
 
@@ -121,6 +122,7 @@ function AppContent({
             path="/upload"
             element={<UploadPage setErrorMessage={setErrorMessage} />}
           />
+          <Route path="/print" element={<PrintPage />} />
           <Route
             path="/register"
             element={<RegisterPage setErrorMessage={setErrorMessage} />}

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -109,14 +109,16 @@ export function Sidebar({
         >
           {getVisibleText('navigation.upload')}
         </SidebarRow>
-        <SidebarRow
-          href="/print"
-          pathname={pathname}
-          matchPrefix={false}
-          onClick={handleNavClick()}
-        >
-          {getVisibleText('navigation.print')}
-        </SidebarRow>
+        {paying && (
+          <SidebarRow
+            href="/print"
+            pathname={pathname}
+            matchPrefix={false}
+            onClick={handleNavClick()}
+          >
+            {getVisibleText('navigation.print')}
+          </SidebarRow>
+        )}
         <SidebarRow
           href="/downloads"
           pathname={pathname}

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -110,6 +110,14 @@ export function Sidebar({
           {getVisibleText('navigation.upload')}
         </SidebarRow>
         <SidebarRow
+          href="/print"
+          pathname={pathname}
+          matchPrefix={false}
+          onClick={handleNavClick()}
+        >
+          {getVisibleText('navigation.print')}
+        </SidebarRow>
+        <SidebarRow
           href="/downloads"
           pathname={pathname}
           onClick={handleNavClick()}

--- a/web/src/components/NavigationBar/components/RightSide.tsx
+++ b/web/src/components/NavigationBar/components/RightSide.tsx
@@ -12,6 +12,9 @@ export function RightSide({ path }: Readonly<RightSideProps>) {
       <NavbarItem href="/upload" path={path}>
         {getVisibleText('navigation.upload')}
       </NavbarItem>
+      <NavbarItem href="/print" path={path}>
+        {getVisibleText('navigation.print')}
+      </NavbarItem>
       <NavbarItem href="/documentation" path={path}>
         {getVisibleText('navigation.docs')}
       </NavbarItem>

--- a/web/src/lib/text/app.document.json
+++ b/web/src/lib/text/app.document.json
@@ -36,5 +36,6 @@
   "navigation.legal.about": "About",
   "navigation.legal.terms": "Terms",
   "navigation.legal.privacy": "Privacy",
+  "navigation.print": "Print",
   "navigation.login.title": "Welcome!"
 }

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -97,6 +97,7 @@ export default function PricingPage({
             'Unlimited flashcards',
             'Run multiple conversions at once',
             'PDFs and large Notion exports',
+            'Print decks to PDF',
             'Cancel anytime',
           ]}
           link={subcribeLink}

--- a/web/src/pages/PrintPage/PrintPage.tsx
+++ b/web/src/pages/PrintPage/PrintPage.tsx
@@ -1,0 +1,20 @@
+import styles from '../../styles/shared.module.css';
+import PrintForm from './components/PrintForm';
+
+export function PrintPage() {
+  return (
+    <div className={styles.page}>
+      <header className={styles.pageHeader}>
+        <h1 className={styles.title}>Print your flashcards</h1>
+        <p className={styles.subtitle}>
+          Drop an Anki deck (.apkg) here. We'll make a PDF you can print or
+          share.
+        </p>
+      </header>
+      <PrintForm />
+      <p className={styles.smallDescription}>
+        All files uploaded here are automatically deleted after 2 hours.
+      </p>
+    </div>
+  );
+}

--- a/web/src/pages/PrintPage/components/PrintForm.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.tsx
@@ -30,7 +30,13 @@ async function extractErrorMessage(response: Response): Promise<string> {
   return GENERIC_ERROR_MESSAGE;
 }
 
-function toUserMessage(serverMessage: string): string {
+const AUTH_MESSAGE = 'Please log in to use PDF export.';
+const UPGRADE_MESSAGE =
+  'PDF export is available to subscribers and lifetime members.';
+
+function toUserMessage(serverMessage: string, status: number): string {
+  if (status === 401) return AUTH_MESSAGE;
+  if (status === 403) return UPGRADE_MESSAGE;
   if (/Invalid .apkg/i.test(serverMessage)) return CORRUPTED_MESSAGE;
   if (/PDF export supports up to/i.test(serverMessage)) return TOO_LARGE_MESSAGE;
   return serverMessage;
@@ -87,7 +93,7 @@ export default function PrintForm() {
       } else {
         const raw = await extractErrorMessage(response);
         setState('error');
-        setErrorMessage(toUserMessage(raw));
+        setErrorMessage(toUserMessage(raw, response.status));
       }
     } catch {
       setState('error');
@@ -163,6 +169,18 @@ export default function PrintForm() {
             <>
               {' '}
               <Link to="/upload">Go to Upload</Link>
+            </>
+          )}
+          {errorMessage === UPGRADE_MESSAGE && (
+            <>
+              {' '}
+              <Link to="/pricing">View plans</Link>
+            </>
+          )}
+          {errorMessage === AUTH_MESSAGE && (
+            <>
+              {' '}
+              <Link to="/login">Log in</Link>
             </>
           )}
         </p>

--- a/web/src/pages/PrintPage/components/PrintForm.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.tsx
@@ -1,0 +1,186 @@
+import { SyntheticEvent, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import formStyles from '../../UploadPage/components/UploadForm/UploadForm.module.css';
+import styles from '../../../styles/shared.module.css';
+
+type PrintState = 'idle' | 'uploading' | 'done' | 'error';
+
+const WRONG_TYPE_MESSAGE =
+  'This tool works with Anki deck files (.apkg). To turn notes into an Anki deck, use the Upload page.';
+const CORRUPTED_MESSAGE =
+  "We couldn't read this file. Make sure it's a valid Anki deck (.apkg) and try again.";
+const TOO_LARGE_MESSAGE =
+  'This deck is too large to print right now. Try a deck with fewer cards.';
+const GENERIC_ERROR_MESSAGE =
+  'Something went wrong while generating the PDF. Please try again.';
+
+function isApkgFile(name: string): boolean {
+  return /\.apkg$/i.test(name);
+}
+
+async function extractErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = await response.clone().json();
+    if (typeof body?.message === 'string' && body.message.trim().length > 0) {
+      return body.message;
+    }
+  } catch {
+    /* response not JSON */
+  }
+  return GENERIC_ERROR_MESSAGE;
+}
+
+function toUserMessage(serverMessage: string): string {
+  if (/Invalid .apkg/i.test(serverMessage)) return CORRUPTED_MESSAGE;
+  if (/PDF export supports up to/i.test(serverMessage)) return TOO_LARGE_MESSAGE;
+  return serverMessage;
+}
+
+export default function PrintForm() {
+  const [state, setState] = useState<PrintState>('idle');
+  const [cardCount, setCardCount] = useState<number | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const submitRef = useRef<HTMLButtonElement>(null);
+  const [dropHover, setDropHover] = useState(false);
+
+  const resetForm = () => {
+    setState('idle');
+    setCardCount(null);
+    setErrorMessage(null);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleFile = async (file: File) => {
+    if (!isApkgFile(file.name)) {
+      setState('error');
+      setErrorMessage(WRONG_TYPE_MESSAGE);
+      return;
+    }
+
+    setState('uploading');
+    setErrorMessage(null);
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    try {
+      const response = await globalThis.fetch('/api/apkg/pdf', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (response.ok) {
+        const blob = await response.blob();
+        const url = globalThis.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        const name = file.name.replace(/\.apkg$/i, '.pdf');
+        link.href = url;
+        link.download = name;
+        link.click();
+        globalThis.URL.revokeObjectURL(url);
+
+        setState('done');
+        setCardCount(null);
+      } else {
+        const raw = await extractErrorMessage(response);
+        setState('error');
+        setErrorMessage(toUserMessage(raw));
+      }
+    } catch {
+      setState('error');
+      setErrorMessage(GENERIC_ERROR_MESSAGE);
+    }
+  };
+
+  const handleSubmit = async (event: SyntheticEvent) => {
+    event.preventDefault();
+    const files = fileInputRef.current?.files;
+    if (files == null || files.length === 0) return;
+    await handleFile(files[0]);
+  };
+
+  const handleDrop = (event: React.DragEvent) => {
+    event.preventDefault();
+    setDropHover(false);
+    const { dataTransfer } = event;
+    if (dataTransfer && dataTransfer.files.length > 0) {
+      handleFile(dataTransfer.files[0]);
+    }
+  };
+
+  const isUploading = state === 'uploading';
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label
+        htmlFor="print-file"
+        className={`${formStyles.dropZone} ${
+          dropHover ? formStyles.dropZoneActive : ''
+        }`}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDropHover(true);
+        }}
+        onDragEnter={(e) => {
+          e.preventDefault();
+          setDropHover(true);
+        }}
+        onDragLeave={() => setDropHover(false)}
+        onDrop={handleDrop}
+      >
+        <span className={formStyles.dropIcon}>🖨️</span>
+        <span className={formStyles.dropText}>
+          Drop an Anki deck (.apkg) here
+        </span>
+        <span className={formStyles.dropHint}>or</span>
+        <span className={formStyles.convertButton}>
+          {isUploading ? 'Making your PDF...' : 'Click to select a file'}
+        </span>
+        <input
+          ref={fileInputRef}
+          className={formStyles.fileInput}
+          id="print-file"
+          type="file"
+          accept=".apkg"
+          disabled={isUploading}
+          onChange={() => submitRef.current?.click()}
+        />
+      </label>
+
+      {state === 'done' && (
+        <p className={styles.notificationSuccess}>
+          Your flashcards as a PDF{cardCount == null ? '' : ` — ${cardCount} cards`}
+        </p>
+      )}
+
+      {state === 'error' && errorMessage && (
+        <p className={styles.notificationDanger}>
+          {errorMessage}
+          {errorMessage === WRONG_TYPE_MESSAGE && (
+            <>
+              {' '}
+              <Link to="/upload">Go to Upload</Link>
+            </>
+          )}
+        </p>
+      )}
+
+      {state === 'done' && (
+        <div style={{ textAlign: 'center', marginTop: '1rem' }}>
+          <button
+            type="button"
+            className={styles.btnSecondary}
+            onClick={resetForm}
+          >
+            Print another deck
+          </button>
+        </div>
+      )}
+
+      <button ref={submitRef} type="submit" className={styles.hidden} />
+    </form>
+  );
+}

--- a/web/src/pages/PrintPage/components/PrintForm.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.tsx
@@ -156,6 +156,16 @@ export default function PrintForm() {
         />
       </label>
 
+      {isUploading && (
+        <div
+          className={styles.notificationInfo}
+          style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', marginTop: '1rem' }}
+        >
+          <div className={styles.spinnerSmall} />
+          <span>Making your PDF — please keep this tab open until the download starts.</span>
+        </div>
+      )}
+
       {state === 'done' && (
         <p className={styles.notificationSuccess}>
           Your flashcards as a PDF{cardCount == null ? '' : ` — ${cardCount} cards`}

--- a/web/src/pages/PrintPage/index.tsx
+++ b/web/src/pages/PrintPage/index.tsx
@@ -1,0 +1,1 @@
+export { PrintPage as default } from './PrintPage';


### PR DESCRIPTION
## What
Adds a new POST `/api/apkg/pdf` endpoint that accepts an `.apkg` file upload and returns a printable PDF of the flashcards. Adds a `/print` page on the frontend with a drop zone for file upload and auto-download.

Closes #1438

## Why
Users have no way to get a printable version of their Anki decks. A PDF export lets them print flashcards for offline study, share with classmates, or review without the Anki app. This expands 2anki's value proposition beyond digital-only decks.

## How
- **Service layer:** `PdfRenderService` wraps Puppeteer — launches headless Chrome, sets HTML content, waits for MathJax to settle, calls `page.pdf()` with A4/portrait/margins, returns a Buffer.
- **Use case:** `ExportApkgToPdfUseCase` parses the `.apkg` via `ApkgPreviewService`, collects all cards, builds an HTML document with two-column table layout (front/back), inlines images as base64 data-URIs, replaces `[sound:]` tokens with italic text labels, and delegates to `PdfRenderService`.
- **Controller:** `ApkgController.exportPdf` validates the upload, reads the temp file, cleans it up, runs the use case, and streams the PDF response with proper Content-Disposition.
- **Route:** `POST /api/apkg/pdf` behind `RequireAuthentication` + `isPaying` check (subscribers and lifetime members only) with multer single-file upload.
- **Frontend:** New `/print` page with drop zone (reuses UploadForm CSS), auto-download on success, error states for wrong file type / corrupted / too large / auth. Added to sidebar ("Make" group, visible to paying users only) and pricing page.
- **Anki 23.10+ support:** zstd decompression for collection/media, COLLATE unicase patching, protobuf decoding for templates and media manifests.

Edge cases handled: 500-card limit returns 400, invalid/corrupted `.apkg` returns 400, missing media renders as empty src, audio/video tokens become `[audio: filename]`, temp files cleaned up on all paths.

## Testing
- Unit tests added: `ExportApkgToPdfUseCase.test.ts` (5 tests: valid PDF, card limit, missing media, sound tokens, base64 inlining)
- Unit tests added: `PdfRenderService.test.ts` (gated behind `PUPPETEER_AVAILABLE` env var)
- Server `tsc --noEmit`: clean
- Web `typecheck`: clean
- Web `vitest`: 193 tests pass
- Web `biome lint`: clean

## Risks
- Puppeteer adds ~170 npm packages and bundles Chromium (~300MB). This is a significant dependency but necessary for PDF rendering. The browser instance is created per-request and closed in a `finally` block.
- MathJax is loaded from CDN in the generated HTML; if Puppeteer has no network access, LaTeX won't render (but the PDF still generates).
- Memory: each PDF generation loads Chromium. The 500-card limit bounds memory usage per request.

## Goal alignment
Printable PDF export differentiates 2anki from competitors and serves a commonly requested use case (study groups, physical flashcards). Makes the product more useful to a broader audience, supporting the 300K-user growth goal.

Generated with [Claude Code](https://claude.com/claude-code)