### PR TITLE
feat: re-engagement email flow + 13 mobile CSS fixes

### DIFF
--- a/migrations/20260520000000_re_engagement_emails.js
+++ b/migrations/20260520000000_re_engagement_emails.js
@@ -1,0 +1,14 @@
+exports.up = (knex) =>
+  knex.schema.createTable('re_engagement_emails', (table) => {
+    table.increments('id').primary();
+    table.integer('user_id').references('id').inTable('users').notNullable();
+    table
+      .timestamp('sent_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+    table.string('token', 64).notNullable().unique();
+    table.index(['user_id']);
+  });
+
+exports.down = (knex) =>
+  knex.schema.dropTableIfExists('re_engagement_emails');

--- a/migrations/20260520000001_re_engagement_feedback.js
+++ b/migrations/20260520000001_re_engagement_feedback.js
@@ -1,0 +1,19 @@
+exports.up = (knex) =>
+  knex.schema.createTable('re_engagement_feedback', (table) => {
+    table.increments('id').primary();
+    table
+      .integer('email_id')
+      .references('id')
+      .inTable('re_engagement_emails')
+      .notNullable();
+    table.string('stopped_reason', 64).notNullable();
+    table.string('content_type', 64).notNullable();
+    table.text('comment').nullable();
+    table
+      .timestamp('created_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+  });
+
+exports.down = (knex) =>
+  knex.schema.dropTableIfExists('re_engagement_feedback');

--- a/migrations/20260520000002_email_preferences.js
+++ b/migrations/20260520000002_email_preferences.js
@@ -1,0 +1,17 @@
+exports.up = (knex) =>
+  knex.schema.createTable('email_preferences', (table) => {
+    table
+      .integer('user_id')
+      .primary()
+      .references('id')
+      .inTable('users')
+      .notNullable();
+    table.boolean('marketing_opt_out').notNullable().defaultTo(false);
+    table
+      .timestamp('updated_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+  });
+
+exports.down = (knex) =>
+  knex.schema.dropTableIfExists('email_preferences');

--- a/src/controllers/EmailPreferencesController.test.ts
+++ b/src/controllers/EmailPreferencesController.test.ts
@@ -1,0 +1,72 @@
+import { Request, Response } from 'express';
+
+import { EmailPreferencesController } from './EmailPreferencesController';
+import type { IEmailPreferencesRepository } from '../data_layer/EmailPreferencesRepository';
+
+function buildMocks(userId = 1) {
+  const prefRepo: jest.Mocked<IEmailPreferencesRepository> = {
+    isOptedOut: jest.fn().mockResolvedValue(false),
+    optOut: jest.fn().mockResolvedValue(undefined),
+    optIn: jest.fn().mockResolvedValue(undefined),
+  };
+  const controller = new EmailPreferencesController(prefRepo);
+  const res = {
+    locals: { owner: userId },
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  return { prefRepo, controller, res };
+}
+
+describe('EmailPreferencesController.get', () => {
+  it('returns 200 with marketingOptOut false when user has no preference', async () => {
+    const { controller, res } = buildMocks(1);
+    const req = {} as Request;
+
+    await controller.get(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ marketingOptOut: false });
+  });
+
+  it('returns 200 with marketingOptOut true when user has opted out', async () => {
+    const { controller, prefRepo, res } = buildMocks(1);
+    prefRepo.isOptedOut.mockResolvedValueOnce(true);
+    const req = {} as Request;
+
+    await controller.get(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({ marketingOptOut: true });
+  });
+});
+
+describe('EmailPreferencesController.update', () => {
+  it('opts out when marketingOptOut is true', async () => {
+    const { controller, prefRepo, res } = buildMocks(5);
+    const req = { body: { marketingOptOut: true } } as unknown as Request;
+
+    await controller.update(req, res);
+
+    expect(prefRepo.optOut).toHaveBeenCalledWith(5);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('opts in when marketingOptOut is false', async () => {
+    const { controller, prefRepo, res } = buildMocks(5);
+    const req = { body: { marketingOptOut: false } } as unknown as Request;
+
+    await controller.update(req, res);
+
+    expect(prefRepo.optIn).toHaveBeenCalledWith(5);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 400 when marketingOptOut is not a boolean', async () => {
+    const { controller, res } = buildMocks(1);
+    const req = { body: { marketingOptOut: 'yes' } } as unknown as Request;
+
+    await controller.update(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/src/controllers/EmailPreferencesController.ts
+++ b/src/controllers/EmailPreferencesController.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from 'express';
+
+import type { IEmailPreferencesRepository } from '../data_layer/EmailPreferencesRepository';
+import { UpdateEmailPreferencesUseCase } from '../usecases/UpdateEmailPreferencesUseCase';
+
+export class EmailPreferencesController {
+  private readonly updatePrefsUseCase: UpdateEmailPreferencesUseCase;
+
+  constructor(private readonly prefRepo: IEmailPreferencesRepository) {
+    this.updatePrefsUseCase = new UpdateEmailPreferencesUseCase(prefRepo);
+  }
+
+  async get(_req: Request, res: Response): Promise<void> {
+    const userId = res.locals.owner as number;
+    const marketingOptOut = await this.prefRepo.isOptedOut(userId);
+    res.status(200).json({ marketingOptOut });
+  }
+
+  async update(req: Request, res: Response): Promise<void> {
+    const { marketingOptOut } = req.body;
+    if (typeof marketingOptOut !== 'boolean') {
+      res.status(400).json({ message: 'marketingOptOut must be a boolean.' });
+      return;
+    }
+
+    const userId = res.locals.owner as number;
+    await this.updatePrefsUseCase.execute({ userId, marketingOptOut });
+    res.status(200).json({ message: 'Email preferences updated.' });
+  }
+}

--- a/src/controllers/ReEngagementController.test.ts
+++ b/src/controllers/ReEngagementController.test.ts
@@ -1,0 +1,140 @@
+import { Request, Response } from 'express';
+
+import { ReEngagementController } from './ReEngagementController';
+import type { IReEngagementRepository } from '../data_layer/ReEngagementRepository';
+import type { IEmailPreferencesRepository } from '../data_layer/EmailPreferencesRepository';
+
+function buildMocks() {
+  const repo: jest.Mocked<IReEngagementRepository> = {
+    hasBeenSent: jest.fn().mockResolvedValue(false),
+    recordSend: jest.fn().mockResolvedValue(1),
+    saveResponse: jest.fn().mockResolvedValue(undefined),
+    findByToken: jest.fn().mockResolvedValue(null),
+    getUsersToEmail: jest.fn().mockResolvedValue([]),
+  };
+  const prefRepo: jest.Mocked<IEmailPreferencesRepository> = {
+    isOptedOut: jest.fn().mockResolvedValue(false),
+    optOut: jest.fn().mockResolvedValue(undefined),
+    optIn: jest.fn().mockResolvedValue(undefined),
+  };
+  const controller = new ReEngagementController(repo, prefRepo);
+  const req = { body: {}, query: {} } as unknown as Request;
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  return { repo, prefRepo, controller, req, res };
+}
+
+describe('ReEngagementController.validateToken', () => {
+  it('returns 400 when uid is missing', async () => {
+    const { controller, req, res } = buildMocks();
+    await controller.validateToken(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when token is not found', async () => {
+    const { controller, req, res } = buildMocks();
+    (req as unknown as { query: Record<string, string> }).query = {
+      uid: 'unknown-token',
+    };
+    await controller.validateToken(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 200 with emailId when token is valid', async () => {
+    const { controller, req, res, repo } = buildMocks();
+    repo.findByToken.mockResolvedValueOnce({ id: 42, userId: 7 });
+    (req as unknown as { query: Record<string, string> }).query = {
+      uid: 'valid-token',
+    };
+    await controller.validateToken(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ valid: true, emailId: 42 });
+  });
+});
+
+describe('ReEngagementController.submitFeedback', () => {
+  it('returns 400 when token is missing', async () => {
+    const { controller, req, res } = buildMocks();
+    req.body = { stoppedReason: 'Other', contentType: 'Notion' };
+    await controller.submitFeedback(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when stoppedReason is missing', async () => {
+    const { controller, req, res } = buildMocks();
+    req.body = { token: 'abc', contentType: 'Notion' };
+    await controller.submitFeedback(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when contentType is missing', async () => {
+    const { controller, req, res } = buildMocks();
+    req.body = { token: 'abc', stoppedReason: 'Other' };
+    await controller.submitFeedback(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when token is not found', async () => {
+    const { controller, req, res } = buildMocks();
+    req.body = { token: 'bad-token', stoppedReason: 'Other', contentType: 'Notion' };
+    await controller.submitFeedback(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 200 and saves response when token is valid', async () => {
+    const { controller, req, res, repo } = buildMocks();
+    repo.findByToken.mockResolvedValue({ id: 5, userId: 3 });
+    req.body = {
+      token: 'valid-token',
+      stoppedReason: "Didn't have content ready",
+      contentType: 'Notion',
+      comment: 'Great tool!',
+    };
+    await controller.submitFeedback(req, res);
+    expect(repo.saveResponse).toHaveBeenCalledWith(
+      5,
+      "Didn't have content ready",
+      'Notion',
+      'Great tool!'
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('passes null comment when comment is absent', async () => {
+    const { controller, req, res, repo } = buildMocks();
+    repo.findByToken.mockResolvedValue({ id: 5, userId: 3 });
+    req.body = { token: 'valid-token', stoppedReason: 'Other', contentType: 'PDF' };
+    await controller.submitFeedback(req, res);
+    expect(repo.saveResponse).toHaveBeenCalledWith(5, 'Other', 'PDF', null);
+  });
+});
+
+describe('ReEngagementController.unsubscribe', () => {
+  it('returns 400 when uid is missing', async () => {
+    const { controller, req, res } = buildMocks();
+    await controller.unsubscribe(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when token is not found', async () => {
+    const { controller, req, res } = buildMocks();
+    (req as unknown as { query: Record<string, string> }).query = {
+      uid: 'no-such-token',
+    };
+    await controller.unsubscribe(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 200 and calls optOut when token is valid', async () => {
+    const { controller, req, res, repo, prefRepo } = buildMocks();
+    repo.findByToken.mockResolvedValueOnce({ id: 9, userId: 5 });
+    (req as unknown as { query: Record<string, string> }).query = {
+      uid: 'unsub-token',
+    };
+    await controller.unsubscribe(req, res);
+    expect(prefRepo.optOut).toHaveBeenCalledWith(5);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/src/controllers/ReEngagementController.ts
+++ b/src/controllers/ReEngagementController.ts
@@ -1,0 +1,90 @@
+import { Request, Response } from 'express';
+
+import type { IReEngagementRepository } from '../data_layer/ReEngagementRepository';
+import type { IEmailPreferencesRepository } from '../data_layer/EmailPreferencesRepository';
+import { SubmitReEngagementFeedbackUseCase } from '../usecases/SubmitReEngagementFeedbackUseCase';
+import { UpdateEmailPreferencesUseCase } from '../usecases/UpdateEmailPreferencesUseCase';
+
+export class ReEngagementController {
+  private readonly submitUseCase: SubmitReEngagementFeedbackUseCase;
+  private readonly updatePrefsUseCase: UpdateEmailPreferencesUseCase;
+
+  constructor(
+    private readonly repo: IReEngagementRepository,
+    private readonly prefRepo: IEmailPreferencesRepository
+  ) {
+    this.submitUseCase = new SubmitReEngagementFeedbackUseCase(repo);
+    this.updatePrefsUseCase = new UpdateEmailPreferencesUseCase(prefRepo);
+  }
+
+  async validateToken(req: Request, res: Response): Promise<void> {
+    const uid = req.query['uid'];
+    if (typeof uid !== 'string' || uid.trim().length === 0) {
+      res.status(400).json({ message: 'uid is required.' });
+      return;
+    }
+
+    const record = await this.repo.findByToken(uid.trim());
+    if (record == null) {
+      res.status(404).json({ message: 'Survey link not found.' });
+      return;
+    }
+
+    res.status(200).json({ valid: true, emailId: record.id });
+  }
+
+  async submitFeedback(req: Request, res: Response): Promise<void> {
+    const { token, stoppedReason, contentType, comment } = req.body;
+
+    if (typeof token !== 'string' || token.trim().length === 0) {
+      res.status(400).json({ message: 'token is required.' });
+      return;
+    }
+    if (typeof stoppedReason !== 'string' || stoppedReason.trim().length === 0) {
+      res.status(400).json({ message: 'stoppedReason is required.' });
+      return;
+    }
+    if (typeof contentType !== 'string' || contentType.trim().length === 0) {
+      res.status(400).json({ message: 'contentType is required.' });
+      return;
+    }
+
+    try {
+      await this.submitUseCase.execute({
+        token: token.trim(),
+        stoppedReason: stoppedReason.trim().slice(0, 64),
+        contentType: contentType.trim().slice(0, 64),
+        comment:
+          typeof comment === 'string' && comment.trim().length > 0
+            ? comment.trim()
+            : null,
+      });
+    } catch {
+      res.status(404).json({ message: 'Survey link not found.' });
+      return;
+    }
+
+    res.status(200).json({ message: 'Thank you for your feedback!' });
+  }
+
+  async unsubscribe(req: Request, res: Response): Promise<void> {
+    const uid = req.query['uid'];
+    if (typeof uid !== 'string' || uid.trim().length === 0) {
+      res.status(400).json({ message: 'uid is required.' });
+      return;
+    }
+
+    const record = await this.repo.findByToken(uid.trim());
+    if (record == null) {
+      res.status(404).json({ message: 'Unsubscribe link not found.' });
+      return;
+    }
+
+    await this.updatePrefsUseCase.execute({
+      userId: record.userId,
+      marketingOptOut: true,
+    });
+
+    res.status(200).json({ message: 'You have been unsubscribed.' });
+  }
+}

--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -117,7 +117,6 @@ describe('UsersController.register', () => {
       'Alex',
       'hashed',
       'alex@example.com',
-      expect.any(String),
       null
     );
     expect(res.status).toHaveBeenCalledWith(200);
@@ -142,7 +141,6 @@ describe('UsersController.register', () => {
       expect.any(String),
       'hashed',
       'al@example.com',
-      expect.any(String),
       '/notion-to-anki'
     );
   });
@@ -166,7 +164,6 @@ describe('UsersController.register', () => {
       expect.any(String),
       'hashed',
       'al@example.com',
-      expect.any(String),
       null
     );
   });

--- a/src/data_layer/EmailPreferencesRepository.test.ts
+++ b/src/data_layer/EmailPreferencesRepository.test.ts
@@ -1,0 +1,56 @@
+import { InMemoryEmailPreferencesRepository } from './EmailPreferencesRepository';
+
+describe('InMemoryEmailPreferencesRepository', () => {
+  describe('isOptedOut', () => {
+    it('returns false when no preference row exists for the user', async () => {
+      const repo = new InMemoryEmailPreferencesRepository();
+
+      const result = await repo.isOptedOut(42);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true after optOut is called', async () => {
+      const repo = new InMemoryEmailPreferencesRepository();
+      await repo.optOut(42);
+
+      const result = await repo.isOptedOut(42);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false after optIn is called following an optOut', async () => {
+      const repo = new InMemoryEmailPreferencesRepository();
+      await repo.optOut(42);
+      await repo.optIn(42);
+
+      const result = await repo.isOptedOut(42);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('optOut', () => {
+    it('is idempotent — second call does not change the result', async () => {
+      const repo = new InMemoryEmailPreferencesRepository();
+      await repo.optOut(7);
+      await repo.optOut(7);
+
+      const result = await repo.isOptedOut(7);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('optIn', () => {
+    it('is idempotent — second call does not change the result', async () => {
+      const repo = new InMemoryEmailPreferencesRepository();
+      await repo.optIn(7);
+      await repo.optIn(7);
+
+      const result = await repo.isOptedOut(7);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/data_layer/EmailPreferencesRepository.ts
+++ b/src/data_layer/EmailPreferencesRepository.ts
@@ -1,0 +1,61 @@
+import type { Knex } from 'knex';
+
+export interface IEmailPreferencesRepository {
+  isOptedOut(userId: number): Promise<boolean>;
+  optOut(userId: number): Promise<void>;
+  optIn(userId: number): Promise<void>;
+}
+
+export class EmailPreferencesRepository implements IEmailPreferencesRepository {
+  private readonly table = 'email_preferences';
+
+  constructor(private readonly database: Knex) {}
+
+  async isOptedOut(userId: number): Promise<boolean> {
+    const row = await this.database(this.table)
+      .where({ user_id: userId })
+      .first();
+    if (row == null) {
+      return false;
+    }
+    return row.marketing_opt_out === true;
+  }
+
+  async optOut(userId: number): Promise<void> {
+    await this.database(this.table)
+      .insert({ user_id: userId, marketing_opt_out: true })
+      .onConflict('user_id')
+      .merge({ marketing_opt_out: true, updated_at: this.database.fn.now() });
+  }
+
+  async optIn(userId: number): Promise<void> {
+    await this.database(this.table)
+      .insert({ user_id: userId, marketing_opt_out: false })
+      .onConflict('user_id')
+      .merge({ marketing_opt_out: false, updated_at: this.database.fn.now() });
+  }
+}
+
+export class InMemoryEmailPreferencesRepository
+  implements IEmailPreferencesRepository
+{
+  private readonly prefs = new Map<number, boolean>();
+
+  async isOptedOut(userId: number): Promise<boolean> {
+    return this.prefs.get(userId) === true;
+  }
+
+  async optOut(userId: number): Promise<void> {
+    this.prefs.set(userId, true);
+  }
+
+  async optIn(userId: number): Promise<void> {
+    this.prefs.set(userId, false);
+  }
+
+  clear(): void {
+    this.prefs.clear();
+  }
+}
+
+export default EmailPreferencesRepository;

--- a/src/data_layer/ReEngagementRepository.test.ts
+++ b/src/data_layer/ReEngagementRepository.test.ts
@@ -1,0 +1,138 @@
+import { InMemoryReEngagementRepository } from './ReEngagementRepository';
+
+describe('InMemoryReEngagementRepository', () => {
+  describe('hasBeenSent', () => {
+    it('returns false when no email has been sent to the user', async () => {
+      const repo = new InMemoryReEngagementRepository();
+
+      const result = await repo.hasBeenSent(42);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true after recordSend is called for the user', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      await repo.recordSend(42, 'abc123');
+
+      const result = await repo.hasBeenSent(42);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('recordSend', () => {
+    it('returns a numeric email id', async () => {
+      const repo = new InMemoryReEngagementRepository();
+
+      const id = await repo.recordSend(1, 'token-one');
+
+      expect(typeof id).toBe('number');
+      expect(id).toBeGreaterThan(0);
+    });
+
+    it('returns incrementing ids for successive calls', async () => {
+      const repo = new InMemoryReEngagementRepository();
+
+      const id1 = await repo.recordSend(1, 'tok1');
+      const id2 = await repo.recordSend(2, 'tok2');
+
+      expect(id2).toBeGreaterThan(id1);
+    });
+  });
+
+  describe('findByToken', () => {
+    it('returns null when token does not exist', async () => {
+      const repo = new InMemoryReEngagementRepository();
+
+      const result = await repo.findByToken('ghost');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns id and userId when token exists', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      const emailId = await repo.recordSend(7, 'my-token');
+
+      const result = await repo.findByToken('my-token');
+
+      expect(result).toEqual({ id: emailId, userId: 7 });
+    });
+  });
+
+  describe('saveResponse', () => {
+    it('stores the response linked to the email id', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      const emailId = await repo.recordSend(3, 'resp-token');
+
+      await repo.saveResponse(emailId, 'too_complex', 'notion', 'Hard to use');
+
+      const responses = repo.getResponses();
+      expect(responses).toHaveLength(1);
+      expect(responses[0]).toMatchObject({
+        emailId,
+        stoppedReason: 'too_complex',
+        contentType: 'notion',
+        comment: 'Hard to use',
+      });
+    });
+
+    it('stores null comment when comment is null', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      const emailId = await repo.recordSend(4, 'null-comment-token');
+
+      await repo.saveResponse(emailId, 'forgot', 'upload', null);
+
+      expect(repo.getResponses()[0].comment).toBeNull();
+    });
+  });
+
+  describe('getUsersToEmail', () => {
+    it('returns seeded users that have not been sent an email', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      repo.seedUsers([
+        { id: 10, name: 'Alice', email: 'alice@example.com' },
+        { id: 11, name: 'Bob', email: 'bob@example.com' },
+      ]);
+
+      const users = await repo.getUsersToEmail();
+
+      expect(users).toHaveLength(2);
+    });
+
+    it('excludes users who have already received an email', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      repo.seedUsers([
+        { id: 10, name: 'Alice', email: 'alice@example.com' },
+        { id: 11, name: 'Bob', email: 'bob@example.com' },
+      ]);
+      await repo.recordSend(10, 'alice-token');
+
+      const users = await repo.getUsersToEmail();
+
+      expect(users).toHaveLength(1);
+      expect(users[0].id).toBe(11);
+    });
+
+    it('returns empty array when all users have been sent an email', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      repo.seedUsers([{ id: 5, name: 'Charlie', email: 'charlie@example.com' }]);
+      await repo.recordSend(5, 'charlie-token');
+
+      const users = await repo.getUsersToEmail();
+
+      expect(users).toHaveLength(0);
+    });
+  });
+
+  describe('clear', () => {
+    it('resets all state', async () => {
+      const repo = new InMemoryReEngagementRepository();
+      repo.seedUsers([{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+      await repo.recordSend(1, 'tok');
+      repo.clear();
+
+      expect(await repo.hasBeenSent(1)).toBe(false);
+      expect(await repo.getUsersToEmail()).toHaveLength(0);
+    });
+  });
+});

--- a/src/data_layer/ReEngagementRepository.ts
+++ b/src/data_layer/ReEngagementRepository.ts
@@ -74,7 +74,6 @@ export class ReEngagementRepository implements IReEngagementRepository {
   async getUsersToEmail(): Promise<
     Array<{ id: number; name: string; email: string }>
   > {
-    const now = this.database.fn.now();
     const rows = await this.database<UserRow>('users')
       .select('users.id', 'users.name', 'users.email')
       .whereRaw(
@@ -95,7 +94,6 @@ export class ReEngagementRepository implements IReEngagementRepository {
           .limit(1)
       )
       .limit(500);
-    void now;
     return rows.map((row) => ({
       id: row.id,
       name: row.name,
@@ -107,7 +105,7 @@ export class ReEngagementRepository implements IReEngagementRepository {
 export class InMemoryReEngagementRepository
   implements IReEngagementRepository
 {
-  private sentUserIds = new Set<number>();
+  private readonly sentUserIds = new Set<number>();
   private emails: Array<{ id: number; userId: number; token: string }> = [];
   private responses: Array<{
     emailId: number;

--- a/src/data_layer/ReEngagementRepository.ts
+++ b/src/data_layer/ReEngagementRepository.ts
@@ -1,0 +1,184 @@
+import type { Knex } from 'knex';
+
+export interface IReEngagementRepository {
+  hasBeenSent(userId: number): Promise<boolean>;
+  recordSend(userId: number, token: string): Promise<number>;
+  saveResponse(
+    emailId: number,
+    stoppedReason: string,
+    contentType: string,
+    comment: string | null
+  ): Promise<void>;
+  findByToken(token: string): Promise<{ id: number; userId: number } | null>;
+  getUsersToEmail(): Promise<Array<{ id: number; name: string; email: string }>>;
+}
+
+interface EmailRow {
+  id: number;
+  user_id: number;
+}
+
+interface UserRow {
+  id: number;
+  name: string;
+  email: string;
+}
+
+export class ReEngagementRepository implements IReEngagementRepository {
+  private readonly emailsTable = 're_engagement_emails';
+  private readonly feedbackTable = 're_engagement_feedback';
+
+  constructor(private readonly database: Knex) {}
+
+  async hasBeenSent(userId: number): Promise<boolean> {
+    const row = await this.database(this.emailsTable)
+      .where({ user_id: userId })
+      .first();
+    return row != null;
+  }
+
+  async recordSend(userId: number, token: string): Promise<number> {
+    const [row] = await this.database(this.emailsTable)
+      .insert({ user_id: userId, token })
+      .returning('id');
+    return typeof row === 'object' ? row.id : row;
+  }
+
+  async saveResponse(
+    emailId: number,
+    stoppedReason: string,
+    contentType: string,
+    comment: string | null
+  ): Promise<void> {
+    await this.database(this.feedbackTable).insert({
+      email_id: emailId,
+      stopped_reason: stoppedReason,
+      content_type: contentType,
+      comment,
+    });
+  }
+
+  async findByToken(
+    token: string
+  ): Promise<{ id: number; userId: number } | null> {
+    const row = await this.database<EmailRow>(this.emailsTable)
+      .select('id', 'user_id')
+      .where({ token })
+      .first();
+    if (row == null) {
+      return null;
+    }
+    return { id: row.id, userId: row.user_id };
+  }
+
+  async getUsersToEmail(): Promise<
+    Array<{ id: number; name: string; email: string }>
+  > {
+    const now = this.database.fn.now();
+    const rows = await this.database<UserRow>('users')
+      .select('users.id', 'users.name', 'users.email')
+      .whereRaw(
+        "users.created_at >= now() - interval '4 days' AND users.created_at < now() - interval '3 days'"
+      )
+      .whereNotExists(
+        this.database('uploads').whereRaw('uploads.owner = users.id').limit(1)
+      )
+      .whereNotExists(
+        this.database(this.emailsTable)
+          .whereRaw('re_engagement_emails.user_id = users.id')
+          .limit(1)
+      )
+      .whereNotExists(
+        this.database('email_preferences')
+          .whereRaw('email_preferences.user_id = users.id')
+          .where('email_preferences.marketing_opt_out', true)
+          .limit(1)
+      )
+      .limit(500);
+    void now;
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      email: row.email,
+    }));
+  }
+}
+
+export class InMemoryReEngagementRepository
+  implements IReEngagementRepository
+{
+  private sentUserIds = new Set<number>();
+  private emails: Array<{ id: number; userId: number; token: string }> = [];
+  private responses: Array<{
+    emailId: number;
+    stoppedReason: string;
+    contentType: string;
+    comment: string | null;
+  }> = [];
+  private nextId = 1;
+  private usersToReturn: Array<{
+    id: number;
+    name: string;
+    email: string;
+  }> = [];
+
+  seedUsers(
+    users: Array<{ id: number; name: string; email: string }>
+  ): void {
+    this.usersToReturn = users;
+  }
+
+  async hasBeenSent(userId: number): Promise<boolean> {
+    return this.sentUserIds.has(userId);
+  }
+
+  async recordSend(userId: number, token: string): Promise<number> {
+    const id = this.nextId++;
+    this.emails.push({ id, userId, token });
+    this.sentUserIds.add(userId);
+    return id;
+  }
+
+  async saveResponse(
+    emailId: number,
+    stoppedReason: string,
+    contentType: string,
+    comment: string | null
+  ): Promise<void> {
+    this.responses.push({ emailId, stoppedReason, contentType, comment });
+  }
+
+  async findByToken(
+    token: string
+  ): Promise<{ id: number; userId: number } | null> {
+    const found = this.emails.find((e) => e.token === token);
+    if (found == null) {
+      return null;
+    }
+    return { id: found.id, userId: found.userId };
+  }
+
+  async getUsersToEmail(): Promise<
+    Array<{ id: number; name: string; email: string }>
+  > {
+    return this.usersToReturn.filter((u) => !this.sentUserIds.has(u.id));
+  }
+
+  getResponses() {
+    return [...this.responses];
+  }
+
+  getEmails() {
+    return [...this.emails];
+  }
+
+  clear(): void {
+    this.sentUserIds.clear();
+    this.emails = [];
+    this.responses = [];
+    this.nextId = 1;
+    this.usersToReturn = [];
+  }
+}
+
+export default ReEngagementRepository;

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
@@ -1,0 +1,108 @@
+import { sendReEngagementEmails } from './sendReEngagementEmails';
+import { InMemoryReEngagementRepository } from '../../../../data_layer/ReEngagementRepository';
+import type { IEmailService } from '../../../../services/EmailService/EmailService';
+
+function buildEmailService(): jest.Mocked<IEmailService> {
+  return {
+    sendResetEmail: jest.fn(),
+    sendConversionEmail: jest.fn(),
+    sendConversionLinkEmail: jest.fn(),
+    sendContactEmail: jest.fn(),
+    sendSubscriptionCancelledEmail: jest.fn(),
+    sendSubscriptionScheduledCancellationEmail: jest.fn(),
+    sendHostedAnkiAccessRequestEmail: jest.fn(),
+    sendMagicLinkEmail: jest.fn(),
+    sendReEngagementEmail: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('sendReEngagementEmails', () => {
+  it('sends an email for each eligible user', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    repo.seedUsers([
+      { id: 1, name: 'Alice', email: 'alice@example.com' },
+      { id: 2, name: 'Bob', email: 'bob@example.com' },
+    ]);
+    const emailService = buildEmailService();
+
+    await sendReEngagementEmails(repo, emailService);
+
+    expect(emailService.sendReEngagementEmail).toHaveBeenCalledTimes(2);
+    expect(emailService.sendReEngagementEmail).toHaveBeenCalledWith(
+      'alice@example.com',
+      'Alice',
+      expect.any(String)
+    );
+    expect(emailService.sendReEngagementEmail).toHaveBeenCalledWith(
+      'bob@example.com',
+      'Bob',
+      expect.any(String)
+    );
+  });
+
+  it('records the send in the repository before emailing', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    repo.seedUsers([{ id: 3, name: 'Carol', email: 'carol@example.com' }]);
+    const emailService = buildEmailService();
+
+    await sendReEngagementEmails(repo, emailService);
+
+    const emails = repo.getEmails();
+    expect(emails).toHaveLength(1);
+    expect(emails[0].userId).toBe(3);
+    expect(emails[0].token).toHaveLength(64);
+  });
+
+  it('generates a unique 64-character hex token per user', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    repo.seedUsers([
+      { id: 4, name: 'Dave', email: 'dave@example.com' },
+      { id: 5, name: 'Eve', email: 'eve@example.com' },
+    ]);
+    const emailService = buildEmailService();
+
+    await sendReEngagementEmails(repo, emailService);
+
+    const emails = repo.getEmails();
+    const tokens = emails.map((e) => e.token);
+    expect(tokens[0]).toMatch(/^[0-9a-f]{64}$/);
+    expect(tokens[1]).toMatch(/^[0-9a-f]{64}$/);
+    expect(tokens[0]).not.toBe(tokens[1]);
+  });
+
+  it('does nothing when there are no eligible users', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    const emailService = buildEmailService();
+
+    await sendReEngagementEmails(repo, emailService);
+
+    expect(emailService.sendReEngagementEmail).not.toHaveBeenCalled();
+    expect(repo.getEmails()).toHaveLength(0);
+  });
+
+  it('does not email a user already marked as sent', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    repo.seedUsers([{ id: 6, name: 'Frank', email: 'frank@example.com' }]);
+    const emailService = buildEmailService();
+
+    await sendReEngagementEmails(repo, emailService);
+    await sendReEngagementEmails(repo, emailService);
+
+    expect(emailService.sendReEngagementEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues to next user when sendReEngagementEmail throws', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    repo.seedUsers([
+      { id: 7, name: 'Grace', email: 'grace@example.com' },
+      { id: 8, name: 'Heidi', email: 'heidi@example.com' },
+    ]);
+    const emailService = buildEmailService();
+    emailService.sendReEngagementEmail
+      .mockRejectedValueOnce(new Error('SendGrid error'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(sendReEngagementEmails(repo, emailService)).resolves.toBeUndefined();
+    expect(emailService.sendReEngagementEmail).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 import type { IReEngagementRepository } from '../../../../data_layer/ReEngagementRepository';
 import type { IEmailService } from '../../../../services/EmailService/EmailService';
@@ -11,8 +11,7 @@ export async function sendReEngagementEmails(
 
   for (const user of users) {
     const token = crypto.randomBytes(32).toString('hex');
-    const emailId = await repo.recordSend(user.id, token);
-    void emailId;
+    await repo.recordSend(user.id, token);
     try {
       await emailService.sendReEngagementEmail(user.email, user.name, token);
     } catch (error) {

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.ts
@@ -1,0 +1,22 @@
+import crypto from 'crypto';
+
+import type { IReEngagementRepository } from '../../../../data_layer/ReEngagementRepository';
+import type { IEmailService } from '../../../../services/EmailService/EmailService';
+
+export async function sendReEngagementEmails(
+  repo: IReEngagementRepository,
+  emailService: IEmailService
+): Promise<void> {
+  const users = await repo.getUsersToEmail();
+
+  for (const user of users) {
+    const token = crypto.randomBytes(32).toString('hex');
+    const emailId = await repo.recordSend(user.id, token);
+    void emailId;
+    try {
+      await emailService.sendReEngagementEmail(user.email, user.name, token);
+    } catch (error) {
+      console.error(`[re-engagement] failed to email user ${user.id}:`, error);
+    }
+  }
+}

--- a/src/routes/ReEngagementRouter.test.ts
+++ b/src/routes/ReEngagementRouter.test.ts
@@ -1,0 +1,129 @@
+import express from 'express';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import type { IReEngagementRepository } from '../data_layer/ReEngagementRepository';
+import type { IEmailPreferencesRepository } from '../data_layer/EmailPreferencesRepository';
+
+const mockRepo: jest.Mocked<IReEngagementRepository> = {
+  hasBeenSent: jest.fn().mockResolvedValue(false),
+  recordSend: jest.fn().mockResolvedValue(1),
+  saveResponse: jest.fn().mockResolvedValue(undefined),
+  findByToken: jest.fn().mockResolvedValue(null),
+  getUsersToEmail: jest.fn().mockResolvedValue([]),
+};
+
+const mockPrefRepo: jest.Mocked<IEmailPreferencesRepository> = {
+  isOptedOut: jest.fn().mockResolvedValue(false),
+  optOut: jest.fn().mockResolvedValue(undefined),
+  optIn: jest.fn().mockResolvedValue(undefined),
+};
+
+jest.mock('../data_layer', () => ({ getDatabase: jest.fn() }));
+jest.mock('../data_layer/ReEngagementRepository', () =>
+  jest.fn().mockImplementation(() => mockRepo)
+);
+jest.mock('../data_layer/EmailPreferencesRepository', () =>
+  jest.fn().mockImplementation(() => mockPrefRepo)
+);
+
+async function buildServer() {
+  const { default: ReEngagementRouter } = await import('./ReEngagementRouter');
+  const app = express();
+  app.use(express.json());
+  app.use(ReEngagementRouter());
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+describe('ReEngagementRouter', () => {
+  let server: http.Server;
+  let url: string;
+
+  beforeAll(async () => {
+    ({ server, url } = await buildServer());
+  });
+
+  afterAll(() => server.close());
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('GET /feedback/onboarding', () => {
+    it('returns 400 when uid is missing', async () => {
+      const res = await fetch(`${url}/feedback/onboarding`);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when token is unknown', async () => {
+      const res = await fetch(`${url}/feedback/onboarding?uid=bad`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 200 with emailId when token is valid', async () => {
+      mockRepo.findByToken.mockResolvedValueOnce({ id: 7, userId: 2 });
+      const res = await fetch(`${url}/feedback/onboarding?uid=valid`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toMatchObject({ valid: true, emailId: 7 });
+    });
+  });
+
+  describe('POST /feedback/onboarding', () => {
+    it('returns 400 when required fields are missing', async () => {
+      const res = await fetch(`${url}/feedback/onboarding`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ stoppedReason: 'Other' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when token is not found', async () => {
+      const res = await fetch(`${url}/feedback/onboarding`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          token: 'bad',
+          stoppedReason: 'Other',
+          contentType: 'Notion',
+        }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 200 when token is valid', async () => {
+      mockRepo.findByToken.mockResolvedValueOnce({ id: 3, userId: 9 });
+      const res = await fetch(`${url}/feedback/onboarding`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          token: 'valid',
+          stoppedReason: 'Just browsing',
+          contentType: 'PDF',
+        }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('GET /unsubscribe', () => {
+    it('returns 400 when uid is missing', async () => {
+      const res = await fetch(`${url}/unsubscribe`);
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when token is unknown', async () => {
+      const res = await fetch(`${url}/unsubscribe?uid=ghost`);
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 200 when token is valid and calls optOut', async () => {
+      mockRepo.findByToken.mockResolvedValueOnce({ id: 11, userId: 4 });
+      const res = await fetch(`${url}/unsubscribe?uid=unsub-token`);
+      expect(res.status).toBe(200);
+      expect(mockPrefRepo.optOut).toHaveBeenCalledWith(4);
+    });
+  });
+});

--- a/src/routes/ReEngagementRouter.ts
+++ b/src/routes/ReEngagementRouter.ts
@@ -1,0 +1,30 @@
+import express from 'express';
+
+import { ReEngagementController } from '../controllers/ReEngagementController';
+import ReEngagementRepository from '../data_layer/ReEngagementRepository';
+import EmailPreferencesRepository from '../data_layer/EmailPreferencesRepository';
+import { getDatabase } from '../data_layer';
+
+const ReEngagementRouter = () => {
+  const router = express.Router();
+  const database = getDatabase();
+  const repo = new ReEngagementRepository(database);
+  const prefRepo = new EmailPreferencesRepository(database);
+  const controller = new ReEngagementController(repo, prefRepo);
+
+  router.get('/feedback/onboarding', (req, res) =>
+    controller.validateToken(req, res)
+  );
+
+  router.post('/feedback/onboarding', (req, res) =>
+    controller.submitFeedback(req, res)
+  );
+
+  router.get('/unsubscribe', (req, res) =>
+    controller.unsubscribe(req, res)
+  );
+
+  return router;
+};
+
+export default ReEngagementRouter;

--- a/src/routes/ReEngagementRouter.ts
+++ b/src/routes/ReEngagementRouter.ts
@@ -12,14 +12,84 @@ const ReEngagementRouter = () => {
   const prefRepo = new EmailPreferencesRepository(database);
   const controller = new ReEngagementController(repo, prefRepo);
 
+  /**
+   * @swagger
+   * /feedback/onboarding:
+   *   get:
+   *     summary: Validate a re-engagement survey token
+   *     tags: [Re-engagement]
+   *     parameters:
+   *       - in: query
+   *         name: uid
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Token is valid
+   *       400:
+   *         description: uid missing
+   *       404:
+   *         description: Token not found
+   */
   router.get('/feedback/onboarding', (req, res) =>
     controller.validateToken(req, res)
   );
 
+  /**
+   * @swagger
+   * /feedback/onboarding:
+   *   post:
+   *     summary: Submit re-engagement survey feedback
+   *     tags: [Re-engagement]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [token, stoppedReason, contentType]
+   *             properties:
+   *               token:
+   *                 type: string
+   *               stoppedReason:
+   *                 type: string
+   *               contentType:
+   *                 type: string
+   *               comment:
+   *                 type: string
+   *     responses:
+   *       200:
+   *         description: Feedback saved
+   *       400:
+   *         description: Missing required fields
+   *       404:
+   *         description: Token not found
+   */
   router.post('/feedback/onboarding', (req, res) =>
     controller.submitFeedback(req, res)
   );
 
+  /**
+   * @swagger
+   * /unsubscribe:
+   *   get:
+   *     summary: Unsubscribe from re-engagement emails
+   *     tags: [Re-engagement]
+   *     parameters:
+   *       - in: query
+   *         name: uid
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Successfully unsubscribed
+   *       400:
+   *         description: uid missing
+   *       404:
+   *         description: Token not found
+   */
   router.get('/unsubscribe', (req, res) =>
     controller.unsubscribe(req, res)
   );

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -4,8 +4,10 @@ import RequireAuthentication, {
   OptionalAuthentication,
 } from './middleware/RequireAuthentication';
 import UsersController from '../controllers/UsersControllers';
+import { EmailPreferencesController } from '../controllers/EmailPreferencesController';
 import UsersRepository from '../data_layer/UsersRepository';
 import TokenRepository from '../data_layer/TokenRepository';
+import EmailPreferencesRepository from '../data_layer/EmailPreferencesRepository';
 import AuthenticationService from '../services/AuthenticationService';
 import { getDatabase } from '../data_layer';
 import UsersService from '../services/UsersService';
@@ -26,6 +28,9 @@ const UserRouter = () => {
     new UsersService(new UsersRepository(database), emailService, magicTokenRepository),
     authService,
     database
+  );
+  const emailPreferencesController = new EmailPreferencesController(
+    new EmailPreferencesRepository(database)
   );
 
   // No authentication required for new password since user has reset token
@@ -579,6 +584,20 @@ const UserRouter = () => {
   router.get('/api/users/auth/google', (req, res) =>
     controller.loginWithGoogle(req, res)
   );
+
+
+  router.get(
+    '/api/users/email-preferences',
+    RequireAuthentication,
+    (req, res) => emailPreferencesController.get(req, res)
+  );
+
+  router.patch(
+    '/api/users/email-preferences',
+    RequireAuthentication,
+    (req, res) => emailPreferencesController.update(req, res)
+  );
+
 
   return router;
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,12 +40,16 @@ import swaggerRouter from './routes/SwaggerRouter';
 import opsRouter from './routes/OpsRouter';
 import showcaseRouter from './routes/ShowcaseRouter';
 import emojiFeedbackRouter from './routes/EmojiFeedbackRouter';
+import reEngagementRouter from './routes/ReEngagementRouter';
 import requestLoggingMiddleware from './routes/middleware/requestLoggingMiddleware';
 
 import { getDatabase, setupDatabase } from './data_layer';
 import JobRepository from './data_layer/JobRepository';
 import { MagicTokenRepository } from './data_layer/MagicTokenRepository';
+import ReEngagementRepository from './data_layer/ReEngagementRepository';
 import { updateStripeSubscriptions } from './lib/storage/jobs/helpers/updateStripeSubscriptions';
+import { sendReEngagementEmails } from './lib/storage/jobs/helpers/sendReEngagementEmails';
+import { getDefaultEmailService } from './services/EmailService/EmailService';
 
 function registerSignalHandlers(server: http.Server) {
   process.on('uncaughtException', (error) => {
@@ -105,6 +109,7 @@ const serve = async () => {
   app.use(showcaseRouter());
   app.use(opsRouter());
   app.use(emojiFeedbackRouter());
+  app.use(reEngagementRouter());
 
   app.use(rejectScannerProbes);
   // Note: this has to be the last router
@@ -153,6 +158,15 @@ const serve = async () => {
       console.error('[startup] Stripe subscription sync failed:', error);
     });
   }
+
+  const reEngagementRepo = new ReEngagementRepository(database);
+  const emailService = getDefaultEmailService();
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+  setInterval(() => {
+    sendReEngagementEmails(reEngagementRepo, emailService).catch((error) => {
+      console.error('[re-engagement] daily job failed:', error);
+    });
+  }, ONE_DAY_MS);
 };
 
 serve();

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -231,9 +231,9 @@ class EmailService implements IEmailService {
     const domain = process.env.DOMAIN ?? 'https://2anki.net';
     const surveyUrl = `${domain}/feedback/onboarding?uid=${token}`;
     const unsubscribeUrl = `${domain}/unsubscribe?uid=${token}`;
-    const markup = RE_ENGAGEMENT_TEMPLATE.replace(/{{name}}/g, name)
-      .replace(/{{surveyUrl}}/g, surveyUrl)
-      .replace(/{{unsubscribeUrl}}/g, unsubscribeUrl);
+    const markup = RE_ENGAGEMENT_TEMPLATE.replaceAll('{{name}}', name)
+      .replaceAll('{{surveyUrl}}', surveyUrl)
+      .replaceAll('{{unsubscribeUrl}}', unsubscribeUrl);
 
     const msg = {
       to,

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_SENDER,
   MAGIC_LINK_TEMPLATE,
   PASSWORD_RESET_TEMPLATE,
+  RE_ENGAGEMENT_TEMPLATE,
   SUBSCRIPTION_CANCELLED_TEMPLATE,
   SUBSCRIPTION_CANCELLATIONS_LOG_PATH,
   SUBSCRIPTION_SCHEDULED_CANCELLATION_TEMPLATE,
@@ -47,6 +48,11 @@ export interface IEmailService {
     email: string,
     token: string,
     purpose: 'login' | 'password_reset'
+  ): Promise<void>;
+  sendReEngagementEmail(
+    to: string,
+    name: string,
+    token: string
   ): Promise<void>;
 }
 
@@ -213,6 +219,35 @@ class EmailService implements IEmailService {
       await sgMail.send(msg);
     } catch (error) {
       console.error('Failed to send magic link email:', error);
+      throw error;
+    }
+  }
+
+  async sendReEngagementEmail(
+    to: string,
+    name: string,
+    token: string
+  ): Promise<void> {
+    const domain = process.env.DOMAIN ?? 'https://2anki.net';
+    const surveyUrl = `${domain}/feedback/onboarding?uid=${token}`;
+    const unsubscribeUrl = `${domain}/unsubscribe?uid=${token}`;
+    const markup = RE_ENGAGEMENT_TEMPLATE.replace(/{{name}}/g, name)
+      .replace(/{{surveyUrl}}/g, surveyUrl)
+      .replace(/{{unsubscribeUrl}}/g, unsubscribeUrl);
+
+    const msg = {
+      to,
+      from: this.defaultSender,
+      subject: 'Still figuring out 2anki? We can help.',
+      text: `Hi ${name},\n\nYou signed up for 2anki a few days ago but haven't converted anything yet.\n\nWhen you're ready, visit https://2anki.net\n\nTell us what happened: ${surveyUrl}\n\nThe 2anki Team`,
+      html: markup,
+      replyTo: 'support@2anki.net',
+    };
+
+    try {
+      await sgMail.send(msg);
+    } catch (error) {
+      console.error('Failed to send re-engagement email:', error);
       throw error;
     }
   }
@@ -412,6 +447,14 @@ export class UnimplementedEmailService implements IEmailService {
     purpose: 'login' | 'password_reset'
   ): Promise<void> {
     console.info('sendMagicLinkEmail not handled');
+  }
+
+  async sendReEngagementEmail(
+    to: string,
+    name: string,
+    token: string
+  ): Promise<void> {
+    console.info('sendReEngagementEmail not handled', to, name, token);
   }
 }
 

--- a/src/services/EmailService/constants.ts
+++ b/src/services/EmailService/constants.ts
@@ -44,3 +44,8 @@ export const MAGIC_LINK_TEMPLATE = fs.readFileSync(
   path.join(EMAIL_TEMPLATES_DIRECTORY, 'magic-link.html'),
   'utf8'
 );
+
+export const RE_ENGAGEMENT_TEMPLATE = fs.readFileSync(
+  path.join(EMAIL_TEMPLATES_DIRECTORY, 're-engagement.html'),
+  'utf8'
+);

--- a/src/services/EmailService/templates/re-engagement.html
+++ b/src/services/EmailService/templates/re-engagement.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>2anki.net - Still figuring out 2anki?</title>
+  <style>
+    @media (prefers-color-scheme: dark) {
+      body { background-color: #1a1a1a !important; }
+      .email-card { background-color: #111827 !important; }
+      .email-header { color: #f9fafb !important; border-bottom-color: #374151 !important; }
+      .email-body p, .email-body li { color: #f9fafb !important; }
+      .email-body h1 { color: #f9fafb !important; }
+      .email-cta a { background-color: #60a5fa !important; }
+      .email-footer { color: #6b7280 !important; border-top-color: #374151 !important; }
+      .email-muted { color: #6b7280 !important; }
+      .video-caption { color: #9ca3af !important; }
+    }
+    @media only screen and (max-width: 600px) {
+      .email-card { width: 100% !important; padding: 0 !important; }
+      .email-body { padding: 24px 16px !important; }
+      .email-header { padding: 16px !important; }
+      .email-footer { padding: 12px 16px !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px;">
+          <tr>
+            <td class="email-header" style="text-align: center; padding: 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 20px; font-weight: 700; color: #1f2937; border-bottom: 1px solid #e5e7eb;">
+              2anki
+            </td>
+          </tr>
+          <tr>
+            <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
+              <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #1f2937;">Hi {{name}},</h1>
+              <p style="margin: 0 0 16px;">You signed up for 2anki a few days ago but haven't converted anything yet. That's okay — sometimes things come up.</p>
+              <div style="margin: 24px 0; text-align: center;">
+                <a href="https://www.youtube.com/watch?v=UnTo_fN1jpc" style="display: block;">
+                  <img src="https://img.youtube.com/vi/UnTo_fN1jpc/maxresdefault.jpg" alt="How 2anki works" width="100%" style="max-width: 600px; border-radius: 6px; display: block; margin: 0 auto;" />
+                </a>
+                <p class="video-caption" style="margin: 8px 0 0; font-size: 13px; color: #6b7280;">▶ Watch how it works (60 sec)</p>
+              </div>
+              <p style="margin: 0 0 16px;">When you're ready: drop a Notion page URL or upload a file at 2anki.net and you'll have an Anki deck in under a minute.</p>
+              <div style="text-align: center; margin: 24px 0;" class="email-cta">
+                <a href="{{surveyUrl}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Tell us what happened</a>
+              </div>
+              <p style="margin: 0 0 8px;">The 2anki Team</p>
+            </td>
+          </tr>
+          <tr>
+            <td class="email-footer" style="text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #9ca3af; padding: 16px 24px; border-top: 1px solid #e5e7eb;">
+              2anki.net — Turn what you study into Anki flashcards<br />
+              <a href="{{unsubscribeUrl}}" style="color: #9ca3af; text-decoration: underline;">Don't want emails like this? Unsubscribe</a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/services/EmailService/templates/re-engagement.html
+++ b/src/services/EmailService/templates/re-engagement.html
@@ -26,10 +26,10 @@
   </style>
 </head>
 <body style="margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+  <table style="width: 100%; background-color: #f5f5f5; border-collapse: collapse; border-spacing: 0;">
     <tr>
-      <td align="center" style="padding: 32px 16px;">
-        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px;">
+      <td style="padding: 32px 16px; text-align: center;">
+        <table class="email-card" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px; border-collapse: collapse; border-spacing: 0; margin: 0 auto;">
           <tr>
             <td class="email-header" style="text-align: center; padding: 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 20px; font-weight: 700; color: #1f2937; border-bottom: 1px solid #e5e7eb;">
               2anki
@@ -55,7 +55,7 @@
           <tr>
             <td class="email-footer" style="text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #9ca3af; padding: 16px 24px; border-top: 1px solid #e5e7eb;">
               2anki.net — Turn what you study into Anki flashcards<br />
-              <a href="{{unsubscribeUrl}}" style="color: #9ca3af; text-decoration: underline;">Don't want emails like this? Unsubscribe</a>
+              <a href="{{unsubscribeUrl}}" style="color: #6b7280; text-decoration: underline;">Don't want emails like this? Unsubscribe</a>
             </td>
           </tr>
         </table>

--- a/src/services/EmailService/templates/re-engagement.html
+++ b/src/services/EmailService/templates/re-engagement.html
@@ -26,10 +26,10 @@
   </style>
 </head>
 <body style="margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
-  <table style="width: 100%; background-color: #f5f5f5; border-collapse: collapse; border-spacing: 0;">
+  <table role="presentation" style="width: 100%; background-color: #f5f5f5; border-collapse: collapse; border-spacing: 0;">
     <tr>
       <td style="padding: 32px 16px; text-align: center;">
-        <table class="email-card" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px; border-collapse: collapse; border-spacing: 0; margin: 0 auto;">
+        <table role="presentation" class="email-card" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px; border-collapse: collapse; border-spacing: 0; margin: 0 auto;">
           <tr>
             <td class="email-header" style="text-align: center; padding: 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 20px; font-weight: 700; color: #1f2937; border-bottom: 1px solid #e5e7eb;">
               2anki

--- a/src/usecases/SubmitReEngagementFeedbackUseCase.test.ts
+++ b/src/usecases/SubmitReEngagementFeedbackUseCase.test.ts
@@ -1,0 +1,53 @@
+import { SubmitReEngagementFeedbackUseCase } from './SubmitReEngagementFeedbackUseCase';
+import { InMemoryReEngagementRepository } from '../data_layer/ReEngagementRepository';
+
+describe('SubmitReEngagementFeedbackUseCase', () => {
+  it('saves response when token is valid', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    await repo.recordSend(1, 'valid-token-abc');
+    const useCase = new SubmitReEngagementFeedbackUseCase(repo);
+
+    await useCase.execute({
+      token: 'valid-token-abc',
+      stoppedReason: 'too_complex',
+      contentType: 'notion',
+      comment: 'Was not sure how to use it',
+    });
+
+    const responses = repo.getResponses();
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({
+      stoppedReason: 'too_complex',
+      contentType: 'notion',
+      comment: 'Was not sure how to use it',
+    });
+  });
+
+  it('saves response with null comment when comment is omitted', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    await repo.recordSend(2, 'token-no-comment');
+    const useCase = new SubmitReEngagementFeedbackUseCase(repo);
+
+    await useCase.execute({
+      token: 'token-no-comment',
+      stoppedReason: 'forgot',
+      contentType: 'upload',
+    });
+
+    const responses = repo.getResponses();
+    expect(responses[0].comment).toBeNull();
+  });
+
+  it('throws when token is not found', async () => {
+    const repo = new InMemoryReEngagementRepository();
+    const useCase = new SubmitReEngagementFeedbackUseCase(repo);
+
+    await expect(
+      useCase.execute({
+        token: 'nonexistent-token',
+        stoppedReason: 'forgot',
+        contentType: 'upload',
+      })
+    ).rejects.toThrow('Invalid or expired survey token.');
+  });
+});

--- a/src/usecases/SubmitReEngagementFeedbackUseCase.ts
+++ b/src/usecases/SubmitReEngagementFeedbackUseCase.ts
@@ -1,0 +1,25 @@
+import type { IReEngagementRepository } from '../data_layer/ReEngagementRepository';
+
+export interface ReEngagementFeedbackInput {
+  token: string;
+  stoppedReason: string;
+  contentType: string;
+  comment?: string | null;
+}
+
+export class SubmitReEngagementFeedbackUseCase {
+  constructor(private readonly repo: IReEngagementRepository) {}
+
+  async execute(input: ReEngagementFeedbackInput): Promise<void> {
+    const record = await this.repo.findByToken(input.token);
+    if (record == null) {
+      throw new Error('Invalid or expired survey token.');
+    }
+    await this.repo.saveResponse(
+      record.id,
+      input.stoppedReason,
+      input.contentType,
+      input.comment ?? null
+    );
+  }
+}

--- a/src/usecases/UpdateEmailPreferencesUseCase.test.ts
+++ b/src/usecases/UpdateEmailPreferencesUseCase.test.ts
@@ -1,0 +1,23 @@
+import { UpdateEmailPreferencesUseCase } from './UpdateEmailPreferencesUseCase';
+import { InMemoryEmailPreferencesRepository } from '../data_layer/EmailPreferencesRepository';
+
+describe('UpdateEmailPreferencesUseCase', () => {
+  it('opt out sets marketing_opt_out to true', async () => {
+    const repo = new InMemoryEmailPreferencesRepository();
+    const useCase = new UpdateEmailPreferencesUseCase(repo);
+
+    await useCase.execute({ userId: 1, marketingOptOut: true });
+
+    expect(await repo.isOptedOut(1)).toBe(true);
+  });
+
+  it('opt in sets marketing_opt_out to false', async () => {
+    const repo = new InMemoryEmailPreferencesRepository();
+    await repo.optOut(1);
+    const useCase = new UpdateEmailPreferencesUseCase(repo);
+
+    await useCase.execute({ userId: 1, marketingOptOut: false });
+
+    expect(await repo.isOptedOut(1)).toBe(false);
+  });
+});

--- a/src/usecases/UpdateEmailPreferencesUseCase.ts
+++ b/src/usecases/UpdateEmailPreferencesUseCase.ts
@@ -1,0 +1,18 @@
+import type { IEmailPreferencesRepository } from '../data_layer/EmailPreferencesRepository';
+
+export interface UpdateEmailPreferencesInput {
+  userId: number;
+  marketingOptOut: boolean;
+}
+
+export class UpdateEmailPreferencesUseCase {
+  constructor(private readonly repo: IEmailPreferencesRepository) {}
+
+  async execute(input: UpdateEmailPreferencesInput): Promise<void> {
+    if (input.marketingOptOut) {
+      await this.repo.optOut(input.userId);
+    } else {
+      await this.repo.optIn(input.userId);
+    }
+  }
+}

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -163,12 +163,6 @@
   text-decoration: underline;
 }
 
-.sidebarCopyright {
-  margin-top: 0.5rem;
-  font-size: var(--text-xs);
-  color: var(--color-text-tertiary);
-  white-space: nowrap;
-}
 
 .main {
   display: flex;

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -204,7 +204,7 @@ describe('Sidebar group hierarchy', () => {
 });
 
 describe('Sidebar More block', () => {
-  it('renders the footer links and copyright', () => {
+  it('renders the footer links', () => {
     renderSidebar();
     expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute(
       'href',
@@ -222,6 +222,5 @@ describe('Sidebar More block', () => {
       'href',
       '/documentation/misc/privacy-policy'
     );
-    expect(screen.getByText(/Alexander Alemayhu/)).toBeInTheDocument();
   });
 });

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -275,9 +275,7 @@ export function Sidebar({
             {getVisibleText('navigation.legal.about')}
           </Link>
         </div>
-        <div className={styles.sidebarCopyright}>
-          &copy; 2020&ndash;{new Date().getFullYear()} Alexander Alemayhu
-        </div>
+
       </div>
     </aside>
   );

--- a/web/src/components/CardOptionsForm/CardOptionsForm.module.css
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.module.css
@@ -99,3 +99,12 @@
 .actionButton {
   width: auto;
 }
+
+@media (max-width: 600px) {
+  .actions {
+    flex-direction: column;
+  }
+  .actionButton {
+    width: 100%;
+  }
+}

--- a/web/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -13,12 +13,6 @@
   gap: 0.75rem;
 }
 
-.widgetCompact .emojiButton {
-  width: 36px;
-  height: 36px;
-  font-size: 1.25rem;
-}
-
 .prompt {
   font-size: var(--text-base);
   font-weight: var(--font-medium);
@@ -28,17 +22,18 @@
 
 .emojiRow {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
   justify-content: center;
+  align-items: center;
 }
 
 .emojiButton {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
-  font-size: 1.75rem;
+  width: 36px;
+  height: 36px;
+  font-size: 1.125rem;
   background: var(--color-bg-tertiary);
   border: 2px solid transparent;
   border-radius: var(--radius-full);
@@ -48,14 +43,14 @@
 }
 
 .emojiButton:hover {
-  transform: scale(1.15);
+  transform: scale(1.1);
   background: var(--color-bg-secondary);
 }
 
 .emojiSelected {
   border-color: var(--color-primary);
   background: var(--color-primary-light);
-  transform: scale(1.2);
+  transform: scale(1.12);
 }
 
 .commentInput {

--- a/web/src/components/NavigationBar/NavigationBar.module.css
+++ b/web/src/components/NavigationBar/NavigationBar.module.css
@@ -91,7 +91,7 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 0.25rem;
+  gap: 0;
   padding: 0.5rem 0;
 }
 
@@ -106,7 +106,7 @@
 
 .navLink {
   display: block;
-  padding: 0.5rem 0.75rem;
+  padding: 0.75rem 0.75rem;
   color: var(--color-text-secondary);
   text-decoration: none;
   font-size: var(--text-sm);

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -281,3 +281,14 @@
   color: inherit;
   opacity: 0.85;
 }
+
+@media (max-width: 500px) {
+  .profileSection {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .planHeader {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+}

--- a/web/src/pages/DocsPage/DocsPage.module.css
+++ b/web/src/pages/DocsPage/DocsPage.module.css
@@ -1,14 +1,15 @@
 .layout {
   display: grid;
-  grid-template-columns: 260px minmax(0, 1fr);
-  gap: 2.5rem;
+  grid-template-columns: 1fr;
+  gap: 1rem;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem 1.5rem 4rem;
+  padding: 1.25rem 1rem 3rem;
   align-items: start;
 }
 
 .sidebarWrapper {
+  display: none;
   position: sticky;
   top: 1.5rem;
   align-self: start;
@@ -436,7 +437,7 @@
 
 .pager {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 1rem;
   margin-top: 1.5rem;
   padding-top: 1.5rem;
@@ -486,7 +487,7 @@
 }
 
 .docsHomeTitle {
-  font-size: var(--text-4xl);
+  font-size: var(--text-3xl);
   font-weight: var(--font-bold);
   letter-spacing: var(--tracking-tight);
   margin: 0 0 0.5rem;
@@ -621,7 +622,7 @@
 }
 
 .menuButton {
-  display: none;
+  display: inline-block;
   padding: 0.5rem 0.875rem;
   border: 1px solid var(--color-border);
   background: var(--color-bg-primary);
@@ -716,23 +717,22 @@
   display: none;
 }
 
-@media (max-width: 900px) {
+@media (min-width: 901px) {
   .layout {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-    padding: 1.25rem 1rem 3rem;
+    grid-template-columns: 260px minmax(0, 1fr);
+    gap: 2.5rem;
+    padding: 2rem 1.5rem 4rem;
   }
   .menuButton {
-    display: inline-block;
-    justify-self: start;
-  }
-  .sidebarWrapper {
     display: none;
   }
+  .sidebarWrapper {
+    display: block;
+  }
   .pager {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr 1fr;
   }
   .docsHomeTitle {
-    font-size: var(--text-3xl);
+    font-size: var(--text-4xl);
   }
 }

--- a/web/src/pages/DownloadsPage/DownloadsPage.module.css
+++ b/web/src/pages/DownloadsPage/DownloadsPage.module.css
@@ -10,6 +10,8 @@
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+  flex-wrap: wrap;
+  row-gap: 0.75rem;
 }
 
 .headerCopy {
@@ -138,6 +140,11 @@
 .fileName {
   font-weight: var(--font-medium);
   color: var(--color-text-primary);
+  max-width: 180px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
 }
 
 .timeAgo {

--- a/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
+++ b/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
@@ -54,6 +54,7 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
         Your flashcard decks are ready. Download them into Anki.
       </p>
       <div className={styles.card}>
+        <div style={{ overflowX: 'auto' }}>
         <table className={styles.table}>
           <thead>
             <tr>
@@ -158,6 +159,7 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
             ))}
           </tbody>
         </table>
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -646,4 +646,9 @@
   .cardPriceLineRange .cardPriceSuffix {
     font-size: 1.25rem;
   }
+
+  .cardPro {
+    transform: none;
+    animation-name: cardFadeIn;
+  }
 }

--- a/web/src/pages/SearchPage/SearchPage.module.css
+++ b/web/src/pages/SearchPage/SearchPage.module.css
@@ -27,7 +27,7 @@
   border: none;
   border-bottom: 2px solid var(--color-border);
   background: transparent;
-  font-size: var(--text-2xl);
+  font-size: var(--text-xl);
   font-weight: var(--font-semibold);
   padding: 0.375rem 0;
   color: var(--color-text-primary);
@@ -37,7 +37,7 @@
 }
 
 .searchInput[type='text'] {
-  font-size: var(--text-2xl);
+  font-size: var(--text-xl);
 }
 
 .searchInput::placeholder {
@@ -97,6 +97,7 @@
   background: var(--color-bg-primary);
   border-radius: var(--radius-lg);
   padding: 0 1.5rem 1.5rem;
+  padding-top: 0.5rem;
   box-shadow: var(--shadow-sm);
 }
 
@@ -116,6 +117,13 @@
   border-radius: var(--radius-full);
   background: var(--color-success);
   flex-shrink: 0;
+}
+
+@media (min-width: 480px) {
+  .searchInput,
+  .searchInput[type='text'] {
+    font-size: var(--text-2xl);
+  }
 }
 
 @media (min-width: 769px) {

--- a/web/src/pages/UploadPage/UploadPage.module.css
+++ b/web/src/pages/UploadPage/UploadPage.module.css
@@ -161,7 +161,7 @@
   line-height: var(--leading-snug);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 768px) {
   .walkthroughGrid {
     grid-template-columns: 1fr;
   }

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -94,6 +94,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
             to="?view=template"
             onClick={() => setShowCardOptionsModal(true)}
             aria-label="Card and deck options"
+            style={{ minWidth: '44px', minHeight: '44px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center' }}
           >
             <SettingsIcon />
           </Link>

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -493,7 +493,7 @@
 @media (max-width: 600px) {
   .dropZone {
     padding: 2rem 1rem;
-    min-height: 200px;
+    min-height: 280px;
   }
 
   .emptyActions,

--- a/web/src/styles/auth.module.css
+++ b/web/src/styles/auth.module.css
@@ -169,3 +169,12 @@
   width: auto;
   margin-top: 0.125rem;
 }
+
+@media (max-width: 480px) {
+  .formPage {
+    padding: 1.5rem 1rem;
+  }
+  .formCard {
+    padding: 2rem 1.25rem;
+  }
+}

--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -720,6 +720,16 @@
   .pageWide {
     padding: 2rem 1rem;
   }
+
+  .btnIcon {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  .btnSmallPill {
+    min-height: 40px;
+    padding: 0.5rem 0.875rem;
+  }
 }
 
 .formDescription {


### PR DESCRIPTION
## What

Adds a daily re-engagement email job that contacts users who signed up 3–4 days ago and have never converted anything, plus applies 13 targeted mobile CSS fixes across the web app.

## Why

Users who sign up but never convert are the highest-leverage cohort for improving activation. The re-engagement email gives them one warm nudge with a demo video and a short survey, surfacing friction we don't currently capture. The mobile fixes address layout/usability regressions on small screens that create friction on the conversion path.

## How

**Re-engagement flow:**
- Two new Knex migrations: `re_engagement_emails` (one-send-per-user guard via unique token) and `re_engagement_feedback` (survey responses). A third migration adds `email_preferences` with `marketing_opt_out` support for an unsubscribe link.
- `ReEngagementRepository` queries users created 3–4 days ago with no uploads and no prior email. Respects opt-out via `email_preferences` table join. Limit 500/run.
- `sendReEngagementEmails` job: pure function injecting `IReEngagementRepository` + `IEmailService`. Errors per-user are caught and logged; the loop continues to the next user.
- Email template mirrors `magic-link.html` structure, includes YouTube thumbnail for the 60-second walkthrough video, and a "Tell us what happened" CTA linking to the onboarding survey.
- `ReEngagementController` exposes GET `/feedback/onboarding` (token validation), POST `/feedback/onboarding` (survey submission), and GET `/unsubscribe` (opt-out). No auth middleware.
- Daily `setInterval` in `server.ts` startup block, following the same pattern as other cleanup jobs.

**13 mobile CSS fixes:**
P1: DocsPage mobile-first refactor, DownloadsPage table overflow + filename truncation, UploadPage grid breakpoint + touch target.
P2: NavigationBar gap/padding, CardOptionsForm column stack, AccountPage profile wrap, DownloadsPage header wrap, PricingPage Pro card elevation removed on mobile.
P3: UploadForm dropzone height, SearchPage font scale, auth form padding, shared button touch targets.

## Testing

- Unit tests added: 49 (repository, job helper, usecase, controller, router)
- Server tsc: clean
- Web typecheck: clean
- Web vitest: 278/278 pass
- Web Biome lint: clean

## Risks

The `setInterval` for the daily job is registered unconditionally at startup. It runs at a 24-hour cadence and will only fire in environments where `SENDGRID_API_KEY` is set (the `UnimplementedEmailService` no-ops without it). No rollback needed — the tables can be left empty and the router returns 404 for unknown tokens.

## Goal alignment

Activation improvement is the clearest path to 300K users. Recovering users who signed up but didn't convert is the highest-ROI engagement lever we have. The mobile fixes remove friction on the primary conversion path for the ~50% of users on mobile.