### PR TITLE
feat: add pre-upload file validation with guided error messages

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -59,9 +59,8 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
       <p className={styles.smallDescription}>
         Coming from Notion?{' '}
         <a href="/documentation/start-here/upload-a-file">
-          See how to export your pages
+          See how to export your pages.
         </a>
-        .
       </p>
       <p className={styles.smallDescription}>
         All files uploaded here are automatically deleted after 2 hours.

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -57,6 +57,13 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
       />
       <p>The following files are supported: {readableSupportedFiles}</p>
       <p className={styles.smallDescription}>
+        Coming from Notion?{' '}
+        <a href="/documentation/start-here/upload-a-file">
+          See how to export your pages
+        </a>
+        .
+      </p>
+      <p className={styles.smallDescription}>
         All files uploaded here are automatically deleted after 2 hours.
       </p>
       <SettingsModal

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -101,6 +101,69 @@
   background: #15803d;
 }
 
+.dropZoneWarning {
+  border-color: var(--color-warning);
+  background: var(--color-warning-light, #fffbeb);
+}
+
+.dropZoneError {
+  border-color: var(--color-danger);
+  background: var(--color-danger-light, #fef2f2);
+}
+
+.validationTitle {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.validationBody {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  max-width: 500px;
+  margin: 0;
+}
+
+.validationActions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.25rem;
+}
+
+.continueLink {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.continueLink:hover {
+  color: var(--color-text-primary);
+}
+
+.resetButton {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-full);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.resetButton:hover {
+  background: var(--color-primary-hover, #4338ca);
+}
+
 @media (max-width: 600px) {
   .dropZone {
     padding: 2rem 1rem;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -86,7 +86,7 @@ function UploadForm({
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const convertRef = useRef<HTMLButtonElement>(null);
-  const { validation, pendingFiles, validate, reset } = useFileValidation();
+  const { validation, validate, reset } = useFileValidation();
 
   const submitFiles = () => {
     convertRef.current?.click();

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -5,6 +5,7 @@ import getAcceptedContentTypes from '../../helpers/getAcceptedContentTypes';
 import getHeadersFilename from '../../helpers/getHeadersFilename';
 import DownloadButton from '../DownloadButton';
 import { useDrag } from './hooks/useDrag';
+import { useFileValidation } from './hooks/useFileValidation';
 import formStyles from './UploadForm.module.css';
 import styles from '../../../../styles/shared.module.css';
 
@@ -85,6 +86,11 @@ function UploadForm({
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const convertRef = useRef<HTMLButtonElement>(null);
+  const { validation, pendingFiles, validate, reset } = useFileValidation();
+
+  const submitFiles = () => {
+    convertRef.current?.click();
+  };
 
   const { dropHover } = useDrag({
     onDrop: (event) => {
@@ -92,7 +98,9 @@ function UploadForm({
       if (dataTransfer && dataTransfer.files.length > 0) {
         fileInputRef.current!.files = dataTransfer.files;
         onFileSelected?.();
-        convertRef.current?.click();
+        if (validate(dataTransfer.files)) {
+          submitFiles();
+        }
       }
       event.preventDefault();
     },
@@ -141,16 +149,58 @@ function UploadForm({
         htmlFor="pakker"
         className={`${formStyles.dropZone} ${
           dropHover ? formStyles.dropZoneActive : ''
+        } ${
+          validation?.status === 'warning' ? formStyles.dropZoneWarning : ''
+        } ${
+          validation?.status === 'error' ? formStyles.dropZoneError : ''
         }`}
       >
-        <span className={formStyles.dropIcon}>📄</span>
-        <span className={formStyles.dropText}>
-          Drag and drop your files here
-        </span>
-        <span className={formStyles.dropHint}>or</span>
-        <span className={formStyles.convertButton}>
-          Click to convert your notes
-        </span>
+        {validation ? (
+          <>
+            <span className={formStyles.dropIcon}>
+              {validation.status === 'error' ? '⚠' : 'ℹ'}
+            </span>
+            <p className={formStyles.validationTitle}>{validation.title}</p>
+            <p className={formStyles.validationBody}>{validation.body}</p>
+            <div className={formStyles.validationActions}>
+              <button
+                type="button"
+                className={formStyles.resetButton}
+                onClick={(e) => {
+                  e.preventDefault();
+                  reset();
+                  if (fileInputRef.current) {
+                    fileInputRef.current.value = '';
+                  }
+                }}
+              >
+                Pick a different file
+              </button>
+              <button
+                type="button"
+                className={formStyles.continueLink}
+                onClick={(e) => {
+                  e.preventDefault();
+                  reset();
+                  submitFiles();
+                }}
+              >
+                {validation.continueLabel}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <span className={formStyles.dropIcon}>📄</span>
+            <span className={formStyles.dropText}>
+              Drag and drop your files here
+            </span>
+            <span className={formStyles.dropHint}>or</span>
+            <span className={formStyles.convertButton}>
+              Click to convert your notes
+            </span>
+          </>
+        )}
         <input
           ref={fileInputRef}
           className={formStyles.fileInput}
@@ -162,7 +212,10 @@ function UploadForm({
           multiple
           onChange={() => {
             onFileSelected?.();
-            convertRef.current?.click();
+            const files = fileInputRef.current?.files;
+            if (files && validate(files)) {
+              submitFiles();
+            }
           }}
         />
       </label>

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { detectUploadIssues } from './useFileValidation';
+
+function fakeFile(name: string): File {
+  return new File([''], name);
+}
+
+describe('detectUploadIssues', () => {
+  it('returns null for a zip file', () => {
+    expect(detectUploadIssues([fakeFile('export.zip')])).toBeNull();
+  });
+
+  it('returns null for an empty file list', () => {
+    expect(detectUploadIssues([])).toBeNull();
+  });
+
+  it('returns error for a single markdown file', () => {
+    const result = detectUploadIssues([fakeFile('notes.md')]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('error');
+    expect(result!.title).toContain('Markdown');
+  });
+
+  it('returns error for multiple markdown files', () => {
+    const result = detectUploadIssues([
+      fakeFile('page1.md'),
+      fakeFile('page2.md'),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('error');
+  });
+
+  it('is case-insensitive for markdown detection', () => {
+    const result = detectUploadIssues([fakeFile('NOTES.MD')]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('error');
+  });
+
+  it('returns warning for a single html file', () => {
+    const result = detectUploadIssues([fakeFile('page.html')]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('warning');
+    expect(result!.title).toContain('images');
+  });
+
+  it('returns safari warning for multiple html files', () => {
+    const result = detectUploadIssues([
+      fakeFile('page1.html'),
+      fakeFile('page2.html'),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('warning');
+    expect(result!.title).toContain('Safari');
+  });
+
+  it('returns null for csv files', () => {
+    expect(detectUploadIssues([fakeFile('data.csv')])).toBeNull();
+  });
+
+  it('returns null for pdf files', () => {
+    expect(detectUploadIssues([fakeFile('slides.pdf')])).toBeNull();
+  });
+
+  it('returns null for xlsx files', () => {
+    expect(detectUploadIssues([fakeFile('sheet.xlsx')])).toBeNull();
+  });
+
+  it('returns null for mixed zip and html', () => {
+    expect(
+      detectUploadIssues([fakeFile('export.zip'), fakeFile('extra.html')])
+    ).toBeNull();
+  });
+
+  it('provides a continue label for each state', () => {
+    const md = detectUploadIssues([fakeFile('n.md')]);
+    expect(md!.continueLabel.length).toBeGreaterThan(0);
+
+    const html = detectUploadIssues([fakeFile('n.html')]);
+    expect(html!.continueLabel.length).toBeGreaterThan(0);
+
+    const safari = detectUploadIssues([
+      fakeFile('a.html'),
+      fakeFile('b.html'),
+    ]);
+    expect(safari!.continueLabel.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.ts
@@ -1,0 +1,82 @@
+import { useCallback, useState } from 'react';
+
+export type ValidationStatus = 'clean' | 'warning' | 'error';
+
+export interface FileValidationResult {
+  status: ValidationStatus;
+  title: string;
+  body: string;
+  continueLabel: string;
+}
+
+export function detectUploadIssues(
+  files: FileList | File[]
+): FileValidationResult | null {
+  const fileArray = Array.from(files);
+  if (fileArray.length === 0) return null;
+
+  const allMarkdown = fileArray.every((f) =>
+    f.name.toLowerCase().endsWith('.md')
+  );
+  if (allMarkdown) {
+    return {
+      status: 'error',
+      title: 'Markdown files make simple cards, not Notion-style decks',
+      body: 'If you exported from Notion, choose HTML instead of Markdown in Notion\'s export menu — you\'ll keep your images, toggles, and formatting. If this is a plain Markdown file, you can continue, but cards will be based on bullet pairs, not toggles.',
+      continueLabel: 'Continue with this file',
+    };
+  }
+
+  const htmlFiles = fileArray.filter((f) =>
+    f.name.toLowerCase().endsWith('.html')
+  );
+
+  if (htmlFiles.length >= 2) {
+    return {
+      status: 'warning',
+      title: 'Did Safari unzip your Notion export?',
+      body: 'If your files came from a Notion export, the images might have been left behind when Safari unpacked the zip. For the best results, re-download the export from Notion using a different browser, or find the original zip in your Downloads folder and upload that instead.',
+      continueLabel: 'Continue with these files',
+    };
+  }
+
+  if (fileArray.length === 1 && htmlFiles.length === 1) {
+    return {
+      status: 'warning',
+      title: 'This will work, but images won’t be included',
+      body: 'A single HTML file doesn\'t carry its images with it. If you exported this from Notion, go back and download the zip file instead — it bundles the images. If you don\'t need images, continue and we\'ll make your deck without them.',
+      continueLabel: 'Continue without images',
+    };
+  }
+
+  return null;
+}
+
+export function useFileValidation() {
+  const [validation, setValidation] = useState<FileValidationResult | null>(
+    null
+  );
+  const [pendingFiles, setPendingFiles] = useState<FileList | null>(null);
+
+  const validate = useCallback(
+    (files: FileList): boolean => {
+      const result = detectUploadIssues(files);
+      if (result) {
+        setValidation(result);
+        setPendingFiles(files);
+        return false;
+      }
+      setValidation(null);
+      setPendingFiles(null);
+      return true;
+    },
+    []
+  );
+
+  const reset = useCallback(() => {
+    setValidation(null);
+    setPendingFiles(null);
+  }, []);
+
+  return { validation, pendingFiles, validate, reset };
+}


### PR DESCRIPTION
## Summary
- Adds client-side file validation that catches the top 3 support-email mistakes **before** upload
- Markdown files (.md): error state with guidance to re-export as HTML from Notion
- Single HTML files: warning that images won't be included, suggests downloading zip instead
- Multiple HTML files: warning about Safari auto-extracting zips
- All warnings show inline in the dropzone with "Pick a different file" (primary) and "Continue anyway" (secondary)
- Zero extra friction for zip uploads — auto-submit works exactly as before
- Adds "Coming from Notion? See how to export your pages" link below supported formats

## Context
Analysis of 90 support emails (2020-2026) revealed that ~15 user errors were the same 3 mistakes: uploading markdown instead of HTML, uploading bare HTML without the zip, and Safari auto-extracting zips. This feature catches all three at the client before the upload round-trip.

Designed by the PM/Designer/Engineer trio:
- **PM**: spec with user stories, acceptance criteria, and exact copy
- **Designer**: inline dropzone replacement pattern, warning/error/tip visual tiers, "Continue anyway" escape hatch
- **Engineer**: `useFileValidation` hook with 12 unit tests

## Test plan
- [x] 12 unit tests for `detectUploadIssues` (all file type combinations)
- [x] Full web test suite passes (229 tests)
- [x] TypeScript typecheck clean
- [x] Biome lint clean
- [x] Manual test: drop a .md file → see error state → click "Pick a different file" → dropzone resets
- [x] Manual test: drop a single .html → see warning → click "Continue without images" → upload proceeds
- [x] Manual test: drop a .zip → auto-submits immediately, no warning shown
- [x] Manual test: "Coming from Notion?" link navigates to docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)