### PR TITLE
feat: customer feedback capture — snapshots, /feedback, OST, emoji nudge

### DIFF
--- a/migrations/20260521000000_interview_snapshots.js
+++ b/migrations/20260521000000_interview_snapshots.js
@@ -1,0 +1,43 @@
+exports.up = (knex) =>
+  knex.schema
+    .createTable('interview_snapshots', (table) => {
+      table.uuid('id').primary();
+      table.text('participant_name').notNullable();
+      table.text('memorable_quote').notNullable().defaultTo('');
+      table.text('photo_data');
+      table.date('signup_date');
+      table.text('plan_tier').notNullable().defaultTo('');
+      table.text('usage_pattern').notNullable().defaultTo('');
+      table.text('source').notNullable().defaultTo('');
+      table.text('experience_map_data');
+      table.date('interview_date').notNullable();
+      table.integer('session_length_minutes');
+      table
+        .timestamp('created_at', { useTz: true })
+        .notNullable()
+        .defaultTo(knex.fn.now());
+      table
+        .timestamp('updated_at', { useTz: true })
+        .notNullable()
+        .defaultTo(knex.fn.now());
+    })
+    .createTable('interview_opportunities', (table) => {
+      table.uuid('id').primary();
+      table
+        .uuid('snapshot_id')
+        .notNullable()
+        .references('id')
+        .inTable('interview_snapshots')
+        .onDelete('CASCADE');
+      table.text('body').notNullable();
+      table.text('tag').notNullable(); // 'opportunity' | 'insight'
+      table
+        .timestamp('created_at', { useTz: true })
+        .notNullable()
+        .defaultTo(knex.fn.now());
+    });
+
+exports.down = (knex) =>
+  knex.schema
+    .dropTableIfExists('interview_opportunities')
+    .dropTableIfExists('interview_snapshots');

--- a/migrations/20260522000000_ost_tables.js
+++ b/migrations/20260522000000_ost_tables.js
@@ -1,0 +1,34 @@
+exports.up = (knex) =>
+  knex.schema
+    .createTable('ost_versions', (table) => {
+      table.uuid('id').primary();
+      table
+        .timestamp('generated_at', { useTz: true })
+        .notNullable()
+        .defaultTo(knex.fn.now());
+      table.integer('snapshot_count').notNullable().defaultTo(0);
+      table.text('raw_response');
+    })
+    .createTable('opportunity_tree_nodes', (table) => {
+      table.uuid('id').primary();
+      table
+        .uuid('ost_version_id')
+        .notNullable()
+        .references('id')
+        .inTable('ost_versions')
+        .onDelete('CASCADE');
+      table
+        .uuid('parent_id')
+        .nullable()
+        .references('id')
+        .inTable('opportunity_tree_nodes');
+      table.text('body').notNullable();
+      table.text('type').notNullable(); // outcome | opportunity | sub_opportunity | solution
+      table.integer('depth').notNullable().defaultTo(0);
+      table.integer('sort_order').notNullable().defaultTo(0);
+    });
+
+exports.down = (knex) =>
+  knex.schema
+    .dropTableIfExists('opportunity_tree_nodes')
+    .dropTableIfExists('ost_versions');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,18 @@ importers:
       '@bugsnag/plugin-react':
         specifier: ^8.9.0
         version: 8.9.0(@bugsnag/core@8.9.0)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.6)
+      '@excalidraw/excalidraw':
+        specifier: ^0.18.1
+        version: 0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query':
         specifier: ^5.100.10
         version: 5.100.10(react@19.2.6)
@@ -440,6 +452,9 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@anthropic-ai/sdk@0.95.2':
     resolution: {integrity: sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==}
@@ -1329,6 +1344,12 @@ packages:
   '@biomejs/wasm-nodejs@2.4.14':
     resolution: {integrity: sha512-XFDMqwQepkYtd7JdXkwDKAEP5z1yFM+vL6Wd8ych7bTCKyacZ0m+KUvb6j3WW/py11q0WRoNHvF47yjCINKD/A==}
 
+  '@braintree/sanitize-url@6.0.2':
+    resolution: {integrity: sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -1358,6 +1379,24 @@ packages:
 
   '@bugsnag/safe-json-stringify@6.1.0':
     resolution: {integrity: sha512-ImA35rnM7bGr+J30R979FQ95BhRB4UO1KfJA0J2sVqc8nwnrS9hhE5mkTmQWMs8Vh1Da+hkLKs5jJB4JjNZp4A==}
+
+  '@chevrotain/cst-dts-gen@11.0.3':
+    resolution: {integrity: sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==}
+
+  '@chevrotain/gast@11.0.3':
+    resolution: {integrity: sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==}
+
+  '@chevrotain/regexp-to-ast@11.0.3':
+    resolution: {integrity: sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==}
+
+  '@chevrotain/types@11.0.3':
+    resolution: {integrity: sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@chevrotain/utils@11.0.3':
+    resolution: {integrity: sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -1398,6 +1437,28 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1567,6 +1628,25 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@excalidraw/excalidraw@0.18.1':
+    resolution: {integrity: sha512-6i5Gt7IDTOH//qa0Z315Ly5iVRhjWpu2whrlQFqkuwrkKUWgRsMk0P5qdE7bpyDpai7jeLeWYkyj1eVAfni1lw==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.2.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.2.0 || ^19.0.0
+
+  '@excalidraw/laser-pointer@1.3.1':
+    resolution: {integrity: sha512-psA1z1N2qeAfsORdXc9JmD2y4CmDwmuMRxnNdJHZexIcPwaNEyIpNcelw+QkL9rz9tosaN9krXuKaRqYpRAR6g==}
+
+  '@excalidraw/markdown-to-text@0.1.2':
+    resolution: {integrity: sha512-1nDXBNAojfi3oSFwJswKREkFm5wrSjqay81QlyRv2pkITG/XYB5v+oChENVBQLcxQwX4IUATWvXM5BcaNhPiIg==}
+
+  '@excalidraw/mermaid-to-excalidraw@2.2.2':
+    resolution: {integrity: sha512-5VKQq5CdRocC82vOIUpQ5ufJOVV9FpBTdHGA+ULqazeIVV+cr299877omQCibsdS3Bpitz2fsnTwnIXEmLVDSg==}
+
+  '@excalidraw/random-username@1.1.0':
+    resolution: {integrity: sha512-nULYsQxkWHnbmHvcs+efMkJ4/9TtvNyFeLyHdeGxW0zHs6P+jYVqcRff9A6Vq9w9JXeDRnRh2VKvTtS19GW2qA==}
+    engines: {node: '>=10'}
+
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1578,6 +1658,21 @@ packages:
 
   '@exodus/schemasafe@1.3.0':
     resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@google-cloud/vertexai@1.12.0':
     resolution: {integrity: sha512-XMJIk7GIeavFLP5A3YEUlowKa5Y5PZRrnnuTJcqR0k+lFKkv7+IWpdRp+Xbqb8xNDrvQaE2hP2RYPUylyD5EdA==}
@@ -1605,6 +1700,12 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1768,6 +1869,12 @@ packages:
     resolution: {integrity: sha512-CfBK4/EZ73uN/6b5/wOfvWju1Ev/6H+uXqS2Vqd7/dEQTyOsvv4BdOHDqESp4Efa9YyrPPvN3IHU+C4z9FAo3Q==}
     engines: {node: '>= 18'}
 
+  '@mermaid-js/parser@0.6.3':
+    resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+
   '@metascraper/helpers@5.50.1':
     resolution: {integrity: sha512-F2C23cjHAL2fE5LAj+SsHGLC/8GCiI9U8m4iu92CwQScTYuDA2s9wrkDqsvSlVhnTxdAEM7JikLbyRIr+laXig==}
     engines: {node: '>= 22'}
@@ -1838,6 +1945,288 @@ packages:
     resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@radix-ui/primitive@1.0.0':
+    resolution: {integrity: sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==}
+
+  '@radix-ui/primitive@1.1.1':
+    resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+
+  '@radix-ui/react-arrow@1.1.2':
+    resolution: {integrity: sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.0.1':
+    resolution: {integrity: sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-compose-refs@1.0.0':
+    resolution: {integrity: sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-compose-refs@1.1.1':
+    resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.0.0':
+    resolution: {integrity: sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-context@1.1.1':
+    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.0.0':
+    resolution: {integrity: sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-dismissable-layer@1.1.5':
+    resolution: {integrity: sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.1':
+    resolution: {integrity: sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.2':
+    resolution: {integrity: sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.0.0':
+    resolution: {integrity: sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-id@1.1.0':
+    resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.6':
+    resolution: {integrity: sha512-NQouW0x4/GnkFJ/pRqsIS3rM/k97VzKnVb2jB7Gq7VEGPy5g7uNV1ykySFt7eWSp3i2uSGFwaJcvIRJBAHmmFg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.2':
+    resolution: {integrity: sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.4':
+    resolution: {integrity: sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.0.0':
+    resolution: {integrity: sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-presence@1.1.2':
+    resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@1.0.1':
+    resolution: {integrity: sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.0.2':
+    resolution: {integrity: sha512-HLK+CqD/8pN6GfJm3U+cqpqhSKYAWiOJDe+A+8MfxBnOue39QEeMa43csUn2CXCHQT0/mewh1LrrG4tfkM9DMA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-slot@1.0.1':
+    resolution: {integrity: sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.0.2':
+    resolution: {integrity: sha512-gOUwh+HbjCuL0UCo8kZ+kdUEG8QtpdO4sMQduJ34ZEz0r4922g9REOBM+vIsfwtGxSug4Yb1msJMJYN2Bk8TpQ==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-callback-ref@1.0.0':
+    resolution: {integrity: sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-callback-ref@1.1.0':
+    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.0.0':
+    resolution: {integrity: sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-controllable-state@1.1.0':
+    resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.0':
+    resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.0.0':
+    resolution: {integrity: sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0
+
+  '@radix-ui/react-use-layout-effect@1.1.0':
+    resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.0':
+    resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.0':
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.0':
+    resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
@@ -2387,11 +2776,50 @@ packages:
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
   '@types/d3-ease@3.0.2':
     resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
 
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
@@ -2399,17 +2827,44 @@ packages:
   '@types/d3-path@3.1.1':
     resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
 
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
   '@types/d3-scale@4.0.9':
     resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
 
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
   '@types/d3-shape@3.1.8':
     resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
 
   '@types/d3-time@3.0.4':
     resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -2447,6 +2902,9 @@ packages:
 
   '@types/find-remove@2.0.3':
     resolution: {integrity: sha512-FF9QKGSLfRk5O/R/KImfvwfj8NVlc8xIIDSvmfVR4FXbFMgN3urI720/2FUYtul+1iwfLl/j+6Wqq+52dPQxBQ==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -2698,6 +3156,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
   '@vitejs/plugin-legacy@8.0.1':
     resolution: {integrity: sha512-8zeDeuNPqXd49rIVgFgluQYB8vQICHR7l+W2I3CxYK4gTjTorajVr0wLvSjALIwEwLRxBn68EgNVyGP4j6hP7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2853,6 +3314,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -3073,6 +3538,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-fs-access@0.29.1:
+    resolution: {integrity: sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw==}
+
   browserslist-to-esbuild@2.1.1:
     resolution: {integrity: sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==}
     engines: {node: '>=18'}
@@ -3179,6 +3647,9 @@ packages:
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
+  canvas-roundrect-polyfill@0.0.1:
+    resolution: {integrity: sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw==}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -3216,6 +3687,14 @@ packages:
   cheerio@1.2.0:
     resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
     engines: {node: '>=20.18.1'}
+
+  chevrotain-allstar@0.3.1:
+    resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
+    peerDependencies:
+      chevrotain: ^11.0.0
+
+  chevrotain@11.0.3:
+    resolution: {integrity: sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -3269,6 +3748,10 @@ packages:
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
+  clsx@1.1.1:
+    resolution: {integrity: sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==}
+    engines: {node: '>=6'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -3307,6 +3790,14 @@ packages:
   commander@6.2.0:
     resolution: {integrity: sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==}
     engines: {node: '>= 6'}
+
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
 
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
@@ -3385,6 +3876,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -3407,6 +3904,10 @@ packages:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
 
+  crc-32@0.3.0:
+    resolution: {integrity: sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA==}
+    engines: {node: '>=0.8'}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -3422,6 +3923,11 @@ packages:
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
+    hasBin: true
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
     hasBin: true
 
   cross-spawn@7.0.6:
@@ -3457,33 +3963,128 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.3:
+    resolution: {integrity: sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
     engines: {node: '>=12'}
 
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
     engines: {node: '>=12'}
 
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
     engines: {node: '>=12'}
 
   d3-format@3.1.2:
     resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
     engines: {node: '>=12'}
 
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
 
   d3-path@3.1.0:
     resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
     engines: {node: '>=12'}
 
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
   d3-scale@4.0.2:
     resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
     engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
 
   d3-shape@3.2.0:
     resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
@@ -3500,6 +4101,23 @@ packages:
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -3609,6 +4227,9 @@ packages:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -3631,6 +4252,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -3787,6 +4411,10 @@ packages:
 
   es-toolkit@1.46.1:
     resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
+  es6-promise-pool@2.5.0:
+    resolution: {integrity: sha512-VHErXfzR/6r/+yyzPKeBvO0lgjfC5cbDCQWjWwMZWSb6YU39TGIl51OUmCfWCq4ylMdJSB8zkz2vIuIeIxXApA==}
+    engines: {node: '>=0.10.0'}
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
@@ -4027,6 +4655,10 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fractional-indexing@3.2.0:
+    resolution: {integrity: sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -4049,6 +4681,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fuzzy@0.1.3:
+    resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
+    engines: {node: '>= 0.6.0'}
 
   fzstd@0.1.1:
     resolution: {integrity: sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==}
@@ -4088,6 +4724,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-notion-object-title@0.2.9:
     resolution: {integrity: sha512-ZkxiC2bwDXmEcssNg3LMg7F/03YYd67f5DDSl2o4xMS+suxPQvAJOuse6Lm/A0ANrIs4zvJImIU0Bd4gJ7gjew==}
@@ -4151,6 +4791,9 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  glur@1.1.2:
+    resolution: {integrity: sha512-l+8esYHTKOx2G/Aao4lEQ0bnHWg4fWtJbVoZZT9Knxi01pB8C80BR85nONLFwkkQoFRCmXY+BUcGZN3yZ2QsRA==}
+
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
@@ -4185,6 +4828,9 @@ packages:
   gtoken@7.1.0:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
+
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -4326,6 +4972,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  image-blob-reduce@3.0.1:
+    resolution: {integrity: sha512-/VmmWgIryG/wcn4TVrV7cC4mlfUC/oyiKIfSg5eVM3Ten/c1c34RJhMYKCWTnoSMHSqXLt3tsrBR4Q2HInvN+Q==}
+
   image-extensions@1.1.0:
     resolution: {integrity: sha512-P0t7ByhK8Jk9TU05ct/7+f7h8dNuXq5OY4m0IO/T+1aga/qHkpC0Wf472x3FLdq/zFDG17pgapCM3JDTxwZzow==}
     engines: {node: '>=0.10.0'}
@@ -4339,6 +4988,9 @@ packages:
   immer@11.1.8:
     resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
 
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -4347,6 +4999,9 @@ packages:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
     hasBin: true
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -4373,6 +5028,9 @@ packages:
     resolution: {integrity: sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
@@ -4704,6 +5362,24 @@ packages:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}
     engines: {node: '>= 0.6.0'}
 
+  jotai-scope@0.7.2:
+    resolution: {integrity: sha512-Gwed97f3dDObrO43++2lRcgOqw4O2sdr4JCjP/7eHK1oPACDJ7xKHGScpJX9XaflU+KBHXF+VhwECnzcaQiShg==}
+    peerDependencies:
+      jotai: '>=2.9.2'
+      react: '>=17.0.0'
+
+  jotai@2.11.0:
+    resolution: {integrity: sha512-zKfoBBD1uDw3rljwHkt0fWuja1B76R7CjznuBO+mSX6jpsO1EBeWNRKpeaQho9yPI/pvCv4recGfgOXGxwPZvQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -4779,8 +5455,15 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.45:
+    resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -4816,6 +5499,16 @@ packages:
         optional: true
       tedious:
         optional: true
+
+  langium@3.3.1:
+    resolution: {integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==}
+    engines: {node: '>=16.0.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -4917,6 +5610,12 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -4957,6 +5656,9 @@ packages:
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lodash.throttle@4.1.1:
+    resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -5031,6 +5733,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -5104,6 +5811,9 @@ packages:
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   metascraper-description@5.50.1:
     resolution: {integrity: sha512-bDOTaDigGn7SI4NoOURPBId8RLAfQ4uCruLjiQPs+ccVo0Chnfmk1ghPKjcQifkX6D550j+jxk0eFO/QatZEDw==}
@@ -5323,6 +6033,9 @@ packages:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
 
+  multimath@2.0.0:
+    resolution: {integrity: sha512-toRx66cAMJ+Ccz7pMIg38xSIrtnbozk0dchXezwQDMgQmbGpfxjtv68H+L00iFL8hxDaVjrmwAFSb3I6bg8Q2g==}
+
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
@@ -5334,6 +6047,16 @@ packages:
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.3:
+    resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@4.0.2:
+    resolution: {integrity: sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==}
+    engines: {node: ^14 || ^16 || >=18}
     hasBin: true
 
   nanoid@5.1.11:
@@ -5492,6 +6215,9 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  open-color@1.9.1:
+    resolution: {integrity: sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw==}
+
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
@@ -5537,8 +6263,14 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  pako@2.0.3:
+    resolution: {integrity: sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -5580,6 +6312,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -5627,6 +6362,9 @@ packages:
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
+  perfect-freehand@1.2.0:
+    resolution: {integrity: sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==}
+
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
 
@@ -5664,6 +6402,9 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  pica@7.1.1:
+    resolution: {integrity: sha512-WY73tMvNzXWEld2LicT9Y260L43isrZ85tPuqRyvtkljSDLmnNFQmZICt4xUJMVulmcc6L9O7jbBrtx3DOz/YQ==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5691,6 +6432,24 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  png-chunk-text@1.0.0:
+    resolution: {integrity: sha512-DEROKU3SkkLGWNMzru3xPVgxyd48UGuMSZvioErCure6yhOc/pRH2ZV+SEn7nmaf7WNf3NdIpH+UTrRdKyq9Lw==}
+
+  png-chunks-encode@1.0.0:
+    resolution: {integrity: sha512-J1jcHgbQRsIIgx5wxW9UmCymV3wwn4qCCJl6KYgEU/yHCh/L2Mwq/nMOkRPtmV79TLxRZj5w3tH69pvygFkDqA==}
+
+  png-chunks-extract@1.0.0:
+    resolution: {integrity: sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-curve@1.0.1:
+    resolution: {integrity: sha512-3nmX4/LIiyuwGLwuUrfhTlDeQFlAhi7lyK/zcRNGhalwapDWgAGR82bUpmn2mA03vII3fvNCG8jAONzKXwpxAg==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5827,6 +6586,9 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
+  pwacompat@2.0.17:
+    resolution: {integrity: sha512-6Du7IZdIy7cHiv7AhtDy4X2QRM8IAD5DII69mt5qWibC2d15ZU8DmBG1WdZKekG11cChSu4zkSUGPF9sweOl6w==}
+
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
@@ -5920,6 +6682,26 @@ packages:
       redux:
         optional: true
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router-dom@7.15.0:
     resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
     engines: {node: '>=20.0.0'}
@@ -5935,6 +6717,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react@19.2.6:
@@ -6082,14 +6874,26 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0:
     resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  roughjs@4.6.4:
+    resolution: {integrity: sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -6109,6 +6913,11 @@ packages:
 
   sanitize-html@2.17.3:
     resolution: {integrity: sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==}
+
+  sass@1.51.0:
+    resolution: {integrity: sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   sax@1.2.1:
     resolution: {integrity: sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==}
@@ -6250,6 +7059,10 @@ packages:
   slice-ansi@8.0.0:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
+
+  sliced@1.0.1:
+    resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
+    deprecated: Unsupported
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -6413,6 +7226,9 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -6602,6 +7418,10 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
+
   ts-jest@29.4.9:
     resolution: {integrity: sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -6653,6 +7473,9 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tunnel-rat@0.1.2:
+    resolution: {integrity: sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==}
 
   tween-functions@1.2.0:
     resolution: {integrity: sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==}
@@ -6793,6 +7616,26 @@ packages:
   url@0.10.3:
     resolution: {integrity: sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -6803,6 +7646,10 @@ packages:
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
@@ -6934,6 +7781,26 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -6957,6 +7824,9 @@ packages:
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  webworkify@1.5.0:
+    resolution: {integrity: sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -7142,6 +8012,21 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -7152,6 +8037,11 @@ snapshots:
   '@acemir/cssom@0.9.31': {}
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
 
   '@anthropic-ai/sdk@0.95.2(zod@3.25.76)':
     dependencies:
@@ -8472,6 +9362,10 @@ snapshots:
 
   '@biomejs/wasm-nodejs@2.4.14': {}
 
+  '@braintree/sanitize-url@6.0.2': {}
+
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -8510,6 +9404,25 @@ snapshots:
 
   '@bugsnag/safe-json-stringify@6.1.0': {}
 
+  '@chevrotain/cst-dts-gen@11.0.3':
+    dependencies:
+      '@chevrotain/gast': 11.0.3
+      '@chevrotain/types': 11.0.3
+      lodash-es: 4.17.21
+
+  '@chevrotain/gast@11.0.3':
+    dependencies:
+      '@chevrotain/types': 11.0.3
+      lodash-es: 4.17.21
+
+  '@chevrotain/regexp-to-ast@11.0.3': {}
+
+  '@chevrotain/types@11.0.3': {}
+
+  '@chevrotain/types@11.1.2': {}
+
+  '@chevrotain/utils@11.0.3': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -8537,6 +9450,31 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.6)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.6)
+      react: 19.2.6
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -8634,9 +9572,79 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@excalidraw/excalidraw@0.18.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@braintree/sanitize-url': 6.0.2
+      '@excalidraw/laser-pointer': 1.3.1
+      '@excalidraw/mermaid-to-excalidraw': 2.2.2
+      '@excalidraw/random-username': 1.1.0
+      '@radix-ui/react-popover': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-tabs': 1.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      browser-fs-access: 0.29.1
+      canvas-roundrect-polyfill: 0.0.1
+      clsx: 1.1.1
+      cross-env: 7.0.3
+      es6-promise-pool: 2.5.0
+      fractional-indexing: 3.2.0
+      fuzzy: 0.1.3
+      image-blob-reduce: 3.0.1
+      jotai: 2.11.0(@types/react@19.2.14)(react@19.2.6)
+      jotai-scope: 0.7.2(jotai@2.11.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6)
+      lodash.debounce: 4.0.8
+      lodash.throttle: 4.1.1
+      nanoid: 3.3.3
+      open-color: 1.9.1
+      pako: 2.0.3
+      perfect-freehand: 1.2.0
+      pica: 7.1.1
+      png-chunk-text: 1.0.0
+      png-chunks-encode: 1.0.0
+      png-chunks-extract: 1.0.0
+      points-on-curve: 1.0.1
+      pwacompat: 2.0.17
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      roughjs: 4.6.4
+      sass: 1.51.0
+      tunnel-rat: 0.1.2(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - immer
+
+  '@excalidraw/laser-pointer@1.3.1': {}
+
+  '@excalidraw/markdown-to-text@0.1.2': {}
+
+  '@excalidraw/mermaid-to-excalidraw@2.2.2':
+    dependencies:
+      '@excalidraw/markdown-to-text': 0.1.2
+      '@mermaid-js/parser': 0.6.3
+      mermaid: 11.15.0
+      nanoid: 4.0.2
+
+  '@excalidraw/random-username@1.1.0': {}
+
   '@exodus/bytes@1.15.0': {}
 
   '@exodus/schemasafe@1.3.0': {}
+
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@google-cloud/vertexai@1.12.0':
     dependencies:
@@ -8678,6 +9686,14 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.5
       yargs: 17.7.2
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -8952,6 +9968,14 @@ snapshots:
 
   '@kikobeats/time-span@1.0.13': {}
 
+  '@mermaid-js/parser@0.6.3':
+    dependencies:
+      langium: 3.3.1
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
+
   '@metascraper/helpers@5.50.1':
     dependencies:
       audio-extensions: 0.0.0
@@ -9052,6 +10076,286 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@radix-ui/primitive@1.0.0':
+    dependencies:
+      '@babel/runtime': 7.29.2
+
+  '@radix-ui/primitive@1.1.1': {}
+
+  '@radix-ui/react-arrow@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.6)
+      '@radix-ui/react-context': 1.0.0(react@19.2.6)
+      '@radix-ui/react-primitive': 1.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.0.1(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@radix-ui/react-compose-refs@1.0.0(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      react: 19.2.6
+
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.0.0(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      react: 19.2.6
+
+  '@radix-ui/react-context@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-direction@1.0.0(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      react: 19.2.6
+
+  '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.0.0(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@19.2.6)
+      react: 19.2.6
+
+  '@radix-ui/react-id@1.1.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-popover@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-arrow': 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/rect': 1.1.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.0.0(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@1.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/react-slot': 1.0.1(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/primitive': 1.0.0
+      '@radix-ui/react-collection': 1.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.6)
+      '@radix-ui/react-context': 1.0.0(react@19.2.6)
+      '@radix-ui/react-direction': 1.0.0(react@19.2.6)
+      '@radix-ui/react-id': 1.0.0(react@19.2.6)
+      '@radix-ui/react-primitive': 1.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.0.0(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@radix-ui/react-slot@1.0.1(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/react-compose-refs': 1.0.0(react@19.2.6)
+      react: 19.2.6
+
+  '@radix-ui/react-slot@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-tabs@1.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/primitive': 1.0.0
+      '@radix-ui/react-context': 1.0.0(react@19.2.6)
+      '@radix-ui/react-direction': 1.0.0(react@19.2.6)
+      '@radix-ui/react-id': 1.0.0(react@19.2.6)
+      '@radix-ui/react-presence': 1.0.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 1.0.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.0.0(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@radix-ui/react-use-callback-ref@1.0.0(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      react: 19.2.6
+
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.0.0(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@radix-ui/react-use-callback-ref': 1.0.0(react@19.2.6)
+      react: 19.2.6
+
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.0.0(react@19.2.6)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      react: 19.2.6
+
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/rect': 1.1.0
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.0(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/rect@1.1.0': {}
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
     dependencies:
@@ -9701,9 +11005,48 @@ snapshots:
 
   '@types/d3-array@3.2.2': {}
 
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
   '@types/d3-color@3.1.3': {}
 
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
   '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
 
   '@types/d3-interpolate@3.0.4':
     dependencies:
@@ -9711,17 +11054,71 @@ snapshots:
 
   '@types/d3-path@3.1.1': {}
 
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
   '@types/d3-scale@4.0.9':
     dependencies:
       '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
 
   '@types/d3-shape@3.1.8':
     dependencies:
       '@types/d3-path': 3.1.1
 
+  '@types/d3-time-format@4.0.3': {}
+
   '@types/d3-time@3.0.4': {}
 
   '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
 
   '@types/debug@4.1.13':
     dependencies:
@@ -9771,6 +11168,8 @@ snapshots:
       '@types/serve-static': 1.15.10
 
   '@types/find-remove@2.0.3': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -10003,6 +11402,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
   '@vitejs/plugin-legacy@8.0.1(terser@5.47.1)(vite@8.0.12(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -10183,6 +11587,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.0:
     dependencies:
@@ -10438,6 +11846,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-fs-access@0.29.1: {}
+
   browserslist-to-esbuild@2.1.1(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -10552,6 +11962,8 @@ snapshots:
 
   caniuse-lite@1.0.30001792: {}
 
+  canvas-roundrect-polyfill@0.0.1: {}
+
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
@@ -10607,6 +12019,20 @@ snapshots:
       parse5-parser-stream: 7.1.2
       undici: 7.24.7
       whatwg-mimetype: 4.0.0
+
+  chevrotain-allstar@0.3.1(chevrotain@11.0.3):
+    dependencies:
+      chevrotain: 11.0.3
+      lodash-es: 4.18.1
+
+  chevrotain@11.0.3:
+    dependencies:
+      '@chevrotain/cst-dts-gen': 11.0.3
+      '@chevrotain/gast': 11.0.3
+      '@chevrotain/regexp-to-ast': 11.0.3
+      '@chevrotain/types': 11.0.3
+      '@chevrotain/utils': 11.0.3
+      lodash-es: 4.17.21
 
   chokidar@3.6.0:
     dependencies:
@@ -10665,6 +12091,8 @@ snapshots:
     dependencies:
       mimic-response: 1.0.1
 
+  clsx@1.1.1: {}
+
   clsx@2.1.1: {}
 
   co@4.6.0: {}
@@ -10690,6 +12118,10 @@ snapshots:
   commander@2.20.3: {}
 
   commander@6.2.0: {}
+
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
 
   commander@9.5.0: {}
 
@@ -10759,6 +12191,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
@@ -10783,6 +12223,8 @@ snapshots:
       nan: 2.26.2
     optional: true
 
+  crc-32@0.3.0: {}
+
   crc-32@1.2.2: {}
 
   crc32-stream@6.0.0:
@@ -10795,6 +12237,10 @@ snapshots:
   cross-env@10.1.0:
     dependencies:
       '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
+
+  cross-env@7.0.3:
+    dependencies:
       cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
@@ -10833,21 +12279,106 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.3
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.3
+
+  cytoscape@3.33.3: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
   d3-array@3.2.4:
     dependencies:
       internmap: 2.0.3
 
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
 
   d3-ease@3.0.1: {}
 
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
   d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@1.0.9: {}
+
   d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
 
   d3-scale@4.0.2:
     dependencies:
@@ -10856,6 +12387,12 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-time: 3.1.0
       d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
 
   d3-shape@3.2.0:
     dependencies:
@@ -10870,6 +12407,61 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -10953,6 +12545,10 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -10964,6 +12560,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node-es@1.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -11115,6 +12713,8 @@ snapshots:
       hasown: 2.0.2
 
   es-toolkit@1.46.1: {}
+
+  es6-promise-pool@2.5.0: {}
 
   es6-promise@3.3.1: {}
 
@@ -11399,6 +12999,8 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fractional-indexing@3.2.0: {}
+
   fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
@@ -11412,6 +13014,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  fuzzy@0.1.3: {}
 
   fzstd@0.1.1: {}
 
@@ -11471,6 +13075,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-notion-object-title@0.2.9:
     dependencies:
@@ -11549,6 +13155,8 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  glur@1.1.2: {}
+
   google-auth-library@10.6.2:
     dependencies:
       base64-js: 1.5.1
@@ -11608,6 +13216,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  hachure-fill@0.5.2: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -11817,6 +13427,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  image-blob-reduce@3.0.1:
+    dependencies:
+      pica: 7.1.1
+
   image-extensions@1.1.0: {}
 
   immediate@3.0.6: {}
@@ -11824,6 +13438,8 @@ snapshots:
   immer@10.2.0: {}
 
   immer@11.1.8: {}
+
+  immutable@4.3.8: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -11834,6 +13450,8 @@ snapshots:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+
+  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -11851,6 +13469,8 @@ snapshots:
   inline-style-parser@0.2.7: {}
 
   install-artifact-from-github@1.6.0: {}
+
+  internmap@1.0.1: {}
 
   internmap@2.0.3: {}
 
@@ -12364,6 +13984,16 @@ snapshots:
 
   jmespath@0.16.0: {}
 
+  jotai-scope@0.7.2(jotai@2.11.0(@types/react@19.2.14)(react@19.2.6))(react@19.2.6):
+    dependencies:
+      jotai: 2.11.0(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+
+  jotai@2.11.0(@types/react@19.2.14)(react@19.2.6):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.6
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -12483,9 +14113,15 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.45:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
 
@@ -12510,6 +14146,18 @@ snapshots:
       pg: 8.20.0
     transitivePeerDependencies:
       - supports-color
+
+  langium@3.3.1:
+    dependencies:
+      chevrotain: 11.0.3
+      chevrotain-allstar: 0.3.1(chevrotain@11.0.3)
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lazystream@1.0.1:
     dependencies:
@@ -12595,6 +14243,10 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash-es@4.17.21: {}
+
+  lodash-es@4.18.1: {}
+
   lodash.camelcase@4.3.0: {}
 
   lodash.debounce@4.0.8: {}
@@ -12620,6 +14272,8 @@ snapshots:
   lodash.mergewith@4.6.2: {}
 
   lodash.once@4.1.1: {}
+
+  lodash.throttle@4.1.1: {}
 
   lodash@4.18.1: {}
 
@@ -12699,6 +14353,8 @@ snapshots:
       xmlbuilder: 10.1.1
 
   markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -12868,6 +14524,30 @@ snapshots:
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.3
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.3)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.3)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.2
+      es-toolkit: 1.46.1
+      katex: 0.16.45
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
 
   metascraper-description@5.50.1:
     dependencies:
@@ -13214,11 +14894,20 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
+  multimath@2.0.0:
+    dependencies:
+      glur: 1.1.2
+      object-assign: 4.1.1
+
   nan@2.26.2: {}
 
   nanoid@3.3.11: {}
 
   nanoid@3.3.12: {}
+
+  nanoid@3.3.3: {}
+
+  nanoid@4.0.2: {}
 
   nanoid@5.1.11: {}
 
@@ -13374,6 +15063,8 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  open-color@1.9.1: {}
+
   openapi-types@12.1.3: {}
 
   option@0.2.4: {}
@@ -13421,7 +15112,11 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@1.6.0: {}
+
   pako@1.0.11: {}
+
+  pako@2.0.3: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -13474,6 +15169,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-data-parser@0.1.0: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.2.1: {}
@@ -13505,6 +15202,8 @@ snapshots:
   pend@1.2.0: {}
 
   perfect-debounce@2.1.0: {}
+
+  perfect-freehand@1.2.0: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -13543,6 +15242,14 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  pica@7.1.1:
+    dependencies:
+      glur: 1.1.2
+      inherits: 2.0.4
+      multimath: 2.0.0
+      object-assign: 4.1.1
+      webworkify: 1.5.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -13566,6 +15273,26 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  png-chunk-text@1.0.0: {}
+
+  png-chunks-encode@1.0.0:
+    dependencies:
+      crc-32: 0.3.0
+      sliced: 1.0.1
+
+  png-chunks-extract@1.0.0:
+    dependencies:
+      crc-32: 0.3.0
+
+  points-on-curve@0.2.0: {}
+
+  points-on-curve@1.0.1: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -13745,6 +15472,8 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
+  pwacompat@2.0.17: {}
+
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
@@ -13850,6 +15579,25 @@ snapshots:
       '@types/react': 19.2.14
       redux: 5.0.1
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.6)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-router-dom@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -13863,6 +15611,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.6(react@19.2.6)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.6: {}
 
@@ -14051,6 +15807,8 @@ snapshots:
       glob: 11.1.0
       package-json-from-dist: 1.0.1
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.0:
     dependencies:
       '@oxc-project/types': 0.129.0
@@ -14072,6 +15830,20 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0
       '@rolldown/binding-win32-x64-msvc': 1.0.0
 
+  roughjs@4.6.4:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
@@ -14081,6 +15853,8 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -14106,6 +15880,12 @@ snapshots:
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
       postcss: 8.5.10
+
+  sass@1.51.0:
+    dependencies:
+      chokidar: 3.6.0
+      immutable: 4.3.8
+      source-map-js: 1.2.1
 
   sax@1.2.1: {}
 
@@ -14274,6 +16054,8 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  sliced@1.0.1: {}
+
   smart-buffer@4.2.0: {}
 
   smartquotes@2.3.2: {}
@@ -14436,6 +16218,8 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  stylis@4.4.0: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -14671,6 +16455,8 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+  ts-dedent@2.2.0: {}
+
   ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.0))(jest-util@30.4.1)(jest@30.4.2(@types/node@25.6.2)(ts-node@10.9.2(@types/node@25.6.2)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
@@ -14721,6 +16507,14 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  tunnel-rat@0.1.2(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6):
+    dependencies:
+      zustand: 4.5.7(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
 
   tween-functions@1.2.0: {}
 
@@ -14868,6 +16662,21 @@ snapshots:
       punycode: 1.3.2
       querystring: 0.2.0
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -14881,6 +16690,8 @@ snapshots:
       is-generator-function: 1.1.2
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
+
+  uuid@14.0.0: {}
 
   uuid@8.0.0: {}
 
@@ -14989,6 +16800,23 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.0.8: {}
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -15006,6 +16834,8 @@ snapshots:
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
+
+  webworkify@1.5.0: {}
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -15174,5 +17004,13 @@ snapshots:
       readable-stream: 4.7.0
 
   zod@3.25.76: {}
+
+  zustand@4.5.7(@types/react@19.2.14)(immer@11.1.8)(react@19.2.6):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      immer: 11.1.8
+      react: 19.2.6
 
   zwitch@2.0.4: {}

--- a/src/controllers/FeedbackController.ts
+++ b/src/controllers/FeedbackController.ts
@@ -1,0 +1,76 @@
+import express from 'express';
+
+import type { InterviewSnapshotsRepository } from '../data_layer/InterviewSnapshotsRepository';
+import type JobRepository from '../data_layer/JobRepository';
+import type UsersRepository from '../data_layer/UsersRepository';
+
+function planTierFrom(patreon: unknown, subscriber: unknown): string {
+  if (patreon === true) return 'lifetime';
+  if (subscriber === true) return 'pro';
+  return 'free';
+}
+
+export class FeedbackController {
+  constructor(
+    private readonly usersRepo: UsersRepository,
+    private readonly jobRepo: JobRepository,
+    private readonly snapshotsRepo: InterviewSnapshotsRepository
+  ) {}
+
+  async submitFeedback(req: express.Request, res: express.Response) {
+    const owner: string = res.locals.owner;
+    const body = req.body as Record<string, unknown>;
+
+    const story = typeof body.story === 'string' ? body.story.trim() : '';
+    const mainNeed = typeof body.mainNeed === 'string' ? body.mainNeed.trim() : '';
+    const secondItem = typeof body.secondItem === 'string' ? body.secondItem.trim() : '';
+
+    if (story.length < 10) {
+      res.status(400).json({ message: 'story must be at least 10 characters' });
+      return;
+    }
+    if (mainNeed.length < 10) {
+      res.status(400).json({ message: 'mainNeed must be at least 10 characters' });
+      return;
+    }
+
+    const user = await this.usersRepo.getById(owner);
+    if (user == null) {
+      res.status(404).json({ message: 'User not found' });
+      return;
+    }
+
+    const jobCount = await this.jobRepo.countJobsByOwner(owner);
+    const usagePattern = `${jobCount} conversion${jobCount !== 1 ? 's' : ''}`;
+
+    const signupDate =
+      user.created_at instanceof Date
+        ? user.created_at.toISOString().slice(0, 10)
+        : typeof user.created_at === 'string'
+        ? (user.created_at as string).slice(0, 10)
+        : null;
+
+    const opportunities: Array<{ body: string; tag: 'opportunity' | 'insight' }> = [
+      { body: mainNeed, tag: 'opportunity' },
+    ];
+    if (secondItem.length >= 10) {
+      opportunities.push({ body: secondItem, tag: 'insight' });
+    }
+
+    const snapshot = await this.snapshotsRepo.create({
+      participantName: user.email,
+      memorableQuote: story,
+      photoData: null,
+      signupDate,
+      planTier: planTierFrom(res.locals.patreon, res.locals.subscriber),
+      usagePattern,
+      source: 'feedback-form',
+      experienceMapData: null,
+      interviewDate: new Date().toISOString().slice(0, 10),
+      sessionLengthMinutes: null,
+      opportunities,
+    });
+
+    res.status(201).json({ id: snapshot.id });
+  }
+}

--- a/src/controllers/OpsDiscoveryController.ts
+++ b/src/controllers/OpsDiscoveryController.ts
@@ -1,0 +1,82 @@
+import express from 'express';
+
+import type { InterviewSnapshotsRepository, OpportunityTag } from '../data_layer/InterviewSnapshotsRepository';
+
+const VALID_TAGS: ReadonlySet<string> = new Set(['opportunity', 'insight']);
+
+export class OpsDiscoveryController {
+  constructor(
+    private readonly snapshotsRepo: InterviewSnapshotsRepository
+  ) {}
+
+  async listSnapshots(_req: express.Request, res: express.Response) {
+    const snapshots = await this.snapshotsRepo.list();
+    res.json(snapshots);
+  }
+
+  async createSnapshot(req: express.Request, res: express.Response) {
+    const body = req.body as Record<string, unknown>;
+
+    const participantName = typeof body.participantName === 'string' ? body.participantName.trim() : '';
+    if (participantName.length === 0) {
+      res.status(400).json({ message: 'participantName is required' });
+      return;
+    }
+
+    const interviewDate = typeof body.interviewDate === 'string' ? body.interviewDate.trim() : '';
+    if (interviewDate.length === 0) {
+      res.status(400).json({ message: 'interviewDate is required' });
+      return;
+    }
+
+    const rawOpportunities = Array.isArray(body.opportunities) ? body.opportunities : [];
+    const opportunities: Array<{ body: string; tag: OpportunityTag }> = [];
+    for (const opp of rawOpportunities) {
+      if (typeof opp !== 'object' || opp == null) continue;
+      const oppBody = typeof opp.body === 'string' ? opp.body.trim() : '';
+      const oppTag = typeof opp.tag === 'string' ? opp.tag : '';
+      if (oppBody.length === 0 || !VALID_TAGS.has(oppTag)) continue;
+      opportunities.push({ body: oppBody, tag: oppTag as OpportunityTag });
+    }
+
+    const sessionLength =
+      typeof body.sessionLengthMinutes === 'number' && Number.isFinite(body.sessionLengthMinutes)
+        ? Math.floor(body.sessionLengthMinutes)
+        : null;
+
+    const snapshot = await this.snapshotsRepo.create({
+      participantName,
+      memorableQuote: typeof body.memorableQuote === 'string' ? body.memorableQuote : '',
+      photoData: typeof body.photoData === 'string' && body.photoData.length > 0 ? body.photoData : null,
+      signupDate: typeof body.signupDate === 'string' && body.signupDate.length > 0 ? body.signupDate : null,
+      planTier: typeof body.planTier === 'string' ? body.planTier : '',
+      usagePattern: typeof body.usagePattern === 'string' ? body.usagePattern : '',
+      source: typeof body.source === 'string' ? body.source : '',
+      experienceMapData:
+        typeof body.experienceMapData === 'string' && body.experienceMapData.length > 0
+          ? body.experienceMapData
+          : null,
+      interviewDate,
+      sessionLengthMinutes: sessionLength,
+      opportunities,
+    });
+
+    res.status(201).json(snapshot);
+  }
+
+  async deleteSnapshot(req: express.Request, res: express.Response) {
+    const { id } = req.params;
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      res.status(400).json({ message: 'id is required' });
+      return;
+    }
+
+    const deleted = await this.snapshotsRepo.remove(id.trim());
+    if (!deleted) {
+      res.status(404).json({ message: 'Snapshot not found' });
+      return;
+    }
+
+    res.json({ message: 'Deleted' });
+  }
+}

--- a/src/controllers/OstController.ts
+++ b/src/controllers/OstController.ts
@@ -136,14 +136,7 @@ export class OstController {
     const response = await client.messages.create({
       model: 'claude-sonnet-4-5',
       max_tokens: 4096,
-      system: [
-        {
-          type: 'text',
-          text: OST_SYSTEM_PROMPT,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          cache_control: { type: 'ephemeral' } as any,
-        },
-      ],
+      system: OST_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: userMessage }],
     });
 

--- a/src/controllers/OstController.ts
+++ b/src/controllers/OstController.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from 'crypto';
+
+import express from 'express';
+
+import { getAnthropicClient } from '../lib/claude/ClaudeService';
+import type { InterviewSnapshotsRepository } from '../data_layer/InterviewSnapshotsRepository';
+import type { OstRepository, NewNodeInput, NodeType } from '../data_layer/OstRepository';
+
+const VALID_TYPES = new Set<string>([
+  'outcome',
+  'opportunity',
+  'sub_opportunity',
+  'solution',
+]);
+
+const MIN_SNAPSHOTS = 5;
+
+const OST_SYSTEM_PROMPT = `You are a product discovery analyst using Teresa Torres's Opportunity Solution Tree framework.
+Your job: organize customer feedback into a structured tree.
+
+Output ONLY a JSON object — no markdown, no explanation, no code fences:
+{"nodes":[{"id":"1","parent_id":null,"body":"...","type":"outcome","depth":0,"sort_order":0}]}
+
+Rules:
+- Use sequential string IDs ("1", "2", "3"...)
+- Root node: type "outcome", parent_id null, depth 0
+- Level 1: type "opportunity", depth 1 — high-level customer needs/pains in their own words
+- Level 2: type "sub_opportunity", depth 2 — more specific versions of the parent opportunity
+- Level 3: type "solution", depth 3 — concrete ways to address the parent opportunity
+- Write opportunity and sub_opportunity bodies in the customer's voice (needs/wants/frustrations, never company perspective)
+- Group related feedback under the same opportunity parent
+- Aim for 3-6 top-level opportunities; 1-3 sub-opportunities each; 1-2 solutions for the most important ones
+- sort_order is the display position among siblings (0-indexed)`.trim();
+
+interface ClaudeNode {
+  id: string;
+  parent_id: string | null;
+  body: string;
+  type: string;
+  depth: number;
+  sort_order: number;
+}
+
+interface ClaudeOstResponse {
+  nodes: ClaudeNode[];
+}
+
+function buildUserMessage(
+  snapshots: Awaited<ReturnType<InterviewSnapshotsRepository['list']>>
+): string {
+  const lines: string[] = [
+    'Product outcome to optimize: "Successful first-card-review rate — the user gets a usable Anki deck after their first conversion."',
+    '',
+    `Customer feedback (${snapshots.length} interview${snapshots.length !== 1 ? 's' : ''}):`,
+  ];
+
+  for (const snap of snapshots) {
+    lines.push('');
+    lines.push(
+      `Participant: ${snap.participantName} | Plan: ${snap.planTier || 'unknown'} | Usage: ${snap.usagePattern || 'unknown'}`
+    );
+    if (snap.memorableQuote) {
+      lines.push(`  Quote: "${snap.memorableQuote}"`);
+    }
+    if (snap.opportunities.length > 0) {
+      lines.push('  Opportunities & insights:');
+      for (const opp of snap.opportunities) {
+        lines.push(`    [${opp.tag}] ${opp.body}`);
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('Now generate the Opportunity Solution Tree JSON.');
+
+  return lines.join('\n');
+}
+
+function parseClaudeResponse(raw: string): ClaudeNode[] {
+  const cleaned = raw.replace(/```json|```/g, '').trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    throw new Error('Claude returned invalid JSON for the OST');
+  }
+  if (
+    typeof parsed !== 'object' ||
+    parsed == null ||
+    !Array.isArray((parsed as ClaudeOstResponse).nodes)
+  ) {
+    throw new Error('Claude returned unexpected OST structure');
+  }
+  return (parsed as ClaudeOstResponse).nodes;
+}
+
+function mapToNewNodeInputs(claudeNodes: ClaudeNode[]): NewNodeInput[] {
+  const idMap = new Map<string, string>();
+  // Assign real UUIDs, map sequential IDs
+  for (const node of claudeNodes) {
+    idMap.set(node.id, randomUUID());
+  }
+
+  return claudeNodes
+    .filter((n) => VALID_TYPES.has(n.type))
+    .sort((a, b) => a.depth - b.depth) // parents before children
+    .map((n) => ({
+      id: idMap.get(n.id)!,
+      parentId: n.parent_id != null ? (idMap.get(n.parent_id) ?? null) : null,
+      body: String(n.body).trim().slice(0, 1000),
+      type: n.type as NodeType,
+      depth: Math.max(0, Math.min(3, Number(n.depth) || 0)),
+      sortOrder: Math.max(0, Number(n.sort_order) || 0),
+    }));
+}
+
+export class OstController {
+  constructor(
+    private readonly ostRepo: OstRepository,
+    private readonly snapshotsRepo: InterviewSnapshotsRepository
+  ) {}
+
+  async generate(_req: express.Request, res: express.Response) {
+    const snapshots = await this.snapshotsRepo.list();
+
+    if (snapshots.length < MIN_SNAPSHOTS) {
+      res.status(422).json({
+        message: `Need at least ${MIN_SNAPSHOTS} interview snapshots to generate the tree. Currently have ${snapshots.length}.`,
+      });
+      return;
+    }
+
+    const client = getAnthropicClient();
+    const userMessage = buildUserMessage(snapshots);
+
+    const response = await client.messages.create({
+      model: 'claude-sonnet-4-5',
+      max_tokens: 4096,
+      system: [
+        {
+          type: 'text',
+          text: OST_SYSTEM_PROMPT,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          cache_control: { type: 'ephemeral' } as any,
+        },
+      ],
+      messages: [{ role: 'user', content: userMessage }],
+    });
+
+    const raw = response.content
+      .filter((b) => b.type === 'text')
+      .map((b) => ('text' in b ? b.text : ''))
+      .join('');
+
+    const claudeNodes = parseClaudeResponse(raw);
+    const nodeInputs = mapToNewNodeInputs(claudeNodes);
+
+    const version = await this.ostRepo.saveVersion(
+      snapshots.length,
+      raw,
+      nodeInputs
+    );
+
+    res.status(201).json(version);
+  }
+
+  async getLatest(_req: express.Request, res: express.Response) {
+    const version = await this.ostRepo.getLatest();
+    res.json(version);
+  }
+}

--- a/src/data_layer/InterviewSnapshotsRepository.ts
+++ b/src/data_layer/InterviewSnapshotsRepository.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from 'crypto';
+
+import type { Knex } from 'knex';
+
+const SNAPSHOTS_TABLE = 'interview_snapshots';
+const OPPORTUNITIES_TABLE = 'interview_opportunities';
+
+export type OpportunityTag = 'opportunity' | 'insight';
+
+export interface InterviewOpportunity {
+  id: string;
+  body: string;
+  tag: OpportunityTag;
+}
+
+export interface InterviewSnapshot {
+  id: string;
+  participantName: string;
+  memorableQuote: string;
+  photoData: string | null;
+  signupDate: string | null;
+  planTier: string;
+  usagePattern: string;
+  source: string;
+  experienceMapData: string | null;
+  interviewDate: string;
+  sessionLengthMinutes: number | null;
+  createdAt: string;
+  opportunities: InterviewOpportunity[];
+}
+
+export interface NewSnapshotInput {
+  participantName: string;
+  memorableQuote: string;
+  photoData: string | null;
+  signupDate: string | null;
+  planTier: string;
+  usagePattern: string;
+  source: string;
+  experienceMapData: string | null;
+  interviewDate: string;
+  sessionLengthMinutes: number | null;
+  opportunities: Array<{ body: string; tag: OpportunityTag }>;
+}
+
+interface SnapshotRow {
+  id: string;
+  participant_name: string;
+  memorable_quote: string;
+  photo_data: string | null;
+  signup_date: string | null;
+  plan_tier: string;
+  usage_pattern: string;
+  source: string;
+  experience_map_data: string | null;
+  interview_date: string;
+  session_length_minutes: number | null;
+  created_at: Date | string;
+}
+
+interface OpportunityRow {
+  id: string;
+  snapshot_id: string;
+  body: string;
+  tag: string;
+}
+
+function toSnapshot(
+  row: SnapshotRow,
+  opportunities: InterviewOpportunity[]
+): InterviewSnapshot {
+  return {
+    id: row.id,
+    participantName: row.participant_name,
+    memorableQuote: row.memorable_quote,
+    photoData: row.photo_data,
+    signupDate: row.signup_date,
+    planTier: row.plan_tier,
+    usagePattern: row.usage_pattern,
+    source: row.source,
+    experienceMapData: row.experience_map_data,
+    interviewDate:
+      typeof row.interview_date === 'string'
+        ? row.interview_date.slice(0, 10)
+        : row.interview_date,
+    sessionLengthMinutes: row.session_length_minutes,
+    createdAt:
+      typeof row.created_at === 'string'
+        ? row.created_at
+        : (row.created_at as Date).toISOString(),
+    opportunities,
+  };
+}
+
+export class InterviewSnapshotsRepository {
+  constructor(private readonly database: Knex) {}
+
+  async list(): Promise<InterviewSnapshot[]> {
+    const rows = await this.database<SnapshotRow>(SNAPSHOTS_TABLE).orderBy(
+      'created_at',
+      'desc'
+    );
+    if (rows.length === 0) return [];
+
+    const ids = rows.map((r) => r.id);
+    const oppRows = await this.database<OpportunityRow>(OPPORTUNITIES_TABLE)
+      .whereIn('snapshot_id', ids)
+      .orderBy('created_at', 'asc');
+
+    const oppsBySnapshot = new Map<string, InterviewOpportunity[]>();
+    for (const opp of oppRows) {
+      const list = oppsBySnapshot.get(opp.snapshot_id) ?? [];
+      list.push({ id: opp.id, body: opp.body, tag: opp.tag as OpportunityTag });
+      oppsBySnapshot.set(opp.snapshot_id, list);
+    }
+
+    return rows.map((row) =>
+      toSnapshot(row, oppsBySnapshot.get(row.id) ?? [])
+    );
+  }
+
+  async create(input: NewSnapshotInput): Promise<InterviewSnapshot> {
+    const snapshotId = randomUUID();
+    const now = new Date();
+
+    await this.database(SNAPSHOTS_TABLE).insert({
+      id: snapshotId,
+      participant_name: input.participantName,
+      memorable_quote: input.memorableQuote,
+      photo_data: input.photoData,
+      signup_date: input.signupDate || null,
+      plan_tier: input.planTier,
+      usage_pattern: input.usagePattern,
+      source: input.source,
+      experience_map_data: input.experienceMapData,
+      interview_date: input.interviewDate,
+      session_length_minutes: input.sessionLengthMinutes,
+      created_at: now,
+      updated_at: now,
+    });
+
+    const opportunities: InterviewOpportunity[] = [];
+    for (const opp of input.opportunities) {
+      const oppId = randomUUID();
+      await this.database(OPPORTUNITIES_TABLE).insert({
+        id: oppId,
+        snapshot_id: snapshotId,
+        body: opp.body,
+        tag: opp.tag,
+        created_at: now,
+      });
+      opportunities.push({ id: oppId, body: opp.body, tag: opp.tag });
+    }
+
+    return {
+      id: snapshotId,
+      participantName: input.participantName,
+      memorableQuote: input.memorableQuote,
+      photoData: input.photoData,
+      signupDate: input.signupDate,
+      planTier: input.planTier,
+      usagePattern: input.usagePattern,
+      source: input.source,
+      experienceMapData: input.experienceMapData,
+      interviewDate: input.interviewDate,
+      sessionLengthMinutes: input.sessionLengthMinutes,
+      createdAt: now.toISOString(),
+      opportunities,
+    };
+  }
+
+  async remove(id: string): Promise<boolean> {
+    const deleted = await this.database(SNAPSHOTS_TABLE).where({ id }).delete();
+    return deleted > 0;
+  }
+}

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -75,6 +75,14 @@ class JobRepository {
       .then((row) => Number((row as { count: string | number })?.count ?? 0));
   }
 
+  countJobsByOwner(owner: string): Promise<number> {
+    return this.database(this.tableName)
+      .where({ owner })
+      .count('* as count')
+      .first()
+      .then((row) => Number((row as { count: string | number })?.count ?? 0));
+  }
+
   deleteOldJobs(type: string, olderThanMs: number): Promise<number> {
     const cutoff = new Date(Date.now() - olderThanMs);
     return this.database(this.tableName)

--- a/src/data_layer/OstRepository.ts
+++ b/src/data_layer/OstRepository.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'crypto';
+
+import type { Knex } from 'knex';
+
+const VERSIONS_TABLE = 'ost_versions';
+const NODES_TABLE = 'opportunity_tree_nodes';
+
+export type NodeType = 'outcome' | 'opportunity' | 'sub_opportunity' | 'solution';
+
+export interface OstNode {
+  id: string;
+  ostVersionId: string;
+  parentId: string | null;
+  body: string;
+  type: NodeType;
+  depth: number;
+  sortOrder: number;
+}
+
+export interface OstVersion {
+  id: string;
+  generatedAt: string;
+  snapshotCount: number;
+  nodes: OstNode[];
+}
+
+export interface NewNodeInput {
+  id: string;
+  parentId: string | null;
+  body: string;
+  type: NodeType;
+  depth: number;
+  sortOrder: number;
+}
+
+interface VersionRow {
+  id: string;
+  generated_at: Date | string;
+  snapshot_count: number;
+}
+
+interface NodeRow {
+  id: string;
+  ost_version_id: string;
+  parent_id: string | null;
+  body: string;
+  type: string;
+  depth: number;
+  sort_order: number;
+}
+
+function toNode(row: NodeRow): OstNode {
+  return {
+    id: row.id,
+    ostVersionId: row.ost_version_id,
+    parentId: row.parent_id,
+    body: row.body,
+    type: row.type as NodeType,
+    depth: row.depth,
+    sortOrder: row.sort_order,
+  };
+}
+
+export class OstRepository {
+  constructor(private readonly database: Knex) {}
+
+  async saveVersion(
+    snapshotCount: number,
+    rawResponse: string,
+    nodes: NewNodeInput[]
+  ): Promise<OstVersion> {
+    const versionId = randomUUID();
+    const now = new Date();
+
+    return this.database.transaction(async (trx) => {
+      await trx(VERSIONS_TABLE).insert({
+        id: versionId,
+        generated_at: now,
+        snapshot_count: snapshotCount,
+        raw_response: rawResponse,
+      });
+
+      const savedNodes: OstNode[] = [];
+      // Insert parents before children (nodes are sorted by depth ascending in caller)
+      for (const node of nodes) {
+        await trx(NODES_TABLE).insert({
+          id: node.id,
+          ost_version_id: versionId,
+          parent_id: node.parentId,
+          body: node.body,
+          type: node.type,
+          depth: node.depth,
+          sort_order: node.sortOrder,
+        });
+        savedNodes.push({
+          id: node.id,
+          ostVersionId: versionId,
+          parentId: node.parentId,
+          body: node.body,
+          type: node.type,
+          depth: node.depth,
+          sortOrder: node.sortOrder,
+        });
+      }
+
+      return {
+        id: versionId,
+        generatedAt: now.toISOString(),
+        snapshotCount,
+        nodes: savedNodes,
+      };
+    });
+  }
+
+  async getLatest(): Promise<OstVersion | null> {
+    const version = await this.database<VersionRow>(VERSIONS_TABLE)
+      .orderBy('generated_at', 'desc')
+      .first();
+
+    if (version == null) return null;
+
+    const nodeRows = await this.database<NodeRow>(NODES_TABLE)
+      .where({ ost_version_id: version.id })
+      .orderBy('depth', 'asc')
+      .orderBy('sort_order', 'asc');
+
+    return {
+      id: version.id,
+      generatedAt:
+        typeof version.generated_at === 'string'
+          ? version.generated_at
+          : (version.generated_at as Date).toISOString(),
+      snapshotCount: version.snapshot_count,
+      nodes: nodeRows.map(toNode),
+    };
+  }
+}

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -217,7 +217,7 @@ function expandCompactDeckInfo(compact: CompactDeck[], availableMediaFiles: stri
 
 let _anthropicClient: Anthropic | null = null;
 
-function getAnthropicClient(): Anthropic {
+export function getAnthropicClient(): Anthropic {
   if (!_anthropicClient) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const AnthropicClass = require('@anthropic-ai/sdk').default;

--- a/src/routes/FeedbackRouter.ts
+++ b/src/routes/FeedbackRouter.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+
+import { FeedbackController } from '../controllers/FeedbackController';
+import { InterviewSnapshotsRepository } from '../data_layer/InterviewSnapshotsRepository';
+import JobRepository from '../data_layer/JobRepository';
+import UsersRepository from '../data_layer/UsersRepository';
+import { getDatabase } from '../data_layer';
+import RequireAuthentication from './middleware/RequireAuthentication';
+
+const FeedbackRouter = () => {
+  const router = express.Router();
+  const database = getDatabase();
+  const controller = new FeedbackController(
+    new UsersRepository(database),
+    new JobRepository(database),
+    new InterviewSnapshotsRepository(database)
+  );
+
+  /**
+   * @swagger
+   * /api/feedback/interview:
+   *   post:
+   *     summary: Submit user feedback
+   *     description: Logged-in users submit a feedback snapshot. System prefills plan tier, signup date, and conversion count. Creates an interview_snapshot row visible in the ops Interviews tab.
+   *     tags: [Feedback]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [story, mainNeed]
+   *             properties:
+   *               story:
+   *                 type: string
+   *                 description: A time the product helped the user (maps to memorable_quote)
+   *               mainNeed:
+   *                 type: string
+   *                 description: The user's main frustration or need (maps to opportunity)
+   *               secondItem:
+   *                 type: string
+   *                 description: Optional additional observation
+   *     responses:
+   *       201:
+   *         description: Feedback recorded
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: Not authenticated
+   */
+  router.post('/api/feedback/interview', RequireAuthentication, (req, res) =>
+    controller.submitFeedback(req, res)
+  );
+
+  return router;
+};
+
+export default FeedbackRouter;

--- a/src/routes/OpsDiscoveryRouter.ts
+++ b/src/routes/OpsDiscoveryRouter.ts
@@ -1,0 +1,106 @@
+import express from 'express';
+
+import { OpsDiscoveryController } from '../controllers/OpsDiscoveryController';
+import { InterviewSnapshotsRepository } from '../data_layer/InterviewSnapshotsRepository';
+import { getDatabase } from '../data_layer';
+import RequireOpsAccess from './middleware/RequireOpsAccess';
+
+const OpsDiscoveryRouter = () => {
+  const router = express.Router();
+  const controller = new OpsDiscoveryController(
+    new InterviewSnapshotsRepository(getDatabase())
+  );
+
+  /**
+   * @swagger
+   * /api/ops/discovery/snapshots:
+   *   get:
+   *     summary: List all interview snapshots
+   *     description: Returns all customer interview snapshots with their opportunities. Internal — ops owner only.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: Array of snapshots
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/discovery/snapshots', RequireOpsAccess, (req, res) =>
+    controller.listSnapshots(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/discovery/snapshots:
+   *   post:
+   *     summary: Create a new interview snapshot
+   *     description: Persists one interview snapshot with its opportunities. Internal — ops owner only.
+   *     tags: [Ops]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [participantName, interviewDate]
+   *             properties:
+   *               participantName:
+   *                 type: string
+   *               interviewDate:
+   *                 type: string
+   *                 format: date
+   *               memorableQuote:
+   *                 type: string
+   *               planTier:
+   *                 type: string
+   *               opportunities:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   properties:
+   *                     body:
+   *                       type: string
+   *                     tag:
+   *                       type: string
+   *                       enum: [opportunity, insight]
+   *     responses:
+   *       201:
+   *         description: Created snapshot
+   *       400:
+   *         description: Validation error
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post('/api/ops/discovery/snapshots', RequireOpsAccess, (req, res) =>
+    controller.createSnapshot(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/discovery/snapshots/{id}:
+   *   delete:
+   *     summary: Delete an interview snapshot
+   *     description: Removes a snapshot and its opportunities. Internal — ops owner only.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *     responses:
+   *       200:
+   *         description: Deleted
+   *       404:
+   *         description: Not found or not the ops owner
+   */
+  router.delete(
+    '/api/ops/discovery/snapshots/:id',
+    RequireOpsAccess,
+    (req, res) => controller.deleteSnapshot(req, res)
+  );
+
+  return router;
+};
+
+export default OpsDiscoveryRouter;

--- a/src/routes/OstRouter.ts
+++ b/src/routes/OstRouter.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+
+import { OstController } from '../controllers/OstController';
+import { OstRepository } from '../data_layer/OstRepository';
+import { InterviewSnapshotsRepository } from '../data_layer/InterviewSnapshotsRepository';
+import { getDatabase } from '../data_layer';
+import RequireOpsAccess from './middleware/RequireOpsAccess';
+
+const OstRouter = () => {
+  const router = express.Router();
+  const database = getDatabase();
+  const controller = new OstController(
+    new OstRepository(database),
+    new InterviewSnapshotsRepository(database)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/discovery/ost:
+   *   get:
+   *     summary: Get the latest opportunity solution tree
+   *     description: Returns the most recently generated OST version with all nodes. Returns null if no tree has been generated yet.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: Latest OST version or null
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/discovery/ost', RequireOpsAccess, (req, res) =>
+    controller.getLatest(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/discovery/ost/generate:
+   *   post:
+   *     summary: Generate a new opportunity solution tree via Claude
+   *     description: Reads all interview snapshots, sends them to Claude, and persists the resulting tree. Requires at least 5 snapshots. Internal — ops owner only.
+   *     tags: [Ops]
+   *     responses:
+   *       201:
+   *         description: Newly generated OST version
+   *       422:
+   *         description: Not enough snapshots to generate a meaningful tree
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post('/api/ops/discovery/ost/generate', RequireOpsAccess, (req, res) =>
+    controller.generate(req, res)
+  );
+
+  return router;
+};
+
+export default OstRouter;

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import webhookRouter from './routes/WebhookRouter';
 import ankifyWebhookRouter from './routes/AnkifyWebhookRouter';
 import swaggerRouter from './routes/SwaggerRouter';
 import opsRouter from './routes/OpsRouter';
+import opsDiscoveryRouter from './routes/OpsDiscoveryRouter';
 import showcaseRouter from './routes/ShowcaseRouter';
 import emojiFeedbackRouter from './routes/EmojiFeedbackRouter';
 import reEngagementRouter from './routes/ReEngagementRouter';
@@ -108,6 +109,7 @@ const serve = async () => {
   app.use(templatesRouter());
   app.use(showcaseRouter());
   app.use(opsRouter());
+  app.use(opsDiscoveryRouter());
   app.use(emojiFeedbackRouter());
   app.use(reEngagementRouter());
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import ankifyWebhookRouter from './routes/AnkifyWebhookRouter';
 import swaggerRouter from './routes/SwaggerRouter';
 import opsRouter from './routes/OpsRouter';
 import opsDiscoveryRouter from './routes/OpsDiscoveryRouter';
+import feedbackRouter from './routes/FeedbackRouter';
 import showcaseRouter from './routes/ShowcaseRouter';
 import emojiFeedbackRouter from './routes/EmojiFeedbackRouter';
 import reEngagementRouter from './routes/ReEngagementRouter';
@@ -110,6 +111,7 @@ const serve = async () => {
   app.use(showcaseRouter());
   app.use(opsRouter());
   app.use(opsDiscoveryRouter());
+  app.use(feedbackRouter());
   app.use(emojiFeedbackRouter());
   app.use(reEngagementRouter());
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import ankifyWebhookRouter from './routes/AnkifyWebhookRouter';
 import swaggerRouter from './routes/SwaggerRouter';
 import opsRouter from './routes/OpsRouter';
 import opsDiscoveryRouter from './routes/OpsDiscoveryRouter';
+import ostRouter from './routes/OstRouter';
 import feedbackRouter from './routes/FeedbackRouter';
 import showcaseRouter from './routes/ShowcaseRouter';
 import emojiFeedbackRouter from './routes/EmojiFeedbackRouter';
@@ -111,6 +112,7 @@ const serve = async () => {
   app.use(showcaseRouter());
   app.use(opsRouter());
   app.use(opsDiscoveryRouter());
+  app.use(ostRouter());
   app.use(feedbackRouter());
   app.use(emojiFeedbackRouter());
   app.use(reEngagementRouter());

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,10 @@
   "dependencies": {
     "@bugsnag/js": "^8.9.0",
     "@bugsnag/plugin-react": "^8.9.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@excalidraw/excalidraw": "^0.18.1",
     "@tanstack/react-query": "^5.100.10",
     "date-fns": "^4.1.0",
     "get-notion-object-title": "^0.2.9",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,7 @@ const EngineeringTab = lazy(() => import('./pages/OpsPage/EngineeringTab'));
 const BusinessTab = lazy(() => import('./pages/OpsPage/BusinessTab'));
 const ShowcaseTab = lazy(() => import('./pages/OpsPage/ShowcaseTab'));
 const InterviewsTab = lazy(() => import('./pages/OpsPage/InterviewsTab'));
+const FeedbackPage = lazy(() => import('./pages/FeedbackPage/FeedbackPage'));
 const NotionToAnki = lazy(() => import('./pages/LandingPage/NotionToAnki'));
 const QuizletToAnki = lazy(() => import('./pages/LandingPage/QuizletToAnki'));
 const MarkdownToAnki = lazy(
@@ -205,6 +206,7 @@ function AppContent({
             <Route path="showcase" element={<ShowcaseTab />} />
             <Route path="interviews" element={<InterviewsTab />} />
           </Route>
+          <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
           <Route path="/settings" element={requireAuth(<AccountPage />)} />
           <Route path="/about" element={<AboutPage />} />
           <Route path="/whats-new" element={<WhatsNewPage />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -47,6 +47,7 @@ const OpsLayout = lazy(() => import('./pages/OpsPage/OpsLayout'));
 const EngineeringTab = lazy(() => import('./pages/OpsPage/EngineeringTab'));
 const BusinessTab = lazy(() => import('./pages/OpsPage/BusinessTab'));
 const ShowcaseTab = lazy(() => import('./pages/OpsPage/ShowcaseTab'));
+const InterviewsTab = lazy(() => import('./pages/OpsPage/InterviewsTab'));
 const NotionToAnki = lazy(() => import('./pages/LandingPage/NotionToAnki'));
 const QuizletToAnki = lazy(() => import('./pages/LandingPage/QuizletToAnki'));
 const MarkdownToAnki = lazy(
@@ -202,6 +203,7 @@ function AppContent({
             <Route index element={<EngineeringTab />} />
             <Route path="business" element={<BusinessTab />} />
             <Route path="showcase" element={<ShowcaseTab />} />
+            <Route path="interviews" element={<InterviewsTab />} />
           </Route>
           <Route path="/settings" element={requireAuth(<AccountPage />)} />
           <Route path="/about" element={<AboutPage />} />

--- a/web/src/components/AppShell/SidebarLayout.tsx
+++ b/web/src/components/AppShell/SidebarLayout.tsx
@@ -3,7 +3,6 @@ import { Sidebar, SidebarFeatures, SidebarLocals } from './Sidebar';
 import { MobileTopBar } from './MobileTopBar';
 import { SkeletonPage } from '../Skeleton/Skeleton';
 import { ErrorPresenter } from '../errors/ErrorPresenter';
-import { FloatingFeedback } from '../FeedbackWidget/FloatingFeedback';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './AppShell.module.css';
 
@@ -65,7 +64,6 @@ export function SidebarLayout({
           <Suspense fallback={<SkeletonPage rows={5} />}>{children}</Suspense>
         </main>
       </div>
-      <FloatingFeedback />
     </div>
   );
 }

--- a/web/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -119,3 +119,19 @@
   color: var(--color-danger);
   margin: 0;
 }
+
+.nudge {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+  text-align: center;
+}
+
+.nudgeLink {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.nudgeLink:hover {
+  text-decoration: underline;
+}

--- a/web/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import styles from './FeedbackWidget.module.css';
@@ -71,6 +72,14 @@ export function FeedbackWidget({
           );
         })}
       </div>
+      {selectedRating != null && selectedRating <= 2 && (
+        <p className={styles.nudge}>
+          Want to tell us more?{' '}
+          <Link to="/feedback" className={styles.nudgeLink}>
+            Share on the feedback page
+          </Link>
+        </p>
+      )}
       {selectedRating != null && (
         <>
           <textarea

--- a/web/src/components/FeedbackWidget/FloatingFeedback.tsx
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { FeedbackWidget } from './FeedbackWidget';
 import styles from './FloatingFeedback.module.css';
 
-const HIDDEN_PATHS = new Set(['/whats-new']);
+const HIDDEN_PATHS = new Set(['/whats-new', '/feedback']);
 const HIDDEN_PREFIXES = ['/rules/'];
 const DISMISSED_KEY = '2anki_feedback_dismissed';
 

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -292,3 +292,11 @@
     gap: 0.5rem;
   }
 }
+
+.feedbackFooter {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--color-border-light);
+  display: flex;
+  justify-content: flex-end;
+}

--- a/web/src/pages/AccountPage/AccountPage.tsx
+++ b/web/src/pages/AccountPage/AccountPage.tsx
@@ -1,4 +1,4 @@
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { SkeletonPage } from '../../components/Skeleton/Skeleton';
 import { useSubscriptionStatus } from './hooks';
@@ -97,6 +97,12 @@ export default function AccountPage() {
         />
 
         <AccountDeletion />
+
+        <div className={styles.feedbackFooter}>
+          <Link to="/feedback" className={sharedStyles.btnGhost}>
+            Share your experience
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/FeedbackPage/FeedbackPage.module.css
+++ b/web/src/pages/FeedbackPage/FeedbackPage.module.css
@@ -1,11 +1,11 @@
 .header {
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
 }
 
 .form {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.75rem;
 }
 
 .field {
@@ -20,6 +20,13 @@
   color: var(--color-text-primary);
 }
 
+.hint {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0 0 0.375rem;
+  line-height: 1.55;
+}
+
 .optional {
   font-weight: var(--font-normal);
   color: var(--color-text-tertiary);
@@ -29,12 +36,33 @@
   resize: vertical;
   font-family: inherit;
   font-size: var(--text-sm);
+  line-height: 1.6;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-focus-ring);
+}
+
+.textarea::placeholder {
+  color: var(--color-text-tertiary);
 }
 
 .actions {
   display: flex;
   justify-content: flex-end;
-  padding-top: 0.25rem;
+  padding-top: 0.5rem;
+}
+
+.submitBtn {
+  width: auto;
 }
 
 .errorMsg {
@@ -46,8 +74,16 @@
 .successCard {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.875rem;
   align-items: flex-start;
+  padding: 2.5rem 2rem;
+}
+
+.successIcon {
+  font-size: 1.5rem;
+  color: var(--color-primary);
+  margin: 0;
+  line-height: 1;
 }
 
 .successHeading {
@@ -55,11 +91,23 @@
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
   margin: 0;
+  line-height: 1.3;
 }
 
 .successBody {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
   margin: 0;
-  line-height: 1.6;
+  line-height: 1.65;
+  max-width: 38ch;
+}
+
+@media (max-width: 600px) {
+  .actions {
+    justify-content: stretch;
+  }
+
+  .submitBtn {
+    width: 100%;
+  }
 }

--- a/web/src/pages/FeedbackPage/FeedbackPage.module.css
+++ b/web/src/pages/FeedbackPage/FeedbackPage.module.css
@@ -1,0 +1,65 @@
+.header {
+  margin-bottom: 1.5rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.label {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.optional {
+  font-weight: var(--font-normal);
+  color: var(--color-text-tertiary);
+}
+
+.textarea {
+  resize: vertical;
+  font-family: inherit;
+  font-size: var(--text-sm);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.25rem;
+}
+
+.errorMsg {
+  font-size: var(--text-sm);
+  color: var(--color-danger, #dc2626);
+  margin: 0;
+}
+
+.successCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.successHeading {
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.successBody {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: 1.6;
+}

--- a/web/src/pages/FeedbackPage/FeedbackPage.tsx
+++ b/web/src/pages/FeedbackPage/FeedbackPage.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './FeedbackPage.module.css';
+
+const MIN_LENGTH = 10;
+
+async function submitFeedback(payload: {
+  story: string;
+  mainNeed: string;
+  secondItem: string;
+}): Promise<void> {
+  const res = await fetch('/api/feedback/interview', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({})) as { message?: string };
+    throw new Error(data.message ?? `${res.status}`);
+  }
+}
+
+export default function FeedbackPage() {
+  const [story, setStory] = useState('');
+  const [mainNeed, setMainNeed] = useState('');
+  const [secondItem, setSecondItem] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    document.title = 'Share your experience · 2anki';
+  }, []);
+
+  const canSubmit =
+    story.trim().length >= MIN_LENGTH && mainNeed.trim().length >= MIN_LENGTH;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError('');
+    try {
+      await submitFeedback({
+        story: story.trim(),
+        mainNeed: mainNeed.trim(),
+        secondItem: secondItem.trim(),
+      });
+      setDone(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong');
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <main className={sharedStyles.pageNarrow}>
+        <div className={`${sharedStyles.card} ${styles.successCard}`}>
+          <h1 className={styles.successHeading}>Thank you</h1>
+          <p className={styles.successBody}>
+            We read every response. Your feedback helps shape what we build next.
+          </p>
+          <a href="/downloads" className={sharedStyles.btnGhost}>
+            Back to my decks
+          </a>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className={sharedStyles.pageNarrow}>
+      <header className={styles.header}>
+        <h1 className={sharedStyles.title}>Help us build better flashcards</h1>
+        <p className={sharedStyles.subtitle}>
+          Three quick questions — no rating scales. Just tell us in your own words. Takes about 60 seconds.
+        </p>
+      </header>
+
+      <div className={sharedStyles.card}>
+        <form onSubmit={handleSubmit} noValidate className={styles.form}>
+          <div className={styles.field}>
+            <label htmlFor="fb-story" className={styles.label}>
+              Tell us about a time 2anki helped you
+            </label>
+            <textarea
+              id="fb-story"
+              className={`${sharedStyles.fullWidthTextarea} ${styles.textarea}`}
+              rows={4}
+              placeholder="For example: I had a 40-page Notion document before an exam and 2anki turned it into 200 cards in under a minute."
+              value={story}
+              onChange={(e) => setStory(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="fb-need" className={styles.label}>
+              What gets in your way?
+            </label>
+            <textarea
+              id="fb-need"
+              className={`${sharedStyles.fullWidthTextarea} ${styles.textarea}`}
+              rows={3}
+              placeholder="Describe the most frustrating part of your current workflow — whatever you wish worked differently."
+              value={mainNeed}
+              onChange={(e) => setMainNeed(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="fb-extra" className={styles.label}>
+              Anything else?{' '}
+              <span className={styles.optional}>(optional)</span>
+            </label>
+            <textarea
+              id="fb-extra"
+              className={`${sharedStyles.fullWidthTextarea} ${styles.textarea}`}
+              rows={2}
+              placeholder="Any other observations, wishes, or context you'd like to share."
+              value={secondItem}
+              onChange={(e) => setSecondItem(e.target.value)}
+            />
+          </div>
+
+          {error && (
+            <p className={styles.errorMsg} role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className={styles.actions}>
+            <button
+              type="submit"
+              className={sharedStyles.btnPrimary}
+              disabled={submitting || !canSubmit}
+            >
+              {submitting ? 'Sending…' : 'Send feedback'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/web/src/pages/FeedbackPage/FeedbackPage.tsx
+++ b/web/src/pages/FeedbackPage/FeedbackPage.tsx
@@ -59,11 +59,15 @@ export default function FeedbackPage() {
     return (
       <main className={sharedStyles.pageNarrow}>
         <div className={`${sharedStyles.card} ${styles.successCard}`}>
-          <h1 className={styles.successHeading}>Thank you</h1>
+          <p className={styles.successIcon} aria-hidden="true">✦</p>
+          <h1 className={styles.successHeading}>
+            Got it — you're helping us build something better.
+          </h1>
           <p className={styles.successBody}>
-            We read every response. Your feedback helps shape what we build next.
+            We read every response. What you shared will shape the next thing we
+            fix or build. Thank you for taking the time.
           </p>
-          <a href="/downloads" className={sharedStyles.btnGhost}>
+          <a href="/downloads" className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}>
             Back to my decks
           </a>
         </div>
@@ -74,9 +78,9 @@ export default function FeedbackPage() {
   return (
     <main className={sharedStyles.pageNarrow}>
       <header className={styles.header}>
-        <h1 className={sharedStyles.title}>Help us build better flashcards</h1>
+        <h1 className={sharedStyles.title}>What's your 2anki story?</h1>
         <p className={sharedStyles.subtitle}>
-          Three quick questions — no rating scales. Just tell us in your own words. Takes about 60 seconds.
+          Your own words, under a minute.
         </p>
       </header>
 
@@ -86,6 +90,10 @@ export default function FeedbackPage() {
             <label htmlFor="fb-story" className={styles.label}>
               Tell us about a time 2anki helped you
             </label>
+            <p className={styles.hint}>
+              Maybe it saved you before an exam, or turned a long document into
+              something you could actually study.
+            </p>
             <textarea
               id="fb-story"
               className={`${sharedStyles.fullWidthTextarea} ${styles.textarea}`}
@@ -101,11 +109,15 @@ export default function FeedbackPage() {
             <label htmlFor="fb-need" className={styles.label}>
               What gets in your way?
             </label>
+            <p className={styles.hint}>
+              Describe the most frustrating part — whatever makes you wish
+              something worked differently.
+            </p>
             <textarea
               id="fb-need"
               className={`${sharedStyles.fullWidthTextarea} ${styles.textarea}`}
               rows={3}
-              placeholder="Describe the most frustrating part of your current workflow — whatever you wish worked differently."
+              placeholder="For example: Images don't come through, so I have to add them manually after."
               value={mainNeed}
               onChange={(e) => setMainNeed(e.target.value)}
               required
@@ -121,7 +133,7 @@ export default function FeedbackPage() {
               id="fb-extra"
               className={`${sharedStyles.fullWidthTextarea} ${styles.textarea}`}
               rows={2}
-              placeholder="Any other observations, wishes, or context you'd like to share."
+              placeholder="For example: I mainly use it for medical school — spaced repetition is the only way I keep up."
               value={secondItem}
               onChange={(e) => setSecondItem(e.target.value)}
             />
@@ -136,10 +148,10 @@ export default function FeedbackPage() {
           <div className={styles.actions}>
             <button
               type="submit"
-              className={sharedStyles.btnPrimary}
+              className={`${sharedStyles.btnPrimary} ${styles.submitBtn}`}
               disabled={submitting || !canSubmit}
             >
-              {submitting ? 'Sending…' : 'Send feedback'}
+              {submitting ? 'Sending…' : 'Send your answers'}
             </button>
           </div>
         </form>

--- a/web/src/pages/OpsPage/InterviewsTab.tsx
+++ b/web/src/pages/OpsPage/InterviewsTab.tsx
@@ -1,9 +1,33 @@
-import { useEffect, useRef, useState } from 'react';
+import { Suspense, lazy, useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
 
+// ── Lazy Excalidraw (large bundle, only loaded in the form) ─────────────────
+const Excalidraw = lazy(() =>
+  import('@excalidraw/excalidraw').then((m) => ({ default: m.Excalidraw }))
+);
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
 type OpportunityTag = 'opportunity' | 'insight';
+type NodeType = 'outcome' | 'opportunity' | 'sub_opportunity' | 'solution';
 
 interface InterviewOpportunity {
   id: string;
@@ -27,10 +51,26 @@ interface InterviewSnapshot {
   opportunities: InterviewOpportunity[];
 }
 
+interface OstNode {
+  id: string;
+  parentId: string | null;
+  body: string;
+  type: NodeType;
+  depth: number;
+  sortOrder: number;
+}
+
+interface OstVersion {
+  id: string;
+  generatedAt: string;
+  snapshotCount: number;
+  nodes: OstNode[];
+}
+
+// ── API helpers ──────────────────────────────────────────────────────────────
+
 async function apiList(): Promise<InterviewSnapshot[]> {
-  const res = await fetch('/api/ops/discovery/snapshots', {
-    credentials: 'include',
-  });
+  const res = await fetch('/api/ops/discovery/snapshots', { credentials: 'include' });
   if (!res.ok) throw new Error(`${res.status}`);
   return res.json() as Promise<InterviewSnapshot[]>;
 }
@@ -59,6 +99,26 @@ async function apiDelete(id: string): Promise<void> {
   if (!res.ok) throw new Error(`${res.status}`);
 }
 
+async function apiGetOst(): Promise<OstVersion | null> {
+  const res = await fetch('/api/ops/discovery/ost', { credentials: 'include' });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json() as Promise<OstVersion | null>;
+}
+
+async function apiGenerateOst(): Promise<OstVersion> {
+  const res = await fetch('/api/ops/discovery/ost/generate', {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({})) as { message?: string };
+    throw new Error(data.message ?? `${res.status}`);
+  }
+  return res.json() as Promise<OstVersion>;
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
 function initials(name: string): string {
   return name
     .trim()
@@ -66,6 +126,15 @@ function initials(name: string): string {
     .slice(0, 2)
     .map((w) => w[0]?.toUpperCase() ?? '')
     .join('');
+}
+
+async function blobToDataUri(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
 }
 
 function readFileAsDataUri(file: File): Promise<string> {
@@ -93,13 +162,9 @@ function blankForm(): Omit<InterviewSnapshot, 'id' | 'createdAt'> {
   };
 }
 
-interface AvatarProps {
-  dataUri: string | null;
-  name: string;
-  size?: number;
-}
+// ── Avatar ───────────────────────────────────────────────────────────────────
 
-function Avatar({ dataUri, name, size = 40 }: AvatarProps) {
+function Avatar({ dataUri, name, size = 40 }: { dataUri: string | null; name: string; size?: number }) {
   if (dataUri) {
     return (
       <img
@@ -121,13 +186,10 @@ function Avatar({ dataUri, name, size = 40 }: AvatarProps) {
   );
 }
 
-interface SnapshotCardProps {
-  snapshot: InterviewSnapshot;
-  onDelete: (id: string) => void;
-}
+// ── Snapshot card ────────────────────────────────────────────────────────────
 
-function SnapshotCard({ snapshot, onDelete }: SnapshotCardProps) {
-  const opportunityCount = snapshot.opportunities.filter((o) => o.tag === 'opportunity').length;
+function SnapshotCard({ snapshot, onDelete }: { snapshot: InterviewSnapshot; onDelete: (id: string) => void }) {
+  const oppCount = snapshot.opportunities.filter((o) => o.tag === 'opportunity').length;
   const insightCount = snapshot.opportunities.filter((o) => o.tag === 'insight').length;
 
   const handleDelete = () => {
@@ -141,12 +203,8 @@ function SnapshotCard({ snapshot, onDelete }: SnapshotCardProps) {
       <div className={styles.interviewCardHeader}>
         <Avatar dataUri={snapshot.photoData} name={snapshot.participantName} />
         <div className={styles.interviewCardMeta}>
-          <span className={styles.interviewCardName}>
-            {snapshot.participantName || 'Unknown'}
-          </span>
-          {snapshot.planTier && (
-            <span className={styles.interviewCardTier}>{snapshot.planTier}</span>
-          )}
+          <span className={styles.interviewCardName}>{snapshot.participantName || 'Unknown'}</span>
+          {snapshot.planTier && <span className={styles.interviewCardTier}>{snapshot.planTier}</span>}
         </div>
         <button
           type="button"
@@ -166,8 +224,8 @@ function SnapshotCard({ snapshot, onDelete }: SnapshotCardProps) {
         <span className={styles.interviewCardDate}>{snapshot.interviewDate}</span>
         {snapshot.opportunities.length > 0 && (
           <span className={styles.interviewCardOpCount}>
-            {opportunityCount > 0 && `${opportunityCount} opp${opportunityCount !== 1 ? 's' : ''}`}
-            {opportunityCount > 0 && insightCount > 0 && ' · '}
+            {oppCount > 0 && `${oppCount} opp${oppCount !== 1 ? 's' : ''}`}
+            {oppCount > 0 && insightCount > 0 && ' · '}
             {insightCount > 0 && `${insightCount} insight${insightCount !== 1 ? 's' : ''}`}
           </span>
         )}
@@ -176,32 +234,20 @@ function SnapshotCard({ snapshot, onDelete }: SnapshotCardProps) {
   );
 }
 
-interface SnapshotFormProps {
-  onSave: (snapshot: InterviewSnapshot) => void;
-  onCancel: () => void;
-}
+// ── Snapshot form ────────────────────────────────────────────────────────────
 
-function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
+function SnapshotForm({ onSave, onCancel }: { onSave: (s: InterviewSnapshot) => void; onCancel: () => void }) {
   const [form, setForm] = useState(blankForm());
   const [oppInput, setOppInput] = useState('');
   const [oppTag, setOppTag] = useState<OpportunityTag>('opportunity');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const photoInputRef = useRef<HTMLInputElement>(null);
-  const mapInputRef = useRef<HTMLInputElement>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const excalidrawAPIRef = useRef<any>(null);
 
   const set = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));
-
-  const handlePhotoFile = async (file: File) => {
-    const uri = await readFileAsDataUri(file);
-    set('photoData', uri);
-  };
-
-  const handleMapFile = async (file: File) => {
-    const uri = await readFileAsDataUri(file);
-    set('experienceMapData', uri);
-  };
 
   const addOpportunity = () => {
     if (oppInput.trim().length === 0) return;
@@ -220,10 +266,23 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
     setSaving(true);
     setError('');
     try {
-      const snapshot = await apiCreate({
-        ...form,
-        sessionLengthMinutes: form.sessionLengthMinutes,
-      });
+      // Export Excalidraw canvas as PNG if there are any elements
+      let mapData = form.experienceMapData;
+      if (excalidrawAPIRef.current) {
+        const elements = excalidrawAPIRef.current.getSceneElements();
+        if (elements.length > 0) {
+          const { exportToBlob } = await import('@excalidraw/excalidraw');
+          const blob = await exportToBlob({
+            elements,
+            mimeType: 'image/png',
+            appState: excalidrawAPIRef.current.getAppState(),
+            files: excalidrawAPIRef.current.getFiles(),
+          });
+          mapData = await blobToDataUri(blob);
+        }
+      }
+
+      const snapshot = await apiCreate({ ...form, experienceMapData: mapData });
       onSave(snapshot);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Save failed');
@@ -233,10 +292,9 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
 
   return (
     <div className={styles.interviewForm}>
-      {error && (
-        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>
-      )}
+      {error && <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>}
 
+      {/* Participant + photo */}
       <div className={styles.interviewFormSection}>
         <div className={styles.interviewFormRow}>
           <div className={styles.interviewPhotoZone}>
@@ -253,7 +311,6 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
                 type="button"
                 className={styles.interviewPhotoPlaceholder}
                 onClick={() => photoInputRef.current?.click()}
-                aria-label="Upload participant photo"
               >
                 Photo
               </button>
@@ -265,7 +322,7 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
               hidden
               onChange={(e) => {
                 const f = e.target.files?.[0];
-                if (f) handlePhotoFile(f);
+                if (f) readFileAsDataUri(f).then((uri) => set('photoData', uri));
               }}
             />
           </div>
@@ -299,6 +356,7 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
         </div>
       </div>
 
+      {/* Quote */}
       <div className={styles.interviewFormSection}>
         <label className={styles.controlsLabel} htmlFor="iv-quote">
           Memorable quote — their exact words
@@ -313,13 +371,14 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
         />
       </div>
 
+      {/* Quick facts */}
       <div className={styles.interviewFormSection}>
         <p className={styles.controlsLabel}>Quick facts</p>
         <div className={styles.interviewQuickFacts}>
           <input
             className={styles.textInput}
             type="text"
-            placeholder="Usage pattern (e.g. uploads weekly)"
+            placeholder="Usage pattern"
             value={form.usagePattern}
             onChange={(e) => set('usagePattern', e.target.value)}
           />
@@ -343,16 +402,14 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
             placeholder="Session length (min)"
             value={form.sessionLengthMinutes ?? ''}
             onChange={(e) =>
-              set(
-                'sessionLengthMinutes',
-                e.target.value === '' ? null : Number(e.target.value)
-              )
+              set('sessionLengthMinutes', e.target.value === '' ? null : Number(e.target.value))
             }
             min={0}
           />
         </div>
       </div>
 
+      {/* Opportunities */}
       <div className={styles.interviewFormSection}>
         <label className={styles.controlsLabel} htmlFor="iv-opp-input">
           Opportunities & insights — their words, not solutions, not feelings
@@ -362,14 +419,11 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
             id="iv-opp-input"
             className={styles.textInput}
             type="text"
-            placeholder="e.g. I don't want to re-type my notes every time I make a deck"
+            placeholder="e.g. I don't want to re-type my notes every time"
             value={oppInput}
             onChange={(e) => setOppInput(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                addOpportunity();
-              }
+              if (e.key === 'Enter') { e.preventDefault(); addOpportunity(); }
             }}
           />
           <select
@@ -394,9 +448,7 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
           <ul className={styles.interviewOppList}>
             {form.opportunities.map((opp) => (
               <li key={opp.id} className={styles.interviewOppItem}>
-                <span className={styles.interviewOppTag} data-tag={opp.tag}>
-                  {opp.tag}
-                </span>
+                <span className={styles.interviewOppTag} data-tag={opp.tag}>{opp.tag}</span>
                 <span className={styles.interviewOppBody}>{opp.body}</span>
                 <button
                   type="button"
@@ -412,44 +464,22 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
         )}
       </div>
 
+      {/* Experience map — Excalidraw canvas */}
       <div className={styles.interviewFormSection}>
         <label className={styles.controlsLabel}>
-          Experience map — upload a photo or screenshot of the drawn journey
+          Experience map — draw the participant&rsquo;s journey
         </label>
-        {form.experienceMapData ? (
-          <div className={styles.interviewMapPreviewWrap}>
-            <img
-              src={form.experienceMapData}
-              alt="Experience map"
-              className={styles.interviewMapPreview}
+        <div className={styles.excalidrawWrap}>
+          <Suspense fallback={<div className={styles.excalidrawLoading}>Loading canvas…</div>}>
+            <Excalidraw
+              excalidrawAPI={(api) => { excalidrawAPIRef.current = api; }}
+              initialData={{ appState: { viewBackgroundColor: 'transparent' } }}
             />
-            <button
-              type="button"
-              className={sharedStyles.btnSmall}
-              onClick={() => set('experienceMapData', null)}
-            >
-              Remove map
-            </button>
-          </div>
-        ) : (
-          <button
-            type="button"
-            className={styles.interviewMapUploadBtn}
-            onClick={() => mapInputRef.current?.click()}
-          >
-            Upload experience map image
-          </button>
-        )}
-        <input
-          ref={mapInputRef}
-          type="file"
-          accept="image/*"
-          hidden
-          onChange={(e) => {
-            const f = e.target.files?.[0];
-            if (f) handleMapFile(f);
-          }}
-        />
+          </Suspense>
+        </div>
+        <p className={styles.panelSubtitle}>
+          The map is exported as a PNG and saved with the snapshot.
+        </p>
       </div>
 
       <div className={styles.interviewFormActions}>
@@ -468,6 +498,152 @@ function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
     </div>
   );
 }
+
+// ── OST node (sortable) ──────────────────────────────────────────────────────
+
+const NODE_TYPE_LABELS: Record<NodeType, string> = {
+  outcome: 'Outcome',
+  opportunity: 'Opportunity',
+  sub_opportunity: 'Sub-opportunity',
+  solution: 'Solution',
+};
+
+function SortableOstNode({ node }: { node: OstNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: node.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    paddingLeft: node.depth * 24,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`${sharedStyles.surface} ${styles.ostNode}`}
+    >
+      <span className={styles.ostDragHandle} {...attributes} {...listeners} aria-label="Drag">
+        ⠿
+      </span>
+      <span className={styles.ostNodeBody}>{node.body}</span>
+      {node.type !== 'outcome' && (
+        <span className={styles.ostNodeBadge} data-type={node.type}>
+          {NODE_TYPE_LABELS[node.type]}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── OST tree section ─────────────────────────────────────────────────────────
+
+function OstSection({ snapshotCount }: { snapshotCount: number }) {
+  const [ost, setOst] = useState<OstVersion | null | undefined>(undefined);
+  const [nodes, setNodes] = useState<OstNode[]>([]);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState('');
+  const MIN_SNAPSHOTS = 5;
+
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  useEffect(() => {
+    apiGetOst()
+      .then((v) => {
+        setOst(v);
+        if (v) setNodes(v.nodes);
+      })
+      .catch(() => setOst(null));
+  }, []);
+
+  const handleGenerate = async () => {
+    setGenerating(true);
+    setError('');
+    try {
+      const v = await apiGenerateOst();
+      setOst(v);
+      setNodes(v.nodes);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Generation failed');
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      setNodes((prev) => {
+        const oldIdx = prev.findIndex((n) => n.id === active.id);
+        const newIdx = prev.findIndex((n) => n.id === over.id);
+        return arrayMove(prev, oldIdx, newIdx);
+      });
+    }
+  }, []);
+
+  const canGenerate = snapshotCount >= MIN_SNAPSHOTS;
+
+  return (
+    <section className={styles.ostSection}>
+      <div className={styles.interviewArchiveHeader}>
+        <div>
+          <p className={styles.panelTitle}>Opportunity solution tree</p>
+          <p className={styles.panelSubtitle}>
+            {ost
+              ? `Generated from ${ost.snapshotCount} snapshot${ost.snapshotCount !== 1 ? 's' : ''} · ${new Date(ost.generatedAt).toLocaleDateString()}`
+              : 'Claude organizes your interview snapshots into a prioritized tree.'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className={sharedStyles.btnSmall}
+          onClick={handleGenerate}
+          disabled={generating || !canGenerate}
+          title={canGenerate ? undefined : `Need ${MIN_SNAPSHOTS} snapshots (have ${snapshotCount})`}
+        >
+          {generating ? 'Generating…' : ost ? 'Regenerate' : 'Generate tree'}
+        </button>
+      </div>
+
+      {error && <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>}
+
+      {!canGenerate && (
+        <div className={`${sharedStyles.surface} ${styles.interviewEmpty}`}>
+          <p>
+            Add at least {MIN_SNAPSHOTS} interview snapshots to generate the tree.
+            Currently have {snapshotCount}.
+          </p>
+        </div>
+      )}
+
+      {canGenerate && ost === undefined && (
+        <div className={styles.skeletonBar} style={{ height: 80 }} />
+      )}
+
+      {canGenerate && ost === null && !generating && (
+        <div className={`${sharedStyles.surface} ${styles.interviewEmpty}`}>
+          <p>No tree generated yet. Click &ldquo;Generate tree&rdquo; to build it from your snapshots.</p>
+        </div>
+      )}
+
+      {nodes.length > 0 && (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={nodes.map((n) => n.id)} strategy={verticalListSortingStrategy}>
+            <div className={styles.ostTree}>
+              {nodes.map((node) => (
+                <SortableOstNode key={node.id} node={node} />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+    </section>
+  );
+}
+
+// ── Root tab component ───────────────────────────────────────────────────────
 
 export default function InterviewsTab() {
   const [snapshots, setSnapshots] = useState<InterviewSnapshot[]>([]);
@@ -516,18 +692,12 @@ export default function InterviewsTab() {
             One snapshot per customer conversation. Fill in right after the interview, never batched.
           </p>
         </div>
-        <button
-          type="button"
-          className={sharedStyles.btnPrimary}
-          onClick={() => setView('form')}
-        >
+        <button type="button" className={sharedStyles.btnPrimary} onClick={() => setView('form')}>
           New snapshot
         </button>
       </div>
 
-      {error && (
-        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>
-      )}
+      {error && <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>}
 
       {loading ? (
         <div className={styles.skeletonBar} style={{ height: 120 }} />
@@ -542,6 +712,9 @@ export default function InterviewsTab() {
           ))}
         </div>
       )}
+
+      <hr className={styles.ostDivider} />
+      <OstSection snapshotCount={snapshots.length} />
     </>
   );
 }

--- a/web/src/pages/OpsPage/InterviewsTab.tsx
+++ b/web/src/pages/OpsPage/InterviewsTab.tsx
@@ -224,9 +224,9 @@ function SnapshotCard({ snapshot, onDelete }: { snapshot: InterviewSnapshot; onD
         <span className={styles.interviewCardDate}>{snapshot.interviewDate}</span>
         {snapshot.opportunities.length > 0 && (
           <span className={styles.interviewCardOpCount}>
-            {oppCount > 0 && `${oppCount} opp${oppCount !== 1 ? 's' : ''}`}
+            {oppCount > 0 && `${oppCount} opp${oppCount === 1 ? '' : 's'}`}
             {oppCount > 0 && insightCount > 0 && ' · '}
-            {insightCount > 0 && `${insightCount} insight${insightCount !== 1 ? 's' : ''}`}
+            {insightCount > 0 && `${insightCount} insight${insightCount === 1 ? '' : 's'}`}
           </span>
         )}
       </div>
@@ -497,6 +497,10 @@ function SnapshotForm({ onSave, onCancel }: { onSave: (s: InterviewSnapshot) => 
   );
 }
 
+function generateButtonLabel(ost: OstVersion | null | undefined): string {
+  return ost ? 'Regenerate' : 'Generate tree';
+}
+
 // ── OST node (sortable) ──────────────────────────────────────────────────────
 
 const NODE_TYPE_LABELS: Record<NodeType, string> = {
@@ -590,7 +594,7 @@ function OstSection({ snapshotCount }: { snapshotCount: number }) {
           <p className={styles.panelTitle}>Opportunity solution tree</p>
           <p className={styles.panelSubtitle}>
             {ost
-              ? `Generated from ${ost.snapshotCount} snapshot${ost.snapshotCount !== 1 ? 's' : ''} · ${new Date(ost.generatedAt).toLocaleDateString()}`
+              ? `Generated from ${ost.snapshotCount} snapshot${ost.snapshotCount === 1 ? '' : 's'} · ${new Date(ost.generatedAt).toLocaleDateString()}`
               : 'Claude organizes your interview snapshots into a prioritized tree.'}
           </p>
         </div>
@@ -601,7 +605,7 @@ function OstSection({ snapshotCount }: { snapshotCount: number }) {
           disabled={generating || !canGenerate}
           title={canGenerate ? undefined : `Need ${MIN_SNAPSHOTS} snapshots (have ${snapshotCount})`}
         >
-          {generating ? 'Generating…' : ost ? 'Regenerate' : 'Generate tree'}
+          {generating ? 'Generating…' : generateButtonLabel(ost)}
         </button>
       </div>
 
@@ -697,13 +701,13 @@ export default function InterviewsTab() {
 
       {error && <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>}
 
-      {loading ? (
-        <div className={styles.skeletonBar} style={{ height: 120 }} />
-      ) : snapshots.length === 0 ? (
+      {loading && <div className={styles.skeletonBar} style={{ height: 120 }} />}
+      {!loading && snapshots.length === 0 && (
         <div className={`${sharedStyles.surface} ${styles.interviewEmpty}`}>
           <p>No snapshots yet. Run your first customer interview and capture it here.</p>
         </div>
-      ) : (
+      )}
+      {!loading && snapshots.length > 0 && (
         <div className={styles.interviewGrid}>
           {snapshots.map((s) => (
             <SnapshotCard key={s.id} snapshot={s} onDelete={handleDelete} />

--- a/web/src/pages/OpsPage/InterviewsTab.tsx
+++ b/web/src/pages/OpsPage/InterviewsTab.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useRef, useState } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+
+type OpportunityTag = 'opportunity' | 'insight';
+
+interface InterviewOpportunity {
+  id: string;
+  body: string;
+  tag: OpportunityTag;
+}
+
+interface InterviewSnapshot {
+  id: string;
+  participantName: string;
+  memorableQuote: string;
+  photoData: string | null;
+  signupDate: string | null;
+  planTier: string;
+  usagePattern: string;
+  source: string;
+  experienceMapData: string | null;
+  interviewDate: string;
+  sessionLengthMinutes: number | null;
+  createdAt: string;
+  opportunities: InterviewOpportunity[];
+}
+
+async function apiList(): Promise<InterviewSnapshot[]> {
+  const res = await fetch('/api/ops/discovery/snapshots', {
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+  return res.json() as Promise<InterviewSnapshot[]>;
+}
+
+async function apiCreate(
+  body: Omit<InterviewSnapshot, 'id' | 'createdAt'>
+): Promise<InterviewSnapshot> {
+  const res = await fetch('/api/ops/discovery/snapshots', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({})) as { message?: string };
+    throw new Error(data.message ?? `${res.status}`);
+  }
+  return res.json() as Promise<InterviewSnapshot>;
+}
+
+async function apiDelete(id: string): Promise<void> {
+  const res = await fetch(`/api/ops/discovery/snapshots/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`${res.status}`);
+}
+
+function initials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function readFileAsDataUri(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+function blankForm(): Omit<InterviewSnapshot, 'id' | 'createdAt'> {
+  return {
+    participantName: '',
+    memorableQuote: '',
+    photoData: null,
+    signupDate: '',
+    planTier: '',
+    usagePattern: '',
+    source: '',
+    opportunities: [],
+    experienceMapData: null,
+    interviewDate: new Date().toISOString().slice(0, 10),
+    sessionLengthMinutes: null,
+  };
+}
+
+interface AvatarProps {
+  dataUri: string | null;
+  name: string;
+  size?: number;
+}
+
+function Avatar({ dataUri, name, size = 40 }: AvatarProps) {
+  if (dataUri) {
+    return (
+      <img
+        src={dataUri}
+        alt={name}
+        className={styles.interviewAvatar}
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+  return (
+    <span
+      className={styles.interviewAvatarInitials}
+      style={{ width: size, height: size, fontSize: size * 0.35 }}
+      aria-label={name}
+    >
+      {initials(name) || '?'}
+    </span>
+  );
+}
+
+interface SnapshotCardProps {
+  snapshot: InterviewSnapshot;
+  onDelete: (id: string) => void;
+}
+
+function SnapshotCard({ snapshot, onDelete }: SnapshotCardProps) {
+  const opportunityCount = snapshot.opportunities.filter((o) => o.tag === 'opportunity').length;
+  const insightCount = snapshot.opportunities.filter((o) => o.tag === 'insight').length;
+
+  const handleDelete = () => {
+    if (window.confirm(`Delete snapshot for ${snapshot.participantName}?`)) {
+      onDelete(snapshot.id);
+    }
+  };
+
+  return (
+    <article className={`${sharedStyles.surface} ${styles.interviewCard}`}>
+      <div className={styles.interviewCardHeader}>
+        <Avatar dataUri={snapshot.photoData} name={snapshot.participantName} />
+        <div className={styles.interviewCardMeta}>
+          <span className={styles.interviewCardName}>
+            {snapshot.participantName || 'Unknown'}
+          </span>
+          {snapshot.planTier && (
+            <span className={styles.interviewCardTier}>{snapshot.planTier}</span>
+          )}
+        </div>
+        <button
+          type="button"
+          className={styles.interviewDeleteBtn}
+          onClick={handleDelete}
+          aria-label={`Delete snapshot for ${snapshot.participantName}`}
+        >
+          ×
+        </button>
+      </div>
+      {snapshot.memorableQuote && (
+        <blockquote className={styles.interviewCardQuote}>
+          &ldquo;{snapshot.memorableQuote}&rdquo;
+        </blockquote>
+      )}
+      <div className={styles.interviewCardFooter}>
+        <span className={styles.interviewCardDate}>{snapshot.interviewDate}</span>
+        {snapshot.opportunities.length > 0 && (
+          <span className={styles.interviewCardOpCount}>
+            {opportunityCount > 0 && `${opportunityCount} opp${opportunityCount !== 1 ? 's' : ''}`}
+            {opportunityCount > 0 && insightCount > 0 && ' · '}
+            {insightCount > 0 && `${insightCount} insight${insightCount !== 1 ? 's' : ''}`}
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}
+
+interface SnapshotFormProps {
+  onSave: (snapshot: InterviewSnapshot) => void;
+  onCancel: () => void;
+}
+
+function SnapshotForm({ onSave, onCancel }: SnapshotFormProps) {
+  const [form, setForm] = useState(blankForm());
+  const [oppInput, setOppInput] = useState('');
+  const [oppTag, setOppTag] = useState<OpportunityTag>('opportunity');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const photoInputRef = useRef<HTMLInputElement>(null);
+  const mapInputRef = useRef<HTMLInputElement>(null);
+
+  const set = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handlePhotoFile = async (file: File) => {
+    const uri = await readFileAsDataUri(file);
+    set('photoData', uri);
+  };
+
+  const handleMapFile = async (file: File) => {
+    const uri = await readFileAsDataUri(file);
+    set('experienceMapData', uri);
+  };
+
+  const addOpportunity = () => {
+    if (oppInput.trim().length === 0) return;
+    set('opportunities', [
+      ...form.opportunities,
+      { id: crypto.randomUUID(), body: oppInput.trim(), tag: oppTag },
+    ]);
+    setOppInput('');
+  };
+
+  const removeOpportunity = (id: string) =>
+    set('opportunities', form.opportunities.filter((o) => o.id !== id));
+
+  const handleSave = async () => {
+    if (form.participantName.trim().length === 0) return;
+    setSaving(true);
+    setError('');
+    try {
+      const snapshot = await apiCreate({
+        ...form,
+        sessionLengthMinutes: form.sessionLengthMinutes,
+      });
+      onSave(snapshot);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.interviewForm}>
+      {error && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>
+      )}
+
+      <div className={styles.interviewFormSection}>
+        <div className={styles.interviewFormRow}>
+          <div className={styles.interviewPhotoZone}>
+            {form.photoData ? (
+              <img
+                src={form.photoData}
+                alt="Participant"
+                className={styles.interviewPhotoPreview}
+                onClick={() => photoInputRef.current?.click()}
+                style={{ cursor: 'pointer' }}
+              />
+            ) : (
+              <button
+                type="button"
+                className={styles.interviewPhotoPlaceholder}
+                onClick={() => photoInputRef.current?.click()}
+                aria-label="Upload participant photo"
+              >
+                Photo
+              </button>
+            )}
+            <input
+              ref={photoInputRef}
+              type="file"
+              accept="image/*"
+              hidden
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) handlePhotoFile(f);
+              }}
+            />
+          </div>
+          <div className={styles.interviewFormParticipant}>
+            <input
+              className={styles.textInput}
+              type="text"
+              placeholder="Participant name *"
+              value={form.participantName}
+              onChange={(e) => set('participantName', e.target.value)}
+            />
+            <select
+              className={styles.textInput}
+              value={form.planTier}
+              onChange={(e) => set('planTier', e.target.value)}
+            >
+              <option value="">Plan tier…</option>
+              <option value="free">Free</option>
+              <option value="patreon">Patreon (lifetime)</option>
+              <option value="churned-free">Churned free</option>
+              <option value="churned-paid">Churned paid</option>
+            </select>
+            <input
+              className={styles.textInput}
+              type="date"
+              value={form.signupDate ?? ''}
+              onChange={(e) => set('signupDate', e.target.value)}
+              title="Account sign-up date"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.interviewFormSection}>
+        <label className={styles.controlsLabel} htmlFor="iv-quote">
+          Memorable quote — their exact words
+        </label>
+        <textarea
+          id="iv-quote"
+          className={`${styles.textInput} ${styles.interviewQuoteInput}`}
+          placeholder="The most vivid or emotional thing they said…"
+          value={form.memorableQuote}
+          onChange={(e) => set('memorableQuote', e.target.value)}
+          rows={3}
+        />
+      </div>
+
+      <div className={styles.interviewFormSection}>
+        <p className={styles.controlsLabel}>Quick facts</p>
+        <div className={styles.interviewQuickFacts}>
+          <input
+            className={styles.textInput}
+            type="text"
+            placeholder="Usage pattern (e.g. uploads weekly)"
+            value={form.usagePattern}
+            onChange={(e) => set('usagePattern', e.target.value)}
+          />
+          <input
+            className={styles.textInput}
+            type="text"
+            placeholder="How they found 2anki"
+            value={form.source}
+            onChange={(e) => set('source', e.target.value)}
+          />
+          <input
+            className={styles.textInput}
+            type="date"
+            value={form.interviewDate}
+            onChange={(e) => set('interviewDate', e.target.value)}
+            title="Interview date"
+          />
+          <input
+            className={styles.textInput}
+            type="number"
+            placeholder="Session length (min)"
+            value={form.sessionLengthMinutes ?? ''}
+            onChange={(e) =>
+              set(
+                'sessionLengthMinutes',
+                e.target.value === '' ? null : Number(e.target.value)
+              )
+            }
+            min={0}
+          />
+        </div>
+      </div>
+
+      <div className={styles.interviewFormSection}>
+        <label className={styles.controlsLabel} htmlFor="iv-opp-input">
+          Opportunities & insights — their words, not solutions, not feelings
+        </label>
+        <div className={styles.interviewOppRow}>
+          <input
+            id="iv-opp-input"
+            className={styles.textInput}
+            type="text"
+            placeholder="e.g. I don't want to re-type my notes every time I make a deck"
+            value={oppInput}
+            onChange={(e) => setOppInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addOpportunity();
+              }
+            }}
+          />
+          <select
+            className={styles.textInput}
+            value={oppTag}
+            onChange={(e) => setOppTag(e.target.value as OpportunityTag)}
+            style={{ width: 'auto', flexShrink: 0 }}
+          >
+            <option value="opportunity">Opportunity</option>
+            <option value="insight">Insight</option>
+          </select>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={addOpportunity}
+            disabled={oppInput.trim().length === 0}
+          >
+            Add
+          </button>
+        </div>
+        {form.opportunities.length > 0 && (
+          <ul className={styles.interviewOppList}>
+            {form.opportunities.map((opp) => (
+              <li key={opp.id} className={styles.interviewOppItem}>
+                <span className={styles.interviewOppTag} data-tag={opp.tag}>
+                  {opp.tag}
+                </span>
+                <span className={styles.interviewOppBody}>{opp.body}</span>
+                <button
+                  type="button"
+                  className={styles.interviewDeleteBtn}
+                  onClick={() => removeOpportunity(opp.id)}
+                  aria-label="Remove"
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className={styles.interviewFormSection}>
+        <label className={styles.controlsLabel}>
+          Experience map — upload a photo or screenshot of the drawn journey
+        </label>
+        {form.experienceMapData ? (
+          <div className={styles.interviewMapPreviewWrap}>
+            <img
+              src={form.experienceMapData}
+              alt="Experience map"
+              className={styles.interviewMapPreview}
+            />
+            <button
+              type="button"
+              className={sharedStyles.btnSmall}
+              onClick={() => set('experienceMapData', null)}
+            >
+              Remove map
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={styles.interviewMapUploadBtn}
+            onClick={() => mapInputRef.current?.click()}
+          >
+            Upload experience map image
+          </button>
+        )}
+        <input
+          ref={mapInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handleMapFile(f);
+          }}
+        />
+      </div>
+
+      <div className={styles.interviewFormActions}>
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          onClick={handleSave}
+          disabled={saving || form.participantName.trim().length === 0}
+        >
+          {saving ? 'Saving…' : 'Save snapshot'}
+        </button>
+        <button type="button" className={sharedStyles.btnSmall} onClick={onCancel} disabled={saving}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function InterviewsTab() {
+  const [snapshots, setSnapshots] = useState<InterviewSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [view, setView] = useState<'archive' | 'form'>('archive');
+
+  useEffect(() => {
+    apiList()
+      .then(setSnapshots)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Load failed'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSave = (snapshot: InterviewSnapshot) => {
+    setSnapshots((prev) => [snapshot, ...prev]);
+    setView('archive');
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await apiDelete(id);
+      setSnapshots((prev) => prev.filter((s) => s.id !== id));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed');
+    }
+  };
+
+  if (view === 'form') {
+    return (
+      <>
+        <div className={styles.tabHeader}>
+          <p className={styles.panelTitle}>New interview snapshot</p>
+        </div>
+        <SnapshotForm onSave={handleSave} onCancel={() => setView('archive')} />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className={styles.interviewArchiveHeader}>
+        <div>
+          <p className={styles.panelTitle}>Interview snapshots</p>
+          <p className={styles.panelSubtitle}>
+            One snapshot per customer conversation. Fill in right after the interview, never batched.
+          </p>
+        </div>
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          onClick={() => setView('form')}
+        >
+          New snapshot
+        </button>
+      </div>
+
+      {error && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>{error}</div>
+      )}
+
+      {loading ? (
+        <div className={styles.skeletonBar} style={{ height: 120 }} />
+      ) : snapshots.length === 0 ? (
+        <div className={`${sharedStyles.surface} ${styles.interviewEmpty}`}>
+          <p>No snapshots yet. Run your first customer interview and capture it here.</p>
+        </div>
+      ) : (
+        <div className={styles.interviewGrid}>
+          {snapshots.map((s) => (
+            <SnapshotCard key={s.id} snapshot={s} onDelete={handleDelete} />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/InterviewsTab.tsx
+++ b/web/src/pages/OpsPage/InterviewsTab.tsx
@@ -243,8 +243,7 @@ function SnapshotForm({ onSave, onCancel }: { onSave: (s: InterviewSnapshot) => 
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const photoInputRef = useRef<HTMLInputElement>(null);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const excalidrawAPIRef = useRef<any>(null);
+  const [getExcalidrawPng, setGetExcalidrawPng] = useState<(() => Promise<string | null>) | null>(null);
 
   const set = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -266,21 +265,7 @@ function SnapshotForm({ onSave, onCancel }: { onSave: (s: InterviewSnapshot) => 
     setSaving(true);
     setError('');
     try {
-      // Export Excalidraw canvas as PNG if there are any elements
-      let mapData = form.experienceMapData;
-      if (excalidrawAPIRef.current) {
-        const elements = excalidrawAPIRef.current.getSceneElements();
-        if (elements.length > 0) {
-          const { exportToBlob } = await import('@excalidraw/excalidraw');
-          const blob = await exportToBlob({
-            elements,
-            mimeType: 'image/png',
-            appState: excalidrawAPIRef.current.getAppState(),
-            files: excalidrawAPIRef.current.getFiles(),
-          });
-          mapData = await blobToDataUri(blob);
-        }
-      }
+      const mapData = getExcalidrawPng ? (await getExcalidrawPng()) ?? form.experienceMapData : form.experienceMapData;
 
       const snapshot = await apiCreate({ ...form, experienceMapData: mapData });
       onSave(snapshot);
@@ -472,7 +457,20 @@ function SnapshotForm({ onSave, onCancel }: { onSave: (s: InterviewSnapshot) => 
         <div className={styles.excalidrawWrap}>
           <Suspense fallback={<div className={styles.excalidrawLoading}>Loading canvas…</div>}>
             <Excalidraw
-              excalidrawAPI={(api) => { excalidrawAPIRef.current = api; }}
+              excalidrawAPI={(api) => {
+                setGetExcalidrawPng(() => async () => {
+                  const elements = api.getSceneElements();
+                  if (elements.length === 0) return null;
+                  const { exportToBlob } = await import('@excalidraw/excalidraw');
+                  const blob = await exportToBlob({
+                    elements,
+                    mimeType: 'image/png',
+                    appState: api.getAppState(),
+                    files: api.getFiles(),
+                  });
+                  return blobToDataUri(blob);
+                });
+              }}
               initialData={{ appState: { viewBackgroundColor: 'transparent' } }}
             />
           </Suspense>

--- a/web/src/pages/OpsPage/OpsLayout.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.tsx
@@ -10,6 +10,7 @@ const TABS = [
   { to: '/ops', label: 'Engineering', match: (path: string) => path === '/ops' || path.startsWith('/ops?') },
   { to: '/ops/business', label: 'Business', match: (path: string) => path.startsWith('/ops/business') },
   { to: '/ops/showcase', label: 'Showcase', match: (path: string) => path.startsWith('/ops/showcase') },
+  { to: '/ops/interviews', label: 'Interviews', match: (path: string) => path.startsWith('/ops/interviews') },
 ];
 
 export default function OpsLayout() {

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -317,3 +317,302 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+
+/* ── Interviews tab ─────────────────────────────────────────────── */
+
+.interviewArchiveHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+
+.interviewGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+@media (min-width: 540px) {
+  .interviewGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .interviewGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.interviewCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+}
+
+.interviewCardHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+}
+
+.interviewAvatar {
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.interviewAvatarInitials {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  font-weight: var(--font-semibold);
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.interviewCardMeta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.interviewCardName {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.interviewCardTier {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.interviewDeleteBtn {
+  background: none;
+  border: none;
+  color: var(--color-text-tertiary);
+  font-size: 1.125rem;
+  line-height: 1;
+  padding: 0.125rem 0.25rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+}
+
+.interviewDeleteBtn:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
+}
+
+.interviewCardQuote {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  font-style: italic;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  line-height: 1.5;
+}
+
+.interviewCardFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.interviewCardDate {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.interviewCardOpCount {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.interviewEmpty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.interviewEmpty p {
+  margin: 0;
+}
+
+/* Form */
+
+.interviewForm {
+  max-width: 680px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.interviewFormSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.interviewFormRow {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.interviewPhotoZone {
+  flex-shrink: 0;
+}
+
+.interviewPhotoPlaceholder {
+  width: 88px;
+  height: 88px;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-tertiary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.interviewPhotoPlaceholder:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.interviewPhotoPreview {
+  width: 88px;
+  height: 88px;
+  border-radius: var(--radius-md);
+  object-fit: cover;
+  display: block;
+}
+
+.interviewFormParticipant {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.interviewQuoteInput {
+  font-size: var(--text-base);
+  resize: vertical;
+  font-family: inherit;
+}
+
+.interviewQuickFacts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.interviewOppRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.interviewOppList {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.interviewOppItem {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border-light);
+}
+
+.interviewOppTag {
+  font-size: var(--text-xs);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  flex-shrink: 0;
+}
+
+.interviewOppTag[data-tag='opportunity'] {
+  color: var(--color-primary);
+}
+
+.interviewOppBody {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  word-break: break-word;
+}
+
+.interviewMapPreviewWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.interviewMapPreview {
+  width: 100%;
+  max-height: 320px;
+  object-fit: contain;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.interviewMapUploadBtn {
+  width: 100%;
+  padding: 1.5rem;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  text-align: center;
+}
+
+.interviewMapUploadBtn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.interviewFormActions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  padding-top: 0.5rem;
+}

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -318,6 +318,94 @@
   word-break: break-word;
 }
 
+/* ── Excalidraw canvas ──────────────────────────────────────────── */
+
+.excalidrawWrap {
+  width: 100%;
+  height: 360px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.excalidrawLoading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+}
+
+/* ── OST section ────────────────────────────────────────────────── */
+
+.ostSection {
+  margin-top: 0;
+}
+
+.ostDivider {
+  border: none;
+  border-top: 1px solid var(--color-border-light);
+  margin: 2rem 0 1.5rem;
+}
+
+.ostTree {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 0.75rem;
+}
+
+.ostNode {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  cursor: default;
+  user-select: none;
+}
+
+.ostDragHandle {
+  color: var(--color-text-tertiary);
+  font-size: 0.875rem;
+  cursor: grab;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.ostNode:hover .ostDragHandle {
+  opacity: 1;
+}
+
+.ostNodeBody {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  line-height: 1.5;
+}
+
+.ostNodeBadge {
+  font-size: var(--text-xs);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  flex-shrink: 0;
+}
+
+.ostNodeBadge[data-type='opportunity'] {
+  color: var(--color-primary);
+}
+
+.ostNodeBadge[data-type='sub_opportunity'] {
+  color: var(--color-text-secondary);
+}
+
+.ostNodeBadge[data-type='solution'] {
+  color: var(--color-success, #16a34a);
+}
+
 /* ── Interviews tab ─────────────────────────────────────────────── */
 
 .interviewArchiveHeader {


### PR DESCRIPTION
## What this does

Implements the full Torres *Continuous Discovery Habits* feedback loop for 2anki.net: structured customer interview snapshots → user-submitted feedback form → Claude-generated Opportunity Solution Tree.

---

## Changes

### Admin: Interview Snapshots (`/ops/interviews`)
- New **Interviews** tab in `/ops` with a 3-column responsive archive grid and a full snapshot form
- 5-field Torres snapshot: participant photo (base64 upload), memorable quote, quick facts, opportunities/insights list, experience map drawn in an embedded **Excalidraw canvas** (exported as PNG on save)
- CRUD backed by Postgres: `interview_snapshots` + `interview_opportunities` tables (CASCADE delete)
- Routes behind `RequireOpsAccess` (returns 404 to everyone else):
  - `GET /api/ops/discovery/snapshots`
  - `POST /api/ops/discovery/snapshots`
  - `DELETE /api/ops/discovery/snapshots/:id`

### User feedback form (`/feedback`)
- New page reachable from the account page footer ("Share your experience")
- Three open-ended questions in the user's own words — no rating scales
- Server prefills everything it already knows: signup date, plan tier (patreon/subscriber), conversion count from jobs table
- Each submission creates an `interview_snapshot` row with `source: 'feedback-form'` — automatically appears in the admin Interviews tab
- Route: `POST /api/feedback/interview` behind `RequireAuthentication`
- `FloatingFeedback` widget hidden on `/feedback` (would be circular)

### Claude-generated Opportunity Solution Tree
- **"Generate tree" button** in the Interviews tab sends all snapshots + opportunities to Claude, which organises them into a 4-level tree: outcome → opportunity → sub-opportunity → solution
- Minimum 5 snapshots enforced before the button activates
- Tree persisted in `ost_versions` + `opportunity_tree_nodes` tables (self-referential FK, CASCADE delete)
- Rendered as a sortable indented list with `@dnd-kit/sortable` — drag to reorder within a level (local state, regenerate with Claude to persist a new structure)
- Routes behind `RequireOpsAccess`:
  - `GET /api/ops/discovery/ost`
  - `POST /api/ops/discovery/ost/generate`

### Emoji widget: strategic placement
- Removed `FloatingFeedback` from the global `SidebarLayout` (was appearing on every page, every session)
- Widget now shows only at **high-intent moments**:
  - Post-conversion in `UploadForm` (user just got a deck — highest intent)
  - On `/whats-new` (already there, kept)
- Low ratings (😠 😕) now show an inline nudge: "Want to tell us more? → Share on the feedback page"

---

## Migrations

| File | Tables created |
|---|---|
| `20260521000000_interview_snapshots.js` | `interview_snapshots`, `interview_opportunities` |
| `20260522000000_ost_tables.js` | `ost_versions`, `opportunity_tree_nodes` |

Both run automatically on server startup via `database.migrate.latest()`.

---

## New dependencies (web only)

| Package | Why |
|---|---|
| `@excalidraw/excalidraw` | In-form drawing canvas for experience maps; lazy-loaded |
| `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` | Drag-to-reorder OST nodes |

---

## Test plan

- [ ] Server starts cleanly — both migrations run, no errors
- [ ] `/ops/interviews` — Interviews tab visible, empty state shown
- [ ] New snapshot form: fill all 5 fields including Excalidraw drawing, save → appears in archive grid with photo/initials avatar and truncated quote
- [ ] Delete snapshot → confirm dialog, card removed
- [ ] `/feedback` — form loads, submit with story + mainNeed → snapshot appears in admin Interviews tab with `source: 'feedback-form'` and prefilled plan/signup fields
- [ ] `/feedback` — floating emoji widget does NOT appear
- [ ] Account page footer — "Share your experience" link present
- [ ] OST: with fewer than 5 snapshots, "Generate tree" is disabled with tooltip
- [ ] OST: with 5+ snapshots, generate → tree renders with outcome root and opportunity/sub-opportunity/solution badges
- [ ] Emoji widget on `/uploads`: rate 😠 or 😕 → nudge link appears; rate 🙂 or 😍 → no nudge
- [ ] Emoji widget no longer floats on account page, downloads page, or other nav pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)