### PR TITLE
chore: move status line config into project .claude/

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,10 @@
       "Edit(Documentation/ankify/*.md)"
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash $CLAUDE_PROJECT_DIR/.claude/statusline-command.sh"
+  },
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Claude Code status line: folder | git branch | PR | token usage
+
+input=$(cat)
+
+# Current folder (basename of cwd from JSON, fallback to pwd)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // empty')
+[ -z "$cwd" ] && cwd="$(pwd)"
+folder=$(basename "$cwd")
+
+# Git branch (run in cwd)
+branch=""
+if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
+  branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+fi
+
+# PR info: number and state for the current branch
+pr_info=""
+if [ -n "$branch" ] && command -v gh > /dev/null 2>&1; then
+  pr_json=$(gh pr list --head "$branch" --json number,state --limit 1 2>/dev/null)
+  pr_num=$(echo "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
+  pr_state=$(echo "$pr_json" | jq -r '.[0].state // empty' 2>/dev/null)
+  if [ -n "$pr_num" ]; then
+    pr_info="PR#${pr_num}(${pr_state})"
+  fi
+fi
+
+# Token usage
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+tokens_part=""
+if [ -n "$used_pct" ]; then
+  tokens_part=$(printf "ctx:%.0f%%" "$used_pct")
+fi
+
+# Assemble parts
+parts=("$folder")
+[ -n "$branch" ]      && parts+=("$branch")
+[ -n "$pr_info" ]     && parts+=("$pr_info")
+[ -n "$tokens_part" ] && parts+=("$tokens_part")
+
+printf '%s' "$(IFS='|'; echo "${parts[*]}")"

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # Claude Code status line: folder | git branch | PR | token usage
 
+RESET='\033[0m'
+DIM='\033[2m'
+CYAN='\033[36m'
+YELLOW='\033[33m'
+GREEN='\033[32m'
+RED='\033[31m'
+MAGENTA='\033[35m'
+SEP="${DIM}|${RESET}"
+
 input=$(cat)
 
 # Current folder (basename of cwd from JSON, fallback to pwd)
@@ -21,21 +30,32 @@ if [ -n "$branch" ] && command -v gh > /dev/null 2>&1; then
   pr_num=$(echo "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
   pr_state=$(echo "$pr_json" | jq -r '.[0].state // empty' 2>/dev/null)
   if [ -n "$pr_num" ]; then
-    pr_info="PR#${pr_num}(${pr_state})"
+    case "$pr_state" in
+      OPEN)   pr_color="$GREEN" ;;
+      MERGED) pr_color="$MAGENTA" ;;
+      CLOSED) pr_color="$DIM" ;;
+      *)      pr_color="$RESET" ;;
+    esac
+    pr_info="${pr_color}PR#${pr_num}(${pr_state})${RESET}"
   fi
 fi
 
-# Token usage
-used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+# Token usage — traffic-light colouring
 tokens_part=""
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 if [ -n "$used_pct" ]; then
-  tokens_part=$(printf "ctx:%.0f%%" "$used_pct")
+  pct_int=$(printf "%.0f" "$used_pct")
+  if   [ "$pct_int" -ge 80 ]; then ctx_color="$RED"
+  elif [ "$pct_int" -ge 50 ]; then ctx_color="$YELLOW"
+  else                              ctx_color="$GREEN"
+  fi
+  tokens_part="${ctx_color}ctx:${pct_int}%${RESET}"
 fi
 
-# Assemble parts
-parts=("$folder")
-[ -n "$branch" ]      && parts+=("$branch")
-[ -n "$pr_info" ]     && parts+=("$pr_info")
-[ -n "$tokens_part" ] && parts+=("$tokens_part")
+# Assemble
+result="${CYAN}${folder}${RESET}"
+[ -n "$branch" ]      && result+="${SEP}${YELLOW}${branch}${RESET}"
+[ -n "$pr_info" ]     && result+="${SEP}${pr_info}"
+[ -n "$tokens_part" ] && result+="${SEP}${tokens_part}"
 
-printf '%s' "$(IFS='|'; echo "${parts[*]}")"
+printf '%b' "$result"

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -8,7 +8,7 @@ YELLOW='\033[33m'
 GREEN='\033[32m'
 RED='\033[31m'
 MAGENTA='\033[35m'
-SEP="${DIM}|${RESET}"
+SEP=" ${DIM}|${RESET} "
 
 input=$(cat)
 

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -40,8 +40,8 @@ if [ -n "$branch" ] && command -v gh > /dev/null 2>&1; then
   fi
 fi
 
-# Token usage — traffic-light colouring
-tokens_part=""
+# Context window — traffic-light colouring
+ctx_part=""
 used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
 if [ -n "$used_pct" ]; then
   pct_int=$(printf "%.0f" "$used_pct")
@@ -49,13 +49,21 @@ if [ -n "$used_pct" ]; then
   elif [ "$pct_int" -ge 50 ]; then ctx_color="$YELLOW"
   else                              ctx_color="$GREEN"
   fi
-  tokens_part="${ctx_color}ctx:${pct_int}%${RESET}"
+  ctx_part="${ctx_color}ctx:${pct_int}%${RESET}"
+fi
+
+# Session cost in USD
+cost_part=""
+total_cost=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+if [ -n "$total_cost" ]; then
+  cost_part="${DIM}\$$(printf "%.4f" "$total_cost")${RESET}"
 fi
 
 # Assemble
 result="${CYAN}${folder}${RESET}"
-[ -n "$branch" ]      && result+="${SEP}${YELLOW}${branch}${RESET}"
-[ -n "$pr_info" ]     && result+="${SEP}${pr_info}"
-[ -n "$tokens_part" ] && result+="${SEP}${tokens_part}"
+[ -n "$branch" ]    && result+="${SEP}${YELLOW}${branch}${RESET}"
+[ -n "$pr_info" ]   && result+="${SEP}${pr_info}"
+[ -n "$ctx_part" ]  && result+="${SEP}${ctx_part}"
+[ -n "$cost_part" ] && result+="${SEP}${cost_part}"
 
 printf '%b' "$result"


### PR DESCRIPTION
## Summary

- Adds `.claude/statusline-command.sh` — displays folder, branch, PR, and token usage in the status line
- Updates `.claude/settings.json` to wire the script via `$CLAUDE_PROJECT_DIR` (same pattern as all other hooks)
- Removes the now-redundant entry from `~/.claude/settings.json`

## Test plan

- [x] Open Claude Code in this repo — status line should show `meta|main|ctx:X%` (or with PR# when on a feature branch)
- [x] Confirm `~/.claude/settings.json` no longer contains a `statusLine` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)