### PR TITLE
fix(claude): drop trailing prose to fix invalid-JSON failures

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -1,6 +1,7 @@
 import {
   looksLikeEmptyContentExplanation,
   EMPTY_CONTENT_USER_MESSAGE,
+  parseDeckResponse,
   rewriteAudioAnchors,
 } from './ClaudeService';
 
@@ -31,6 +32,34 @@ describe('looksLikeEmptyContentExplanation', () => {
 
   it('does not match an empty JSON array', () => {
     expect(looksLikeEmptyContentExplanation('[]')).toBe(false);
+  });
+});
+
+describe('parseDeckResponse', () => {
+  const deck = [{ deck: 'Test', cards: [{ q: 'Q', a: 'A' }] }];
+  const deckJson = JSON.stringify(deck);
+
+  it('parses clean JSON', () => {
+    expect(parseDeckResponse(deckJson, deckJson, 0)).toEqual(deck);
+  });
+
+  it('parses JSON followed by Claude explanation prose (the prod failure pattern)', () => {
+    const cleaned = `${deckJson}\n\nI've created flashcards for all key concepts.`;
+    expect(parseDeckResponse(cleaned, cleaned, 0)).toEqual(deck);
+  });
+
+  it('parses [] followed by explanation text as an empty deck (downstream no-cards error handles it)', () => {
+    const cleaned = '[]\n\nThe document appears to be a course overview with no actual Q&A content to convert. I cannot find any flashcard material.';
+    expect(parseDeckResponse(cleaned, cleaned, 0)).toEqual([]);
+  });
+
+  it('throws generic error for truncated/invalid JSON', () => {
+    const cleaned = '[{"deck":"Bio","cards":[{"q":"What is';
+    expect(() => parseDeckResponse(cleaned, cleaned, 0)).toThrow('Claude returned invalid JSON');
+  });
+
+  it('throws generic error when there is no ] at all', () => {
+    expect(() => parseDeckResponse('not json', 'not json', 0)).toThrow('Claude returned invalid JSON');
   });
 });
 

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -288,20 +288,27 @@ function buildUserMessage(
   return `Convert this HTML content into the compact deck JSON:\n\n${strippedContent}${mediaFilesList}${instructionsSection}`;
 }
 
-function parseDeckResponse(
+export function parseDeckResponse(
   cleaned: string,
   raw: string,
   chunkIndex: number
 ): CompactDeck[] {
+  // Claude sometimes appends explanation prose after the closing fence/bracket.
+  // Truncate at the last ']' so trailing text doesn't break JSON.parse.
+  const jsonEnd = cleaned.lastIndexOf(']');
+  const toParse = jsonEnd >= 0 ? cleaned.slice(0, jsonEnd + 1) : cleaned;
+
   let parsed: unknown;
   try {
-    parsed = JSON.parse(cleaned);
+    parsed = JSON.parse(toParse);
   } catch {
-    console.error('[Claude] Failed to parse response as JSON', { raw, chunkIndex });
-    if (
-      !cleaned.trim().startsWith('[') &&
-      looksLikeEmptyContentExplanation(cleaned)
-    ) {
+    console.error('[Claude] Failed to parse response as JSON', {
+      raw,
+      cleaned,
+      toParse,
+      chunkIndex,
+    });
+    if (looksLikeEmptyContentExplanation(cleaned)) {
       throw new Error(EMPTY_CONTENT_USER_MESSAGE);
     }
     throw new Error(`Claude returned invalid JSON:\n${raw}`);


### PR DESCRIPTION
## Summary

- Claude occasionally appends explanation prose after the closing JSON fence/bracket (e.g. `[]\n\nThe document appears to be...`)
- The existing fence-strip regex removed the backtick fences but left the trailing text intact, causing `JSON.parse` to fail
- This was the most common conversion failure pattern in the jobs table (~8–9 failures over recent weeks)

**Fix:** truncate `cleaned` at the last `]` before parsing, dropping any trailing sentences Claude adds.

**Logging:** the `catch` block now logs both `cleaned` and `toParse` alongside `raw`, making future failures easier to diagnose.

**Behaviour change for `[]` + trailing explanation:** previously threw "Claude returned invalid JSON"; now returns an empty deck and the downstream "no cards" error surfaces instead (equally user-friendly, more accurate).

## Test plan

- [x] `pnpm test src/lib/claude/ClaudeService.test.ts` — 17 tests, all green
- [x] Five new test cases covering: clean JSON, JSON + trailing prose, `[]` + trailing prose, truncated JSON, no `]` at all
- [x] Verified against the exact `job_reason_failure` strings pulled from prod DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)