### PR TITLE
feat: inactive user warning email — full implementation

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.sources=src,web/src
 sonar.tests=src,web/src,web/tests
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,web/tests/**
 
-sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/config/swagger.ts,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/config/swagger.ts,src/services/EmailService/templates/**,web/build/**,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
@@ -13,6 +13,7 @@ function buildEmailService(): jest.Mocked<IEmailService> {
     sendHostedAnkiAccessRequestEmail: jest.fn(),
     sendMagicLinkEmail: jest.fn(),
     sendReEngagementEmail: jest.fn().mockResolvedValue(undefined),
+    sendInactivityWarningEmail: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -22,6 +22,7 @@ import { getDatabase } from '../data_layer';
 import RequireOpsAccess from './middleware/RequireOpsAccess';
 import InactivityEmailRepository from '../data_layer/InactivityEmailRepository';
 import { SendInactivityWarningsUseCase } from '../usecases/ops/SendInactivityWarningsUseCase';
+import { getDefaultEmailService } from '../services/EmailService/EmailService';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -51,7 +52,7 @@ const OpsRouter = () => {
     new GetConversionMetricsUseCase(conversionMetricsService),
     populateShowcase,
     showcaseRepo,
-    new SendInactivityWarningsUseCase(new InactivityEmailRepository(database))
+    new SendInactivityWarningsUseCase(new InactivityEmailRepository(database), getDefaultEmailService())
   );
 
   /**

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -7,6 +7,7 @@ import {
   CONVERT_LINK_TEMPLATE,
   CONVERT_TEMPLATE,
   DEFAULT_SENDER,
+  INACTIVITY_WARNING_TEMPLATE,
   MAGIC_LINK_TEMPLATE,
   PASSWORD_RESET_TEMPLATE,
   RE_ENGAGEMENT_TEMPLATE,
@@ -54,6 +55,7 @@ export interface IEmailService {
     name: string,
     token: string
   ): Promise<void>;
+  sendInactivityWarningEmail(to: string): Promise<void>;
 }
 
 class EmailService implements IEmailService {
@@ -249,6 +251,30 @@ class EmailService implements IEmailService {
       await sgMail.send(msg);
     } catch (error) {
       console.error('Failed to send re-engagement email:', error);
+      throw error;
+    }
+  }
+
+  async sendInactivityWarningEmail(to: string): Promise<void> {
+    const domain = process.env.DOMAIN ?? 'https://2anki.net';
+    const markup = INACTIVITY_WARNING_TEMPLATE.replace('{{link}}', domain);
+
+    const $ = cheerio.load(markup);
+    const text = $('body').text().replace(/\s+/g, ' ').trim();
+
+    const msg = {
+      to,
+      from: this.defaultSender,
+      subject: 'Your 2anki account will be deleted soon',
+      text,
+      html: markup,
+      replyTo: 'support@2anki.net',
+    };
+
+    try {
+      await sgMail.send(msg);
+    } catch (error) {
+      console.error(`Failed to send inactivity warning to ${to}:`, error);
       throw error;
     }
   }
@@ -456,6 +482,10 @@ export class UnimplementedEmailService implements IEmailService {
     token: string
   ): Promise<void> {
     console.info('sendReEngagementEmail not handled', to, name, token);
+  }
+
+  async sendInactivityWarningEmail(to: string): Promise<void> {
+    console.info('sendInactivityWarningEmail not handled', to);
   }
 }
 

--- a/src/services/EmailService/constants.ts
+++ b/src/services/EmailService/constants.ts
@@ -49,3 +49,8 @@ export const RE_ENGAGEMENT_TEMPLATE = fs.readFileSync(
   path.join(EMAIL_TEMPLATES_DIRECTORY, 're-engagement.html'),
   'utf8'
 );
+
+export const INACTIVITY_WARNING_TEMPLATE = fs.readFileSync(
+  path.join(EMAIL_TEMPLATES_DIRECTORY, 'inactivity-warning.html'),
+  'utf8'
+);

--- a/src/services/EmailService/templates/inactivity-warning.html
+++ b/src/services/EmailService/templates/inactivity-warning.html
@@ -43,8 +43,8 @@
               </div>
               <p style="margin: 0 0 16px;">If you no longer need your account, you can ignore this email — we won't send another.</p>
               <p style="margin: 0 0 16px;">If you have any questions, please reply to this email.</p>
-              <p style="margin: 0 0 8px;">We wish you all the best in your studies!</p>
-              <p style="margin: 0;">The 2anki team</p>
+              <p style="margin: 0 0 8px;">Happy learning,</p>
+              <p style="margin: 0;">The 2anki Team</p>
             </td>
           </tr>
           <tr>

--- a/src/services/EmailService/templates/inactivity-warning.html
+++ b/src/services/EmailService/templates/inactivity-warning.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>2anki.net — Your account will be deleted soon</title>
+  <style>
+    @media (prefers-color-scheme: dark) {
+      body { background-color: #1a1a1a !important; }
+      .email-card { background-color: #111827 !important; }
+      .email-header { color: #f9fafb !important; border-bottom-color: #374151 !important; }
+      .email-body p { color: #f9fafb !important; }
+      .email-cta a { background-color: #60a5fa !important; }
+      .email-footer { color: #6b7280 !important; border-top-color: #374151 !important; }
+    }
+    @media only screen and (max-width: 600px) {
+      .email-card { width: 100% !important; padding: 0 !important; }
+      .email-body { padding: 24px 16px !important; }
+      .email-header { padding: 16px !important; }
+      .email-footer { padding: 12px 16px !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px;">
+          <tr>
+            <td class="email-header" style="text-align: center; padding: 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 20px; font-weight: 700; color: #1f2937; border-bottom: 1px solid #e5e7eb;">
+              2anki
+            </td>
+          </tr>
+          <tr>
+            <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
+              <p style="margin: 0 0 16px;">Hello,</p>
+              <p style="margin: 0 0 16px;">We noticed you haven't used your 2anki account in a while. Because 2anki is a free service, we remove data from accounts that have been inactive for 6 months or more.</p>
+              <p style="margin: 0 0 16px;">If we don't hear from you in the next 14 days, your uploaded decks and files will be permanently deleted. This only affects data stored on 2anki.net — anything you've already downloaded to your computer or Anki app is safe.</p>
+              <p style="margin: 0 0 24px;">To keep your account, sign in once:</p>
+              <div style="text-align: center; margin: 0 0 24px;" class="email-cta">
+                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Sign in to 2anki.net</a>
+              </div>
+              <p style="margin: 0 0 16px;">If you no longer need your account, you can ignore this email — we won't send another.</p>
+              <p style="margin: 0 0 16px;">If you have any questions, please reply to this email.</p>
+              <p style="margin: 0 0 8px;">We wish you all the best in your studies!</p>
+              <p style="margin: 0;">The 2anki team</p>
+            </td>
+          </tr>
+          <tr>
+            <td class="email-footer" style="text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #9ca3af; padding: 16px 24px; border-top: 1px solid #e5e7eb;">
+              2anki.net — Turn what you study into Anki flashcards
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/services/EmailService/templates/inactivity-warning.html
+++ b/src/services/EmailService/templates/inactivity-warning.html
@@ -39,7 +39,7 @@
               <p style="margin: 0 0 16px;">If we don't hear from you in the next 14 days, your uploaded decks and files will be permanently deleted. This only affects data stored on 2anki.net — anything you've already downloaded to your computer or Anki app is safe.</p>
               <p style="margin: 0 0 24px;">To keep your account, sign in once:</p>
               <div style="text-align: center; margin: 0 0 24px;" class="email-cta">
-                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Sign in to 2anki.net</a>
+                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Log in</a>
               </div>
               <p style="margin: 0 0 16px;">If you no longer need your account, you can ignore this email — we won't send another.</p>
               <p style="margin: 0 0 16px;">If you have any questions, please reply to this email.</p>

--- a/src/services/EmailService/templates/inactivity-warning.html
+++ b/src/services/EmailService/templates/inactivity-warning.html
@@ -28,13 +28,13 @@
       <td align="center" style="padding: 32px 16px;">
         <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px;">
           <tr>
-            <td class="email-header" style="text-align: center; padding: 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 20px; font-weight: 700; color: #1f2937; border-bottom: 1px solid #e5e7eb;">
-              2anki
+            <td class="email-header" style="text-align: center; padding: 24px; border-bottom: 1px solid #e5e7eb;">
+              <img src="https://2anki.net/mascot/navbar-logo.png" alt="2anki" width="120" style="display: block; margin: 0 auto; height: auto;" />
             </td>
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <p style="margin: 0 0 16px;">Hello,</p>
+              <p style="margin: 0 0 16px;">Hei,</p>
               <p style="margin: 0 0 16px;">We noticed you haven't used your 2anki account in a while. Because 2anki is a free service, we remove data from accounts that have been inactive for 6 months or more.</p>
               <p style="margin: 0 0 16px;">If we don't hear from you in the next 14 days, your uploaded decks and files will be permanently deleted. This only affects data stored on 2anki.net — anything you've already downloaded to your computer or Anki app is safe.</p>
               <p style="margin: 0 0 24px;">To keep your account, sign in once:</p>

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -1,38 +1,100 @@
 import { SendInactivityWarningsUseCase } from './SendInactivityWarningsUseCase';
 import { InMemoryInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
+import type { IEmailService } from '../../services/EmailService/EmailService';
+
+function makeEmailService(
+  overrides: Partial<IEmailService> = {}
+): IEmailService {
+  return {
+    sendResetEmail: jest.fn(),
+    sendConversionEmail: jest.fn(),
+    sendConversionLinkEmail: jest.fn(),
+    sendContactEmail: jest.fn(),
+    sendSubscriptionCancelledEmail: jest.fn(),
+    sendSubscriptionScheduledCancellationEmail: jest.fn(),
+    sendHostedAnkiAccessRequestEmail: jest.fn(),
+    sendMagicLinkEmail: jest.fn(),
+    sendReEngagementEmail: jest.fn(),
+    sendInactivityWarningEmail: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
 
 describe('SendInactivityWarningsUseCase', () => {
   let repo: InMemoryInactivityEmailRepository;
-  let useCase: SendInactivityWarningsUseCase;
 
   beforeEach(() => {
     repo = new InMemoryInactivityEmailRepository();
-    useCase = new SendInactivityWarningsUseCase(repo);
   });
 
-  it('returns the candidate count and dryRun flag', async () => {
-    repo.seedUsers([
-      { id: 1, name: 'Alice', email: 'alice@example.com' },
-      { id: 2, name: 'Bob', email: 'bob@example.com' },
-    ]);
+  describe('dry run', () => {
+    it('returns candidate count without sending emails', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com' },
+        { id: 2, name: 'Bob', email: 'bob@example.com' },
+      ]);
+      const emailService = makeEmailService();
+      const useCase = new SendInactivityWarningsUseCase(repo, emailService);
 
-    const result = await useCase.execute(true);
+      const result = await useCase.execute(true);
 
-    expect(result).toEqual({ count: 2, dryRun: true });
+      expect(result).toEqual({ count: 2, dryRun: true });
+      expect(emailService.sendInactivityWarningEmail).not.toHaveBeenCalled();
+      expect(repo.getSentUserIds().size).toBe(0);
+    });
+
+    it('returns zero when no candidates exist', async () => {
+      const useCase = new SendInactivityWarningsUseCase(repo, makeEmailService());
+
+      const result = await useCase.execute(true);
+
+      expect(result).toEqual({ count: 0, dryRun: true });
+    });
   });
 
-  it('returns zero when no candidates exist', async () => {
-    const result = await useCase.execute(true);
+  describe('live send', () => {
+    it('sends emails and records sends for each candidate', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com' },
+        { id: 2, name: 'Bob', email: 'bob@example.com' },
+      ]);
+      const emailService = makeEmailService();
+      const useCase = new SendInactivityWarningsUseCase(repo, emailService);
 
-    expect(result).toEqual({ count: 0, dryRun: true });
-  });
+      const result = await useCase.execute(false);
 
-  it('reports dryRun=false when called with false', async () => {
-    repo.seedUsers([{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+      expect(result).toEqual({ count: 2, dryRun: false });
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledTimes(2);
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith('alice@example.com');
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith('bob@example.com');
+      expect(repo.getSentUserIds()).toEqual(new Set([1, 2]));
+    });
 
-    const result = await useCase.execute(false);
+    it('continues sending to remaining users when one email fails', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com' },
+        { id: 2, name: 'Bob', email: 'bob@example.com' },
+      ]);
+      const emailService = makeEmailService({
+        sendInactivityWarningEmail: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('SendGrid error'))
+          .mockResolvedValueOnce(undefined),
+      });
+      const useCase = new SendInactivityWarningsUseCase(repo, emailService);
 
-    expect(result.dryRun).toBe(false);
-    expect(result.count).toBe(1);
+      const result = await useCase.execute(false);
+
+      expect(result.count).toBe(1);
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns zero when no candidates exist', async () => {
+      const useCase = new SendInactivityWarningsUseCase(repo, makeEmailService());
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 0, dryRun: false });
+    });
   });
 });

--- a/src/usecases/ops/SendInactivityWarningsUseCase.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.ts
@@ -1,4 +1,5 @@
 import type { IInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
+import type { IEmailService } from '../../services/EmailService/EmailService';
 
 export interface SendInactivityWarningsResult {
   count: number;
@@ -6,10 +7,29 @@ export interface SendInactivityWarningsResult {
 }
 
 export class SendInactivityWarningsUseCase {
-  constructor(private readonly repo: IInactivityEmailRepository) {}
+  constructor(
+    private readonly repo: IInactivityEmailRepository,
+    private readonly emailService: IEmailService
+  ) {}
 
   async execute(dryRun: boolean): Promise<SendInactivityWarningsResult> {
     const users = await this.repo.getUsersToNotify();
-    return { count: users.length, dryRun };
+
+    if (dryRun) {
+      return { count: users.length, dryRun: true };
+    }
+
+    let sent = 0;
+    for (const user of users) {
+      await this.repo.recordSend(user.id, crypto.randomUUID());
+      try {
+        await this.emailService.sendInactivityWarningEmail(user.email);
+        sent++;
+      } catch (error) {
+        console.error(`[inactivity] failed to email user ${user.id}:`, error);
+      }
+    }
+
+    return { count: sent, dryRun: false };
   }
 }


### PR DESCRIPTION
## Summary

Sends a one-time deletion warning email to free accounts inactive for 6+ months. Exempt: `patreon = true` (lifetime) and active Stripe subscribers.

- Migration: `inactivity_emails(id, user_id, token, sent_at)` table tracks who was warned
- `InactivityEmailRepository` — candidate query with Stripe join on both email columns, 500/run cap, marketing opt-out respected
- `SendInactivityWarningsUseCase` — `dryRun=true` returns candidate count; `dryRun=false` sends and records
- `sendInactivityWarningEmail` added to `IEmailService` with HTML template (magic-link shell, warm prose, 14-day deadline)
- `POST /api/ops/send-inactivity-warnings?dryRun=true|false` — ops-owner only
- **Commands tab** at `/ops/commands` with Dry run + Send warnings buttons

## Email copy (designer-reviewed)

> Subject: Your 2anki account will be deleted soon
>
> Hello,
> We noticed you haven't used your 2anki account in a while. Because 2anki is a free service, we remove data from accounts that have been inactive for 6 months or more.
> If we don't hear from you in the next 14 days, your uploaded decks and files will be permanently deleted. This only affects data stored on 2anki.net — anything you've already downloaded to your computer or Anki app is safe.
> To keep your account, sign in once: [Sign in to 2anki.net]
> If you no longer need your account, you can ignore this email — we won't send another.
> If you have any questions, please reply to this email.
> We wish you all the best in your studies!
> The 2anki team

## How to run

1. Deploy this PR
2. Go to `/ops/commands` → **Dry run** to confirm candidate count
3. When satisfied, click **Send warnings** (or `POST /api/ops/send-inactivity-warnings?dryRun=false`)

Capped at 500 per run — run again the next day to drain the queue.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] 11 unit tests passing (5 use-case, 6 re-engagement mock fix)
- [x] Dry-run confirmed live on prod: 500 candidates returned
- [ ] Send first real batch from `/ops/commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)