### PR TITLE
Fix reversed card sort order

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -140,6 +140,31 @@ test('Markdown nested bullet points', async () => {
   expect(deck.cards.length).toBe(4);
 });
 
+test('Markdown reversed cards keep numeric sort order', async () => {
+  const fixturePath = path.join(__dirname, '../../test/fixtures/simple-deck.md');
+  const contents = fs.readFileSync(fixturePath).toString();
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'simple-deck.md',
+    settings: new CardOption({
+      'markdown-nested-bullet-points': 'true',
+      reversed: 'true',
+      'basic-reversed': 'false',
+    }),
+    files: [{ name: 'simple-deck.md', contents }],
+    noLimits: true,
+    workspace,
+  });
+
+  parser.customExporter.save = jest.fn().mockResolvedValue('');
+  await parser.build(workspace);
+
+  const deck = parser.payload[0];
+
+  expect(deck.cards.map((card) => card.number)).toEqual([0, 1, 2, 3]);
+  expect(deck.cards).not.toContainEqual(expect.objectContaining({ number: -1 }));
+});
+
 test('Markdown nested bullets auto-detected without explicit setting', () => {
   const fixturePath = path.join(__dirname, '../../test/fixtures/notion-nested-bullets.md');
   const contents = fs.readFileSync(fixturePath).toString();

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -586,8 +586,6 @@ export class DeckParser {
           const tmp = card.back;
           card.back = card.name;
           card.name = tmp;
-          // Due to backwards compatability, do not increment number here
-          card.number = -1;
         }
       }
       deck.cards = Deck.CleanCards(deck.cards.concat(addThese));

--- a/src/lib/parser/Note.test.ts
+++ b/src/lib/parser/Note.test.ts
@@ -9,8 +9,9 @@ describe('Note', () => {
     const note = new Note('this is the back', '🔄this is the front');
     expect(note.reversed(note).name).toBe('🔄this is the front');
   });
-  test('reversed number is negative', () => {
+  test('reversed number sorts after source card', () => {
     const note = new Note('this is the back', '🔄this is the front');
-    expect(note.reversed(note).number).toBe(-1);
+    note.number = 4;
+    expect(note.reversed(note).number).toBe(4.5);
   });
 });

--- a/src/lib/parser/Note.ts
+++ b/src/lib/parser/Note.ts
@@ -63,8 +63,7 @@ export default class Note {
     const note = new Note(input.back, input.name);
     note.tags = input.tags;
     note.media = input.media;
-    // Due to backwards compatability, do not increment number here
-    note.number = -1;
+    note.number = input.number + 0.5;
     return note;
   }
 


### PR DESCRIPTION
## Summary
- keep reversed cards on their existing numeric sort order instead of assigning `-1`
- make `Note.reversed()` companion cards sort immediately after the source card
- add regression coverage for reversed-card numbering

Fixes #2137

## Verification
- `pnpm test -- src/lib/parser/Note.test.ts --runInBand`
- `pnpm test -- src/lib/parser/DeckParser.test.ts --runInBand --testNamePattern "Markdown reversed cards keep numeric sort order"`
- `pnpm run build`