### PR TITLE
chore: bump version to 2.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "notion2anki"
   ],
   "author": "Alexander Alemayhu",
-  "version": "1.2.1",
+  "version": "2.0.0-beta.1",
   "engines": {
     "node": ">=12.0.0"
   },


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `1.2.1` to `2.0.0-beta.1`
- Syncs package version with git tags (previous tags reached `v1.1.0`, package was at `1.2.1`)
- After merge, tag `v2.0.0-beta.1` and create a GitHub release

## Test plan

- [x] `pnpm install` succeeds with updated version
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)