### PR TITLE
chore: wire analytics-mcp and traffic sources into weekly retro

### DIFF
--- a/.claude/commands/weekly-retro.md
+++ b/.claude/commands/weekly-retro.md
@@ -5,12 +5,19 @@ argument-hint: paste this week's numbers, or leave empty to ask for them
 
 Use the `pm` agent.
 
-1. Get this week's numbers (signups, churn, conversion-success rate, top 3 support themes). If the user hasn't pasted them, ask for them in one structured block.
+1. Pull this week's traffic and engagement data using the `analytics-mcp` tools (GA4 property `properties/286902985`). Run these reports before asking the user for anything:
+   - Sessions + active users + new users by date (last 7 days vs prior 7 days).
+   - **Traffic Sources**: sessions, new users, and engagement rate by `sessionDefaultChannelGroup` + `sessionSource` — flag any channel that is up or down >20% week-over-week.
+   - Top events by event count.
+   - New vs returning users with avg session duration and engagement rate.
+
+   Then ask the user to supply: churn signal and top 3 support themes (if not already pasted).
 
 2. Compute:
-   - Week-over-week change for each metric.
+   - Week-over-week change for each metric (sessions, new users, engagement rate, paid conversions).
    - Required weekly growth rate to reach the 300K-user goal in 24 / 18 / 12 months.
    - Gap between actual and required.
+   - **Traffic Sources table**: which channels grew, which shrank, which drove engaged users vs bounce-and-leave.
 
 3. Identify the **single biggest gap** this week. Not three. One.
 
@@ -21,6 +28,6 @@ Use the `pm` agent.
    - Ship Y (and which spec is ready).
    - Pause Z to focus on the gap.
 
-6. Output is two screens max. Numbers in a table. Recommendation in one paragraph.
+6. Output is two screens max. Numbers in a table. Traffic Sources section required. Recommendation in one paragraph.
 
 Do not list five things. The point of the retro is to force a single decision.


### PR DESCRIPTION
## Summary

- `/weekly-retro` now auto-pulls GA4 data via `analytics-mcp` before asking the user for anything: sessions (7d vs prior 7d), traffic sources with WoW change, top events, and new vs returning engagement.
- **Traffic Sources table is now a required section** — channel shifts (>20% WoW) are always surfaced alongside the single priority decision.
- Follows up directly from the analytics-mcp trio review session that revealed our only current visibility is standard auto-events; retros should close that loop weekly.

## Goal alignment

Moves us toward 300K by making the weekly retro decision data-driven rather than gut-feel. The Apr 19 spike (3,841 new users, source unknown) and the near-zero new-user engagement rate (8.5%) would both have been caught immediately with this retro format.

## Test plan

- [x] Run `/weekly-retro` — confirm it calls `analytics-mcp` tools automatically without prompting for numbers first
- [x] Confirm Traffic Sources table appears in the output
- [x] Confirm single priority recommendation still ends the retro

🤖 Generated with [Claude Code](https://claude.com/claude-code)