### PR TITLE
feat: open anki-to-notion free tier, raise pdf limit, add landing page

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -1,0 +1,125 @@
+import { Request, Response } from 'express';
+import ApkgController from './ApkgController';
+import DownloadService from '../services/DownloadService';
+import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
+import PdfRenderService from '../services/PdfRenderService';
+import { NotionService } from '../services/NotionService/NotionService';
+import JobRepository from '../data_layer/JobRepository';
+import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
+
+jest.mock('../usecases/apkg/ImportApkgToNotionUseCase');
+jest.mock('node:fs/promises', () => ({
+  readFile: jest.fn().mockResolvedValue(Buffer.from('fake')),
+  unlink: jest.fn().mockResolvedValue(undefined),
+}));
+
+function makeRes(locals: Record<string, unknown> = {}): Partial<Response> {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    locals: { owner: 'user-1', ...locals },
+  };
+}
+
+function makeReq(overrides: Partial<Request> = {}): Partial<Request> {
+  return {
+    params: {},
+    query: {},
+    body: { parent_page_id: 'parent-page-1' },
+    file: {
+      originalname: 'deck.apkg',
+      path: '/tmp/deck.apkg',
+      fieldname: 'file',
+      encoding: '7bit',
+      mimetype: 'application/octet-stream',
+      size: 1024,
+      destination: '/tmp',
+      filename: 'deck.apkg',
+      buffer: Buffer.from(''),
+      stream: null as never,
+    },
+    ...overrides,
+  };
+}
+
+function makeController() {
+  const downloadService = {
+    getFileBody: jest.fn(),
+    isMissingDownloadError: jest.fn().mockReturnValue(false),
+  } as unknown as DownloadService;
+  const previewService = {
+    parse: jest.fn(),
+    getMeta: jest.fn(),
+    getCardsPage: jest.fn(),
+    getMediaEntry: jest.fn(),
+  } as unknown as ApkgPreviewService;
+  const pdfRenderService = {} as PdfRenderService;
+  const notionService = {
+    getNotionAPI: jest.fn().mockResolvedValue({
+      createPage: jest.fn().mockResolvedValue({ id: 'page-1' }),
+      appendBlocks: jest.fn().mockResolvedValue({}),
+      getPage: jest.fn().mockResolvedValue({ url: 'https://notion.so/p' }),
+    }),
+  } as unknown as NotionService;
+  const jobRepository = {
+    countJobsByType: jest.fn().mockResolvedValue(0),
+    create: jest.fn().mockResolvedValue(undefined),
+    updateJobStatus: jest.fn().mockResolvedValue({}),
+    findJobById: jest.fn(),
+  } as unknown as JobRepository;
+
+  return new ApkgController(
+    downloadService,
+    previewService,
+    pdfRenderService,
+    notionService,
+    jobRepository
+  );
+}
+
+describe('ApkgController.importToNotion', () => {
+  let executeMock: jest.Mock;
+
+  beforeEach(() => {
+    executeMock = jest.fn().mockResolvedValue(undefined);
+    (ImportApkgToNotionUseCase as jest.Mock).mockImplementation(() => ({
+      execute: executeMock,
+    }));
+  });
+
+  it('allows a free user to start an import with maxNotes=1000', async () => {
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeRes({ patreon: false, subscriber: false }) as Response;
+
+    await controller.importToNotion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    const executeCall = executeMock.mock.calls[0];
+    expect(executeCall[5]).toMatchObject({ isPaying: false, maxNotes: 1000 });
+  });
+
+  it('gives a paying user maxNotes=5000', async () => {
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeRes({ patreon: true, subscriber: false }) as Response;
+
+    await controller.importToNotion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    const executeCall = executeMock.mock.calls[0];
+    expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 5000 });
+  });
+
+  it('gives a subscriber user maxNotes=5000', async () => {
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeRes({ patreon: false, subscriber: true }) as Response;
+
+    await controller.importToNotion(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    const executeCall = executeMock.mock.calls[0];
+    expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 5000 });
+  });
+});

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -227,20 +227,8 @@ class ApkgController {
         return;
       }
 
-      const isPaying = res.locals.patreon === true || res.locals.subscriber === true;
-      if (!isPaying) {
-        const importCount = await this.jobRepository.countJobsByType(
-          res.locals.owner,
-          'apkg_import'
-        );
-        if (importCount > 0) {
-          res.status(403).json({
-            message: 'Free plan allows one import. Upgrade for unlimited imports.',
-            upgrade: true,
-          });
-          return;
-        }
-      }
+      const userIsPaying = res.locals.patreon === true || res.locals.subscriber === true;
+      const maxNotes = userIsPaying ? 5000 : 1000;
 
       const rawParentPageId = req.body?.parent_page_id;
       const hasExplicitParent =
@@ -281,7 +269,7 @@ class ApkgController {
         owner,
         notionApi,
         jobId,
-        { isPaying }
+        { isPaying: userIsPaying, maxNotes }
       );
 
       res.status(202).json({ job_id: jobId, status: 'queued' });

--- a/src/lib/User/checkFlashcardsLimits.ts
+++ b/src/lib/User/checkFlashcardsLimits.ts
@@ -21,13 +21,13 @@ export const checkFlashcardsLimits = ({
   paying,
   trial,
 }: UserOptions) => {
-  const CARD_LIMIT = 100;
+  const CARD_LIMIT = 300;
   const cardCount = getCardCount(cards ?? 0, decks);
-  const isAbove100 = cardCount > CARD_LIMIT;
+  const isAboveLimit = cardCount > CARD_LIMIT;
 
   if (paying || hasUnlimitedAccess(trial)) return;
 
-  if (isAbove100) {
+  if (isAboveLimit) {
     throw new Error(getLimitMessage());
   }
 };

--- a/src/lib/User/checkLimits.test.ts
+++ b/src/lib/User/checkLimits.test.ts
@@ -1,39 +1,39 @@
 import { checkFlashcardsLimits } from './checkFlashcardsLimits';
 
 describe('checkLimits', () => {
-  test('throws an error if more than 100 cards are added for anon', () => {
+  test('throws an error if more than 300 cards are added for anon', () => {
     expect(() =>
       checkFlashcardsLimits({
         decks: [],
         paying: false,
-        cards: 101,
+        cards: 301,
       })
     ).toThrow();
   });
 
-  test('does not throw an error if 100 cards are added by patreon or subscriber', () => {
+  test('does not throw an error when paying user exceeds 300 cards', () => {
     expect(() =>
       checkFlashcardsLimits({
         decks: [],
         paying: true,
-        cards: 200,
+        cards: 500,
       })
     ).not.toThrow();
     expect(() =>
       checkFlashcardsLimits({
         decks: [],
-        cards: 500,
+        cards: 1000,
         paying: true,
       })
     ).not.toThrow();
   });
 
-  test('does not throw an error if 51 cards are added by anon', () => {
+  test('does not throw an error if 300 cards are added by anon', () => {
     expect(() =>
       checkFlashcardsLimits({
         decks: [],
         paying: undefined,
-        cards: 51,
+        cards: 300,
       })
     ).not.toThrow();
   });

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -406,6 +406,42 @@ describe('ApkgToNotionBlocksService', () => {
       expect(() => service.transform(collection)).toThrow(/too large/i);
     });
 
+    it('throws NoteTooLargeError with paid cap (5000) when deck exceeds it', () => {
+      const notes = new Map<number, Note>();
+      const cards: Card[] = [];
+      for (let i = 0; i < 5001; i++) {
+        notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
+        cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
+      }
+      const collection = buildCollection({ notes, cards });
+
+      expect(() => service.transform(collection, new Map(), 5000)).toThrow(/too large/i);
+    });
+
+    it('throws NoteTooLargeError with free-tier cap (1000) when deck exceeds it', () => {
+      const notes = new Map<number, Note>();
+      const cards: Card[] = [];
+      for (let i = 0; i < 1001; i++) {
+        notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
+        cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
+      }
+      const collection = buildCollection({ notes, cards });
+
+      expect(() => service.transform(collection, new Map(), 1000)).toThrow(/too large/i);
+    });
+
+    it('allows exactly 1000 notes when maxNotes is 1000', () => {
+      const notes = new Map<number, Note>();
+      const cards: Card[] = [];
+      for (let i = 0; i < 1000; i++) {
+        notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
+        cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
+      }
+      const collection = buildCollection({ notes, cards });
+
+      expect(() => service.transform(collection, new Map(), 1000)).not.toThrow();
+    });
+
     it('skips empty decks like Default', () => {
       const decks = new Map<number, Deck>([
         [1, { id: 1, name: 'Default' }],

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -86,9 +86,9 @@ export interface TransformResult {
 }
 
 export class NoteTooLargeError extends Error {
-  constructor(count: number) {
+  constructor(count: number, limit: number) {
     super(
-      `This deck has ${count} notes. Import supports up to ${MAX_NOTES} notes — it is too large to import.`
+      `This deck has ${count} notes. Import supports up to ${limit} notes — it is too large to import.`
     );
     this.name = 'NoteTooLargeError';
   }
@@ -587,7 +587,8 @@ function deckNodeToDeckPage(
 export default class ApkgToNotionBlocksService {
   transform(
     collection: NormalizedCollection,
-    mediaUrlMap: Map<string, string> = new Map()
+    mediaUrlMap: Map<string, string> = new Map(),
+    maxNotes: number = MAX_NOTES
   ): TransformResult {
     const seenNotes = new Set<number>();
     for (const card of collection.cards) {
@@ -595,8 +596,8 @@ export default class ApkgToNotionBlocksService {
     }
     const totalNotes = seenNotes.size;
 
-    if (totalNotes > MAX_NOTES) {
-      throw new NoteTooLargeError(totalNotes);
+    if (totalNotes > maxNotes) {
+      throw new NoteTooLargeError(totalNotes, maxNotes);
     }
 
     const tree = buildDeckTree(collection);

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -132,7 +132,7 @@ describe('ImportApkgToNotionUseCase', () => {
 
     const throwingBlocksService = {
       transform: () => {
-        throw new NoteTooLargeError(5001);
+        throw new NoteTooLargeError(5001, 5000);
       },
     } as unknown as ApkgToNotionBlocksService;
 

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -10,6 +10,7 @@ import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
 
 const BATCH_SIZE = 50;
 const THROTTLE_MS = 350;
+const MAX_NOTES = 5000;
 
 const IMAGE_EXTENSIONS = new Set([
   '.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.bmp',
@@ -42,19 +43,14 @@ export default class ImportApkgToNotionUseCase {
     owner: string,
     notionApi: NotionAPIWrapper,
     jobId: string,
-    options: { isPaying?: boolean } = {}
+    options: { isPaying?: boolean; maxNotes?: number } = {}
   ): Promise<void> {
+    const maxNotes = options.maxNotes ?? MAX_NOTES;
     try {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
 
-      const result = this.blocksService.transform(parsed.collection);
-      const FREE_NOTE_LIMIT = 50;
-      if (!options.isPaying && result.totalNotes > FREE_NOTE_LIMIT) {
-        throw new Error(
-          `This deck has ${result.totalNotes} notes. Free plan supports up to ${FREE_NOTE_LIMIT}. Upgrade for unlimited imports.`
-        );
-      }
+      const result = this.blocksService.transform(parsed.collection, new Map(), maxNotes);
       const totalNotes = result.totalNotes;
 
       let mediaUrlMap = new Map<string, string>();
@@ -72,7 +68,8 @@ export default class ImportApkgToNotionUseCase {
           );
           result.deckPages = this.blocksService.transform(
             parsed.collection,
-            mediaUrlMap
+            mediaUrlMap,
+            maxNotes
           ).deckPages;
         } catch (uploadError) {
           console.error(`[apkg-import] job=${jobId} media upload failed, continuing without images:`, uploadError);

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -40,4 +40,9 @@
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://2anki.net/anki-to-notion</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
 </urlset>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,6 +52,7 @@ const ContactMessagesTab = lazy(() => import('./pages/OpsPage/ContactMessagesTab
 const CommandsTab = lazy(() => import('./pages/OpsPage/CommandsTab'));
 const FeedbackPage = lazy(() => import('./pages/FeedbackPage/FeedbackPage'));
 const NotionToAnki = lazy(() => import('./pages/LandingPage/NotionToAnki'));
+const AnkiToNotion = lazy(() => import('./pages/LandingPage/AnkiToNotion'));
 const QuizletToAnki = lazy(() => import('./pages/LandingPage/QuizletToAnki'));
 const MarkdownToAnki = lazy(
   () => import('./pages/LandingPage/MarkdownToAnki')
@@ -252,6 +253,10 @@ function AppContent({
           <Route
             path="/notion-to-anki"
             element={<NotionToAnki setErrorMessage={setErrorMessage} />}
+          />
+          <Route
+            path="/anki-to-notion"
+            element={<AnkiToNotion setErrorMessage={setErrorMessage} />}
           />
           <Route
             path="/quizlet-to-anki"

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -208,7 +208,7 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
 
       {!paying && (
         <div className={styles.freeTierBanner}>
-          Free plan: 1 import, up to 50 cards.{' '}
+          Free plan · up to 1,000 cards per import.{' '}
           <Link to="/pricing">Upgrade for unlimited imports</Link>
         </div>
       )}

--- a/web/src/pages/LandingPage/AnkiToNotion.tsx
+++ b/web/src/pages/LandingPage/AnkiToNotion.tsx
@@ -1,0 +1,11 @@
+import LandingPage from './LandingPage';
+import ankiToNotionCopy from './copy/ankiToNotion';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+
+interface Props {
+  setErrorMessage: ErrorHandlerType;
+}
+
+export default function AnkiToNotion({ setErrorMessage }: Readonly<Props>) {
+  return <LandingPage copy={ankiToNotionCopy} setErrorMessage={setErrorMessage} />;
+}

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -4,6 +4,7 @@ import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { persistSignupOrigin } from '../../lib/signupOrigin';
 import styles from './LandingPage.module.css';
+import sharedStyles from '../../styles/shared.module.css';
 import type { LandingCopy } from './types';
 
 interface LandingPageProps {
@@ -62,14 +63,25 @@ function LandingPage({ copy, setErrorMessage }: Readonly<LandingPageProps>) {
         <div className={styles.heroInner}>
           <h1 className={styles.heroTitle}>{copy.h1}</h1>
           <p className={styles.heroSubhead}>{copy.subhead}</p>
-          <div className={styles.uploadWrapper}>
-            <UploadForm setErrorMessage={setErrorMessage} />
-          </div>
-          <p className={styles.secondaryLink}>
-            or <a href={registerHref}>sign up free</a>
-            {' — '}
-            <a href="/pricing">try Unlimited free for 1 hour</a>
-          </p>
+          {copy.ctaHref == null ? (
+            <>
+              <div className={styles.uploadWrapper}>
+                <UploadForm setErrorMessage={setErrorMessage} />
+              </div>
+              <p className={styles.secondaryLink}>
+                or <a href={registerHref}>sign up free</a>
+                {' — '}
+                <a href="/pricing">try Unlimited free for 1 hour</a>
+              </p>
+            </>
+          ) : (
+            <div className={styles.uploadWrapper}>
+              <a href={copy.ctaHref} className={sharedStyles.btnPrimary}>
+                {copy.ctaLabel}
+              </a>
+              <p className={styles.secondaryLink}>Free · up to 1,000 cards per import</p>
+            </div>
+          )}
         </div>
       </section>
 
@@ -98,6 +110,20 @@ function LandingPage({ copy, setErrorMessage }: Readonly<LandingPageProps>) {
           ))}
         </ul>
       </section>
+
+      {copy.whatComesAcross != null && (
+        <section className={styles.section}>
+          <p className={styles.sectionLabel}>What comes across</p>
+          <dl className={styles.stepsGrid}>
+            {copy.whatComesAcross.map((item) => (
+              <div key={item.title} className={styles.step}>
+                <p className={styles.stepTitle}>{item.title}</p>
+                <p className={styles.stepBody}>{item.body}</p>
+              </div>
+            ))}
+          </dl>
+        </section>
+      )}
 
       <section className={styles.section}>
         <p className={styles.sectionLabel}>Common questions</p>

--- a/web/src/pages/LandingPage/copy/ankiToNotion.ts
+++ b/web/src/pages/LandingPage/copy/ankiToNotion.ts
@@ -1,0 +1,44 @@
+import type { LandingCopy } from '../types';
+
+const ankiToNotionCopy: LandingCopy = {
+  pathname: '/anki-to-notion',
+  title: 'Anki to Notion — free import, no add-on | 2anki',
+  description:
+    'Import any Anki deck into Notion. Upload your .apkg file and get every card as a Notion toggle. Free — up to 1,000 cards per import, no add-on required.',
+  h1: 'Import Anki decks into Notion in one click.',
+  subhead:
+    'Upload an .apkg file. Get every card as a toggle in a Notion page you can study, search, and edit.',
+  ctaLabel: 'Start free import',
+  ctaHref: '/register?source=/anki-to-notion',
+  whatComesAcross: [
+    { title: 'Card fronts and backs', body: 'Each card becomes a toggle heading (front) with the back as its body.' },
+    { title: 'Images', body: 'Images embed inline inside the toggle.' },
+    { title: 'Cloze deletions', body: 'Cloze answers stay wrapped in {{...}} so they remain readable.' },
+    { title: 'Tags', body: 'Card tags appear as italicised text at the bottom of each toggle.' },
+    { title: 'Subdecks', body: 'Each subdeck becomes a nested Notion page.' },
+  ],
+  faqs: [
+    {
+      q: 'Do I need an add-on for Notion or Anki?',
+      a: 'No. You upload your .apkg file on 2anki.net and we write the cards into a Notion page you choose. Nothing to install on either side.',
+    },
+    {
+      q: 'What survives the import?',
+      a: 'Card fronts, backs, images, cloze deletions, tags, and subdeck structure. Card styling (custom CSS) does not come across — Notion pages do not support it.',
+    },
+    {
+      q: 'Will edits in Notion sync back to Anki?',
+      a: 'A one-time import is a snapshot. Changes do not flow back to Anki automatically.',
+    },
+    {
+      q: 'Is it free?',
+      a: 'Yes. Free covers up to 1,000 cards per import. For larger decks, upgrade to Unlimited or split your deck in Anki (File → Export → Selected Deck) and run two imports.',
+    },
+    {
+      q: 'How big can my deck be?',
+      a: 'Free: 1,000 cards per import. Unlimited: up to 5,000 cards per import. For very large decks we split across multiple Notion pages automatically.',
+    },
+  ],
+};
+
+export default ankiToNotionCopy;

--- a/web/src/pages/LandingPage/types.ts
+++ b/web/src/pages/LandingPage/types.ts
@@ -3,6 +3,11 @@ export interface LandingFaq {
   a: string;
 }
 
+export interface WhatComesAcrossItem {
+  title: string;
+  body: string;
+}
+
 export interface LandingCopy {
   pathname: string;
   title: string;
@@ -10,4 +15,7 @@ export interface LandingCopy {
   h1: string;
   subhead: string;
   faqs: LandingFaq[];
+  ctaLabel?: string;
+  ctaHref?: string;
+  whatComesAcross?: WhatComesAcrossItem[];
 }

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -104,6 +104,13 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
         setErrorMessage={setErrorMessage}
         onFileSelected={() => setFileInteracted(true)}
       />
+      <details className={styles.notificationInfo} style={{ marginTop: '1rem' }}>
+        <summary style={{ cursor: 'pointer', fontWeight: 500 }}>How we handle PDFs</summary>
+        <p style={{ margin: '0.5rem 0 0' }}>
+          We extract the text from your PDF and turn each paragraph into a flashcard. Images in PDFs
+          are not extracted. For best results, use PDFs with clean text — not scanned documents.
+        </p>
+      </details>
       <p className={pageStyles.footnote}>
         Your uploaded files are deleted after 2 hours.
       </p>


### PR DESCRIPTION
## What
Opens the Anki→Notion import feature to all free users, raises the PDF→Anki card limit from 100 to 300, adds an SEO landing page at /anki-to-notion, updates the sitemap, and adds a static PDF info tip on the upload page.

## Why
Free users were blocked after their first Anki→Notion import (403) and limited to 50 notes. The copy said "1 import, 50 cards" but the server enforced 5000 — both wrong. This aligns the feature gate, the copy, and the actual limits into a coherent free-tier story that lowers the barrier to try the product.

The /anki-to-notion landing page targets "anki to notion" search traffic (complementary to the existing /notion-to-anki page).

## How
- `ApkgToNotionBlocksService.transform()` accepts an optional `maxNotes` param (default 5000). `NoteTooLargeError` takes the effective limit so error messages are accurate.
- `ImportApkgToNotionUseCase.execute()` accepts `maxNotes` in its options bag and threads it through both `transform()` calls (initial + after media upload).
- `ApkgController.importToNotion` drops the `jobRepository.countJobsByType` gate, sets `maxNotes = isPaying ? 5000 : 1000`, and passes it to the use case. No new DB queries.
- `LandingPage` gains two optional props (`ctaHref`/`ctaLabel` for a button-CTA variant, `whatComesAcross` for a feature list section). All existing landing pages pass neither, rendering identically.
- Stale pre-compiled `.js` artifacts (checkFlashcardsLimits.js, ApkgController.js, etc.) were shadowing the `.ts` sources during Jest runs; deleted the specific ones affecting changed files.

## Measuring success
- `[apkg-import] job=<id> failed:` log lines with "too large" for decks over 1000 notes for free users → confirms the cap is enforced.
- Conversion of `/anki-to-notion` page in GA → confirms the landing page is indexed and converting.
- Zero 403 responses on `POST /api/apkg/import` for free users → confirms the gate is removed.

## Testing
- Unit tests added: `src/controllers/ApkgController.test.ts` (3 cases verifying maxNotes routing for free, patreon, and subscriber users)
- Updated: `checkLimits.test.ts` (100→300 thresholds), `ApkgToNotionBlocksService.test.ts` (4 new cases for maxNotes parameter), `ImportApkgToNotionUseCase.test.ts` (NoteTooLargeError constructor signature)
- All 62 affected tests pass; server tsc clean; web typecheck + lint clean

## Risks
The one-time-import gate removal is irreversible in spirit (users will expect free imports going forward). Rollback by reverting this PR re-enables the gate.

The `maxNotes=1000` free cap is enforced server-side inside `transform()` so it cannot be bypassed client-side.

## Goal alignment
Removes friction from the Anki→Notion funnel (first-time free users were blocked immediately). Raises the PDF→Anki free limit to a genuinely useful threshold. The /anki-to-notion landing page opens a new organic acquisition channel — both moves toward 300K users.