### PR TITLE
feat: show PDF upload info explaining page-pair card creation

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -117,6 +117,11 @@
   background: var(--color-danger-light);
 }
 
+.dropZoneInfo {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
 .validationTitle {
   font-size: var(--text-base);
   font-weight: var(--font-semibold);

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -171,6 +171,8 @@ function UploadForm({
           validation?.status === 'warning' ? formStyles.dropZoneWarning : ''
         } ${
           validation?.status === 'error' ? formStyles.dropZoneError : ''
+        } ${
+          validation?.status === 'info' ? formStyles.dropZoneInfo : ''
         }`}
       >
         {validation ? (

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.test.ts
@@ -57,8 +57,26 @@ describe('detectUploadIssues', () => {
     expect(detectUploadIssues([fakeFile('data.csv')])).toBeNull();
   });
 
-  it('returns null for pdf files', () => {
-    expect(detectUploadIssues([fakeFile('slides.pdf')])).toBeNull();
+  it('returns info for a single pdf file', () => {
+    const result = detectUploadIssues([fakeFile('slides.pdf')]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('info');
+    expect(result!.title).toContain('pair');
+  });
+
+  it('returns info for multiple pdf files', () => {
+    const result = detectUploadIssues([
+      fakeFile('chapter1.pdf'),
+      fakeFile('chapter2.pdf'),
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('info');
+  });
+
+  it('is case-insensitive for pdf detection', () => {
+    const result = detectUploadIssues([fakeFile('NOTES.PDF')]);
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('info');
   });
 
   it('returns null for xlsx files', () => {
@@ -74,6 +92,9 @@ describe('detectUploadIssues', () => {
   it('provides a continue label for each state', () => {
     const md = detectUploadIssues([fakeFile('n.md')]);
     expect(md!.continueLabel.length).toBeGreaterThan(0);
+
+    const pdf = detectUploadIssues([fakeFile('n.pdf')]);
+    expect(pdf!.continueLabel.length).toBeGreaterThan(0);
 
     const html = detectUploadIssues([fakeFile('n.html')]);
     expect(html!.continueLabel.length).toBeGreaterThan(0);

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useFileValidation.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 
-export type ValidationStatus = 'clean' | 'warning' | 'error';
+export type ValidationStatus = 'clean' | 'info' | 'warning' | 'error';
 
 export interface FileValidationResult {
   status: ValidationStatus;
@@ -37,6 +37,18 @@ export function detectUploadIssues(
       title: 'Did Safari unzip your Notion export?',
       body: 'If your files came from a Notion export, the images might have been left behind when Safari unpacked the zip. For the best results, re-download the export from Notion using a different browser, or find the original zip in your Downloads folder and upload that instead.',
       continueLabel: 'Continue with these files',
+    };
+  }
+
+  const allPdf = fileArray.every((f) =>
+    f.name.toLowerCase().endsWith('.pdf')
+  );
+  if (allPdf) {
+    return {
+      status: 'info',
+      title: 'Each pair of pages becomes one card',
+      body: "Page 1 is the front of your first card, page 2 is the back, page 3 is the next front, and so on. This works well for lecture slides where each topic spans two pages. You can customize how cards are created in Card Options.",
+      continueLabel: 'Make cards from this PDF',
     };
   }
 


### PR DESCRIPTION
## Summary

- When users upload a PDF, the upload form now shows an informational message explaining how conversion works: each pair of pages becomes one card (page 1 = front, page 2 = back)
- Adds `info` validation status with blue/neutral styling, distinct from warning (amber) and error (red)
- Points users to Card Options for customization

### Copy

> **Each pair of pages becomes one card**
>
> Page 1 is the front of your first card, page 2 is the back, page 3 is the next front, and so on. This works well for lecture slides where each topic spans two pages. You can customize how cards are created in Card Options.

## Test plan

- [x] 3 new tests: single PDF, multiple PDFs, case-insensitive `.PDF` detection
- [x] Updated continue-label coverage test to include PDF
- [x] All 267 web tests pass
- [x] `tsc --noEmit` clean
- [x] Biome lint clean
- [x] Visual: upload a PDF and verify the blue info message appears with correct copy
- [x] Visual: verify "Pick a different file" resets and "Make cards from this PDF" submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)