### PR TITLE
fix: send emoji feedback fields in business metrics response

### DIFF
--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -14,6 +14,8 @@ import {
   InMemoryCancellationFeedbackRepository,
 } from '../../data_layer/CancellationFeedbackRepository';
 import {
+  EmojiFeedbackCommentEntry,
+  EmojiFeedbackRatingCount,
   IEmojiFeedbackRepository,
   InMemoryEmojiFeedbackRepository,
 } from '../../data_layer/EmojiFeedbackRepository';
@@ -73,6 +75,8 @@ export interface BusinessMetricsResponse {
   failed_payments_weekly: FailedPaymentsWeekPoint[] | null;
   cancellation_reasons_top: CancellationReasonCount[] | null;
   cancellation_comments_recent: CancellationCommentEntry[] | null;
+  emoji_feedback_ratings: EmojiFeedbackRatingCount[] | null;
+  emoji_feedback_comments: EmojiFeedbackCommentEntry[] | null;
   as_of: string;
   cache_age_seconds: number;
   errors?: BusinessMetricError[];
@@ -295,6 +299,8 @@ export class BusinessMetricsService {
       cancellation_comments_recent: valueByKey.get(
         'cancellation_comments_recent'
       ) as CancellationCommentEntry[] | null,
+      emoji_feedback_ratings: valueByKey.get('emoji_feedback_ratings') as EmojiFeedbackRatingCount[] | null,
+      emoji_feedback_comments: valueByKey.get('emoji_feedback_comments') as EmojiFeedbackCommentEntry[] | null,
       as_of: now.toISOString(),
       cache_age_seconds: cacheAgeSeconds,
     };

--- a/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
+++ b/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
@@ -19,6 +19,8 @@ describe('GetBusinessMetricsUseCase', () => {
       failed_payments_weekly: [],
       cancellation_reasons_top: [],
       cancellation_comments_recent: [],
+      emoji_feedback_ratings: [],
+      emoji_feedback_comments: [],
       as_of: '2026-05-09T14:32:07.000Z',
       cache_age_seconds: 412,
     };


### PR DESCRIPTION
## Summary
- `emoji_feedback_ratings` and `emoji_feedback_comments` were computed in `BusinessMetricsService.getMetrics()` but never written into the `BusinessMetricsResponse` interface or the response object
- The frontend `businessTypes.ts` declared both as required fields, so the emoji rating bar chart and comments list on `/ops/business` always received `undefined`
- Added both types to the backend interface and response object, and updated the test fixture to match

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [x] `GetBusinessMetricsUseCase.test.ts` — passes
- [ ] Log into 2anki.net and verify the emoji panels populate on `/ops/business`

🤖 Generated with [Claude Code](https://claude.com/claude-code)