### PR TITLE
feat: show emoji feedback in /ops business tab

### DIFF
--- a/src/controllers/EmojiFeedbackController.test.ts
+++ b/src/controllers/EmojiFeedbackController.test.ts
@@ -6,6 +6,8 @@ import { IEmojiFeedbackRepository } from '../data_layer/EmojiFeedbackRepository'
 function buildMocks() {
   const repo: jest.Mocked<IEmojiFeedbackRepository> = {
     insert: jest.fn().mockResolvedValue(undefined),
+    countByRating: jest.fn().mockResolvedValue([]),
+    recentComments: jest.fn().mockResolvedValue([]),
   };
   const controller = new EmojiFeedbackController(repo);
   const req = { body: {} } as Request;

--- a/src/data_layer/EmojiFeedbackRepository.ts
+++ b/src/data_layer/EmojiFeedbackRepository.ts
@@ -6,9 +6,38 @@ interface EmojiFeedbackEntry {
   page: string;
 }
 
+export interface EmojiFeedbackRatingCount {
+  rating: number;
+  count: number;
+}
+
+export interface EmojiFeedbackCommentEntry {
+  rating: number;
+  comment: string;
+  page: string;
+  created_at: string;
+}
+
 export interface IEmojiFeedbackRepository {
   insert(entry: EmojiFeedbackEntry): Promise<void>;
+  countByRating(since: Date): Promise<EmojiFeedbackRatingCount[]>;
+  recentComments(limit: number): Promise<EmojiFeedbackCommentEntry[]>;
 }
+
+interface RatingRow {
+  rating: number;
+  count: string | number;
+}
+
+interface CommentRow {
+  rating: number;
+  comment: string;
+  page: string;
+  created_at: Date | string;
+}
+
+const toIso = (value: Date | string): string =>
+  typeof value === 'string' ? value : value.toISOString();
 
 export class EmojiFeedbackRepository implements IEmojiFeedbackRepository {
   private readonly table = 'emoji_feedback';
@@ -21,5 +50,76 @@ export class EmojiFeedbackRepository implements IEmojiFeedbackRepository {
       comment: entry.comment,
       page: entry.page,
     });
+  }
+
+  async countByRating(since: Date): Promise<EmojiFeedbackRatingCount[]> {
+    const rows = await this.database(this.table)
+      .select('rating')
+      .count<RatingRow[]>('* as count')
+      .where('created_at', '>=', since)
+      .groupBy('rating')
+      .orderBy('rating', 'asc');
+    return rows.map((row) => ({
+      rating: row.rating,
+      count: Number(row.count),
+    }));
+  }
+
+  async recentComments(limit: number): Promise<EmojiFeedbackCommentEntry[]> {
+    const rows = await this.database<CommentRow>(this.table)
+      .select('rating', 'comment', 'page', 'created_at')
+      .whereNotNull('comment')
+      .andWhere('comment', '!=', '')
+      .orderBy('created_at', 'desc')
+      .limit(limit);
+    return rows.map((row) => ({
+      rating: row.rating,
+      comment: row.comment,
+      page: row.page,
+      created_at: toIso(row.created_at),
+    }));
+  }
+}
+
+export class InMemoryEmojiFeedbackRepository
+  implements IEmojiFeedbackRepository
+{
+  private readonly rows: Array<{
+    rating: number;
+    comment: string | null;
+    page: string;
+    created_at: Date;
+  }> = [];
+
+  async insert(entry: EmojiFeedbackEntry): Promise<void> {
+    this.rows.push({ ...entry, created_at: new Date() });
+  }
+
+  async countByRating(since: Date): Promise<EmojiFeedbackRatingCount[]> {
+    const counts = new Map<number, number>();
+    for (const row of this.rows) {
+      if (row.created_at >= since) {
+        counts.set(row.rating, (counts.get(row.rating) ?? 0) + 1);
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([rating, count]) => ({ rating, count }))
+      .sort((a, b) => a.rating - b.rating);
+  }
+
+  async recentComments(limit: number): Promise<EmojiFeedbackCommentEntry[]> {
+    return this.rows
+      .filter(
+        (r): r is { rating: number; comment: string; page: string; created_at: Date } =>
+          r.comment != null && r.comment !== ''
+      )
+      .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+      .slice(0, limit)
+      .map((r) => ({
+        rating: r.rating,
+        comment: r.comment,
+        page: r.page,
+        created_at: r.created_at.toISOString(),
+      }));
   }
 }

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -11,6 +11,7 @@ import { BusinessMetricsService } from '../services/ops/BusinessMetricsService';
 import { ConversionMetricsService } from '../services/ops/ConversionMetricsService';
 import { BusinessMetricsCacheRepository } from '../data_layer/BusinessMetricsCacheRepository';
 import { CancellationFeedbackRepository } from '../data_layer/CancellationFeedbackRepository';
+import { EmojiFeedbackRepository } from '../data_layer/EmojiFeedbackRepository';
 import { ShowcaseRepository } from '../data_layer/ShowcaseRepository';
 import DownloadRepository from '../data_layer/DownloadRepository';
 import NotionRepository from '../data_layer/NotionRespository';
@@ -29,6 +30,7 @@ const OpsRouter = () => {
   const businessMetricsService = new BusinessMetricsService({
     cacheRepository: new BusinessMetricsCacheRepository(database),
     cancellationRepository: new CancellationFeedbackRepository(database),
+    emojiFeedbackRepository: new EmojiFeedbackRepository(database),
   });
 
   const conversionMetricsService = new ConversionMetricsService(database);

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -13,6 +13,10 @@ import {
   ICancellationFeedbackRepository,
   InMemoryCancellationFeedbackRepository,
 } from '../../data_layer/CancellationFeedbackRepository';
+import {
+  IEmojiFeedbackRepository,
+  InMemoryEmojiFeedbackRepository,
+} from '../../data_layer/EmojiFeedbackRepository';
 
 export type BusinessMetricKey =
   | 'mrr_usd'
@@ -26,7 +30,9 @@ export type BusinessMetricKey =
   | 'conversions_vs_churn_weekly'
   | 'failed_payments_weekly'
   | 'cancellation_reasons_top'
-  | 'cancellation_comments_recent';
+  | 'cancellation_comments_recent'
+  | 'emoji_feedback_ratings'
+  | 'emoji_feedback_comments';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -75,12 +81,15 @@ export interface BusinessMetricsResponse {
 export const BUSINESS_METRICS_CACHE_TTL_MS = 15 * 60 * 1000;
 export const CANCELLATION_REASONS_LOOKBACK_DAYS = 90;
 export const CANCELLATION_COMMENTS_LIMIT = 20;
+export const EMOJI_FEEDBACK_LOOKBACK_DAYS = 30;
+export const EMOJI_FEEDBACK_COMMENTS_LIMIT = 20;
 
 interface BusinessMetricsServiceDeps {
   stripeFactory?: () => Stripe;
   cacheTtlMs?: number;
   cacheRepository?: IBusinessMetricsCacheRepository;
   cancellationRepository?: ICancellationFeedbackRepository;
+  emojiFeedbackRepository?: IEmojiFeedbackRepository;
 }
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
@@ -120,6 +129,8 @@ export class BusinessMetricsService {
 
   private readonly cancellationRepository: ICancellationFeedbackRepository;
 
+  private readonly emojiFeedbackRepository: IEmojiFeedbackRepository;
+
   private allSubsPromise: Promise<NormalizedSubscription[]> | null = null;
 
   private invoicesPromise: Promise<NormalizedInvoice[]> | null = null;
@@ -132,6 +143,9 @@ export class BusinessMetricsService {
     this.cancellationRepository =
       deps.cancellationRepository ??
       new InMemoryCancellationFeedbackRepository();
+    this.emojiFeedbackRepository =
+      deps.emojiFeedbackRepository ??
+      new InMemoryEmojiFeedbackRepository();
   }
 
   async getMetrics(): Promise<BusinessMetricsResponse> {
@@ -202,6 +216,23 @@ export class BusinessMetricsService {
         fetch: () =>
           this.cancellationRepository.recentComments(
             CANCELLATION_COMMENTS_LIMIT
+          ),
+      },
+      {
+        key: 'emoji_feedback_ratings',
+        fetch: () =>
+          this.emojiFeedbackRepository.countByRating(
+            new Date(
+              now.getTime() -
+                EMOJI_FEEDBACK_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
+            )
+          ),
+      },
+      {
+        key: 'emoji_feedback_comments',
+        fetch: () =>
+          this.emojiFeedbackRepository.recentComments(
+            EMOJI_FEEDBACK_COMMENTS_LIMIT
           ),
       },
     ];

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -58,6 +58,18 @@ const buildSampleMetrics = (
       created_at: '2026-05-08T11:00:00.000Z',
     },
   ],
+  emoji_feedback_ratings: [
+    { rating: 4, count: 5 },
+    { rating: 5, count: 3 },
+  ],
+  emoji_feedback_comments: [
+    {
+      rating: 5,
+      comment: 'Love it!',
+      page: '/upload',
+      created_at: '2026-05-08T12:00:00.000Z',
+    },
+  ],
   as_of: '2026-05-09T14:32:07.000Z',
   cache_age_seconds: 412,
   ...overrides,

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -13,6 +13,8 @@ import ActiveSubsTimeseriesChart from './charts/ActiveSubsTimeseriesChart';
 import CancellationCommentsList from './charts/CancellationCommentsList';
 import CancellationReasonsChart from './charts/CancellationReasonsChart';
 import ChartPanel from './charts/ChartPanel';
+import EmojiFeedbackChart from './charts/EmojiFeedbackChart';
+import EmojiFeedbackCommentsList from './charts/EmojiFeedbackCommentsList';
 import ConversionsChurnChart from './charts/ConversionsChurnChart';
 import FailedPaymentsWeeklyChart from './charts/FailedPaymentsWeeklyChart';
 import MrrTimeseriesChart from './charts/MrrTimeseriesChart';
@@ -190,6 +192,29 @@ export default function BusinessTab() {
         >
           <CancellationCommentsList
             points={visible?.cancellation_comments_recent ?? []}
+          />
+        </ChartPanel>
+
+        <ChartPanel
+          title="Emoji feedback, last 30 days"
+          isLoading={showInitialSkeleton}
+          isEmpty={(visible?.emoji_feedback_ratings?.length ?? 0) === 0}
+          emptyText="No emoji feedback yet."
+        >
+          <EmojiFeedbackChart
+            points={visible?.emoji_feedback_ratings ?? []}
+          />
+        </ChartPanel>
+
+        <ChartPanel
+          title="Recent feedback comments"
+          subtitle="Latest text feedback from the emoji widget"
+          isLoading={showInitialSkeleton}
+          isEmpty={(visible?.emoji_feedback_comments?.length ?? 0) === 0}
+          emptyText="No feedback comments yet."
+        >
+          <EmojiFeedbackCommentsList
+            points={visible?.emoji_feedback_comments ?? []}
           />
         </ChartPanel>
       </div>

--- a/web/src/pages/OpsPage/businessTypes.ts
+++ b/web/src/pages/OpsPage/businessTypes.ts
@@ -10,7 +10,9 @@ export type BusinessMetricKey =
   | 'conversions_vs_churn_weekly'
   | 'failed_payments_weekly'
   | 'cancellation_reasons_top'
-  | 'cancellation_comments_recent';
+  | 'cancellation_comments_recent'
+  | 'emoji_feedback_ratings'
+  | 'emoji_feedback_comments';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -49,6 +51,18 @@ export interface CancellationCommentPoint {
   created_at: string;
 }
 
+export interface EmojiFeedbackRatingPoint {
+  rating: number;
+  count: number;
+}
+
+export interface EmojiFeedbackCommentPoint {
+  rating: number;
+  comment: string;
+  page: string;
+  created_at: string;
+}
+
 export interface BusinessMetricsResponse {
   mrr_usd: number | null;
   net_new_mrr_mtd_usd: number | null;
@@ -62,6 +76,8 @@ export interface BusinessMetricsResponse {
   failed_payments_weekly: FailedPaymentsWeekPoint[] | null;
   cancellation_reasons_top: CancellationReasonPoint[] | null;
   cancellation_comments_recent: CancellationCommentPoint[] | null;
+  emoji_feedback_ratings: EmojiFeedbackRatingPoint[] | null;
+  emoji_feedback_comments: EmojiFeedbackCommentPoint[] | null;
   as_of: string;
   cache_age_seconds: number;
   errors?: BusinessMetricError[];

--- a/web/src/pages/OpsPage/charts/EmojiFeedbackChart.tsx
+++ b/web/src/pages/OpsPage/charts/EmojiFeedbackChart.tsx
@@ -1,0 +1,88 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipContentProps,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { EmojiFeedbackRatingPoint } from '../businessTypes';
+import TimeSeriesTooltipShell, {
+  TimeSeriesTooltipRow,
+} from './TimeSeriesTooltipShell';
+import {
+  AXIS_STROKE,
+  AXIS_TICK_STYLE,
+  GRID_STROKE,
+  SERIES_BLUE,
+  TOOLTIP_CURSOR_FILL,
+} from './timeSeriesChartHelpers';
+
+const EMOJI_LABELS: Record<number, string> = {
+  1: '\u{1F620}',
+  2: '\u{1F615}',
+  3: '\u{1F610}',
+  4: '\u{1F642}',
+  5: '\u{1F60D}',
+};
+
+interface ChartRow {
+  label: string;
+  count: number;
+}
+
+const buildRows = (points: EmojiFeedbackRatingPoint[]): ChartRow[] => {
+  const map = new Map(points.map((p) => [p.rating, p.count]));
+  return [1, 2, 3, 4, 5].map((r) => ({
+    label: EMOJI_LABELS[r] ?? String(r),
+    count: map.get(r) ?? 0,
+  }));
+};
+
+function RatingTooltip({ active, payload }: TooltipContentProps) {
+  if (!active || payload == null || payload.length === 0) return null;
+  const row = payload[0].payload as ChartRow;
+  return (
+    <TimeSeriesTooltipShell title={row.label}>
+      <TimeSeriesTooltipRow
+        label="responses"
+        value={row.count.toLocaleString()}
+      />
+    </TimeSeriesTooltipShell>
+  );
+}
+
+const MARGIN = { top: 8, right: 16, left: 0, bottom: 0 } as const;
+
+interface EmojiFeedbackChartProps {
+  points: EmojiFeedbackRatingPoint[];
+}
+
+export default function EmojiFeedbackChart({
+  points,
+}: Readonly<EmojiFeedbackChartProps>) {
+  const data = buildRows(points);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={MARGIN}>
+        <CartesianGrid stroke={GRID_STROKE} vertical={false} />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 20 }}
+          stroke={AXIS_STROKE}
+        />
+        <YAxis
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          allowDecimals={false}
+        />
+        <Tooltip content={RatingTooltip} cursor={TOOLTIP_CURSOR_FILL} />
+        <Bar dataKey="count" fill={SERIES_BLUE} radius={[4, 4, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web/src/pages/OpsPage/charts/EmojiFeedbackCommentsList.tsx
+++ b/web/src/pages/OpsPage/charts/EmojiFeedbackCommentsList.tsx
@@ -1,0 +1,46 @@
+import { EmojiFeedbackCommentPoint } from '../businessTypes';
+import styles from '../OpsPage.module.css';
+
+const EMOJI_LABELS: Record<number, string> = {
+  1: '\u{1F620}',
+  2: '\u{1F615}',
+  3: '\u{1F610}',
+  4: '\u{1F642}',
+  5: '\u{1F60D}',
+};
+
+interface EmojiFeedbackCommentsListProps {
+  points: EmojiFeedbackCommentPoint[];
+}
+
+const formatDate = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  });
+};
+
+export default function EmojiFeedbackCommentsList({
+  points,
+}: Readonly<EmojiFeedbackCommentsListProps>) {
+  return (
+    <ul className={styles.commentList}>
+      {points.map((point, idx) => (
+        <li key={`${point.created_at}-${idx}`} className={styles.commentItem}>
+          <div className={styles.commentMeta}>
+            <span className={styles.commentReason}>
+              {EMOJI_LABELS[point.rating] ?? point.rating} {point.page}
+            </span>
+            <span className={styles.commentDate}>
+              {formatDate(point.created_at)}
+            </span>
+          </div>
+          <p className={styles.commentBody}>{point.comment}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `countByRating` and `recentComments` read methods to `EmojiFeedbackRepository`
- Wire emoji feedback into `BusinessMetricsService` (30-day lookback for ratings, 20 most recent comments)
- Two new panels in the business tab:
  - Bar chart of emoji rating distribution (1-5 emojis on x-axis)
  - Scrollable list of recent feedback comments with emoji, page context, and date

## Test plan
- [ ] Verify `/ops/business` shows the two new panels
- [ ] Verify panels show "No emoji feedback yet" when table is empty
- [ ] Verify bar chart renders correctly with sample data
- [ ] Run `/check` for full CI gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)