### PR TITLE
style: redesign pass — toggles, pricing, feedback, what's new

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -55,6 +55,7 @@ const MarkdownToAnki = lazy(
 const PdfToAnki = lazy(() => import('./pages/LandingPage/PdfToAnki'));
 const MagicLinkPage = lazy(() => import('./pages/MagicLinkPage'));
 const PrintPage = lazy(() => import('./pages/PrintPage'));
+const WhatsNewPage = lazy(() => import('./pages/WhatsNewPage/WhatsNewPage'));
 const ImportPage = lazy(() => import('./pages/ImportPage'));
 
 const queryClient = new QueryClient();
@@ -204,6 +205,7 @@ function AppContent({
           </Route>
           <Route path="/settings" element={requireAuth(<AccountPage />)} />
           <Route path="/about" element={<AboutPage />} />
+          <Route path="/whats-new" element={<WhatsNewPage />} />
           <Route path="/documentation" element={<DocsPage />} />
           <Route path="/documentation/*" element={<DocsPage />} />
           <Route

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -253,15 +253,6 @@ export function Sidebar({
       </div>
       <div className={styles.sidebarMore}>
         <div className={styles.sidebarMoreLinks}>
-          <Link to="/whats-new" onClick={handleNavClick()}>
-            What's new
-          </Link>
-          <Link to="/about" onClick={handleNavClick()}>
-            {getVisibleText('navigation.legal.about')}
-          </Link>
-          <Link to="/contact" onClick={handleNavClick()}>
-            {getVisibleText('navigation.contact')}
-          </Link>
           <Link
             to="/documentation/misc/terms-of-service"
             onClick={handleNavClick()}
@@ -273,6 +264,15 @@ export function Sidebar({
             onClick={handleNavClick()}
           >
             {getVisibleText('navigation.legal.privacy')}
+          </Link>
+          <Link to="/whats-new" onClick={handleNavClick()}>
+            What's new
+          </Link>
+          <Link to="/contact" onClick={handleNavClick()}>
+            {getVisibleText('navigation.contact')}
+          </Link>
+          <Link to="/about" onClick={handleNavClick()}>
+            {getVisibleText('navigation.legal.about')}
           </Link>
         </div>
         <div className={styles.sidebarCopyright}>

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../../lib/hooks/useTheme';
 import { getVisibleText } from '../../lib/text/getVisibleText';
@@ -16,8 +16,6 @@ import SparklesIcon from '../icons/SparklesIcon';
 import UserCircleIcon from '../icons/UserCircleIcon';
 import WrenchIcon from '../icons/WrenchIcon';
 import { ThemeSwitcher } from '../ThemeSwitcher/ThemeSwitcher';
-import ChatBubbleIcon from '../icons/ChatBubbleIcon';
-import { FeedbackModal } from '../FeedbackWidget/FeedbackModal';
 import styles from './AppShell.module.css';
 
 export interface SidebarLocals {
@@ -90,7 +88,6 @@ export function Sidebar({
 }: Readonly<SidebarProps>) {
   const { pathname } = useLocation();
   const theme = useTheme();
-  const [feedbackOpen, setFeedbackOpen] = useState(false);
   const logoSrc = theme === 'light' ? '/mascot/navbar-logo.png' : '/mascot/Notion 1.png';
   const showAnkify = locals?.patreon === true;
   const paying = isPayingUser(locals);
@@ -256,14 +253,6 @@ export function Sidebar({
       </div>
       <div className={styles.sidebarMore}>
         <div className={styles.sidebarMoreLinks}>
-          <button
-            type="button"
-            className={styles.sidebarFeedbackLink}
-            onClick={() => setFeedbackOpen(true)}
-          >
-            <ChatBubbleIcon width={14} height={14} />
-            Feedback
-          </button>
           <Link to="/about" onClick={handleNavClick()}>
             {getVisibleText('navigation.legal.about')}
           </Link>
@@ -287,10 +276,6 @@ export function Sidebar({
           &copy; 2020&ndash;{new Date().getFullYear()} Alexander Alemayhu
         </div>
       </div>
-      <FeedbackModal
-        isActive={feedbackOpen}
-        onClose={() => setFeedbackOpen(false)}
-      />
     </aside>
   );
 }

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -253,6 +253,9 @@ export function Sidebar({
       </div>
       <div className={styles.sidebarMore}>
         <div className={styles.sidebarMoreLinks}>
+          <Link to="/whats-new" onClick={handleNavClick()}>
+            What's new
+          </Link>
           <Link to="/about" onClick={handleNavClick()}>
             {getVisibleText('navigation.legal.about')}
           </Link>

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -253,11 +253,11 @@ export function Sidebar({
       </div>
       <div className={styles.sidebarMore}>
         <div className={styles.sidebarMoreLinks}>
-          <Link
-            to="/documentation/misc/terms-of-service"
-            onClick={handleNavClick()}
-          >
-            {getVisibleText('navigation.legal.terms')}
+          <Link to="/whats-new" onClick={handleNavClick()}>
+            What's new
+          </Link>
+          <Link to="/contact" onClick={handleNavClick()}>
+            {getVisibleText('navigation.contact')}
           </Link>
           <Link
             to="/documentation/misc/privacy-policy"
@@ -265,11 +265,11 @@ export function Sidebar({
           >
             {getVisibleText('navigation.legal.privacy')}
           </Link>
-          <Link to="/whats-new" onClick={handleNavClick()}>
-            What's new
-          </Link>
-          <Link to="/contact" onClick={handleNavClick()}>
-            {getVisibleText('navigation.contact')}
+          <Link
+            to="/documentation/misc/terms-of-service"
+            onClick={handleNavClick()}
+          >
+            {getVisibleText('navigation.legal.terms')}
           </Link>
           <Link to="/about" onClick={handleNavClick()}>
             {getVisibleText('navigation.legal.about')}

--- a/web/src/components/AppShell/SidebarLayout.tsx
+++ b/web/src/components/AppShell/SidebarLayout.tsx
@@ -3,6 +3,8 @@ import { Sidebar, SidebarFeatures, SidebarLocals } from './Sidebar';
 import { MobileTopBar } from './MobileTopBar';
 import { SkeletonPage } from '../Skeleton/Skeleton';
 import { ErrorPresenter } from '../errors/ErrorPresenter';
+import { FloatingFeedback } from '../FeedbackWidget/FloatingFeedback';
+import { TeamBanner } from '../TeamBanner/TeamBanner';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './AppShell.module.css';
 
@@ -54,6 +56,7 @@ export function SidebarLayout({
         onClick={() => setIsDrawerOpen(false)}
       />
       <div className={styles.main}>
+        <TeamBanner />
         <MobileTopBar
           isOpen={isDrawerOpen}
           onOpen={() => setIsDrawerOpen(true)}
@@ -64,6 +67,7 @@ export function SidebarLayout({
           <Suspense fallback={<SkeletonPage rows={5} />}>{children}</Suspense>
         </main>
       </div>
+      <FloatingFeedback />
     </div>
   );
 }

--- a/web/src/components/FeedbackWidget/FeedbackModal.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackModal.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom';
 import { useLocation } from 'react-router-dom';
 
 import sharedStyles from '../../styles/shared.module.css';
@@ -11,7 +12,7 @@ interface Props {
 export function FeedbackModal({ isActive, onClose }: Readonly<Props>) {
   const { pathname } = useLocation();
 
-  return (
+  return createPortal(
     <div className={isActive ? sharedStyles.modal : sharedStyles.modalHidden}>
       <button
         type="button"
@@ -35,6 +36,7 @@ export function FeedbackModal({ isActive, onClose }: Readonly<Props>) {
           <FeedbackWidget page={pathname} onSubmitted={onClose} />
         </section>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/web/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -13,6 +13,12 @@
   gap: 0.75rem;
 }
 
+.widgetCompact .emojiButton {
+  width: 36px;
+  height: 36px;
+  font-size: 1.25rem;
+}
+
 .prompt {
   font-size: var(--text-base);
   font-weight: var(--font-medium);

--- a/web/src/components/FeedbackWidget/FloatingFeedback.module.css
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.module.css
@@ -1,91 +1,44 @@
 .container {
   position: fixed;
-  bottom: 1.5rem;
   right: 1.5rem;
+  top: 50%;
+  transform: translateY(-50%);
   z-index: 50;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 0.75rem;
-}
-
-.fab {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  border-radius: var(--radius-full);
-  border: none;
-  background: var(--color-primary);
-  color: var(--color-bg-primary);
-  cursor: pointer;
-  box-shadow: var(--shadow-lg);
-  transition: background var(--transition-fast), transform var(--transition-fast);
-}
-
-.fab:hover {
-  background: var(--color-primary-hover);
-  transform: scale(1.05);
 }
 
 .panel {
-  width: 340px;
-  max-width: calc(100vw - 3rem);
+  width: 220px;
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-xl);
-  overflow: hidden;
-  animation: slideUp 180ms ease-out;
-}
-
-.panelHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.875rem 1rem;
-  border-bottom: 1px solid var(--color-border);
+  box-shadow: var(--shadow-md);
+  padding: 1rem;
+  text-align: center;
 }
 
 .panelTitle {
-  font-size: var(--text-base);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-}
-
-.panelClose {
-  background: none;
-  border: none;
-  font-size: var(--text-xl);
-  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
   color: var(--color-text-secondary);
-  line-height: 1;
-  padding: 0 0.25rem;
+  margin: 0 0 0.5rem;
 }
 
-.panelClose:hover {
-  color: var(--color-text-primary);
-}
-
-@keyframes slideUp {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@media (max-width: 600px) {
+@media (max-width: 1500px) {
   .container {
-    bottom: 1rem;
+    position: fixed;
     right: 1rem;
+    top: auto;
+    bottom: 1.5rem;
+    transform: none;
   }
 
   .panel {
-    width: calc(100vw - 2rem);
+    width: 200px;
+  }
+}
+
+@media (max-width: 1023px) {
+  .container {
+    display: none;
   }
 }

--- a/web/src/components/FeedbackWidget/FloatingFeedback.module.css
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.module.css
@@ -4,9 +4,11 @@
   top: 50%;
   transform: translateY(-50%);
   z-index: 50;
+  pointer-events: none;
 }
 
 .panel {
+  pointer-events: auto;
   width: 220px;
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border);

--- a/web/src/components/FeedbackWidget/FloatingFeedback.module.css
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.module.css
@@ -1,8 +1,7 @@
 .container {
   position: fixed;
   right: 1.5rem;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 1.5rem;
   z-index: 50;
   pointer-events: none;
 }
@@ -27,11 +26,8 @@
 
 @media (max-width: 1500px) {
   .container {
-    position: fixed;
     right: 1rem;
-    top: auto;
-    bottom: 1.5rem;
-    transform: none;
+    bottom: 1rem;
   }
 
   .panel {

--- a/web/src/components/FeedbackWidget/FloatingFeedback.module.css
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.module.css
@@ -1,0 +1,91 @@
+.container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.fab {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: var(--radius-full);
+  border: none;
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
+  cursor: pointer;
+  box-shadow: var(--shadow-lg);
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.fab:hover {
+  background: var(--color-primary-hover);
+  transform: scale(1.05);
+}
+
+.panel {
+  width: 340px;
+  max-width: calc(100vw - 3rem);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+  animation: slideUp 180ms ease-out;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.panelTitle {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.panelClose {
+  background: none;
+  border: none;
+  font-size: var(--text-xl);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  line-height: 1;
+  padding: 0 0.25rem;
+}
+
+.panelClose:hover {
+  color: var(--color-text-primary);
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 600px) {
+  .container {
+    bottom: 1rem;
+    right: 1rem;
+  }
+
+  .panel {
+    width: calc(100vw - 2rem);
+  }
+}

--- a/web/src/components/FeedbackWidget/FloatingFeedback.tsx
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation } from 'react-router-dom';
 
@@ -5,17 +6,27 @@ import { FeedbackWidget } from './FeedbackWidget';
 import styles from './FloatingFeedback.module.css';
 
 const PAGES_WITH_OWN_FEEDBACK = new Set(['/whats-new']);
+const DISMISSED_KEY = '2anki_feedback_dismissed';
 
 export function FloatingFeedback() {
   const { pathname } = useLocation();
+  const [dismissed, setDismissed] = useState(
+    () => sessionStorage.getItem(DISMISSED_KEY) === '1'
+  );
 
+  if (dismissed) return null;
   if (PAGES_WITH_OWN_FEEDBACK.has(pathname)) return null;
+
+  const handleSubmitted = () => {
+    sessionStorage.setItem(DISMISSED_KEY, '1');
+    setDismissed(true);
+  };
 
   return createPortal(
     <div className={styles.container}>
       <div className={styles.panel}>
         <p className={styles.panelTitle}>How's your experience?</p>
-        <FeedbackWidget page={pathname} compact />
+        <FeedbackWidget page={pathname} compact onSubmitted={handleSubmitted} />
       </div>
     </div>,
     document.body

--- a/web/src/components/FeedbackWidget/FloatingFeedback.tsx
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useLocation } from 'react-router-dom';
+
+import ChatBubbleIcon from '../icons/ChatBubbleIcon';
+import { FeedbackWidget } from './FeedbackWidget';
+import styles from './FloatingFeedback.module.css';
+
+export function FloatingFeedback() {
+  const [open, setOpen] = useState(false);
+  const { pathname } = useLocation();
+
+  return createPortal(
+    <div className={styles.container}>
+      {open && (
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <span className={styles.panelTitle}>Send feedback</span>
+            <button
+              type="button"
+              className={styles.panelClose}
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+            >
+              &times;
+            </button>
+          </div>
+          <FeedbackWidget
+            page={pathname}
+            onSubmitted={() => setTimeout(() => setOpen(false), 1500)}
+          />
+        </div>
+      )}
+      <button
+        type="button"
+        className={styles.fab}
+        onClick={() => setOpen((v) => !v)}
+        aria-label={open ? 'Close feedback' : 'Send feedback'}
+      >
+        <ChatBubbleIcon width={22} height={22} />
+      </button>
+    </div>,
+    document.body
+  );
+}

--- a/web/src/components/FeedbackWidget/FloatingFeedback.tsx
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.tsx
@@ -5,8 +5,14 @@ import { useLocation } from 'react-router-dom';
 import { FeedbackWidget } from './FeedbackWidget';
 import styles from './FloatingFeedback.module.css';
 
-const PAGES_WITH_OWN_FEEDBACK = new Set(['/whats-new']);
+const HIDDEN_PATHS = new Set(['/whats-new']);
+const HIDDEN_PREFIXES = ['/rules/'];
 const DISMISSED_KEY = '2anki_feedback_dismissed';
+
+function shouldHide(pathname: string): boolean {
+  if (HIDDEN_PATHS.has(pathname)) return true;
+  return HIDDEN_PREFIXES.some((p) => pathname.startsWith(p));
+}
 
 export function FloatingFeedback() {
   const { pathname } = useLocation();
@@ -15,7 +21,7 @@ export function FloatingFeedback() {
   );
 
   if (dismissed) return null;
-  if (PAGES_WITH_OWN_FEEDBACK.has(pathname)) return null;
+  if (shouldHide(pathname)) return null;
 
   const handleSubmitted = () => {
     sessionStorage.setItem(DISMISSED_KEY, '1');

--- a/web/src/components/FeedbackWidget/FloatingFeedback.tsx
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.tsx
@@ -4,8 +4,12 @@ import { useLocation } from 'react-router-dom';
 import { FeedbackWidget } from './FeedbackWidget';
 import styles from './FloatingFeedback.module.css';
 
+const PAGES_WITH_OWN_FEEDBACK = new Set(['/whats-new']);
+
 export function FloatingFeedback() {
   const { pathname } = useLocation();
+
+  if (PAGES_WITH_OWN_FEEDBACK.has(pathname)) return null;
 
   return createPortal(
     <div className={styles.container}>

--- a/web/src/components/FeedbackWidget/FloatingFeedback.tsx
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.tsx
@@ -1,44 +1,18 @@
-import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation } from 'react-router-dom';
 
-import ChatBubbleIcon from '../icons/ChatBubbleIcon';
 import { FeedbackWidget } from './FeedbackWidget';
 import styles from './FloatingFeedback.module.css';
 
 export function FloatingFeedback() {
-  const [open, setOpen] = useState(false);
   const { pathname } = useLocation();
 
   return createPortal(
     <div className={styles.container}>
-      {open && (
-        <div className={styles.panel}>
-          <div className={styles.panelHeader}>
-            <span className={styles.panelTitle}>Send feedback</span>
-            <button
-              type="button"
-              className={styles.panelClose}
-              onClick={() => setOpen(false)}
-              aria-label="Close"
-            >
-              &times;
-            </button>
-          </div>
-          <FeedbackWidget
-            page={pathname}
-            onSubmitted={() => setTimeout(() => setOpen(false), 1500)}
-          />
-        </div>
-      )}
-      <button
-        type="button"
-        className={styles.fab}
-        onClick={() => setOpen((v) => !v)}
-        aria-label={open ? 'Close feedback' : 'Send feedback'}
-      >
-        <ChatBubbleIcon width={22} height={22} />
-      </button>
+      <div className={styles.panel}>
+        <p className={styles.panelTitle}>How's your experience?</p>
+        <FeedbackWidget page={pathname} compact />
+      </div>
     </div>,
     document.body
   );

--- a/web/src/components/TeamBanner/TeamBanner.module.css
+++ b/web/src/components/TeamBanner/TeamBanner.module.css
@@ -1,10 +1,10 @@
 .banner {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1.25rem;
-  background: var(--color-primary-light);
-  border-bottom: 1px solid var(--color-primary);
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  background: var(--color-success-light);
+  border-bottom: 1px solid var(--color-success-border);
 }
 
 .content {
@@ -15,8 +15,17 @@
 }
 
 .label {
+  display: inline-block;
+  font-size: var(--text-xs);
   font-weight: var(--font-semibold);
-  margin-right: 0.375rem;
+  color: var(--color-success-text);
+  background: var(--color-success-border);
+  padding: 0.0625rem 0.5rem;
+  border-radius: var(--radius-full);
+  margin-right: 0.5rem;
+  vertical-align: middle;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
 }
 
 .text {
@@ -24,9 +33,10 @@
 }
 
 .link {
-  color: var(--color-primary);
+  color: var(--color-success-text);
   font-weight: var(--font-medium);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .link:hover {
@@ -37,7 +47,7 @@
   flex-shrink: 0;
   background: none;
   border: none;
-  font-size: var(--text-xl);
+  font-size: var(--text-lg);
   cursor: pointer;
   color: var(--color-text-tertiary);
   line-height: 1;

--- a/web/src/components/TeamBanner/TeamBanner.module.css
+++ b/web/src/components/TeamBanner/TeamBanner.module.css
@@ -1,0 +1,49 @@
+.banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--color-primary-light);
+  border-bottom: 1px solid var(--color-primary);
+}
+
+.content {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  line-height: var(--leading-normal);
+}
+
+.label {
+  font-weight: var(--font-semibold);
+  margin-right: 0.375rem;
+}
+
+.text {
+  color: var(--color-text-secondary);
+}
+
+.link {
+  color: var(--color-primary);
+  font-weight: var(--font-medium);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  font-size: var(--text-xl);
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  line-height: 1;
+  padding: 0.25rem;
+}
+
+.close:hover {
+  color: var(--color-text-primary);
+}

--- a/web/src/components/TeamBanner/TeamBanner.tsx
+++ b/web/src/components/TeamBanner/TeamBanner.tsx
@@ -19,12 +19,11 @@ export function TeamBanner() {
   return (
     <div className={styles.banner}>
       <div className={styles.content}>
-        <strong className={styles.label}>Team update</strong>
+        <span className={styles.label}>New</span>
         <span className={styles.text}>
-          Designer, PM, and a second engineer just joined Alexander as lead dev.
-          Shipping faster than ever.{' '}
+          The team just grew — new features are shipping faster than ever.{' '}
           <Link to="/whats-new" className={styles.link}>
-            See what's new &rarr;
+            See what's new
           </Link>
         </span>
       </div>

--- a/web/src/components/TeamBanner/TeamBanner.tsx
+++ b/web/src/components/TeamBanner/TeamBanner.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import styles from './TeamBanner.module.css';
+
+const DISMISSED_KEY = '2anki_team_banner_dismissed';
+
+export function TeamBanner() {
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISSED_KEY) === '1'
+  );
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    setDismissed(true);
+  };
+
+  return (
+    <div className={styles.banner}>
+      <div className={styles.content}>
+        <strong className={styles.label}>Team update</strong>
+        <span className={styles.text}>
+          Designer, PM, and a second engineer just joined Alexander as lead dev.
+          Shipping faster than ever.{' '}
+          <Link to="/whats-new" className={styles.link}>
+            See what's new &rarr;
+          </Link>
+        </span>
+      </div>
+      <button
+        type="button"
+        className={styles.close}
+        onClick={handleDismiss}
+        aria-label="Dismiss"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/ThemeSwitcher/ThemeSwitcher.module.css
+++ b/web/src/components/ThemeSwitcher/ThemeSwitcher.module.css
@@ -25,8 +25,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   border: none;
   border-radius: var(--radius-full);
   background: transparent;

--- a/web/src/pages/DocsPage/DocsHome.tsx
+++ b/web/src/pages/DocsPage/DocsHome.tsx
@@ -102,7 +102,7 @@ export function DocsHome() {
 
       <footer className={styles.docsHomeFooter}>
         Stuck? Email{' '}
-        <a href="mailto:alexander@alemayhu.com">alexander@alemayhu.com</a> or{' '}
+        <a href="mailto:support@2anki.net">support@2anki.net</a> or{' '}
         <a
           href="https://github.com/2anki/server/issues/new"
           target="_blank"

--- a/web/src/pages/HomePage/ShowcaseSection.module.css
+++ b/web/src/pages/HomePage/ShowcaseSection.module.css
@@ -103,6 +103,13 @@
   color: var(--color-text-secondary);
 }
 
+.toggleContentEmpty {
+  padding-left: 1.25rem;
+  font-style: italic;
+  color: var(--color-text-tertiary);
+  font-size: var(--text-sm);
+}
+
 .toggleContent img {
   max-width: 100%;
   height: auto;

--- a/web/src/pages/HomePage/ShowcaseSection.tsx
+++ b/web/src/pages/HomePage/ShowcaseSection.tsx
@@ -12,11 +12,15 @@ function NotionBlock({ block, defaultOpen }: Readonly<{ block: ShowcaseBlock; de
           className={styles.toggleSummary}
           dangerouslySetInnerHTML={{ __html: block.summaryHtml }}
         />
-        {block.childrenHtml && (
+        {block.childrenHtml ? (
           <div
             className={styles.toggleContent}
             dangerouslySetInnerHTML={{ __html: block.childrenHtml }}
           />
+        ) : (
+          <div className={styles.toggleContentEmpty}>
+            This is a cloze deletion — the answer is in the toggle title above.
+          </div>
         )}
       </details>
     );

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -313,7 +313,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.625rem;
-  min-height: 7.5rem;
+  min-height: 6.5rem;
 }
 
 .cardTitle {
@@ -418,7 +418,7 @@
 
 .cardBadge {
   position: absolute;
-  top: -0.75rem;
+  top: -0.5rem;
   right: 1.25rem;
   display: inline-flex;
   align-items: center;

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -92,7 +92,7 @@
 .grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
+  gap: 1.5rem;
   align-items: stretch;
   position: relative;
 }
@@ -309,11 +309,11 @@
    ===================================================================== */
 .cardHeader {
   position: relative;
-  padding: 1.85rem 1.5rem 0;
+  padding: 2.25rem 2rem 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  min-height: 6.25rem;
+  gap: 0.625rem;
+  min-height: 7.5rem;
 }
 
 .cardTitle {
@@ -439,11 +439,11 @@
    BENEFITS
    ===================================================================== */
 .cardBody {
-  padding: 1.4rem 1.5rem;
+  padding: 1.75rem 2rem;
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.7rem;
+  gap: 0.875rem;
 }
 
 .benefit {
@@ -480,10 +480,10 @@
    FOOTER
    ===================================================================== */
 .cardFooter {
-  padding: 0.75rem 1.5rem 1.5rem;
+  padding: 1rem 2rem 2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.625rem;
+  gap: 0.75rem;
 }
 
 .cardCaption {

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -418,8 +418,8 @@
 
 .cardBadge {
   position: absolute;
-  top: -0.5rem;
-  right: 1.25rem;
+  top: 1rem;
+  right: 1.5rem;
   display: inline-flex;
   align-items: center;
   padding: 0.32rem 0.7rem;

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -418,7 +418,7 @@
 
 .cardBadge {
   position: absolute;
-  top: 0.95rem;
+  top: -0.75rem;
   right: 1.25rem;
   display: inline-flex;
   align-items: center;

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -1,0 +1,61 @@
+.empty {
+  text-align: center;
+  color: var(--color-text-secondary);
+  padding: 2rem 0;
+}
+
+.issueList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.issueItem {
+  padding: 1rem 1.25rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast);
+}
+
+.issueItem:hover {
+  border-color: var(--color-primary);
+}
+
+.issueLink {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.issueTitle {
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
+.issueMeta {
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+}
+
+.labelRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+}
+
+.label {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  font-size: var(--text-sm);
+  border: 1px solid;
+  border-radius: var(--radius-full);
+  line-height: var(--leading-normal);
+}

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -47,31 +47,46 @@
 }
 
 .dateHeading {
-  font-size: var(--text-sm);
+  font-size: var(--text-lg);
   font-weight: var(--font-semibold);
-  color: var(--color-text-tertiary);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-wider);
-  margin: 0;
+  color: var(--color-text-primary);
+  letter-spacing: var(--tracking-tight);
+  margin: 0 0 0.75rem;
 }
 
 .commitList {
   list-style: none;
-  padding: 0;
+  padding: 0 0 0 1rem;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0;
+  border-left: 2px solid var(--color-border);
 }
 
 .commitItem {
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+  padding: 0.5rem 0 0.5rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  position: relative;
+}
+
+.commitItem:last-child {
+  border-bottom: none;
+}
+
+.commitItem::before {
+  content: '';
+  position: absolute;
+  left: -1rem;
+  top: 0.875rem;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--color-border);
+  transform: translateX(-50%);
 }
 
 .typeBadge {
@@ -162,26 +177,18 @@
   line-height: var(--leading-normal);
 }
 
-/* ── Feedback section ── */
+/* ── Inline rating ── */
 
-.feedbackSection {
-  margin-top: 3rem;
-  padding: 2rem;
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  text-align: center;
+.inlineRating {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
 }
 
-.feedbackHeading {
-  font-size: var(--text-xl);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-  margin: 0 0 0.375rem;
-}
-
-.feedbackSubtext {
+.ratingLabel {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
-  margin: 0 0 1rem;
+  white-space: nowrap;
 }

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -59,3 +59,25 @@
   border-radius: var(--radius-full);
   line-height: var(--leading-normal);
 }
+
+.feedbackSection {
+  margin-top: 3rem;
+  padding: 2rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  text-align: center;
+}
+
+.feedbackHeading {
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 0.375rem;
+}
+
+.feedbackSubtext {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 1rem;
+}

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -85,7 +85,7 @@
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
-  background: var(--color-border);
+  background: var(--color-text-tertiary);
   transform: translateX(-50%);
 }
 
@@ -99,18 +99,18 @@
 }
 
 .badge_feature {
-  background: var(--color-primary-light);
-  color: var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
 }
 
 .badge_fix {
-  background: var(--color-success-light);
-  color: var(--color-success);
+  background: var(--color-success);
+  color: var(--color-bg-primary);
 }
 
 .badge_style {
-  background: var(--color-warning-light);
-  color: var(--color-warning-text);
+  background: var(--color-text-tertiary);
+  color: var(--color-bg-primary);
 }
 
 .commitText {

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -1,8 +1,110 @@
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tab {
+  padding: 0.625rem 1.25rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tab:hover {
+  color: var(--color-text-primary);
+}
+
+.tabActive {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
 .empty {
   text-align: center;
   color: var(--color-text-secondary);
   padding: 2rem 0;
 }
+
+/* ── Shipped timeline ── */
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.dateGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dateHeading {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  margin: 0;
+}
+
+.commitList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.commitItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.typeBadge {
+  flex-shrink: 0;
+  padding: 0.125rem 0.5rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  border-radius: var(--radius-full);
+  line-height: var(--leading-normal);
+}
+
+.badge_feature {
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+}
+
+.badge_fix {
+  background: var(--color-success-light);
+  color: var(--color-success);
+}
+
+.badge_style {
+  background: var(--color-warning-light);
+  color: var(--color-warning-text);
+}
+
+.commitText {
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+  line-height: var(--leading-normal);
+}
+
+/* ── In progress issues ── */
 
 .issueList {
   list-style: none;
@@ -59,6 +161,8 @@
   border-radius: var(--radius-full);
   line-height: var(--leading-normal);
 }
+
+/* ── Feedback section ── */
 
 .feedbackSection {
   margin-top: 3rem;

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
@@ -31,6 +31,8 @@ function getPriorityWeight(issue: GitHubIssue): number {
   return PRIORITY_LABELS.length;
 }
 
+const TYPE_ORDER: Record<string, number> = { feature: 0, style: 1, fix: 2 };
+
 const TYPE_LABELS: Record<string, string> = {
   feature: 'New',
   fix: 'Fix',
@@ -52,7 +54,9 @@ function groupByDate(entries: ChangelogEntry[]): DateGroup[] {
     .map(([date, items]) => ({
       date,
       label: formatGroupDate(date),
-      entries: items,
+      entries: items.sort(
+        (a, b) => (TYPE_ORDER[a.type] ?? 3) - (TYPE_ORDER[b.type] ?? 3)
+      ),
     }));
 }
 
@@ -120,8 +124,11 @@ export default function WhatsNewPage() {
         <h1 className={sharedStyles.title}>What's new</h1>
         <p className={sharedStyles.subtitle}>
           Track what we've shipped and what's coming next.
-          What do you want us to build? Tell us below.
         </p>
+        <div className={styles.inlineRating}>
+          <span className={styles.ratingLabel}>How are we doing?</span>
+          <FeedbackWidget page="/whats-new" compact />
+        </div>
       </header>
 
       <div className={styles.tabs}>
@@ -211,13 +218,6 @@ export default function WhatsNewPage() {
         </>
       )}
 
-      <div className={styles.feedbackSection}>
-        <h2 className={styles.feedbackHeading}>What do you want us to build next?</h2>
-        <p className={styles.feedbackSubtext}>
-          Your feedback shapes our roadmap. Tell us what matters most to you.
-        </p>
-        <FeedbackWidget page="/whats-new" />
-      </div>
     </div>
   );
 }

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
@@ -1,16 +1,24 @@
 import { useEffect, useState } from 'react';
 import { FeedbackWidget } from '../../components/FeedbackWidget/FeedbackWidget';
+import { changelog, ChangelogEntry } from './changelog';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './WhatsNewPage.module.css';
+
+type Tab = 'shipped' | 'in-progress';
 
 interface GitHubIssue {
   id: number;
   number: number;
   title: string;
   html_url: string;
-  state: string;
   created_at: string;
   labels: Array<{ name: string; color: string }>;
+}
+
+interface DateGroup {
+  date: string;
+  label: string;
+  entries: ChangelogEntry[];
 }
 
 const PRIORITY_LABELS = ['priority: high', 'priority: medium', 'priority: low'];
@@ -23,6 +31,31 @@ function getPriorityWeight(issue: GitHubIssue): number {
   return PRIORITY_LABELS.length;
 }
 
+const TYPE_LABELS: Record<string, string> = {
+  feature: 'New',
+  fix: 'Fix',
+  style: 'Design',
+};
+
+function groupByDate(entries: ChangelogEntry[]): DateGroup[] {
+  const map = new Map<string, ChangelogEntry[]>();
+  for (const entry of entries) {
+    const group = map.get(entry.date);
+    if (group) {
+      group.push(entry);
+    } else {
+      map.set(entry.date, [entry]);
+    }
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([date, items]) => ({
+      date,
+      label: formatGroupDate(date),
+      entries: items,
+    }));
+}
+
 const formatDate = (iso: string): string => {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
@@ -33,97 +66,149 @@ const formatDate = (iso: string): string => {
   });
 };
 
+const formatGroupDate = (dateStr: string): string => {
+  const date = new Date(dateStr + 'T00:00:00');
+  if (Number.isNaN(date.getTime())) return dateStr;
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
 export default function WhatsNewPage() {
+  const [tab, setTab] = useState<Tab>('shipped');
   const [issues, setIssues] = useState<GitHubIssue[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [issuesLoading, setIssuesLoading] = useState(false);
+  const [issuesError, setIssuesError] = useState<string | null>(null);
+
+  const shipped = groupByDate(changelog);
 
   useEffect(() => {
+    if (tab !== 'in-progress') return;
     let cancelled = false;
-    async function load() {
-      try {
-        const response = await fetch(
-          'https://api.github.com/repos/2anki/server/issues?state=open&per_page=50&sort=updated&direction=desc',
-          { headers: { Accept: 'application/vnd.github.v3+json' } }
-        );
-        if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
-        const data: GitHubIssue[] = await response.json();
-        if (!cancelled) {
-          const sorted = data
+    setIssuesLoading(true);
+    fetch(
+      'https://api.github.com/repos/2anki/server/issues?state=open&per_page=30&sort=updated&direction=desc',
+      { headers: { Accept: 'application/vnd.github.v3+json' } }
+    )
+      .then((res) => {
+        if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+        return res.json();
+      })
+      .then((data: GitHubIssue[]) => {
+        if (cancelled) return;
+        setIssues(
+          data
             .filter((i) => !i.html_url.includes('/pull/'))
-            .sort((a, b) => getPriorityWeight(a) - getPriorityWeight(b));
-          setIssues(sorted);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Failed to load issues');
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    load();
+            .sort((a, b) => getPriorityWeight(a) - getPriorityWeight(b))
+        );
+      })
+      .catch((err) => {
+        if (!cancelled) setIssuesError(err instanceof Error ? err.message : 'Failed');
+      })
+      .finally(() => {
+        if (!cancelled) setIssuesLoading(false);
+      });
     return () => { cancelled = true; };
-  }, []);
+  }, [tab]);
 
   return (
     <div className={sharedStyles.page}>
       <header className={sharedStyles.pageHeader}>
         <h1 className={sharedStyles.title}>What's new</h1>
         <p className={sharedStyles.subtitle}>
-          Features and improvements the team is working on, prioritized by impact.
+          Track what we've shipped and what's coming next.
+          What do you want us to build? Tell us below.
         </p>
       </header>
 
-      {loading && (
-        <div className={sharedStyles.flexCenter}>
-          <div className={sharedStyles.spinnerSmall} />
+      <div className={styles.tabs}>
+        <button
+          type="button"
+          className={`${styles.tab} ${tab === 'shipped' ? styles.tabActive : ''}`}
+          onClick={() => setTab('shipped')}
+        >
+          Shipped
+        </button>
+        <button
+          type="button"
+          className={`${styles.tab} ${tab === 'in-progress' ? styles.tabActive : ''}`}
+          onClick={() => setTab('in-progress')}
+        >
+          In progress
+        </button>
+      </div>
+
+      {tab === 'shipped' && (
+        <div className={styles.timeline}>
+          {shipped.map((group) => (
+            <div key={group.date} className={styles.dateGroup}>
+              <h3 className={styles.dateHeading}>{group.label}</h3>
+              <ul className={styles.commitList}>
+                {group.entries.map((entry, idx) => (
+                  <li key={`${entry.date}-${idx}`} className={styles.commitItem}>
+                    <span className={`${styles.typeBadge} ${styles[`badge_${entry.type}`]}`}>
+                      {TYPE_LABELS[entry.type] ?? entry.type}
+                    </span>
+                    <span className={styles.commitText}>{entry.title}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       )}
 
-      {error && (
-        <div className={sharedStyles.alertDanger}>{error}</div>
-      )}
-
-      {!loading && !error && issues.length === 0 && (
-        <p className={styles.empty}>No open issues right now — check back soon.</p>
-      )}
-
-      {issues.length > 0 && (
-        <ul className={styles.issueList}>
-          {issues.map((issue) => (
-            <li key={issue.id} className={styles.issueItem}>
-              <a
-                href={issue.html_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.issueLink}
-              >
-                <span className={styles.issueTitle}>{issue.title}</span>
-                <span className={styles.issueMeta}>
-                  #{issue.number} &middot; {formatDate(issue.created_at)}
-                </span>
-              </a>
-              {issue.labels.length > 0 && (
-                <div className={styles.labelRow}>
-                  {issue.labels.map((label) => (
-                    <span
-                      key={label.name}
-                      className={styles.label}
-                      style={{
-                        background: `#${label.color}20`,
-                        color: `#${label.color}`,
-                        borderColor: `#${label.color}40`,
-                      }}
-                    >
-                      {label.name}
+      {tab === 'in-progress' && (
+        <>
+          {issuesLoading && (
+            <div className={sharedStyles.flexCenter}>
+              <div className={sharedStyles.spinnerSmall} />
+            </div>
+          )}
+          {issuesError && <div className={sharedStyles.alertDanger}>{issuesError}</div>}
+          {!issuesLoading && !issuesError && issues.length === 0 && (
+            <p className={styles.empty}>No open issues right now.</p>
+          )}
+          {issues.length > 0 && (
+            <ul className={styles.issueList}>
+              {issues.map((issue) => (
+                <li key={issue.id} className={styles.issueItem}>
+                  <a
+                    href={issue.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.issueLink}
+                  >
+                    <span className={styles.issueTitle}>{issue.title}</span>
+                    <span className={styles.issueMeta}>
+                      #{issue.number} &middot; {formatDate(issue.created_at)}
                     </span>
-                  ))}
-                </div>
-              )}
-            </li>
-          ))}
-        </ul>
+                  </a>
+                  {issue.labels.length > 0 && (
+                    <div className={styles.labelRow}>
+                      {issue.labels.map((label) => (
+                        <span
+                          key={label.name}
+                          className={styles.label}
+                          style={{
+                            background: `#${label.color}20`,
+                            color: `#${label.color}`,
+                            borderColor: `#${label.color}40`,
+                          }}
+                        >
+                          {label.name}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
 
       <div className={styles.feedbackSection}>

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { FeedbackWidget } from '../../components/FeedbackWidget/FeedbackWidget';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './WhatsNewPage.module.css';
 
@@ -124,6 +125,14 @@ export default function WhatsNewPage() {
           ))}
         </ul>
       )}
+
+      <div className={styles.feedbackSection}>
+        <h2 className={styles.feedbackHeading}>What do you want us to build next?</h2>
+        <p className={styles.feedbackSubtext}>
+          Your feedback shapes our roadmap. Tell us what matters most to you.
+        </p>
+        <FeedbackWidget page="/whats-new" />
+      </div>
     </div>
   );
 }

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
@@ -54,9 +54,9 @@ function groupByDate(entries: ChangelogEntry[]): DateGroup[] {
     .map(([date, items]) => ({
       date,
       label: formatGroupDate(date),
-      entries: items.sort(
-        (a, b) => (TYPE_ORDER[a.type] ?? 3) - (TYPE_ORDER[b.type] ?? 3)
-      ),
+      entries: items
+        .slice()
+        .sort((a, b) => (TYPE_ORDER[a.type] ?? 3) - (TYPE_ORDER[b.type] ?? 3)),
     }));
 }
 
@@ -156,7 +156,7 @@ export default function WhatsNewPage() {
               <ul className={styles.commitList}>
                 {group.entries.map((entry, idx) => (
                   <li key={`${entry.date}-${idx}`} className={styles.commitItem}>
-                    <span className={`${styles.typeBadge} ${styles[`badge_${entry.type}`]}`}>
+                    <span className={`${styles.typeBadge} ${styles['badge_' + entry.type]}`}>
                       {TYPE_LABELS[entry.type] ?? entry.type}
                     </span>
                     <span className={styles.commitText}>{entry.title}</span>

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './WhatsNewPage.module.css';
+
+interface GitHubIssue {
+  id: number;
+  number: number;
+  title: string;
+  html_url: string;
+  state: string;
+  created_at: string;
+  labels: Array<{ name: string; color: string }>;
+}
+
+const PRIORITY_LABELS = ['priority: high', 'priority: medium', 'priority: low'];
+
+function getPriorityWeight(issue: GitHubIssue): number {
+  for (const label of issue.labels) {
+    const idx = PRIORITY_LABELS.indexOf(label.name.toLowerCase());
+    if (idx >= 0) return idx;
+  }
+  return PRIORITY_LABELS.length;
+}
+
+const formatDate = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+export default function WhatsNewPage() {
+  const [issues, setIssues] = useState<GitHubIssue[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const response = await fetch(
+          'https://api.github.com/repos/2anki/server/issues?state=open&per_page=50&sort=updated&direction=desc',
+          { headers: { Accept: 'application/vnd.github.v3+json' } }
+        );
+        if (!response.ok) throw new Error(`GitHub API returned ${response.status}`);
+        const data: GitHubIssue[] = await response.json();
+        if (!cancelled) {
+          const sorted = data
+            .filter((i) => !i.html_url.includes('/pull/'))
+            .sort((a, b) => getPriorityWeight(a) - getPriorityWeight(b));
+          setIssues(sorted);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load issues');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <div className={sharedStyles.page}>
+      <header className={sharedStyles.pageHeader}>
+        <h1 className={sharedStyles.title}>What's new</h1>
+        <p className={sharedStyles.subtitle}>
+          Features and improvements the team is working on, prioritized by impact.
+        </p>
+      </header>
+
+      {loading && (
+        <div className={sharedStyles.flexCenter}>
+          <div className={sharedStyles.spinnerSmall} />
+        </div>
+      )}
+
+      {error && (
+        <div className={sharedStyles.alertDanger}>{error}</div>
+      )}
+
+      {!loading && !error && issues.length === 0 && (
+        <p className={styles.empty}>No open issues right now — check back soon.</p>
+      )}
+
+      {issues.length > 0 && (
+        <ul className={styles.issueList}>
+          {issues.map((issue) => (
+            <li key={issue.id} className={styles.issueItem}>
+              <a
+                href={issue.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.issueLink}
+              >
+                <span className={styles.issueTitle}>{issue.title}</span>
+                <span className={styles.issueMeta}>
+                  #{issue.number} &middot; {formatDate(issue.created_at)}
+                </span>
+              </a>
+              {issue.labels.length > 0 && (
+                <div className={styles.labelRow}>
+                  {issue.labels.map((label) => (
+                    <span
+                      key={label.name}
+                      className={styles.label}
+                      style={{
+                        background: `#${label.color}20`,
+                        color: `#${label.color}`,
+                        borderColor: `#${label.color}40`,
+                      }}
+                    >
+                      {label.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -1,0 +1,32 @@
+export interface ChangelogEntry {
+  type: 'feature' | 'fix' | 'style';
+  title: string;
+  date: string;
+}
+
+export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Stop emoji-triggered card reversal and improve conversion path', date: '2026-05-12' },
+  { type: 'feature', title: 'Emoji feedback widget — rate your experience after every upload', date: '2026-05-12' },
+  { type: 'feature', title: 'Feedback dashboard in /ops for tracking user sentiment', date: '2026-05-12' },
+  { type: 'style', title: 'Redesign pass X — wider content, polished Notion and Import pages', date: '2026-05-12' },
+  { type: 'style', title: 'Enforce 18px minimum font-size across all pages', date: '2026-05-12' },
+  { type: 'fix', title: 'Persist Ankify welcome banner dismissal server-side', date: '2026-05-12' },
+  { type: 'style', title: 'Rename Print to Print Decks in sidebar nav', date: '2026-05-12' },
+  { type: 'feature', title: 'Revamp upload form into self-contained morphing zone', date: '2026-05-12' },
+  { type: 'feature', title: 'Homepage showcase — Notion to Anki before/after preview', date: '2026-05-12' },
+  { type: 'feature', title: 'Carousel navigation for Anki cards in showcase', date: '2026-05-12' },
+  { type: 'feature', title: 'Render Notion toggle blocks with expand/collapse', date: '2026-05-12' },
+  { type: 'feature', title: 'Login as text, compact theme toggle, per-conversion copy', date: '2026-05-12' },
+  { type: 'feature', title: 'Showcase tab in /ops page', date: '2026-05-12' },
+  { type: 'style', title: 'Redesign contact page, footer, and sidebar copyright', date: '2026-05-12' },
+  { type: 'feature', title: 'Show PDF upload info explaining page-pair card creation', date: '2026-05-12' },
+  { type: 'fix', title: 'Download headers and preserve card formatting', date: '2026-05-12' },
+  { type: 'fix', title: 'Handle deleted Notion pages in polling and preview', date: '2026-05-12' },
+  { type: 'feature', title: 'Rename Conversions to My Decks on downloads page', date: '2026-05-12' },
+  { type: 'feature', title: 'Homepage funnel, limit banner, SEO, system theme', date: '2026-05-12' },
+  { type: 'feature', title: 'Light, dark, gold, and purple theme switcher', date: '2026-05-12' },
+  { type: 'style', title: 'Voice sweep — buttons, CTAs, errors, and helper text', date: '2026-05-12' },
+  { type: 'style', title: 'Redesign Account and About pages, fix dark mode', date: '2026-05-12' },
+  { type: 'style', title: 'Token consistency across 12 CSS files', date: '2026-05-12' },
+  { type: 'style', title: 'Redesign NotFoundPage, AboutPage, and ContactPage', date: '2026-05-12' },
+];

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -40,7 +40,7 @@
     sans-serif;
 
   /* Type scale */
-  --text-xs: 1.125rem;
+  --text-xs: 0.9375rem;
   --text-sm: 1.125rem;
   --text-base: 1.125rem;
   --text-lg: 1.25rem;


### PR DESCRIPTION
## Summary
- **Empty toggle placeholder** — show italic hint for cloze deletions with no body on homepage showcase
- **Bigger pricing cards** — increased padding (header, body, footer) and grid gap for 18px font floor
- **Larger theme switcher** — buttons 28px → 36px for better tap targets
- **Floating feedback widget** — always-visible panel on the right side of every page (hidden on mobile and pages with their own feedback)
- **Feedback modal fix** — portal rendering to escape sidebar stacking context
- **Team update banner** — dismissible banner linking to /whats-new
- **What's New page** (`/whats-new`) — tabbed view with static changelog (Shipped) and GitHub issues (In progress), timeline design with type badges, inline "How are we doing?" feedback
- **support@2anki.net** — replace personal email in docs footer
- **Sidebar footer** — add What's new link, reverse christmas tree order

## Test plan
- [x] Homepage: open a toggle with no body, verify hint text
- [x] Pricing: cards look proportional at desktop and mobile
- [x] Theme switcher: larger buttons fill sidebar width better
- [x] Floating feedback: visible on right side, hidden on /whats-new and mobile
- [x] Team banner: shows on first visit, dismisses and stays dismissed
- [x] /whats-new: Shipped tab shows timeline, In progress shows issues, inline feedback works
- [x] Sidebar footer: What's new → Contact → Privacy → Terms → About order

🤖 Generated with [Claude Code](https://claude.com/claude-code)