### PR TITLE
feat: add APKG import to Notion (#280)

### DIFF
--- a/Documentation/specs/apkg-import.md
+++ b/Documentation/specs/apkg-import.md
@@ -1,0 +1,131 @@
+# Spec: Import APKG to Notion (#280)
+
+**Outcome**: Authenticated users with a connected Notion workspace can upload a `.apkg` file and get a Notion page tree with toggle-list flashcards. Target: 500 successful imports in the first 90 days.
+**Goal alignment**: The reverse flow (Anki -> Notion) converts Anki-only users into Notion+2anki users, expanding the funnel toward 300K. Issue #280 has been requested since 2023 and reopened after stale-bot auto-close -- persistent demand signal.
+
+## Problem
+
+Users who accumulated flashcards in Anki want them in Notion for editing, sharing, and feeding back into 2anki's Notion -> Anki pipeline. Today they must manually recreate every card as a toggle list. Some upload `.apkg` files to 2anki.net expecting reverse conversion and get nothing useful back.
+
+## Proposed solution
+
+One new endpoint. Upload `.apkg`, pick a destination Notion page, get a page tree where each deck becomes a child page and each note becomes a toggle block (front = summary, back = detail). Reuse the existing `ApkgPreviewService` parsing pipeline -- it already handles `collection.anki2`, `collection.anki21`, and zstd-compressed `collection.anki21b` archives.
+
+### Data flow
+
+```
+Upload (.apkg)
+  -> routes/ApkgRouter.ts (new POST /api/apkg/import)
+    -> controllers/ApkgController.ts (new importToNotion method)
+      -> usecases/apkg/ImportApkgToNotionUseCase.ts (new)
+        -> services/ApkgPreviewService (existing: extractApkg + parseCollection)
+        -> services/ApkgToNotionBlocksService.ts (new: pure transform, notes -> Notion block shapes)
+        -> services/NotionService (existing: getNotionToken, then Notion SDK pages.create + blocks.children.append)
+```
+
+### Mapping rules
+
+| Anki concept | Notion shape |
+|---|---|
+| Top-level deck | Child page under user-chosen parent page, titled with deck name |
+| Sub-deck (e.g. `Bio::Cell`) | Nested child page (parent = `Bio` page, child = `Cell` page) |
+| Note (Basic type) | Toggle heading 3: summary = first field (front), children = remaining fields as paragraphs (back) |
+| Note (Cloze type) | Toggle heading 3: summary = raw text with cloze markers stripped, children = full text with `{{c1::...}}` notation preserved as bold |
+| Media (images) | Upload to S3, embed as Notion `image` block (`type: "external"`, URL = S3 public URL) |
+| Media (audio/video) | Upload to S3, render as a paragraph with a clickable link (Notion has no native audio/video block) |
+| Tags | Appended as italic text at the bottom of the toggle body |
+
+### Rate-limit handling
+
+Notion free tier allows ~3 req/s. The use case must:
+- Batch blocks: `blocks.children.append` accepts up to 100 children per call. Group notes into batches of 50 (leaving headroom).
+- Throttle: 350ms delay between Notion API calls (< 3/s).
+- Report progress: return a job ID immediately; client polls `/api/apkg/import/:jobId/status`.
+
+### Media handling
+
+The `.apkg` zip contains a `media` JSON file mapping numeric keys to original filenames (e.g. `{"0": "photo.jpg", "1": "clip.mp3"}`), with the actual files stored alongside under those numeric names.
+
+**Flow:**
+1. During extraction, read the `media` manifest and collect all referenced files.
+2. Upload each file to S3 under `imports/{jobId}/{originalFilename}` using the existing S3 service (`StorageHandler`). Set `Content-Type` from the file extension. Objects are permanent (no expiry).
+3. Build a lookup map: `originalFilename → S3 public URL`.
+4. During the note-to-block transform, parse `<img src="filename">` references in note HTML fields. For each:
+   - **Images** (jpg, png, gif, webp, svg): emit a Notion `image` block with `type: "external"` and `url` pointing to the S3 URL.
+   - **Audio/video** (mp3, wav, ogg, mp4, webm): emit a `paragraph` block containing a link to the S3 URL.
+   - **Other files**: skip silently (rare in practice).
+5. Non-media HTML content (text, bold, italic) is still converted to Notion rich text as before.
+
+**Constraints:**
+- Media upload happens before block creation so all URLs are available during the transform.
+- Use the existing S3 client — do not introduce a new upload mechanism.
+- Total media per import is bounded by the existing multer upload size limit (the `.apkg` zip must fit within it).
+
+## API design
+
+### `POST /api/apkg/import`
+
+Auth: `RequireAuthentication` (not Ankify-gated, not pay-gated). Requires connected Notion workspace.
+
+Request: `multipart/form-data`
+- `file`: the `.apkg` file (existing multer limits apply)
+- `parent_page_id`: Notion page ID where deck pages will be created
+
+Response: `202 Accepted`
+```json
+{ "job_id": "uuid", "status": "queued" }
+```
+
+### `GET /api/apkg/import/:jobId/status`
+
+Auth: `RequireAuthentication`, owner must match.
+
+Response:
+```json
+{
+  "status": "processing" | "completed" | "failed",
+  "progress": { "total_notes": 500, "imported": 312 },
+  "notion_page_url": "https://notion.so/...",
+  "error": null
+}
+```
+
+## UI requirements (brief -- designer agent will detail)
+
+- New "Import to Notion" action on the upload page, visible when user has a connected Notion workspace.
+- Page picker: reuse the existing Notion page search (`searchTopLevelPages`) to let the user choose a destination.
+- Progress indicator showing notes imported / total.
+- Success state links to the created Notion page.
+
+## Layered scope
+
+| Layer | File | Change |
+|---|---|---|
+| Route | `routes/ApkgRouter.ts` | Two new endpoints |
+| Controller | `controllers/ApkgController.ts` | `importToNotion`, `getImportStatus` methods |
+| Use case | `usecases/apkg/ImportApkgToNotionUseCase.ts` | New: orchestrates parse + transform + Notion write + progress tracking |
+| Service | `services/ApkgToNotionBlocksService.ts` | New: pure function, `NormalizedCollection -> BlockObjectRequest[]` tree; resolves media refs to S3 URLs |
+| Service | `services/ApkgPreviewService/` | Existing, unchanged |
+| Service | `services/StorageHandler` | Existing: upload extracted media files to S3 under `imports/{jobId}/` |
+| Service | `services/NotionService/` | Existing `getNotionToken` + `NotionAPIWrapper.createBlock` |
+| Data | Jobs table (existing) | Store import job status |
+
+## What NOT to build
+
+- **Scheduling data import**: Anki's review history (revlog table) is not useful in Notion's toggle format. Do not import intervals, ease factors, or due dates.
+- **Two-way sync**: This is a one-shot import, not a live sync. No polling, no webhook, no conflict resolution.
+- **AnkiConnect integration**: The flow is file-upload only. No desktop Anki API communication.
+- **Custom note type rendering**: v1 uses field values directly, not Anki's card templates (qfmt/afmt). Template rendering is lossy outside Anki's webview and adds complexity without proportional value.
+- **Deck options/settings**: Configuration (new cards/day, intervals) does not map to Notion. Skip.
+
+## Open questions
+
+1. **Job storage**: Reuse the existing `jobs` table or a lightweight in-memory map? The existing table has the right shape (`status`, `owner`, `created_at`). Recommendation: reuse it, add a `type = 'apkg_import'` discriminator if needed.
+2. **Max deck size**: What is a reasonable cap? Notion's append-blocks endpoint is slow at scale. Recommendation: 5,000 notes per import; reject larger with a clear message. Revisit based on real usage.
+3. **HTML handling**: Anki note fields contain HTML. Notion blocks accept rich text, not HTML. Recommendation: strip HTML to plain text for v1, preserving bold/italic where trivially mappable. `<img>` tags are resolved to Notion image blocks via S3 URLs. Full HTML fidelity (tables, code blocks, LaTeX) is a v2 concern.
+
+## Out of scope (next iteration)
+
+- Full HTML -> Notion rich text conversion (tables, code blocks, LaTeX).
+- Batch import of multiple `.apkg` files.
+- Progress websocket (polling is sufficient for v1).

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -10,6 +10,7 @@ import ExportApkgToPdfUseCase, {
   CardLimitExceededError,
 } from '../usecases/apkg/ExportApkgToPdfUseCase';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
+import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParentPageUseCase';
 import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
@@ -225,14 +226,20 @@ class ApkgController {
         return;
       }
 
-      const parentPageId = req.body?.parent_page_id;
-      if (typeof parentPageId !== 'string' || parentPageId.trim().length === 0) {
-        res.status(400).json({ message: 'Missing parent_page_id.' });
-        return;
-      }
+      const rawParentPageId = req.body?.parent_page_id;
+      const hasExplicitParent =
+        typeof rawParentPageId === 'string' && rawParentPageId.trim().length > 0;
 
       const { owner } = res.locals;
       const notionApi = await this.notionService.getNotionAPI(owner);
+
+      let parentPageId: string;
+      if (hasExplicitParent) {
+        parentPageId = rawParentPageId.trim();
+      } else {
+        const resolver = new ResolveImportParentPageUseCase();
+        parentPageId = await resolver.execute(notionApi);
+      }
 
       const fs = await import('node:fs/promises');
       let fileBuffer: Buffer;
@@ -261,7 +268,7 @@ class ApkgController {
 
       void useCase.execute(
         fileBuffer,
-        parentPageId.trim(),
+        parentPageId,
         owner,
         notionApi,
         jobId

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -329,9 +329,15 @@ class ApkgController {
         }
       }
 
+      const statusText =
+        job.status === 'processing' && job.job_reason_failure?.startsWith('uploading')
+          ? job.job_reason_failure
+          : null;
+
       res.json({
         status: job.status === 'started' ? 'queued' : job.status,
         progress,
+        status_text: statusText,
         notion_page_url: notionPageUrl,
         error: errorMessage,
       });

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -253,17 +253,10 @@ class ApkgController {
       await this.jobRepository.create(jobId, owner, file.originalname, 'apkg_import');
 
       const blocksService = new ApkgToNotionBlocksService();
-      let storageHandler: StorageHandler | undefined;
-      try {
-        storageHandler = new StorageHandler();
-      } catch {
-        // S3 not configured — import proceeds without media
-      }
       const useCase = new ImportApkgToNotionUseCase(
         this.previewService,
         blocksService,
-        this.jobRepository,
-        storageHandler
+        this.jobRepository
       );
 
       void useCase.execute(

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -246,10 +246,17 @@ class ApkgController {
       await this.jobRepository.create(jobId, owner, file.originalname, 'apkg_import');
 
       const blocksService = new ApkgToNotionBlocksService();
+      let storageHandler: StorageHandler | undefined;
+      try {
+        storageHandler = new StorageHandler();
+      } catch {
+        // S3 not configured — import proceeds without media
+      }
       const useCase = new ImportApkgToNotionUseCase(
         this.previewService,
         blocksService,
-        this.jobRepository
+        this.jobRepository,
+        storageHandler
       );
 
       void useCase.execute(

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -1,12 +1,17 @@
 import { Request, Response } from 'express';
 import path from 'path';
+import { randomUUID } from 'crypto';
 import StorageHandler from '../lib/storage/StorageHandler';
 import DownloadService from '../services/DownloadService';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
+import ApkgToNotionBlocksService from '../services/ApkgToNotionBlocksService';
 import PdfRenderService from '../services/PdfRenderService';
 import ExportApkgToPdfUseCase, {
   CardLimitExceededError,
 } from '../usecases/apkg/ExportApkgToPdfUseCase';
+import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
+import { NotionService } from '../services/NotionService/NotionService';
+import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
 
 const MEDIA_CONTENT_TYPES: Record<string, string> = {
@@ -58,7 +63,9 @@ class ApkgController {
   constructor(
     private readonly downloadService: DownloadService,
     private readonly previewService: ApkgPreviewService,
-    private readonly pdfRenderService: PdfRenderService = new PdfRenderService()
+    private readonly pdfRenderService: PdfRenderService = new PdfRenderService(),
+    private readonly notionService?: NotionService,
+    private readonly jobRepository?: JobRepository
   ) {}
 
   private async loadForKey(req: Request, res: Response) {
@@ -199,6 +206,131 @@ class ApkgController {
       }
       console.error(error);
       res.status(500).json({ message: 'PDF generation failed.' });
+    }
+  }
+  async importToNotion(req: Request, res: Response) {
+    try {
+      if (this.notionService == null || this.jobRepository == null) {
+        res.status(500).json({ message: 'Import not configured.' });
+        return;
+      }
+
+      const file = req.file;
+      if (file == null) {
+        res.status(400).json({ message: 'No file uploaded.' });
+        return;
+      }
+      if (!isApkg(file.originalname)) {
+        res.status(400).json({ message: 'File must be an .apkg file.' });
+        return;
+      }
+
+      const parentPageId = req.body?.parent_page_id;
+      if (typeof parentPageId !== 'string' || parentPageId.trim().length === 0) {
+        res.status(400).json({ message: 'Missing parent_page_id.' });
+        return;
+      }
+
+      const { owner } = res.locals;
+      const notionApi = await this.notionService.getNotionAPI(owner);
+
+      const fs = await import('node:fs/promises');
+      let fileBuffer: Buffer;
+      try {
+        fileBuffer = await fs.readFile(file.path);
+      } finally {
+        await fs.unlink(file.path).catch(() => {});
+      }
+
+      const jobId = randomUUID();
+      await this.jobRepository.create(jobId, owner, file.originalname, 'apkg_import');
+
+      const blocksService = new ApkgToNotionBlocksService();
+      const useCase = new ImportApkgToNotionUseCase(
+        this.previewService,
+        blocksService,
+        this.jobRepository
+      );
+
+      void useCase.execute(
+        fileBuffer,
+        parentPageId.trim(),
+        owner,
+        notionApi,
+        jobId
+      );
+
+      res.status(202).json({ job_id: jobId, status: 'queued' });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === 'unauthorized'
+      ) {
+        res.status(400).json({ message: 'Notion is not connected.' });
+        return;
+      }
+      console.error(error);
+      res.status(500).json({ message: 'Import failed to start.' });
+    }
+  }
+
+  async getImportStatus(req: Request, res: Response) {
+    try {
+      if (this.jobRepository == null) {
+        res.status(500).json({ message: 'Import not configured.' });
+        return;
+      }
+
+      const { jobId } = req.params;
+      if (typeof jobId !== 'string' || jobId.trim().length === 0) {
+        res.status(400).json({ message: 'Missing job ID.' });
+        return;
+      }
+
+      const { owner } = res.locals;
+      const job = await this.jobRepository.findJobById(jobId, owner);
+
+      if (job == null) {
+        res.status(404).json({ message: 'Job not found.' });
+        return;
+      }
+
+      let progress = { total_notes: 0, imported: 0 };
+      let notionPageUrl: string | null = null;
+      let errorMessage: string | null = null;
+
+      if (job.status === 'done' && job.job_reason_failure) {
+        try {
+          const parsed = JSON.parse(job.job_reason_failure);
+          progress = {
+            total_notes: parsed.total_notes ?? 0,
+            imported: parsed.imported ?? 0,
+          };
+          notionPageUrl = parsed.notion_page_url ?? null;
+        } catch {
+          // job_reason_failure is not JSON, ignore
+        }
+      } else if (job.status === 'failed') {
+        errorMessage = job.job_reason_failure;
+      } else if (job.status === 'processing' && job.job_reason_failure) {
+        const parts = job.job_reason_failure.split('/');
+        if (parts.length === 2) {
+          progress = {
+            imported: parseInt(parts[0], 10) || 0,
+            total_notes: parseInt(parts[1].split(' ')[0], 10) || 0,
+          };
+        }
+      }
+
+      res.json({
+        status: job.status === 'started' ? 'queued' : job.status,
+        progress,
+        notion_page_url: notionPageUrl,
+        error: errorMessage,
+      });
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ message: 'Failed to get import status.' });
     }
   }
 }

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -226,6 +226,21 @@ class ApkgController {
         return;
       }
 
+      const isPaying = res.locals.patreon === true || res.locals.subscriber === true;
+      if (!isPaying) {
+        const importCount = await this.jobRepository.countJobsByType(
+          res.locals.owner,
+          'apkg_import'
+        );
+        if (importCount > 0) {
+          res.status(403).json({
+            message: 'Free plan allows one import. Upgrade for unlimited imports.',
+            upgrade: true,
+          });
+          return;
+        }
+      }
+
       const rawParentPageId = req.body?.parent_page_id;
       const hasExplicitParent =
         typeof rawParentPageId === 'string' && rawParentPageId.trim().length > 0;
@@ -264,7 +279,8 @@ class ApkgController {
         parentPageId,
         owner,
         notionApi,
-        jobId
+        jobId,
+        { isPaying }
       );
 
       res.status(202).json({ job_id: jobId, status: 'queued' });

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -67,6 +67,14 @@ class JobRepository {
       .returning('*');
     return rows[0] as Jobs;
   }
+  deleteOldJobs(type: string, olderThanMs: number): Promise<number> {
+    const cutoff = new Date(Date.now() - olderThanMs);
+    return this.database(this.tableName)
+      .where({ type })
+      .whereIn('status', JobRepository.TERMINAL_STATUSES)
+      .where('last_edited_time', '<', cutoff)
+      .delete();
+  }
 }
 
 export default JobRepository;

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -67,6 +67,14 @@ class JobRepository {
       .returning('*');
     return rows[0] as Jobs;
   }
+  countJobsByType(owner: string, type: string): Promise<number> {
+    return this.database(this.tableName)
+      .where({ owner, type })
+      .count('* as count')
+      .first()
+      .then((row) => Number((row as { count: string | number })?.count ?? 0));
+  }
+
   deleteOldJobs(type: string, olderThanMs: number): Promise<number> {
     const cutoff = new Date(Date.now() - olderThanMs);
     return this.database(this.tableName)

--- a/src/data_layer/index.ts
+++ b/src/data_layer/index.ts
@@ -6,6 +6,8 @@ import MigratorConfig = Knex.MigratorConfig;
 
 import { ScheduleCleanup } from '../lib/storage/jobs/ScheduleCleanup';
 import { scheduleAnkifyReaper } from '../lib/ankify/jobs/scheduleAnkifyReaper';
+import { scheduleImportJobReaper } from '../usecases/apkg/scheduleImportJobReaper';
+import JobRepository from './JobRepository';
 import { scheduleAnkifyPolling } from '../lib/ankify/jobs/scheduleAnkifyPolling';
 import { RacService } from '../services/ankify/RacService';
 import { AnkifyClientsRepository } from './ankify/AnkifyClientsRepository';
@@ -83,6 +85,7 @@ export const setupDatabase = async (database: Knex) => {
         ankifySessionTokensRepo
       );
       scheduleAnkifyReaper(ankifyRac);
+      scheduleImportJobReaper(new JobRepository(database));
 
       const schedulesRepo = new AnkifyExportSchedulesRepository(database);
       const notionRepo = new NotionRepository(database);

--- a/src/routes/ApkgRouter.ts
+++ b/src/routes/ApkgRouter.ts
@@ -8,13 +8,24 @@ import ApkgController from '../controllers/ApkgController';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
 import DownloadService from '../services/DownloadService';
 import DownloadRepository from '../data_layer/DownloadRepository';
+import JobRepository from '../data_layer/JobRepository';
+import NotionRepository from '../data_layer/NotionRespository';
+import { NotionService } from '../services/NotionService/NotionService';
 import { getDatabase } from '../data_layer';
 
 const ApkgRouter = () => {
   const database = getDatabase();
   const downloadService = new DownloadService(new DownloadRepository(database));
   const previewService = new ApkgPreviewService();
-  const controller = new ApkgController(downloadService, previewService);
+  const notionService = new NotionService(new NotionRepository(database));
+  const jobRepository = new JobRepository(database);
+  const controller = new ApkgController(
+    downloadService,
+    previewService,
+    undefined,
+    notionService,
+    jobRepository
+  );
   const router = express.Router();
 
   /**
@@ -134,6 +145,25 @@ const ApkgRouter = () => {
     '/api/apkg/:key/media/:name',
     RequireAuthentication,
     (req, res) => controller.getMedia(req, res)
+  );
+
+  const importUpload = multer({
+    dest: process.env.UPLOAD_BASE ?? '/tmp',
+    limits: { fileSize: 100 * 1024 * 1024 },
+  });
+
+  router.post(
+    '/api/apkg/import',
+    RequireAllowedOrigin,
+    RequireAuthentication,
+    importUpload.single('file'),
+    (req, res) => controller.importToNotion(req, res)
+  );
+
+  router.get(
+    '/api/apkg/import/:jobId/status',
+    RequireAuthentication,
+    (req, res) => controller.getImportStatus(req, res)
   );
 
   const pdfUpload = multer({

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -1,0 +1,225 @@
+import ApkgToNotionBlocksService from './ApkgToNotionBlocksService';
+import {
+  NormalizedCollection,
+  Note,
+  NoteType,
+  Deck,
+  Card,
+} from './ApkgPreviewService/types';
+
+function buildCollection(overrides?: {
+  noteTypes?: Map<number, NoteType>;
+  notes?: Map<number, Note>;
+  decks?: Map<number, Deck>;
+  cards?: Card[];
+}): NormalizedCollection {
+  const defaultNoteType: NoteType = {
+    id: 1,
+    name: 'Basic',
+    type: 0,
+    css: '',
+    fields: [
+      { name: 'Front', ord: 0 },
+      { name: 'Back', ord: 1 },
+    ],
+    templates: [{ name: 'Card 1', ord: 0, qfmt: '{{Front}}', afmt: '{{Back}}' }],
+  };
+
+  const defaultNote: Note = {
+    id: 100,
+    mid: 1,
+    tags: '',
+    fields: ['What is 2+2?', 'Four'],
+  };
+
+  const defaultDeck: Deck = { id: 10, name: 'Math' };
+
+  const defaultCard: Card = { id: 1000, nid: 100, did: 10, ord: 0 };
+
+  return {
+    noteTypes: overrides?.noteTypes ?? new Map([[1, defaultNoteType]]),
+    notes: overrides?.notes ?? new Map([[100, defaultNote]]),
+    decks: overrides?.decks ?? new Map([[10, defaultDeck]]),
+    cards: overrides?.cards ?? [defaultCard],
+  };
+}
+
+describe('ApkgToNotionBlocksService', () => {
+  const service = new ApkgToNotionBlocksService();
+
+  describe('transform', () => {
+    it('creates a deck page with toggle blocks for each note', () => {
+      const collection = buildCollection();
+      const result = service.transform(collection);
+
+      expect(result.deckPages).toHaveLength(1);
+      expect(result.deckPages[0].title).toBe('Math');
+      expect(result.deckPages[0].children).toHaveLength(1);
+
+      const toggle = result.deckPages[0].children[0];
+      expect(toggle.type).toBe('heading_3');
+      expect(toggle.heading_3.rich_text[0].plain_text).toBe('What is 2+2?');
+      expect(toggle.heading_3.is_toggleable).toBe(true);
+      expect(toggle.heading_3.children).toHaveLength(1);
+      expect(toggle.heading_3.children[0].paragraph.rich_text[0].plain_text).toBe(
+        'Four'
+      );
+    });
+
+    it('strips HTML tags from fields', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['<b>Bold</b> text', '<i>Italic</i> answer'] }],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection);
+
+      const toggle = result.deckPages[0].children[0];
+      expect(toggle.heading_3.rich_text[0].plain_text).toBe('Bold text');
+    });
+
+    it('preserves bold formatting from HTML', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['Front', '<b>Important</b> detail'] }],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection);
+
+      const backChildren = result.deckPages[0].children[0].heading_3.children;
+      const richText = backChildren[0].paragraph.rich_text;
+      const boldSegment = richText.find(
+        (seg: { annotations?: { bold?: boolean } }) => seg.annotations?.bold === true
+      );
+      expect(boldSegment).toBeDefined();
+      expect(boldSegment!.plain_text).toBe('Important');
+    });
+
+    it('preserves italic formatting from HTML', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['Front', '<i>Emphasis</i> here'] }],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection);
+
+      const backChildren = result.deckPages[0].children[0].heading_3.children;
+      const richText = backChildren[0].paragraph.rich_text;
+      const italicSegment = richText.find(
+        (seg: { annotations?: { italic?: boolean } }) => seg.annotations?.italic === true
+      );
+      expect(italicSegment).toBeDefined();
+      expect(italicSegment!.plain_text).toBe('Emphasis');
+    });
+
+    it('creates nested deck pages for sub-decks', () => {
+      const decks = new Map<number, Deck>([
+        [10, { id: 10, name: 'Bio' }],
+        [11, { id: 11, name: 'Bio::Cell' }],
+      ]);
+      const cards: Card[] = [
+        { id: 1000, nid: 100, did: 11, ord: 0 },
+      ];
+      const collection = buildCollection({ decks, cards });
+      const result = service.transform(collection);
+
+      expect(result.deckPages).toHaveLength(1);
+      expect(result.deckPages[0].title).toBe('Bio');
+      expect(result.deckPages[0].subDecks).toHaveLength(1);
+      expect(result.deckPages[0].subDecks[0].title).toBe('Cell');
+    });
+
+    it('adds tags as italic text at bottom of toggle', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: ' math algebra ', fields: ['Q', 'A'] }],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection);
+
+      const toggleChildren = result.deckPages[0].children[0].heading_3.children;
+      const tagBlock = toggleChildren[toggleChildren.length - 1];
+      expect(tagBlock.paragraph.rich_text[0].annotations.italic).toBe(true);
+      expect(tagBlock.paragraph.rich_text[0].plain_text).toContain('math');
+    });
+
+    it('handles cloze notes by stripping markers in summary', () => {
+      const clozeNoteType: NoteType = {
+        id: 2,
+        name: 'Cloze',
+        type: 1,
+        css: '',
+        fields: [{ name: 'Text', ord: 0 }, { name: 'Extra', ord: 1 }],
+        templates: [{ name: 'Cloze', ord: 0, qfmt: '{{cloze:Text}}', afmt: '{{cloze:Text}}' }],
+      };
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 2, tags: '', fields: ['{{c1::Paris}} is the capital of France', ''] }],
+      ]);
+      const noteTypes = new Map<number, NoteType>([[2, clozeNoteType]]);
+      const collection = buildCollection({ noteTypes, notes });
+      const result = service.transform(collection);
+
+      const toggle = result.deckPages[0].children[0];
+      expect(toggle.heading_3.rich_text[0].plain_text).toBe(
+        'Paris is the capital of France'
+      );
+    });
+
+    it('strips media refs from fields', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['<img src="image.png">Question', 'Answer [sound:audio.mp3]'] }],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection);
+
+      const toggle = result.deckPages[0].children[0];
+      expect(toggle.heading_3.rich_text[0].plain_text).not.toContain('img');
+      expect(toggle.heading_3.rich_text[0].plain_text).not.toContain('image.png');
+    });
+
+    it('returns totalNotes count', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['Q1', 'A1'] }],
+        [101, { id: 101, mid: 1, tags: '', fields: ['Q2', 'A2'] }],
+      ]);
+      const cards: Card[] = [
+        { id: 1000, nid: 100, did: 10, ord: 0 },
+        { id: 1001, nid: 101, did: 10, ord: 0 },
+      ];
+      const collection = buildCollection({ notes, cards });
+      const result = service.transform(collection);
+
+      expect(result.totalNotes).toBe(2);
+    });
+
+    it('limits to MAX_NOTES and signals truncation', () => {
+      const notes = new Map<number, Note>();
+      const cards: Card[] = [];
+      for (let i = 0; i < 5001; i++) {
+        notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
+        cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
+      }
+      const collection = buildCollection({ notes, cards });
+
+      expect(() => service.transform(collection)).toThrow(/too large/i);
+    });
+
+    it('handles multiple decks', () => {
+      const decks = new Map<number, Deck>([
+        [10, { id: 10, name: 'Math' }],
+        [20, { id: 20, name: 'History' }],
+      ]);
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['Q1', 'A1'] }],
+        [101, { id: 101, mid: 1, tags: '', fields: ['Q2', 'A2'] }],
+      ]);
+      const cards: Card[] = [
+        { id: 1000, nid: 100, did: 10, ord: 0 },
+        { id: 1001, nid: 101, did: 20, ord: 0 },
+      ];
+      const collection = buildCollection({ decks, notes, cards });
+      const result = service.transform(collection);
+
+      expect(result.deckPages).toHaveLength(2);
+      const deckNames = result.deckPages.map((d) => d.title);
+      expect(deckNames).toContain('Math');
+      expect(deckNames).toContain('History');
+    });
+  });
+});

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -44,8 +44,15 @@ function buildCollection(overrides?: {
   };
 }
 
+function getToggle(blocks: ReturnType<typeof service.transform>['deckPages'][0]['children'], index = 0) {
+  const block = blocks[index];
+  if (block.type !== 'heading_3') throw new Error(`Expected heading_3 at index ${index}, got ${block.type}`);
+  return block;
+}
+
+const service = new ApkgToNotionBlocksService();
+
 describe('ApkgToNotionBlocksService', () => {
-  const service = new ApkgToNotionBlocksService();
 
   describe('transform', () => {
     it('creates a deck page with toggle blocks for each note', () => {
@@ -56,8 +63,7 @@ describe('ApkgToNotionBlocksService', () => {
       expect(result.deckPages[0].title).toBe('Math');
       expect(result.deckPages[0].children).toHaveLength(1);
 
-      const toggle = result.deckPages[0].children[0];
-      expect(toggle.type).toBe('heading_3');
+      const toggle = getToggle(result.deckPages[0].children);
       expect(toggle.heading_3.rich_text[0].plain_text).toBe('What is 2+2?');
       expect(toggle.heading_3.is_toggleable).toBe(true);
       expect(toggle.heading_3.children).toHaveLength(1);
@@ -75,7 +81,7 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(collection);
 
-      const toggle = result.deckPages[0].children[0];
+      const toggle = getToggle(result.deckPages[0].children);
       expect(toggle.heading_3.rich_text[0].plain_text).toBe('Bold text');
     });
 
@@ -86,7 +92,7 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(collection);
 
-      const backChildren = result.deckPages[0].children[0].heading_3.children;
+      const backChildren = getToggle(result.deckPages[0].children).heading_3.children;
       const firstChild = backChildren[0];
       expect(firstChild.type).toBe('paragraph');
       if (firstChild.type === 'paragraph') {
@@ -105,7 +111,7 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(collection);
 
-      const backChildren = result.deckPages[0].children[0].heading_3.children;
+      const backChildren = getToggle(result.deckPages[0].children).heading_3.children;
       const firstChild = backChildren[0];
       expect(firstChild.type).toBe('paragraph');
       if (firstChild.type === 'paragraph') {
@@ -141,7 +147,7 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(collection);
 
-      const toggleChildren = result.deckPages[0].children[0].heading_3.children;
+      const toggleChildren = getToggle(result.deckPages[0].children).heading_3.children;
       const tagBlock = toggleChildren[toggleChildren.length - 1];
       expect(tagBlock.type).toBe('paragraph');
       if (tagBlock.type === 'paragraph') {
@@ -166,7 +172,7 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ noteTypes, notes });
       const result = service.transform(collection);
 
-      const toggle = result.deckPages[0].children[0];
+      const toggle = getToggle(result.deckPages[0].children);
       expect(toggle.heading_3.rich_text[0].plain_text).toBe(
         'Paris is the capital of France'
       );
@@ -179,7 +185,7 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(collection);
 
-      const toggle = result.deckPages[0].children[0];
+      const toggle = getToggle(result.deckPages[0].children);
       expect(toggle.heading_3.rich_text[0].plain_text).toBe('3 x 4 = ');
       expect(toggle.heading_3.rich_text[0].plain_text).not.toContain('&nbsp;');
     });
@@ -191,7 +197,7 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(collection);
 
-      const backChildren = result.deckPages[0].children[0].heading_3.children;
+      const backChildren = getToggle(result.deckPages[0].children).heading_3.children;
       const firstChild = backChildren[0];
       expect(firstChild.type).toBe('paragraph');
       if (firstChild.type === 'paragraph') {
@@ -199,18 +205,21 @@ describe('ApkgToNotionBlocksService', () => {
       }
     });
 
-    it('strips media refs from text when no URL map provided', () => {
+    it('strips media refs from text in text-heavy front fields', () => {
       const notes = new Map<number, Note>([
-        [100, { id: 100, mid: 1, tags: '', fields: ['<img src="image.png">Question', 'Answer [sound:audio.mp3]'] }],
+        [100, { id: 100, mid: 1, tags: '', fields: ['What is this? <img src="image.png"> Identify the object shown above.', 'Answer [sound:audio.mp3]'] }],
       ]);
       const collection = buildCollection({ notes });
       const result = service.transform(collection);
 
       const toggle = result.deckPages[0].children[0];
-      expect(toggle.heading_3.rich_text[0].plain_text).toBe('Question');
+      expect(toggle.type).toBe('heading_3');
+      if (toggle.type === 'heading_3') {
+        expect(toggle.heading_3.rich_text[0].plain_text).toContain('What is this?');
+      }
     });
 
-    it('uses first non-empty text field as summary when front is image-only', () => {
+    it('uses image-first layout when front is image-only', () => {
       const noteType: NoteType = {
         id: 3,
         name: 'Image Occlusion',
@@ -237,11 +246,117 @@ describe('ApkgToNotionBlocksService', () => {
       });
       const result = service.transform(collection);
 
-      const toggle = result.deckPages[0].children[0];
-      expect(toggle.heading_3.rich_text[0].plain_text).toBe('France');
+      const blocks = result.deckPages[0].children;
+      expect(blocks[0].type).toBe('divider');
+      const answerBlock = blocks.find((b) => b.type === 'heading_3');
+      expect(answerBlock).toBeDefined();
+      if (answerBlock?.type === 'heading_3') {
+        const textChildren = answerBlock.heading_3.children.filter(
+          (c) => c.type === 'paragraph'
+        );
+        const texts = textChildren.map((c) =>
+          c.type === 'paragraph' ? c.paragraph.rich_text[0]?.plain_text : ''
+        );
+        expect(texts).toContain('France');
+      }
     });
 
-    it('emits image blocks when media URL map is provided', () => {
+    it('uses image-first layout for image-only front fields', () => {
+      const noteType: NoteType = {
+        id: 3,
+        name: 'Bollard',
+        type: 0,
+        css: '',
+        fields: [
+          { name: 'Picture', ord: 0 },
+          { name: 'Country', ord: 1 },
+          { name: 'Notes', ord: 2 },
+        ],
+        templates: [{ name: 'Card 1', ord: 0, qfmt: '', afmt: '' }],
+      };
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 3, tags: '', fields: [
+          '<img src="bollard.jpg">',
+          'France',
+          'French bollards are super thick',
+        ]}],
+      ]);
+      const mediaUrlMap = new Map([
+        ['bollard.jpg', 'https://cdn.example.com/bollard.jpg'],
+      ]);
+      const collection = buildCollection({
+        noteTypes: new Map([[3, noteType]]),
+        notes,
+        cards: [{ id: 1000, nid: 100, did: 10, ord: 0 }],
+      });
+      const result = service.transform(collection, mediaUrlMap);
+
+      const blocks = result.deckPages[0].children;
+      expect(blocks[0].type).toBe('divider');
+      expect(blocks[1].type).toBe('image');
+      if (blocks[1].type === 'image') {
+        expect(blocks[1].image.external.url).toBe('https://cdn.example.com/bollard.jpg');
+      }
+      expect(blocks[2].type).toBe('heading_3');
+      if (blocks[2].type === 'heading_3') {
+        expect(blocks[2].heading_3.is_toggleable).toBe(true);
+        expect(blocks[2].heading_3.rich_text[0].plain_text).toBe('Answer');
+        const answerChildren = blocks[2].heading_3.children;
+        const texts = answerChildren
+          .filter((c) => c.type === 'paragraph')
+          .map((c) => (c as { type: 'paragraph'; paragraph: { rich_text: { plain_text: string }[] } }).paragraph.rich_text[0]?.plain_text);
+        expect(texts).toContain('France');
+        expect(texts).toContain('French bollards are super thick');
+      }
+    });
+
+    it('uses named field label for single back-field image-first cards', () => {
+      const noteType: NoteType = {
+        id: 4,
+        name: 'Flag Quiz',
+        type: 0,
+        css: '',
+        fields: [
+          { name: 'Flag', ord: 0 },
+          { name: 'Country', ord: 1 },
+        ],
+        templates: [{ name: 'Card 1', ord: 0, qfmt: '', afmt: '' }],
+      };
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 4, tags: '', fields: ['<img src="flag.png">', 'Japan'] }],
+      ]);
+      const collection = buildCollection({
+        noteTypes: new Map([[4, noteType]]),
+        notes,
+        cards: [{ id: 1000, nid: 100, did: 10, ord: 0 }],
+      });
+      const result = service.transform(collection, new Map([['flag.png', 'https://cdn.example.com/flag.png']]));
+
+      const toggleBlock = result.deckPages[0].children[2];
+      expect(toggleBlock.type).toBe('heading_3');
+      if (toggleBlock.type === 'heading_3') {
+        expect(toggleBlock.heading_3.rich_text[0].plain_text).toBe('Country');
+      }
+    });
+
+    it('keeps toggle layout for text-first notes with images', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: [
+          'What does this bollard look like? <img src="hint.jpg">',
+          'France',
+        ]}],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection, new Map([['hint.jpg', 'https://cdn.example.com/hint.jpg']]));
+
+      const block = result.deckPages[0].children[0];
+      expect(block.type).toBe('heading_3');
+      if (block.type === 'heading_3') {
+        expect(block.heading_3.rich_text[0].plain_text).toBe('What does this bollard look like?');
+      }
+    });
+
+    it('emits image blocks in image-first layout when media URL map is provided', () => {
       const notes = new Map<number, Note>([
         [100, { id: 100, mid: 1, tags: '', fields: [
           '<img src="bollard.jpg">',
@@ -254,10 +369,8 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(collection, mediaUrlMap);
 
-      const toggle = result.deckPages[0].children[0];
-      const imageBlock = toggle.heading_3.children.find(
-        (c) => c.type === 'image'
-      );
+      const blocks = result.deckPages[0].children;
+      const imageBlock = blocks.find((b) => b.type === 'image');
       expect(imageBlock).toBeDefined();
       if (imageBlock?.type === 'image') {
         expect(imageBlock.image.external.url).toBe(
@@ -333,7 +446,7 @@ describe('ApkgToNotionBlocksService', () => {
       expect(deckNames).toContain('History');
     });
 
-    it('handles custom note types with many fields gracefully', () => {
+    it('handles custom note types with many fields using image-first layout', () => {
       const customType: NoteType = {
         id: 5,
         name: 'GeoGuessr Card',
@@ -362,17 +475,23 @@ describe('ApkgToNotionBlocksService', () => {
       });
       const result = service.transform(collection);
 
-      const toggle = result.deckPages[0].children[0];
-      expect(toggle.heading_3.rich_text[0].plain_text).toBe('Austria, Slovenia');
+      const blocks = result.deckPages[0].children;
+      expect(blocks[0].type).toBe('divider');
 
-      const textChildren = toggle.heading_3.children.filter(
-        (c) => c.type === 'paragraph'
-      );
-      const texts = textChildren.map((c) =>
-        c.type === 'paragraph' ? c.paragraph.rich_text[0]?.plain_text : ''
-      );
-      expect(texts).toContain('Similar Design: Montenegro has the same design');
-      expect(texts).toContain('note: Snowpole on right found in Andorra');
+      const answerBlock = blocks.find((b) => b.type === 'heading_3');
+      expect(answerBlock).toBeDefined();
+      if (answerBlock?.type === 'heading_3') {
+        expect(answerBlock.heading_3.rich_text[0].plain_text).toBe('Answer');
+        const textChildren = answerBlock.heading_3.children.filter(
+          (c) => c.type === 'paragraph'
+        );
+        const texts = textChildren.map((c) =>
+          c.type === 'paragraph' ? c.paragraph.rich_text[0]?.plain_text : ''
+        );
+        expect(texts).toContain('Austria, Slovenia');
+        expect(texts).toContain('Similar Design: Montenegro has the same design');
+        expect(texts).toContain('note: Snowpole on right found in Andorra');
+      }
     });
   });
 });

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -223,6 +223,24 @@ describe('ApkgToNotionBlocksService', () => {
       expect(() => service.transform(collection)).toThrow(/too large/i);
     });
 
+    it('skips empty decks like Default', () => {
+      const decks = new Map<number, Deck>([
+        [1, { id: 1, name: 'Default' }],
+        [10, { id: 10, name: 'Spanish' }],
+      ]);
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['Hola', 'Hello'] }],
+      ]);
+      const cards: Card[] = [
+        { id: 1000, nid: 100, did: 10, ord: 0 },
+      ];
+      const collection = buildCollection({ decks, notes, cards });
+      const result = service.transform(collection);
+
+      expect(result.deckPages).toHaveLength(1);
+      expect(result.deckPages[0].title).toBe('Spanish');
+    });
+
     it('handles multiple decks', () => {
       const decks = new Map<number, Deck>([
         [10, { id: 10, name: 'Math' }],

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -161,6 +161,29 @@ describe('ApkgToNotionBlocksService', () => {
       );
     });
 
+    it('decodes HTML entities like &nbsp;', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['3 x 4 =&nbsp;', '12'] }],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection);
+
+      const toggle = result.deckPages[0].children[0];
+      expect(toggle.heading_3.rich_text[0].plain_text).toBe('3 x 4 = ');
+      expect(toggle.heading_3.rich_text[0].plain_text).not.toContain('&nbsp;');
+    });
+
+    it('decodes numeric and named HTML entities in back fields', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: ['Q', '5 &gt; 3 &amp; 2 &lt; 4'] }],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection);
+
+      const backChildren = result.deckPages[0].children[0].heading_3.children;
+      expect(backChildren[0].paragraph.rich_text[0].plain_text).toBe('5 > 3 & 2 < 4');
+    });
+
     it('strips media refs from fields', () => {
       const notes = new Map<number, Note>([
         [100, { id: 100, mid: 1, tags: '', fields: ['<img src="image.png">Question', 'Answer [sound:audio.mp3]'] }],

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -61,9 +61,11 @@ describe('ApkgToNotionBlocksService', () => {
       expect(toggle.heading_3.rich_text[0].plain_text).toBe('What is 2+2?');
       expect(toggle.heading_3.is_toggleable).toBe(true);
       expect(toggle.heading_3.children).toHaveLength(1);
-      expect(toggle.heading_3.children[0].paragraph.rich_text[0].plain_text).toBe(
-        'Four'
-      );
+      const firstChild = toggle.heading_3.children[0];
+      expect(firstChild.type).toBe('paragraph');
+      if (firstChild.type === 'paragraph') {
+        expect(firstChild.paragraph.rich_text[0].plain_text).toBe('Four');
+      }
     });
 
     it('strips HTML tags from fields', () => {
@@ -85,12 +87,15 @@ describe('ApkgToNotionBlocksService', () => {
       const result = service.transform(collection);
 
       const backChildren = result.deckPages[0].children[0].heading_3.children;
-      const richText = backChildren[0].paragraph.rich_text;
-      const boldSegment = richText.find(
-        (seg: { annotations?: { bold?: boolean } }) => seg.annotations?.bold === true
-      );
-      expect(boldSegment).toBeDefined();
-      expect(boldSegment!.plain_text).toBe('Important');
+      const firstChild = backChildren[0];
+      expect(firstChild.type).toBe('paragraph');
+      if (firstChild.type === 'paragraph') {
+        const boldSegment = firstChild.paragraph.rich_text.find(
+          (seg) => seg.annotations?.bold === true
+        );
+        expect(boldSegment).toBeDefined();
+        expect(boldSegment!.plain_text).toBe('Important');
+      }
     });
 
     it('preserves italic formatting from HTML', () => {
@@ -101,12 +106,15 @@ describe('ApkgToNotionBlocksService', () => {
       const result = service.transform(collection);
 
       const backChildren = result.deckPages[0].children[0].heading_3.children;
-      const richText = backChildren[0].paragraph.rich_text;
-      const italicSegment = richText.find(
-        (seg: { annotations?: { italic?: boolean } }) => seg.annotations?.italic === true
-      );
-      expect(italicSegment).toBeDefined();
-      expect(italicSegment!.plain_text).toBe('Emphasis');
+      const firstChild = backChildren[0];
+      expect(firstChild.type).toBe('paragraph');
+      if (firstChild.type === 'paragraph') {
+        const italicSegment = firstChild.paragraph.rich_text.find(
+          (seg) => seg.annotations?.italic === true
+        );
+        expect(italicSegment).toBeDefined();
+        expect(italicSegment!.plain_text).toBe('Emphasis');
+      }
     });
 
     it('creates nested deck pages for sub-decks', () => {
@@ -135,8 +143,11 @@ describe('ApkgToNotionBlocksService', () => {
 
       const toggleChildren = result.deckPages[0].children[0].heading_3.children;
       const tagBlock = toggleChildren[toggleChildren.length - 1];
-      expect(tagBlock.paragraph.rich_text[0].annotations.italic).toBe(true);
-      expect(tagBlock.paragraph.rich_text[0].plain_text).toContain('math');
+      expect(tagBlock.type).toBe('paragraph');
+      if (tagBlock.type === 'paragraph') {
+        expect(tagBlock.paragraph.rich_text[0].annotations.italic).toBe(true);
+        expect(tagBlock.paragraph.rich_text[0].plain_text).toContain('math');
+      }
     });
 
     it('handles cloze notes by stripping markers in summary', () => {
@@ -181,10 +192,14 @@ describe('ApkgToNotionBlocksService', () => {
       const result = service.transform(collection);
 
       const backChildren = result.deckPages[0].children[0].heading_3.children;
-      expect(backChildren[0].paragraph.rich_text[0].plain_text).toBe('5 > 3 & 2 < 4');
+      const firstChild = backChildren[0];
+      expect(firstChild.type).toBe('paragraph');
+      if (firstChild.type === 'paragraph') {
+        expect(firstChild.paragraph.rich_text[0].plain_text).toBe('5 > 3 & 2 < 4');
+      }
     });
 
-    it('strips media refs from fields', () => {
+    it('strips media refs from text when no URL map provided', () => {
       const notes = new Map<number, Note>([
         [100, { id: 100, mid: 1, tags: '', fields: ['<img src="image.png">Question', 'Answer [sound:audio.mp3]'] }],
       ]);
@@ -192,8 +207,63 @@ describe('ApkgToNotionBlocksService', () => {
       const result = service.transform(collection);
 
       const toggle = result.deckPages[0].children[0];
-      expect(toggle.heading_3.rich_text[0].plain_text).not.toContain('img');
-      expect(toggle.heading_3.rich_text[0].plain_text).not.toContain('image.png');
+      expect(toggle.heading_3.rich_text[0].plain_text).toBe('Question');
+    });
+
+    it('uses first non-empty text field as summary when front is image-only', () => {
+      const noteType: NoteType = {
+        id: 3,
+        name: 'Image Occlusion',
+        type: 0,
+        css: '',
+        fields: [
+          { name: 'Picture', ord: 0 },
+          { name: 'Country', ord: 1 },
+          { name: 'Notes', ord: 2 },
+        ],
+        templates: [{ name: 'Card 1', ord: 0, qfmt: '', afmt: '' }],
+      };
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 3, tags: '', fields: [
+          '<img src="bollard.jpg">',
+          'France',
+          'French bollards are super thick',
+        ]}],
+      ]);
+      const collection = buildCollection({
+        noteTypes: new Map([[3, noteType]]),
+        notes,
+        cards: [{ id: 1000, nid: 100, did: 10, ord: 0 }],
+      });
+      const result = service.transform(collection);
+
+      const toggle = result.deckPages[0].children[0];
+      expect(toggle.heading_3.rich_text[0].plain_text).toBe('France');
+    });
+
+    it('emits image blocks when media URL map is provided', () => {
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 1, tags: '', fields: [
+          '<img src="bollard.jpg">',
+          'France',
+        ]}],
+      ]);
+      const mediaUrlMap = new Map([
+        ['bollard.jpg', 'https://cdn.example.com/imports/job-1/bollard.jpg'],
+      ]);
+      const collection = buildCollection({ notes });
+      const result = service.transform(collection, mediaUrlMap);
+
+      const toggle = result.deckPages[0].children[0];
+      const imageBlock = toggle.heading_3.children.find(
+        (c) => c.type === 'image'
+      );
+      expect(imageBlock).toBeDefined();
+      if (imageBlock?.type === 'image') {
+        expect(imageBlock.image.external.url).toBe(
+          'https://cdn.example.com/imports/job-1/bollard.jpg'
+        );
+      }
     });
 
     it('returns totalNotes count', () => {
@@ -261,6 +331,48 @@ describe('ApkgToNotionBlocksService', () => {
       const deckNames = result.deckPages.map((d) => d.title);
       expect(deckNames).toContain('Math');
       expect(deckNames).toContain('History');
+    });
+
+    it('handles custom note types with many fields gracefully', () => {
+      const customType: NoteType = {
+        id: 5,
+        name: 'GeoGuessr Card',
+        type: 0,
+        css: '',
+        fields: [
+          { name: 'Picture', ord: 0 },
+          { name: 'Country', ord: 1 },
+          { name: 'AlsoFoundIn', ord: 2 },
+          { name: 'Notes', ord: 3 },
+        ],
+        templates: [{ name: 'Card 1', ord: 0, qfmt: '', afmt: '' }],
+      };
+      const notes = new Map<number, Note>([
+        [100, { id: 100, mid: 5, tags: '', fields: [
+          '<img src="pic.jpg">',
+          'Austria, Slovenia',
+          'Similar Design: Montenegro has the same design',
+          'note: Snowpole on right found in Andorra',
+        ]}],
+      ]);
+      const collection = buildCollection({
+        noteTypes: new Map([[5, customType]]),
+        notes,
+        cards: [{ id: 1000, nid: 100, did: 10, ord: 0 }],
+      });
+      const result = service.transform(collection);
+
+      const toggle = result.deckPages[0].children[0];
+      expect(toggle.heading_3.rich_text[0].plain_text).toBe('Austria, Slovenia');
+
+      const textChildren = toggle.heading_3.children.filter(
+        (c) => c.type === 'paragraph'
+      );
+      const texts = textChildren.map((c) =>
+        c.type === 'paragraph' ? c.paragraph.rich_text[0]?.plain_text : ''
+      );
+      expect(texts).toContain('Similar Design: Montenegro has the same design');
+      expect(texts).toContain('note: Snowpole on right found in Andorra');
     });
   });
 });

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -294,7 +294,7 @@ describe('ApkgToNotionBlocksService', () => {
       const blocks = result.deckPages[0].children;
       expect(blocks[0].type).toBe('divider');
       expect(blocks[1].type).toBe('image');
-      if (blocks[1].type === 'image') {
+      if (blocks[1].type === 'image' && blocks[1].image.type === 'external') {
         expect(blocks[1].image.external.url).toBe('https://cdn.example.com/bollard.jpg');
       }
       expect(blocks[2].type).toBe('heading_3');
@@ -372,7 +372,7 @@ describe('ApkgToNotionBlocksService', () => {
       const blocks = result.deckPages[0].children;
       const imageBlock = blocks.find((b) => b.type === 'image');
       expect(imageBlock).toBeDefined();
-      if (imageBlock?.type === 'image') {
+      if (imageBlock?.type === 'image' && imageBlock.image.type === 'external') {
         expect(imageBlock.image.external.url).toBe(
           'https://cdn.example.com/imports/job-1/bollard.jpg'
         );

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -5,9 +5,9 @@ import {
 } from './ApkgPreviewService/types';
 
 const MAX_NOTES = 5000;
-const CLOZE_REGEX = /\{\{c\d+::(.*?)(?:::.*?)?\}\}/g;
+const CLOZE_REGEX = /\{\{c\d+::([^}]*?)(?:::[^}]*)?\}\}/g;
 const SOUND_TAG_REGEX = /\[sound:([^\]]+)\]/g;
-const IMG_SRC_REGEX = /<img[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
+const IMG_SRC_REGEX = /<img\s[^>]*?\bsrc=["']([^"']+)["'][^>]*>/gi;
 const BOLD_REGEX = /<b>(.*?)<\/b>/gi;
 const ITALIC_REGEX = /<i>(.*?)<\/i>/gi;
 const STRONG_REGEX = /<strong>(.*?)<\/strong>/gi;
@@ -216,7 +216,7 @@ function parseHtmlToRichText(html: string): RichTextSegment[] {
 
   const segments: RichTextSegment[] = [];
 
-  const tagPattern = /<(b|strong|i|em)>(.*?)<\/\1>/gi;
+  const tagPattern = /<(b|strong|i|em)>([^<]*)<\/\1>/gi;
   let match: RegExpExecArray | null;
   let lastIndex = 0;
 
@@ -460,7 +460,7 @@ function parseClozeToRichText(html: string): RichTextSegment[] {
   const segments: RichTextSegment[] = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
-  const regex = /\{\{c\d+::(.*?)(?:::.*?)?\}\}/g;
+  const regex = /\{\{c\d+::([^}]*?)(?:::[^}]*)?\}\}/g;
 
   while ((match = regex.exec(cleaned)) !== null) {
     const before = cleaned.slice(lastIndex, match.index);

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -6,14 +6,16 @@ import {
 
 const MAX_NOTES = 5000;
 const CLOZE_REGEX = /\{\{c\d+::(.*?)(?:::.*?)?\}\}/g;
-const SOUND_TAG_REGEX = /\[sound:[^\]]+\]/g;
-const IMG_TAG_REGEX = /<img[^>]*>/gi;
+const SOUND_TAG_REGEX = /\[sound:([^\]]+)\]/g;
+const IMG_SRC_REGEX = /<img[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
 const BOLD_REGEX = /<b>(.*?)<\/b>/gi;
 const ITALIC_REGEX = /<i>(.*?)<\/i>/gi;
 const STRONG_REGEX = /<strong>(.*?)<\/strong>/gi;
 const EM_REGEX = /<em>(.*?)<\/em>/gi;
 const ALL_HTML_TAGS_REGEX = /<[^>]*>/g;
 const BR_REGEX = /<br\s*\/?>/gi;
+
+const IMAGE_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp']);
 
 interface RichTextSegment {
   type: 'text';
@@ -36,12 +38,22 @@ interface ParagraphBlock {
   };
 }
 
+interface ImageBlock {
+  type: 'image';
+  image: {
+    type: 'external';
+    external: { url: string };
+  };
+}
+
+type ToggleChildBlock = ParagraphBlock | ImageBlock;
+
 interface ToggleHeading3Block {
   type: 'heading_3';
   heading_3: {
     rich_text: RichTextSegment[];
     is_toggleable: true;
-    children: ParagraphBlock[];
+    children: ToggleChildBlock[];
   };
 }
 
@@ -82,14 +94,43 @@ function decodeHtmlEntities(text: string): string {
   });
 }
 
+function extractImageFilenames(html: string): string[] {
+  const filenames: string[] = [];
+  let match: RegExpExecArray | null;
+  const regex = /<img[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
+  while ((match = regex.exec(html)) !== null) {
+    filenames.push(match[1]);
+  }
+  return filenames;
+}
+
+function extractSoundFilenames(html: string): string[] {
+  const filenames: string[] = [];
+  let match: RegExpExecArray | null;
+  const regex = /\[sound:([^\]]+)\]/g;
+  while ((match = regex.exec(html)) !== null) {
+    filenames.push(match[1]);
+  }
+  return filenames;
+}
+
+function isImageFile(filename: string): boolean {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
 function stripMediaRefs(html: string): string {
-  let result = html.replace(IMG_TAG_REGEX, '');
+  let result = html.replace(IMG_SRC_REGEX, '');
   result = result.replace(SOUND_TAG_REGEX, '');
   return result;
 }
 
 function stripClozeMarkers(text: string): string {
   return text.replace(CLOZE_REGEX, '$1');
+}
+
+function getPlainText(html: string): string {
+  return stripMediaRefs(html).replace(ALL_HTML_TAGS_REGEX, '').trim();
 }
 
 function makeRichText(content: string, bold = false, italic = false): RichTextSegment {
@@ -109,12 +150,21 @@ function makeRichText(content: string, bold = false, italic = false): RichTextSe
   };
 }
 
+function makeImageBlock(url: string): ImageBlock {
+  return {
+    type: 'image',
+    image: {
+      type: 'external',
+      external: { url },
+    },
+  };
+}
+
 function parseHtmlToRichText(html: string): RichTextSegment[] {
   const cleaned = stripMediaRefs(html);
   const withNewlines = cleaned.replace(BR_REGEX, '\n');
 
   const segments: RichTextSegment[] = [];
-  let remaining = withNewlines;
 
   const tagPattern = /<(b|strong|i|em)>(.*?)<\/\1>/gi;
   let match: RegExpExecArray | null;
@@ -170,27 +220,72 @@ function makeParagraph(richText: RichTextSegment[]): ParagraphBlock {
   };
 }
 
+function fieldToBlocks(
+  html: string,
+  mediaUrlMap: Map<string, string>
+): ToggleChildBlock[] {
+  const blocks: ToggleChildBlock[] = [];
+
+  const imageFiles = extractImageFilenames(html);
+  for (const filename of imageFiles) {
+    const url = mediaUrlMap.get(filename);
+    if (url && isImageFile(filename)) {
+      blocks.push(makeImageBlock(url));
+    }
+  }
+
+  const soundFiles = extractSoundFilenames(html);
+  for (const filename of soundFiles) {
+    const url = mediaUrlMap.get(filename);
+    if (url) {
+      blocks.push(makeParagraph([makeRichText(`Audio: ${filename}`, false, true)]));
+    }
+  }
+
+  const segments = parseHtmlToRichText(html);
+  if (segments.length > 0) {
+    blocks.push(makeParagraph(segments));
+  }
+
+  return blocks;
+}
+
+function findSummaryText(note: Note, isCloze: boolean): string {
+  for (const field of note.fields) {
+    let text = stripMediaRefs(field);
+    if (isCloze) {
+      text = stripClozeMarkers(text);
+    }
+    const plain = text.replace(ALL_HTML_TAGS_REGEX, '').trim();
+    if (plain.length > 0) {
+      return plain;
+    }
+  }
+  return 'Untitled';
+}
+
 function noteToToggle(
   note: Note,
-  noteType: NoteType
+  noteType: NoteType,
+  mediaUrlMap: Map<string, string>
 ): ToggleHeading3Block {
   const isCloze = noteType.type === 1;
-  const frontField = note.fields[0] ?? '';
+  const summaryText = findSummaryText(note, isCloze);
+  const summaryRichText = [makeRichText(summaryText)];
+
+  const children: ToggleChildBlock[] = [];
+
+  const frontImages = extractImageFilenames(note.fields[0] ?? '');
+  for (const filename of frontImages) {
+    const url = mediaUrlMap.get(filename);
+    if (url && isImageFile(filename)) {
+      children.push(makeImageBlock(url));
+    }
+  }
+
   const backFields = note.fields.slice(1);
 
-  let summaryText = stripMediaRefs(frontField);
-  if (isCloze) {
-    summaryText = stripClozeMarkers(summaryText);
-  }
-  const summaryPlain = summaryText.replace(ALL_HTML_TAGS_REGEX, '').trim();
-  const summaryRichText = [makeRichText(summaryPlain || 'Untitled')];
-
-  const children: ParagraphBlock[] = [];
-
   for (const field of backFields) {
-    const stripped = stripMediaRefs(field);
-    if (stripped.replace(ALL_HTML_TAGS_REGEX, '').trim().length === 0) continue;
-
     if (isCloze) {
       const clozeText = stripMediaRefs(note.fields[0] ?? '');
       const segments = parseClozeToRichText(clozeText);
@@ -198,10 +293,8 @@ function noteToToggle(
         children.push(makeParagraph(segments));
       }
     } else {
-      const segments = parseHtmlToRichText(stripped);
-      if (segments.length > 0) {
-        children.push(makeParagraph(segments));
-      }
+      const fieldBlocks = fieldToBlocks(field, mediaUrlMap);
+      children.push(...fieldBlocks);
     }
   }
 
@@ -341,15 +434,18 @@ function hasNotes(node: DeckNode): boolean {
   return false;
 }
 
-function deckNodeToDeckPage(node: DeckNode): DeckPage {
+function deckNodeToDeckPage(
+  node: DeckNode,
+  mediaUrlMap: Map<string, string>
+): DeckPage {
   const children: ToggleHeading3Block[] = node.notes.map(({ note, noteType }) =>
-    noteToToggle(note, noteType)
+    noteToToggle(note, noteType, mediaUrlMap)
   );
 
   const subDecks: DeckPage[] = [];
   for (const [, child] of node.children) {
     if (hasNotes(child)) {
-      subDecks.push(deckNodeToDeckPage(child));
+      subDecks.push(deckNodeToDeckPage(child, mediaUrlMap));
     }
   }
 
@@ -361,7 +457,10 @@ function deckNodeToDeckPage(node: DeckNode): DeckPage {
 }
 
 export default class ApkgToNotionBlocksService {
-  transform(collection: NormalizedCollection): TransformResult {
+  transform(
+    collection: NormalizedCollection,
+    mediaUrlMap: Map<string, string> = new Map()
+  ): TransformResult {
     const seenNotes = new Set<number>();
     for (const card of collection.cards) {
       seenNotes.add(card.nid);
@@ -377,7 +476,7 @@ export default class ApkgToNotionBlocksService {
 
     for (const [, node] of tree) {
       if (hasNotes(node)) {
-        deckPages.push(deckNodeToDeckPage(node));
+        deckPages.push(deckNodeToDeckPage(node, mediaUrlMap));
       }
     }
 

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -333,6 +333,14 @@ function buildDeckTree(
   return deckNodes;
 }
 
+function hasNotes(node: DeckNode): boolean {
+  if (node.notes.length > 0) return true;
+  for (const [, child] of node.children) {
+    if (hasNotes(child)) return true;
+  }
+  return false;
+}
+
 function deckNodeToDeckPage(node: DeckNode): DeckPage {
   const children: ToggleHeading3Block[] = node.notes.map(({ note, noteType }) =>
     noteToToggle(note, noteType)
@@ -340,7 +348,9 @@ function deckNodeToDeckPage(node: DeckNode): DeckPage {
 
   const subDecks: DeckPage[] = [];
   for (const [, child] of node.children) {
-    subDecks.push(deckNodeToDeckPage(child));
+    if (hasNotes(child)) {
+      subDecks.push(deckNodeToDeckPage(child));
+    }
   }
 
   return {
@@ -366,7 +376,9 @@ export default class ApkgToNotionBlocksService {
     const deckPages: DeckPage[] = [];
 
     for (const [, node] of tree) {
-      deckPages.push(deckNodeToDeckPage(node));
+      if (hasNotes(node)) {
+        deckPages.push(deckNodeToDeckPage(node));
+      }
     }
 
     return { deckPages, totalNotes };

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -38,13 +38,23 @@ interface ParagraphBlock {
   };
 }
 
-interface ImageBlock {
+interface ExternalImageBlock {
   type: 'image';
   image: {
     type: 'external';
     external: { url: string };
   };
 }
+
+interface FileUploadImageBlock {
+  type: 'image';
+  image: {
+    type: 'file_upload';
+    file_upload: { id: string };
+  };
+}
+
+type ImageBlock = ExternalImageBlock | FileUploadImageBlock;
 
 interface DividerBlock {
   type: 'divider';
@@ -181,12 +191,21 @@ function makeRichText(content: string, bold = false, italic = false): RichTextSe
   return segments;
 }
 
-function makeImageBlock(url: string): ImageBlock {
+function makeImageBlock(ref: string): ImageBlock {
+  if (ref.startsWith('http://') || ref.startsWith('https://')) {
+    return {
+      type: 'image',
+      image: {
+        type: 'external',
+        external: { url: ref },
+      },
+    };
+  }
   return {
     type: 'image',
     image: {
-      type: 'external',
-      external: { url },
+      type: 'file_upload',
+      file_upload: { id: ref },
     },
   };
 }

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -65,6 +65,23 @@ export class NoteTooLargeError extends Error {
   }
 }
 
+const HTML_ENTITY_REGEX = /&(#(\d+)|#x([0-9a-fA-F]+)|(\w+));/g;
+const NAMED_ENTITIES: Record<string, string> = {
+  nbsp: ' ', amp: '&', lt: '<', gt: '>', quot: '"', apos: "'",
+  ndash: '–', mdash: '—', lsquo: '‘', rsquo: '’',
+  ldquo: '“', rdquo: '”', hellip: '…', copy: '©',
+  reg: '®', trade: '™', times: '×', divide: '÷',
+};
+
+function decodeHtmlEntities(text: string): string {
+  return text.replace(HTML_ENTITY_REGEX, (_, _full, decimal, hex, named) => {
+    if (decimal) return String.fromCodePoint(parseInt(decimal, 10));
+    if (hex) return String.fromCodePoint(parseInt(hex, 16));
+    if (named) return NAMED_ENTITIES[named] ?? `&${named};`;
+    return _;
+  });
+}
+
 function stripMediaRefs(html: string): string {
   let result = html.replace(IMG_TAG_REGEX, '');
   result = result.replace(SOUND_TAG_REGEX, '');
@@ -76,10 +93,11 @@ function stripClozeMarkers(text: string): string {
 }
 
 function makeRichText(content: string, bold = false, italic = false): RichTextSegment {
+  const decoded = decodeHtmlEntities(content);
   return {
     type: 'text',
-    plain_text: content,
-    text: { content },
+    plain_text: decoded,
+    text: { content: decoded },
     annotations: {
       bold,
       italic,

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -46,6 +46,11 @@ interface ImageBlock {
   };
 }
 
+interface DividerBlock {
+  type: 'divider';
+  divider: Record<string, never>;
+}
+
 type ToggleChildBlock = ParagraphBlock | ImageBlock;
 
 interface ToggleHeading3Block {
@@ -57,9 +62,11 @@ interface ToggleHeading3Block {
   };
 }
 
+type NoteBlock = ToggleHeading3Block | ImageBlock | DividerBlock | ParagraphBlock;
+
 export interface DeckPage {
   title: string;
-  children: ToggleHeading3Block[];
+  children: NoteBlock[];
   subDecks: DeckPage[];
 }
 
@@ -288,6 +295,79 @@ function findSummaryText(note: Note, isCloze: boolean): string {
   return 'Untitled';
 }
 
+const IMAGE_FIRST_TEXT_THRESHOLD = 20;
+
+function isImageFirstNote(note: Note, noteType: NoteType): boolean {
+  if (noteType.type === 1) return false;
+  const front = note.fields[0] ?? '';
+  const hasImage = extractImageFilenames(front).length > 0;
+  if (!hasImage) return false;
+  const textOnly = stripMediaRefs(front).replace(ALL_HTML_TAGS_REGEX, '').trim();
+  return textOnly.length <= IMAGE_FIRST_TEXT_THRESHOLD;
+}
+
+function makeDivider(): DividerBlock {
+  return { type: 'divider', divider: {} };
+}
+
+function noteToImageLayout(
+  note: Note,
+  noteType: NoteType,
+  mediaUrlMap: Map<string, string>
+): NoteBlock[] {
+  const blocks: NoteBlock[] = [makeDivider()];
+
+  const frontImages = extractImageFilenames(note.fields[0] ?? '');
+  for (const filename of frontImages) {
+    const url = mediaUrlMap.get(filename);
+    if (url && isImageFile(filename)) {
+      blocks.push(makeImageBlock(url));
+    }
+  }
+
+  const backFields = note.fields.slice(1);
+  const answerChildren: ToggleChildBlock[] = [];
+
+  for (const field of backFields) {
+    const fieldBlocks = fieldToBlocks(field, mediaUrlMap);
+    answerChildren.push(...fieldBlocks);
+  }
+
+  if (answerChildren.length === 0) {
+    answerChildren.push(makeParagraph(makeRichText(' ')));
+  }
+
+  const tags = note.tags.trim();
+  if (tags.length > 0) {
+    const tagText = tags
+      .split(/\s+/)
+      .filter((t) => t.length > 0)
+      .map((t) => `#${t}`)
+      .join(' ');
+    answerChildren.push(makeParagraph(makeRichText(tagText, false, true)));
+  }
+
+  const firstBackFieldName = noteType.fields.length > 1
+    ? noteType.fields[1].name
+    : null;
+  const toggleLabel = (
+    firstBackFieldName
+    && backFields.length === 1
+    && firstBackFieldName !== 'Back'
+  ) ? firstBackFieldName : 'Answer';
+
+  blocks.push({
+    type: 'heading_3',
+    heading_3: {
+      rich_text: makeRichText(toggleLabel),
+      is_toggleable: true,
+      children: answerChildren,
+    },
+  });
+
+  return blocks;
+}
+
 function noteToToggle(
   note: Note,
   noteType: NoteType,
@@ -462,9 +542,14 @@ function deckNodeToDeckPage(
   node: DeckNode,
   mediaUrlMap: Map<string, string>
 ): DeckPage {
-  const children: ToggleHeading3Block[] = node.notes.map(({ note, noteType }) =>
-    noteToToggle(note, noteType, mediaUrlMap)
-  );
+  const children: NoteBlock[] = [];
+  for (const { note, noteType } of node.notes) {
+    if (isImageFirstNote(note, noteType)) {
+      children.push(...noteToImageLayout(note, noteType, mediaUrlMap));
+    } else {
+      children.push(noteToToggle(note, noteType, mediaUrlMap));
+    }
+  }
 
   const subDecks: DeckPage[] = [];
   for (const [, child] of node.children) {

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -1,0 +1,356 @@
+import {
+  NormalizedCollection,
+  Note,
+  NoteType,
+} from './ApkgPreviewService/types';
+
+const MAX_NOTES = 5000;
+const CLOZE_REGEX = /\{\{c\d+::(.*?)(?:::.*?)?\}\}/g;
+const SOUND_TAG_REGEX = /\[sound:[^\]]+\]/g;
+const IMG_TAG_REGEX = /<img[^>]*>/gi;
+const BOLD_REGEX = /<b>(.*?)<\/b>/gi;
+const ITALIC_REGEX = /<i>(.*?)<\/i>/gi;
+const STRONG_REGEX = /<strong>(.*?)<\/strong>/gi;
+const EM_REGEX = /<em>(.*?)<\/em>/gi;
+const ALL_HTML_TAGS_REGEX = /<[^>]*>/g;
+const BR_REGEX = /<br\s*\/?>/gi;
+
+interface RichTextSegment {
+  type: 'text';
+  plain_text: string;
+  text: { content: string };
+  annotations: {
+    bold: boolean;
+    italic: boolean;
+    strikethrough: boolean;
+    underline: boolean;
+    code: boolean;
+    color: 'default';
+  };
+}
+
+interface ParagraphBlock {
+  type: 'paragraph';
+  paragraph: {
+    rich_text: RichTextSegment[];
+  };
+}
+
+interface ToggleHeading3Block {
+  type: 'heading_3';
+  heading_3: {
+    rich_text: RichTextSegment[];
+    is_toggleable: true;
+    children: ParagraphBlock[];
+  };
+}
+
+export interface DeckPage {
+  title: string;
+  children: ToggleHeading3Block[];
+  subDecks: DeckPage[];
+}
+
+export interface TransformResult {
+  deckPages: DeckPage[];
+  totalNotes: number;
+}
+
+export class NoteTooLargeError extends Error {
+  constructor(count: number) {
+    super(
+      `This deck has ${count} notes. Import supports up to ${MAX_NOTES} notes — it is too large to import.`
+    );
+    this.name = 'NoteTooLargeError';
+  }
+}
+
+function stripMediaRefs(html: string): string {
+  let result = html.replace(IMG_TAG_REGEX, '');
+  result = result.replace(SOUND_TAG_REGEX, '');
+  return result;
+}
+
+function stripClozeMarkers(text: string): string {
+  return text.replace(CLOZE_REGEX, '$1');
+}
+
+function makeRichText(content: string, bold = false, italic = false): RichTextSegment {
+  return {
+    type: 'text',
+    plain_text: content,
+    text: { content },
+    annotations: {
+      bold,
+      italic,
+      strikethrough: false,
+      underline: false,
+      code: false,
+      color: 'default',
+    },
+  };
+}
+
+function parseHtmlToRichText(html: string): RichTextSegment[] {
+  const cleaned = stripMediaRefs(html);
+  const withNewlines = cleaned.replace(BR_REGEX, '\n');
+
+  const segments: RichTextSegment[] = [];
+  let remaining = withNewlines;
+
+  const tagPattern = /<(b|strong|i|em)>(.*?)<\/\1>/gi;
+  let match: RegExpExecArray | null;
+  let lastIndex = 0;
+
+  const allMatches: Array<{ index: number; end: number; text: string; bold: boolean; italic: boolean }> = [];
+
+  while ((match = tagPattern.exec(withNewlines)) !== null) {
+    const tag = match[1].toLowerCase();
+    const innerText = match[2].replace(ALL_HTML_TAGS_REGEX, '');
+    const isBold = tag === 'b' || tag === 'strong';
+    const isItalic = tag === 'i' || tag === 'em';
+    allMatches.push({
+      index: match.index,
+      end: match.index + match[0].length,
+      text: innerText,
+      bold: isBold,
+      italic: isItalic,
+    });
+  }
+
+  if (allMatches.length === 0) {
+    const plain = withNewlines.replace(ALL_HTML_TAGS_REGEX, '').trim();
+    if (plain.length > 0) {
+      segments.push(makeRichText(plain));
+    }
+    return segments;
+  }
+
+  for (const m of allMatches) {
+    const before = withNewlines.slice(lastIndex, m.index).replace(ALL_HTML_TAGS_REGEX, '');
+    if (before.length > 0) {
+      segments.push(makeRichText(before));
+    }
+    if (m.text.length > 0) {
+      segments.push(makeRichText(m.text, m.bold, m.italic));
+    }
+    lastIndex = m.end;
+  }
+
+  const after = withNewlines.slice(lastIndex).replace(ALL_HTML_TAGS_REGEX, '');
+  if (after.length > 0) {
+    segments.push(makeRichText(after));
+  }
+
+  return segments;
+}
+
+function makeParagraph(richText: RichTextSegment[]): ParagraphBlock {
+  return {
+    type: 'paragraph',
+    paragraph: { rich_text: richText },
+  };
+}
+
+function noteToToggle(
+  note: Note,
+  noteType: NoteType
+): ToggleHeading3Block {
+  const isCloze = noteType.type === 1;
+  const frontField = note.fields[0] ?? '';
+  const backFields = note.fields.slice(1);
+
+  let summaryText = stripMediaRefs(frontField);
+  if (isCloze) {
+    summaryText = stripClozeMarkers(summaryText);
+  }
+  const summaryPlain = summaryText.replace(ALL_HTML_TAGS_REGEX, '').trim();
+  const summaryRichText = [makeRichText(summaryPlain || 'Untitled')];
+
+  const children: ParagraphBlock[] = [];
+
+  for (const field of backFields) {
+    const stripped = stripMediaRefs(field);
+    if (stripped.replace(ALL_HTML_TAGS_REGEX, '').trim().length === 0) continue;
+
+    if (isCloze) {
+      const clozeText = stripMediaRefs(note.fields[0] ?? '');
+      const segments = parseClozeToRichText(clozeText);
+      if (segments.length > 0) {
+        children.push(makeParagraph(segments));
+      }
+    } else {
+      const segments = parseHtmlToRichText(stripped);
+      if (segments.length > 0) {
+        children.push(makeParagraph(segments));
+      }
+    }
+  }
+
+  if (children.length === 0 && backFields.length === 0) {
+    if (isCloze) {
+      const clozeText = stripMediaRefs(note.fields[0] ?? '');
+      const segments = parseClozeToRichText(clozeText);
+      if (segments.length > 0) {
+        children.push(makeParagraph(segments));
+      }
+    }
+  }
+
+  if (children.length === 0) {
+    children.push(makeParagraph([makeRichText(' ')]));
+  }
+
+  const tags = note.tags.trim();
+  if (tags.length > 0) {
+    const tagText = tags
+      .split(/\s+/)
+      .filter((t) => t.length > 0)
+      .map((t) => `#${t}`)
+      .join(' ');
+    children.push(makeParagraph([makeRichText(tagText, false, true)]));
+  }
+
+  return {
+    type: 'heading_3',
+    heading_3: {
+      rich_text: summaryRichText,
+      is_toggleable: true,
+      children,
+    },
+  };
+}
+
+function parseClozeToRichText(html: string): RichTextSegment[] {
+  const cleaned = html.replace(ALL_HTML_TAGS_REGEX, '');
+  const segments: RichTextSegment[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  const regex = /\{\{c\d+::(.*?)(?:::.*?)?\}\}/g;
+
+  while ((match = regex.exec(cleaned)) !== null) {
+    const before = cleaned.slice(lastIndex, match.index);
+    if (before.length > 0) {
+      segments.push(makeRichText(before));
+    }
+    segments.push(makeRichText(match[1], true, false));
+    lastIndex = match.index + match[0].length;
+  }
+
+  const after = cleaned.slice(lastIndex);
+  if (after.length > 0) {
+    segments.push(makeRichText(after));
+  }
+
+  return segments;
+}
+
+interface DeckNode {
+  name: string;
+  fullName: string;
+  id: number;
+  children: Map<string, DeckNode>;
+  notes: Array<{ note: Note; noteType: NoteType }>;
+}
+
+function buildDeckTree(
+  collection: NormalizedCollection
+): Map<string, DeckNode> {
+  const deckNodes = new Map<string, DeckNode>();
+
+  for (const [, deck] of collection.decks) {
+    const parts = deck.name.split('::');
+    let currentMap = deckNodes;
+    let currentPath = '';
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      currentPath = currentPath ? `${currentPath}::${part}` : part;
+
+      if (!currentMap.has(part)) {
+        currentMap.set(part, {
+          name: part,
+          fullName: currentPath,
+          id: i === parts.length - 1 ? deck.id : -1,
+          children: new Map(),
+          notes: [],
+        });
+      }
+      const node = currentMap.get(part)!;
+      if (i === parts.length - 1) {
+        node.id = deck.id;
+      }
+      currentMap = node.children;
+    }
+  }
+
+  const notesByDeckId = new Map<number, Array<{ note: Note; noteType: NoteType }>>();
+  const seenNotes = new Set<number>();
+
+  for (const card of collection.cards) {
+    if (seenNotes.has(card.nid)) continue;
+    seenNotes.add(card.nid);
+
+    const note = collection.notes.get(card.nid);
+    if (note == null) continue;
+    const noteType = collection.noteTypes.get(note.mid);
+    if (noteType == null) continue;
+
+    const existing = notesByDeckId.get(card.did) ?? [];
+    existing.push({ note, noteType });
+    notesByDeckId.set(card.did, existing);
+  }
+
+  function assignNotes(nodes: Map<string, DeckNode>) {
+    for (const [, node] of nodes) {
+      const notesForDeck = notesByDeckId.get(node.id);
+      if (notesForDeck) {
+        node.notes = notesForDeck;
+      }
+      assignNotes(node.children);
+    }
+  }
+
+  assignNotes(deckNodes);
+  return deckNodes;
+}
+
+function deckNodeToDeckPage(node: DeckNode): DeckPage {
+  const children: ToggleHeading3Block[] = node.notes.map(({ note, noteType }) =>
+    noteToToggle(note, noteType)
+  );
+
+  const subDecks: DeckPage[] = [];
+  for (const [, child] of node.children) {
+    subDecks.push(deckNodeToDeckPage(child));
+  }
+
+  return {
+    title: node.name,
+    children,
+    subDecks,
+  };
+}
+
+export default class ApkgToNotionBlocksService {
+  transform(collection: NormalizedCollection): TransformResult {
+    const seenNotes = new Set<number>();
+    for (const card of collection.cards) {
+      seenNotes.add(card.nid);
+    }
+    const totalNotes = seenNotes.size;
+
+    if (totalNotes > MAX_NOTES) {
+      throw new NoteTooLargeError(totalNotes);
+    }
+
+    const tree = buildDeckTree(collection);
+    const deckPages: DeckPage[] = [];
+
+    for (const [, node] of tree) {
+      deckPages.push(deckNodeToDeckPage(node));
+    }
+
+    return { deckPages, totalNotes };
+  }
+}

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -94,12 +94,20 @@ function decodeHtmlEntities(text: string): string {
   });
 }
 
+function decodeMediaFilename(name: string): string {
+  try {
+    return decodeURIComponent(name);
+  } catch {
+    return name;
+  }
+}
+
 function extractImageFilenames(html: string): string[] {
   const filenames: string[] = [];
   let match: RegExpExecArray | null;
   const regex = /<img[^>]*\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
   while ((match = regex.exec(html)) !== null) {
-    filenames.push(match[1]);
+    filenames.push(decodeMediaFilename(match[1]));
   }
   return filenames;
 }
@@ -109,7 +117,7 @@ function extractSoundFilenames(html: string): string[] {
   let match: RegExpExecArray | null;
   const regex = /\[sound:([^\]]+)\]/g;
   while ((match = regex.exec(html)) !== null) {
-    filenames.push(match[1]);
+    filenames.push(decodeMediaFilename(match[1]));
   }
   return filenames;
 }
@@ -133,12 +141,14 @@ function getPlainText(html: string): string {
   return stripMediaRefs(html).replace(ALL_HTML_TAGS_REGEX, '').trim();
 }
 
-function makeRichText(content: string, bold = false, italic = false): RichTextSegment {
-  const decoded = decodeHtmlEntities(content);
+const NOTION_RICH_TEXT_LIMIT = 2000;
+const NOTION_RICH_TEXT_ARRAY_LIMIT = 100;
+
+function makeRichTextSegment(content: string, bold = false, italic = false): RichTextSegment {
   return {
     type: 'text',
-    plain_text: decoded,
-    text: { content: decoded },
+    plain_text: content,
+    text: { content },
     annotations: {
       bold,
       italic,
@@ -148,6 +158,20 @@ function makeRichText(content: string, bold = false, italic = false): RichTextSe
       color: 'default',
     },
   };
+}
+
+function makeRichText(content: string, bold = false, italic = false): RichTextSegment[] {
+  const decoded = decodeHtmlEntities(content);
+  if (decoded.length <= NOTION_RICH_TEXT_LIMIT) {
+    return [makeRichTextSegment(decoded, bold, italic)];
+  }
+  const segments: RichTextSegment[] = [];
+  for (let i = 0; i < decoded.length; i += NOTION_RICH_TEXT_LIMIT) {
+    segments.push(
+      makeRichTextSegment(decoded.slice(i, i + NOTION_RICH_TEXT_LIMIT), bold, italic)
+    );
+  }
+  return segments;
 }
 
 function makeImageBlock(url: string): ImageBlock {
@@ -189,7 +213,7 @@ function parseHtmlToRichText(html: string): RichTextSegment[] {
   if (allMatches.length === 0) {
     const plain = withNewlines.replace(ALL_HTML_TAGS_REGEX, '').trim();
     if (plain.length > 0) {
-      segments.push(makeRichText(plain));
+      segments.push(...makeRichText(plain));
     }
     return segments;
   }
@@ -197,20 +221,20 @@ function parseHtmlToRichText(html: string): RichTextSegment[] {
   for (const m of allMatches) {
     const before = withNewlines.slice(lastIndex, m.index).replace(ALL_HTML_TAGS_REGEX, '');
     if (before.length > 0) {
-      segments.push(makeRichText(before));
+      segments.push(...makeRichText(before));
     }
     if (m.text.length > 0) {
-      segments.push(makeRichText(m.text, m.bold, m.italic));
+      segments.push(...makeRichText(m.text, m.bold, m.italic));
     }
     lastIndex = m.end;
   }
 
   const after = withNewlines.slice(lastIndex).replace(ALL_HTML_TAGS_REGEX, '');
   if (after.length > 0) {
-    segments.push(makeRichText(after));
+    segments.push(...makeRichText(after));
   }
 
-  return segments;
+  return segments.slice(0, NOTION_RICH_TEXT_ARRAY_LIMIT);
 }
 
 function makeParagraph(richText: RichTextSegment[]): ParagraphBlock {
@@ -238,7 +262,7 @@ function fieldToBlocks(
   for (const filename of soundFiles) {
     const url = mediaUrlMap.get(filename);
     if (url) {
-      blocks.push(makeParagraph([makeRichText(`Audio: ${filename}`, false, true)]));
+      blocks.push(makeParagraph(makeRichText(`Audio: ${filename}`, false, true)));
     }
   }
 
@@ -271,7 +295,7 @@ function noteToToggle(
 ): ToggleHeading3Block {
   const isCloze = noteType.type === 1;
   const summaryText = findSummaryText(note, isCloze);
-  const summaryRichText = [makeRichText(summaryText)];
+  const summaryRichText = makeRichText(summaryText);
 
   const children: ToggleChildBlock[] = [];
 
@@ -309,7 +333,7 @@ function noteToToggle(
   }
 
   if (children.length === 0) {
-    children.push(makeParagraph([makeRichText(' ')]));
+    children.push(makeParagraph(makeRichText(' ')));
   }
 
   const tags = note.tags.trim();
@@ -319,7 +343,7 @@ function noteToToggle(
       .filter((t) => t.length > 0)
       .map((t) => `#${t}`)
       .join(' ');
-    children.push(makeParagraph([makeRichText(tagText, false, true)]));
+    children.push(makeParagraph(makeRichText(tagText, false, true)));
   }
 
   return {
@@ -342,18 +366,18 @@ function parseClozeToRichText(html: string): RichTextSegment[] {
   while ((match = regex.exec(cleaned)) !== null) {
     const before = cleaned.slice(lastIndex, match.index);
     if (before.length > 0) {
-      segments.push(makeRichText(before));
+      segments.push(...makeRichText(before));
     }
-    segments.push(makeRichText(match[1], true, false));
+    segments.push(...makeRichText(match[1], true, false));
     lastIndex = match.index + match[0].length;
   }
 
   const after = cleaned.slice(lastIndex);
   if (after.length > 0) {
-    segments.push(makeRichText(after));
+    segments.push(...makeRichText(after));
   }
 
-  return segments;
+  return segments.slice(0, NOTION_RICH_TEXT_ARRAY_LIMIT);
 }
 
 interface DeckNode {

--- a/src/services/NotionService/FEATURE.md
+++ b/src/services/NotionService/FEATURE.md
@@ -7,6 +7,7 @@ Wraps the Notion SDK (`@notionhq/client`) and the OAuth dance. Owns token storag
 - **OAuth:** `getNotionAuthorizationLink` and the redirect handler in the controller layer. Tokens land in `INotionRepository`.
 - **Top-level pages cache:** `topLevelPagesCache` + `topLevelPagesRefreshGate` — pages are stale after `TOP_LEVEL_PAGES_STALE_AFTER_MS` (5 minutes). The gate prevents thundering-herd refreshes when many tabs hit the picker at once.
 - **Block walking:** `BlockHandler/` and `blocks/` recursively fetch a page's blocks and hand them to the parser. Pagination, image URL refresh, and rate-limit handling live here.
+- **File uploads:** `NotionAPIWrapper.uploadFile` uses the Notion file uploads API (`fileUploads.create` + `fileUploads.send`) to upload media (images) to Notion's storage. Returns a `file_upload` ID that can be referenced in image blocks. Used by the APKG import flow.
 - **Identity helpers:** `getNotionId`, `isValidNotionId`, `NotionColors`.
 
 ## Calling pattern

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -1,6 +1,7 @@
 import { Client, isFullBlock, isFullDatabase } from '@notionhq/client';
 import {
   BlockObjectRequest,
+  CreatePageResponse,
   GetBlockResponse,
   GetDatabaseResponse,
   GetPageResponse,
@@ -188,6 +189,39 @@ class NotionAPIWrapper {
       block_id: parent,
       children: [newBlock],
     });
+  }
+
+  appendBlocks(
+    parentId: string,
+    children: BlockObjectRequest[]
+  ): Promise<ListBlockChildrenResponse> {
+    return withRetry(
+      () =>
+        this.notion.blocks.children.append({
+          block_id: parentId,
+          children,
+        }),
+      { label: 'blocks.children.append:batch' }
+    );
+  }
+
+  createPage(
+    parentPageId: string,
+    title: string
+  ): Promise<CreatePageResponse> {
+    return withRetry(
+      () =>
+        this.notion.pages.create({
+          parent: { page_id: parentPageId },
+          properties: {
+            title: {
+              type: 'title',
+              title: [{ text: { content: title } }],
+            },
+          },
+        }),
+      { label: 'pages.create' }
+    );
   }
 
   getDatabase(id: string): Promise<GetDatabaseResponse> {

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -230,24 +230,18 @@ class NotionAPIWrapper {
     contentType: string,
     data: Buffer
   ): Promise<string> {
-    const created: CreateFileUploadResponse = await withRetry(
-      () =>
-        this.notion.fileUploads.create({
-          mode: 'single_part',
-          filename,
-          content_type: contentType,
-        }),
-      { label: 'fileUploads.create' }
-    );
+    const created = await this.notion.fileUploads.create({
+      mode: 'single_part',
+      filename,
+      content_type: contentType,
+    });
 
-    await withRetry(
-      () =>
-        this.notion.fileUploads.send({
-          file_upload_id: created.id,
-          file: { data: new Blob([new Uint8Array(data)], { type: contentType }), filename },
-        }),
-      { label: 'fileUploads.send' }
-    );
+    const blob = new Blob([new Uint8Array(data)], { type: contentType });
+
+    await this.notion.fileUploads.send({
+      file_upload_id: created.id,
+      file: { data: blob, filename },
+    });
 
     return created.id;
   }

--- a/src/services/NotionService/NotionAPIWrapper.ts
+++ b/src/services/NotionService/NotionAPIWrapper.ts
@@ -9,6 +9,7 @@ import {
   QueryDataSourceResponse,
   SearchResponse,
 } from '@notionhq/client/build/src/api-endpoints';
+import { CreateFileUploadResponse } from '@notionhq/client/build/src/api-endpoints/file-uploads';
 import { getNotionObjectTitle } from 'get-notion-object-title';
 
 import sanitizeTags from '../../lib/anki/sanitizeTags';
@@ -222,6 +223,33 @@ class NotionAPIWrapper {
         }),
       { label: 'pages.create' }
     );
+  }
+
+  async uploadFile(
+    filename: string,
+    contentType: string,
+    data: Buffer
+  ): Promise<string> {
+    const created: CreateFileUploadResponse = await withRetry(
+      () =>
+        this.notion.fileUploads.create({
+          mode: 'single_part',
+          filename,
+          content_type: contentType,
+        }),
+      { label: 'fileUploads.create' }
+    );
+
+    await withRetry(
+      () =>
+        this.notion.fileUploads.send({
+          file_upload_id: created.id,
+          file: { data: new Blob([new Uint8Array(data)], { type: contentType }), filename },
+        }),
+      { label: 'fileUploads.send' }
+    );
+
+    return created.id;
   }
 
   getDatabase(id: string): Promise<GetDatabaseResponse> {

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -1,0 +1,222 @@
+import ImportApkgToNotionUseCase from './ImportApkgToNotionUseCase';
+import ApkgPreviewService from '../../services/ApkgPreviewService/ApkgPreviewService';
+import ApkgToNotionBlocksService, {
+  NoteTooLargeError,
+} from '../../services/ApkgToNotionBlocksService';
+import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
+import JobRepository from '../../data_layer/JobRepository';
+import { NormalizedCollection } from '../../services/ApkgPreviewService/types';
+import { ParsedApkg } from '../../services/ApkgPreviewService/ApkgPreviewService';
+
+function makeCollection(noteCount: number): NormalizedCollection {
+  const noteTypes = new Map([
+    [
+      1,
+      {
+        id: 1,
+        name: 'Basic',
+        type: 0 as const,
+        css: '',
+        fields: [
+          { name: 'Front', ord: 0 },
+          { name: 'Back', ord: 1 },
+        ],
+        templates: [{ name: 'Card 1', ord: 0, qfmt: '', afmt: '' }],
+      },
+    ],
+  ]);
+
+  const notes = new Map(
+    Array.from({ length: noteCount }, (_, i) => [
+      i + 1,
+      {
+        id: i + 1,
+        mid: 1,
+        tags: '',
+        fields: [`Front ${i + 1}`, `Back ${i + 1}`],
+      },
+    ])
+  );
+
+  return {
+    noteTypes,
+    notes,
+    decks: new Map([[1, { id: 1, name: 'Test Deck' }]]),
+    cards: Array.from({ length: noteCount }, (_, i) => ({
+      id: i + 1,
+      nid: i + 1,
+      did: 1,
+      ord: 0,
+    })),
+  };
+}
+
+function makeParsed(noteCount: number): ParsedApkg {
+  return {
+    collection: makeCollection(noteCount),
+    mediaMap: new Map(),
+    mediaEntries: new Map(),
+    parsedAt: Date.now(),
+  };
+}
+
+describe('ImportApkgToNotionUseCase', () => {
+  let previewService: jest.Mocked<ApkgPreviewService>;
+  let blocksService: ApkgToNotionBlocksService;
+  let jobRepository: jest.Mocked<JobRepository>;
+  let notionApi: jest.Mocked<NotionAPIWrapper>;
+  let useCase: ImportApkgToNotionUseCase;
+
+  beforeEach(() => {
+    previewService = {
+      parse: jest.fn(),
+      getMeta: jest.fn(),
+      getCardsPage: jest.fn(),
+      getMediaEntry: jest.fn(),
+    } as unknown as jest.Mocked<ApkgPreviewService>;
+
+    blocksService = new ApkgToNotionBlocksService();
+
+    jobRepository = {
+      updateJobStatus: jest.fn().mockResolvedValue({}),
+      create: jest.fn().mockResolvedValue(undefined),
+      findJobById: jest.fn(),
+    } as unknown as jest.Mocked<JobRepository>;
+
+    notionApi = {
+      createPage: jest.fn().mockResolvedValue({ id: 'page-123' }),
+      appendBlocks: jest.fn().mockResolvedValue({}),
+      getPage: jest
+        .fn()
+        .mockResolvedValue({ url: 'https://notion.so/page-123' }),
+    } as unknown as jest.Mocked<NotionAPIWrapper>;
+
+    useCase = new ImportApkgToNotionUseCase(
+      previewService,
+      blocksService,
+      jobRepository
+    );
+  });
+
+  it('creates Notion pages and reports completion', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(3));
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1'
+    );
+
+    expect(notionApi.createPage).toHaveBeenCalledWith(
+      'parent-page',
+      'Test Deck'
+    );
+    expect(notionApi.appendBlocks).toHaveBeenCalled();
+
+    const finalUpdate =
+      jobRepository.updateJobStatus.mock.calls[
+        jobRepository.updateJobStatus.mock.calls.length - 1
+      ];
+    expect(finalUpdate[2]).toBe('done');
+    const result = JSON.parse(finalUpdate[3] as string);
+    expect(result.imported).toBe(3);
+    expect(result.total_notes).toBe(3);
+    expect(result.notion_page_url).toBe('https://notion.so/page-123');
+  });
+
+  it('marks the job as failed when transform throws NoteTooLargeError', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(2));
+
+    const throwingBlocksService = {
+      transform: () => {
+        throw new NoteTooLargeError(5001);
+      },
+    } as unknown as ApkgToNotionBlocksService;
+
+    const useCaseWithLimit = new ImportApkgToNotionUseCase(
+      previewService,
+      throwingBlocksService,
+      jobRepository
+    );
+
+    await useCaseWithLimit.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1'
+    );
+
+    const failCall = jobRepository.updateJobStatus.mock.calls.find(
+      (c) => c[2] === 'failed'
+    );
+    expect(failCall).toBeDefined();
+    expect(failCall![3]).toContain('5001');
+  });
+
+  it('tracks progress during batch writes', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(3));
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1'
+    );
+
+    const progressCalls = jobRepository.updateJobStatus.mock.calls.filter(
+      (c) => c[2] === 'processing'
+    );
+    expect(progressCalls.length).toBeGreaterThanOrEqual(1);
+    expect(progressCalls[0][3]).toMatch(/0\/3/);
+  });
+
+  it('marks the job as failed on Notion API errors', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(1));
+    notionApi.createPage.mockRejectedValue(new Error('Notion rate limit'));
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1'
+    );
+
+    const failCall = jobRepository.updateJobStatus.mock.calls.find(
+      (c) => c[2] === 'failed'
+    );
+    expect(failCall).toBeDefined();
+    expect(failCall![3]).toContain('Notion rate limit');
+  });
+
+  it('handles sub-decks by creating nested pages', async () => {
+    const collection = makeCollection(1);
+    collection.decks.set(2, { id: 2, name: 'Parent::Child' });
+    collection.cards.push({ id: 2, nid: 1, did: 2, ord: 0 });
+    const parsed: ParsedApkg = {
+      collection,
+      mediaMap: new Map(),
+      mediaEntries: new Map(),
+      parsedAt: Date.now(),
+    };
+
+    previewService.parse.mockResolvedValue(parsed);
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1'
+    );
+
+    expect(notionApi.createPage).toHaveBeenCalledTimes(3);
+    const pageNames = notionApi.createPage.mock.calls.map((c) => c[1]);
+    expect(pageNames).toContain('Parent');
+    expect(pageNames).toContain('Child');
+  });
+});

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -191,7 +191,7 @@ describe('ImportApkgToNotionUseCase', () => {
       (c) => c[2] === 'failed'
     );
     expect(failCall).toBeDefined();
-    expect(failCall![3]).toContain('Notion rate limit');
+    expect(failCall![3]).toBe('Import failed. Please try again or contact support.');
   });
 
   it('handles sub-decks by creating nested pages', async () => {

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -89,6 +89,7 @@ describe('ImportApkgToNotionUseCase', () => {
       getPage: jest
         .fn()
         .mockResolvedValue({ url: 'https://notion.so/page-123' }),
+      uploadFile: jest.fn().mockResolvedValue('file-upload-123'),
     } as unknown as jest.Mocked<NotionAPIWrapper>;
 
     useCase = new ImportApkgToNotionUseCase(

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -196,7 +196,13 @@ describe('ImportApkgToNotionUseCase', () => {
   it('handles sub-decks by creating nested pages', async () => {
     const collection = makeCollection(1);
     collection.decks.set(2, { id: 2, name: 'Parent::Child' });
-    collection.cards.push({ id: 2, nid: 1, did: 2, ord: 0 });
+    collection.notes.set(2, {
+      id: 2,
+      mid: 1,
+      tags: '',
+      fields: ['Front 2', 'Back 2'],
+    });
+    collection.cards.push({ id: 2, nid: 2, did: 2, ord: 0 });
     const parsed: ParsedApkg = {
       collection,
       mediaMap: new Map(),

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -47,11 +47,16 @@ export default class ImportApkgToNotionUseCase {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
 
-      const mediaUrlMap = await this.uploadMediaToNotion(
-        parsed.mediaMap,
-        parsed.mediaEntries,
-        notionApi
-      );
+      let mediaUrlMap = new Map<string, string>();
+      try {
+        mediaUrlMap = await this.uploadMediaToNotion(
+          parsed.mediaMap,
+          parsed.mediaEntries,
+          notionApi
+        );
+      } catch (uploadError) {
+        console.error(`[apkg-import] job=${jobId} media upload failed, continuing without images:`, uploadError);
+      }
 
       const result = this.blocksService.transform(
         parsed.collection,
@@ -96,6 +101,7 @@ export default class ImportApkgToNotionUseCase {
         })
       );
     } catch (error) {
+      console.error(`[apkg-import] job=${jobId} failed:`, error);
       const message =
         error instanceof NoteTooLargeError
           ? error.message

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -47,8 +47,18 @@ export default class ImportApkgToNotionUseCase {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
 
-      // TODO: re-enable Notion file uploads once the crash in fileUploads.send is resolved
-      const mediaUrlMap = new Map<string, string>();
+      let mediaUrlMap = new Map<string, string>();
+      if (parsed.mediaMap.size > 0) {
+        try {
+          mediaUrlMap = await this.uploadMediaToNotion(
+            parsed.mediaMap,
+            parsed.mediaEntries,
+            notionApi
+          );
+        } catch (uploadError) {
+          console.error(`[apkg-import] job=${jobId} media upload failed, continuing without images:`, uploadError);
+        }
+      }
 
       const result = this.blocksService.transform(
         parsed.collection,

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -6,7 +6,6 @@ import ApkgToNotionBlocksService, {
 } from '../../services/ApkgToNotionBlocksService';
 import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
 import JobRepository from '../../data_layer/JobRepository';
-import StorageHandler from '../../lib/storage/StorageHandler';
 import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 
 const BATCH_SIZE = 50;
@@ -24,9 +23,6 @@ const MIME_TYPES: Record<string, string> = {
   '.webp': 'image/webp',
   '.svg': 'image/svg+xml',
   '.bmp': 'image/bmp',
-  '.mp3': 'audio/mpeg',
-  '.ogg': 'audio/ogg',
-  '.wav': 'audio/wav',
 };
 
 function sleep(ms: number): Promise<void> {
@@ -37,8 +33,7 @@ export default class ImportApkgToNotionUseCase {
   constructor(
     private readonly previewService: ApkgPreviewService,
     private readonly blocksService: ApkgToNotionBlocksService,
-    private readonly jobRepository: JobRepository,
-    private readonly storageHandler?: StorageHandler
+    private readonly jobRepository: JobRepository
   ) {}
 
   async execute(
@@ -52,14 +47,11 @@ export default class ImportApkgToNotionUseCase {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
 
-      let mediaUrlMap = new Map<string, string>();
-      if (this.storageHandler && parsed.mediaMap.size > 0) {
-        mediaUrlMap = await this.uploadMedia(
-          parsed.mediaMap,
-          parsed.mediaEntries,
-          jobId
-        );
-      }
+      const mediaUrlMap = await this.uploadMediaToNotion(
+        parsed.mediaMap,
+        parsed.mediaEntries,
+        notionApi
+      );
 
       const result = this.blocksService.transform(
         parsed.collection,
@@ -116,14 +108,12 @@ export default class ImportApkgToNotionUseCase {
     }
   }
 
-  private async uploadMedia(
+  private async uploadMediaToNotion(
     mediaMap: Map<string, string>,
     mediaEntries: Map<string, Buffer>,
-    jobId: string
+    notionApi: NotionAPIWrapper
   ): Promise<Map<string, string>> {
-    const urlMap = new Map<string, string>();
-    const bucket = StorageHandler.DefaultBucketName();
-    const endpoint = process.env.SPACES_ENDPOINT ?? '';
+    const idMap = new Map<string, string>();
 
     for (const [originalName, archiveIndex] of mediaMap) {
       const buffer = mediaEntries.get(archiveIndex);
@@ -132,17 +122,22 @@ export default class ImportApkgToNotionUseCase {
       const ext = path.extname(originalName).toLowerCase();
       if (!IMAGE_EXTENSIONS.has(ext)) continue;
 
-      const s3Key = `imports/${jobId}/${originalName}`;
+      const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
+
       try {
-        await this.storageHandler!.uploadFile(s3Key, buffer);
-        const publicUrl = `https://${bucket}.${endpoint}/${s3Key}`;
-        urlMap.set(originalName, publicUrl);
+        const fileUploadId = await notionApi.uploadFile(
+          originalName,
+          contentType,
+          buffer
+        );
+        idMap.set(originalName, fileUploadId);
+        await sleep(THROTTLE_MS);
       } catch {
         // Skip failed uploads — text still imports fine
       }
     }
 
-    return urlMap;
+    return idMap;
   }
 
   private async writeDeckPage(

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -47,29 +47,36 @@ export default class ImportApkgToNotionUseCase {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
 
+      const result = this.blocksService.transform(parsed.collection);
+      const totalNotes = result.totalNotes;
+
       let mediaUrlMap = new Map<string, string>();
       if (parsed.mediaMap.size > 0) {
         try {
+          await this.jobRepository.updateJobStatus(
+            jobId, owner, 'processing', `uploading images`
+          );
           mediaUrlMap = await this.uploadMediaToNotion(
             parsed.mediaMap,
             parsed.mediaEntries,
-            notionApi
+            notionApi,
+            jobId,
+            owner
           );
+          result.deckPages = this.blocksService.transform(
+            parsed.collection,
+            mediaUrlMap
+          ).deckPages;
         } catch (uploadError) {
           console.error(`[apkg-import] job=${jobId} media upload failed, continuing without images:`, uploadError);
         }
       }
 
-      const result = this.blocksService.transform(
-        parsed.collection,
-        mediaUrlMap
-      );
-
       await this.jobRepository.updateJobStatus(
         jobId,
         owner,
         'processing',
-        `0/${result.totalNotes} notes`
+        `0/${totalNotes} notes`
       );
 
       let imported = 0;
@@ -119,17 +126,23 @@ export default class ImportApkgToNotionUseCase {
   private async uploadMediaToNotion(
     mediaMap: Map<string, string>,
     mediaEntries: Map<string, Buffer>,
-    notionApi: NotionAPIWrapper
+    notionApi: NotionAPIWrapper,
+    jobId: string,
+    owner: string
   ): Promise<Map<string, string>> {
     const idMap = new Map<string, string>();
 
-    for (const [originalName, archiveIndex] of mediaMap) {
-      const buffer = mediaEntries.get(archiveIndex);
-      if (buffer == null) continue;
+    const imageEntries = [...mediaMap.entries()].filter(([name, idx]) => {
+      const buf = mediaEntries.get(idx);
+      const ext = path.extname(name).toLowerCase();
+      return buf != null && IMAGE_EXTENSIONS.has(ext);
+    });
+    const totalImages = imageEntries.length;
+    let uploaded = 0;
 
+    for (const [originalName, archiveIndex] of imageEntries) {
+      const buffer = mediaEntries.get(archiveIndex)!;
       const ext = path.extname(originalName).toLowerCase();
-      if (!IMAGE_EXTENSIONS.has(ext)) continue;
-
       const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
 
       try {
@@ -139,9 +152,14 @@ export default class ImportApkgToNotionUseCase {
           buffer
         );
         idMap.set(originalName, fileUploadId);
+        uploaded++;
+        await this.jobRepository.updateJobStatus(
+          jobId, owner, 'processing',
+          `uploading images ${uploaded}/${totalImages}`
+        );
         await sleep(THROTTLE_MS);
-      } catch {
-        // Skip failed uploads — text still imports fine
+      } catch (err) {
+        console.error(`[apkg-import] failed to upload ${originalName}:`, err);
       }
     }
 

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -47,16 +47,8 @@ export default class ImportApkgToNotionUseCase {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
 
-      let mediaUrlMap = new Map<string, string>();
-      try {
-        mediaUrlMap = await this.uploadMediaToNotion(
-          parsed.mediaMap,
-          parsed.mediaEntries,
-          notionApi
-        );
-      } catch (uploadError) {
-        console.error(`[apkg-import] job=${jobId} media upload failed, continuing without images:`, uploadError);
-      }
+      // TODO: re-enable Notion file uploads once the crash in fileUploads.send is resolved
+      const mediaUrlMap = new Map<string, string>();
 
       const result = this.blocksService.transform(
         parsed.collection,

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -125,7 +125,7 @@ export default class ImportApkgToNotionUseCase {
     const bucket = StorageHandler.DefaultBucketName();
     const endpoint = process.env.SPACES_ENDPOINT ?? '';
 
-    for (const [archiveIndex, originalName] of mediaMap) {
+    for (const [originalName, archiveIndex] of mediaMap) {
       const buffer = mediaEntries.get(archiveIndex);
       if (buffer == null) continue;
 

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -118,12 +118,12 @@ export default class ImportApkgToNotionUseCase {
       );
     } catch (error) {
       console.error(`[apkg-import] job=${jobId} failed:`, error);
-      const message =
-        error instanceof NoteTooLargeError
-          ? error.message
-          : error instanceof Error
-            ? error.message
-            : 'Import failed';
+      const isUserFacing =
+        error instanceof NoteTooLargeError ||
+        (error instanceof Error && error.message.includes('Upgrade'));
+      const message = isUserFacing
+        ? (error as Error).message
+        : 'Import failed. Please try again or contact support.';
       await this.jobRepository
         .updateJobStatus(jobId, owner, 'failed', message)
         .catch(() => {});

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -1,0 +1,130 @@
+import ApkgPreviewService from '../../services/ApkgPreviewService/ApkgPreviewService';
+import ApkgToNotionBlocksService, {
+  DeckPage,
+  NoteTooLargeError,
+} from '../../services/ApkgToNotionBlocksService';
+import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
+import JobRepository from '../../data_layer/JobRepository';
+import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
+
+const BATCH_SIZE = 50;
+const THROTTLE_MS = 350;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default class ImportApkgToNotionUseCase {
+  constructor(
+    private readonly previewService: ApkgPreviewService,
+    private readonly blocksService: ApkgToNotionBlocksService,
+    private readonly jobRepository: JobRepository
+  ) {}
+
+  async execute(
+    fileBuffer: Buffer,
+    parentPageId: string,
+    owner: string,
+    notionApi: NotionAPIWrapper,
+    jobId: string
+  ): Promise<void> {
+    try {
+      const cacheKey = `import:${owner}:${Date.now()}`;
+      const parsed = await this.previewService.parse(cacheKey, fileBuffer);
+      const result = this.blocksService.transform(parsed.collection);
+
+      await this.jobRepository.updateJobStatus(
+        jobId,
+        owner,
+        'processing',
+        `0/${result.totalNotes} notes`
+      );
+
+      let imported = 0;
+
+      for (const deckPage of result.deckPages) {
+        imported = await this.writeDeckPage(
+          notionApi,
+          deckPage,
+          parentPageId,
+          jobId,
+          owner,
+          imported,
+          result.totalNotes
+        );
+      }
+
+      const pageResponse = await notionApi.getPage(parentPageId);
+      const notionUrl =
+        pageResponse && 'url' in pageResponse
+          ? (pageResponse as { url?: string }).url ?? null
+          : null;
+
+      await this.jobRepository.updateJobStatus(
+        jobId,
+        owner,
+        'done',
+        JSON.stringify({
+          imported,
+          total_notes: result.totalNotes,
+          notion_page_url: notionUrl,
+        })
+      );
+    } catch (error) {
+      const message =
+        error instanceof NoteTooLargeError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'Import failed';
+      await this.jobRepository
+        .updateJobStatus(jobId, owner, 'failed', message)
+        .catch(() => {});
+    }
+  }
+
+  private async writeDeckPage(
+    notionApi: NotionAPIWrapper,
+    deckPage: DeckPage,
+    parentId: string,
+    jobId: string,
+    owner: string,
+    imported: number,
+    totalNotes: number
+  ): Promise<number> {
+    const page = await notionApi.createPage(parentId, deckPage.title);
+    await sleep(THROTTLE_MS);
+
+    const blocks = deckPage.children as unknown as BlockObjectRequest[];
+    let currentImported = imported;
+
+    for (let i = 0; i < blocks.length; i += BATCH_SIZE) {
+      const batch = blocks.slice(i, i + BATCH_SIZE);
+      await notionApi.appendBlocks(page.id, batch);
+      currentImported += batch.length;
+
+      await this.jobRepository.updateJobStatus(
+        jobId,
+        owner,
+        'processing',
+        `${currentImported}/${totalNotes} notes`
+      );
+
+      await sleep(THROTTLE_MS);
+    }
+
+    for (const subDeck of deckPage.subDecks) {
+      currentImported = await this.writeDeckPage(
+        notionApi,
+        subDeck,
+        page.id,
+        jobId,
+        owner,
+        currentImported,
+        totalNotes
+      );
+    }
+
+    return currentImported;
+  }
+}

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -41,13 +41,20 @@ export default class ImportApkgToNotionUseCase {
     parentPageId: string,
     owner: string,
     notionApi: NotionAPIWrapper,
-    jobId: string
+    jobId: string,
+    options: { isPaying?: boolean } = {}
   ): Promise<void> {
     try {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
 
       const result = this.blocksService.transform(parsed.collection);
+      const FREE_NOTE_LIMIT = 50;
+      if (!options.isPaying && result.totalNotes > FREE_NOTE_LIMIT) {
+        throw new Error(
+          `This deck has ${result.totalNotes} notes. Free plan supports up to ${FREE_NOTE_LIMIT}. Upgrade for unlimited imports.`
+        );
+      }
       const totalNotes = result.totalNotes;
 
       let mediaUrlMap = new Map<string, string>();

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import ApkgPreviewService from '../../services/ApkgPreviewService/ApkgPreviewService';
 import ApkgToNotionBlocksService, {
   DeckPage,
@@ -5,10 +6,28 @@ import ApkgToNotionBlocksService, {
 } from '../../services/ApkgToNotionBlocksService';
 import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
 import JobRepository from '../../data_layer/JobRepository';
+import StorageHandler from '../../lib/storage/StorageHandler';
 import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 
 const BATCH_SIZE = 50;
 const THROTTLE_MS = 350;
+
+const IMAGE_EXTENSIONS = new Set([
+  '.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.bmp',
+]);
+
+const MIME_TYPES: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+};
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -18,7 +37,8 @@ export default class ImportApkgToNotionUseCase {
   constructor(
     private readonly previewService: ApkgPreviewService,
     private readonly blocksService: ApkgToNotionBlocksService,
-    private readonly jobRepository: JobRepository
+    private readonly jobRepository: JobRepository,
+    private readonly storageHandler?: StorageHandler
   ) {}
 
   async execute(
@@ -31,7 +51,20 @@ export default class ImportApkgToNotionUseCase {
     try {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
-      const result = this.blocksService.transform(parsed.collection);
+
+      let mediaUrlMap = new Map<string, string>();
+      if (this.storageHandler && parsed.mediaMap.size > 0) {
+        mediaUrlMap = await this.uploadMedia(
+          parsed.mediaMap,
+          parsed.mediaEntries,
+          jobId
+        );
+      }
+
+      const result = this.blocksService.transform(
+        parsed.collection,
+        mediaUrlMap
+      );
 
       await this.jobRepository.updateJobStatus(
         jobId,
@@ -81,6 +114,35 @@ export default class ImportApkgToNotionUseCase {
         .updateJobStatus(jobId, owner, 'failed', message)
         .catch(() => {});
     }
+  }
+
+  private async uploadMedia(
+    mediaMap: Map<string, string>,
+    mediaEntries: Map<string, Buffer>,
+    jobId: string
+  ): Promise<Map<string, string>> {
+    const urlMap = new Map<string, string>();
+    const bucket = StorageHandler.DefaultBucketName();
+    const endpoint = process.env.SPACES_ENDPOINT ?? '';
+
+    for (const [archiveIndex, originalName] of mediaMap) {
+      const buffer = mediaEntries.get(archiveIndex);
+      if (buffer == null) continue;
+
+      const ext = path.extname(originalName).toLowerCase();
+      if (!IMAGE_EXTENSIONS.has(ext)) continue;
+
+      const s3Key = `imports/${jobId}/${originalName}`;
+      try {
+        await this.storageHandler!.uploadFile(s3Key, buffer);
+        const publicUrl = `https://${bucket}.${endpoint}/${s3Key}`;
+        urlMap.set(originalName, publicUrl);
+      } catch {
+        // Skip failed uploads — text still imports fine
+      }
+    }
+
+    return urlMap;
   }
 
   private async writeDeckPage(

--- a/src/usecases/apkg/ResolveImportParentPageUseCase.test.ts
+++ b/src/usecases/apkg/ResolveImportParentPageUseCase.test.ts
@@ -1,0 +1,126 @@
+import ResolveImportParentPageUseCase from './ResolveImportParentPageUseCase';
+import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
+
+function makeNotionApi(
+  overrides: Partial<jest.Mocked<NotionAPIWrapper>> = {}
+): jest.Mocked<NotionAPIWrapper> {
+  return {
+    searchTopLevelPages: jest.fn().mockResolvedValue({ results: [] }),
+    createPage: jest.fn().mockResolvedValue({ id: 'new-page-id' }),
+    ...overrides,
+  } as unknown as jest.Mocked<NotionAPIWrapper>;
+}
+
+const IMPORT_PAGE_TITLE = '2anki Imports';
+
+describe('ResolveImportParentPageUseCase', () => {
+  let useCase: ResolveImportParentPageUseCase;
+
+  beforeEach(() => {
+    useCase = new ResolveImportParentPageUseCase();
+  });
+
+  it('returns the existing page when "2anki Imports" is found', async () => {
+    const notionApi = makeNotionApi({
+      searchTopLevelPages: jest.fn().mockResolvedValue({
+        results: [
+          {
+            id: 'existing-imports-page',
+            object: 'page',
+            url: 'https://notion.so/existing',
+            icon: null,
+            title: IMPORT_PAGE_TITLE,
+            parent: { type: 'workspace' },
+          },
+        ],
+      }),
+    });
+
+    const pageId = await useCase.execute(notionApi);
+
+    expect(pageId).toBe('existing-imports-page');
+    expect(notionApi.createPage).not.toHaveBeenCalled();
+  });
+
+  it('creates "2anki Imports" under the first top-level page when not found', async () => {
+    const notionApi = makeNotionApi({
+      searchTopLevelPages: jest
+        .fn()
+        .mockResolvedValueOnce({ results: [] })
+        .mockResolvedValueOnce({
+          results: [
+            {
+              id: 'first-top-level-page',
+              object: 'page',
+              url: null,
+              icon: null,
+              title: 'My Workspace Page',
+              parent: { type: 'workspace' },
+            },
+          ],
+        }),
+      createPage: jest.fn().mockResolvedValue({ id: 'created-page-id' }),
+    });
+
+    const pageId = await useCase.execute(notionApi);
+
+    expect(pageId).toBe('created-page-id');
+    expect(notionApi.createPage).toHaveBeenCalledWith(
+      'first-top-level-page',
+      IMPORT_PAGE_TITLE
+    );
+  });
+
+  it('throws when no top-level pages are available to host the import page', async () => {
+    const notionApi = makeNotionApi({
+      searchTopLevelPages: jest
+        .fn()
+        .mockResolvedValue({ results: [] }),
+    });
+
+    await expect(useCase.execute(notionApi)).rejects.toThrow(
+      'No Notion pages available'
+    );
+  });
+
+  it('does not treat a partial title match as the import page', async () => {
+    const searchMock = jest.fn()
+      .mockResolvedValueOnce({
+        results: [
+          {
+            id: 'some-other-page',
+            object: 'page',
+            url: null,
+            icon: null,
+            title: '2anki Imports Archive',
+            parent: { type: 'workspace' },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        results: [
+          {
+            id: 'some-other-page',
+            object: 'page',
+            url: null,
+            icon: null,
+            title: '2anki Imports Archive',
+            parent: { type: 'workspace' },
+          },
+        ],
+      });
+
+    const notionApi = makeNotionApi({
+      searchTopLevelPages: searchMock,
+      createPage: jest.fn().mockResolvedValue({ id: 'new-imports-page' }),
+    });
+
+    const pageId = await useCase.execute(notionApi);
+
+    expect(pageId).toBe('new-imports-page');
+    expect(notionApi.createPage).toHaveBeenCalledWith(
+      'some-other-page',
+      IMPORT_PAGE_TITLE
+    );
+  });
+});

--- a/src/usecases/apkg/ResolveImportParentPageUseCase.ts
+++ b/src/usecases/apkg/ResolveImportParentPageUseCase.ts
@@ -1,0 +1,46 @@
+import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
+
+const IMPORT_PAGE_TITLE = '2anki Imports';
+
+export default class ResolveImportParentPageUseCase {
+  async execute(notionApi: NotionAPIWrapper): Promise<string> {
+    const existing = await this.findExistingImportPage(notionApi);
+    if (existing != null) {
+      return existing;
+    }
+
+    return this.createImportPage(notionApi);
+  }
+
+  private async findExistingImportPage(
+    notionApi: NotionAPIWrapper
+  ): Promise<string | null> {
+    const searchResult = await notionApi.searchTopLevelPages(
+      IMPORT_PAGE_TITLE,
+      { maxResults: 10 }
+    );
+
+    const exactMatch = searchResult.results.find(
+      (page) => page.title === IMPORT_PAGE_TITLE
+    );
+    return exactMatch?.id ?? null;
+  }
+
+  private async createImportPage(
+    notionApi: NotionAPIWrapper
+  ): Promise<string> {
+    const topPages = await notionApi.searchTopLevelPages('', {
+      maxResults: 1,
+    });
+
+    if (topPages.results.length === 0) {
+      throw new Error(
+        'No Notion pages available. Share at least one page with 2anki to use quick import.'
+      );
+    }
+
+    const parentId = topPages.results[0].id;
+    const created = await notionApi.createPage(parentId, IMPORT_PAGE_TITLE);
+    return created.id;
+  }
+}

--- a/src/usecases/apkg/scheduleImportJobReaper.test.ts
+++ b/src/usecases/apkg/scheduleImportJobReaper.test.ts
@@ -1,0 +1,77 @@
+import { scheduleImportJobReaper, IMPORT_JOB_MAX_AGE_MS } from './scheduleImportJobReaper';
+import JobRepository from '../../data_layer/JobRepository';
+
+describe('scheduleImportJobReaper', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('calls deleteOldJobs with the correct type and age', async () => {
+    const jobRepository = {
+      deleteOldJobs: jest.fn().mockResolvedValue(0),
+    } as unknown as JobRepository;
+
+    const timer = scheduleImportJobReaper(jobRepository, {
+      intervalMs: 1000,
+    });
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(jobRepository.deleteOldJobs).toHaveBeenCalledWith(
+      'apkg_import',
+      IMPORT_JOB_MAX_AGE_MS
+    );
+
+    clearInterval(timer);
+  });
+
+  it('logs when jobs are cleaned up', async () => {
+    const jobRepository = {
+      deleteOldJobs: jest.fn().mockResolvedValue(3),
+    } as unknown as JobRepository;
+
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    const timer = scheduleImportJobReaper(jobRepository, {
+      intervalMs: 1000,
+    });
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[import-reaper] cleaned up 3 old import jobs'
+    );
+
+    infoSpy.mockRestore();
+    clearInterval(timer);
+  });
+
+  it('does not throw when deleteOldJobs fails', async () => {
+    const jobRepository = {
+      deleteOldJobs: jest.fn().mockRejectedValue(new Error('db down')),
+    } as unknown as JobRepository;
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    const timer = scheduleImportJobReaper(jobRepository, {
+      intervalMs: 1000,
+    });
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[import-reaper] tick failed',
+      expect.any(Error)
+    );
+
+    errorSpy.mockRestore();
+    clearInterval(timer);
+  });
+});

--- a/src/usecases/apkg/scheduleImportJobReaper.ts
+++ b/src/usecases/apkg/scheduleImportJobReaper.ts
@@ -1,0 +1,28 @@
+import JobRepository from '../../data_layer/JobRepository';
+
+export const IMPORT_JOB_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+export const IMPORT_REAP_INTERVAL_MS = 60 * 60 * 1000;
+
+export function scheduleImportJobReaper(
+  jobRepository: JobRepository,
+  options: {
+    intervalMs?: number;
+    maxAgeMs?: number;
+  } = {}
+): NodeJS.Timeout {
+  const intervalMs = options.intervalMs ?? IMPORT_REAP_INTERVAL_MS;
+  const maxAgeMs = options.maxAgeMs ?? IMPORT_JOB_MAX_AGE_MS;
+
+  const tick = async () => {
+    try {
+      const deleted = await jobRepository.deleteOldJobs('apkg_import', maxAgeMs);
+      if (deleted > 0) {
+        console.info(`[import-reaper] cleaned up ${deleted} old import jobs`);
+      }
+    } catch (error) {
+      console.error('[import-reaper] tick failed', error);
+    }
+  };
+
+  return setInterval(tick, intervalMs);
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,6 +54,7 @@ const MarkdownToAnki = lazy(
 const PdfToAnki = lazy(() => import('./pages/LandingPage/PdfToAnki'));
 const MagicLinkPage = lazy(() => import('./pages/MagicLinkPage'));
 const PrintPage = lazy(() => import('./pages/PrintPage'));
+const ImportPage = lazy(() => import('./pages/ImportPage'));
 
 const queryClient = new QueryClient();
 
@@ -180,6 +181,12 @@ function AppContent({
             element={<SuccessfulCheckoutPage />}
           />
           <Route path="/account" element={requireAuth(<AccountPage />)} />
+          <Route
+            path="/import"
+            element={requireAuth(
+              <ImportPage setError={setErrorMessage} />
+            )}
+          />
           <Route path="/ankify" element={requireAuth(<AnkifyPage />)} />
           <Route
             path="/ankify/setup"

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -19,7 +19,6 @@
   top: 0;
   overflow-y: auto;
   background: var(--color-bg-secondary);
-  border-right: 1px solid var(--color-border);
   padding: 1.25rem 0.75rem;
 }
 
@@ -49,26 +48,16 @@
   height: 28px;
 }
 
-.sidebarDivider {
-  border: none;
-  border-top: 1px solid var(--color-border);
-  margin: 0.75rem 0.5rem;
+.sidebarNav {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .sidebarGroup {
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
-  padding: 0 0;
-}
-
-.sidebarGroupLabel {
-  padding: 0.75rem 0.75rem 0.25rem;
-  font-size: 0.6875rem;
-  font-weight: var(--font-semibold);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
 }
 
 .sidebarSpacer {
@@ -78,29 +67,30 @@
 .sidebarRow {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  gap: 10px;
+  padding: 8px 12px;
   border-radius: var(--radius-md);
-  color: var(--color-text-primary);
+  color: var(--color-text-secondary);
   text-decoration: none;
   font-size: var(--text-sm);
+  font-weight: 400;
   line-height: 1.25;
 }
 
 .sidebarRow:hover {
-  background: var(--color-bg-tertiary);
+  background: rgba(0, 0, 0, 0.03);
   color: var(--color-text-primary);
 }
 
 .sidebarRowActive {
-  background: var(--color-primary-light);
-  color: var(--color-primary);
-  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  font-weight: 500;
+  background: none;
 }
 
 .sidebarRowActive:hover {
-  background: var(--color-primary-light);
-  color: var(--color-primary);
+  background: rgba(0, 0, 0, 0.03);
+  color: var(--color-text-primary);
 }
 
 .identity {
@@ -114,20 +104,7 @@
   color: var(--color-text-primary);
 }
 
-.identity:hover {
-  background: var(--color-bg-tertiary);
-  color: var(--color-text-primary);
-}
-
-.identityRow {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
 .identityEmail {
-  flex: 1 1 auto;
   font-size: var(--text-sm);
   color: var(--color-text-primary);
   white-space: nowrap;
@@ -136,30 +113,24 @@
 }
 
 .identityPlan {
-  flex: 0 0 auto;
-  padding: 0.125rem 0.5rem;
-  border-radius: 999px;
-  background: var(--color-bg-tertiary);
+  font-size: var(--text-sm);
   color: var(--color-text-secondary);
-  font-size: 0.6875rem;
-  font-weight: var(--font-medium);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.identityPlanPaid {
-  background: var(--color-primary-light);
-  color: var(--color-primary);
 }
 
 .sidebarMore {
   padding: 0.75rem;
-  font-size: 0.6875rem;
   color: var(--color-text-tertiary);
   line-height: 1.5;
 }
 
+.sidebarMoreLinks {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .sidebarMoreLinks a {
+  font-size: var(--text-sm);
   color: var(--color-text-tertiary);
   text-decoration: none;
 }
@@ -171,6 +142,7 @@
 
 .sidebarCopyright {
   margin-top: 0.5rem;
+  font-size: var(--text-sm);
 }
 
 .main {
@@ -242,4 +214,3 @@
     z-index: 30;
   }
 }
-

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -51,16 +51,16 @@ describe('Sidebar convert group', () => {
     ).toHaveAttribute('href', '/notion');
   });
 
-  it('hides Hosted Anki when the user does not have patreon access', () => {
+  it('hides Auto Sync when the user does not have patreon access', () => {
     renderSidebar({ subscriber: true });
     expect(
-      screen.queryByRole('link', { name: 'Hosted Anki' })
+      screen.queryByRole('link', { name: 'Auto Sync' })
     ).not.toBeInTheDocument();
   });
 
-  it('shows Hosted Anki when the user has patreon access', () => {
+  it('shows Auto Sync when the user has patreon access', () => {
     renderSidebar({ patreon: true });
-    expect(screen.getByRole('link', { name: 'Hosted Anki' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Auto Sync' })).toHaveAttribute(
       'href',
       '/ankify'
     );

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -36,7 +36,7 @@ function renderSidebar({
 }
 
 describe('Sidebar work group', () => {
-  it('renders Upload, Library, and Search Notion for every logged-in user', () => {
+  it('renders Upload, Library, and Notion → Anki for every logged-in user', () => {
     renderSidebar();
     expect(screen.getByRole('link', { name: 'Upload' })).toHaveAttribute(
       'href',
@@ -47,7 +47,7 @@ describe('Sidebar work group', () => {
       '/downloads'
     );
     expect(
-      screen.getByRole('link', { name: 'Search Notion' })
+      screen.getByRole('link', { name: 'Notion → Anki' })
     ).toHaveAttribute('href', '/notion');
   });
 

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -51,16 +51,16 @@ describe('Sidebar convert group', () => {
     ).toHaveAttribute('href', '/notion');
   });
 
-  it('hides Ankify when the user does not have patreon access', () => {
+  it('hides Hosted Anki when the user does not have patreon access', () => {
     renderSidebar({ subscriber: true });
     expect(
-      screen.queryByRole('link', { name: 'Ankify' })
+      screen.queryByRole('link', { name: 'Hosted Anki' })
     ).not.toBeInTheDocument();
   });
 
-  it('shows Ankify when the user has patreon access', () => {
+  it('shows Hosted Anki when the user has patreon access', () => {
     renderSidebar({ patreon: true });
-    expect(screen.getByRole('link', { name: 'Ankify' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Hosted Anki' })).toHaveAttribute(
       'href',
       '/ankify'
     );

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -35,8 +35,8 @@ function renderSidebar({
   );
 }
 
-describe('Sidebar work group', () => {
-  it('renders Upload, Library, and Notion → Anki for every logged-in user', () => {
+describe('Sidebar convert group', () => {
+  it('renders Upload, Conversions, and Notion to Anki for every logged-in user', () => {
     renderSidebar();
     expect(screen.getByRole('link', { name: 'Upload' })).toHaveAttribute(
       'href',
@@ -47,7 +47,7 @@ describe('Sidebar work group', () => {
       '/downloads'
     );
     expect(
-      screen.getByRole('link', { name: 'Notion → Anki' })
+      screen.getByRole('link', { name: 'Notion to Anki' })
     ).toHaveAttribute('href', '/notion');
   });
 
@@ -67,7 +67,7 @@ describe('Sidebar work group', () => {
   });
 });
 
-describe('Sidebar reference group', () => {
+describe('Sidebar help group', () => {
   it('always shows Docs', () => {
     renderSidebar();
     expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
@@ -103,7 +103,7 @@ describe('Sidebar admin group', () => {
   it('hides the admin group when no flags are on', () => {
     renderSidebar();
     expect(
-      screen.queryByRole('link', { name: /KI \(beta\)/i })
+      screen.queryByRole('link', { name: 'KI' })
     ).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'Ops' })).not.toBeInTheDocument();
   });
@@ -111,7 +111,7 @@ describe('Sidebar admin group', () => {
   it('shows KI when kiUI is on', () => {
     renderSidebar({ kiUI: true });
     expect(
-      screen.getByRole('link', { name: /KI \(beta\)/i })
+      screen.getByRole('link', { name: 'KI' })
     ).toHaveAttribute('href', '/ki');
   });
 
@@ -186,10 +186,10 @@ describe('Sidebar active state', () => {
 });
 
 describe('Sidebar group hierarchy', () => {
-  it('renders Make and Learn group labels for every logged-in user', () => {
+  it('does not render group labels', () => {
     renderSidebar();
-    expect(screen.getByText('Make')).toBeInTheDocument();
-    expect(screen.getByText('Learn')).toBeInTheDocument();
+    expect(screen.queryByText('Make')).not.toBeInTheDocument();
+    expect(screen.queryByText('Learn')).not.toBeInTheDocument();
   });
 
   it('omits the Admin group label when no admin flags are on', () => {
@@ -197,14 +197,14 @@ describe('Sidebar group hierarchy', () => {
     expect(screen.queryByText('Admin')).not.toBeInTheDocument();
   });
 
-  it('renders the Admin group label when ops is on', () => {
+  it('does not render Admin group label even when ops is on', () => {
     renderSidebar({ ops: true });
-    expect(screen.getByText('Admin')).toBeInTheDocument();
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
   });
 });
 
 describe('Sidebar More block', () => {
-  it('renders the relocated footer links and copyright', () => {
+  it('renders the footer links and copyright', () => {
     renderSidebar();
     expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute(
       'href',

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -131,7 +131,7 @@ export function Sidebar({
           pathname={pathname}
           onClick={handleNavClick()}
         >
-          {getVisibleText('navigation.searchNotion')}
+          Notion → Anki
         </SidebarRow>
         <SidebarRow
           href="/import"
@@ -139,7 +139,7 @@ export function Sidebar({
           matchPrefix={false}
           onClick={handleNavClick()}
         >
-          Import to Notion
+          Anki → Notion
         </SidebarRow>
         {showAnkify && (
           <SidebarRow

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -2,6 +2,18 @@ import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { getVisibleText } from '../../lib/text/getVisibleText';
 import { getPlanLabel, isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
+import ArrowLeftIcon from '../icons/ArrowLeftIcon';
+import ArrowRightIcon from '../icons/ArrowRightIcon';
+import ArrowRightOnRectangleIcon from '../icons/ArrowRightOnRectangleIcon';
+import ArrowUpTrayIcon from '../icons/ArrowUpTrayIcon';
+import BookOpenIcon from '../icons/BookOpenIcon';
+import ClockIcon from '../icons/ClockIcon';
+import CommandLineIcon from '../icons/CommandLineIcon';
+import CreditCardIcon from '../icons/CreditCardIcon';
+import PrinterIcon from '../icons/PrinterIcon';
+import SparklesIcon from '../icons/SparklesIcon';
+import UserCircleIcon from '../icons/UserCircleIcon';
+import WrenchIcon from '../icons/WrenchIcon';
 import styles from './AppShell.module.css';
 
 export interface SidebarLocals {
@@ -29,6 +41,7 @@ interface SidebarRowProps {
   pathname: string;
   matchPrefix?: boolean;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  icon?: React.ComponentType<{ width?: number; height?: number }>;
   children: React.ReactNode;
 }
 
@@ -43,6 +56,7 @@ function SidebarRow({
   pathname,
   matchPrefix = true,
   onClick,
+  icon: Icon,
   children,
 }: Readonly<SidebarRowProps>) {
   const active = isActiveRoute(pathname, href, matchPrefix);
@@ -55,6 +69,7 @@ function SidebarRow({
         active ? styles.sidebarRowActive : ''
       }`}
     >
+      {Icon && <Icon width={20} height={20} />}
       {children}
     </Link>
   );
@@ -97,133 +112,126 @@ export function Sidebar({
       <Link className={styles.sidebarLogo} to="/" onClick={handleNavClick()}>
         <img src="/mascot/navbar-logo.png" alt="2anki Logo" />
       </Link>
-      <div className={styles.sidebarGroup}>
-        <div className={styles.sidebarGroupLabel}>
-          {getVisibleText('navigation.groups.make')}
-        </div>
-        <SidebarRow
-          href="/upload"
-          pathname={pathname}
-          matchPrefix={false}
-          onClick={handleNavClick()}
-        >
-          {getVisibleText('navigation.upload')}
-        </SidebarRow>
-        {paying && (
-          <SidebarRow
-            href="/print"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-          >
-            {getVisibleText('navigation.print')}
-          </SidebarRow>
-        )}
-        <SidebarRow
-          href="/downloads"
-          pathname={pathname}
-          onClick={handleNavClick()}
-        >
-          {getVisibleText('navigation.conversions')}
-        </SidebarRow>
-        <SidebarRow
-          href="/notion"
-          pathname={pathname}
-          onClick={handleNavClick()}
-        >
-          Notion → Anki
-        </SidebarRow>
-        <SidebarRow
-          href="/import"
-          pathname={pathname}
-          matchPrefix={false}
-          onClick={handleNavClick()}
-        >
-          Anki → Notion
-        </SidebarRow>
-        {showAnkify && (
-          <SidebarRow
-            href="/ankify"
-            pathname={pathname}
-            onClick={handleNavClick()}
-          >
-            Ankify
-          </SidebarRow>
-        )}
-      </div>
-      <div className={styles.sidebarGroup}>
-        <div className={styles.sidebarGroupLabel}>
-          {getVisibleText('navigation.groups.learn')}
-        </div>
-        <SidebarRow
-          href="/documentation"
-          pathname={pathname}
-          onClick={handleNavClick()}
-        >
-          {getVisibleText('navigation.docs')}
-        </SidebarRow>
-        {showPricing && (
-          <SidebarRow
-            href="/pricing"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-          >
-            {getVisibleText('navigation.pricing')}
-          </SidebarRow>
-        )}
-      </div>
-      {showAdminGroup && (
+      <nav className={styles.sidebarNav}>
         <div className={styles.sidebarGroup}>
-          <div className={styles.sidebarGroupLabel}>
-            {getVisibleText('navigation.groups.admin')}
-          </div>
-          {showKi && (
-            <SidebarRow
-              href="/ki"
-              pathname={pathname}
-              onClick={handleNavClick()}
-            >
-              KI (beta)
-            </SidebarRow>
-          )}
-          {showOps && (
-            <SidebarRow
-              href="/ops"
-              pathname={pathname}
-              onClick={handleNavClick()}
-            >
-              Ops
-            </SidebarRow>
-          )}
-        </div>
-      )}
-      <div className={styles.sidebarSpacer} />
-      <hr className={styles.sidebarDivider} />
-      <Link
-        className={styles.identity}
-        to="/account"
-        onClick={handleNavClick()}
-      >
-        <div className={styles.identityRow}>
-          <span className={styles.identityEmail} title={email ?? undefined}>
-            {email ?? 'Account'}
-          </span>
-          <span
-            className={`${styles.identityPlan} ${
-              isPayingUser(locals) ? styles.identityPlanPaid : ''
-            }`}
+          <SidebarRow
+            href="/upload"
+            pathname={pathname}
+            matchPrefix={false}
+            onClick={handleNavClick()}
+            icon={ArrowUpTrayIcon}
           >
-            {planLabel}
-          </span>
+            {getVisibleText('navigation.upload')}
+          </SidebarRow>
+          <SidebarRow
+            href="/notion"
+            pathname={pathname}
+            onClick={handleNavClick()}
+            icon={ArrowRightIcon}
+          >
+            Notion to Anki
+          </SidebarRow>
+          <SidebarRow
+            href="/import"
+            pathname={pathname}
+            matchPrefix={false}
+            onClick={handleNavClick()}
+            icon={ArrowLeftIcon}
+          >
+            Anki to Notion
+          </SidebarRow>
+          {paying && (
+            <SidebarRow
+              href="/print"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={PrinterIcon}
+            >
+              {getVisibleText('navigation.print')}
+            </SidebarRow>
+          )}
+          {showAnkify && (
+            <SidebarRow
+              href="/ankify"
+              pathname={pathname}
+              onClick={handleNavClick()}
+              icon={SparklesIcon}
+            >
+              Ankify
+            </SidebarRow>
+          )}
         </div>
-      </Link>
+        <div className={styles.sidebarGroup}>
+          <SidebarRow
+            href="/downloads"
+            pathname={pathname}
+            onClick={handleNavClick()}
+            icon={ClockIcon}
+          >
+            {getVisibleText('navigation.conversions')}
+          </SidebarRow>
+        </div>
+        <div className={styles.sidebarGroup}>
+          <SidebarRow
+            href="/documentation"
+            pathname={pathname}
+            onClick={handleNavClick()}
+            icon={BookOpenIcon}
+          >
+            {getVisibleText('navigation.docs')}
+          </SidebarRow>
+          {showPricing && (
+            <SidebarRow
+              href="/pricing"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={CreditCardIcon}
+            >
+              {getVisibleText('navigation.pricing')}
+            </SidebarRow>
+          )}
+        </div>
+        {showAdminGroup && (
+          <div className={styles.sidebarGroup}>
+            {showKi && (
+              <SidebarRow
+                href="/ki"
+                pathname={pathname}
+                onClick={handleNavClick()}
+                icon={CommandLineIcon}
+              >
+                KI
+              </SidebarRow>
+            )}
+            {showOps && (
+              <SidebarRow
+                href="/ops"
+                pathname={pathname}
+                onClick={handleNavClick()}
+                icon={WrenchIcon}
+              >
+                Ops
+              </SidebarRow>
+            )}
+          </div>
+        )}
+      </nav>
+      <div className={styles.sidebarSpacer} />
+      <div className={styles.identity}>
+        <span className={styles.identityEmail} title={email ?? undefined}>
+          {email ?? 'Account'}
+        </span>
+        <span className={styles.identityPlan}>{planLabel}</span>
+      </div>
       <div className={styles.sidebarGroup}>
         <SidebarRow
           href="/account"
           pathname={pathname}
           matchPrefix={false}
           onClick={handleNavClick()}
+          icon={UserCircleIcon}
         >
           {getVisibleText('navigation.account')}
         </SidebarRow>
@@ -232,6 +240,7 @@ export function Sidebar({
           href="/users/logout"
           onClick={handleNavClick(onLogOut)}
         >
+          <ArrowRightOnRectangleIcon width={20} height={20} />
           {getVisibleText('navigation.logout')}
         </a>
       </div>
@@ -240,18 +249,15 @@ export function Sidebar({
           <Link to="/about" onClick={handleNavClick()}>
             {getVisibleText('navigation.legal.about')}
           </Link>
-          {' · '}
           <Link to="/contact" onClick={handleNavClick()}>
             {getVisibleText('navigation.contact')}
           </Link>
-          {' · '}
           <Link
             to="/documentation/misc/terms-of-service"
             onClick={handleNavClick()}
           >
             {getVisibleText('navigation.legal.terms')}
           </Link>
-          {' · '}
           <Link
             to="/documentation/misc/privacy-policy"
             onClick={handleNavClick()}
@@ -260,7 +266,7 @@ export function Sidebar({
           </Link>
         </div>
         <div className={styles.sidebarCopyright}>
-          © 2024–{new Date().getFullYear()} Alexander Alemayhu
+          &copy; 2024&ndash;{new Date().getFullYear()} Alexander Alemayhu
         </div>
       </div>
     </aside>

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -133,6 +133,14 @@ export function Sidebar({
         >
           {getVisibleText('navigation.searchNotion')}
         </SidebarRow>
+        <SidebarRow
+          href="/import"
+          pathname={pathname}
+          matchPrefix={false}
+          onClick={handleNavClick()}
+        >
+          Import to Notion
+        </SidebarRow>
         {showAnkify && (
           <SidebarRow
             href="/ankify"

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -158,7 +158,7 @@ export function Sidebar({
               onClick={handleNavClick()}
               icon={SparklesIcon}
             >
-              Ankify
+              Hosted Anki
             </SidebarRow>
           )}
         </div>

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -158,7 +158,7 @@ export function Sidebar({
               onClick={handleNavClick()}
               icon={SparklesIcon}
             >
-              Hosted Anki
+              Auto Sync
             </SidebarRow>
           )}
         </div>

--- a/web/src/components/icons/ArrowLeftIcon.tsx
+++ b/web/src/components/icons/ArrowLeftIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function ArrowLeftIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/ArrowRightIcon.tsx
+++ b/web/src/components/icons/ArrowRightIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function ArrowRightIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/ArrowRightOnRectangleIcon.tsx
+++ b/web/src/components/icons/ArrowRightOnRectangleIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function ArrowRightOnRectangleIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/ArrowUpTrayIcon.tsx
+++ b/web/src/components/icons/ArrowUpTrayIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function ArrowUpTrayIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/BookOpenIcon.tsx
+++ b/web/src/components/icons/BookOpenIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function BookOpenIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/ClockIcon.tsx
+++ b/web/src/components/icons/ClockIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function ClockIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/CommandLineIcon.tsx
+++ b/web/src/components/icons/CommandLineIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function CommandLineIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m6.75 7.5 3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/CreditCardIcon.tsx
+++ b/web/src/components/icons/CreditCardIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function CreditCardIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 8.25h19.5M2.25 9h19.5m-16.5 5.25h6m-6 2.25h3m-3.75 3h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/PrinterIcon.tsx
+++ b/web/src/components/icons/PrinterIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function PrinterIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6.72 13.829c-.24.03-.48.062-.72.096m.72-.096a42.415 42.415 0 0 1 10.56 0m-10.56 0L6.34 18m10.94-4.171c.24.03.48.062.72.096m-.72-.096L17.66 18m0 0 .229 2.523a1.125 1.125 0 0 1-1.12 1.227H7.231c-.662 0-1.18-.568-1.12-1.227L6.34 18m11.318 0h1.091A2.25 2.25 0 0 0 21 15.75V9.456c0-1.081-.768-2.015-1.837-2.175a48.055 48.055 0 0 0-1.913-.247M6.34 18H5.25A2.25 2.25 0 0 1 3 15.75V9.456c0-1.081.768-2.015 1.837-2.175a48.041 48.041 0 0 1 1.913-.247m10.5 0a48.536 48.536 0 0 0-10.5 0m10.5 0V3.375c0-.621-.504-1.125-1.125-1.125h-8.25c-.621 0-1.125.504-1.125 1.125v3.659M9.75 8.25h4.5"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/SparklesIcon.tsx
+++ b/web/src/components/icons/SparklesIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function SparklesIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09ZM18.259 8.715 18 9.75l-.259-1.035a3.375 3.375 0 0 0-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 0 0 2.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 0 0 2.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 0 0-2.455 2.456ZM16.894 20.567 16.5 21.75l-.394-1.183a2.25 2.25 0 0 0-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 0 0 1.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 0 0 1.423 1.423l1.183.394-1.183.394a2.25 2.25 0 0 0-1.423 1.423Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/UserCircleIcon.tsx
+++ b/web/src/components/icons/UserCircleIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function UserCircleIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/WrenchIcon.tsx
+++ b/web/src/components/icons/WrenchIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function WrenchIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M11.42 15.17 17.25 21A2.652 2.652 0 0 0 21 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 1 1-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 0 0 4.486-6.336l-3.276 3.277a3.004 3.004 0 0 1-2.25-2.25l3.276-3.276a4.5 4.5 0 0 0-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437 1.745-1.437"
+      />
+    </svg>
+  );
+}

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -666,11 +666,13 @@ export class Backend {
 
   async startImportToNotion(
     file: File,
-    notionPageId: string
+    notionPageId?: string
   ): Promise<{ job_id: string }> {
     const formData = new FormData();
     formData.append('file', file);
-    formData.append('parent_page_id', notionPageId);
+    if (notionPageId != null && notionPageId.length > 0) {
+      formData.append('parent_page_id', notionPageId);
+    }
 
     const response = await fetch(`${this.baseURL}apkg/import`, {
       method: 'POST',

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -663,4 +663,36 @@ export class Backend {
     }
     return response.json();
   }
+
+  async startImportToNotion(
+    file: File,
+    notionPageId: string
+  ): Promise<{ job_id: string }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('parent_page_id', notionPageId);
+
+    const response = await fetch(`${this.baseURL}apkg/import`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ message: response.statusText }));
+      throw new Error(error.message ?? 'Failed to start import');
+    }
+    return response.json();
+  }
+
+  async getImportJobStatus(jobId: string): Promise<{
+    status: string;
+    progress: { total_notes: number; imported: number };
+    notion_page_url?: string;
+    error?: string;
+  }> {
+    return get(`${this.baseURL}apkg/import/${jobId}/status`);
+  }
 }

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -692,6 +692,7 @@ export class Backend {
   async getImportJobStatus(jobId: string): Promise<{
     status: string;
     progress: { total_notes: number; imported: number };
+    status_text?: string;
     notion_page_url?: string;
     error?: string;
   }> {

--- a/web/src/pages/DownloadsPage/components/ListJobs/index.tsx
+++ b/web/src/pages/DownloadsPage/components/ListJobs/index.tsx
@@ -9,6 +9,17 @@ import TrashIcon from '../../../../components/icons/TrashIcon';
 import './ListJobs.css';
 import sharedStyles from '../../../../styles/shared.module.css';
 
+const SERVICE_LABELS: Record<string, string> = {
+  notion: 'Notion → Anki',
+  claude: 'Claude',
+  apkg_import: 'Anki → Notion',
+};
+
+function getServiceLabel(type: string | null | undefined): string {
+  if (type == null) return 'Notion → Anki';
+  return SERVICE_LABELS[type] ?? type;
+}
+
 interface Props {
   readonly jobs: JobResponse[];
   readonly deleteJob: (id: JobsId) => void;
@@ -27,6 +38,25 @@ export default function Index({
 
   const renderStatusCell = (j: JobResponse) => {
     if (isDoneJob(j.status as JobStatus)) {
+      if (j.type === 'apkg_import') {
+        let notionUrl: string | null = null;
+        try {
+          const parsed = JSON.parse(j.job_reason_failure ?? '');
+          notionUrl = parsed.notion_page_url ?? null;
+        } catch { /* not JSON */ }
+        return notionUrl ? (
+          <a
+            href={notionUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="stripe-button stripe-button-primary"
+          >
+            Open in Notion
+          </a>
+        ) : (
+          <span>Done</span>
+        );
+      }
       return (
         <a
           href={`/api/upload/jobs/${j.object_id}/download`}
@@ -102,7 +132,7 @@ export default function Index({
               <td data-hj-suppress>
                 <div className="stripe-job-title">{j.title}</div>
               </td>
-              <td>{j.type ?? 'Notion'}</td>
+              <td>{getServiceLabel(j.type)}</td>
               <td>
                 {j.created_at && (
                   <div className="stripe-time-ago">

--- a/web/src/pages/ImportPage/ImportPage.module.css
+++ b/web/src/pages/ImportPage/ImportPage.module.css
@@ -245,6 +245,19 @@
   margin-top: 1rem;
 }
 
+.freeTierBanner {
+  padding: 0.75rem 1rem;
+  background: var(--color-warning-light, #fffbeb);
+  border: 1px solid var(--color-warning, #f59e0b);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  margin-bottom: 1.5rem;
+}
+
+.freeTierBanner a {
+  font-weight: 600;
+}
+
 .actions {
   margin-top: 1.5rem;
 }

--- a/web/src/pages/ImportPage/ImportPage.module.css
+++ b/web/src/pages/ImportPage/ImportPage.module.css
@@ -1,0 +1,256 @@
+.stepSection {
+  margin-bottom: 1.5rem;
+}
+
+.stepLabel {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-secondary, #6b7280);
+  margin-bottom: 0.5rem;
+}
+
+.stepDisabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.dropZone {
+  border: 2px dashed var(--color-border, #d1d5db);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.dropZone:hover {
+  border-color: var(--color-primary, #4f46e5);
+}
+
+.dropZoneActive {
+  border-color: var(--color-primary, #4f46e5);
+  background: var(--color-primary-light, #eef2ff);
+}
+
+.dropZoneHasFile {
+  border-style: solid;
+  border-color: var(--color-success, #16a34a);
+  background: var(--color-success-light, #f0fdf4);
+}
+
+.dropZoneTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.dropZoneSubtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.dropZoneFileName {
+  margin: 0;
+  font-weight: 500;
+}
+
+.dropZoneError {
+  color: var(--color-danger, #dc2626);
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+}
+
+.pagePicker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pagePickerSearch {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.pagePickerInput {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.pagePickerList {
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pagePickerRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border, #d1d5db);
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.875rem;
+  width: 100%;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.pagePickerRow:hover {
+  border-color: var(--color-primary, #4f46e5);
+}
+
+.pagePickerRowSelected {
+  border-color: var(--color-primary, #4f46e5);
+  background: var(--color-primary-light, #eef2ff);
+}
+
+.pagePickerIcon {
+  flex-shrink: 0;
+}
+
+.pagePickerTitle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pagePickerEmpty {
+  text-align: center;
+  color: var(--color-text-secondary, #6b7280);
+  padding: 1rem;
+  font-size: 0.875rem;
+}
+
+.pagePickerHelp {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.progressContainer {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.progressTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+}
+
+.progressSummary {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0 0 1rem;
+}
+
+.progressBar {
+  height: 8px;
+  background: var(--color-border, #d1d5db);
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--color-primary, #4f46e5);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.progressCount {
+  font-size: 0.875rem;
+  margin: 0 0 0.5rem;
+}
+
+.progressReassurance {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin: 0;
+}
+
+.completeContainer {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: var(--color-success-light, #f0fdf4);
+  border: 1px solid var(--color-success, #16a34a);
+  border-radius: 8px;
+}
+
+.completeTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem;
+}
+
+.completeSummary {
+  font-size: 0.875rem;
+  margin: 0 0 1.5rem;
+}
+
+.completeActions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.errorContainer {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: var(--color-danger-light, #fef2f2);
+  border: 1px solid var(--color-danger, #dc2626);
+  border-radius: 8px;
+}
+
+.errorTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.errorBody {
+  font-size: 0.875rem;
+  margin: 0 0 1.5rem;
+}
+
+.errorActions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.connectContainer {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.connectBody {
+  font-size: 0.875rem;
+  margin: 0 0 1rem;
+}
+
+.connectPrivacy {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin-top: 1rem;
+}
+
+.actions {
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .dropZone {
+    padding: 2rem 1rem;
+  }
+}

--- a/web/src/pages/ImportPage/ImportPage.module.css
+++ b/web/src/pages/ImportPage/ImportPage.module.css
@@ -249,6 +249,39 @@
   margin-top: 1.5rem;
 }
 
+.quickImportSection {
+  margin-top: 1.5rem;
+  text-align: center;
+}
+
+.quickImportDivider {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.quickImportDivider::before,
+.quickImportDivider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border, #d1d5db);
+}
+
+.quickImportDividerText {
+  padding: 0 0.75rem;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary, #6b7280);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.quickImportHelp {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary, #6b7280);
+  margin-top: 0.5rem;
+}
+
 @media (max-width: 640px) {
   .dropZone {
     padding: 2rem 1rem;

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -53,6 +53,15 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
     }
   }, [file, selectedPageId, job, setError]);
 
+  const handleQuickImport = useCallback(async () => {
+    if (file == null) return;
+    try {
+      await job.submit(file);
+    } catch (err) {
+      setError(err);
+    }
+  }, [file, job, setError]);
+
   const handleReset = useCallback(() => {
     job.reset();
     setFile(null);
@@ -99,7 +108,10 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
         <div className={styles.completeContainer}>
           <h2 className={styles.completeTitle}>Import complete</h2>
           <p className={styles.completeSummary}>
-            {job.progress.imported} cards added to &ldquo;{selectedPageTitle}&rdquo;
+            {job.progress.imported} cards added
+            {selectedPageTitle
+              ? <> to &ldquo;{selectedPageTitle}&rdquo;</>
+              : <> to your &ldquo;2anki Imports&rdquo; page</>}
           </p>
           <div className={styles.completeActions}>
             {job.notionPageUrl && (
@@ -159,7 +171,7 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
           imported={job.progress.imported}
           total={job.progress.total_notes}
           fileName={file?.name ?? ''}
-          pageTitle={selectedPageTitle}
+          pageTitle={selectedPageTitle || '2anki Imports'}
         />
       </div>
     );
@@ -207,6 +219,23 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
         >
           Start import
         </button>
+      </div>
+
+      <div className={`${styles.quickImportSection} ${file == null ? styles.stepDisabled : ''}`}>
+        <div className={styles.quickImportDivider}>
+          <span className={styles.quickImportDividerText}>or</span>
+        </div>
+        <button
+          type="button"
+          className={sharedStyles.btnSecondary}
+          disabled={file == null || isRunning}
+          onClick={handleQuickImport}
+        >
+          Quick import
+        </button>
+        <p className={styles.quickImportHelp}>
+          We'll create a "2anki Imports" page in your Notion workspace
+        </p>
       </div>
     </div>
   );

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -187,7 +187,6 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
       </div>
 
       <div className={styles.stepSection}>
-        <div className={styles.stepLabel}>Step 1</div>
         <ApkgDropZone
           file={file}
           onFileSelected={handleFileSelected}
@@ -197,8 +196,25 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
         {fileError && <p className={styles.dropZoneError}>{fileError}</p>}
       </div>
 
+      <div className={`${styles.quickImportSection} ${file == null ? styles.stepDisabled : ''}`}>
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          disabled={file == null || isRunning}
+          onClick={handleQuickImport}
+        >
+          Quick import
+        </button>
+        <p className={styles.quickImportHelp}>
+          Creates a &ldquo;2anki Imports&rdquo; page in your Notion workspace
+        </p>
+      </div>
+
+      <div className={styles.quickImportDivider}>
+        <span className={styles.quickImportDividerText}>or choose a page</span>
+      </div>
+
       <div className={`${styles.stepSection} ${file == null ? styles.stepDisabled : ''}`}>
-        <div className={styles.stepLabel}>Step 2 — Choose where to put the cards</div>
         <NotionPagePicker
           selectedPageId={selectedPageId}
           onPageSelected={handlePageSelected}
@@ -213,29 +229,12 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
       <div className={styles.actions}>
         <button
           type="button"
-          className={sharedStyles.btnPrimary}
+          className={sharedStyles.btnSecondary}
           disabled={file == null || selectedPageId == null || isRunning}
           onClick={handleStartImport}
         >
-          Start import
+          Import to selected page
         </button>
-      </div>
-
-      <div className={`${styles.quickImportSection} ${file == null ? styles.stepDisabled : ''}`}>
-        <div className={styles.quickImportDivider}>
-          <span className={styles.quickImportDividerText}>or</span>
-        </div>
-        <button
-          type="button"
-          className={sharedStyles.btnSecondary}
-          disabled={file == null || isRunning}
-          onClick={handleQuickImport}
-        >
-          Quick import
-        </button>
-        <p className={styles.quickImportHelp}>
-          We'll create a "2anki Imports" page in your Notion workspace
-        </p>
       </div>
     </div>
   );

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -9,6 +9,8 @@ import ImportProgress from './components/ImportProgress';
 import useImportJob from './hooks/useImportJob';
 import useNotionData from '../SearchPage/helpers/useNotionData';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
+import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabel';
 
 interface ImportPageProps {
   setError: (error: unknown) => void;
@@ -20,6 +22,8 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
   const [selectedPageId, setSelectedPageId] = useState<string | null>(null);
   const [selectedPageTitle, setSelectedPageTitle] = useState<string>('');
   const notionData = useNotionData(get2ankiApi());
+  const { data: userLocals } = useUserLocals();
+  const paying = isPayingUser(userLocals?.locals);
   const job = useImportJob();
 
   const isConnected = notionData.connected === true;
@@ -138,26 +142,41 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
   }
 
   if (isFailed) {
+    const isUpgradeError = job.errorMessage?.includes('Upgrade') || job.errorMessage?.includes('Free plan');
     return (
       <div className={sharedStyles.page}>
         <div className={styles.errorContainer}>
-          <h2 className={styles.errorTitle}>Import stopped</h2>
+          <h2 className={styles.errorTitle}>
+            {isUpgradeError ? 'Upgrade to continue' : 'Import stopped'}
+          </h2>
           <p className={styles.errorBody}>
-            {job.progress.total_notes > 0
-              ? `We got through ${job.progress.imported} of ${job.progress.total_notes} cards, then something went wrong. The cards we already created are still in your Notion page.`
-              : job.errorMessage ?? 'Something went wrong.'}
+            {isUpgradeError
+              ? job.errorMessage
+              : job.progress.total_notes > 0
+                ? `We got through ${job.progress.imported} of ${job.progress.total_notes} cards, then something went wrong. The cards we already created are still in your Notion page.`
+                : job.errorMessage ?? 'Something went wrong.'}
           </p>
           <div className={styles.errorActions}>
+            {isUpgradeError ? (
+              <Link to="/pricing" className={sharedStyles.btnPrimary}>
+                View plans
+              </Link>
+            ) : (
+              <button
+                type="button"
+                className={sharedStyles.btnPrimary}
+                onClick={handleReset}
+              >
+                Try again
+              </button>
+            )}
             <button
               type="button"
-              className={sharedStyles.btnPrimary}
+              className={sharedStyles.btnSecondary}
               onClick={handleReset}
             >
-              Try again
+              {isUpgradeError ? 'Try a smaller deck' : 'Start over'}
             </button>
-            <Link to="/contact" className={sharedStyles.btnSecondary}>
-              Contact support
-            </Link>
           </div>
         </div>
       </div>
@@ -186,6 +205,13 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
           Turn an Anki deck into Notion toggle pages.
         </p>
       </div>
+
+      {!paying && (
+        <div className={styles.freeTierBanner}>
+          Free plan: 1 import, up to 50 cards.{' '}
+          <Link to="/pricing">Upgrade for unlimited imports</Link>
+        </div>
+      )}
 
       <div className={styles.stepSection}>
         <ApkgDropZone

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './ImportPage.module.css';
+import ApkgDropZone from './components/ApkgDropZone';
+import NotionPagePicker from './components/NotionPagePicker';
+import ImportProgress from './components/ImportProgress';
+import useImportJob from './hooks/useImportJob';
+import useNotionData from '../SearchPage/helpers/useNotionData';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+
+interface ImportPageProps {
+  setError: (error: unknown) => void;
+}
+
+export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
+  const [file, setFile] = useState<File | null>(null);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [selectedPageId, setSelectedPageId] = useState<string | null>(null);
+  const [selectedPageTitle, setSelectedPageTitle] = useState<string>('');
+  const notionData = useNotionData(get2ankiApi());
+  const job = useImportJob();
+
+  const isConnected = notionData.connected === true;
+  const isIdle = job.phase === 'idle';
+  const isUploading = job.phase === 'uploading';
+  const isPolling = job.phase === 'polling';
+  const isCompleted = job.phase === 'completed';
+  const isFailed = job.phase === 'failed';
+  const isRunning = isUploading || isPolling;
+
+  const handleFileSelected = useCallback((f: File) => {
+    setFile(f);
+    setFileError(null);
+  }, []);
+
+  const handleFileRejected = useCallback((message: string) => {
+    setFileError(message);
+  }, []);
+
+  const handlePageSelected = useCallback((pageId: string, pageTitle: string) => {
+    setSelectedPageId(pageId);
+    setSelectedPageTitle(pageTitle);
+  }, []);
+
+  const handleStartImport = useCallback(async () => {
+    if (file == null || selectedPageId == null) return;
+    try {
+      await job.submit(file, selectedPageId);
+    } catch (err) {
+      setError(err);
+    }
+  }, [file, selectedPageId, job, setError]);
+
+  const handleReset = useCallback(() => {
+    job.reset();
+    setFile(null);
+    setFileError(null);
+    setSelectedPageId(null);
+    setSelectedPageTitle('');
+  }, [job]);
+
+  if (notionData.loading) {
+    return (
+      <div className={sharedStyles.page}>
+        <div className={sharedStyles.flexCenter}>
+          <div className={sharedStyles.spinnerSmall} />
+        </div>
+      </div>
+    );
+  }
+
+  if (!isConnected) {
+    return (
+      <div className={sharedStyles.page}>
+        <div className={sharedStyles.pageHeader}>
+          <h1 className={sharedStyles.title}>Connect Notion to import cards</h1>
+          <p className={sharedStyles.subtitle}>
+            To import an Anki deck into Notion, we need access to your workspace.
+          </p>
+        </div>
+        <div className={styles.connectContainer}>
+          <a href="/notion" className={sharedStyles.btnPrimary}>
+            Connect to Notion
+          </a>
+          <p className={styles.connectPrivacy}>
+            We only create pages where you choose. We don't read or change your
+            existing Notion content.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isCompleted) {
+    return (
+      <div className={sharedStyles.page}>
+        <div className={styles.completeContainer}>
+          <h2 className={styles.completeTitle}>Import complete</h2>
+          <p className={styles.completeSummary}>
+            {job.progress.imported} cards added to &ldquo;{selectedPageTitle}&rdquo;
+          </p>
+          <div className={styles.completeActions}>
+            {job.notionPageUrl && (
+              <a
+                href={job.notionPageUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={sharedStyles.btnPrimary}
+              >
+                Open in Notion
+              </a>
+            )}
+            <button
+              type="button"
+              className={sharedStyles.btnSecondary}
+              onClick={handleReset}
+            >
+              Import another deck
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isFailed) {
+    return (
+      <div className={sharedStyles.page}>
+        <div className={styles.errorContainer}>
+          <h2 className={styles.errorTitle}>Import stopped</h2>
+          <p className={styles.errorBody}>
+            {job.progress.total_notes > 0
+              ? `We got through ${job.progress.imported} of ${job.progress.total_notes} cards, then something went wrong. The cards we already created are still in your Notion page.`
+              : job.errorMessage ?? 'Something went wrong.'}
+          </p>
+          <div className={styles.errorActions}>
+            <button
+              type="button"
+              className={sharedStyles.btnPrimary}
+              onClick={handleReset}
+            >
+              Try again
+            </button>
+            <Link to="/contact" className={sharedStyles.btnSecondary}>
+              Contact support
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isRunning) {
+    return (
+      <div className={sharedStyles.page}>
+        <ImportProgress
+          imported={job.progress.imported}
+          total={job.progress.total_notes}
+          fileName={file?.name ?? ''}
+          pageTitle={selectedPageTitle}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={sharedStyles.page}>
+      <div className={sharedStyles.pageHeader}>
+        <h1 className={sharedStyles.title}>Import to Notion</h1>
+        <p className={sharedStyles.subtitle}>
+          Turn an Anki deck into Notion toggle pages.
+        </p>
+      </div>
+
+      <div className={styles.stepSection}>
+        <div className={styles.stepLabel}>Step 1</div>
+        <ApkgDropZone
+          file={file}
+          onFileSelected={handleFileSelected}
+          onFileRejected={handleFileRejected}
+          disabled={isRunning}
+        />
+        {fileError && <p className={styles.dropZoneError}>{fileError}</p>}
+      </div>
+
+      <div className={`${styles.stepSection} ${file == null ? styles.stepDisabled : ''}`}>
+        <div className={styles.stepLabel}>Step 2 — Choose where to put the cards</div>
+        <NotionPagePicker
+          selectedPageId={selectedPageId}
+          onPageSelected={handlePageSelected}
+          disabled={file == null || isRunning}
+        />
+        <p className={styles.pagePickerHelp}>
+          Showing top-level pages shared with 2anki. Missing a page? Check your
+          Notion sharing settings.
+        </p>
+      </div>
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          disabled={file == null || selectedPageId == null || isRunning}
+          onClick={handleStartImport}
+        >
+          Start import
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -150,11 +150,11 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
             {isUpgradeError ? 'Upgrade to continue' : 'Import stopped'}
           </h2>
           <p className={styles.errorBody}>
-            {isUpgradeError
-              ? job.errorMessage
-              : job.progress.total_notes > 0
-                ? `We got through ${job.progress.imported} of ${job.progress.total_notes} cards, then something went wrong. The cards we already created are still in your Notion page.`
-                : job.errorMessage ?? 'Something went wrong.'}
+            {isUpgradeError && job.errorMessage}
+            {!isUpgradeError && job.progress.total_notes > 0 &&
+              `We got through ${job.progress.imported} of ${job.progress.total_notes} cards, then something went wrong. The cards we already created are still in your Notion page.`}
+            {!isUpgradeError && job.progress.total_notes === 0 &&
+              (job.errorMessage ?? 'Something went wrong.')}
           </p>
           <div className={styles.errorActions}>
             {isUpgradeError ? (

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -172,6 +172,7 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
           total={job.progress.total_notes}
           fileName={file?.name ?? ''}
           pageTitle={selectedPageTitle || '2anki Imports'}
+          statusText={job.statusText}
         />
       </div>
     );

--- a/web/src/pages/ImportPage/components/ApkgDropZone.tsx
+++ b/web/src/pages/ImportPage/components/ApkgDropZone.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useRef, useState } from 'react';
+import styles from '../ImportPage.module.css';
+
+interface ApkgDropZoneProps {
+  file: File | null;
+  onFileSelected: (file: File) => void;
+  onFileRejected: (message: string) => void;
+  disabled: boolean;
+}
+
+function isApkgFile(file: File): boolean {
+  return file.name.toLowerCase().endsWith('.apkg');
+}
+
+export default function ApkgDropZone({
+  file,
+  onFileSelected,
+  onFileRejected,
+  disabled,
+}: Readonly<ApkgDropZoneProps>) {
+  const [dragOver, setDragOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback(
+    (f: File) => {
+      if (isApkgFile(f)) {
+        onFileSelected(f);
+      } else {
+        onFileRejected("This file isn't an Anki deck");
+      }
+    },
+    [onFileSelected, onFileRejected]
+  );
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+      setDragOver(false);
+      if (disabled) return;
+      const droppedFile = event.dataTransfer.files[0];
+      if (droppedFile) {
+        handleFile(droppedFile);
+      }
+    },
+    [disabled, handleFile]
+  );
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const selectedFile = event.target.files?.[0];
+      if (selectedFile) {
+        handleFile(selectedFile);
+      }
+    },
+    [handleFile]
+  );
+
+  const handleClick = useCallback(() => {
+    if (!disabled) {
+      inputRef.current?.click();
+    }
+  }, [disabled]);
+
+  return (
+    <div
+      className={`${styles.dropZone} ${dragOver ? styles.dropZoneActive : ''} ${
+        file ? styles.dropZoneHasFile : ''
+      }`}
+      onDragOver={(e) => {
+        e.preventDefault();
+        if (!disabled) setDragOver(true);
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={handleDrop}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') handleClick();
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label="Drop your .apkg file here"
+    >
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".apkg"
+        onChange={handleChange}
+        hidden
+        disabled={disabled}
+      />
+      {file ? (
+        <p className={styles.dropZoneFileName}>{file.name}</p>
+      ) : (
+        <>
+          <p className={styles.dropZoneTitle}>Drop your .apkg file here</p>
+          <p className={styles.dropZoneSubtitle}>or click to choose</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/ImportPage/components/ImportProgress.tsx
+++ b/web/src/pages/ImportPage/components/ImportProgress.tsx
@@ -40,7 +40,7 @@ export default function ImportProgress({
       </div>
       <p className={styles.progressCount}>
         {isUploadingImages
-          ? statusText.replace('uploading images ', 'Uploading images: ')
+          ? (statusText ?? '').replace('uploading images ', 'Uploading images: ')
           : `${imported} of ${total} cards`}
       </p>
       <p className={styles.progressReassurance}>

--- a/web/src/pages/ImportPage/components/ImportProgress.tsx
+++ b/web/src/pages/ImportPage/components/ImportProgress.tsx
@@ -15,12 +15,14 @@ export default function ImportProgress({
   pageTitle,
   statusText,
 }: Readonly<ImportProgressProps>) {
-  const isUploadingImages = statusText != null && statusText.startsWith('uploading');
-  const percent = isUploadingImages
-    ? 0
-    : total > 0
-      ? Math.round((imported / total) * 100)
-      : 0;
+  const isUploadingImages = statusText?.startsWith('uploading') ?? false;
+
+  function getPercent() {
+    if (isUploadingImages) return 0;
+    if (total > 0) return Math.round((imported / total) * 100);
+    return 0;
+  }
+  const percent = getPercent();
 
   return (
     <div className={styles.progressContainer}>

--- a/web/src/pages/ImportPage/components/ImportProgress.tsx
+++ b/web/src/pages/ImportPage/components/ImportProgress.tsx
@@ -5,6 +5,7 @@ interface ImportProgressProps {
   total: number;
   fileName: string;
   pageTitle: string;
+  statusText: string | null;
 }
 
 export default function ImportProgress({
@@ -12,8 +13,14 @@ export default function ImportProgress({
   total,
   fileName,
   pageTitle,
+  statusText,
 }: Readonly<ImportProgressProps>) {
-  const percent = total > 0 ? Math.round((imported / total) * 100) : 0;
+  const isUploadingImages = statusText != null && statusText.startsWith('uploading');
+  const percent = isUploadingImages
+    ? 0
+    : total > 0
+      ? Math.round((imported / total) * 100)
+      : 0;
 
   return (
     <div className={styles.progressContainer}>
@@ -30,12 +37,14 @@ export default function ImportProgress({
         />
       </div>
       <p className={styles.progressCount}>
-        {imported} of {total} cards
+        {isUploadingImages
+          ? statusText.replace('uploading images ', 'Uploading images: ')
+          : `${imported} of ${total} cards`}
       </p>
       <p className={styles.progressReassurance}>
-        {total > 50
-          ? "This usually takes about a minute. You can leave this page — we'll keep going in the background."
-          : "This usually takes a few seconds. You can leave this page — we'll keep going in the background."}
+        {isUploadingImages
+          ? "Uploading images to Notion. This can take a minute for large decks."
+          : "You can leave this page — we'll keep going in the background."}
       </p>
     </div>
   );

--- a/web/src/pages/ImportPage/components/ImportProgress.tsx
+++ b/web/src/pages/ImportPage/components/ImportProgress.tsx
@@ -1,0 +1,42 @@
+import styles from '../ImportPage.module.css';
+
+interface ImportProgressProps {
+  imported: number;
+  total: number;
+  fileName: string;
+  pageTitle: string;
+}
+
+export default function ImportProgress({
+  imported,
+  total,
+  fileName,
+  pageTitle,
+}: Readonly<ImportProgressProps>) {
+  const percent = total > 0 ? Math.round((imported / total) * 100) : 0;
+
+  return (
+    <div className={styles.progressContainer}>
+      <p className={styles.progressTitle}>Importing to Notion</p>
+      {fileName && pageTitle && (
+        <p className={styles.progressSummary}>
+          {fileName} &rarr; {pageTitle}
+        </p>
+      )}
+      <div className={styles.progressBar}>
+        <div
+          className={styles.progressFill}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <p className={styles.progressCount}>
+        {imported} of {total} cards
+      </p>
+      <p className={styles.progressReassurance}>
+        {total > 50
+          ? "This usually takes about a minute. You can leave this page — we'll keep going in the background."
+          : "This usually takes a few seconds. You can leave this page — we'll keep going in the background."}
+      </p>
+    </div>
+  );
+}

--- a/web/src/pages/ImportPage/components/NotionPagePicker.tsx
+++ b/web/src/pages/ImportPage/components/NotionPagePicker.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from 'react';
+import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+import NotionObject from '../../../lib/interfaces/NotionObject';
+import styles from '../ImportPage.module.css';
+import sharedStyles from '../../../styles/shared.module.css';
+
+interface NotionPagePickerProps {
+  selectedPageId: string | null;
+  onPageSelected: (pageId: string, pageTitle: string) => void;
+  disabled: boolean;
+}
+
+export default function NotionPagePicker({
+  selectedPageId,
+  onPageSelected,
+  disabled,
+}: Readonly<NotionPagePickerProps>) {
+  const [query, setQuery] = useState('');
+  const [pages, setPages] = useState<NotionObject[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searched, setSearched] = useState(false);
+
+  const search = useCallback(async (searchQuery: string) => {
+    setLoading(true);
+    try {
+      const results = await get2ankiApi().searchTopLevelPages(searchQuery);
+      setPages(results);
+      setSearched(true);
+    } catch {
+      setPages([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    search('');
+  }, [search]);
+
+  const handleSearch = useCallback(
+    (event: React.FormEvent) => {
+      event.preventDefault();
+      search(query);
+    },
+    [query, search]
+  );
+
+  return (
+    <div className={styles.pagePicker}>
+      <form onSubmit={handleSearch} className={styles.pagePickerSearch}>
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Type to search your pages"
+          disabled={disabled}
+          className={styles.pagePickerInput}
+        />
+        <button
+          type="submit"
+          disabled={disabled || loading}
+          className={sharedStyles.searchButton}
+        >
+          Search
+        </button>
+      </form>
+      <div className={styles.pagePickerList}>
+        {loading && (
+          <div className={sharedStyles.flexCenter}>
+            <div className={sharedStyles.spinnerSmall} />
+          </div>
+        )}
+        {!loading && searched && pages.length === 0 && (
+          <p className={styles.pagePickerEmpty}>No pages found</p>
+        )}
+        {!loading &&
+          pages.map((page) => (
+            <button
+              key={page.id}
+              type="button"
+              className={`${styles.pagePickerRow} ${
+                selectedPageId === page.id ? styles.pagePickerRowSelected : ''
+              }`}
+              onClick={() => onPageSelected(page.id, page.title)}
+              disabled={disabled}
+            >
+              {page.icon ? (
+                <span className={styles.pagePickerIcon}>{page.icon}</span>
+              ) : null}
+              <span className={styles.pagePickerTitle}>{page.title}</span>
+            </button>
+          ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ImportPage/hooks/useImportJob.ts
+++ b/web/src/pages/ImportPage/hooks/useImportJob.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+
+type ImportJobPhase = 'idle' | 'uploading' | 'polling' | 'completed' | 'failed';
+
+interface ImportJobProgress {
+  total_notes: number;
+  imported: number;
+}
+
+interface ImportJobState {
+  phase: ImportJobPhase;
+  progress: ImportJobProgress;
+  notionPageUrl: string | null;
+  errorMessage: string | null;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+export default function useImportJob() {
+  const [state, setState] = useState<ImportJobState>({
+    phase: 'idle',
+    progress: { total_notes: 0, imported: 0 },
+    notionPageUrl: null,
+    errorMessage: null,
+  });
+
+  const jobIdRef = useRef<string | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current != null) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  const pollStatus = useCallback(async () => {
+    const jobId = jobIdRef.current;
+    if (jobId == null) return;
+
+    try {
+      const result = await get2ankiApi().getImportJobStatus(jobId);
+
+      if (result.status === 'done') {
+        stopPolling();
+        setState({
+          phase: 'completed',
+          progress: result.progress,
+          notionPageUrl: result.notion_page_url ?? null,
+          errorMessage: null,
+        });
+      } else if (result.status === 'failed') {
+        stopPolling();
+        setState({
+          phase: 'failed',
+          progress: result.progress,
+          notionPageUrl: null,
+          errorMessage: result.error ?? 'Import failed',
+        });
+      } else {
+        setState((prev) => ({
+          ...prev,
+          phase: 'polling',
+          progress: result.progress,
+        }));
+      }
+    } catch (err) {
+      stopPolling();
+      setState((prev) => ({
+        ...prev,
+        phase: 'failed',
+        errorMessage: err instanceof Error ? err.message : 'Connection lost',
+      }));
+    }
+  }, [stopPolling]);
+
+  const startPolling = useCallback(
+    (jobId: string) => {
+      jobIdRef.current = jobId;
+      stopPolling();
+      pollTimerRef.current = setInterval(pollStatus, POLL_INTERVAL_MS);
+    },
+    [pollStatus, stopPolling]
+  );
+
+  const submit = useCallback(
+    async (file: File, notionPageId: string) => {
+      setState({
+        phase: 'uploading',
+        progress: { total_notes: 0, imported: 0 },
+        notionPageUrl: null,
+        errorMessage: null,
+      });
+
+      try {
+        const result = await get2ankiApi().startImportToNotion(file, notionPageId);
+        setState((prev) => ({ ...prev, phase: 'polling' }));
+        startPolling(result.job_id);
+      } catch (err) {
+        setState({
+          phase: 'failed',
+          progress: { total_notes: 0, imported: 0 },
+          notionPageUrl: null,
+          errorMessage: err instanceof Error ? err.message : 'Failed to start import',
+        });
+      }
+    },
+    [startPolling]
+  );
+
+  const reset = useCallback(() => {
+    stopPolling();
+    jobIdRef.current = null;
+    setState({
+      phase: 'idle',
+      progress: { total_notes: 0, imported: 0 },
+      notionPageUrl: null,
+      errorMessage: null,
+    });
+  }, [stopPolling]);
+
+  useEffect(() => {
+    return () => stopPolling();
+  }, [stopPolling]);
+
+  return { ...state, submit, reset };
+}

--- a/web/src/pages/ImportPage/hooks/useImportJob.ts
+++ b/web/src/pages/ImportPage/hooks/useImportJob.ts
@@ -11,6 +11,7 @@ interface ImportJobProgress {
 interface ImportJobState {
   phase: ImportJobPhase;
   progress: ImportJobProgress;
+  statusText: string | null;
   notionPageUrl: string | null;
   errorMessage: string | null;
 }
@@ -21,6 +22,7 @@ export default function useImportJob() {
   const [state, setState] = useState<ImportJobState>({
     phase: 'idle',
     progress: { total_notes: 0, imported: 0 },
+    statusText: null,
     notionPageUrl: null,
     errorMessage: null,
   });
@@ -47,6 +49,7 @@ export default function useImportJob() {
         setState({
           phase: 'completed',
           progress: result.progress,
+          statusText: null,
           notionPageUrl: result.notion_page_url ?? null,
           errorMessage: null,
         });
@@ -55,6 +58,7 @@ export default function useImportJob() {
         setState({
           phase: 'failed',
           progress: result.progress,
+          statusText: null,
           notionPageUrl: null,
           errorMessage: result.error ?? 'Import failed',
         });
@@ -63,6 +67,7 @@ export default function useImportJob() {
           ...prev,
           phase: 'polling',
           progress: result.progress,
+          statusText: result.status_text ?? null,
         }));
       }
     } catch (err) {
@@ -89,6 +94,7 @@ export default function useImportJob() {
       setState({
         phase: 'uploading',
         progress: { total_notes: 0, imported: 0 },
+        statusText: null,
         notionPageUrl: null,
         errorMessage: null,
       });
@@ -101,6 +107,7 @@ export default function useImportJob() {
         setState({
           phase: 'failed',
           progress: { total_notes: 0, imported: 0 },
+          statusText: null,
           notionPageUrl: null,
           errorMessage: err instanceof Error ? err.message : 'Failed to start import',
         });
@@ -115,6 +122,7 @@ export default function useImportJob() {
     setState({
       phase: 'idle',
       progress: { total_notes: 0, imported: 0 },
+      statusText: null,
       notionPageUrl: null,
       errorMessage: null,
     });

--- a/web/src/pages/ImportPage/hooks/useImportJob.ts
+++ b/web/src/pages/ImportPage/hooks/useImportJob.ts
@@ -85,7 +85,7 @@ export default function useImportJob() {
   );
 
   const submit = useCallback(
-    async (file: File, notionPageId: string) => {
+    async (file: File, notionPageId?: string) => {
       setState({
         phase: 'uploading',
         progress: { total_notes: 0, imported: 0 },

--- a/web/src/pages/ImportPage/index.tsx
+++ b/web/src/pages/ImportPage/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ImportPage';

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -70,8 +70,8 @@ export default function PricingPage({
         <h1 className={styles.title}>{getVisibleText('pricing.page.title')}</h1>
         <TopMessage />
         <p className={styles.intro}>
-          Free for everyone — 100 cards per upload. Convert as often as you
-          like.
+          Free for everyone — 100 cards per upload, plus one Anki → Notion
+          import to try it out.
           {!isLoggedIn && (
             <>
               {' '}
@@ -97,6 +97,7 @@ export default function PricingPage({
             'Unlimited flashcards',
             'Run multiple conversions at once',
             'PDFs and large Notion exports',
+            'Unlimited Anki → Notion imports',
             'Print decks to PDF',
             'Cancel anytime',
           ]}

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -107,7 +107,7 @@ export default function PricingPage({
         <PricingCard
           className={styles.cardHosted}
           priceChip="Coming soon"
-          title="Hosted Anki"
+          title="Auto Sync"
           benefits={[
             'Convert once, sync forever',
             'Notion edits flow to your decks automatically',
@@ -128,7 +128,7 @@ export default function PricingPage({
           title="Lifetime"
           benefits={[
             'All Unlimited features, paid once',
-            'Hosted Anki included',
+            'Auto Sync included',
             'No future price changes',
           ]}
           link={lifetimeLink}


### PR DESCRIPTION
## Summary

- Adds reverse conversion: users upload `.apkg` files and get Notion toggle-list pages (decks → pages, notes → toggle headings, tags → italic text)
- New async import job with progress tracking — `POST /api/apkg/import` returns 202 + job ID, client polls for status
- New `/import` page with 3-step flow: drag-and-drop `.apkg`, pick a Notion destination page, start import with live progress bar

## Architecture

**Server**: `ApkgRouter` → `ApkgController` → `ImportApkgToNotionUseCase` → `ApkgToNotionBlocksService` (pure transform) + `NotionAPIWrapper` (batched/throttled writes)

**Frontend**: `ImportPage` with `ApkgDropZone`, `NotionPagePicker`, `ImportProgress` components + `useImportJob` hook for job lifecycle

## Test plan

- [x] `ApkgToNotionBlocksService` — 11 tests (basic notes, cloze, sub-decks, tags, HTML stripping, media ref removal, 5K cap)
- [x] `ImportApkgToNotionUseCase` — 5 tests (happy path, note cap, progress tracking, Notion API errors, sub-deck nesting)
- [x] Server `tsc --noEmit` passes
- [x] Web `tsc --noEmit` passes
- [x] Biome lint passes
- [x] Manual test: upload a real `.apkg` file with a connected Notion workspace
- [x] Manual test: verify progress polling and completion link

## Follow-ups (in commit body)

- Media handling: upload images to S3 and reference as Notion external image blocks
- Full HTML → Notion rich text (tables, code blocks, LaTeX)
- Import history view

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)