### PR TITLE
refactor(web): route Footer links through getVisibleText

### DIFF
--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import shared from '../styles/shared.module.css';
+import { getVisibleText } from '../lib/text/getVisibleText';
 import styles from './Footer.module.css';
 
 function Footer() {
@@ -9,19 +10,23 @@ function Footer() {
         <div className={shared.flexColumn}>
           <ul className={styles.links}>
             <li>
-              <a href="/about">About</a>
+              <a href="/about">{getVisibleText('navigation.legal.about')}</a>
             </li>
             <li>
-              <a href="/documentation">Docs</a>
+              <a href="/documentation">{getVisibleText('navigation.docs')}</a>
             </li>
             <li>
-              <a href="/contact">Contact</a>
+              <a href="/contact">{getVisibleText('navigation.contact')}</a>
             </li>
             <li>
-              <a href="/documentation/misc/terms-of-service">Terms</a>
+              <a href="/documentation/misc/terms-of-service">
+                {getVisibleText('navigation.legal.terms')}
+              </a>
             </li>
             <li>
-              <a href="/documentation/misc/privacy-policy">Privacy</a>
+              <a href="/documentation/misc/privacy-policy">
+                {getVisibleText('navigation.legal.privacy')}
+              </a>
             </li>
           </ul>
           <div>{`© 2024–${currentYear} Alexander Alemayhu`}</div>


### PR DESCRIPTION
## Summary

#1234 (just reopened after the stale-bot mis-close) asks contributors to "replace static strings with calls to `getVisibleText`" so the UI can be translated. This PR migrates `web/src/components/Footer.tsx`. The footer's five nav links - About, Docs, Contact, Terms, Privacy - already have matching keys in `web/src/lib/text/app.document.json`, so the swap is pure plumbing: rendered text is identical and no JSON entry needs to change.

## Mapping

| JSX literal | Existing key |
|---|---|
| `About` | `navigation.legal.about` |
| `Docs` | `navigation.docs` |
| `Contact` | `navigation.contact` |
| `Terms` | `navigation.legal.terms` |
| `Privacy` | `navigation.legal.privacy` |

The `Docs` label specifically maps to `navigation.docs` ("Docs"), not `navigation.documentation` ("Documentation") - the existing `Footer.test.tsx` has an explicit `queryByRole('link', { name: 'Documentation' }).not.toBeInTheDocument()` assertion that locks that choice in.

## Verification

From `web/`:

    $ pnpm test src/components/Footer.test.tsx
    Test Files  1 passed (1)
         Tests  3 passed (3)
         Duration  2.30s

    $ pnpm typecheck
    (no output, clean)

    $ pnpm lint
    Checked 381 files in 43ms. No fixes applied.

The copyright line `© 2024–${currentYear} Alexander Alemayhu` is intentionally left as a template literal because the year is dynamic; if you want it routed through `getVisibleText` later, it would need either a parameterized lookup or a separate string with a `{year}` placeholder, which is a different shape of API change.

Closes #1234

---

AI disclosure: refactor + PR body drafted with Claude as a coding assistant; I ran the tests, typecheck, and Biome lint locally before pushing.
