### PR TITLE
fix: image collision + preserve Notion highlight colors

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -9,6 +9,28 @@ import Workspace from './WorkSpace';
 
 beforeEach(() => setupTests());
 
+test('deck style includes Notion highlight color rules for file uploads', async () => {
+  const html = `<html><head><title>Colors</title><style>body { font-size: 16px; }</style></head>
+<body><article>
+<h2 class="toggle"><summary>Q</summary><div>
+  Answer with <span class="highlight-red">red highlight</span>
+</div></h2>
+</article></body></html>`;
+
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'colors.html',
+    settings: new CardOption({ cherry: 'false' }),
+    files: [{ name: 'colors.html', contents: html }],
+    noLimits: true,
+    workspace,
+  });
+  await parser.build(workspace);
+
+  const style = parser.payload[0].style ?? '';
+  expect(style).toContain('.highlight-red');
+});
+
 test('Toggle Headings', async () => {
   const deck = await getDeck(
     'Toggle Hea 0e02b 2.html',

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -31,6 +31,7 @@ import { getTitleFromMarkdown } from './getTitleFromMarkdown';
 import { checkFlashcardsLimits } from '../User/checkFlashcardsLimits';
 import { extractStyles } from './extractStyles';
 import { withFontSize } from './withFontSize';
+import { NOTION_STYLE } from '../../templates/helper';
 import { transformDetailsTagToNotionToggleList } from './transformDetailsTagToNotionToggleList';
 import { findNotionToggleLists } from './findNotionToggleLists';
 import { getNoPackageError } from '../error/constants';
@@ -290,7 +291,11 @@ export class DeckParser {
   ) {
     const { dom, isNewFormat } = this.loadAndNormalizeDOM(contents);
 
-    const style = withFontSize(extractStyles(dom), this.settings.fontSize);
+    const extractedStyle = extractStyles(dom);
+    const style = withFontSize(
+      extractedStyle ? `${NOTION_STYLE}\n${extractedStyle}` : NOTION_STYLE,
+      this.settings.fontSize
+    );
     let image: string | undefined = this.extractCoverImage(dom);
 
     const name = extractName({

--- a/src/lib/parser/exporters/embedFile.test.ts
+++ b/src/lib/parser/exporters/embedFile.test.ts
@@ -1,0 +1,82 @@
+import { setupTests } from '../../../test/configure-jest';
+import { embedFile } from './embedFile';
+import CustomExporter from './CustomExporter';
+import Workspace from '../WorkSpace';
+
+beforeEach(() => setupTests());
+
+const makeExporter = (firstDeckName = 'deck') =>
+  ({
+    firstDeckName,
+    workspace: '/tmp',
+    media: [],
+    addMedia: jest.fn().mockReturnValue('/tmp/mock.png'),
+  }) as unknown as CustomExporter;
+
+const makeWorkspace = () =>
+  ({ location: '/nonexistent-workspace-xyzzy' }) as unknown as Workspace;
+
+describe('embedFile — filename-only fallback', () => {
+  it('returns the single matching file when there is no collision', () => {
+    const exporter = makeExporter();
+    const file = { name: 'chapter1/image.png', contents: 'img-data' };
+
+    const result = embedFile({
+      exporter,
+      files: [file],
+      filePath: 'chapter1/sub/image.png',
+      workspace: makeWorkspace(),
+    });
+
+    expect(result).not.toBeNull();
+    expect(exporter.addMedia).toHaveBeenCalledWith(expect.any(String), 'img-data');
+  });
+
+  it('picks the file whose directory shares the most path segments with the request', () => {
+    const exporter = makeExporter();
+    const chapter1 = { name: 'chapter1/image.png', contents: 'chapter1-data' };
+    const chapter2 = { name: 'chapter2/image.png', contents: 'chapter2-data' };
+
+    embedFile({
+      exporter,
+      files: [chapter1, chapter2],
+      // Does not suffix-match either file, so filename-only fallback is used.
+      // requestDir = 'chapter2/sub' → chapter2 scores 1 shared segment, chapter1 scores 0.
+      filePath: 'chapter2/sub/image.png',
+      workspace: makeWorkspace(),
+    });
+
+    expect(exporter.addMedia).toHaveBeenCalledWith(
+      expect.any(String),
+      chapter2.contents
+    );
+  });
+
+  it('falls back to first match when all colliding files score equally', () => {
+    const exporter = makeExporter();
+    const fileA = { name: 'a/image.png', contents: 'file-a' };
+    const fileB = { name: 'b/image.png', contents: 'file-b' };
+
+    // filePath has no directory, so requestDir is '' and both score 0.
+    embedFile({
+      exporter,
+      files: [fileA, fileB],
+      filePath: 'image.png',
+      workspace: makeWorkspace(),
+    });
+
+    expect(exporter.addMedia).toHaveBeenCalledWith(expect.any(String), fileA.contents);
+  });
+
+  it('returns null when no file matches', () => {
+    const exporter = makeExporter();
+    const result = embedFile({
+      exporter,
+      files: [{ name: 'other/thing.png', contents: 'data' }],
+      filePath: 'missing.png',
+      workspace: makeWorkspace(),
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/parser/exporters/embedFile.ts
+++ b/src/lib/parser/exporters/embedFile.ts
@@ -54,15 +54,32 @@ const getFile = (
   /*
    * Last resort: match by filename only.
    * Mirrors ClaudeService's resolveMediaPath behaviour.
+   * When multiple files share the same filename, prefer the one whose
+   * directory is closest to the requesting path's directory.
    */
   const filename = normalizedFilePath.split('/').pop();
   if (filename) {
-    const byFilename = files.find((f) => {
+    const matches = files.filter((f) => {
       const normalizedName = f.name.replaceAll('\\', '/');
       return normalizedName === filename || normalizedName.endsWith('/' + filename);
     });
-    if (byFilename) {
-      return byFilename;
+    if (matches.length === 1) {
+      return matches[0];
+    }
+    if (matches.length > 1) {
+      const requestDir = normalizedFilePath.split('/').slice(0, -1).join('/');
+      const scored = matches.map((f) => {
+        const fDir = f.name.replaceAll('\\', '/').split('/').slice(0, -1).join('/');
+        const reqParts = requestDir.split('/');
+        const fParts = fDir.split('/');
+        let shared = 0;
+        while (shared < reqParts.length && shared < fParts.length && reqParts[shared] === fParts[shared]) {
+          shared++;
+        }
+        return { file: f, shared };
+      });
+      scored.sort((a, b) => b.shared - a.shared);
+      return scored[0].file;
     }
   }
 


### PR DESCRIPTION
## Summary

- **#2155 — Image filename collision**: `embedFile.ts` filename-only fallback used `find()`, silently returning the first match when multiple zip entries shared a filename (e.g. `chapter1/image.png` and `chapter2/image.png`). Changed to `filter()` + directory-proximity scoring: when multiple files match, pick the one whose directory shares the most path segments with the requesting path. Falls back to first match when all scores tie.

- **#2138 — Notion highlight colors**: `DeckParser.handleHTML` built card style from `extractStyles(dom)` only — the inline `<style>` tag of the Notion HTML export — which does not include `highlight-red`, `highlight-blue`, etc. Prepended `NOTION_STYLE` (the same `notion.css` template the Notion API path already uses), so all color classes render correctly in the generated deck.

- Removed stale `embedFile.js` / `DeckParser.js` compiled artifacts that were shadowing the `.ts` source and causing the new `embedFile` tests to load old code.

## Test plan

- [x] `pnpm test src/lib/parser/exporters/embedFile.test.ts` — 4 new tests covering single match, collision with proximity win, tied scores, and no match
- [x] `pnpm test src/lib/parser/DeckParser.test.ts` — 1 new test asserting `deck.style` contains `.highlight-red` after parsing a Notion HTML export with highlight spans; all 33 existing tests green
- [x] Full check: server tsc, web typecheck, web vitest, web lint — all clean

Closes #2155
Closes #2138

🤖 Generated with [Claude Code](https://claude.com/claude-code)