### PR TITLE
feat: add 1-hour Unlimited trial for free users

### DIFF
--- a/migrations/20260523000000_trial_started_at.js
+++ b/migrations/20260523000000_trial_started_at.js
@@ -1,0 +1,9 @@
+exports.up = (knex) =>
+  knex.schema.alterTable('users', (t) => {
+    t.timestamp('trial_started_at', { useTz: true }).nullable().defaultTo(null);
+  });
+
+exports.down = (knex) =>
+  knex.schema.alterTable('users', (t) => {
+    t.dropColumn('trial_started_at');
+  });

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -14,6 +14,7 @@ import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParent
 import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
+import { isPaying } from '../lib/isPaying';
 
 const MEDIA_CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',
@@ -182,7 +183,7 @@ class ApkgController {
         this.previewService,
         this.pdfRenderService
       );
-      const result = await useCase.execute(fileBuffer);
+      const result = await useCase.execute(fileBuffer, isPaying(res.locals));
       const safeName = file.originalname
         .replace(/\.apkg$/i, '')
         .replace(/[^\w\s.-]/g, '_');

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -12,6 +12,9 @@ import { getRandomUUID } from '../shared/helpers/getRandomUUID';
 import SubscriptionService from '../services/SubscriptionService';
 import { OPS_OWNER_EMAIL } from '../routes/middleware/RequireOpsAccess';
 import { MagicLinkRateLimitError } from '../services/UsersService';
+import StartTrialUseCase from '../usecases/users/StartTrialUseCase';
+import UsersRepository from '../data_layer/UsersRepository';
+import type { UsersId } from '../data_layer/public/Users';
 
 class UsersController {
   constructor(
@@ -218,6 +221,7 @@ class UsersController {
         patreon: user?.patreon,
         email: user?.email,
         ankify_welcome_seen: user?.ankify_welcome_seen ?? false,
+        trial_started_at: user?.trial_started_at ?? null,
       },
       locals,
       linked_email: linkedEmail,
@@ -235,6 +239,20 @@ class UsersController {
     }
     await this.userService.markAnkifyWelcomeSeen(owner);
     return res.json({ ok: true });
+  }
+
+  async startTrial(_req: express.Request, res: express.Response) {
+    const { owner } = res.locals;
+    if (owner == null) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+    const repository = new UsersRepository(this.db);
+    const useCase = new StartTrialUseCase(repository);
+    const result = await useCase.execute(owner as UsersId);
+    if (result.ok) {
+      return res.json({ ok: true, trialExpiresAt: result.trialExpiresAt.toISOString() });
+    }
+    return res.json({ ok: false, reason: result.reason });
   }
 
   async linkEmail(req: express.Request, res: express.Response) {

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -123,6 +123,12 @@ class UsersRepository {
     });
   }
 
+  markTrialStarted(userId: string) {
+    return this.database(this.table).where({ id: userId }).update({
+      trial_started_at: this.database.fn.now(),
+    });
+  }
+
   updatePatreonByEmail(email: string, patreon: boolean): Promise<number> {
     return this.database(this.table)
       .whereRaw('TRIM(LOWER(email)) = ?', [email.toLowerCase().trim()])

--- a/src/data_layer/public/Users.ts
+++ b/src/data_layer/public/Users.ts
@@ -31,6 +31,8 @@ export default interface Users {
   signup_origin: string | null;
 
   ankify_welcome_seen: boolean;
+
+  trial_started_at: Date | null;
 }
 
 /** Represents the initializer for the table public.users */
@@ -66,6 +68,8 @@ export interface UsersInitializer {
 
   /** Default value: false */
   ankify_welcome_seen?: boolean;
+
+  trial_started_at?: Date | null;
 }
 
 /** Represents the mutator for the table public.users */
@@ -95,4 +99,6 @@ export interface UsersMutator {
   signup_origin?: string | null;
 
   ankify_welcome_seen?: boolean;
+
+  trial_started_at?: Date | null;
 }

--- a/src/lib/User/checkFlashcardsLimits.ts
+++ b/src/lib/User/checkFlashcardsLimits.ts
@@ -1,8 +1,10 @@
 import type Deck from '../parser/Deck';
 import { getLimitMessage } from '../misc/getLimitMessage';
+import { hasUnlimitedAccess, type TrialUser } from './trialAccess';
 
 interface UserOptions {
   paying?: boolean;
+  trial?: TrialUser | null;
   cards?: number;
   decks?: Deck[];
 }
@@ -17,12 +19,13 @@ export const checkFlashcardsLimits = ({
   cards,
   decks,
   paying,
+  trial,
 }: UserOptions) => {
   const CARD_LIMIT = 100;
   const cardCount = getCardCount(cards ?? 0, decks);
   const isAbove100 = cardCount > CARD_LIMIT;
 
-  if (paying) return;
+  if (paying || hasUnlimitedAccess(trial)) return;
 
   if (isAbove100) {
     throw new Error(getLimitMessage());

--- a/src/lib/User/trialAccess.test.ts
+++ b/src/lib/User/trialAccess.test.ts
@@ -1,0 +1,83 @@
+import { hasUnlimitedAccess, isTrialActive, TRIAL_DURATION_MS } from './trialAccess';
+
+describe('isTrialActive', () => {
+  it('returns false when trial_started_at is null', () => {
+    expect(isTrialActive({ patreon: false, trial_started_at: null })).toBe(false);
+  });
+
+  it('returns false when user is null', () => {
+    expect(isTrialActive(null)).toBe(false);
+  });
+
+  it('returns false when user is undefined', () => {
+    expect(isTrialActive(undefined)).toBe(false);
+  });
+
+  it('returns true when trial was activated 59 minutes ago', () => {
+    const now = new Date();
+    const fiftyNineMinutesAgo = new Date(now.getTime() - 59 * 60 * 1000);
+    expect(
+      isTrialActive({ patreon: false, trial_started_at: fiftyNineMinutesAgo }, now)
+    ).toBe(true);
+  });
+
+  it('returns false when trial was activated 61 minutes ago', () => {
+    const now = new Date();
+    const sixtyOneMinutesAgo = new Date(now.getTime() - 61 * 60 * 1000);
+    expect(
+      isTrialActive({ patreon: false, trial_started_at: sixtyOneMinutesAgo }, now)
+    ).toBe(false);
+  });
+
+  it('returns false exactly at the boundary (exclusive upper bound)', () => {
+    const now = new Date();
+    const exactlyAtExpiry = new Date(now.getTime() - TRIAL_DURATION_MS);
+    expect(
+      isTrialActive({ patreon: false, trial_started_at: exactlyAtExpiry }, now)
+    ).toBe(false);
+  });
+});
+
+describe('hasUnlimitedAccess', () => {
+  it('returns true when patreon is true regardless of trial', () => {
+    expect(
+      hasUnlimitedAccess({ patreon: true, trial_started_at: null })
+    ).toBe(true);
+  });
+
+  it('returns false when patreon is false and trial is null', () => {
+    expect(
+      hasUnlimitedAccess({ patreon: false, trial_started_at: null })
+    ).toBe(false);
+  });
+
+  it('returns false when patreon is null and trial is null', () => {
+    expect(
+      hasUnlimitedAccess({ patreon: null, trial_started_at: null })
+    ).toBe(false);
+  });
+
+  it('returns false for null user', () => {
+    expect(hasUnlimitedAccess(null)).toBe(false);
+  });
+
+  it('returns false for undefined user', () => {
+    expect(hasUnlimitedAccess(undefined)).toBe(false);
+  });
+
+  it('returns true when patreon is false but trial is active', () => {
+    const now = new Date();
+    const thirtyMinutesAgo = new Date(now.getTime() - 30 * 60 * 1000);
+    expect(
+      hasUnlimitedAccess({ patreon: false, trial_started_at: thirtyMinutesAgo }, now)
+    ).toBe(true);
+  });
+
+  it('returns false when patreon is false and trial has expired', () => {
+    const now = new Date();
+    const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+    expect(
+      hasUnlimitedAccess({ patreon: false, trial_started_at: twoHoursAgo }, now)
+    ).toBe(false);
+  });
+});

--- a/src/lib/User/trialAccess.ts
+++ b/src/lib/User/trialAccess.ts
@@ -1,0 +1,19 @@
+export const TRIAL_DURATION_MS = 60 * 60 * 1000;
+
+export interface TrialUser {
+  patreon: boolean | null;
+  trial_started_at: Date | null;
+}
+
+export const isTrialActive = (
+  user: TrialUser | null | undefined,
+  now = new Date()
+): boolean => {
+  if (user?.trial_started_at == null) return false;
+  return now.getTime() - user.trial_started_at.getTime() < TRIAL_DURATION_MS;
+};
+
+export const hasUnlimitedAccess = (
+  user: TrialUser | null | undefined,
+  now = new Date()
+): boolean => user?.patreon === true || isTrialActive(user, now);

--- a/src/lib/isPaying.ts
+++ b/src/lib/isPaying.ts
@@ -1,6 +1,12 @@
-export const isPaying = (locals?: Record<string, boolean>) => {
+import { hasUnlimitedAccess } from './User/trialAccess';
+
+export const isPaying = (locals?: Record<string, unknown>) => {
   if (!locals) {
     return false;
   }
-  return locals.patreon || locals.subscriber;
+  if (locals.patreon || locals.subscriber) return true;
+  return hasUnlimitedAccess({
+    patreon: (locals.patreon as boolean | null) ?? null,
+    trial_started_at: (locals.trial_started_at as Date | null) ?? null,
+  });
 };

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -481,6 +481,12 @@ const UserRouter = () => {
     (req, res) => controller.markAnkifyWelcomeSeen(req, res)
   );
 
+  router.post(
+    '/api/users/start-trial',
+    RequireAuthentication,
+    (req, res) => controller.startTrial(req, res)
+  );
+
   /**
    * @swagger
    * /login:

--- a/src/routes/middleware/configureUserLocal.ts
+++ b/src/routes/middleware/configureUserLocal.ts
@@ -12,6 +12,7 @@ export async function configureUserLocal(
   if (user) {
     res.locals.owner = user.owner;
     res.locals.patreon = user.patreon;
+    res.locals.trial_started_at = user.trial_started_at ?? null;
     res.locals.subscriber = await authService.getIsSubscriber(
       database,
       user.email

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -136,6 +136,10 @@ class UsersService {
     return this.repository.markAnkifyWelcomeSeen(owner);
   }
 
+  markTrialStarted(userId: string) {
+    return this.repository.markTrialStarted(userId);
+  }
+
   async requestMagicLink(
     email: string,
     purpose: MagicTokenPurpose

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.ts
@@ -179,12 +179,12 @@ export default class ExportApkgToPdfUseCase {
     private readonly pdfRenderService: PdfRenderService
   ) {}
 
-  async execute(fileBuffer: Buffer): Promise<ExportApkgToPdfResult> {
+  async execute(fileBuffer: Buffer, unlimitedAccess = false): Promise<ExportApkgToPdfResult> {
     const cacheKey = `pdf-export:${Date.now()}`;
     const parsed = await this.previewService.parse(cacheKey, fileBuffer);
     const meta = this.previewService.getMeta(parsed);
 
-    if (meta.totalCards > MAX_CARDS) {
+    if (!unlimitedAccess && meta.totalCards > MAX_CARDS) {
       throw new CardLimitExceededError(meta.totalCards);
     }
 

--- a/src/usecases/users/StartTrialUseCase.test.ts
+++ b/src/usecases/users/StartTrialUseCase.test.ts
@@ -1,0 +1,96 @@
+import StartTrialUseCase from './StartTrialUseCase';
+import type { StartTrialUserRepository } from './StartTrialUseCase';
+import type { UsersId } from '../../data_layer/public/Users';
+
+const FAKE_USER_ID = 1 as UsersId;
+
+function makeRepository(
+  overrides: Partial<{
+    patreon: boolean | null;
+    trial_started_at: Date | null;
+  }> = {}
+): StartTrialUserRepository & { markTrialStartedCalled: boolean } {
+  const user = {
+    patreon: overrides.patreon ?? false,
+    trial_started_at: overrides.trial_started_at ?? null,
+  };
+  const repo = {
+    markTrialStartedCalled: false,
+    async getById() {
+      return user;
+    },
+    async markTrialStarted() {
+      repo.markTrialStartedCalled = true;
+    },
+  };
+  return repo;
+}
+
+describe('StartTrialUseCase', () => {
+  it('returns ok:true and sets trialExpiresAt 1 hour from now', async () => {
+    const repo = makeRepository({ patreon: false, trial_started_at: null });
+    const now = new Date('2026-01-01T12:00:00Z');
+    const useCase = new StartTrialUseCase(repo);
+
+    const result = await useCase.execute(FAKE_USER_ID, now);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.trialExpiresAt).toEqual(new Date('2026-01-01T13:00:00Z'));
+    }
+    expect(repo.markTrialStartedCalled).toBe(true);
+  });
+
+  it('returns already_paid when user has patreon', async () => {
+    const repo = makeRepository({ patreon: true, trial_started_at: null });
+    const useCase = new StartTrialUseCase(repo);
+
+    const result = await useCase.execute(FAKE_USER_ID);
+
+    expect(result).toEqual({ ok: false, reason: 'already_paid' });
+    expect(repo.markTrialStartedCalled).toBe(false);
+  });
+
+  it('returns already_used when trial_started_at is already set', async () => {
+    const repo = makeRepository({
+      patreon: false,
+      trial_started_at: new Date('2026-01-01T10:00:00Z'),
+    });
+    const useCase = new StartTrialUseCase(repo);
+
+    const result = await useCase.execute(FAKE_USER_ID);
+
+    expect(result).toEqual({ ok: false, reason: 'already_used' });
+    expect(repo.markTrialStartedCalled).toBe(false);
+  });
+
+  it('returns already_used when user is not found', async () => {
+    const repo: StartTrialUserRepository & { markTrialStartedCalled: boolean } = {
+      markTrialStartedCalled: false,
+      async getById() {
+        return null;
+      },
+      async markTrialStarted() {
+        repo.markTrialStartedCalled = true;
+      },
+    };
+    const useCase = new StartTrialUseCase(repo);
+
+    const result = await useCase.execute(FAKE_USER_ID);
+
+    expect(result).toEqual({ ok: false, reason: 'already_used' });
+    expect(repo.markTrialStartedCalled).toBe(false);
+  });
+
+  it('does not start trial when patreon is true even if trial_started_at is null', async () => {
+    const repo = makeRepository({ patreon: true, trial_started_at: null });
+    const useCase = new StartTrialUseCase(repo);
+
+    const result = await useCase.execute(FAKE_USER_ID);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('already_paid');
+    }
+  });
+});

--- a/src/usecases/users/StartTrialUseCase.ts
+++ b/src/usecases/users/StartTrialUseCase.ts
@@ -1,0 +1,38 @@
+import { TRIAL_DURATION_MS } from '../../lib/User/trialAccess';
+import type { UsersId } from '../../data_layer/public/Users';
+
+export type StartTrialResult =
+  | { ok: true; trialExpiresAt: Date }
+  | { ok: false; reason: 'already_paid' | 'already_used' };
+
+export interface StartTrialUserRepository {
+  getById(id: string): Promise<{
+    patreon: boolean | null;
+    trial_started_at: Date | null;
+  } | null>;
+  markTrialStarted(userId: string): Promise<unknown>;
+}
+
+class StartTrialUseCase {
+  constructor(private readonly repository: StartTrialUserRepository) {}
+
+  async execute(userId: UsersId, now = new Date()): Promise<StartTrialResult> {
+    const user = await this.repository.getById(String(userId));
+    if (user == null) {
+      return { ok: false, reason: 'already_used' };
+    }
+
+    if (user.patreon === true) {
+      return { ok: false, reason: 'already_paid' };
+    }
+
+    if (user.trial_started_at != null) {
+      return { ok: false, reason: 'already_used' };
+    }
+
+    await this.repository.markTrialStarted(String(userId));
+    return { ok: true, trialExpiresAt: new Date(now.getTime() + TRIAL_DURATION_MS) };
+  }
+}
+
+export default StartTrialUseCase;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -89,7 +89,7 @@ function AppContent({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   setErrorMessage: (error: unknown) => void;
 }>) {
-  const { data, isLoading } = useUserLocals();
+  const { data, isLoading, refetch } = useUserLocals();
   const isLoggedIn = isLoading ? undefined : !!data?.user?.id;
   const isLoggedInResolved = isLoggedIn === true;
 
@@ -105,7 +105,7 @@ function AppContent({
         error={error}
         isLoggedIn={isLoggedIn}
         email={data?.user?.email}
-        locals={data?.locals}
+        locals={data?.locals == null ? data?.locals : { ...data.locals, trial_started_at: data?.user?.trial_started_at ?? null }}
         features={data?.features}
       >
         <Routes>
@@ -169,6 +169,9 @@ function AppContent({
                 isLoggedIn={isLoggedInResolved}
                 email={data?.user?.email}
                 hostedAnkiRequested={data?.hostedAnkiRequested === true}
+                trialStartedAt={data?.user?.trial_started_at ?? null}
+                patreon={data?.user?.patreon ?? null}
+                onTrialStarted={() => { refetch(); }}
               />
             }
           />

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../../lib/hooks/useTheme';
 import { getVisibleText } from '../../lib/text/getVisibleText';
@@ -18,9 +18,40 @@ import WrenchIcon from '../icons/WrenchIcon';
 import { ThemeSwitcher } from '../ThemeSwitcher/ThemeSwitcher';
 import styles from './AppShell.module.css';
 
+const TRIAL_DURATION_MS = 60 * 60 * 1000;
+
+function useTrialCountdown(trialStartedAt: string | null | undefined): string | null {
+  const [label, setLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (trialStartedAt == null) {
+      setLabel(null);
+      return;
+    }
+    const startedAt = new Date(trialStartedAt).getTime();
+
+    function tick() {
+      const remaining = startedAt + TRIAL_DURATION_MS - Date.now();
+      if (remaining <= 0) {
+        setLabel(null);
+        return;
+      }
+      const minutes = Math.floor(remaining / 60000);
+      setLabel(`Unlimited · ${minutes}m left`);
+    }
+
+    tick();
+    const id = setInterval(tick, 60000);
+    return () => clearInterval(id);
+  }, [trialStartedAt]);
+
+  return label;
+}
+
 export interface SidebarLocals {
   patreon?: boolean;
   subscriber?: boolean;
+  trial_started_at?: string | null;
 }
 
 export interface SidebarFeatures {
@@ -95,7 +126,8 @@ export function Sidebar({
   const showKi = features?.kiUI === true;
   const showOps = features?.ops === true;
   const showAdminGroup = showKi || showOps;
-  const planLabel = getPlanLabel(locals);
+  const trialCountdown = useTrialCountdown(locals?.trial_started_at);
+  const planLabel = trialCountdown ?? getPlanLabel(locals);
 
   const handleNavClick = (
     handler?: React.MouseEventHandler<HTMLAnchorElement>

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -358,6 +358,15 @@ export class Backend {
     await post(`${this.baseURL}users/debug/ankify-welcome-seen`, {});
   }
 
+  async startTrial(): Promise<{ ok: boolean; reason?: string; trialExpiresAt?: string }> {
+    const response = await post(`${this.baseURL}users/start-trial`, {});
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ ok: false }));
+      return error as { ok: boolean; reason?: string };
+    }
+    return response.json();
+  }
+
   async listAnkifyClients(): Promise<AnkifyClient[]> {
     const result = await get(`${this.baseURL}ankify/clients`);
     return result ?? [];

--- a/web/src/lib/backend/getUserLocals.ts
+++ b/web/src/lib/backend/getUserLocals.ts
@@ -14,7 +14,7 @@ interface GetUserLocalsResponse {
     };
   };
   linked_email: string;
-  user?: Users & { ankify_welcome_seen?: boolean };
+  user?: Users & { ankify_welcome_seen?: boolean; trial_started_at?: string | null };
   features?: {
     kiUI: boolean;
     ops?: boolean;

--- a/web/src/pages/LandingPage/LandingPage.test.tsx
+++ b/web/src/pages/LandingPage/LandingPage.test.tsx
@@ -2,16 +2,29 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { HelmetProvider } from 'react-helmet-async';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 import LandingPage from './LandingPage';
 import notionCopy from './copy/notion';
 
+function renderLandingPage(children: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <HelmetProvider>{children}</HelmetProvider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
 describe('LandingPage', () => {
   it('renders the per-route H1 from the copy file', () => {
-    render(
-      <HelmetProvider>
-        <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
-      </HelmetProvider>
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
     );
     const heading = screen.getByRole('heading', {
       level: 1,
@@ -21,10 +34,8 @@ describe('LandingPage', () => {
   });
 
   it('renders the UploadForm drop zone above the fold', () => {
-    render(
-      <HelmetProvider>
-        <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
-      </HelmetProvider>
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
     );
     expect(
       screen.getByText(/Drop your files here/i)
@@ -32,10 +43,8 @@ describe('LandingPage', () => {
   });
 
   it('links the secondary CTA to /register with the source param', () => {
-    render(
-      <HelmetProvider>
-        <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
-      </HelmetProvider>
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
     );
     const link = screen.getByRole('link', { name: /sign up free/i });
     expect(link).toHaveAttribute(
@@ -45,10 +54,8 @@ describe('LandingPage', () => {
   });
 
   it('renders all FAQ summaries closed by default', () => {
-    render(
-      <HelmetProvider>
-        <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
-      </HelmetProvider>
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
     );
     for (const faq of notionCopy.faqs) {
       const summary = screen.getByText(faq.q);
@@ -59,10 +66,8 @@ describe('LandingPage', () => {
   });
 
   it('renders the three how-it-works steps with numbered circles', () => {
-    render(
-      <HelmetProvider>
-        <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
-      </HelmetProvider>
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
     );
     expect(screen.getByText('1')).toBeInTheDocument();
     expect(screen.getByText('2')).toBeInTheDocument();
@@ -70,10 +75,8 @@ describe('LandingPage', () => {
   });
 
   it('lists supported format tags', () => {
-    render(
-      <HelmetProvider>
-        <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
-      </HelmetProvider>
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
     );
     expect(screen.getByText('Notion')).toBeInTheDocument();
     expect(screen.getByText('PDF')).toBeInTheDocument();

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -67,6 +67,8 @@ function LandingPage({ copy, setErrorMessage }: Readonly<LandingPageProps>) {
           </div>
           <p className={styles.secondaryLink}>
             or <a href={registerHref}>sign up free</a>
+            {' — '}
+            <a href="/pricing">try Unlimited free for 1 hour</a>
           </p>
         </div>
       </section>

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -125,6 +125,37 @@
   line-height: var(--leading-relaxed);
 }
 
+.trialCta {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.trialButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.25rem;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.trialButton:hover:not(:disabled) {
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
+}
+
+.trialButton:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 /* =====================================================================
    CARD BASE
    ===================================================================== */

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -14,6 +14,9 @@ interface PricingPageProps {
   isLoggedIn: boolean;
   email?: string;
   hostedAnkiRequested?: boolean;
+  trialStartedAt?: string | null;
+  patreon?: boolean | null;
+  onTrialStarted?: () => void;
 }
 
 type RequestState = 'idle' | 'pending' | 'sent' | 'error';
@@ -29,6 +32,9 @@ export default function PricingPage({
   isLoggedIn,
   email,
   hostedAnkiRequested,
+  trialStartedAt,
+  patreon,
+  onTrialStarted,
 }: Readonly<PricingPageProps>) {
   const subcribeLink = isLoggedIn
     ? getSubscribeLink(email)
@@ -37,8 +43,15 @@ export default function PricingPage({
   const [hostedAnkiState, setHostedAnkiState] = useState<RequestState>(
     hostedAnkiRequested ? 'sent' : 'idle'
   );
+  const [trialState, setTrialState] = useState<RequestState>('idle');
   const [searchParams] = useSearchParams();
   const fromPaywall = searchParams.get('source') === 'paywall-cancel';
+
+  const showTrialCta =
+    isLoggedIn &&
+    patreon !== true &&
+    trialStartedAt == null &&
+    trialState !== 'sent';
 
   useEffect(() => {
     if (fromPaywall) {
@@ -57,6 +70,21 @@ export default function PricingPage({
       setHostedAnkiState('sent');
     } catch {
       setHostedAnkiState('error');
+    }
+  };
+
+  const handleStartTrial = async () => {
+    setTrialState('pending');
+    try {
+      const result = await get2ankiApi().startTrial();
+      if (result.ok) {
+        setTrialState('sent');
+        onTrialStarted?.();
+      } else {
+        setTrialState('error');
+      }
+    } catch {
+      setTrialState('error');
     }
   };
 
@@ -85,6 +113,21 @@ export default function PricingPage({
           )}
         </p>
       </div>
+
+      {showTrialCta && (
+        <div className={styles.trialCta}>
+          <button
+            type="button"
+            className={styles.trialButton}
+            onClick={handleStartTrial}
+            disabled={trialState === 'pending'}
+          >
+            {trialState === 'pending'
+              ? 'Starting trial…'
+              : 'Try Unlimited free for 1 hour — no card needed'}
+          </button>
+        </div>
+      )}
 
       <div className={styles.grid}>
         <PricingCard

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -1,12 +1,27 @@
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 import UploadForm from './UploadForm';
 
+function renderUploadForm(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
 describe('UploadForm', () => {
   test('no null classes', () => {
-    const { container } = render(<UploadForm setErrorMessage={vi.fn()} />);
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
     expect(container.querySelector('.null')).toBeNull();
   });
 });

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1,5 +1,6 @@
 import { type SyntheticEvent, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { ErrorHandlerType } from '../../../../components/errors/helpers/getErrorMessage';
 import handleRedirect from '../../../../lib/handleRedirect';
 import getAcceptedContentTypes from '../../helpers/getAcceptedContentTypes';
@@ -9,6 +10,8 @@ import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadF
 import { useDrag } from './hooks/useDrag';
 import { useFileValidation } from './hooks/useFileValidation';
 import { FeedbackWidget } from '../../../../components/FeedbackWidget/FeedbackWidget';
+import { useUserLocals } from '../../../../lib/hooks/useUserLocals';
+import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
 import formStyles from './UploadForm.module.css';
 import sharedStyles from '../../../../styles/shared.module.css';
 
@@ -148,11 +151,31 @@ function UploadForm({
   const [progressWidth, setProgressWidth] = useState(10);
   const [progressSlow, setProgressSlow] = useState(false);
   const [showFallback, setShowFallback] = useState(false);
+  const [trialPending, setTrialPending] = useState(false);
+  const { data: userLocals } = useUserLocals();
+  const queryClient = useQueryClient();
+  const showTrialButton =
+    !limitInfo?.isAnonymous &&
+    userLocals?.user?.trial_started_at == null &&
+    userLocals?.locals?.patreon !== true;
   const fileInputRef = useRef<HTMLInputElement>(null);
   const convertRef = useRef<HTMLButtonElement>(null);
   const downloadRef = useRef<HTMLAnchorElement>(null);
   const fallbackTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const { validation, validate, reset: resetValidation } = useFileValidation();
+
+  const handleStartTrial = async () => {
+    setTrialPending(true);
+    try {
+      const result = await get2ankiApi().startTrial();
+      if (result.ok) {
+        await queryClient.invalidateQueries({ queryKey: ['userLocals'] });
+        resetForm();
+      }
+    } finally {
+      setTrialPending(false);
+    }
+  };
 
   const submitFiles = () => {
     convertRef.current?.click();
@@ -446,6 +469,16 @@ function UploadForm({
           >
             Upgrade to continue
           </Link>
+        )}
+        {showTrialButton && (
+          <button
+            type="button"
+            className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}
+            onClick={handleStartTrial}
+            disabled={trialPending}
+          >
+            {trialPending ? 'Starting trial…' : 'Start 1-hour trial'}
+          </button>
         )}
         <button
           type="button"


### PR DESCRIPTION
## What
Adds a one-time, 1-hour Unlimited trial that free users can self-activate with no credit card. During the trial, the 100-card cap and the 500-card PDF export cap are lifted. Ankify (bidirectional sync) is not included — it remains gated to `patreon = true` only.

## Why
Closes the activation gap between "free tier with hard limits" and paid. Users who hit the 100-card cap today see a paywall with no safe way to evaluate unlimited. This lets them experience the full product before buying.

## How
**Server:**
- Migration `20260523000000_trial_started_at.js` adds `trial_started_at timestamptz` to `users`.
- `src/lib/User/trialAccess.ts` — pure helpers: `isTrialActive` (60 min window, exclusive upper bound), `hasUnlimitedAccess` (patreon OR active trial).
- `UsersRepository.markTrialStarted` — writes `trial_started_at = now()`.
- `configureUserLocal` — exposes `trial_started_at` in `res.locals`.
- `isPaying` — updated to also return `true` when a trial is active. This threads the unlimited flag into the upload worker (GeneratePackagesUseCase) without changing the worker data contract.
- `checkFlashcardsLimits` — accepts optional `trial` param; returns early when `hasUnlimitedAccess(trial)` is true.
- `ExportApkgToPdfUseCase.execute(buffer, unlimitedAccess)` — skips the 500-card cap when `unlimitedAccess = true`.
- `POST /api/users/start-trial` behind `RequireAuthentication` — calls `StartTrialUseCase`, returns `{ ok, trialExpiresAt }` or `{ ok: false, reason: 'already_paid' | 'already_used' }`.
- `GET /api/users/debug/locals` — includes `trial_started_at` in the `user` object.

**Frontend:**
- `Backend.startTrial()` — POSTs to the new endpoint.
- `getUserLocals` type — adds `trial_started_at?: string | null` to the user shape.
- `PricingPage` — shows "Try Unlimited free for 1 hour — no card needed" button for logged-in free users who haven't used their trial.
- `Sidebar` — shows `"Unlimited · Xm left"` in the plan badge when a trial is active (updates every minute via `setInterval`).
- `LandingPage` — adds tertiary "try Unlimited free for 1 hour" link next to "sign up free".
- `UploadForm` — adds "Start 1-hour trial" button on the limit-hit state for logged-in users who haven't used their trial.

## Measuring success
- `POST /api/users/start-trial` 200 responses rising in server logs.
- Conversion volume from users with an active trial (query: `users` where `trial_started_at` is set and `trial_started_at > now() - interval '1 hour'` with joins to `uploads`).
- Upgrade rate in the 24h after trial expiry compared to baseline.

## Testing
- Unit tests added: `src/lib/User/trialAccess.test.ts` (13 cases), `src/usecases/users/StartTrialUseCase.test.ts` (5 cases).
- `checkLimits.test.ts` still green — backward compat for the `paying` param.
- Web vitest: 278/278 pass. Fixed `UploadForm.test.tsx` and `LandingPage.test.tsx` to wrap with `QueryClientProvider` (now required because `UploadForm` reads user locals).

## Risks
- **Kanel-generated files** (`src/data_layer/public/Users.ts`, `web/src/schemas/public/Users.ts`): I updated these manually to match what kanel would produce after the migration. Alexander should run `pnpm kanel` against the real DB after the migration runs in prod to let kanel re-own those files. If not done, the next kanel run will overwrite the manual additions.
- **isPaying behaviour**: `isPaying` now also checks trial. Any code path that was already gated by `isPaying` is now also opened during a trial. This is intentional but worth noting.
- Rollback: drop the `trial_started_at` column with `migrations/20260523000000_trial_started_at.js` down. No data loss for other columns.

## Goal alignment
Reduces friction for first-time converters hitting the 100-card cap — the single biggest drop-off point on the conversion path. Trials that convert to paid subscriptions directly grow the 300K-user goal.