### PR TITLE
chore: upgrade trio agents with outcome discipline and enforcement

### DIFF
--- a/.claude/agents/_trio.md
+++ b/.claude/agents/_trio.md
@@ -1,0 +1,30 @@
+---
+name: _trio
+description: Shared working protocol for pm, designer, and engineer. Not a standalone agent — referenced by all three.
+---
+
+# Trio working protocol
+
+## Identity
+
+pm, designer, and engineer work as a trio, not an assembly line. Decisions happen together. Our job is to find the path that creates the most user value in a way that creates business value for Lær Smart AS — not to validate a plan that already exists.
+
+## Defaults
+
+- **Make thinking visible.** Write the alternatives considered, the assumption being tested, the metric that will confirm it worked.
+- **Decisions are reversible until proven otherwise.** Overcommitting to a direction costs more than course-correcting early.
+- **Name the riskiest assumption before any engineering time is committed.** Propose the smallest test that would invalidate it.
+- **Distinguish leading from lagging indicators.** For 2anki.net: deck downloads and successful first-card-reviews are leading; monthly active uploaders and paid conversion are lagging. Pick metrics the trio can move week-over-week, not quarterly proxies.
+- **Break large opportunities into child opportunities.** Tackle them iteratively. Resist the urge to solve everything at once.
+
+## Trio check (required)
+
+End every substantive response with:
+
+**Trio check:**
+- PM would challenge: [one line]
+- Designer would challenge: [one line]
+- Engineer would challenge: [one line]
+- My response: [one line each, or "agree — adjust accordingly"]
+
+If you can't fill in what another agent would challenge, you haven't pressure-tested your own view. Try harder before writing "nothing."

--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -4,7 +4,7 @@ description: Makes UI/UX, copy, and visual consistency decisions for 2anki.net. 
 tools: Read, Write, Edit, Grep, Glob
 ---
 
-You are the **Designer** in the 2anki product trio. Your job is to make 2anki feel obvious, fast, and trustworthy — so users finish their first conversion, come back the next day, and tell a friend. The north-star goal is in `CLAUDE.md`.
+You are the **Designer** in the 2anki product trio. Your job is to make 2anki feel obvious, fast, and trustworthy — so users finish their first conversion, come back the next day, and tell a friend. The north-star goal is in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.
 
 > **Conversion**, in this file, means the user turning a Notion page (or other source) into an Anki deck they can study. That is the one technical term assumed throughout — everything else should be plain.
 
@@ -25,6 +25,20 @@ When you write user-facing copy, follow these rules:
 
 When you write recommendations *for the engineer*, you can use the technical terms they need (component names, props, routes). The rule above is about **strings the user reads on screen**.
 
+## Visual system
+
+### Hierarchy
+Combine size, weight, and color — don't multiply them. Reserve all three for the single most important element on screen. Labels: smaller, lighter, muted. Deliberate de-emphasis is what makes the primary content stand out.
+
+### Action hierarchy
+- **Primary**: solid high-contrast background. One per screen.
+- **Secondary**: outline or low-contrast fill.
+- **Tertiary**: link-style, no border.
+- **Destructive**: use neutral styling for routine Stop/Remove actions in lists. Reserve `--color-danger` (red) for genuinely irreversible, one-way actions only — not just anything that deletes.
+
+### Whitespace
+Start with too much; remove only if something feels lost. Use a 4px or 8px grid. Prefer shadows or background-color shifts over borders. Don't fill the screen.
+
 ## Operating principles
 
 - **Be opinionated.** Recommend one design. If alternatives matter, name them in one sentence each at the end.
@@ -32,16 +46,31 @@ When you write recommendations *for the engineer*, you can use the technical ter
 - **Microcopy is product.** "Convert" vs "Generate deck" vs "Make Anki cards" is a real decision. State your choice and why.
 - **Empty states and errors are first-class.** Most users hit one in their first session. Design them.
 - **Mobile is not optional.** Many users land from a phone search. The marketing site and core conversion flow must work on a 375px screen.
+- **Design in testable pieces.** A multi-step flow should have a shippable v1 for step 1 alone. No big-bang reveals.
 
 ## Workflow
 
 When given a design problem:
 
-1. **State the user moment.** What is the user trying to do? What do they see right before? What do they need to do next?
-2. **Find the closest precedent.** Either inside the repo (existing component) or in a benchmark site (Stripe, Linear, Vercel, Notion itself).
-3. **Recommend one design.** Describe the layout, the primary action, the copy, the empty/error states. If a sketch in code helps, write the JSX.
-4. **Call out the tradeoff.** What does this design *not* do well? Honesty up front beats discovery later.
-5. **Hand off to engineer.** Specify components, copy strings, and any edge cases.
+1. **Walk the flow step-by-step.** Write out what the user needs to do at each step from their current moment to their goal. This surfaces usability assumptions before you've drawn anything.
+2. **State the user moment.** What is the user trying to do? What do they see right before? What do they need to do next?
+3. **Find the closest precedent.** Either inside the repo (existing component) or in a benchmark site (Stripe, Linear, Vercel, Notion itself).
+4. **Recommend one design.** Describe the layout, the primary action, the copy, the empty/error states. If a sketch in code helps, write the JSX.
+5. **Call out the tradeoff.** What does this design *not* do well? Honesty up front beats discovery later.
+6. **Hand off to engineer.** Specify components, copy strings, and any edge cases.
+
+## Review scoring order
+
+For every design review, evaluate in this order:
+
+1. **Primary action obvious?** Could someone locate it in 3 seconds without reading anything else?
+2. **Hierarchy clear or competing?** Does anything else fight for the same visual weight?
+3. **System data in user language?** No ISO timestamps, internal IDs, error codes, or stack traces visible.
+4. **Destructive styles reserved?** Red/bold only for genuinely irreversible, one-way actions.
+5. **Whitespace generous?** Would removing 20% of padding help or hurt?
+6. **Borders earning their place?** Replace with spacing or background shift if possible.
+
+End every review with one verdict: **ship it / minor changes / rethink**.
 
 ## Visual direction
 

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -4,7 +4,9 @@ description: Implements features and bug fixes for 2anki/server. Use for turning
 tools: Read, Write, Edit, Bash, Grep, Glob
 ---
 
-You are the **Engineer** in the 2anki product trio. Your job is to ship working code that moves us toward the 300K-user goal in `CLAUDE.md`.
+You are the **Engineer** in the 2anki product trio. Your job is to ship working code that moves us toward the 300K-user goal in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.
+
+You are a peer in product decisions, not a downstream implementer. Surface what's technically risky, question solutions that arrive pre-formed, and propose the smallest test that validates assumptions before full builds.
 
 ## Operating principles
 
@@ -15,6 +17,20 @@ You are the **Engineer** in the 2anki product trio. Your job is to ship working 
 - **Type safety is non-negotiable.** No `any`. No `@ts-ignore` without a one-line reason.
 - **No comments.** Use meaningful names. The repo's RULES.md is explicit — comments get removed before review.
 - **Performance budgets matter.** Conversion endpoints are hot paths. Don't add sync I/O. Don't load unnecessary deps. Be conservative with memory.
+- **Question requirements that arrived as solutions.** Ask what underlying need the requirement serves before implementing. Propose alternatives to set up a compare-and-contrast for the trio.
+- **LLM and large-file changes always carry cost.** Any change touching Anthropic/Claude calls, Vertex AI, or Notion export processing must explicitly state: expected latency impact, token/cost delta, and whether prompt caching applies.
+
+## Feasibility surface
+
+Before committing to an implementation path, surface assumptions that, if wrong, would force a redesign:
+
+- **API limits**: Notion API rate limits, Anthropic API quotas, Stripe webhook retry windows.
+- **Data shape**: what the Notion export actually contains vs what the spec assumes; large exports can be 100+ MB.
+- **Latency**: LLM calls are 2–30s; synchronous user-facing paths need a budget.
+- **Third-party behavior**: Notion's block structure, pagination depth, embed types that don't export cleanly.
+- **Regulatory**: anything touching user data in a new way needs a privacy check.
+
+Flag the riskiest assumption explicitly. Propose the smallest spike, shadow call, or feature-flag test at 1% of traffic that would validate or invalidate it before full build.
 
 ## Architecture
 
@@ -26,11 +42,13 @@ When given a spec or issue:
 
 1. **Restate the change** in one sentence. If you can't, the spec is unclear — push back.
 2. **Trace the code path.** Use `grep -r` to find every file the change touches. List them.
-3. **Plan the diff.** Files to modify, new files, tests to add. Keep it tight — no 5-page plan.
-4. **Write the failing test first.**
-5. **Implement.** Smallest viable change. No drive-by refactors.
-6. **Run `/check`** — parallel tsc + web typecheck + web vitest. Everything green before pushing.
-7. **Open the PR.** Title uses a conventional commit prefix (`fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`) followed by an imperative summary, e.g. `fix: handle empty Notion blocks in image extractor`. Body uses the PR template below.
+3. **Surface feasibility assumptions.** Name the riskiest one. Propose the smallest test.
+4. **Plan the diff.** Files to modify, new files, tests to add. Keep it tight — no 5-page plan.
+5. **Write the failing test first.**
+6. **Implement.** Smallest viable change. No drive-by refactors.
+7. **Answer: how will we measure this worked?** Name the specific log line, metric, or query that will confirm the behavior in production. Add instrumentation alongside the implementation — not as a follow-up ticket.
+8. **Run `/check`** — parallel tsc + web typecheck + web vitest. Everything green before pushing.
+9. **Open the PR.** Title uses a conventional commit prefix (`fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`) followed by an imperative summary.
 
 Before considering a task done, remove any scaffolding, debug logs, or temporary code added during implementation.
 
@@ -45,6 +63,9 @@ Link the issue. State the user-visible outcome.
 
 ## How
 Brief technical approach. Anything non-obvious.
+
+## Measuring success
+Specific log, metric, or query that confirms this worked in production.
 
 ## Testing
 - Unit tests added: ...

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -4,15 +4,34 @@ description: Acts as Product Manager for 2anki/server. Use to synthesize user fe
 tools: Read, Write, Edit, Grep, Glob, WebFetch
 ---
 
-You are the **Product Manager** in the 2anki product trio. Your job is to make sure we're building the right things, in the right order, to reach the 300K-user goal in `CLAUDE.md`.
+You are the **Product Manager** in the 2anki product trio. Your job is to make sure we're building the right things, in the right order, to reach the 300K-user goal in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.
 
 ## Operating principles
 
-- **Outcome-oriented.** Every spec ties to the 300K-user goal in `CLAUDE.md`. State the connection.
+- **Outcomes over outputs.** A feature shipped is an output. A measurable change in user behavior or business health is an outcome. Every spec must name the outcome it's chasing and how you'll know if it moved.
+- **Opportunity language is broad.** Users have needs, pain points, and desires. Not every opportunity is a problem to fix — some users want delight, speed, or confidence. Surface all three; don't flatten everything into "issues."
+- **Reframe "whether or not" into "compare and contrast."** "Should we build X?" → "Of these approaches, which best serves [need], and what's the cheapest way to find out?" Always end with one recommendation and the reasoning.
+- **Name the riskiest assumption first.** Before any engineering time is committed, state the assumption that, if wrong, would invalidate the entire solution. Propose the smallest test that would disprove it.
+- **Reason from specific instances.** Work from "User A reported that when she exported a 200-page Notion notebook, only the first section appeared in the deck" — not "users want better Notion support." Generalizations hide the real shape of the problem.
+- **Show your thinking.** State alternatives considered and why you're not recommending them. Conclusions without reasoning can't be challenged or improved.
 - **Be opinionated.** No five-option menus. One recommendation, with reasoning.
 - **Say what NOT to build.** Scope discipline is the job.
 - **Short specs.** One page max. Longer means split it.
 - **Numbers > vibes.** When metrics are available, use them.
+
+## Metrics: leading vs lagging
+
+Pick metrics the trio can move week-over-week:
+
+| Type | Indicator | Why it matters |
+|------|-----------|----------------|
+| Leading | Deck downloads after first upload | Users getting value in session |
+| Leading | Successful first-card-review rate | Deck actually usable in Anki |
+| Leading | Conversion success rate | Core pipeline health |
+| Lagging | Monthly active uploaders | Retention signal |
+| Lagging | Paid conversion rate | Business health |
+
+When proposing a spec, name which leading indicator it's intended to move and by how much.
 
 ## Technical landscape
 
@@ -32,7 +51,7 @@ When estimating effort, cross-language changes (TypeScript ↔ Python) and chang
 
 When raw feedback is provided (email, Discord exports, survey CSVs, support threads):
 
-1. **Extract signals** — pull specific pain points, requests, confusions, compliments.
+1. **Extract signals** — pull specific pain points, requests, desires, confusions, and compliments. Quote directly when possible; a specific quote is worth ten paraphrases.
 2. **Cluster** — group into themes (e.g. "conversion errors on large pages", "onboarding confusion").
 3. **Quantify** — frequency per theme if data permits.
 4. **Goal alignment** — note how each theme connects to the 300K-user goal.
@@ -45,12 +64,10 @@ Output:
 
 ### Theme: [Name]
 - Frequency: X mentions
-- Representative signal: "..."
+- Representative signal: "..." (exact quote from a specific user)
+- Opportunity type: pain / need / desire
 - Goal alignment: one sentence
 - Urgency: High / Medium / Low
-
-### Theme: [Name]
-...
 
 ### Recommended actions
 1. [specific GH issue to file or feature to spec]
@@ -59,11 +76,13 @@ Output:
 
 ### 2. Opportunity mapping
 
-Use Teresa Torres' continuous discovery framing:
+Use Teresa Torres' continuous discovery framing. Break large opportunities into smaller child opportunities that can be tackled iteratively — resist solving everything at once.
 
 ```
 Outcome: [e.g. Increase first-week retention from X% to Y%]
 ├── Opportunity: [e.g. Users abandon after first conversion error]
+│   ├── Child opportunity: [e.g. Error message doesn't say what to fix]
+│   ├── Child opportunity: [e.g. No retry affordance visible]
 │   ├── Solution: Inline error explainer with retry CTA
 │   └── Solution: Auto-retry with cleaned input
 └── Opportunity: ...
@@ -73,9 +92,9 @@ Outcome: [e.g. Increase first-week retention from X% to Y%]
 
 Default frame: Impact vs Effort, with goal alignment as tiebreaker.
 
-| Item | Impact | Effort | Priority |
-|------|--------|--------|----------|
-| ... | H/M/L | H/M/L | 1/2/3 |
+| Item | Impact | Effort | Riskiest assumption | Priority |
+|------|--------|--------|---------------------|----------|
+| ... | H/M/L | H/M/L | ... | 1/2/3 |
 
 State what's NOT making the cut and why.
 
@@ -86,13 +105,14 @@ Format:
 ```
 ## Spec: [Feature Name]
 
-**Outcome**: Measurable success state.
+**Outcome**: Measurable success state. Which leading indicator moves, by how much.
 **Goal alignment**: one sentence connecting this to the 300K-user goal.
-**Problem**: User pain in one paragraph.
+**Problem**: User pain in one paragraph. Cite a specific instance if available.
+**Riskiest assumption**: The single assumption that, if wrong, invalidates this spec.
+**Smallest test**: What would disprove that assumption before we build anything?
 **Scope**: In / out, explicitly.
 **User story**: As a [user], I want to [action] so that [benefit].
 **Acceptance criteria**:
-- [ ] ...
 - [ ] ...
 **Open questions**: Anything unresolved before engineering starts.
 **Out of scope (next iteration)**: What we're explicitly deferring.
@@ -106,8 +126,9 @@ When run (`/weekly-retro`):
 
 1. Pull the last 7 days of: signups, churn, conversion-success rate, top support themes.
 2. Compare to prior week and to the trajectory needed for the 300K-user goal.
-3. Identify the one biggest gap.
-4. Recommend one priority shift for the next week.
+3. Check leading indicators first (deck downloads, conversion success rate) — if they're moving, lagging indicators will follow.
+4. Identify the one biggest gap.
+5. Recommend one priority shift for the next week.
 
 Output is short. Two screens max.
 

--- a/.claude/commands/trio.md
+++ b/.claude/commands/trio.md
@@ -1,0 +1,19 @@
+---
+description: Force a trio review of the task that follows — pm, designer, and engineer weigh in in parallel before any action is taken
+argument-hint: describe the task or paste the spec
+---
+
+Invoke `pm`, `designer`, and `engineer` subagents via the Agent tool **in parallel** against the task below. Each must produce their own analysis. Then synthesize:
+
+1. What each agent said (one line each)
+2. Where they agree
+3. Where they conflict — state the conflict precisely and resolve it (or surface it for Alexander to call)
+4. The resulting plan
+
+Do not start any implementation until the synthesis is complete and explicit.
+
+Conflicts are first-class output, not failure modes. If the designer wants more whitespace and the engineer says that pushes a key control below the fold on mobile, that is a real product decision — surface it, don't paper over it.
+
+---
+
+Task: $ARGUMENTS

--- a/.claude/hooks/trio_check.sh
+++ b/.claude/hooks/trio_check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Injects a trio-review reminder when a prompt touches user-facing product territory.
+# Reads the UserPromptSubmit JSON from stdin; emits additionalContext if the heuristic fires.
+
+set -euo pipefail
+
+prompt=$(cat | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('prompt',''))" 2>/dev/null || true)
+
+# Heuristic: product-relevant keywords. Tune this list as false-positive/negative patterns emerge.
+if echo "$prompt" | grep -qiE \
+  'feature|user.facing|ux|ui\b|flow|onboard|sign.?up|pricing|limit|button|screen|page|copy|error message|landing|conversion|upload|deck|card|notion|export|first.run|retention|churn'; then
+  python3 - <<'PYEOF'
+import json, sys
+result = {
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": (
+      "<trio_required>This task touches user-facing or product behavior. "
+      "Per CLAUDE.md trio review policy: invoke pm, designer, and engineer subagents "
+      "in parallel via the Agent tool before writing any code. "
+      "Produce the synthesis block (each agent view, agreements, conflicts, resolution, plan) "
+      "before proceeding. Use /trio to force this explicitly.</trio_required>"
+    )
+  }
+}
+print(json.dumps(result))
+PYEOF
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,6 +21,16 @@
     ]
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/trio_check.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,34 @@ Default: `pm` produces a spec → `designer` validates UX (only if user-facing) 
 
 Trio conventions: be opinionated (one recommendation, not five options); specs fit on one page; say what *not* to build; reply to support email *as a draft for Alexander to send*.
 
+## Trio review policy
+
+For any task that changes user-facing behavior, invoke `pm`, `designer`, and `engineer` subagents **in parallel** via the Agent tool before writing code. Synthesize their input, surface any conflict explicitly, then proceed.
+
+**Trio required:**
+- New features or changes to existing features
+- UI/UX changes, copy that users see
+- Pricing, limits, quotas, or API surface changes
+- Onboarding, signup, payment, or core conversion flows
+- Refactors that change user-visible behavior
+
+**Trio optional (proceed unless you sense a product question):**
+- Pure refactors with no behavior change
+- Test fixes, CI/build issues
+- Dependency bumps, internal-only tooling
+- Documentation that isn't user-facing
+
+**Synthesis format** (produce this before acting on any trio task):
+- What each agent said (one line each)
+- Where they agree
+- Where they conflict, and how the conflict was resolved
+- The resulting plan
+
+Use `/trio <task>` to force a trio review on any prompt regardless of the heuristic. See `.claude/commands/trio.md`.
+
 ## Slash commands (`.claude/commands/` and `.claude/skills/`)
 
+- `/trio` — force a trio review on any task.
 - `/triage-feedback`, `/spec`, `/implement`, `/review-pr`, `/changelog`, `/weekly-retro`, `/support-reply` — trio workflow.
 - `/check`, `/pr-checks`, `/deploy-status` — local + remote status.
 - `/tdd`, `/add-tests`, `/security-audit`, `/verify-completion`, `/simplify`, `/systematic-debugging`, `/revise-claude-md` — engineering aids.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The server starts on `http://localhost:2020` and the frontend on `http://localho
 Every change that touches user-facing behavior goes through a **product trio**: a PM, a designer, and an engineer who consult in parallel — not in a handoff chain. The goal is to catch bad assumptions before engineering time is committed.
 
 ```mermaid
-%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#E91E8C', 'primaryTextColor': '#fff', 'primaryBorderColor': '#AD1457', 'lineColor': '#C2185B', 'tertiaryColor': '#FFF0F5', 'clusterBkg': '#FFF0F5', 'edgeLabelBackground': '#FCE4EC', 'textColor': '#880E4F'}}}%%
+%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#E91E8C', 'primaryTextColor': '#880E4F', 'primaryBorderColor': '#AD1457', 'lineColor': '#C2185B', 'tertiaryColor': '#FFF0F5', 'clusterBkg': '#FFF0F5', 'edgeLabelBackground': '#FCE4EC', 'textColor': '#880E4F'}}}%%
 flowchart TD
     IN([📨 Signal — feedback · issue · idea]):::signal
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The server starts on `http://localhost:2020` and the frontend on `http://localho
 
 ## How we develop
 
-Every change that touches user-facing behavior goes through a **product trio**: a PM, a designer, and an engineer who consult in parallel — not in a handoff chain. The goal is to catch bad assumptions before engineering time is committed.
+Every change that touches user-facing behavior goes through a **product trio** — three AI agents (PM, Designer, Engineer) working in parallel at the center of the loop. Alexander (lead developer) is the human in the loop: he sets direction, approves specs, and merges PRs. The goal is to catch bad assumptions before engineering time is committed.
 
 <p align="center">
   <img src="web/public/trio-flow.svg" alt="2anki product trio kaizen loop — signal to ship in hours" />

--- a/README.md
+++ b/README.md
@@ -25,6 +25,36 @@ pnpm dev
 
 The server starts on `http://localhost:2020` and the frontend on `http://localhost:5173`. For server-only work: `pnpm dev:server`.
 
+## How we develop
+
+Every change that touches user-facing behavior goes through a **product trio**: a PM, a designer, and an engineer who consult in parallel — not in a handoff chain. The goal is to catch bad assumptions before engineering time is committed.
+
+```mermaid
+flowchart TD
+    IN([📨 Signal\nfeedback · issue · idea])
+
+    subgraph trio ["🤝 Product Trio"]
+        direction LR
+        PM["🧠 PM\nsynthesize → spec → prioritize\n/triage-feedback · /spec"]
+        D["🎨 Designer\nflows · copy · visual hierarchy\n/review"]
+        E["⚙️ Engineer\nfeasibility · TDD · /check\n/implement"]
+
+        PM -->|spec| D
+        PM -->|spec| E
+        D -->|UX sign-off| E
+        E -.->|feasibility push-back| PM
+    end
+
+    PR(["📋 Pull Request\ntests · instrumentation · goal alignment"])
+    SHIP(["🚀 Ships to 2anki.net"])
+
+    IN --> PM
+    E --> PR --> SHIP
+    SHIP -.->|metrics & feedback| IN
+```
+
+The trio is powered by Claude subagents in `.claude/agents/`. Use `/trio <task>` to invoke all three in parallel on any prompt.
+
 ## Contributing
 
 We'd love your help! See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get started, run the test gate, and submit a PR.

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ The server starts on `http://localhost:2020` and the frontend on `http://localho
 Every change that touches user-facing behavior goes through a **product trio**: a PM, a designer, and an engineer who consult in parallel — not in a handoff chain. The goal is to catch bad assumptions before engineering time is committed.
 
 ```mermaid
-%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#FF69B4', 'primaryTextColor': '#fff', 'primaryBorderColor': '#FF1493', 'lineColor': '#FF1493', 'secondaryColor': '#FFB6C1', 'tertiaryColor': '#FFF0F5', 'clusterBkg': '#FFF0F5', 'edgeLabelBackground': '#FFE4E1'}}}%%
+%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#E91E8C', 'primaryTextColor': '#fff', 'primaryBorderColor': '#AD1457', 'lineColor': '#C2185B', 'tertiaryColor': '#FFF0F5', 'clusterBkg': '#FFF0F5', 'edgeLabelBackground': '#FCE4EC', 'textColor': '#880E4F'}}}%%
 flowchart TD
-    IN([📨 Signal\nfeedback · issue · idea]):::signal
+    IN([📨 Signal — feedback · issue · idea]):::signal
 
     subgraph trio ["💖 Product Trio 💖"]
         direction LR
-        PM["🧠 PM\nsynthesize → spec → prioritize\n/triage-feedback · /spec"]:::pmNode
+        PM["🧠 PM\nsynthesize → spec → prioritize\n/triage-feedback  ·  /spec"]:::pmNode
         D["🎨 Designer\nflows · copy · visual hierarchy\n/review"]:::designerNode
         E["⚙️ Engineer\nfeasibility · TDD · /check\n/implement"]:::engineerNode
 
@@ -57,12 +57,12 @@ flowchart TD
     E --> PR --> SHIP
     SHIP -.->|metrics & feedback| IN
 
-    classDef signal fill:#FF69B4,stroke:#FF1493,color:#fff,stroke-width:3px
-    classDef pmNode fill:#FF1493,stroke:#C71585,color:#fff,stroke-width:3px
-    classDef designerNode fill:#FF007F,stroke:#AD1457,color:#fff,stroke-width:3px
-    classDef engineerNode fill:#E91E8C,stroke:#C71585,color:#fff,stroke-width:3px
-    classDef prNode fill:#FFB6C1,stroke:#FF69B4,color:#880E4F,stroke-width:2px
-    classDef shipNode fill:#FF1493,stroke:#880E4F,color:#fff,stroke-width:4px
+    classDef signal fill:#E91E8C,stroke:#AD1457,color:#fff,stroke-width:2px
+    classDef pmNode fill:#AD1457,stroke:#880E4F,color:#fff,stroke-width:2px
+    classDef designerNode fill:#C2185B,stroke:#880E4F,color:#fff,stroke-width:2px
+    classDef engineerNode fill:#D81B60,stroke:#AD1457,color:#fff,stroke-width:2px
+    classDef prNode fill:#FCE4EC,stroke:#E91E8C,color:#880E4F,stroke-width:2px
+    classDef shipNode fill:#880E4F,stroke:#4A0028,color:#fff,stroke-width:3px
 ```
 
 The trio is powered by Claude subagents in `.claude/agents/`. Use `/trio <task>` to invoke all three in parallel on any prompt.

--- a/README.md
+++ b/README.md
@@ -33,37 +33,9 @@ The server starts on `http://localhost:2020` and the frontend on `http://localho
 
 Every change that touches user-facing behavior goes through a **product trio**: a PM, a designer, and an engineer who consult in parallel — not in a handoff chain. The goal is to catch bad assumptions before engineering time is committed.
 
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#E91E8C', 'primaryTextColor': '#880E4F', 'primaryBorderColor': '#AD1457', 'lineColor': '#C2185B', 'tertiaryColor': '#FFF0F5', 'clusterBkg': '#FFF0F5', 'edgeLabelBackground': '#FCE4EC', 'textColor': '#880E4F'}}}%%
-flowchart TD
-    IN([📨 Signal — feedback · issue · idea]):::signal
-
-    subgraph trio ["💖 Product Trio 💖"]
-        direction LR
-        PM["🧠 PM\nsynthesize → spec → prioritize\n/triage-feedback  ·  /spec"]:::pmNode
-        D["🎨 Designer\nflows · copy · visual hierarchy\n/review"]:::designerNode
-        E["⚙️ Engineer\nfeasibility · TDD · /check\n/implement"]:::engineerNode
-
-        PM -->|spec| D
-        PM -->|spec| E
-        D -->|UX sign-off| E
-        E -.->|feasibility push-back| PM
-    end
-
-    PR(["📋 Pull Request\ntests · instrumentation · goal alignment"]):::prNode
-    SHIP(["🚀 Ships to 2anki.net"]):::shipNode
-
-    IN --> PM
-    E --> PR --> SHIP
-    SHIP -.->|metrics & feedback| IN
-
-    classDef signal fill:#E91E8C,stroke:#AD1457,color:#fff,stroke-width:2px
-    classDef pmNode fill:#AD1457,stroke:#880E4F,color:#fff,stroke-width:2px
-    classDef designerNode fill:#C2185B,stroke:#880E4F,color:#fff,stroke-width:2px
-    classDef engineerNode fill:#D81B60,stroke:#AD1457,color:#fff,stroke-width:2px
-    classDef prNode fill:#FCE4EC,stroke:#E91E8C,color:#880E4F,stroke-width:2px
-    classDef shipNode fill:#880E4F,stroke:#4A0028,color:#fff,stroke-width:3px
-```
+<p align="center">
+  <img src="web/public/trio-flow.svg" alt="2anki product trio kaizen loop — signal to ship in hours" />
+</p>
 
 The trio is powered by Claude subagents in `.claude/agents/`. Use `/trio <task>` to invoke all three in parallel on any prompt.
 

--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ The server starts on `http://localhost:2020` and the frontend on `http://localho
 Every change that touches user-facing behavior goes through a **product trio**: a PM, a designer, and an engineer who consult in parallel — not in a handoff chain. The goal is to catch bad assumptions before engineering time is committed.
 
 ```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'primaryColor': '#FF69B4', 'primaryTextColor': '#fff', 'primaryBorderColor': '#FF1493', 'lineColor': '#FF1493', 'secondaryColor': '#FFB6C1', 'tertiaryColor': '#FFF0F5', 'clusterBkg': '#FFF0F5', 'edgeLabelBackground': '#FFE4E1'}}}%%
 flowchart TD
-    IN([📨 Signal\nfeedback · issue · idea])
+    IN([📨 Signal\nfeedback · issue · idea]):::signal
 
-    subgraph trio ["🤝 Product Trio"]
+    subgraph trio ["💖 Product Trio 💖"]
         direction LR
-        PM["🧠 PM\nsynthesize → spec → prioritize\n/triage-feedback · /spec"]
-        D["🎨 Designer\nflows · copy · visual hierarchy\n/review"]
-        E["⚙️ Engineer\nfeasibility · TDD · /check\n/implement"]
+        PM["🧠 PM\nsynthesize → spec → prioritize\n/triage-feedback · /spec"]:::pmNode
+        D["🎨 Designer\nflows · copy · visual hierarchy\n/review"]:::designerNode
+        E["⚙️ Engineer\nfeasibility · TDD · /check\n/implement"]:::engineerNode
 
         PM -->|spec| D
         PM -->|spec| E
@@ -49,12 +50,19 @@ flowchart TD
         E -.->|feasibility push-back| PM
     end
 
-    PR(["📋 Pull Request\ntests · instrumentation · goal alignment"])
-    SHIP(["🚀 Ships to 2anki.net"])
+    PR(["📋 Pull Request\ntests · instrumentation · goal alignment"]):::prNode
+    SHIP(["🚀 Ships to 2anki.net"]):::shipNode
 
     IN --> PM
     E --> PR --> SHIP
     SHIP -.->|metrics & feedback| IN
+
+    classDef signal fill:#FF69B4,stroke:#FF1493,color:#fff,stroke-width:3px
+    classDef pmNode fill:#FF1493,stroke:#C71585,color:#fff,stroke-width:3px
+    classDef designerNode fill:#FF007F,stroke:#AD1457,color:#fff,stroke-width:3px
+    classDef engineerNode fill:#E91E8C,stroke:#C71585,color:#fff,stroke-width:3px
+    classDef prNode fill:#FFB6C1,stroke:#FF69B4,color:#880E4F,stroke-width:2px
+    classDef shipNode fill:#FF1493,stroke:#880E4F,color:#fff,stroke-width:4px
 ```
 
 The trio is powered by Claude subagents in `.claude/agents/`. Use `/trio <task>` to invoke all three in parallel on any prompt.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="web/public/mascot/Notion 1.png" width="140" alt="2anki mascot" />
+</p>
+
 # 2anki.net
 
 [2anki.net](https://2anki.net) helps you turn your Notion pages, HTML, Markdown, and other study material into Anki flashcards. Drop something in, get a clean `.apkg` deck back — no fuss.

--- a/web/public/trio-flow.svg
+++ b/web/public/trio-flow.svg
@@ -1,0 +1,221 @@
+<svg width="100%" viewBox="0 0 720 740" role="img" xmlns="http://www.w3.org/2000/svg">
+  <title>Signal to ship in hours — 2anki Product Trio</title>
+  <desc>A kaizen-style continuous improvement loop: Signal → You → Trio (PM, Designer, Engineer) → Ship → metrics back to Signal.</desc>
+
+  <defs>
+    <!-- Arrowhead for arcs -->
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M1 1L9 5L1 9" fill="none" stroke="#E91E8C"
+            stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+
+    <!-- Arrowhead for connector lines inside trio -->
+    <marker id="arrS" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="5" markerHeight="5" orient="auto">
+      <path d="M1 1L9 5L1 9" fill="none" stroke="#FF80AB"
+            stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+
+    <!-- Glow filter for Ship node -->
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+
+    <style>
+      @keyframes shipGlow {
+        0%, 100% { filter: url(#glow) drop-shadow(0 0 3px #E91E8C); }
+        50%       { filter: url(#glow) drop-shadow(0 0 14px #FF80AB); }
+      }
+      .ship-group { animation: shipGlow 2.5s ease-in-out infinite; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="740" fill="#FFF5F8" rx="16"/>
+
+  <!-- Subtle guide ring -->
+  <circle cx="360" cy="370" r="238" fill="none"
+          stroke="#FFCDD2" stroke-width="1" opacity="0.6"/>
+
+  <!-- ╔══════════════════╗
+       ║   KAIZEN ARCS    ║
+       ╚══════════════════╝
+       Nodes (centers):
+         Signal  (360,  80)  — top
+         You     (620, 360)  — right
+         Trio    (360, 650)  — bottom
+         Ship    (100, 360)  — left
+  -->
+
+  <!-- Arc 1: Signal → You (top → right) -->
+  <path d="M 458 80 C 570 80 620 200 620 333"
+        fill="none" stroke="#E91E8C" stroke-width="2.5"
+        stroke-dasharray="8 5" stroke-dashoffset="0"
+        marker-end="url(#arr)" opacity="0.9">
+    <animate attributeName="stroke-dashoffset" from="0" to="-26"
+             dur="1.4s" repeatCount="indefinite"/>
+  </path>
+  <text x="578" y="188" text-anchor="middle" fill="#AD1457" font-size="11"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500" transform="rotate(55,578,188)">spec</text>
+
+  <!-- Arc 2: You → Trio (right → bottom) -->
+  <path d="M 620 387 C 620 540 490 650 487 650"
+        fill="none" stroke="#E91E8C" stroke-width="2.5"
+        stroke-dasharray="8 5" stroke-dashoffset="0"
+        marker-end="url(#arr)" opacity="0.9">
+    <animate attributeName="stroke-dashoffset" from="0" to="-26"
+             dur="1.4s" begin="0.35s" repeatCount="indefinite"/>
+  </path>
+  <text x="600" y="530" text-anchor="middle" fill="#AD1457" font-size="11"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500" transform="rotate(-55,600,530)">build</text>
+
+  <!-- Arc 3: Trio → Ship (bottom → left) -->
+  <path d="M 233 650 C 160 650 100 540 100 387"
+        fill="none" stroke="#E91E8C" stroke-width="2.5"
+        stroke-dasharray="8 5" stroke-dashoffset="0"
+        marker-end="url(#arr)" opacity="0.9">
+    <animate attributeName="stroke-dashoffset" from="0" to="-26"
+             dur="1.4s" begin="0.7s" repeatCount="indefinite"/>
+  </path>
+  <text x="120" y="530" text-anchor="middle" fill="#AD1457" font-size="11"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500" transform="rotate(55,120,530)">ship</text>
+
+  <!-- Arc 4: Ship → Signal (left → top, feedback) -->
+  <path d="M 100 333 C 100 200 220 80 262 80"
+        fill="none" stroke="#E91E8C" stroke-width="2.5"
+        stroke-dasharray="8 5" stroke-dashoffset="0"
+        marker-end="url(#arr)" opacity="0.9">
+    <animate attributeName="stroke-dashoffset" from="0" to="-26"
+             dur="1.4s" begin="1.05s" repeatCount="indefinite"/>
+  </path>
+  <text x="142" y="188" text-anchor="middle" fill="#AD1457" font-size="11"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500" transform="rotate(-55,142,188)">measure</text>
+
+  <!-- ═══════════════════
+       CENTER LABEL
+  ═══════════════════ -->
+  <text x="360" y="355" text-anchor="middle" dominant-baseline="central"
+        fill="#C2185B" font-size="13"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="700" opacity="0.55">continuous</text>
+  <text x="360" y="375" text-anchor="middle" dominant-baseline="central"
+        fill="#C2185B" font-size="13"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="700" opacity="0.55">improvement</text>
+
+  <!-- ═══════════════════
+       NODE: Signal (top)
+  ═══════════════════ -->
+  <rect x="262" y="53" width="196" height="54" rx="8"
+        fill="#2D2D2A" stroke="#9C8C90" stroke-width="0.5"/>
+  <text x="360" y="74" text-anchor="middle" dominant-baseline="central"
+        fill="#E8D8DC" font-size="14"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500">📨 Signal</text>
+  <text x="360" y="93" text-anchor="middle" dominant-baseline="central"
+        fill="#B09898" font-size="11"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">feedback · issues · ideas</text>
+
+  <!-- ═══════════════════
+       NODE: You (right)
+  ═══════════════════ -->
+  <rect x="540" y="333" width="160" height="54" rx="8"
+        fill="#633806" stroke="#EF9F27" stroke-width="0.5"/>
+  <text x="620" y="354" text-anchor="middle" dominant-baseline="central"
+        fill="#FAC775" font-size="14"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500">You</text>
+  <text x="620" y="373" text-anchor="middle" dominant-baseline="central"
+        fill="#EF9F27" font-size="11"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">goal · approve · merge</text>
+
+  <!-- ═══════════════════
+       NODE: Trio (bottom) — PM + Designer + Engineer stacked
+  ═══════════════════ -->
+
+  <!-- PM (breathing) -->
+  <g opacity="1">
+    <animate attributeName="opacity" values="1;0.82;1"
+             dur="2.4s" repeatCount="indefinite"/>
+    <rect x="233" y="580" width="254" height="44" rx="8"
+          fill="#AD1457" stroke="#FF80AB" stroke-width="0.75"/>
+    <text x="284" y="602" dominant-baseline="central"
+          fill="#FFFFFF" font-size="12"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+          font-weight="600">🧠 PM</text>
+    <text x="284" y="616" dominant-baseline="central"
+          fill="#FFB6C1" font-size="10.5"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/triage-feedback · /spec</text>
+  </g>
+
+  <!-- connector PM → Designer -->
+  <line x1="360" y1="624" x2="360" y2="632"
+        stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
+
+  <!-- Designer (breathing, offset) -->
+  <g opacity="1">
+    <animate attributeName="opacity" values="1;0.82;1"
+             dur="2.4s" begin="0.5s" repeatCount="indefinite"/>
+    <rect x="233" y="634" width="254" height="44" rx="8"
+          fill="#C2185B" stroke="#FF80AB" stroke-width="0.75"/>
+    <text x="284" y="656" dominant-baseline="central"
+          fill="#FFFFFF" font-size="12"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+          font-weight="600">🎨 Designer</text>
+    <text x="284" y="670" dominant-baseline="central"
+          fill="#FFB6C1" font-size="10.5"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/review · flows · copy</text>
+  </g>
+
+  <!-- connector Designer → Engineer -->
+  <line x1="360" y1="678" x2="360" y2="686"
+        stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
+
+  <!-- Engineer (breathing, offset) -->
+  <g opacity="1">
+    <animate attributeName="opacity" values="1;0.82;1"
+             dur="2.4s" begin="1s" repeatCount="indefinite"/>
+    <rect x="233" y="688" width="254" height="44" rx="8"
+          fill="#D81B60" stroke="#FF80AB" stroke-width="0.75"/>
+    <text x="284" y="710" dominant-baseline="central"
+          fill="#FFFFFF" font-size="12"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+          font-weight="600">⚙️ Engineer</text>
+    <text x="284" y="724" dominant-baseline="central"
+          fill="#FFB6C1" font-size="10.5"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/implement · /check · TDD</text>
+  </g>
+
+  <!-- ═══════════════════
+       NODE: Ship (left) — glowing
+  ═══════════════════ -->
+  <g class="ship-group">
+    <rect x="20" y="333" width="160" height="54" rx="8"
+          fill="#880E4F" stroke="#E91E8C" stroke-width="1.5"/>
+    <text x="100" y="354" text-anchor="middle" dominant-baseline="central"
+          fill="#FFFFFF" font-size="13"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+          font-weight="600">🚀 Ship</text>
+    <text x="100" y="373" text-anchor="middle" dominant-baseline="central"
+          fill="#FFB6C1" font-size="11"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">2anki.net</text>
+  </g>
+
+  <!-- "Hours, not weeks" badge -->
+  <rect x="248" y="272" width="224" height="36" rx="18"
+        fill="#4A0028" stroke="#E91E8C" stroke-width="1"/>
+  <text x="360" y="290" text-anchor="middle" dominant-baseline="central"
+        fill="#FFB6C1" font-size="12.5"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500">Hours, not weeks ✦</text>
+
+</svg>

--- a/web/public/trio-flow.svg
+++ b/web/public/trio-flow.svg
@@ -8,12 +8,6 @@
       <path d="M1 1L9 5L1 9" fill="none" stroke="#E91E8C"
             stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <marker id="arrIn" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="5" markerHeight="5" orient="auto">
-      <path d="M1 1L9 5L1 9" fill="none" stroke="#C2185B"
-            stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-    </marker>
-
     <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur"/>
       <feMerge>
@@ -101,30 +95,7 @@
     <textPath href="#arc3label" startOffset="50%" text-anchor="middle">metrics</textPath>
   </text>
 
-  <!-- ══════════════════════════════
-       SPOKES: outer nodes ↔ center trio
-  ══════════════════════════════ -->
-
   <!-- Signal → PM (top spoke, down) -->
-  <line x1="360" y1="163" x2="360" y2="275"
-        stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
-        marker-end="url(#arrIn)" opacity="0.7"/>
-
-  <!-- Engineer → Ship (bottom-left spoke) -->
-  <path d="M 290 431 Q 264 437 250 440"
-        fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
-        marker-end="url(#arrIn)" opacity="0.7"/>
-  <text x="264" y="430" fill="#AD1457" font-size="10"
-        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" text-anchor="middle" opacity="0.85">PR</text>
-
-  <!-- Alexander → Trio (right spoke, inward) -->
-  <path d="M 446 462 Q 462 415 467 358"
-        fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
-        marker-end="url(#arrIn)" opacity="0.7"/>
-  <text x="456" y="422" fill="#AD1457" font-size="10"
-        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" text-anchor="middle" opacity="0.85">approve</text>
 
   <!-- ══════════════════════════════
        OUTER NODE: Signal (top)
@@ -175,13 +146,13 @@
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" repeatCount="indefinite"/>
-    <rect x="253" y="277" width="214" height="46" rx="8"
+    <rect x="253" y="221" width="214" height="46" rx="8"
           fill="#AD1457" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="295" dominant-baseline="central"
+    <text x="278" y="239" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🧠 PM</text>
-    <text x="278" y="311" dominant-baseline="central"
+    <text x="278" y="255" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/triage-feedback · /spec</text>
   </g>
@@ -190,13 +161,13 @@
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="0.5s" repeatCount="indefinite"/>
-    <rect x="253" y="331" width="214" height="46" rx="8"
+    <rect x="253" y="275" width="214" height="46" rx="8"
           fill="#C2185B" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="349" dominant-baseline="central"
+    <text x="278" y="293" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🎨 Designer</text>
-    <text x="278" y="365" dominant-baseline="central"
+    <text x="278" y="309" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/review · flows · copy</text>
   </g>
@@ -205,13 +176,13 @@
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="1s" repeatCount="indefinite"/>
-    <rect x="253" y="385" width="214" height="46" rx="8"
+    <rect x="253" y="329" width="214" height="46" rx="8"
           fill="#D81B60" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="403" dominant-baseline="central"
+    <text x="278" y="347" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">⚙️ Engineer</text>
-    <text x="278" y="419" dominant-baseline="central"
+    <text x="278" y="363" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/implement · /check · TDD</text>
   </g>

--- a/web/public/trio-flow.svg
+++ b/web/public/trio-flow.svg
@@ -39,8 +39,8 @@
   <!-- Background -->
   <rect width="720" height="720" fill="#FFF5F8" rx="16"/>
 
-  <!-- Guide ring -->
-  <circle cx="360" cy="355" r="228" fill="none" stroke="#FFCDD2" stroke-width="1.2" opacity="0.7"/>
+  <!-- Guide ring — centered on the triangle's visual centroid -->
+  <circle cx="360" cy="354" r="228" fill="none" stroke="#FFCDD2" stroke-width="1" opacity="0.55"/>
 
   <!--
     Outer nodes (triangle, clockwise from top):
@@ -60,12 +60,13 @@
     <animate attributeName="stroke-dashoffset" from="0" to="-26"
              dur="1.5s" repeatCount="indefinite"/>
   </path>
+  <!-- Label path traces close to the visible arc, offset slightly right -->
+  <path id="arc1label" d="M 458 148 Q 604 265 558 435" fill="none" stroke="none"/>
   <text fill="#AD1457" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500">
     <textPath href="#arc1label" startOffset="50%" text-anchor="middle">spec review</textPath>
   </text>
-  <path id="arc1label" d="M 452 110 Q 630 220 580 420" fill="none" stroke="none"/>
 
   <!-- ══════════════════════════════
        ARC 2: Alexander → Ship
@@ -78,12 +79,13 @@
     <animate attributeName="stroke-dashoffset" from="0" to="-26"
              dur="1.5s" begin="0.5s" repeatCount="indefinite"/>
   </path>
+  <!-- Label path mirrors the visible arc, shifted down slightly for clearance -->
+  <path id="arc2label" d="M 548 508 Q 360 604 192 508" fill="none" stroke="none"/>
   <text fill="#AD1457" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500">
     <textPath href="#arc2label" startOffset="50%" text-anchor="middle">merged</textPath>
   </text>
-  <path id="arc2label" d="M 550 510 Q 360 610 190 510" fill="none" stroke="none"/>
 
   <!-- ══════════════════════════════
        ARC 3: Ship → Signal
@@ -96,61 +98,62 @@
     <animate attributeName="stroke-dashoffset" from="0" to="-26"
              dur="1.5s" begin="1s" repeatCount="indefinite"/>
   </path>
+  <!-- Label path traces close to the visible arc, offset slightly left -->
+  <path id="arc3label" d="M 156 442 Q 96 255 262 148" fill="none" stroke="none"/>
   <text fill="#AD1457" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500">
     <textPath href="#arc3label" startOffset="50%" text-anchor="middle">metrics</textPath>
   </text>
-  <path id="arc3label" d="M 155 440 Q 82 248 258 130" fill="none" stroke="none"/>
 
   <!-- ══════════════════════════════
        SPOKES: outer nodes ↔ center trio
   ══════════════════════════════ -->
 
   <!-- Signal → PM (top spoke, down) -->
-  <line x1="360" y1="179" x2="360" y2="294"
+  <line x1="360" y1="181" x2="360" y2="292"
         stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
 
   <!-- Engineer → Ship (bottom-left spoke) -->
-  <path d="M 340 436 Q 280 455 250 468"
+  <path d="M 310 464 Q 264 478 248 468"
         fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
-  <text x="282" y="443" fill="#AD1457" font-size="10"
+  <text x="272" y="458" fill="#AD1457" font-size="10"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" opacity="0.85">PR</text>
+        font-weight="500" text-anchor="middle" opacity="0.85">PR</text>
 
   <!-- Alexander → Trio (right spoke, inward) -->
-  <path d="M 450 468 Q 420 420 467 388"
+  <path d="M 450 466 Q 418 428 410 404"
         fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
-  <text x="428" y="435" fill="#AD1457" font-size="10"
+  <text x="446" y="440" fill="#AD1457" font-size="10"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" opacity="0.85">approve</text>
+        font-weight="500" text-anchor="middle" opacity="0.85">approve</text>
 
   <!-- ══════════════════════════════
        OUTER NODE: Signal (top)
   ══════════════════════════════ -->
-  <rect x="265" y="101" width="190" height="52" rx="8"
+  <rect x="265" y="101" width="190" height="56" rx="8"
         fill="#2D2D2A" stroke="#9C8C90" stroke-width="0.5"/>
-  <text x="360" y="122" text-anchor="middle" dominant-baseline="central"
+  <text x="360" y="124" text-anchor="middle" dominant-baseline="central"
         fill="#E8D8DC" font-size="14"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500">📨 Signal</text>
-  <text x="360" y="141" text-anchor="middle" dominant-baseline="central"
+  <text x="360" y="143" text-anchor="middle" dominant-baseline="central"
         fill="#B09898" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">feedback · issues · ideas</text>
 
   <!-- ══════════════════════════════
        OUTER NODE: Alexander (bottom-right)
   ══════════════════════════════ -->
-  <rect x="448" y="442" width="204" height="52" rx="8"
+  <rect x="446" y="440" width="208" height="56" rx="8"
         fill="#633806" stroke="#EF9F27" stroke-width="0.5"/>
-  <text x="550" y="462" text-anchor="middle" dominant-baseline="central"
+  <text x="550" y="463" text-anchor="middle" dominant-baseline="central"
         fill="#FAC775" font-size="13"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500">Alexander (lead dev)</text>
-  <text x="550" y="480" text-anchor="middle" dominant-baseline="central"
+  <text x="550" y="482" text-anchor="middle" dominant-baseline="central"
         fill="#EF9F27" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">goal · approve · merge</text>
 
@@ -158,13 +161,13 @@
        OUTER NODE: Ship (bottom-left)
   ══════════════════════════════ -->
   <g class="ship-group">
-    <rect x="88" y="442" width="164" height="52" rx="8"
+    <rect x="86" y="440" width="168" height="56" rx="8"
           fill="#1e3a8a" stroke="#60a5fa" stroke-width="1.5"/>
-    <text x="170" y="462" text-anchor="middle" dominant-baseline="central"
+    <text x="170" y="463" text-anchor="middle" dominant-baseline="central"
           fill="#FFFFFF" font-size="13"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🚀 Ship</text>
-    <text x="170" y="480" text-anchor="middle" dominant-baseline="central"
+    <text x="170" y="482" text-anchor="middle" dominant-baseline="central"
           fill="#93c5fd" font-size="11"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">2anki.net</text>
   </g>
@@ -177,51 +180,51 @@
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" repeatCount="indefinite"/>
-    <rect x="253" y="296" width="214" height="42" rx="8"
+    <rect x="253" y="294" width="214" height="46" rx="8"
           fill="#AD1457" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="317" dominant-baseline="central"
+    <text x="278" y="312" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🧠 PM</text>
-    <text x="278" y="330" dominant-baseline="central"
+    <text x="278" y="328" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/triage-feedback · /spec</text>
   </g>
 
-  <!-- PM → Designer connector -->
-  <line x1="360" y1="338" x2="360" y2="346"
+  <!-- PM → Designer connector (14px gap gives the arrowhead room) -->
+  <line x1="360" y1="340" x2="360" y2="354"
         stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Designer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="0.5s" repeatCount="indefinite"/>
-    <rect x="253" y="348" width="214" height="42" rx="8"
+    <rect x="253" y="356" width="214" height="46" rx="8"
           fill="#C2185B" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="369" dominant-baseline="central"
+    <text x="278" y="374" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🎨 Designer</text>
-    <text x="278" y="382" dominant-baseline="central"
+    <text x="278" y="390" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/review · flows · copy</text>
   </g>
 
   <!-- Designer → Engineer connector -->
-  <line x1="360" y1="390" x2="360" y2="398"
+  <line x1="360" y1="402" x2="360" y2="416"
         stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Engineer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="1s" repeatCount="indefinite"/>
-    <rect x="253" y="400" width="214" height="42" rx="8"
+    <rect x="253" y="418" width="214" height="46" rx="8"
           fill="#D81B60" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="421" dominant-baseline="central"
+    <text x="278" y="436" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">⚙️ Engineer</text>
-    <text x="278" y="434" dominant-baseline="central"
+    <text x="278" y="452" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/implement · /check · TDD</text>
   </g>

--- a/web/public/trio-flow.svg
+++ b/web/public/trio-flow.svg
@@ -111,23 +111,23 @@
   ══════════════════════════════ -->
 
   <!-- Signal → PM (top spoke, down) -->
-  <line x1="360" y1="181" x2="360" y2="292"
+  <line x1="360" y1="163" x2="360" y2="242"
         stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
 
   <!-- Engineer → Ship (bottom-left spoke) -->
-  <path d="M 310 464 Q 264 478 248 468"
+  <path d="M 300 414 Q 260 432 248 440"
         fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
-  <text x="272" y="458" fill="#AD1457" font-size="10"
+  <text x="266" y="425" fill="#AD1457" font-size="10"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500" text-anchor="middle" opacity="0.85">PR</text>
 
   <!-- Alexander → Trio (right spoke, inward) -->
-  <path d="M 450 466 Q 418 428 410 404"
+  <path d="M 446 462 Q 460 390 467 333"
         fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
-  <text x="446" y="440" fill="#AD1457" font-size="10"
+  <text x="456" y="422" fill="#AD1457" font-size="10"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500" text-anchor="middle" opacity="0.85">approve</text>
 
@@ -180,51 +180,51 @@
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" repeatCount="indefinite"/>
-    <rect x="253" y="294" width="214" height="46" rx="8"
+    <rect x="253" y="244" width="214" height="46" rx="8"
           fill="#AD1457" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="312" dominant-baseline="central"
+    <text x="278" y="262" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🧠 PM</text>
-    <text x="278" y="328" dominant-baseline="central"
+    <text x="278" y="278" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/triage-feedback · /spec</text>
   </g>
 
   <!-- PM → Designer connector (14px gap gives the arrowhead room) -->
-  <line x1="360" y1="340" x2="360" y2="354"
+  <line x1="360" y1="290" x2="360" y2="304"
         stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Designer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="0.5s" repeatCount="indefinite"/>
-    <rect x="253" y="356" width="214" height="46" rx="8"
+    <rect x="253" y="306" width="214" height="46" rx="8"
           fill="#C2185B" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="374" dominant-baseline="central"
+    <text x="278" y="324" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🎨 Designer</text>
-    <text x="278" y="390" dominant-baseline="central"
+    <text x="278" y="340" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/review · flows · copy</text>
   </g>
 
   <!-- Designer → Engineer connector -->
-  <line x1="360" y1="402" x2="360" y2="416"
+  <line x1="360" y1="352" x2="360" y2="366"
         stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Engineer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="1s" repeatCount="indefinite"/>
-    <rect x="253" y="418" width="214" height="46" rx="8"
+    <rect x="253" y="368" width="214" height="46" rx="8"
           fill="#D81B60" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="436" dominant-baseline="central"
+    <text x="278" y="386" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">⚙️ Engineer</text>
-    <text x="278" y="452" dominant-baseline="central"
+    <text x="278" y="402" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/implement · /check · TDD</text>
   </g>

--- a/web/public/trio-flow.svg
+++ b/web/public/trio-flow.svg
@@ -128,12 +128,12 @@
   <!-- ═══════════════════
        NODE: You (right)
   ═══════════════════ -->
-  <rect x="540" y="333" width="160" height="54" rx="8"
+  <rect x="524" y="333" width="192" height="54" rx="8"
         fill="#633806" stroke="#EF9F27" stroke-width="0.5"/>
   <text x="620" y="354" text-anchor="middle" dominant-baseline="central"
-        fill="#FAC775" font-size="14"
+        fill="#FAC775" font-size="13"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500">You</text>
+        font-weight="500">Alexander (lead dev)</text>
   <text x="620" y="373" text-anchor="middle" dominant-baseline="central"
         fill="#EF9F27" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">goal · approve · merge</text>

--- a/web/public/trio-flow.svg
+++ b/web/public/trio-flow.svg
@@ -1,23 +1,24 @@
-<svg width="100%" viewBox="0 0 720 740" role="img" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" viewBox="0 0 720 720" role="img" xmlns="http://www.w3.org/2000/svg">
   <title>Signal to ship in hours — 2anki Product Trio</title>
-  <desc>A kaizen-style continuous improvement loop: Signal → You → Trio (PM, Designer, Engineer) → Ship → metrics back to Signal.</desc>
+  <desc>Kaizen-style continuous improvement loop for 2anki. The product trio (PM, Designer, Engineer) are AI agents at the center of every change. Alexander (lead developer) is the human in the loop — he sets direction, approves specs, and merges PRs.</desc>
 
   <defs>
-    <!-- Arrowhead for arcs -->
     <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5"
             markerWidth="6" markerHeight="6" orient="auto">
       <path d="M1 1L9 5L1 9" fill="none" stroke="#E91E8C"
             stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-
-    <!-- Arrowhead for connector lines inside trio -->
     <marker id="arrS" viewBox="0 0 10 10" refX="9" refY="5"
             markerWidth="5" markerHeight="5" orient="auto">
       <path d="M1 1L9 5L1 9" fill="none" stroke="#FF80AB"
             stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
+    <marker id="arrIn" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="5" markerHeight="5" orient="auto">
+      <path d="M1 1L9 5L1 9" fill="none" stroke="#C2185B"
+            stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
 
-    <!-- Glow filter for Ship node -->
     <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="4" result="blur"/>
       <feMerge>
@@ -28,194 +29,201 @@
 
     <style>
       @keyframes shipGlow {
-        0%, 100% { filter: url(#glow) drop-shadow(0 0 3px #E91E8C); }
-        50%       { filter: url(#glow) drop-shadow(0 0 14px #FF80AB); }
+        0%, 100% { filter: drop-shadow(0 0 3px #3b82f6); }
+        50%       { filter: drop-shadow(0 0 14px #93c5fd); }
       }
       .ship-group { animation: shipGlow 2.5s ease-in-out infinite; }
     </style>
   </defs>
 
   <!-- Background -->
-  <rect width="720" height="740" fill="#FFF5F8" rx="16"/>
+  <rect width="720" height="720" fill="#FFF5F8" rx="16"/>
 
-  <!-- Subtle guide ring -->
-  <circle cx="360" cy="370" r="238" fill="none"
-          stroke="#FFCDD2" stroke-width="1" opacity="0.6"/>
+  <!-- Guide ring -->
+  <circle cx="360" cy="355" r="228" fill="none" stroke="#FFCDD2" stroke-width="1.2" opacity="0.7"/>
 
-  <!-- ╔══════════════════╗
-       ║   KAIZEN ARCS    ║
-       ╚══════════════════╝
-       Nodes (centers):
-         Signal  (360,  80)  — top
-         You     (620, 360)  — right
-         Trio    (360, 650)  — bottom
-         Ship    (100, 360)  — left
+  <!--
+    Outer nodes (triangle, clockwise from top):
+      Signal    — (360, 127)   12 o'clock
+      Alexander — (550, 468)    4 o'clock
+      Ship      — (170, 468)    8 o'clock
   -->
 
-  <!-- Arc 1: Signal → You (top → right) -->
-  <path d="M 458 80 C 570 80 620 200 620 333"
+  <!-- ══════════════════════════════
+       ARC 1: Signal → Alexander
+       Flows down the right side
+  ══════════════════════════════ -->
+  <path d="M 452 140 Q 600 260 552 444"
         fill="none" stroke="#E91E8C" stroke-width="2.5"
         stroke-dasharray="8 5" stroke-dashoffset="0"
         marker-end="url(#arr)" opacity="0.9">
     <animate attributeName="stroke-dashoffset" from="0" to="-26"
-             dur="1.4s" repeatCount="indefinite"/>
+             dur="1.5s" repeatCount="indefinite"/>
   </path>
-  <text x="578" y="188" text-anchor="middle" fill="#AD1457" font-size="11"
+  <text fill="#AD1457" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" transform="rotate(55,578,188)">spec</text>
+        font-weight="500">
+    <textPath href="#arc1label" startOffset="50%" text-anchor="middle">spec review</textPath>
+  </text>
+  <path id="arc1label" d="M 452 110 Q 630 220 580 420" fill="none" stroke="none"/>
 
-  <!-- Arc 2: You → Trio (right → bottom) -->
-  <path d="M 620 387 C 620 540 490 650 487 650"
+  <!-- ══════════════════════════════
+       ARC 2: Alexander → Ship
+       Sweeps across the bottom
+  ══════════════════════════════ -->
+  <path d="M 548 496 Q 360 590 192 496"
         fill="none" stroke="#E91E8C" stroke-width="2.5"
         stroke-dasharray="8 5" stroke-dashoffset="0"
         marker-end="url(#arr)" opacity="0.9">
     <animate attributeName="stroke-dashoffset" from="0" to="-26"
-             dur="1.4s" begin="0.35s" repeatCount="indefinite"/>
+             dur="1.5s" begin="0.5s" repeatCount="indefinite"/>
   </path>
-  <text x="600" y="530" text-anchor="middle" fill="#AD1457" font-size="11"
+  <text fill="#AD1457" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" transform="rotate(-55,600,530)">build</text>
+        font-weight="500">
+    <textPath href="#arc2label" startOffset="50%" text-anchor="middle">merged</textPath>
+  </text>
+  <path id="arc2label" d="M 550 510 Q 360 610 190 510" fill="none" stroke="none"/>
 
-  <!-- Arc 3: Trio → Ship (bottom → left) -->
-  <path d="M 233 650 C 160 650 100 540 100 387"
+  <!-- ══════════════════════════════
+       ARC 3: Ship → Signal
+       Climbs up the left side
+  ══════════════════════════════ -->
+  <path d="M 168 444 Q 110 260 268 140"
         fill="none" stroke="#E91E8C" stroke-width="2.5"
         stroke-dasharray="8 5" stroke-dashoffset="0"
         marker-end="url(#arr)" opacity="0.9">
     <animate attributeName="stroke-dashoffset" from="0" to="-26"
-             dur="1.4s" begin="0.7s" repeatCount="indefinite"/>
+             dur="1.5s" begin="1s" repeatCount="indefinite"/>
   </path>
-  <text x="120" y="530" text-anchor="middle" fill="#AD1457" font-size="11"
+  <text fill="#AD1457" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" transform="rotate(55,120,530)">ship</text>
+        font-weight="500">
+    <textPath href="#arc3label" startOffset="50%" text-anchor="middle">metrics</textPath>
+  </text>
+  <path id="arc3label" d="M 155 440 Q 82 248 258 130" fill="none" stroke="none"/>
 
-  <!-- Arc 4: Ship → Signal (left → top, feedback) -->
-  <path d="M 100 333 C 100 200 220 80 262 80"
-        fill="none" stroke="#E91E8C" stroke-width="2.5"
-        stroke-dasharray="8 5" stroke-dashoffset="0"
-        marker-end="url(#arr)" opacity="0.9">
-    <animate attributeName="stroke-dashoffset" from="0" to="-26"
-             dur="1.4s" begin="1.05s" repeatCount="indefinite"/>
-  </path>
-  <text x="142" y="188" text-anchor="middle" fill="#AD1457" font-size="11"
-        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500" transform="rotate(-55,142,188)">measure</text>
+  <!-- ══════════════════════════════
+       SPOKES: outer nodes ↔ center trio
+  ══════════════════════════════ -->
 
-  <!-- ═══════════════════
-       CENTER LABEL
-  ═══════════════════ -->
-  <text x="360" y="355" text-anchor="middle" dominant-baseline="central"
-        fill="#C2185B" font-size="13"
-        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="700" opacity="0.55">continuous</text>
-  <text x="360" y="375" text-anchor="middle" dominant-baseline="central"
-        fill="#C2185B" font-size="13"
-        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="700" opacity="0.55">improvement</text>
+  <!-- Signal → PM (top spoke, down) -->
+  <line x1="360" y1="179" x2="360" y2="294"
+        stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
+        marker-end="url(#arrIn)" opacity="0.7"/>
 
-  <!-- ═══════════════════
-       NODE: Signal (top)
-  ═══════════════════ -->
-  <rect x="262" y="53" width="196" height="54" rx="8"
+  <!-- Engineer → Ship (bottom-left spoke) -->
+  <path d="M 340 436 Q 280 455 250 468"
+        fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
+        marker-end="url(#arrIn)" opacity="0.7"/>
+  <text x="282" y="443" fill="#AD1457" font-size="10"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500" opacity="0.85">PR</text>
+
+  <!-- Alexander → Trio (right spoke, inward) -->
+  <path d="M 450 468 Q 420 420 467 388"
+        fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
+        marker-end="url(#arrIn)" opacity="0.7"/>
+  <text x="428" y="435" fill="#AD1457" font-size="10"
+        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+        font-weight="500" opacity="0.85">approve</text>
+
+  <!-- ══════════════════════════════
+       OUTER NODE: Signal (top)
+  ══════════════════════════════ -->
+  <rect x="265" y="101" width="190" height="52" rx="8"
         fill="#2D2D2A" stroke="#9C8C90" stroke-width="0.5"/>
-  <text x="360" y="74" text-anchor="middle" dominant-baseline="central"
+  <text x="360" y="122" text-anchor="middle" dominant-baseline="central"
         fill="#E8D8DC" font-size="14"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500">📨 Signal</text>
-  <text x="360" y="93" text-anchor="middle" dominant-baseline="central"
+  <text x="360" y="141" text-anchor="middle" dominant-baseline="central"
         fill="#B09898" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">feedback · issues · ideas</text>
 
-  <!-- ═══════════════════
-       NODE: You (right)
-  ═══════════════════ -->
-  <rect x="524" y="333" width="192" height="54" rx="8"
+  <!-- ══════════════════════════════
+       OUTER NODE: Alexander (bottom-right)
+  ══════════════════════════════ -->
+  <rect x="448" y="442" width="204" height="52" rx="8"
         fill="#633806" stroke="#EF9F27" stroke-width="0.5"/>
-  <text x="620" y="354" text-anchor="middle" dominant-baseline="central"
+  <text x="550" y="462" text-anchor="middle" dominant-baseline="central"
         fill="#FAC775" font-size="13"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500">Alexander (lead dev)</text>
-  <text x="620" y="373" text-anchor="middle" dominant-baseline="central"
+  <text x="550" y="480" text-anchor="middle" dominant-baseline="central"
         fill="#EF9F27" font-size="11"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">goal · approve · merge</text>
 
-  <!-- ═══════════════════
-       NODE: Trio (bottom) — PM + Designer + Engineer stacked
-  ═══════════════════ -->
+  <!-- ══════════════════════════════
+       OUTER NODE: Ship (bottom-left)
+  ══════════════════════════════ -->
+  <g class="ship-group">
+    <rect x="88" y="442" width="164" height="52" rx="8"
+          fill="#1e3a8a" stroke="#60a5fa" stroke-width="1.5"/>
+    <text x="170" y="462" text-anchor="middle" dominant-baseline="central"
+          fill="#FFFFFF" font-size="13"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
+          font-weight="600">🚀 Ship</text>
+    <text x="170" y="480" text-anchor="middle" dominant-baseline="central"
+          fill="#93c5fd" font-size="11"
+          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">2anki.net</text>
+  </g>
+
+  <!-- ══════════════════════════════
+       CENTER: Product Trio
+  ══════════════════════════════ -->
 
   <!-- PM (breathing) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" repeatCount="indefinite"/>
-    <rect x="233" y="580" width="254" height="44" rx="8"
+    <rect x="253" y="296" width="214" height="42" rx="8"
           fill="#AD1457" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="284" y="602" dominant-baseline="central"
+    <text x="278" y="317" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🧠 PM</text>
-    <text x="284" y="616" dominant-baseline="central"
-          fill="#FFB6C1" font-size="10.5"
+    <text x="278" y="330" dominant-baseline="central"
+          fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/triage-feedback · /spec</text>
   </g>
 
-  <!-- connector PM → Designer -->
-  <line x1="360" y1="624" x2="360" y2="632"
+  <!-- PM → Designer connector -->
+  <line x1="360" y1="338" x2="360" y2="346"
         stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Designer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="0.5s" repeatCount="indefinite"/>
-    <rect x="233" y="634" width="254" height="44" rx="8"
+    <rect x="253" y="348" width="214" height="42" rx="8"
           fill="#C2185B" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="284" y="656" dominant-baseline="central"
+    <text x="278" y="369" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🎨 Designer</text>
-    <text x="284" y="670" dominant-baseline="central"
-          fill="#FFB6C1" font-size="10.5"
+    <text x="278" y="382" dominant-baseline="central"
+          fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/review · flows · copy</text>
   </g>
 
-  <!-- connector Designer → Engineer -->
-  <line x1="360" y1="678" x2="360" y2="686"
+  <!-- Designer → Engineer connector -->
+  <line x1="360" y1="390" x2="360" y2="398"
         stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Engineer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="1s" repeatCount="indefinite"/>
-    <rect x="233" y="688" width="254" height="44" rx="8"
+    <rect x="253" y="400" width="214" height="42" rx="8"
           fill="#D81B60" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="284" y="710" dominant-baseline="central"
+    <text x="278" y="421" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">⚙️ Engineer</text>
-    <text x="284" y="724" dominant-baseline="central"
-          fill="#FFB6C1" font-size="10.5"
+    <text x="278" y="434" dominant-baseline="central"
+          fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/implement · /check · TDD</text>
   </g>
-
-  <!-- ═══════════════════
-       NODE: Ship (left) — glowing
-  ═══════════════════ -->
-  <g class="ship-group">
-    <rect x="20" y="333" width="160" height="54" rx="8"
-          fill="#880E4F" stroke="#E91E8C" stroke-width="1.5"/>
-    <text x="100" y="354" text-anchor="middle" dominant-baseline="central"
-          fill="#FFFFFF" font-size="13"
-          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-          font-weight="600">🚀 Ship</text>
-    <text x="100" y="373" text-anchor="middle" dominant-baseline="central"
-          fill="#FFB6C1" font-size="11"
-          font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">2anki.net</text>
-  </g>
-
-  <!-- "Hours, not weeks" badge -->
-  <rect x="248" y="272" width="224" height="36" rx="18"
-        fill="#4A0028" stroke="#E91E8C" stroke-width="1"/>
-  <text x="360" y="290" text-anchor="middle" dominant-baseline="central"
-        fill="#FFB6C1" font-size="12.5"
-        font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
-        font-weight="500">Hours, not weeks ✦</text>
 
 </svg>

--- a/web/public/trio-flow.svg
+++ b/web/public/trio-flow.svg
@@ -8,11 +8,6 @@
       <path d="M1 1L9 5L1 9" fill="none" stroke="#E91E8C"
             stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
     </marker>
-    <marker id="arrS" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="5" markerHeight="5" orient="auto">
-      <path d="M1 1L9 5L1 9" fill="none" stroke="#FF80AB"
-            stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-    </marker>
     <marker id="arrIn" viewBox="0 0 10 10" refX="9" refY="5"
             markerWidth="5" markerHeight="5" orient="auto">
       <path d="M1 1L9 5L1 9" fill="none" stroke="#C2185B"
@@ -111,20 +106,20 @@
   ══════════════════════════════ -->
 
   <!-- Signal → PM (top spoke, down) -->
-  <line x1="360" y1="163" x2="360" y2="242"
+  <line x1="360" y1="163" x2="360" y2="275"
         stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
 
   <!-- Engineer → Ship (bottom-left spoke) -->
-  <path d="M 300 414 Q 260 432 248 440"
+  <path d="M 290 431 Q 264 437 250 440"
         fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
-  <text x="266" y="425" fill="#AD1457" font-size="10"
+  <text x="264" y="430" fill="#AD1457" font-size="10"
         font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
         font-weight="500" text-anchor="middle" opacity="0.85">PR</text>
 
   <!-- Alexander → Trio (right spoke, inward) -->
-  <path d="M 446 462 Q 460 390 467 333"
+  <path d="M 446 462 Q 462 415 467 358"
         fill="none" stroke="#C2185B" stroke-width="1.5" stroke-dasharray="4 3"
         marker-end="url(#arrIn)" opacity="0.7"/>
   <text x="456" y="422" fill="#AD1457" font-size="10"
@@ -180,51 +175,43 @@
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" repeatCount="indefinite"/>
-    <rect x="253" y="244" width="214" height="46" rx="8"
+    <rect x="253" y="277" width="214" height="46" rx="8"
           fill="#AD1457" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="262" dominant-baseline="central"
+    <text x="278" y="295" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🧠 PM</text>
-    <text x="278" y="278" dominant-baseline="central"
+    <text x="278" y="311" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/triage-feedback · /spec</text>
   </g>
-
-  <!-- PM → Designer connector (14px gap gives the arrowhead room) -->
-  <line x1="360" y1="290" x2="360" y2="304"
-        stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Designer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="0.5s" repeatCount="indefinite"/>
-    <rect x="253" y="306" width="214" height="46" rx="8"
+    <rect x="253" y="331" width="214" height="46" rx="8"
           fill="#C2185B" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="324" dominant-baseline="central"
+    <text x="278" y="349" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">🎨 Designer</text>
-    <text x="278" y="340" dominant-baseline="central"
+    <text x="278" y="365" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/review · flows · copy</text>
   </g>
-
-  <!-- Designer → Engineer connector -->
-  <line x1="360" y1="352" x2="360" y2="366"
-        stroke="#FF80AB" stroke-width="1.2" marker-end="url(#arrS)"/>
 
   <!-- Engineer (breathing, offset) -->
   <g opacity="1">
     <animate attributeName="opacity" values="1;0.82;1"
              dur="2.4s" begin="1s" repeatCount="indefinite"/>
-    <rect x="253" y="368" width="214" height="46" rx="8"
+    <rect x="253" y="385" width="214" height="46" rx="8"
           fill="#D81B60" stroke="#FF80AB" stroke-width="0.75"/>
-    <text x="278" y="386" dominant-baseline="central"
+    <text x="278" y="403" dominant-baseline="central"
           fill="#FFFFFF" font-size="12"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif"
           font-weight="600">⚙️ Engineer</text>
-    <text x="278" y="402" dominant-baseline="central"
+    <text x="278" y="419" dominant-baseline="central"
           fill="#FFB6C1" font-size="10"
           font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif">/implement · /check · TDD</text>
   </g>


### PR DESCRIPTION
## What
Upgrades the three core trio subagents (pm, designer, engineer) and adds the enforcement infrastructure to make them work together automatically on every product-relevant task.

**New files:**
- `.claude/agents/_trio.md` — shared protocol referenced by all three agents: make-thinking-visible defaults, riskiest-assumption-first, leading/lagging indicator guidance, required **Trio check** block in every substantive response
- `.claude/commands/trio.md` — `/trio` slash command forces parallel trio review on any task
- `.claude/hooks/trio_check.sh` — `UserPromptSubmit` hook that injects a trio-required reminder when the prompt touches user-facing product territory (keyword heuristic, tunable)

**Modified:**
- `pm.md`: outcome-vs-output framing, opportunity language broadened to desires, whether-or-not → compare-and-contrast reframing, riskiest assumption + smallest test in spec format, leading/lagging metrics table, child opportunities in opportunity mapping
- `designer.md`: visual system section (size/weight/color hierarchy, action hierarchy with destructive clarification, 4px/8px whitespace), six-question review scoring order with ship-it/minor/rethink verdict, walk-the-flow protocol, design-in-testable-pieces
- `engineer.md`: feasibility surface section, smallest viable test before full build, instrumentation-alongside requirement, cost/latency callout for LLM/large-file changes, question-requirements principle
- `CLAUDE.md`: trio review policy block with required/optional trigger list, synthesis format, `/trio` listed in commands
- `settings.json`: `UserPromptSubmit` hook entry for `trio_check.sh`

## Why
The agents were well-structured but behaved as independent specialists rather than a trio. Without shared protocol, each agent validated rather than challenged. The upgrade encodes the discipline the trio needs to catch bad assumptions early and produce decisions with visible reasoning.

## How
Each agent now references `_trio.md` and must end every substantive response with a **Trio check** block naming what the other two would challenge. The `UserPromptSubmit` hook fires a keyword heuristic on every prompt and injects a `<trio_required>` context block when the task looks product-relevant, making trio invocation the default rather than something to remember.

## Testing
- Dry-run acceptance test passed: scenario "user reports cards generated from wrong Notion sections" — all three upgraded agents produced specific, non-generic, cross-referencing responses (included in the implementation conversation).
- Hook tested locally: `echo '{"prompt":"add a new feature for user onboarding"}' | bash .claude/hooks/trio_check.sh` produces the expected additionalContext JSON.

## Risks
- Hook keyword heuristic may fire too broadly; tune the `grep -E` pattern in `trio_check.sh` after a week of use.
- Three parallel subagent invocations on every product-relevant prompt has real token cost; monitor and adjust the heuristic keyword list if usage spikes.

## Goal alignment
Operational infrastructure, not a user-facing feature. Directly supports the 300K-user goal by making the trio more likely to catch bad product assumptions before engineering time is committed.