### PR TITLE
feat: redesign contact page, footer, and sidebar copyright

### DIFF
--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -149,6 +149,7 @@
   margin-top: 0.5rem;
   font-size: var(--text-xs);
   color: var(--color-text-tertiary);
+  white-space: nowrap;
 }
 
 .main {

--- a/web/src/components/Footer.module.css
+++ b/web/src/components/Footer.module.css
@@ -1,43 +1,70 @@
 .footer {
-  padding: 2rem 1.5rem;
+  padding: 2.5rem 1.5rem 1.5rem;
   width: 100%;
-  background: var(--color-primary-light);
+  background: var(--color-bg-secondary);
+  border-top: 1px solid var(--color-border);
 }
 
 .inner {
   max-width: 960px;
   margin: 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 3rem;
 }
 
-.links {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  gap: 1.5rem;
-  flex-wrap: wrap;
+.brand {
+  max-width: 240px;
 }
 
-.links a {
+.brandName {
+  font-size: var(--text-lg);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+  letter-spacing: var(--tracking-tight);
+}
+
+.brandTag {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0.25rem 0 0;
+  line-height: var(--leading-normal);
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.groupTitle {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  margin-bottom: 0.25rem;
+}
+
+.group a {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
   text-decoration: none;
   transition: color var(--transition-fast);
 }
 
-.links a:hover {
+.group a:hover {
   color: var(--color-text-primary);
 }
 
-.right {
+.bottom {
+  max-width: 960px;
+  margin: 2rem auto 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
   display: flex;
   align-items: center;
-  gap: 1.25rem;
+  justify-content: space-between;
 }
 
 .copyright {
@@ -57,15 +84,11 @@
 
 @media (max-width: 639px) {
   .inner {
-    flex-direction: column;
-    text-align: center;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
   }
 
-  .links {
-    justify-content: center;
-  }
-
-  .right {
-    justify-content: center;
+  .brand {
+    grid-column: 1 / -1;
   }
 }

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -6,43 +6,48 @@ function Footer() {
   return (
     <footer className={styles.footer}>
       <div className={styles.inner}>
-        <ul className={styles.links}>
-          <li>
-            <a href="/about">{getVisibleText('navigation.legal.about')}</a>
-          </li>
-          <li>
-            <a href="/documentation">{getVisibleText('navigation.docs')}</a>
-          </li>
-          <li>
-            <a href="/contact">{getVisibleText('navigation.contact')}</a>
-          </li>
-          <li>
-            <a href="/documentation/misc/terms-of-service">
-              {getVisibleText('navigation.legal.terms')}
-            </a>
-          </li>
-          <li>
-            <a href="/documentation/misc/privacy-policy">
-              {getVisibleText('navigation.legal.privacy')}
-            </a>
-          </li>
-        </ul>
-        <div className={styles.right}>
-          <a
-            href="https://github.com/2anki/server"
-            target="_blank"
-            rel="noreferrer"
-            className={styles.githubLink}
-            aria-label="GitHub"
-          >
-            <svg viewBox="0 0 16 16" fill="currentColor" width="18" height="18">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
-            </svg>
-          </a>
-          <span className={styles.copyright}>
-            {`© 2024–${currentYear} Alexander Alemayhu`}
-          </span>
+        <div className={styles.brand}>
+          <span className={styles.brandName}>2anki</span>
+          <p className={styles.brandTag}>
+            Turn what you study into Anki flashcards.
+          </p>
         </div>
+        <div className={styles.group}>
+          <span className={styles.groupTitle}>Product</span>
+          <a href="/about">{getVisibleText('navigation.legal.about')}</a>
+          <a href="/documentation">{getVisibleText('navigation.docs')}</a>
+          <a href="/contact">{getVisibleText('navigation.contact')}</a>
+        </div>
+        <div className={styles.group}>
+          <span className={styles.groupTitle}>Legal</span>
+          <a href="/documentation/misc/terms-of-service">
+            {getVisibleText('navigation.legal.terms')}
+          </a>
+          <a href="/documentation/misc/privacy-policy">
+            {getVisibleText('navigation.legal.privacy')}
+          </a>
+        </div>
+      </div>
+      <div className={styles.bottom}>
+        <span className={styles.copyright}>
+          {`© 2024–${currentYear} Alexander Alemayhu`}
+        </span>
+        <a
+          href="https://github.com/2anki/server"
+          target="_blank"
+          rel="noreferrer"
+          className={styles.githubLink}
+          aria-label="GitHub"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            width="18"
+            height="18"
+          >
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
+          </svg>
+        </a>
       </div>
     </footer>
   );

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -698,4 +698,15 @@ export class Backend {
   }> {
     return get(`${this.baseURL}apkg/import/${jobId}/status`);
   }
+
+  async contactUs(name: string, email: string, message: string): Promise<void> {
+    const response = await post(`${this.baseURL}contact-us`, {
+      name,
+      email,
+      message,
+    });
+    if (!response.ok) {
+      throw new Error('Failed to send message');
+    }
+  }
 }

--- a/web/src/pages/ContactPage/ContactPage.module.css
+++ b/web/src/pages/ContactPage/ContactPage.module.css
@@ -1,0 +1,38 @@
+.layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 769px) {
+  .layout {
+    grid-template-columns: 1fr 340px;
+    align-items: start;
+  }
+}
+
+.formLead {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0.25rem 0 1.25rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cardText {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+  margin: 0.5rem 0 0;
+}
+
+.tipList {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  padding-left: 1.25rem;
+  margin: 0.75rem 0 0;
+  line-height: var(--leading-relaxed);
+}

--- a/web/src/pages/ContactPage/ContactPage.tsx
+++ b/web/src/pages/ContactPage/ContactPage.tsx
@@ -1,40 +1,133 @@
+import { FormEvent, useState } from 'react';
+
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import styles from '../../styles/shared.module.css';
+import contactStyles from './ContactPage.module.css';
+
+type FormStatus = 'idle' | 'sending' | 'sent' | 'error';
 
 export function ContactPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<FormStatus>('idle');
+
+  const canSubmit =
+    status !== 'sending' &&
+    name.trim().length > 0 &&
+    email.trim().length > 0 &&
+    message.trim().length > 0;
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setStatus('sending');
+    try {
+      await get2ankiApi().contactUs(name, email, message);
+      setStatus('sent');
+      setName('');
+      setEmail('');
+      setMessage('');
+    } catch {
+      setStatus('error');
+    }
+  }
+
   return (
     <div className={styles.page}>
-      <header className={styles.pageHeader}>
-        <h1 className={styles.title}>Contact and support</h1>
+      <header className={styles.pageHeaderCenter}>
+        <h1 className={styles.title}>Get in touch</h1>
         <p className={styles.subtitle}>
-          Questions, feedback, or need help? We typically reply within
-          24 to 48 hours.
+          Have a question, idea, or just want to say hi? We'd love to hear from
+          you.
         </p>
       </header>
 
-      <section className={styles.card}>
-        <h2 className={styles.subHeading}>Email us</h2>
-        <p>
-          Reach us at{' '}
-          <a href="mailto:support@2anki.net">support@2anki.net</a>. To help
-          us resolve things faster, include:
-        </p>
-        <ul>
-          <li>A brief description of your question or issue</li>
-          <li>Steps to reproduce the problem (if technical)</li>
-          <li>Any screenshots or error messages you see</li>
-        </ul>
-      </section>
+      <div className={contactStyles.layout}>
+        <section className={styles.surface}>
+          <h2 className={styles.surfaceTitle}>Send us a message</h2>
+          <p className={contactStyles.formLead}>
+            We typically reply within 24–48 hours.
+          </p>
 
-      <section className={styles.card}>
-        <h2 className={styles.subHeading}>Share your workflow</h2>
-        <p>
-          Made a video or tutorial about how you use 2anki? Send it to{' '}
-          <a href="mailto:support@2anki.net">support@2anki.net</a> and we
-          will feature it on the homepage for free. We already showcase
-          walkthroughs in English, German, French, and Spanish — any
-          language is welcome.
-        </p>
-      </section>
+          {status === 'sent' && (
+            <div className={styles.alertSuccess}>
+              Thanks for reaching out — we'll get back to you soon.
+            </div>
+          )}
+          {status === 'error' && (
+            <div className={styles.alertDanger}>
+              Something went wrong. Please try emailing us directly at{' '}
+              <a href="mailto:support@2anki.net">support@2anki.net</a>.
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <div className={styles.field}>
+              <label htmlFor="contact-name">Name</label>
+              <input
+                id="contact-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Your name"
+              />
+            </div>
+            <div className={styles.field}>
+              <label htmlFor="contact-email">Email</label>
+              <input
+                id="contact-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+              />
+            </div>
+            <div className={styles.field}>
+              <label htmlFor="contact-message">Message</label>
+              <textarea
+                id="contact-message"
+                rows={5}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="Tell us what's on your mind…"
+              />
+            </div>
+            <button
+              type="submit"
+              className={styles.btnPrimary}
+              disabled={!canSubmit}
+            >
+              {status === 'sending' ? 'Sending…' : 'Send message'}
+            </button>
+          </form>
+        </section>
+
+        <aside className={contactStyles.sidebar}>
+          <div className={styles.surface}>
+            <h3 className={styles.sectionTitle}>Email us directly</h3>
+            <p className={contactStyles.cardText}>
+              Prefer email? Reach us at{' '}
+              <a href="mailto:support@2anki.net">support@2anki.net</a>. To help
+              us resolve things faster, include:
+            </p>
+            <ul className={contactStyles.tipList}>
+              <li>A brief description of your question or issue</li>
+              <li>Steps to reproduce the problem (if technical)</li>
+              <li>Any screenshots or error messages</li>
+            </ul>
+          </div>
+
+          <div className={styles.surface}>
+            <h3 className={styles.sectionTitle}>Share your workflow</h3>
+            <p className={contactStyles.cardText}>
+              Made a video or tutorial about how you use 2anki? Send it to{' '}
+              <a href="mailto:support@2anki.net">support@2anki.net</a> and we'll
+              feature it on the homepage. We already showcase walkthroughs in
+              English, German, French, and Spanish — any language is welcome.
+            </p>
+          </div>
+        </aside>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **Contact page**: total redesign — replaces static "email us" text with a working contact form (name, email, message) that submits to the existing `POST /api/contact-us` endpoint. Info cards for direct email and workflow sharing sit in a sidebar on desktop
- **Footer**: restructured into a three-column grid with brand tagline, Product links (About, Docs, Contact), and Legal links (Terms, Privacy), plus a bottom bar for copyright and GitHub icon
- **Sidebar copyright**: added `white-space: nowrap` so "© 2024–2026 Alexander Alemayhu" no longer wraps to two lines in the 240px sidebar

## Test plan

- [ ] Visit `/contact` — form renders, all three fields validate, submit hits the API and shows success/error states
- [ ] Footer renders correctly on desktop and mobile, all links work
- [ ] Sidebar copyright text stays on one line when logged in
- [ ] Run `/check` — typecheck + tests pass (267 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)