### PR TITLE
fix: stop emoji-triggered card reversal and improve conversion path

### DIFF
--- a/src/lib/parser/Deck.ts
+++ b/src/lib/parser/Deck.ts
@@ -14,6 +14,8 @@ export default class Deck {
 
   settings: CardOption | null;
 
+  globalTags: string[];
+
   get cardCount() {
     return this.cards.length;
   }
@@ -32,6 +34,7 @@ export default class Deck {
     this.image = image;
     this.style = style;
     this.id = id;
+    this.globalTags = [];
     console.log(`New Deck with ${this.cards.length} cards`);
   }
 

--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -94,8 +94,48 @@ test('Global Tags', async () => {
   expect(deck.cards[0].tags.includes('global')).toBe(true);
 });
 
+test('global tags per file are preserved in multi-file uploads', async () => {
+  const fixtureDir = path.join(__dirname, '../../test/fixtures');
+  const fileAContents = fs.readFileSync(path.join(fixtureDir, 'multi-file-tags-a.html')).toString();
+  const fileBContents = fs.readFileSync(path.join(fixtureDir, 'multi-file-tags-b.html')).toString();
+
+  const files = [
+    { name: 'multi-file-tags-a.html', contents: fileAContents },
+    { name: 'multi-file-tags-b.html', contents: fileBContents },
+  ];
+
+  const workspace = new Workspace(true, 'fs');
+  const settings = new CardOption({ tags: 'true', cherry: 'false' });
+  const parser = new DeckParser({
+    name: 'multi-file-tags-a.html',
+    settings,
+    files,
+    noLimits: true,
+    workspace,
+  });
+
+  const decks = parser.handleHTML('multi-file-tags-b.html', fileBContents, '', parser.payload);
+  parser.payload = decks;
+
+  expect(parser.payload.length).toBe(2);
+
+  parser.customExporter.save = jest.fn().mockResolvedValue('');
+  await parser.build(workspace);
+
+  const deckA = parser.payload[0];
+  const deckB = parser.payload[1];
+
+  expect(deckA.cards.length).toBe(1);
+  expect(deckB.cards.length).toBe(1);
+
+  expect(deckA.cards[0].tags).toContain('alpha-tag');
+  expect(deckA.cards[0].tags).not.toContain('beta-tag');
+
+  expect(deckB.cards[0].tags).toContain('beta-tag');
+  expect(deckB.cards[0].tags).not.toContain('alpha-tag');
+});
+
 test.todo('Input Cards ');
-test.todo('Multiple File Uploads');
 test.todo('Test Basic Card');
 
 test('Markdown empty deck', async () => {
@@ -375,6 +415,30 @@ test('empty paragraphs preserved as spacing in card back', async () => {
   expect(deck.cards[0].back).toContain('end-organ damage');
   const emptyParagraphs = deck.cards[0].back.match(/<p[^>]*><\/p>/g);
   expect(emptyParagraphs).not.toBeNull();
+});
+
+test('refresh emoji does not reverse cards when reversed setting is off', async () => {
+  const fixturePath = path.join(__dirname, '../../test/fixtures/refresh-emoji-toggle.html');
+  const contents = fs.readFileSync(fixturePath).toString();
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'refresh-emoji-toggle.html',
+    settings: new CardOption({ reversed: 'false', 'basic-reversed': 'false', cherry: 'false' }),
+    files: [{ name: 'refresh-emoji-toggle.html', contents }],
+    noLimits: true,
+    workspace,
+  });
+
+  expect(parser.payload[0].cards.length).toBe(2);
+  parser.customExporter.save = jest.fn().mockResolvedValue('');
+  await parser.build(workspace);
+
+  const deck = parser.payload[0];
+  expect(deck.cards.length).toBe(2);
+  expect(deck.cards[0].name).toContain('capital of France');
+  expect(deck.cards[0].back).toContain('Paris');
+  expect(deck.cards[1].name).toContain('capital of Germany');
+  expect(deck.cards[1].back).toContain('Berlin');
 });
 
 describe('removeNewlinesInSVGPathAttributeD', () => {

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -51,8 +51,6 @@ function hasNestedBullets(content: string | undefined): boolean {
 }
 
 export class DeckParser {
-  globalTags: cheerio.Cheerio<Element> | null;
-
   firstDeckName: string;
 
   settings: CardOption;
@@ -78,7 +76,6 @@ export class DeckParser {
     this.firstDeckName = input.name;
     this.noLimits = input.noLimits;
     this.usedHeuristic = false;
-    this.globalTags = null;
     this.payload = [];
     this.workspace = input.workspace ?? new Workspace(true, 'fs');
     this.customExporter = new CustomExporter(
@@ -308,15 +305,13 @@ export class DeckParser {
       settings: this.settings,
     });
 
-    // XXX: review this tag reassignment, does it overwrite?
-    this.globalTags = this.extractGlobalTags(dom);
+    const fileGlobalTags = this.extractGlobalTags(dom);
 
     const toggleList = this.extractToggleLists(dom);
     const paragraphs = this.extractCardsFromParagraph(dom);
     let cards: Note[] = this.extractCards(dom, toggleList, isNewFormat);
 
     const disableIndentedBullets = this.settings.disableIndentedBulletPoints;
-    // Note: this is a fallback behaviour until we can provide people more flexibility on picking non-toggles
     if (cards.length === 0) {
       cards.push(
         ...[
@@ -330,12 +325,11 @@ export class DeckParser {
       );
     }
 
-    //  Prevent bad cards from leaking out
     cards = cards.filter(Boolean);
 
-    decks.push(
-      new Deck(name, cards, image, style, get16DigitRandomId(), this.settings)
-    );
+    const deck = new Deck(name, cards, image, style, get16DigitRandomId(), this.settings);
+    deck.globalTags = fileGlobalTags;
+    decks.push(deck);
 
     const subpages = dom('.link-to-page').toArray();
     for (const page of subpages) {
@@ -356,8 +350,12 @@ export class DeckParser {
     return decks;
   }
 
-  private extractGlobalTags(dom: cheerio.CheerioAPI) {
-    return dom('.page-body > p > del');
+  private extractGlobalTags(dom: cheerio.CheerioAPI): string[] {
+    const tags: string[] = [];
+    dom('.page-body > p > del').each((_i: number, elem: Element) => {
+      tags.push(...sanitizeTags(dom(elem).text().split(',')));
+    });
+    return tags;
   }
 
   // https://stackoverflow.com/questions/6903823/regex-for-youtube-id
@@ -432,8 +430,12 @@ export class DeckParser {
     return { mangle, answer };
   }
 
-  locateTags(card: Note) {
+  locateTags(card: Note, deckGlobalTags: string[]) {
     const input = [card.name, card.back];
+
+    if (!card.tags) {
+      card.tags = [];
+    }
 
     for (const i of input) {
       if (!i) {
@@ -442,22 +444,15 @@ export class DeckParser {
 
       const dom = cheerio.load(i);
       const deletionsDOM = dom('del');
-      const deletionsArray = [deletionsDOM, this.globalTags];
-      if (!card.tags) {
-        card.tags = [];
-      }
-      for (const deletions of deletionsArray) {
-        if (!deletions) {
-          continue;
-        }
-        deletions.each((_i: number, elem: Element) => {
-          const del = dom(elem);
-          card.tags.push(...sanitizeTags(del.text().split(',')));
-          card.back = replaceAll(card.back, `<del>${del.html()}</del>`, '');
-          card.name = replaceAll(card.name, `<del>${del.html()}</del>`, '');
-        });
-      }
+      deletionsDOM.each((_i: number, elem: Element) => {
+        const del = dom(elem);
+        card.tags.push(...sanitizeTags(del.text().split(',')));
+        card.back = replaceAll(card.back, `<del>${del.html()}</del>`, '');
+        card.name = replaceAll(card.name, `<del>${del.html()}</del>`, '');
+      });
     }
+
+    card.tags.push(...deckGlobalTags);
     return card;
   }
 
@@ -569,7 +564,7 @@ export class DeckParser {
           card.tags = [];
         }
         if (this.settings.useTags) {
-          card = this.locateTags(card);
+          card = this.locateTags(card, deck.globalTags);
         }
 
         if (this.settings.basicReversed) {
@@ -580,7 +575,7 @@ export class DeckParser {
           addThese.push(note);
         }
 
-        if (this.settings.reversed || card.hasRefreshIcon()) {
+        if (this.settings.reversed) {
           const tmp = card.back;
           card.back = card.name;
           card.name = tmp;

--- a/src/services/ApkgPreviewService/sanitize.test.ts
+++ b/src/services/ApkgPreviewService/sanitize.test.ts
@@ -1,0 +1,55 @@
+import { sanitizeCardHtml, sanitizeCss } from './sanitize';
+
+describe('sanitizeCardHtml', () => {
+  it('preserves mark tags with highlight-yellow_background class', () => {
+    const html =
+      '<p><mark class="highlight-yellow_background">yellow highlighted</mark></p>';
+    expect(sanitizeCardHtml(html)).toBe(html);
+  });
+
+  it('preserves mark tags with highlight-red_background class', () => {
+    const html =
+      '<p><mark class="highlight-red_background">red highlighted</mark></p>';
+    expect(sanitizeCardHtml(html)).toBe(html);
+  });
+
+  it('preserves mark tags with inline background style', () => {
+    const input =
+      '<p><mark style="background: rgb(251,243,219)">styled highlight</mark></p>';
+    const result = sanitizeCardHtml(input);
+    expect(result).toContain('<mark');
+    expect(result).toContain('background');
+    expect(result).toContain('styled highlight</mark>');
+  });
+
+  it('preserves multiple highlight colors in the same card', () => {
+    const html =
+      '<p><mark class="highlight-yellow_background">yellow</mark> and <mark class="highlight-blue_background">blue</mark></p>';
+    expect(sanitizeCardHtml(html)).toBe(html);
+  });
+
+  it('strips script tags', () => {
+    expect(sanitizeCardHtml('<script>alert(1)</script>')).toBe('');
+  });
+
+  it('preserves basic formatting tags', () => {
+    const html = '<p><strong>bold</strong> and <em>italic</em></p>';
+    expect(sanitizeCardHtml(html)).toBe(html);
+  });
+});
+
+describe('sanitizeCss', () => {
+  it('strips @import rules', () => {
+    expect(sanitizeCss('@import url("evil.css");')).toBe('');
+  });
+
+  it('strips javascript: in expressions', () => {
+    expect(sanitizeCss('expression(alert(1))')).toBe('alert(1))');
+  });
+
+  it('preserves highlight class definitions', () => {
+    const css =
+      '.highlight-yellow_background { background: rgb(251,243,219); }';
+    expect(sanitizeCss(css)).toBe(css);
+  });
+});

--- a/src/services/ApkgPreviewService/sanitize.ts
+++ b/src/services/ApkgPreviewService/sanitize.ts
@@ -21,6 +21,7 @@ const ALLOWED_TAGS = [
   'i',
   'img',
   'li',
+  'mark',
   'ol',
   'p',
   'pre',

--- a/src/test/fixtures/multi-file-tags-a.html
+++ b/src/test/fixtures/multi-file-tags-a.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>File A</title></head>
+<body>
+<article class="page sans">
+<header><h1 class="page-title">File A</h1></header>
+<div class="page-body">
+<p><del>alpha-tag</del></p>
+<ul class="toggle">
+<li><details open="">
+<summary>Question A</summary>
+<p>Answer A</p>
+</details></li>
+</ul>
+</div>
+</article>
+</body>
+</html>

--- a/src/test/fixtures/multi-file-tags-b.html
+++ b/src/test/fixtures/multi-file-tags-b.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>File B</title></head>
+<body>
+<article class="page sans">
+<header><h1 class="page-title">File B</h1></header>
+<div class="page-body">
+<p><del>beta-tag</del></p>
+<ul class="toggle">
+<li><details open="">
+<summary>Question B</summary>
+<p>Answer B</p>
+</details></li>
+</ul>
+</div>
+</article>
+</body>
+</html>

--- a/src/test/fixtures/refresh-emoji-toggle.html
+++ b/src/test/fixtures/refresh-emoji-toggle.html
@@ -1,0 +1,4 @@
+<html><head><title>Refresh Emoji Test</title><style>
+ul.toggle > li { list-style: none; }
+.toggle { padding-inline-start: 0em; list-style-type: none; }
+</style></head><body><article id="test-article" class="page sans"><header><h1 class="page-title">Refresh Emoji Test</h1></header><div class="page-body"><ul id="toggle-1" class="toggle"><li><details open=""><summary>🔄 What is the capital of France?</summary><p>Paris</p></details></li></ul><ul id="toggle-2" class="toggle"><li><details open=""><summary>What is the capital of Germany?</summary><p>Berlin</p></details></li></ul></div></article></body></html>

--- a/web/src/components/errors/helpers/getErrorMessage.test.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.test.ts
@@ -46,6 +46,22 @@ describe('classifyError', () => {
       /Something went wrong/i
     );
   });
+
+  test('short HTML-wrapped error is stripped and shown to the user', () => {
+    const htmlError =
+      '<p>Could not create a deck using your file</p>';
+    const result = classifyError(new Error(htmlError));
+    expect(result.title).toBe(
+      'Could not create a deck using your file'
+    );
+  });
+
+  test('rich HTML error with links is stripped to plain text', () => {
+    const htmlError =
+      '<div class="info">Verify your <a href="/upload?view=template">settings</a>.</div>';
+    const result = classifyError(new Error(htmlError));
+    expect(result.title).toBe('Verify your settings.');
+  });
 });
 
 describe('getErrorMessage', () => {

--- a/web/src/components/errors/helpers/getErrorMessage.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.ts
@@ -1,3 +1,5 @@
+import { stripHtmlTags } from '../../../lib/text/stripHtmlTags';
+
 export type ErrorHandlerType = (error: unknown) => void;
 
 interface FriendlyError {
@@ -83,9 +85,9 @@ export function classifyError(error: unknown): FriendlyError {
     };
   }
 
-  // Server-provided message — trust it, it was already JSON { message: "..." }
-  if (raw.length > 0 && raw.length < 280 && !raw.startsWith('<')) {
-    return { title: raw };
+  const stripped = stripHtmlTags(raw);
+  if (stripped.length > 0 && stripped.length < 280) {
+    return { title: stripped };
   }
 
   return FALLBACK;

--- a/web/src/lib/text/stripHtmlTags.test.ts
+++ b/web/src/lib/text/stripHtmlTags.test.ts
@@ -1,0 +1,41 @@
+import { stripHtmlTags } from './stripHtmlTags';
+
+describe('stripHtmlTags', () => {
+  test('returns plain text unchanged', () => {
+    expect(stripHtmlTags('No active subscription.')).toBe(
+      'No active subscription.'
+    );
+  });
+
+  test('strips simple HTML tags', () => {
+    expect(
+      stripHtmlTags('<p>Could not create a deck using your file</p>')
+    ).toBe('Could not create a deck using your file');
+  });
+
+  test('strips nested HTML tags', () => {
+    expect(
+      stripHtmlTags(
+        '<div class="info">Could not create a deck using your file(s) and rules. Make sure to at least create on valid toggle or verify your <a href="/upload?view=template">settings</a>.</div>'
+      )
+    ).toBe(
+      'Could not create a deck using your file(s) and rules. Make sure to at least create on valid toggle or verify your settings.'
+    );
+  });
+
+  test('collapses extra whitespace from stripped markup', () => {
+    expect(stripHtmlTags('<p>  Hello   world  </p>')).toBe('Hello world');
+  });
+
+  test('handles self-closing tags', () => {
+    expect(stripHtmlTags('Line one<br />Line two')).toBe('Line one Line two');
+  });
+
+  test('returns empty string for empty input', () => {
+    expect(stripHtmlTags('')).toBe('');
+  });
+
+  test('handles string with only tags and no text', () => {
+    expect(stripHtmlTags('<div><br/></div>')).toBe('');
+  });
+});

--- a/web/src/lib/text/stripHtmlTags.ts
+++ b/web/src/lib/text/stripHtmlTags.ts
@@ -1,0 +1,7 @@
+export function stripHtmlTags(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+([.,;:!?])/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { ErrorHandlerType } from '../../../../components/errors/helpers/getErrorMessage';
 import handleRedirect from '../../../../lib/handleRedirect';
 import getAcceptedContentTypes from '../../helpers/getAcceptedContentTypes';
+import { extractErrorMessage } from '../../helpers/extractErrorMessage';
 import getHeadersFilename from '../../helpers/getHeadersFilename';
 import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadFileName';
 import { useDrag } from './hooks/useDrag';
@@ -34,24 +35,6 @@ const REJECTED_FALLBACK =
   'The server rejected the upload. Try again or email support@2anki.net.';
 const NETWORK_FALLBACK =
   "Couldn't upload your file. Check your connection and try again.";
-
-async function extractErrorMessage(response: Response): Promise<string> {
-  try {
-    const body = await response.clone().json();
-    if (
-      typeof body?.message === 'string' &&
-      body.message.trim().length > 0
-    ) {
-      return body.message;
-    }
-  } catch {
-    const text = await response.text().catch(() => '');
-    if (text.length > 0 && text.length < 500 && !text.startsWith('<')) {
-      return text;
-    }
-  }
-  return REJECTED_FALLBACK;
-}
 
 function toFriendlyThrownError(error: unknown): string {
   const isNetworkError =

--- a/web/src/pages/UploadPage/helpers/extractErrorMessage.test.ts
+++ b/web/src/pages/UploadPage/helpers/extractErrorMessage.test.ts
@@ -1,0 +1,60 @@
+import { extractErrorMessage } from './extractErrorMessage';
+
+function jsonResponse(body: object, status = 400): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function textResponse(body: string, status = 400): Response {
+  return new Response(body, { status });
+}
+
+describe('extractErrorMessage', () => {
+  test('extracts message from JSON response body', async () => {
+    const response = jsonResponse({ message: 'No active subscription.' });
+    expect(await extractErrorMessage(response)).toBe(
+      'No active subscription.'
+    );
+  });
+
+  test('strips HTML tags from plain-text error response', async () => {
+    const response = textResponse(
+      '<p>Could not create a deck using your file</p>'
+    );
+    expect(await extractErrorMessage(response)).toBe(
+      'Could not create a deck using your file'
+    );
+  });
+
+  test('strips rich HTML with links from error response', async () => {
+    const html =
+      '<div class="info">Could not create a deck using your file(s) and rules. Make sure to at least create on valid toggle or verify your <a href="/upload?view=template">settings</a>.</div>';
+    const response = textResponse(html);
+    expect(await extractErrorMessage(response)).toBe(
+      'Could not create a deck using your file(s) and rules. Make sure to at least create on valid toggle or verify your settings.'
+    );
+  });
+
+  test('returns fallback for empty response body', async () => {
+    const response = textResponse('');
+    expect(await extractErrorMessage(response)).toMatch(
+      /server rejected the upload/i
+    );
+  });
+
+  test('returns fallback for very long response body', async () => {
+    const response = textResponse('x'.repeat(600));
+    expect(await extractErrorMessage(response)).toMatch(
+      /server rejected the upload/i
+    );
+  });
+
+  test('returns plain text when response is not JSON', async () => {
+    const response = textResponse('Something broke on our end');
+    expect(await extractErrorMessage(response)).toBe(
+      'Something broke on our end'
+    );
+  });
+});

--- a/web/src/pages/UploadPage/helpers/extractErrorMessage.ts
+++ b/web/src/pages/UploadPage/helpers/extractErrorMessage.ts
@@ -1,0 +1,25 @@
+import { stripHtmlTags } from '../../../lib/text/stripHtmlTags';
+
+const REJECTED_FALLBACK =
+  'The server rejected the upload. Try again or email support@2anki.net.';
+
+export async function extractErrorMessage(
+  response: Response
+): Promise<string> {
+  try {
+    const body = await response.clone().json();
+    if (
+      typeof body?.message === 'string' &&
+      body.message.trim().length > 0
+    ) {
+      return body.message;
+    }
+  } catch {
+    const text = await response.text().catch(() => '');
+    const stripped = stripHtmlTags(text);
+    if (stripped.length > 0 && stripped.length < 500) {
+      return stripped;
+    }
+  }
+  return REJECTED_FALLBACK;
+}


### PR DESCRIPTION
## Summary

- **#1443 — Reversed cards from emoji:** Cards with 🔄 emoji in the toggle header were silently reversed even when the user never enabled the reversed setting. This inflated card counts (hitting the 100-card free limit faster) and confused first-time users. Fix: reversal now gated strictly on `this.settings.reversed`, ignoring emoji presence.
- **#2136 — HTML error messages discarded:** Server error messages containing HTML were rejected by the frontend (`!text.startsWith('<')` guard), showing a generic fallback. Fix: strip HTML tags and show the cleaned text to users.
- **#2126 — Per-file globalTags in zip uploads:** Multi-file zip uploads overwrote `this.globalTags` on each file — only the last file's tags survived. Fix: store tags per-deck via `deck.globalTags`.
- **Bonus:** Added `mark` to APKG preview sanitizer allowlist for Notion highlight colors.

Closes #1443

## Test plan

- [x] New test: refresh emoji toggle with `reversed: false` — card front/back not swapped
- [x] New test: multi-file zip with distinct `<del>` tags — each deck carries its own tags
- [x] New test: HTML-wrapped error message stripped to plain text
- [x] New test: `stripHtmlTags` utility — 7 cases covering tags, whitespace, edge cases
- [x] New test: `extractErrorMessage` — JSON body, HTML stripping, fallback
- [x] New test: `sanitizeCardHtml` preserves `<mark>` tags with highlight classes
- [x] All existing DeckParser tests pass (32/32)
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)