### PR TITLE
fix: download headers and preserve card formatting

### DIFF
--- a/src/controllers/DownloadController.test.ts
+++ b/src/controllers/DownloadController.test.ts
@@ -1,0 +1,65 @@
+import DownloadController from './DownloadController';
+import { Request, Response } from 'express';
+
+function mockResponse(): Response {
+  const headers: Record<string, string> = {};
+  const res = {
+    locals: { owner: 'test-owner' },
+    setHeader: jest.fn((name: string, value: string) => {
+      headers[name] = value;
+    }),
+    send: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    redirect: jest.fn(),
+    _headers: headers,
+  } as unknown as Response;
+  return res;
+}
+
+describe('DownloadController.getFile', () => {
+  it('sets Content-Type and Content-Disposition headers for .apkg files', async () => {
+    const service = {
+      isValidKey: () => true,
+      getFileBody: jest.fn().mockResolvedValue(Buffer.from('fake-apkg')),
+      isMissingDownloadError: () => false,
+      deleteMissingFile: jest.fn(),
+    };
+
+    const controller = new DownloadController(service as any);
+    const req = { params: { key: '123-deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as any);
+
+    expect(res.send).toHaveBeenCalledWith(Buffer.from('fake-apkg'));
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/octet-stream'
+    );
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="123-deck.apkg"'
+    );
+  });
+
+  it('appends .apkg extension when key lacks it', async () => {
+    const service = {
+      isValidKey: () => true,
+      getFileBody: jest.fn().mockResolvedValue(Buffer.from('data')),
+      isMissingDownloadError: () => false,
+      deleteMissingFile: jest.fn(),
+    };
+
+    const controller = new DownloadController(service as any);
+    const req = { params: { key: '123-deck' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as any);
+
+    expect(res.send).toHaveBeenCalled();
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="123-deck.apkg"'
+    );
+  });
+});

--- a/src/controllers/DownloadController.ts
+++ b/src/controllers/DownloadController.ts
@@ -22,6 +22,12 @@ class DownloadController {
     try {
       const body = await this.service.getFileBody(owner, key, storage);
       if (body) {
+        const filename = key.endsWith('.apkg') ? key : `${key}.apkg`;
+        res.setHeader('Content-Type', 'application/octet-stream');
+        res.setHeader(
+          'Content-Disposition',
+          `attachment; filename="${filename}"`
+        );
         res.send(body);
       } else {
         throw new Error(`File not found: ${key}`);

--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -322,6 +322,61 @@ test('Nested toggles produce one card without maxOne (legacy format)', async () 
   expect(deck.cards[0].back).toContain('Capital');
 });
 
+test('bullet points inside toggle are preserved (legacy format)', async () => {
+  const deck = await getDeck(
+    'toggle-with-bullets.html',
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  expect(deck.cards[0].name).toContain('symptoms');
+  expect(deck.cards[0].back).toContain('<li');
+  expect(deck.cards[0].back).toContain('Fever');
+  expect(deck.cards[0].back).toContain('Cough');
+  expect(deck.cards[0].back).toContain('Fatigue');
+});
+
+test('bullet points preserved alongside nested toggles (legacy format)', async () => {
+  const deck = await getDeck(
+    'toggle-with-bullets-and-nested-toggle.html',
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  expect(deck.cards[0].name).toContain('Cardiology');
+  expect(deck.cards[0].back).toContain('Study of the heart');
+  expect(deck.cards[0].back).toContain('Includes diagnosis and treatment');
+  expect(deck.cards[0].back).toContain('<li');
+  expect(deck.cards[0].back).not.toContain('Sub-specialties');
+});
+
+test('bullet points inside toggle are preserved (new format)', async () => {
+  const deck = await getDeck(
+    'notion-new-export-bullets-in-toggle.html',
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  expect(deck.cards[0].name).toContain('symptoms');
+  expect(deck.cards[0].back).toContain('<li');
+  expect(deck.cards[0].back).toContain('Fever');
+  expect(deck.cards[0].back).toContain('Cough');
+  expect(deck.cards[0].back).toContain('Fatigue');
+});
+
+test('empty paragraphs preserved as spacing in card back', async () => {
+  const deck = await getDeck(
+    'toggle-with-spacing.html',
+    new CardOption({ 'max-one-toggle-per-card': 'true', cherry: 'false' })
+  );
+
+  expect(deck.cards.length).toBe(1);
+  expect(deck.cards[0].back).toContain('Sustained elevation');
+  expect(deck.cards[0].back).toContain('end-organ damage');
+  const emptyParagraphs = deck.cards[0].back.match(/<p[^>]*><\/p>/g);
+  expect(emptyParagraphs).not.toBeNull();
+});
+
 describe('removeNewlinesInSVGPathAttributeD', () => {
   const newParser = () =>
     new DeckParser({

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -167,7 +167,6 @@ export class DeckParser {
       .replace(/<ul[^/>][^>]*><\/ul>/g, '')
       .replace(/<\/details><\/li><\/ul><\/details><\/li><\/ul>/g, '')
       .replace(/<\/details><\/li><\/ul>/g, '')
-      .replace(/<p[^/>][^>]*><\/p>/g, '')
       .replaceAll('<summary class="toggle"></summary>', '');
   }
 
@@ -234,9 +233,8 @@ export class DeckParser {
 
   private cleanupEmptyElements(html: string, isNewFormat: boolean = false): string {
     let result = html
-      .replace(/<li><\/li>/g, '')
-      .replace(/<p[^/>][^>]*><\/p>/g, '');
-    
+      .replace(/<li><\/li>/g, '');
+
     if (isNewFormat) {
       result = result.replace(/<summary[^>]*class="toggle"[^>]*><\/summary>/g, '');
       result = result.replace(/<summary[^>]*><\/summary>/g, '');
@@ -244,7 +242,7 @@ export class DeckParser {
     } else {
       result = result.replaceAll('<summary class="toggle"></summary>', '');
     }
-    
+
     return result;
   }
 

--- a/src/test/fixtures/notion-new-export-bullets-in-toggle.html
+++ b/src/test/fixtures/notion-new-export-bullets-in-toggle.html
@@ -1,0 +1,6 @@
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><title>Bullets In Toggle</title><style>
+body { line-height: 1.5; white-space: pre-wrap; }
+ul > li { list-style: disc; }
+ul.toggle > li { list-style: none; }
+.toggle { padding-inline-start: 0em; list-style-type: none; }
+</style></head><body><article id="test-article-new" class="page sans"><header><h1 class="page-title">Bullets In Toggle</h1></header><div class="page-body"><div style="display:contents" dir="auto"><ul id="toggle-new-1" class="toggle"><li><details open=""><summary>What are the symptoms?</summary><div style="display:contents" dir="auto"><ul class="bulleted-list"><li style="list-style-type:disc">Fever</li></ul></div><div style="display:contents" dir="auto"><ul class="bulleted-list"><li style="list-style-type:disc">Cough</li></ul></div><div style="display:contents" dir="auto"><ul class="bulleted-list"><li style="list-style-type:disc">Fatigue</li></ul></div><div style="display:contents" dir="auto"><p id="p-new-1" class="">Additional notes about recovery.</p></div></details></li></ul></div></div></article></body></html>

--- a/src/test/fixtures/toggle-with-bullets-and-nested-toggle.html
+++ b/src/test/fixtures/toggle-with-bullets-and-nested-toggle.html
@@ -1,0 +1,6 @@
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><title>Toggle Mixed</title><style>
+body { line-height: 1.5; white-space: pre-wrap; }
+ul > li { list-style: disc; }
+ul.toggle > li { list-style: none; }
+.toggle { padding-inline-start: 0em; list-style-type: none; }
+</style></head><body><article id="test-mixed" class="page sans"><header><h1 class="page-title">Toggle Mixed</h1></header><div class="page-body"><ul id="toggle-mixed-1" class="toggle"><li><details open=""><summary>What is Cardiology?</summary><ul class="bulleted-list"><li style="list-style-type:disc">Study of the heart</li></ul><ul class="bulleted-list"><li style="list-style-type:disc">Includes diagnosis and treatment</li></ul><ul id="nested-toggle-1" class="toggle"><li><details open=""><summary>Sub-specialties</summary><p>Interventional, Electrophysiology</p></details></li></ul><p id="p-mixed" class="">Important for board exams.</p></details></li></ul></div></article></body></html>

--- a/src/test/fixtures/toggle-with-bullets.html
+++ b/src/test/fixtures/toggle-with-bullets.html
@@ -1,0 +1,6 @@
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><title>Toggle With Bullets</title><style>
+body { line-height: 1.5; white-space: pre-wrap; }
+ul > li { list-style: disc; }
+ul.toggle > li { list-style: none; }
+.toggle { padding-inline-start: 0em; list-style-type: none; }
+</style></head><body><article id="test-article" class="page sans"><header><h1 class="page-title">Toggle With Bullets</h1></header><div class="page-body"><ul id="toggle-1" class="toggle"><li><details open=""><summary>What are the symptoms?</summary><ul class="bulleted-list"><li style="list-style-type:disc">Fever</li></ul><ul class="bulleted-list"><li style="list-style-type:disc">Cough</li></ul><ul class="bulleted-list"><li style="list-style-type:disc">Fatigue</li></ul><p id="p1" class="">Additional notes about recovery.</p></details></li></ul></div></article></body></html>

--- a/src/test/fixtures/toggle-with-spacing.html
+++ b/src/test/fixtures/toggle-with-spacing.html
@@ -1,0 +1,5 @@
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><title>Toggle Spacing</title><style>
+body { line-height: 1.5; white-space: pre-wrap; }
+ul.toggle > li { list-style: none; }
+.toggle { padding-inline-start: 0em; list-style-type: none; }
+</style></head><body><article id="test-spacing" class="page sans"><header><h1 class="page-title">Toggle Spacing</h1></header><div class="page-body"><ul id="toggle-spacing-1" class="toggle"><li><details open=""><summary>Define hypertension</summary><p id="p1" class="">Sustained elevation of blood pressure above 140/90 mmHg.</p><p id="p2" class=""></p><p id="p3" class="">Can lead to end-organ damage over time.</p></details></li></ul></div></article></body></html>


### PR DESCRIPTION
## Summary

Addresses the two highest-priority bugs identified from triaging 37 support emails (30 distinct users):

- **Individual download links broken** (P2) — `/api/download/u/:key` sent raw S3 body without `Content-Type` or `Content-Disposition` headers. Browsers displayed file content instead of triggering a download. Bulk download worked fine because it already set both headers. Added `application/octet-stream` type and `attachment` disposition to `DownloadController.getFile`.

- **Card spacing/formatting collapsed** (P1 partial) — `removeNestedTogglesLegacy` and `cleanupEmptyElements` stripped empty `<p>` tags from card backs. Notion uses empty paragraphs as visual separators between content blocks — removing them caused the "clumped together" look that 11 users reported. Stopped stripping empty `<p>` tags in both code paths.

### Not in scope (follow-ups documented in commit body)
- Font color pass-through (Notion dark-mode `rgba()` values rendering wrong in Anki)
- Equation/KaTeX/LaTeX rendering (zero parser support currently)
- Image mapping ambiguity (filename-only fallback in `embedFile.ts`)

## Test plan

- [x] `DownloadController.test.ts` — verifies `Content-Type` and `Content-Disposition` headers set for `.apkg` downloads, and `.apkg` extension appended when key lacks it
- [x] `DeckParser.test.ts` — 4 new tests:
  - Bullet points preserved inside toggle (legacy format)
  - Bullet points preserved alongside nested toggles (legacy format)
  - Bullet points preserved inside toggle (new Notion export format)
  - Empty paragraphs preserved as spacing in card back
- [x] All 32 tests pass; pre-existing `Markdown reversed cards` test failure is unrelated (present on main)
- [x] `tsc --noEmit` clean
- [ ] Manual: download an individual .apkg link and verify browser triggers download
- [ ] Manual: convert a Notion page with spaced-out content and verify spacing preserved in Anki

🤖 Generated with [Claude Code](https://claude.com/claude-code)