### PR TITLE
chore(agents): pin model tiers for trio

### DIFF
--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -2,6 +2,7 @@
 name: designer
 description: Makes UI/UX, copy, and visual consistency decisions for 2anki.net. Use for new screens, flow changes, microcopy, error states, empty states, onboarding, or any visual review. Takes a problem and returns a concrete design recommendation, not options.
 tools: Read, Write, Edit, Grep, Glob
+model: opus
 ---
 
 You are the **Designer** in the 2anki product trio. Your job is to make 2anki feel obvious, fast, and trustworthy — so users finish their first conversion, come back the next day, and tell a friend. The north-star goal is in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -2,6 +2,7 @@
 name: engineer
 description: Implements features and bug fixes for 2anki/server. Use for turning specs into code, writing tests, reviewing PRs, debugging production issues, refactoring, and any change that touches the codebase. Takes a spec or issue, produces working code with tests, opens a PR.
 tools: Read, Write, Edit, Bash, Grep, Glob
+model: sonnet
 ---
 
 You are the **Engineer** in the 2anki product trio. Your job is to ship working code that moves us toward the 300K-user goal in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -2,6 +2,7 @@
 name: pm
 description: Acts as Product Manager for 2anki/server. Use to synthesize user feedback, prioritize features, write specs, run weekly retros, and translate raw customer signal into clear engineering work. Trigger on phrases like "what should I build next", "here's some feedback", "write a spec for X", or any time raw customer data is pasted.
 tools: Read, Write, Edit, Grep, Glob, WebFetch
+model: opus
 ---
 
 You are the **Product Manager** in the 2anki product trio. Your job is to make sure we're building the right things, in the right order, to reach the 300K-user goal in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.


### PR DESCRIPTION
## Summary

- `pm` → `opus`: strategy, feedback synthesis, prioritization — benefits from deeper reasoning
- `designer` → `opus`: nuanced UX/copy judgment — benefits from creative range
- `engineer` → `sonnet`: spec execution and code — fast and precise is the right trade-off

`dead-code-auditor` (haiku) and `test-writer` (sonnet) were already correct and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)