### PR TITLE
fix: magic link delivery for Google sign-in users

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -366,10 +366,9 @@ describe('UsersController.requestMagicLink', () => {
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
-  it('returns 200 even when the service throws a non-rate-limit error', async () => {
-    const requestMagicLink = jest
-      .fn()
-      .mockRejectedValue(new Error('SendGrid down'));
+  it('forwards infrastructure errors to next() so ErrorHandler can surface them', async () => {
+    const sendgridError = new Error('SendGrid down');
+    const requestMagicLink = jest.fn().mockRejectedValue(sendgridError);
     const { controller } = buildMagicController({ requestMagicLink });
     const req = {
       body: { email: 'al@example.com', purpose: 'login' },
@@ -379,8 +378,8 @@ describe('UsersController.requestMagicLink', () => {
 
     await controller.requestMagicLink(req, res, next);
 
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ message: 'ok' });
+    expect(next).toHaveBeenCalledWith(sendgridError);
+    expect(res.status).not.toHaveBeenCalledWith(200);
   });
 });
 

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -478,7 +478,7 @@ class UsersController {
       let user = await this.userService.getUserFrom(email);
       if (!user) {
         const hashedPassword = this.authService.getHashPassword(getRandomUUID());
-        await this.userService.register(name, hashedPassword, email);
+        await this.userService.register(name, hashedPassword, email, null, true);
         user = await this.userService.getUserFrom(email);
       }
 
@@ -488,6 +488,8 @@ class UsersController {
           .status(400)
           .send('Unknown error. Please try again or register a new account.');
       }
+
+      await this.userService.markEmailVerified(user.id.toString());
 
       const token = await this.authService.newJWTToken(user);
       if (!token) {
@@ -508,7 +510,7 @@ class UsersController {
   async requestMagicLink(
     req: express.Request,
     res: express.Response,
-    _next: express.NextFunction
+    next: express.NextFunction
   ) {
     const { email, purpose: rawPurpose } = req.body;
     const purpose = rawPurpose ?? 'login';
@@ -523,9 +525,10 @@ class UsersController {
     try {
       await this.userService.requestMagicLink(email.trim(), purpose);
     } catch (error) {
-      if (!(error instanceof MagicLinkRateLimitError)) {
-        console.error('Magic link request failed:', error);
+      if (error instanceof MagicLinkRateLimitError) {
+        return res.status(200).json({ message: 'ok' });
       }
+      return next(error);
     }
     return res.status(200).json({ message: 'ok' });
   }

--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -58,6 +58,22 @@ describe('UsersRepository.createUser', () => {
   });
 });
 
+describe('UsersRepository.getByEmail', () => {
+  it('uses LOWER(TRIM(email)) so mixed-case stored emails still match', async () => {
+    const firstSpy = jest.fn().mockResolvedValue({ id: 1, email: 'user@example.com' });
+    const whereRawSpy = jest.fn().mockReturnValue({ first: firstSpy });
+    const knex = jest.fn().mockReturnValue({ whereRaw: whereRawSpy }) as unknown as jest.Mock;
+    const repo = new UsersRepository(knex as any);
+
+    await repo.getByEmail('  User@Example.COM  ');
+
+    expect(whereRawSpy).toHaveBeenCalledWith(
+      'LOWER(TRIM(email)) = LOWER(?)',
+      ['  User@Example.COM  '.trim()]
+    );
+  });
+});
+
 describe('UsersRepository.updatePatreonByEmail', () => {
   it('matches the user by email using TRIM + lowercase so Stripe casing differences still update', async () => {
     const knex = buildKnexMock();

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -28,8 +28,7 @@ class UsersRepository {
 
   getByEmail(email: string) {
     return this.database(this.table)
-      .whereRaw('TRIM(email) = ?', [email.toLocaleLowerCase().trim()])
-      .returning(['reset_token', 'id'])
+      .whereRaw('LOWER(TRIM(email)) = LOWER(?)', [email.trim()])
       .first();
   }
 

--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -122,6 +122,17 @@ describe('UsersService.register', () => {
     );
   });
 
+  it('skips the verification email and magic token when skipEmailVerification is true', async () => {
+    const repository = buildRegisterRepository();
+    const emailService = buildEmailService();
+    const magicTokenRepo = new InMemoryMagicTokenRepository();
+    const service = new UsersService(repository, emailService, magicTokenRepo);
+
+    await service.register('Alex', 'hashed', 'alex@example.com', null, true);
+
+    expect(emailService.sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
   it('forwards a validated signup_origin to the repository', async () => {
     const repository = buildRegisterRepository();
     const service = new UsersService(repository, buildEmailService());

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -65,7 +65,8 @@ class UsersService {
     name: string,
     password: string,
     email: string,
-    signupOrigin?: string | null
+    signupOrigin?: string | null,
+    skipEmailVerification?: boolean
   ) {
     const normalizedEmail = email.toLowerCase();
     const trimmedName = name?.trim() ?? '';
@@ -78,7 +79,7 @@ class UsersService {
       signupOrigin ?? null
     );
     const userId = Array.isArray(rows) ? rows[0]?.id : null;
-    if (userId != null && this.magicTokenRepository != null) {
+    if (userId != null && this.magicTokenRepository != null && !skipEmailVerification) {
       const token = crypto.randomBytes(64).toString('hex');
       const expiresAt = new Date(Date.now() + VERIFY_EMAIL_EXPIRY_MS);
       await this.magicTokenRepository.create(

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -37,7 +37,9 @@ function LoginForm() {
       await get2ankiApi().requestMagicLink(email, 'login');
       setStep('check-email');
     } catch {
-      setError('Something went wrong. Try again.');
+      setError(
+        "We couldn't send your sign-in link right now. Try again in a minute, or use your password below."
+      );
     } finally {
       setMagicLinkLoading(false);
     }
@@ -53,6 +55,7 @@ function LoginForm() {
         email={email}
         onRetry={handleRetryMagicLink}
         purpose="login"
+        onResend={handleSendMagicLink}
       />
     );
   }


### PR DESCRIPTION
## Summary

- **Case-insensitive email lookup** — `getByEmail` used `TRIM(email) = ?` (case-sensitive in PostgreSQL), silently dropping any user with a mixed-case stored email. Changed to `LOWER(TRIM(email)) = LOWER(?)`, consistent with `updatePatreonByEmail` in the same file.
- **Spurious verification email for OAuth users** — `loginWithGoogle` called `register()` which fired `sendVerificationEmail` on every new Google user. Google already verified the address; this extra email primed Gmail's spam filter against `2anki.net`, causing subsequent magic link emails to land in spam. Added `skipEmailVerification` param to `register()` and pass `true` from `loginWithGoogle`. Also calls `markEmailVerified` on every Google sign-in to backfill existing accounts.
- **Silent error swallowing** — `requestMagicLink` caught all errors and returned 200, so SendGrid failures were invisible ("check your email" with nothing arriving). Infrastructure errors now forward to `next()` so `ErrorHandler` surfaces them; `MagicLinkRateLimitError` still 200s silently (enumeration prevention). Updated frontend error copy to designer spec.
- Wires `onResend` into `CheckYourEmail` from the login form — users can resend without losing context.

## Test plan

- [x] `pnpm test src/data_layer/UsersRepository.test.ts` — new `getByEmail` case-insensitive assertion
- [x] `pnpm test src/services/UsersService.test.ts` — new `skipEmailVerification` assertion
- [x] `pnpm test src/controllers/UsersControllers.test.ts` — infra-error test flipped to expect `next(error)` not 200
- [x] Log into app with a Google account → confirm no verification email arrives
- [x] Use "Email me a sign-in link" with a Google account email → confirm magic link arrives
- [x] Simulate SendGrid failure → confirm login page shows error copy instead of silent "check your email"

🤖 Generated with [Claude Code](https://claude.com/claude-code)