### PR TITLE
fix: deduplicate done jobs and uploads on Conversions page

### DIFF
--- a/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
+++ b/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
@@ -24,7 +24,10 @@ interface Prop {
 export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }: Prop) {
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
 
-  if ((!uploads || uploads.length === 0) && doneJobs.length === 0) {
+  const uploadObjectIds = new Set((uploads ?? []).map((u) => u.object_id));
+  const uniqueDoneJobs = doneJobs.filter((j) => !uploadObjectIds.has(j.object_id));
+
+  if ((!uploads || uploads.length === 0) && uniqueDoneJobs.length === 0) {
     return null;
   }
 
@@ -60,7 +63,7 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
             </tr>
           </thead>
           <tbody>
-            {doneJobs.map((j) => (
+            {uniqueDoneJobs.map((j) => (
               <tr key={j.id}>
                 <td>
                   <span data-hj-suppress className={styles.fileName}>


### PR DESCRIPTION
## Summary
- Completed jobs appeared twice on the Conversions page — once from the `jobs` table (without "Send this to Anki") and once from the `uploads` table (with full actions)
- Root cause: when a job finishes, it inserts into `uploads` **and** stays in `jobs` with `status='done'`; the `FinishedJobs` component rendered both without deduplication
- Fix: filter done jobs by `object_id` so any job that already has a matching upload is skipped, keeping the richer upload row (preview + Send to Anki)

## Test plan
- [ ] Open the Conversions page with completed jobs — each deck should appear once, not twice
- [ ] Verify "Send this to Anki" button is present on download rows
- [ ] Verify download links still work
- [ ] Edge case: a done job without a matching upload (e.g. upload was deleted) should still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)