### PR TITLE
fix: preserve original formatting in nested toggle summaries

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -245,6 +245,36 @@ test('Notion new export: deeply nested toggles (3 levels)', async () => {
   expect(deck.cards[0].back).toContain('summary');
 });
 
+test('nested toggle summaries are not forcibly bolded', async () => {
+  const deck = await getDeck(
+    'Notion Page grandchildren 2ce7ab29a11e809998e3d22ed65fc5f2.html',
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false', 'enable-input': 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  const summaryMatches = deck.cards[0].back.match(/<summary[^>]*>([\s\S]*?)<\/summary>/g) || [];
+  expect(summaryMatches.length).toBeGreaterThan(0);
+  for (const match of summaryMatches) {
+    expect(match).not.toContain('<strong>');
+  }
+});
+
+test('nested toggle summaries preserve non-empty content', async () => {
+  const deck = await getDeck(
+    'Notion Page grandchildren 2ce7ab29a11e809998e3d22ed65fc5f2.html',
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false', 'enable-input': 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  const back = deck.cards[0].back;
+  const summaryMatches = back.match(/<summary[^>]*>([\s\S]*?)<\/summary>/g) || [];
+  expect(summaryMatches.length).toBeGreaterThan(0);
+  for (const match of summaryMatches) {
+    const inner = match.replace(/<summary[^>]*>/g, '').replace(/<\/summary>/g, '').trim();
+    expect(inner.length).toBeGreaterThan(0);
+  }
+});
+
 test('Nested toggles produce one card without maxOne (new format)', async () => {
   const deck = await getDeck(
     'Notion Page grandchildren 2ce7ab29a11e809998e3d22ed65fc5f2.html',

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -673,12 +673,12 @@ export class DeckParser {
           this.processNestedTogglesDepthFirst($nestedDetails, dom);
           
           const $summary = $nestedDetails.children('summary').first();
-          const summaryText = $summary.text().trim();
-          
-          if (summaryText) {
+          const summaryHTML = $summary.html()?.trim();
+
+          if (summaryHTML) {
             const $contentAfterSummary = $nestedDetails.contents().not('summary');
             let contentHTML = '';
-            
+
             $contentAfterSummary.each((_, content) => {
               if (dom(content).is('[style*="display:contents"]')) {
                 contentHTML += dom(content).html() || '';
@@ -686,9 +686,9 @@ export class DeckParser {
                 contentHTML += dom(content).toString();
               }
             });
-            
+
             const nestedDetailsHTML = `<details style="margin-left: 20px; margin-bottom: 10px;">
-              <summary><strong>${summaryText}</strong></summary>
+              <summary>${summaryHTML}</summary>
               ${contentHTML}
             </details>`;
             


### PR DESCRIPTION
## Summary
- Nested toggle summaries were unconditionally wrapped in `<strong>` tags by `processNestedTogglesDepthFirst`, causing two user-reported bugs:
  - **Toggle text became bolded** when the Notion source was not bold (reported Jan 30, 2026)
  - **Summary content rendered as browser-default "Details" text** (e.g. "詳細資料" in Chinese locale) when `.text()` returned empty for summaries with only HTML children (reported Dec 19, 2025)
- Fix: use `$summary.html()` instead of `$summary.text()` and drop the hard-coded `<strong>` wrapper

## Regression assessment
- All 739 existing tests pass, 0 failures
- TypeScript typecheck clean (`tsc --noEmit`)
- Existing nested toggle fixtures (grandchildren 3-level, new-export nested, legacy nested) all still produce correct output
- Change is scoped to one method (`processNestedTogglesDepthFirst`) in the HTML export path only — Notion API path and Ankify path are unaffected

## Test plan
- [x] Existing 3-level grandchildren test still passes (1 card, back contains "Child" and "Grand child")
- [x] New test: nested toggle summaries contain no `<strong>` tags
- [x] New test: nested toggle summaries have non-empty content (no empty `<summary>` that would trigger browser default text)
- [x] `maxOne=false` path still produces 1 card for nested toggles
- [x] Legacy format nested toggles unaffected
- [x] Manual test with Notion HTML export containing non-bold nested toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)