### PR TITLE
docs: add framework-specific best practices to all agent files

### DIFF
--- a/.claude/agents/dead-code-auditor.md
+++ b/.claude/agents/dead-code-auditor.md
@@ -23,6 +23,7 @@ Read-only. You produce a list; you do not delete.
 - Type-only exports consumed only by `.d.ts` declarations or `tsconfig` paths.
 - Anything explicitly marked with `// keep` comment-style waivers.
 - Ankify code paths (`src/lib/ankify/`, `src/services/ankify/`) gated behind the allowlist — they're "unused in prod" by design until the beta widens.
+- `create_deck/` — Python workspace, not part of the TypeScript module graph. Dead code there requires `pylint` or manual `pytest` analysis, not TS import tracing.
 
 ## Method
 

--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -49,6 +49,15 @@ When given a design problem:
 - **Tone**: Friendly but precise. Not whimsical. Users are trying to study — respect that.
 - **Density**: Mid-density. Not airy marketing pages, not packed dashboards. Closer to Linear than Notion.
 
+## Frontend stack context
+
+The web app uses:
+- **React 19** with **React Router 7** (library mode) for routing.
+- **CSS Modules** with custom properties (CSS variables) for styling — `shared.module.css` provides the design system utilities (`.page`, `.card`, `.btnPrimary`, `.btnInline`). Do not introduce Tailwind, styled-components, or SCSS.
+- **Vite 8** as the build tool — dev server on port 3000, proxies API to port 2020.
+- When recommending component structure, check `web/src/styles/shared.module.css` for existing utility classes before proposing new ones.
+- Copy strings should be compatible with the CSS Modules scoped naming pattern — class names in recommendations should reference module exports, not global classes.
+
 ## Areas of focus
 
 These get extra design attention because they directly affect conversion and retention:

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -83,6 +83,40 @@ If the PR is good, post a comment-only review with a clear "approve" verdict, th
 - Validate and sanitize user input at the handler level.
 - Never log sensitive data (passwords, tokens, personal info).
 - Use `res.locals` for authenticated user data through middleware.
+- `ErrorHandler` sends raw `err.message` to the client (`res.status(400).send(err.message)`) — ensure error messages from internal code are user-safe before throwing.
+
+## Framework-specific patterns
+
+**Express 5 (server)**
+- Async errors propagate to the error middleware natively — do not add `express-async-errors` or try/catch wrappers around route handlers.
+- `ErrorHandler` has a non-standard signature `(res, req, err)`, not Express's `(err, req, res, next)`. It is wired through a wrapper in `server.ts` — never mount it directly as middleware.
+- `req.query` values can be `undefined` — always validate before use.
+
+**React 19 + React Router 7 (web)**
+- `forwardRef` is unnecessary in React 19 — pass `ref` as a regular prop.
+- We use React Router 7 in **library mode** (`<BrowserRouter>` + `<Routes>`), not the data router. Do not introduce `createBrowserRouter`, loaders, or actions.
+- Lazy-load non-critical pages with `React.lazy()` — critical pages (`HomePage`, `UploadPage`) are eagerly imported.
+
+**TanStack Query 5 (web)**
+- All server-state fetching uses `useQuery`/`useMutation` from `@tanstack/react-query`, backed by `Backend.ts` as the fetch wrapper.
+- Invalidate caches via `useQueryClient().invalidateQueries()` after mutations.
+- Local UI state uses plain `useState` — do not reach for React Query for client-only state.
+
+**Vite 8 + Biome (web)**
+- Dev proxy: `/api` and `/v` route to `localhost:2020` (configured in `vite.config.ts`).
+- Env vars use `REACT_APP_*` prefix (CRA compatibility layer in vite config). Do not use `VITE_*` or bare `process.env.*`.
+- Biome enforces: `useOptionalChain`, `noNestedTernary`, `noNegationElse`, `noUselessTernary`. Run `pnpm --filter 2anki-web lint` locally.
+
+**Testing**
+- Server: **Jest** + ts-jest. Use `jest.mock()`, `jest.fn()`, `jest.spyOn()`.
+- Web: **Vitest**. Use `vi.mock()`, `vi.fn()`, `vi.spyOn()`. Do not use Jest API in web tests.
+- E2E: **Playwright**. Config in `web/playwright.config.ts`.
+
+**create_deck (Python bridge)**
+- `CardGenerator.ts` spawns Python to run `create_deck/create_deck.py`. The contract: it reads `deck_info.json` from the workspace, writes an `.apkg` file, and prints its path to stdout.
+- Changes to the JSON shape (`deck_info.json`) require coordinated updates in both TypeScript (the parser that writes it) and Python (the script that reads it).
+- Test Python changes with `pytest` in the `create_deck/` directory.
+- Python discovery: venv → platform lookup → env override (`PYTHON` / `ANKI_PYTHON`). Do not hardcode Python paths.
 
 ## When stuck
 

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -14,6 +14,18 @@ You are the **Product Manager** in the 2anki product trio. Your job is to make s
 - **Short specs.** One page max. Longer means split it.
 - **Numbers > vibes.** When metrics are available, use them.
 
+## Technical landscape
+
+When writing specs that touch the tech stack, know what you're scoping against:
+
+- **Server**: Express 5 + Knex 3 + TypeScript 6. Request path: `routes/` → `controllers/` → `usecases/` → `services/` → `data_layer/`.
+- **Web**: React 19 + React Router 7 (library mode) + TanStack Query 5 + Vite 8. Data fetching through `Backend.ts` → React Query hooks.
+- **Deck generation**: Python subprocess (`create_deck/`) using `genanki` and `pydantic`. Called via `CardGenerator.ts`. Changes here span two languages — specs should flag cross-language coordination.
+- **Testing**: server uses Jest, web uses Vitest, Python uses pytest, E2E uses Playwright. Specs that add features should note which test layer is relevant.
+- **CSS**: CSS Modules with design tokens. No Tailwind. Specs proposing UI changes should reference existing utility classes in `shared.module.css` when possible.
+
+When estimating effort, cross-language changes (TypeScript ↔ Python) and changes spanning server + web are inherently higher effort than single-layer work.
+
 ## Workflows
 
 ### 1. Synthesizing feedback

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -16,6 +16,7 @@ You write tests. Only tests. The user gives you a source path; you produce a col
 - **Parameterise.** `it.each([...])` for tables of cases. One `it` per behaviour, not five behaviours per `it`.
 - **Determinism.** Inject a clock or seed. Never depend on `Date.now`, `Math.random`, wall-clock ordering, or network.
 - **Read the layer's CLAUDE.md** (controllers / usecases / services / data_layer / routes / lib/parser / lib/ankify) before designing the test — it tells you what the file is *supposed* to be responsible for, which is what your tests should pin.
+- **Know which test runner you're writing for.** Server tests (`src/**/*.test.ts`) use **Jest** (`jest.mock`, `jest.fn`, `jest.spyOn`). Web tests (`web/src/**/*.test.ts(x)`) use **Vitest** (`vi.mock`, `vi.fn`, `vi.spyOn`). Using the wrong API produces confusing runtime errors. Check the nearest `package.json` or config if unsure.
 
 ## Workflow
 
@@ -33,6 +34,7 @@ You write tests. Only tests. The user gives you a source path; you produce a col
 - Snapshot blobs that include timestamps, IDs, or ordering.
 - Commit `.only` / `.skip` / `xit` / `xdescribe`.
 - Open PRs. You return the diff; the parent decides what to do with it.
+- Write Python tests for `create_deck/`. That uses `pytest` — surface the need and let the engineer handle it.
 
 ## Final report
 


### PR DESCRIPTION
## Summary
- Adds framework-version-aware guidance to all 5 agent files in `.claude/agents/`
- Covers Express 5, React 19, React Router 7, TanStack Query 5, Vite 8, Biome, Vitest, Playwright, and the Python `create_deck` bridge
- Each agent gets only the context relevant to its role (engineer gets the most, dead-code-auditor gets the least)

## Test plan
- [x] Read each agent file — new sections are factually accurate against the current `package.json` versions
- [x] Verify no existing guidance was removed or contradicted
- [x] Run `/check` to confirm no build/lint regressions (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)