### PR TITLE
feat: email notification + /ops/messages tab for contact form

### DIFF
--- a/src/controllers/ContactMessagesController.ts
+++ b/src/controllers/ContactMessagesController.ts
@@ -19,7 +19,7 @@ class ContactMessagesController {
   }
 
   async acknowledge(req: express.Request, res: express.Response) {
-    const id = parseInt(req.params.id, 10);
+    const id = Number.parseInt(req.params.id, 10);
     if (Number.isNaN(id)) {
       return res.status(400).json({ error: 'Invalid id' });
     }

--- a/src/controllers/ContactMessagesController.ts
+++ b/src/controllers/ContactMessagesController.ts
@@ -1,0 +1,32 @@
+import express from 'express';
+import { getDatabase } from '../data_layer';
+
+class ContactMessagesController {
+  async list(_req: express.Request, res: express.Response) {
+    const database = getDatabase();
+    const messages = await database('feedback')
+      .select(
+        'id',
+        'name',
+        'email',
+        'message',
+        'attachments',
+        'is_acknowledged',
+        'created_at'
+      )
+      .orderBy('created_at', 'desc');
+    return res.json(messages);
+  }
+
+  async acknowledge(req: express.Request, res: express.Response) {
+    const id = parseInt(req.params.id, 10);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Invalid id' });
+    }
+    const database = getDatabase();
+    await database('feedback').where({ id }).update({ is_acknowledged: true });
+    return res.status(200).send();
+  }
+}
+
+export default ContactMessagesController;

--- a/src/controllers/IndexController/IndexController.ts
+++ b/src/controllers/IndexController/IndexController.ts
@@ -5,6 +5,7 @@ import TokenRepository from '../../data_layer/TokenRepository';
 import UsersRepository from '../../data_layer/UsersRepository';
 import { configureUserLocal } from '../../routes/middleware/configureUserLocal';
 import { getIndexFileContents } from './getIndexFileContents';
+import { getDefaultEmailService } from '../../services/EmailService/EmailService';
 
 class IndexController {
   public getIndex(request: express.Request, response: express.Response) {
@@ -32,7 +33,12 @@ class IndexController {
       name,
       email,
       message,
-      attachments: JSON.stringify(attachments.map((a) => a.path)),
+      attachments: JSON.stringify(attachments.map((a) => a.originalname)),
+    });
+
+    const emailService = getDefaultEmailService();
+    emailService.sendContactEmail(name, email, message, attachments).catch((err) => {
+      console.error('Failed to send contact email notification', err);
     });
 
     return res.status(200).send();

--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -7,9 +7,10 @@ import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUse
 const buildRes = () => {
   const json = jest.fn();
   const status = jest.fn().mockReturnValue({ json });
-  return { json, status, end: jest.fn() } as unknown as express.Response & {
+  return { json, status, end: jest.fn(), set: jest.fn() } as unknown as express.Response & {
     json: jest.Mock;
     status: jest.Mock;
+    set: jest.Mock;
   };
 };
 

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -33,7 +33,7 @@ class OpsController {
     }
     try {
       const result = await this.getBusinessMetricsUseCase.execute();
-      res.set('Cache-Control', 'public, max-age=86400');
+      res.set('Cache-Control', 'private, max-age=86400');
       res.status(200).json(result);
     } catch (error) {
       console.error('[ops] getBusinessMetrics failed', error);

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -33,6 +33,7 @@ class OpsController {
     }
     try {
       const result = await this.getBusinessMetricsUseCase.execute();
+      res.set('Cache-Control', 'public, max-age=86400');
       res.status(200).json(result);
     } catch (error) {
       console.error('[ops] getBusinessMetrics failed', error);

--- a/src/routes/ContactMessagesRouter.ts
+++ b/src/routes/ContactMessagesRouter.ts
@@ -6,10 +6,48 @@ const ContactMessagesRouter = () => {
   const router = express.Router();
   const controller = new ContactMessagesController();
 
+  /**
+   * @swagger
+   * /api/ops/contact-messages:
+   *   get:
+   *     summary: List contact form submissions
+   *     description: Returns all messages from the contact form, newest first (ops only)
+   *     tags: [Ops]
+   *     security:
+   *       - cookieAuth: []
+   *     responses:
+   *       200:
+   *         description: Array of contact messages
+   *       404:
+   *         description: Not found (non-ops user)
+   */
   router.get('/api/ops/contact-messages', RequireOpsAccess, (req, res) =>
     controller.list(req, res)
   );
 
+  /**
+   * @swagger
+   * /api/ops/contact-messages/{id}/acknowledge:
+   *   patch:
+   *     summary: Mark a contact message as read
+   *     description: Sets is_acknowledged=true for the given message (ops only)
+   *     tags: [Ops]
+   *     security:
+   *       - cookieAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: integer
+   *     responses:
+   *       200:
+   *         description: Acknowledged
+   *       400:
+   *         description: Invalid id
+   *       404:
+   *         description: Not found (non-ops user)
+   */
   router.patch(
     '/api/ops/contact-messages/:id/acknowledge',
     RequireOpsAccess,

--- a/src/routes/ContactMessagesRouter.ts
+++ b/src/routes/ContactMessagesRouter.ts
@@ -1,0 +1,22 @@
+import express from 'express';
+import RequireOpsAccess from './middleware/RequireOpsAccess';
+import ContactMessagesController from '../controllers/ContactMessagesController';
+
+const ContactMessagesRouter = () => {
+  const router = express.Router();
+  const controller = new ContactMessagesController();
+
+  router.get('/api/ops/contact-messages', RequireOpsAccess, (req, res) =>
+    controller.list(req, res)
+  );
+
+  router.patch(
+    '/api/ops/contact-messages/:id/acknowledge',
+    RequireOpsAccess,
+    (req, res) => controller.acknowledge(req, res)
+  );
+
+  return router;
+};
+
+export default ContactMessagesRouter;

--- a/src/routes/DefaultRouter.ts
+++ b/src/routes/DefaultRouter.ts
@@ -9,6 +9,11 @@ const upload = multer({
   dest: process.env.FEEDBACK_DIR || '~/',
 });
 
+const contactUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10 * 1024 * 1024 },
+});
+
 const DefaultRouter = () => {
   const controller = new IndexController();
   const router = express.Router();
@@ -146,7 +151,7 @@ const DefaultRouter = () => {
    *             schema:
    *               $ref: '#/components/schemas/Error'
    */
-  router.post('/api/contact-us', upload.array('attachments'), (req, res) =>
+  router.post('/api/contact-us', contactUpload.array('attachments'), (req, res) =>
     controller.contactUs(req, res)
   );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,6 +41,7 @@ import opsRouter from './routes/OpsRouter';
 import opsDiscoveryRouter from './routes/OpsDiscoveryRouter';
 import ostRouter from './routes/OstRouter';
 import feedbackRouter from './routes/FeedbackRouter';
+import contactMessagesRouter from './routes/ContactMessagesRouter';
 import showcaseRouter from './routes/ShowcaseRouter';
 import emojiFeedbackRouter from './routes/EmojiFeedbackRouter';
 import reEngagementRouter from './routes/ReEngagementRouter';
@@ -114,6 +115,7 @@ const serve = async () => {
   app.use(opsDiscoveryRouter());
   app.use(ostRouter());
   app.use(feedbackRouter());
+  app.use(contactMessagesRouter());
   app.use(emojiFeedbackRouter());
   app.use(reEngagementRouter());
 

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -138,6 +138,7 @@ class EmailService implements IEmailService {
     const msg = {
       to: SUPPORT_EMAIL_ADDRESS,
       from: DEFAULT_SENDER,
+      replyTo: email,
       subject: `Contact form submission on behalf of ${
         name ?? 'Anon'
       } <${email}>`,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,7 @@ const EngineeringTab = lazy(() => import('./pages/OpsPage/EngineeringTab'));
 const BusinessTab = lazy(() => import('./pages/OpsPage/BusinessTab'));
 const ShowcaseTab = lazy(() => import('./pages/OpsPage/ShowcaseTab'));
 const InterviewsTab = lazy(() => import('./pages/OpsPage/InterviewsTab'));
+const ContactMessagesTab = lazy(() => import('./pages/OpsPage/ContactMessagesTab'));
 const FeedbackPage = lazy(() => import('./pages/FeedbackPage/FeedbackPage'));
 const NotionToAnki = lazy(() => import('./pages/LandingPage/NotionToAnki'));
 const QuizletToAnki = lazy(() => import('./pages/LandingPage/QuizletToAnki'));
@@ -205,6 +206,7 @@ function AppContent({
             <Route path="business" element={<BusinessTab />} />
             <Route path="showcase" element={<ShowcaseTab />} />
             <Route path="interviews" element={<InterviewsTab />} />
+            <Route path="messages" element={<ContactMessagesTab />} />
           </Route>
           <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
           <Route path="/settings" element={requireAuth(<AccountPage />)} />

--- a/web/src/components/FeedbackWidget/FloatingFeedback.module.css
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.module.css
@@ -17,11 +17,33 @@
   text-align: center;
 }
 
+.panelHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 0 0.5rem;
+}
+
 .panelTitle {
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
   color: var(--color-text-secondary);
-  margin: 0 0 0.5rem;
+  margin: 0;
+}
+
+.dismissButton {
+  background: none;
+  border: none;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  font-size: 1.125rem;
+  line-height: 1;
+  padding: 0 0 0 0.5rem;
+  flex-shrink: 0;
+}
+
+.dismissButton:hover {
+  color: var(--color-text-primary);
 }
 
 @media (max-width: 1500px) {

--- a/web/src/components/FeedbackWidget/FloatingFeedback.tsx
+++ b/web/src/components/FeedbackWidget/FloatingFeedback.tsx
@@ -23,7 +23,7 @@ export function FloatingFeedback() {
   if (dismissed) return null;
   if (shouldHide(pathname)) return null;
 
-  const handleSubmitted = () => {
+  const handleDismiss = () => {
     sessionStorage.setItem(DISMISSED_KEY, '1');
     setDismissed(true);
   };
@@ -31,8 +31,18 @@ export function FloatingFeedback() {
   return createPortal(
     <div className={styles.container}>
       <div className={styles.panel}>
-        <p className={styles.panelTitle}>How's your experience?</p>
-        <FeedbackWidget page={pathname} compact onSubmitted={handleSubmitted} />
+        <div className={styles.panelHeader}>
+          <p className={styles.panelTitle}>How's your experience?</p>
+          <button
+            type="button"
+            className={styles.dismissButton}
+            onClick={handleDismiss}
+            aria-label="Dismiss feedback widget"
+          >
+            ×
+          </button>
+        </div>
+        <FeedbackWidget page={pathname} compact onSubmitted={handleDismiss} />
       </div>
     </div>,
     document.body

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -740,4 +740,28 @@ export class Backend {
       throw new Error('Failed to submit feedback');
     }
   }
+
+  async listContactMessages(): Promise<ContactMessage[]> {
+    return get(`${this.baseURL}ops/contact-messages`);
+  }
+
+  async acknowledgeContactMessage(id: number): Promise<void> {
+    const response = await fetch(
+      `${this.baseURL}ops/contact-messages/${id}/acknowledge`,
+      { method: 'PATCH', credentials: 'include' }
+    );
+    if (!response.ok) {
+      throw new Error('Failed to acknowledge message');
+    }
+  }
+}
+
+export interface ContactMessage {
+  id: number;
+  name: string;
+  email: string;
+  message: string;
+  attachments: string | null;
+  is_acknowledged: boolean;
+  created_at: string;
 }

--- a/web/src/pages/OpsPage/ContactMessagesTab.tsx
+++ b/web/src/pages/OpsPage/ContactMessagesTab.tsx
@@ -75,7 +75,7 @@ interface MessageCardProps {
   onAcknowledge: (id: number) => void;
 }
 
-function MessageCard({ message, onAcknowledge }: MessageCardProps) {
+function MessageCard({ message, onAcknowledge }: Readonly<MessageCardProps>) {
   const attachments: string[] = (() => {
     try {
       return message.attachments ? JSON.parse(message.attachments) : [];

--- a/web/src/pages/OpsPage/ContactMessagesTab.tsx
+++ b/web/src/pages/OpsPage/ContactMessagesTab.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react';
+
+import { ContactMessage } from '../../lib/backend/Backend';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+
+export default function ContactMessagesTab() {
+  const [messages, setMessages] = useState<ContactMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    get2ankiApi()
+      .listContactMessages()
+      .then(setMessages)
+      .catch(() => setError('Failed to load messages'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function handleAcknowledge(id: number) {
+    await get2ankiApi().acknowledgeContactMessage(id);
+    setMessages((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, is_acknowledged: true } : m))
+    );
+  }
+
+  if (loading) {
+    return <p className={sharedStyles.emptyState}>Loading…</p>;
+  }
+
+  if (error) {
+    return <p className={sharedStyles.alertDanger}>{error}</p>;
+  }
+
+  if (messages.length === 0) {
+    return (
+      <p className={sharedStyles.emptyState}>No contact messages yet.</p>
+    );
+  }
+
+  const unread = messages.filter((m) => !m.is_acknowledged);
+  const read = messages.filter((m) => m.is_acknowledged);
+
+  return (
+    <div className={styles.contactMessages}>
+      {unread.length > 0 && (
+        <section>
+          <h2 className={sharedStyles.sectionTitle}>
+            Unread ({unread.length})
+          </h2>
+          <ul className={styles.messageList}>
+            {unread.map((m) => (
+              <MessageCard key={m.id} message={m} onAcknowledge={handleAcknowledge} />
+            ))}
+          </ul>
+        </section>
+      )}
+      {read.length > 0 && (
+        <section>
+          <h2 className={sharedStyles.sectionTitle}>Read ({read.length})</h2>
+          <ul className={styles.messageList}>
+            {read.map((m) => (
+              <MessageCard key={m.id} message={m} onAcknowledge={handleAcknowledge} />
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}
+
+interface MessageCardProps {
+  message: ContactMessage;
+  onAcknowledge: (id: number) => void;
+}
+
+function MessageCard({ message, onAcknowledge }: MessageCardProps) {
+  const attachments: string[] = (() => {
+    try {
+      return message.attachments ? JSON.parse(message.attachments) : [];
+    } catch {
+      return [];
+    }
+  })();
+
+  const date = new Date(message.created_at).toLocaleString();
+
+  return (
+    <li
+      className={`${styles.messageCard} ${message.is_acknowledged ? styles.messageCardRead : ''}`}
+    >
+      <div className={styles.messageHeader}>
+        <div>
+          <span className={styles.messageName}>{message.name}</span>
+          <a
+            href={`mailto:${message.email}`}
+            className={styles.messageEmail}
+          >
+            {message.email}
+          </a>
+        </div>
+        <span className={styles.messageDate}>{date}</span>
+      </div>
+      <p className={styles.messageBody}>{message.message}</p>
+      {attachments.length > 0 && (
+        <p className={styles.messageAttachments}>
+          {attachments.length} attachment{attachments.length === 1 ? '' : 's'}:{' '}
+          {attachments.join(', ')}
+        </p>
+      )}
+      {!message.is_acknowledged && (
+        <div className={styles.messageActions}>
+          <button
+            type="button"
+            className={sharedStyles.btnSecondary}
+            onClick={() => onAcknowledge(message.id)}
+          >
+            Mark as read
+          </button>
+          <a
+            href={`mailto:${message.email}?subject=Re: your message to 2anki`}
+            className={sharedStyles.btnPrimary}
+          >
+            Reply
+          </a>
+        </div>
+      )}
+    </li>
+  );
+}

--- a/web/src/pages/OpsPage/OpsLayout.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.tsx
@@ -11,6 +11,7 @@ const TABS = [
   { to: '/ops/business', label: 'Business', match: (path: string) => path.startsWith('/ops/business') },
   { to: '/ops/showcase', label: 'Showcase', match: (path: string) => path.startsWith('/ops/showcase') },
   { to: '/ops/interviews', label: 'Interviews', match: (path: string) => path.startsWith('/ops/interviews') },
+  { to: '/ops/messages', label: 'Messages', match: (path: string) => path.startsWith('/ops/messages') },
 ];
 
 export default function OpsLayout() {

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -704,3 +704,75 @@
   align-items: center;
   padding-top: 0.5rem;
 }
+
+/* Contact Messages Tab */
+.contactMessages {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.messageList {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.messageCard {
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+}
+
+.messageCardRead {
+  opacity: 0.65;
+}
+
+.messageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.625rem;
+}
+
+.messageName {
+  font-weight: var(--font-semibold);
+  font-size: var(--text-sm);
+  margin-right: 0.5rem;
+}
+
+.messageEmail {
+  font-size: var(--text-sm);
+  color: var(--color-primary);
+}
+
+.messageDate {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+}
+
+.messageBody {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  line-height: var(--leading-relaxed);
+  white-space: pre-wrap;
+  margin: 0 0 0.75rem;
+}
+
+.messageAttachments {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0 0 0.75rem;
+}
+
+.messageActions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -13,7 +13,7 @@ import { getVisibleText } from '../../lib/text/getVisibleText';
 const WALKTHROUGHS: ReadonlyArray<[string, string]> = [
   ['UnTo_fN1jpc', 'How I use Notion to Anki as a medical student'],
   ['JrYdp18Hbs8', 'Notion to Anki — complete guide'],
-  ['57dW_buqtGM', 'How to use cloze deletions'],
+  ['57dW_buqtGM', 'Cómo crear FLASHCARDS de ANKI usando NOTION | + Plantilla Gratis'],
 ];
 
 interface Props {

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -13,7 +13,7 @@ import { getVisibleText } from '../../lib/text/getVisibleText';
 const WALKTHROUGHS: ReadonlyArray<[string, string]> = [
   ['UnTo_fN1jpc', 'How I use Notion to Anki as a medical student'],
   ['JrYdp18Hbs8', 'Notion to Anki — complete guide'],
-  ['r9pPNl8Mx_Q', 'How to use cloze deletions'],
+  ['57dW_buqtGM', 'How to use cloze deletions'],
 ];
 
 interface Props {

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -13,7 +13,7 @@ import { getVisibleText } from '../../lib/text/getVisibleText';
 const WALKTHROUGHS: ReadonlyArray<[string, string]> = [
   ['UnTo_fN1jpc', 'How I use Notion to Anki as a medical student'],
   ['JrYdp18Hbs8', 'Notion to Anki — complete guide'],
-  ['57dW_buqtGM', 'Cómo crear FLASHCARDS de ANKI usando NOTION | + Plantilla Gratis'],
+  ['57dW_buqtGM', 'Cómo crear FLASHCARDS de ANKI usando NOTION'],
 ];
 
 interface Props {


### PR DESCRIPTION
## Summary

- **Email on submission**: every `/contact` form submission now fires `sendContactEmail` (fire-and-forget after DB write), so you get an email at `support@2anki.net` immediately. Reply-To is set to the sender, so hitting reply goes straight to them.
- **Memory-storage multer**: switched the contact-us route from disk to memory storage so `file.buffer` is available for SendGrid attachment encoding. Filenames (originalname) stored in DB instead of temp paths.
- **`GET /api/ops/contact-messages`** + **`PATCH .../acknowledge`** — both behind `RequireOpsAccess`.
- **`/ops/messages` tab**: unread/read sections, each card shows name, email, date, message body, attachment count, a "Mark as read" button, and a "Reply" mailto link.

## Test plan

- [x] Submit the contact form at `/contact` — email lands at support@2anki.net with attachments forwarded
- [x] Visit `/ops/messages` — message appears in Unread section
- [x] Click "Reply" — mailto opens with sender pre-filled
- [x] Click "Mark as read" — card moves to Read section
- [x] Verify unauthenticated users get 404 on `/api/ops/contact-messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)