### PR TITLE
feat: register CTA on login + pricing nudge after deck download

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.module.css
+++ b/web/src/pages/DownloadsPage/DownloadsPage.module.css
@@ -305,6 +305,23 @@
   box-shadow: var(--shadow-sm);
 }
 
+.upgradeFooter {
+  border-top: 1px solid var(--color-border-light);
+  padding: 0.875rem 1rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.upgradeFooter a {
+  color: var(--color-primary);
+  font-weight: var(--font-medium);
+  text-decoration: none;
+}
+
+.upgradeFooter a:hover {
+  text-decoration: underline;
+}
+
 .preparingBanner {
   display: flex;
   align-items: center;

--- a/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
+++ b/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
@@ -163,6 +163,10 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
           </tbody>
         </table>
         </div>
+        <div className={styles.upgradeFooter}>
+          Hitting the 100-card limit?{' '}
+          <Link to="/pricing">Upgrade to Unlimited — $5/month, cancel anytime →</Link>
+        </div>
       </div>
     </div>
   );

--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
@@ -119,13 +119,11 @@ describe('LoginForm', () => {
     });
   });
 
-  it('shows sign up link on every step', () => {
+  it('shows create account button on the email step', () => {
     renderLoginForm();
-    expect(screen.getByText('Sign up')).toBeInTheDocument();
-    expect(screen.getByText('Sign up').closest('a')).toHaveAttribute(
-      'href',
-      '/register'
-    );
+    const link = screen.getByText('Create a free account');
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')).toHaveAttribute('href', '/register');
   });
 
   it('persists email to localStorage on blur when value looks like an email', () => {

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -105,6 +105,11 @@ function LoginForm() {
             <WithGoogleLink
               text={getVisibleText('navigation.login.google')}
             />
+            <div className={styles.divider} />
+            <p className={styles.registerHint}>New to 2anki?</p>
+            <a href={registerHref} className={styles.createAccountButton}>
+              Create a free account
+            </a>
           </>
         ) : (
           <form onSubmit={onSubmit}>
@@ -179,12 +184,14 @@ function LoginForm() {
             </p>
           </form>
         )}
-        <p className={styles.footerText}>
-          {getVisibleText('navigation.register.question')}{' '}
-          <a rel="noreferrer" href={registerHref}>
-            Sign up
-          </a>
-        </p>
+        {!isEmailStep && (
+          <p className={styles.footerText}>
+            {getVisibleText('navigation.register.question')}{' '}
+            <a rel="noreferrer" href={registerHref}>
+              Sign up
+            </a>
+          </p>
+        )}
       </div>
     </div>
   );

--- a/web/src/styles/auth.module.css
+++ b/web/src/styles/auth.module.css
@@ -146,6 +146,36 @@
   font-weight: var(--font-medium);
 }
 
+.registerHint {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  text-align: center;
+  margin: 0 0 0.5rem;
+}
+
+.createAccountButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.625rem 1.25rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  box-shadow: var(--shadow-xs);
+  transition: all var(--transition-fast);
+}
+
+.createAccountButton:hover {
+  background: var(--color-bg-secondary);
+  border-color: var(--color-text-secondary);
+}
+
 .topBar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- **Login page**: replaces the muted footer "Sign up" text link with a full-width outline button "Create a free account" on the email step. The 20:1 login:register ratio is the signal — the current link is empirically not being found. Password step keeps the quiet footer link as an exit hatch.
- **Downloads page**: adds a "Hitting the 100-card limit? Upgrade to Unlimited — $5/month, cancel anytime →" footer inside the Ready to Download card. No subscription-state prop needed — static link to /pricing. Captures the highest-intent moment in the product (deck just downloaded) which currently has zero monetization surface.

## What was deferred

`stripe.checkout.sessions.create()` for `_ga` attribution: PM flagged that channel attribution data isn't actionable at current conversion volume. `STRIPE_PRICE_ID` and `BASE_URL` env vars also don't exist yet. Revisit when monthly paid conversions are high enough that channel splits would change a spend decision.

## Test plan

- [x] Visit /login — email step shows "Create a free account" outline button below Google sign-in, no "Sign up" footer
- [x] Enter email and click "Continue with email" — password step shows "Sign up" footer, no outline button
- [x] "Create a free account" link goes to /register; upload_limit_exceeded error redirects to /register?redirect=/pricing
- [x] Visit /downloads with at least one completed deck — "Hitting the 100-card limit?" footer appears at the bottom of the Ready to Download card
- [x] Footer link navigates to /pricing

## Goal alignment

Grows registration from /login (addresses 20:1 ratio) and surfaces monetization at peak intent — both move toward 300K users and sustainable scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)