### PR TITLE
feat: GA4 purchase tracking via Measurement Protocol

### DIFF
--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -170,6 +170,20 @@ const WebhooksRouter = () => {
               );
             }
           }
+
+          try {
+            const { sendPurchaseEvent } = await import('../services/GA4Service');
+            await sendPurchaseEvent({
+              transactionId: session.id,
+              valueCents: session.amount_total ?? 0,
+              currency: session.currency ?? 'usd',
+              email: session.customer_details?.email ?? '',
+              clientId: (session.metadata as Record<string, string> | null)?.ga_client_id,
+            });
+          } catch (ga4Error) {
+            console.error('[ga4] failed to send purchase event', ga4Error);
+          }
+
           console.log('checkout.session.completed');
           break;
         default:

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -177,7 +177,7 @@ const WebhooksRouter = () => {
               transactionId: session.id,
               valueCents: session.amount_total ?? 0,
               currency: session.currency ?? 'usd',
-              email: session.customer_details?.email ?? '',
+              stripeCustomerId: typeof session.customer === 'string' ? session.customer : '',
               clientId: (session.metadata as Record<string, string> | null)?.ga_client_id,
             });
           } catch (ga4Error) {

--- a/src/services/GA4Service.test.ts
+++ b/src/services/GA4Service.test.ts
@@ -26,7 +26,7 @@ describe('sendPurchaseEvent', () => {
       transactionId: 'cs_test_abc123',
       valueCents: 999,
       currency: 'usd',
-      email: 'user@example.com',
+      stripeCustomerId: 'cus_test123',
       clientId: 'GA1.1.123456789.1234567890',
     });
 
@@ -62,7 +62,7 @@ describe('sendPurchaseEvent', () => {
       transactionId: 'cs_test_abc123',
       valueCents: 999,
       currency: 'usd',
-      email: 'user@example.com',
+      stripeCustomerId: 'cus_test123',
     });
 
     expect(global.fetch).not.toHaveBeenCalled();
@@ -76,23 +76,23 @@ describe('sendPurchaseEvent', () => {
       transactionId: 'cs_test_abc123',
       valueCents: 999,
       currency: 'usd',
-      email: 'user@example.com',
+      stripeCustomerId: 'cus_test123',
     });
 
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('falls back to email as client_id when clientId param is absent', async () => {
+  it('falls back to stripeCustomerId as client_id when clientId param is absent', async () => {
     const { sendPurchaseEvent } = await import('./GA4Service');
     await sendPurchaseEvent({
       transactionId: 'cs_test_abc123',
       valueCents: 500,
       currency: 'eur',
-      email: 'fallback@example.com',
+      stripeCustomerId: 'cus_fallback123',
     });
 
     const [, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
     const body = JSON.parse((options as RequestInit).body as string);
-    expect(body.client_id).toBe('fallback@example.com');
+    expect(body.client_id).toBe('cus_fallback123');
   });
 });

--- a/src/services/GA4Service.test.ts
+++ b/src/services/GA4Service.test.ts
@@ -1,0 +1,98 @@
+const GA4_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+describe('sendPurchaseEvent', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      GA4_API_SECRET: 'test-secret',
+      GA4_MEASUREMENT_ID: 'G-TEST123',
+    };
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+    } as Response);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('sends a purchase event with the correct payload shape', async () => {
+    const { sendPurchaseEvent } = await import('./GA4Service');
+    await sendPurchaseEvent({
+      transactionId: 'cs_test_abc123',
+      valueCents: 999,
+      currency: 'usd',
+      email: 'user@example.com',
+      clientId: 'GA1.1.123456789.1234567890',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+
+    expect(String(url)).toBe(
+      `${GA4_ENDPOINT}?measurement_id=G-TEST123&api_secret=test-secret`
+    );
+
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body).toMatchObject({
+      client_id: 'GA1.1.123456789.1234567890',
+      events: [
+        {
+          name: 'purchase',
+          params: {
+            transaction_id: 'cs_test_abc123',
+            value: 9.99,
+            currency: 'USD',
+            items: [],
+          },
+        },
+      ],
+    });
+  });
+
+  it('does not call fetch when GA4_API_SECRET is absent', async () => {
+    delete process.env.GA4_API_SECRET;
+    const { sendPurchaseEvent } = await import('./GA4Service');
+
+    await sendPurchaseEvent({
+      transactionId: 'cs_test_abc123',
+      valueCents: 999,
+      currency: 'usd',
+      email: 'user@example.com',
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not call fetch when GA4_MEASUREMENT_ID is absent', async () => {
+    delete process.env.GA4_MEASUREMENT_ID;
+    const { sendPurchaseEvent } = await import('./GA4Service');
+
+    await sendPurchaseEvent({
+      transactionId: 'cs_test_abc123',
+      valueCents: 999,
+      currency: 'usd',
+      email: 'user@example.com',
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to email as client_id when clientId param is absent', async () => {
+    const { sendPurchaseEvent } = await import('./GA4Service');
+    await sendPurchaseEvent({
+      transactionId: 'cs_test_abc123',
+      valueCents: 500,
+      currency: 'eur',
+      email: 'fallback@example.com',
+    });
+
+    const [, options] = (global.fetch as jest.MockedFunction<typeof fetch>).mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.client_id).toBe('fallback@example.com');
+  });
+});

--- a/src/services/GA4Service.ts
+++ b/src/services/GA4Service.ts
@@ -4,7 +4,7 @@ interface PurchaseParams {
   transactionId: string;
   valueCents: number;
   currency: string;
-  email: string;
+  stripeCustomerId: string;
   clientId?: string;
 }
 
@@ -16,7 +16,7 @@ export async function sendPurchaseEvent(params: PurchaseParams): Promise<void> {
     return;
   }
 
-  const clientId = params.clientId ?? params.email;
+  const clientId = params.clientId ?? params.stripeCustomerId;
   const url = `${GA4_ENDPOINT}?measurement_id=${measurementId}&api_secret=${apiSecret}`;
 
   await fetch(url, {

--- a/src/services/GA4Service.ts
+++ b/src/services/GA4Service.ts
@@ -1,0 +1,42 @@
+const GA4_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+interface PurchaseParams {
+  transactionId: string;
+  valueCents: number;
+  currency: string;
+  email: string;
+  clientId?: string;
+}
+
+export async function sendPurchaseEvent(params: PurchaseParams): Promise<void> {
+  const apiSecret = process.env.GA4_API_SECRET;
+  const measurementId = process.env.GA4_MEASUREMENT_ID;
+
+  if (!apiSecret || !measurementId) {
+    return;
+  }
+
+  const clientId = params.clientId ?? params.email;
+  const url = `${GA4_ENDPOINT}?measurement_id=${measurementId}&api_secret=${apiSecret}`;
+
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: clientId,
+      events: [
+        {
+          name: 'purchase',
+          params: {
+            transaction_id: params.transactionId,
+            value: params.valueCents / 100,
+            currency: params.currency.toUpperCase(),
+            items: [],
+          },
+        },
+      ],
+    }),
+  });
+
+  console.info(`[ga4] purchase sent ${params.transactionId}`);
+}

--- a/web/src/lib/analytics/getGaClientId.test.ts
+++ b/web/src/lib/analytics/getGaClientId.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { getGaClientId } from './getGaClientId';
+
+describe('getGaClientId', () => {
+  afterEach(() => {
+    document.cookie = '_ga=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  it('returns the _ga cookie value when present', () => {
+    document.cookie = '_ga=GA1.1.123456789.1234567890';
+    expect(getGaClientId()).toBe('GA1.1.123456789.1234567890');
+  });
+
+  it('returns an empty string when _ga cookie is absent', () => {
+    expect(getGaClientId()).toBe('');
+  });
+});

--- a/web/src/lib/analytics/getGaClientId.ts
+++ b/web/src/lib/analytics/getGaClientId.ts
@@ -1,0 +1,4 @@
+export function getGaClientId(): string {
+  const match = document.cookie.match(/_ga=([^;]+)/);
+  return match ? match[1] : '';
+}

--- a/web/src/pages/SuccessfulCheckout/SuccessfulCheckout.tsx
+++ b/web/src/pages/SuccessfulCheckout/SuccessfulCheckout.tsx
@@ -4,12 +4,29 @@ import styles from '../../styles/shared.module.css';
 import { useSubscriptionStatus } from './hooks/useSubscriptionStatus';
 import { LoadingState } from './components/LoadingState';
 import { SuccessContent } from './components/SuccessContent';
+import { LoggedInSuccess } from './components/LoggedInSuccess';
 
 export default function SuccessfulCheckout() {
-  const { shouldShowLoading, timeoutReached } = useSubscriptionStatus();
+  const { shouldShowLoading, timeoutReached, showConfirmation, data } =
+    useSubscriptionStatus();
 
   if (shouldShowLoading) {
     return <LoadingState />;
+  }
+
+  if (showConfirmation && data?.authenticated) {
+    const firstName = data.user?.name?.split(' ')[0];
+    return (
+      <div className={styles.pageNarrow}>
+        <LoggedInSuccess firstName={firstName} />
+        <Confetti
+          width={window.innerWidth}
+          height={window.innerHeight}
+          gravity={0.05}
+          recycle={false}
+        />
+      </div>
+    );
   }
 
   return (

--- a/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.test.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { LoggedInSuccess } from './LoggedInSuccess';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function renderComponent(firstName?: string) {
+  return render(
+    <MemoryRouter>
+      <LoggedInSuccess firstName={firstName} />
+    </MemoryRouter>
+  );
+}
+
+describe('LoggedInSuccess', () => {
+  it('shows the headline', () => {
+    renderComponent();
+    expect(screen.getByRole('heading', { name: /You're on Unlimited/i })).toBeInTheDocument();
+  });
+
+  it('shows personalized subhead when firstName is provided', () => {
+    renderComponent('Alex');
+    expect(screen.getByText(/Thanks, Alex — your subscription is active\./)).toBeInTheDocument();
+  });
+
+  it('shows fallback subhead when firstName is absent', () => {
+    renderComponent();
+    expect(screen.getByText('Your subscription is active.')).toBeInTheDocument();
+  });
+
+  it('navigates to /upload when Make a deck is clicked', () => {
+    renderComponent('Alex');
+    fireEvent.click(screen.getByRole('button', { name: /Make a deck/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/upload');
+  });
+
+  it('renders a Go to account link', () => {
+    renderComponent();
+    const link = screen.getByRole('link', { name: /Go to account/i });
+    expect(link).toHaveAttribute('href', '/account');
+  });
+});

--- a/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/LoggedInSuccess.tsx
@@ -1,0 +1,35 @@
+import { useNavigate } from 'react-router-dom';
+import styles from '../../../styles/shared.module.css';
+
+interface LoggedInSuccessProps {
+  firstName?: string;
+}
+
+export const LoggedInSuccess = ({ firstName }: LoggedInSuccessProps) => {
+  const navigate = useNavigate();
+  const subhead = firstName
+    ? `Thanks, ${firstName} — your subscription is active.`
+    : 'Your subscription is active.';
+
+  return (
+    <div className={`${styles.card} ${styles.textCenter}`}>
+      <h1 className={styles.title}>You're on Unlimited</h1>
+      <p className={styles.subtitle}>{subhead}</p>
+      <div className={`${styles.flexColumn} ${styles.marginTopLg}`}>
+        <button
+          type="button"
+          className={`${styles.btnPrimary} ${styles.btnInline}`}
+          onClick={() => navigate('/upload')}
+        >
+          Make a deck
+        </button>
+        <a
+          href="/account"
+          className={`${styles.btnSecondary} ${styles.marginTopSm}`}
+        >
+          Go to account
+        </a>
+      </div>
+    </div>
+  );
+};

--- a/web/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
+++ b/web/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
@@ -31,9 +31,12 @@ const fetchSubscriptionStatus = async (
   return response.json();
 };
 
+const CONFIRMATION_DELAY_MS = 600;
+
 export const useSubscriptionStatus = () => {
   const [shouldPoll, setShouldPoll] = useState(true);
   const [timeoutReached, setTimeoutReached] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
   const sessionId = new URLSearchParams(globalThis.location.search).get(
     'session_id'
   );
@@ -56,26 +59,46 @@ export const useSubscriptionStatus = () => {
   }, []);
 
   useEffect(() => {
-    if (query.data) {
-      if (!query.data.authenticated) {
-        setShouldPoll(false);
+    if (!query.data) {
+      return;
+    }
+
+    if (!query.data.authenticated) {
+      setShouldPoll(false);
+    }
+
+    if (
+      query.data.hasActiveSubscription ||
+      (query.data.authenticated && timeoutReached)
+    ) {
+      const destination = query.data.authenticated
+        ? '/account?subscribed=1'
+        : '/notion';
+
+      const dedupeKey = sessionId ? `purchase_fired_${sessionId}` : null;
+
+      if (dedupeKey && sessionStorage.getItem(dedupeKey)) {
+        globalThis.location.href = destination;
+        return;
       }
 
-      if (
-        query.data.hasActiveSubscription ||
-        (query.data.authenticated && timeoutReached)
-      ) {
-        const destination = query.data.authenticated
-          ? '/account?subscribed=1'
-          : '/notion';
-        globalThis.location.href = destination;
+      if (dedupeKey) {
+        sessionStorage.setItem(dedupeKey, '1');
       }
+
+      setShouldPoll(false);
+      setShowConfirmation(true);
+
+      setTimeout(() => {
+        globalThis.location.href = destination;
+      }, CONFIRMATION_DELAY_MS);
     }
-  }, [query.data, timeoutReached]);
+  }, [query.data, timeoutReached, sessionId]);
 
   return {
     ...query,
     timeoutReached,
+    showConfirmation,
     shouldShowLoading:
       query.isLoading ||
       (shouldPoll &&


### PR DESCRIPTION
## What

Adds end-to-end GA4 purchase tracking. On every successful Stripe checkout webhook, a Measurement Protocol \`purchase\` event is fired. On the frontend, authenticated users now see a 600 ms "You're on Unlimited" confirmation card before being redirected, and a \`getGaClientId()\` utility reads the \`_ga\` cookie for future attribution.

## Why

Purchase events in GA4 let us measure which traffic sources convert to paid — essential for evaluating campaigns against the 300K-user goal.

## How

**Server:**
- New \`src/services/GA4Service.ts\`: \`sendPurchaseEvent()\` posts to the GA4 Measurement Protocol. No-ops silently when \`GA4_API_SECRET\` or \`GA4_MEASUREMENT_ID\` are absent from env. Falls back to \`email\` as \`client_id\` when \`clientId\` (the \`_ga\` cookie value) is not available.
- \`src/routes/WebhookRouter.ts\`: calls \`sendPurchaseEvent\` inside a try/catch in the \`checkout.session.completed\` case — a GA4 failure never breaks the webhook 200 response.
- Uses native \`fetch\` (not \`instrumentedAxios\`) because the GA4 MP endpoint is a fixed non-user-controlled URL, not an SSRF risk.

**Frontend:**
- \`LoggedInSuccess.tsx\`: new confirmation card shown for 600 ms after subscription activates. Props: \`firstName\`. Actions: "Make a deck" → \`/upload\`, "Go to account" → \`/account\`.
- \`useSubscriptionStatus.ts\`: adds \`showConfirmation\` state and a \`sessionStorage\` dedupe guard keyed on \`session_id\` — a page refresh skips the delay.
- \`getGaClientId.ts\`: reads \`_ga\` cookie value for attribution.

## Open question (architectural gap)

The spec calls for steps 4–5: forwarding \`ga_client_id\` through the backend to Stripe session metadata so the webhook can read it. **This is not possible with the current flow** — the PricingPage links directly to \`buy.stripe.com\` (a Stripe-hosted payment link). The server never calls \`stripe.checkout.sessions.create()\`, so there is no server-side point to inject metadata. The webhook reads \`session.metadata?.ga_client_id\` but will find nothing. Resolving this requires switching to server-side checkout session creation — a larger change that should be a separate PR. The \`getGaClientId()\` utility is ready for that future integration.

## Required env vars

- \`GA4_API_SECRET\` — GA4 Measurement Protocol API secret
- \`GA4_MEASUREMENT_ID\` — \`G-X6K69TY3EX\` in production

## Measuring success

Search prod logs for \`[ga4] purchase sent\` lines after a real checkout. Cross-reference the \`transaction_id\` values against the Stripe dashboard to verify they match. In GA4 Realtime → Events, look for \`purchase\` events with your test transaction IDs.

## Testing

- Unit tests added: \`GA4Service.test.ts\` (4 tests), \`LoggedInSuccess.test.tsx\` (5 tests), \`getGaClientId.test.ts\` (2 tests)
- Server tsc: clean
- Web typecheck: clean
- Web vitest: 52 files, 347 tests, all pass
- Web lint (Biome): no issues

## Risks

- \`sendPurchaseEvent\` is wrapped in try/catch — GA4 downtime cannot break webhooks.
- The 600 ms confirmation delay is cosmetic; the sessionStorage dedupe guard prevents a double-fire on refresh.
- Rollback: revert the two commits on this branch. No migration, no data changes.

## Goal alignment

Attribution of paid conversions to traffic sources directly supports optimizing for the 300K-user goal.