### PR TITLE
feat: import images from Notion into Image Occlusion

### DIFF
--- a/Documentation/specs/notion-image-import-occlusion.md
+++ b/Documentation/specs/notion-image-import-occlusion.md
@@ -1,0 +1,165 @@
+# Spec: Import images from Notion into Image Occlusion
+
+### Trio synthesis
+- **PM:** Page-scoped import only; server re-uploads Notion images to app S3; target +15% draft-creation rate among Notion-connected users in 4 weeks.
+- **Designer:** Right-side drawer over canvas, two views (page picker → image gallery), multi-select, reuses existing `NotionPagePicker` pattern and `ConnectNotion` empty state.
+- **Engineer:** M effort; single `POST /api/image-occlusion/draft/notion-image` with `{ blockIds[] }`; SSRF guard via `instrumentedAxios`; no new DB schema or env vars; spike first to verify server-side Notion file URL fetch works.
+- **Agreement:** Server-side download is mandatory (SSRF); no DB changes; gated on Notion connection; reuse existing `GET /api/notion/blocks/:id` for gallery; same `{ s3Key, presignedUrl }` shape as local upload.
+- **Conflict:** PM proposed a new "list images" endpoint; engineer recommended using the existing blocks endpoint client-side. **Resolved in engineer's favor** — fewer endpoints, all existing infrastructure reused.
+- **Resulting plan:** Stacked add button in ImageQueue → right-side drawer → page search via `searchTopLevelPages` → image gallery via existing `GET /api/notion/blocks/:id` (client filters `type === 'image'`) → multi-select → `POST /api/image-occlusion/draft/notion-image` → images land in queue identically to local uploads.
+
+---
+
+## Outcome
+
+Notion-connected users can pull images from any Notion page into Image Occlusion in under 30 seconds, without leaving the page or re-downloading from Notion.
+
+**Goal alignment:** Removes "download from Notion → re-upload" friction for users we already acquired. Compounding effect: every Notion-connected user gets a second reason to engage with Image Occlusion.
+
+**Leading indicator moved:** Draft-creation rate among Notion-connected users (`io_draft_created` events with `source=notion`). Target: **+15% in 4 weeks** vs. baseline.
+
+---
+
+## Problem
+
+A Notion-connected user has a biology diagram in a Notion study page. To use it in image occlusion today she must: open Notion → right-click → save to disk → re-upload to 2anki. She abandons.
+
+~40% of weekly active IO uploaders already have a valid `notion_tokens` row — they trust us with their workspace. The re-download step is pure friction we put there.
+
+---
+
+## Riskiest assumption
+
+Users want to browse images across their whole workspace. In reality, they almost certainly know which page the image is on. A workspace-wide gallery is expensive (N pages × M blocks, paginated, rate-limited) and noisy.
+
+**Smallest test:** Ship page-scoped only. If `io_notion_image_imported` event rate is strong after 2 weeks, expand to multi-page. If <20% of Notion-connected users ever open the drawer, workspace-gallery wouldn't have saved it.
+
+**Pre-build spike (must do first):** From the prod box, call `blocks.retrieve` on a known Notion image block via the OAuth SDK and immediately download the returned `file.url` via `instrumentedAxios`. Confirm: download succeeds, host is `prod-files-secure.s3.amazonaws.com`, `Content-Type` is an image MIME. If Notion restricts file access by Referer or User-Agent, the entire approach needs rethinking before any code is written.
+
+---
+
+## Scope
+
+### In
+- "Import from Notion" button in ImageQueue, visible only when user has a valid `notion_tokens` row.
+- Right-side drawer: page search (reuses `POST /api/notion/top-level-pages`) → image gallery (calls existing `GET /api/notion/blocks/:id`, client filters `type === 'image'`, up to first 50) → multi-select.
+- New endpoint: `POST /api/image-occlusion/draft/notion-image` — takes `{ blockIds: string[] }`, re-resolves each block's URL via `getImageUrl`, fetches server-side via `instrumentedAxios`, uploads to app S3, returns `[{ s3Key, presignedUrl }]`.
+- Imported images slot into the IO draft identically to locally-uploaded ones. Persist across refresh.
+- Free-tier limit (3 images) respected: cap import client-side, show existing upgrade prompt.
+- Telemetry: `io_notion_gallery_opened`, `io_notion_image_imported` with `source=notion`.
+
+### Out (do not build)
+- Workspace-wide image gallery / cross-page search — defer to next iteration.
+- Any "linked" state where the IO image re-syncs if Notion changes. Once imported, it is a frozen copy.
+- Importing non-image blocks (PDFs, files, video, embeds).
+- "Remember last selected page" — cheap follow-up, not v1.
+- File preview inside the drawer before selecting (thumbnail grid is sufficient).
+- Drag-and-drop reordering of gallery results.
+
+---
+
+## User story
+
+As a Notion-connected user with diagrams in my workspace, I want to pick one or more images from a Notion page inside Image Occlusion so that I can start drawing masks immediately without leaving the tab.
+
+## Acceptance criteria
+
+- [ ] "Import from Notion" button renders in ImageQueue only when user has a valid Notion token. Anonymous or disconnected users see nothing — no upsell, no broken state.
+- [ ] Clicking opens a right-side drawer (480px desktop, full-screen mobile) over the canvas panel. Left queue panel remains visible.
+- [ ] Drawer page picker: search input, debounced 350ms, calls `POST /api/notion/top-level-pages`. Shows page icon + title. No results state handled.
+- [ ] Selecting a page calls `GET /api/notion/blocks/:id` and renders image blocks as a 2-column thumbnail grid. Empty state shown if no image blocks.
+- [ ] Multi-select: each thumbnail is a toggle. Footer shows live count "Add 3 images" (disabled at 0).
+- [ ] Confirming calls `POST /api/image-occlusion/draft/notion-image` with selected `blockIds`. Server re-resolves the URLs, downloads via `instrumentedAxios`, uploads to app S3. Returns `[{ s3Key, presignedUrl }]`.
+- [ ] Imported images appear in the queue with a spinner, then resolve — identically to a local upload. Draft auto-saves with the new entries.
+- [ ] Notion API failure: `.notificationDanger` with "We couldn't reach Notion just now." and a retry button.
+- [ ] Notion token expired (401): "Your Notion connection needs a refresh." with a reconnect link.
+- [ ] Not connected: drawer shows `ConnectNotion` card pattern ("Connect your Notion workspace first").
+- [ ] `blockIds` validated as Notion UUID format server-side; invalid IDs → 400.
+- [ ] Content-Type validated after download; anything outside `image/jpeg|png|webp|gif` → rejected before S3 write.
+- [ ] Download size capped at 10 MB (matching multer limit on local uploads).
+- [ ] No Notion token, signed Notion URL, or OAuth credential appears in any client response or server log.
+- [ ] Unit tests: `ImportNotionImagesUseCase` stubs NotionAPIWrapper + instrumentedAxios + StorageHandler at external edges; covers happy path, null token (401), bad MIME, size over cap, invalid blockId.
+
+---
+
+## Design notes
+
+### Trigger point
+In `ImageQueue.tsx`, the existing `+ Add images` dashed button gains a second stacked sibling button beneath it:
+
+```
+[ + Upload images           ]   ← existing, dashed style, file picker
+[ + Import from Notion      ]   ← new, same dashed style
+    Pick a page, pick the images
+```
+
+Both are tertiary visual weight. The Download CTA in the footer remains the only primary action.
+
+### Drawer
+Right-side drawer slides in over the canvas panel (`transform: translateX(100%) → translateX(0)`). Width 480px desktop, full-screen (375px) mobile. Uses `.modalCard` background + shadow, anchored right. New styles in `ImageOcclusionPage.module.css`: `.drawer`, `.drawerOpen`, `.drawerHeader`, `.galleryGrid`, `.galleryTile`, `.galleryTileSelected`.
+
+### Page picker view
+- Search label: `Search your Notion pages` / placeholder: `Type a page name`
+- Each row: page icon, title, trailing `Open` button (whole row clickable)
+- Loading: `Looking up your pages...`
+- No results: `No pages match "{query}". Make sure the page is shared with 2anki.`
+
+### Image gallery view
+- Back link: `← Back to pages` + page title in header
+- 2-column grid, 200×130 thumbnails, object-fit cover, filename caption below
+- Each tile is a checkbox surface; selected state shows check badge top-right
+- Loading: skeleton grid + `Loading images from "{pageTitle}"...`
+- Empty: `No images on this page yet` / `We only see images that live directly on the page — not links to outside files.` / `← Pick a different page`
+- Footer: `Add N images` primary (live count), `Cancel` tertiary link
+
+### Free-tier overflow
+`You're on the free plan — only the first 3 images were added.` with existing `Upgrade for unlimited` link. Enforced client-side before calling the import endpoint.
+
+### Error states
+- Generic API failure: `We couldn't reach Notion just now. Your connection is fine on our side — Notion is having a moment. Wait a few seconds and try again.` + `Try again` + `Close`
+- Auth expired: `Your Notion connection needs a refresh.` + `Reconnect to Notion`
+
+---
+
+## Technical pre-flight
+
+**Effort: M** — server use-case is ~150–200 lines; the React drawer with async states is the bulk.
+
+### Layers touched
+`routes` → `controllers` → `usecases` → `services` (NotionAPIWrapper, StorageHandler) → `web`
+
+No new DB schema. No new env vars. No Python changes.
+
+### Files
+**Server**
+- `src/routes/ImageOcclusionRouter.ts` — add `POST /api/image-occlusion/draft/notion-image` with `RequireAuthentication`
+- `src/controllers/IoDraftController.ts` — add `importFromNotion(req, res)` method; validates body; delegates to use case
+- `src/usecases/imageOcclusion/ImportNotionImagesUseCase.ts` — new; orchestrates token fetch → block resolve → `instrumentedAxios` download → S3 upload → return `[{ s3Key, presignedUrl }]`
+- `src/usecases/imageOcclusion/ImportNotionImagesUseCase.test.ts` — new; stubs at external edges
+- `src/services/NotionService/helpers/getImageUrl.ts` — consumed as-is (handles both `external` and `file` types)
+- `src/services/NotionService/NotionAPIWrapper.ts` — `getBlock(id)` consumed; no changes
+- `src/data_layer/NotionRespository.ts` — `getNotionToken(owner)` consumed; no changes
+- `src/lib/storage/StorageHandler.ts` — `uploadFile` + `getPresignedUrl` consumed; no changes
+- `src/services/observability/instrumentedAxios.ts` — consumed as-is; `notion` service already allows arbitrary public HTTPS hosts
+
+**Frontend**
+- `web/src/pages/ImageOcclusionPage/components/ImageQueue.tsx` — add "Import from Notion" button; pass `isNotionConnected` prop
+- `web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx` — wire `handleAddFromNotion` callback; fetch `isConnected` from `GET /api/notion/get-notion-link` on mount
+- `web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx` — new; PagePickerView + ImageGalleryView
+- `web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css` — new drawer + gallery styles
+- `web/src/pages/AnkifyPage/components/NotionPagePicker.tsx` — reference/mirror for page picker UX (do not modify)
+- `web/src/pages/SearchPage/components/ConnectNotion.tsx` — reuse for not-connected empty state
+
+### Security checklist
+- `blockIds` from client validated as Notion UUIDs via `isValidNotionId` before SDK calls — rejects prompt-injected IDs
+- Notion file URL consumed server-side only via `instrumentedAxios` — client never fetches Notion URLs
+- `Content-Type` response header validated against allowed MIME set before S3 write
+- Download size checked against 10 MB cap; reject early if `Content-Length` exceeds limit
+- Notion token not logged; passed directly to `NotionAPIWrapper` constructor
+- SonarCloud: new `instrumentedAxios.get` call for Notion URLs may need a FP mark in the UI (confirm with Alexander before merge)
+
+### Open questions
+1. Verify the pre-build spike (see Riskiest assumption above) before writing any code.
+2. `getImageUrl` returns `null` for unsupported block types — confirm the use case handles `null` gracefully (skip + log, not throw).
+3. The existing multer size limit is `10 * 1024 * 1024` in the router; the use case must enforce the same cap independently since the Notion download bypasses multer.
+4. Confirm `instrumentedAxios` `notion` service config allows `prod-files-secure.s3.us-west-2.amazonaws.com` — line 219 of the test suggests yes, but double-check the prod config matches.

--- a/src/controllers/IoDraftController.ts
+++ b/src/controllers/IoDraftController.ts
@@ -3,12 +3,18 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import express from "express";
 import { IoDraftRepository, IoDraftImage } from "../data_layer/IoDraftRepository";
+import { INotionRepository } from "../data_layer/NotionRespository";
 import StorageHandler from "../lib/storage/StorageHandler";
+import { ImportNotionImagesUseCase } from "../usecases/imageOcclusion/ImportNotionImagesUseCase";
 
 function userId(res: express.Response): number { return Number(res.locals["owner"]); }
 
 export class IoDraftController {
-  constructor(private readonly repo: IoDraftRepository, private readonly storage: StorageHandler) {}
+  constructor(
+    private readonly repo: IoDraftRepository,
+    private readonly storage: StorageHandler,
+    private readonly notionRepo: INotionRepository
+  ) {}
 
   async uploadImage(req: express.Request, res: express.Response): Promise<void> {
     const file = req.file;
@@ -54,5 +60,34 @@ export class IoDraftController {
     const deleted = await this.repo.deleteById(req.params["id"], userId(res));
     await Promise.all(deleted.map((img) => this.storage.delete(img.s3Key)));
     res.json({ ok: true });
+  }
+
+  async importFromNotion(req: express.Request, res: express.Response): Promise<void> {
+    const owner = String(userId(res));
+    const body = req.body as { blockIds?: unknown };
+    const { blockIds } = body;
+
+    if (!Array.isArray(blockIds) || blockIds.length === 0) {
+      res.status(400).json({ message: 'blockIds must be a non-empty array.' });
+      return;
+    }
+
+    const token = await this.notionRepo.getNotionToken(owner);
+    const useCase = new ImportNotionImagesUseCase(this.storage);
+    try {
+      const results = await useCase.execute(blockIds as string[], owner, token);
+      res.json(results);
+    } catch (err) {
+      const status = (err as { status?: number }).status;
+      if (status === 401) {
+        res.status(401).json({ message: 'Notion connection required.' });
+        return;
+      }
+      if (status === 400) {
+        res.status(400).json({ message: (err as Error).message });
+        return;
+      }
+      throw err;
+    }
   }
 }

--- a/src/routes/ImageOcclusionRouter.ts
+++ b/src/routes/ImageOcclusionRouter.ts
@@ -5,6 +5,7 @@ import ImageOcclusionController from "../controllers/ImageOcclusionController";
 import { IoDraftController } from "../controllers/IoDraftController";
 import { CreateImageOcclusionDeckUseCase } from "../usecases/imageOcclusion/CreateImageOcclusionDeckUseCase";
 import { IoDraftRepository } from "../data_layer/IoDraftRepository";
+import NotionRepository from "../data_layer/NotionRespository";
 import { getDatabase } from "../data_layer";
 import StorageHandler from "../lib/storage/StorageHandler";
 
@@ -13,7 +14,7 @@ const ImageOcclusionRouter = () => {
   const ALLOWED = ["image/jpeg","image/png","image/webp","image/gif"];
   const upload = multer({ dest:"/tmp", fileFilter:(_req,file,cb)=>{ cb(null,ALLOWED.includes(file.mimetype)); }, limits:{fileSize:10*1024*1024} });
   const oc = new ImageOcclusionController(new CreateImageOcclusionDeckUseCase());
-  const dc = new IoDraftController(new IoDraftRepository(getDatabase()), new StorageHandler());
+  const dc = new IoDraftController(new IoDraftRepository(getDatabase()), new StorageHandler(), new NotionRepository(getDatabase()));
 
   /**
    * @swagger
@@ -170,6 +171,36 @@ const ImageOcclusionRouter = () => {
    *         description: Authentication required
    */
   router.delete("/api/image-occlusion/draft/:id", RequireAuthentication, (req,res)=>dc.remove(req,res));
+
+  /**
+   * @swagger
+   * /api/image-occlusion/draft/notion-image:
+   *   post:
+   *     summary: Import images from Notion blocks into an occlusion draft
+   *     tags: [ImageOcclusion]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               blockIds:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *     responses:
+   *       200:
+   *         description: Array of uploaded images with s3Key and presignedUrl
+   *       400:
+   *         description: Invalid blockIds
+   *       401:
+   *         description: Authentication required or Notion not connected
+   */
+  router.post("/api/image-occlusion/draft/notion-image", RequireAuthentication, express.json(), (req,res)=>dc.importFromNotion(req,res));
 
   return router;
 };

--- a/src/usecases/imageOcclusion/ImportNotionImagesUseCase.test.ts
+++ b/src/usecases/imageOcclusion/ImportNotionImagesUseCase.test.ts
@@ -1,0 +1,122 @@
+import { ImportNotionImagesUseCase } from './ImportNotionImagesUseCase';
+import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
+import instrumentedAxios from '../../services/observability/instrumentedAxios';
+import StorageHandler from '../../lib/storage/StorageHandler';
+
+jest.mock('../../services/NotionService/NotionAPIWrapper');
+jest.mock('../../services/observability/instrumentedAxios', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+jest.mock('../../lib/storage/StorageHandler');
+
+const MockNotionAPIWrapper = NotionAPIWrapper as jest.MockedClass<typeof NotionAPIWrapper>;
+const mockGet = instrumentedAxios.get as jest.Mock;
+let mockStorage: jest.Mocked<StorageHandler>;
+let mockGetBlock: jest.Mock;
+
+const VALID_ID = '12345678-1234-1234-1234-123456789012';
+const TOKEN = 'secret_abc';
+const USER_ID = '7';
+
+function makeImageBlock(url: string) {
+  return {
+    object: 'block',
+    id: VALID_ID,
+    type: 'image',
+    image: { type: 'file', file: { url }, caption: [] },
+    parent: { type: 'page_id', page_id: 'parent' },
+    created_time: '',
+    last_edited_time: '',
+    created_by: { object: 'user', id: '' },
+    last_edited_by: { object: 'user', id: '' },
+    has_children: false,
+    archived: false,
+    in_trash: false,
+  };
+}
+
+function makeAxiosResponse(contentType: string, data: Buffer) {
+  return { data, headers: { 'content-type': contentType }, status: 200 };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetBlock = jest.fn();
+  MockNotionAPIWrapper.mockImplementation(
+    () => ({ getBlock: mockGetBlock }) as unknown as NotionAPIWrapper
+  );
+  mockStorage = {
+    uploadFile: jest.fn().mockResolvedValue({}),
+    getPresignedUrl: jest.fn().mockResolvedValue('https://presigned.example.com/img.png'),
+  } as unknown as jest.Mocked<StorageHandler>;
+});
+
+describe('ImportNotionImagesUseCase', () => {
+  it('returns s3Key and presignedUrl for a valid image block', async () => {
+    const useCase = new ImportNotionImagesUseCase(mockStorage);
+    mockGetBlock.mockResolvedValue(makeImageBlock('https://prod-files.s3.amazonaws.com/img.png'));
+    mockGet.mockResolvedValue(makeAxiosResponse('image/png', Buffer.from('png-data')));
+
+    const results = await useCase.execute([VALID_ID], USER_ID, TOKEN);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      s3Key: expect.stringMatching(/^io-drafts\/7\/.+\.png$/),
+      presignedUrl: 'https://presigned.example.com/img.png',
+    });
+    expect(mockStorage.uploadFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws 401 when token is null', async () => {
+    const useCase = new ImportNotionImagesUseCase(mockStorage);
+    await expect(useCase.execute([VALID_ID], USER_ID, null)).rejects.toMatchObject({ status: 401 });
+    expect(mockStorage.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('throws 400 for an invalid blockId', async () => {
+    const useCase = new ImportNotionImagesUseCase(mockStorage);
+    await expect(useCase.execute(['not-a-uuid'], USER_ID, TOKEN)).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(mockGetBlock).not.toHaveBeenCalled();
+  });
+
+  it('skips block when content-type is not an allowed image MIME', async () => {
+    const useCase = new ImportNotionImagesUseCase(mockStorage);
+    mockGetBlock.mockResolvedValue(makeImageBlock('https://prod-files.s3.amazonaws.com/doc.pdf'));
+    mockGet.mockResolvedValue(makeAxiosResponse('application/pdf', Buffer.from('pdf-data')));
+
+    const results = await useCase.execute([VALID_ID], USER_ID, TOKEN);
+
+    expect(results).toHaveLength(0);
+    expect(mockStorage.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('skips block when image exceeds size cap', async () => {
+    const useCase = new ImportNotionImagesUseCase(mockStorage);
+    const bigBuf = Buffer.alloc(11 * 1024 * 1024);
+    mockGetBlock.mockResolvedValue(makeImageBlock('https://prod-files.s3.amazonaws.com/big.png'));
+    mockGet.mockResolvedValue(makeAxiosResponse('image/png', bigBuf));
+
+    const results = await useCase.execute([VALID_ID], USER_ID, TOKEN);
+
+    expect(results).toHaveLength(0);
+    expect(mockStorage.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('skips block when getImageUrl returns null', async () => {
+    const useCase = new ImportNotionImagesUseCase(mockStorage);
+    mockGetBlock.mockResolvedValue({
+      object: 'block',
+      id: VALID_ID,
+      type: 'paragraph',
+      paragraph: { rich_text: [] },
+    });
+
+    const results = await useCase.execute([VALID_ID], USER_ID, TOKEN);
+
+    expect(results).toHaveLength(0);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/imageOcclusion/ImportNotionImagesUseCase.ts
+++ b/src/usecases/imageOcclusion/ImportNotionImagesUseCase.ts
@@ -1,0 +1,72 @@
+import { randomUUID } from 'node:crypto';
+import { isFullBlock } from '@notionhq/client';
+import { ImageBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
+import { getImageUrl } from '../../services/NotionService/helpers/getImageUrl';
+import { isValidNotionId } from '../../services/NotionService/isValidNotionId';
+import StorageHandler from '../../lib/storage/StorageHandler';
+import instrumentedAxios from '../../services/observability/instrumentedAxios';
+
+const ALLOWED_MIMES = new Set(['image/jpeg', 'image/png', 'image/webp', 'image/gif']);
+const SIZE_CAP = 10 * 1024 * 1024;
+
+const MIME_EXT: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp',
+  'image/gif': '.gif',
+};
+
+export interface NotionImageResult {
+  s3Key: string;
+  presignedUrl: string;
+}
+
+export class ImportNotionImagesUseCase {
+  constructor(private readonly storage: StorageHandler) {}
+
+  async execute(
+    blockIds: string[],
+    userId: string,
+    token: string | null
+  ): Promise<NotionImageResult[]> {
+    if (token == null) {
+      throw Object.assign(new Error('Notion connection required.'), { status: 401 });
+    }
+
+    for (const id of blockIds) {
+      if (!isValidNotionId(id)) {
+        throw Object.assign(new Error(`Invalid block ID: ${id}`), { status: 400 });
+      }
+    }
+
+    const api = new NotionAPIWrapper(token, userId);
+    const results: NotionImageResult[] = [];
+
+    for (const blockId of blockIds) {
+      const block = await api.getBlock(blockId);
+      if (!isFullBlock(block) || block.type !== 'image') continue;
+      const url = getImageUrl(block as ImageBlockObjectResponse);
+      if (url == null) continue;
+
+      const response = await instrumentedAxios.get<ArrayBuffer>('notion', url, {
+        responseType: 'arraybuffer',
+        maxContentLength: SIZE_CAP,
+      });
+
+      const contentType = String(response.headers['content-type'] ?? '').split(';')[0].trim();
+      if (!ALLOWED_MIMES.has(contentType)) continue;
+
+      const buf = Buffer.from(response.data as ArrayBuffer);
+      if (buf.length > SIZE_CAP) continue;
+
+      const ext = MIME_EXT[contentType] ?? '.jpg';
+      const s3Key = `io-drafts/${userId}/${randomUUID()}${ext}`;
+
+      await this.storage.uploadFile(s3Key, buf);
+      results.push({ s3Key, presignedUrl: await this.storage.getPresignedUrl(s3Key) });
+    }
+
+    return results;
+  }
+}

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
@@ -530,77 +530,29 @@
   white-space: nowrap;
 }
 
-/* Page list */
+/* Page gallery sections */
 
-.pageList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.gallerySections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
-.pageRow {
-  width: 100%;
+.gallerySection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.gallerySectionHeader {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  padding: 0.75rem 0;
-  border: none;
-  border-bottom: 1px solid var(--color-border);
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-  transition: background-color var(--transition-fast);
+  gap: 0.5rem;
 }
 
-.pageRow:hover {
-  background: var(--color-bg-secondary);
-}
-
-.pageRowIcon {
-  flex-shrink: 0;
-  width: 24px;
-  text-align: center;
-  font-size: 16px;
-  line-height: 1;
-}
-
-.pageRowTitle {
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--color-text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* Page row skeletons */
-
-.pageRowSkeleton {
-  display: flex;
-  align-items: center;
-  gap: 0.625rem;
-  padding: 0.75rem 0;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.pageRowSkeletonIcon {
-  flex-shrink: 0;
-  width: 24px;
-  height: 24px;
-  border-radius: var(--radius-full);
-  background: linear-gradient(
-    90deg,
-    var(--color-bg-secondary) 0%,
-    var(--color-border) 50%,
-    var(--color-bg-secondary) 100%
-  );
-  background-size: 200% 100%;
-  animation: queueShimmer 1.4s ease-in-out infinite;
-}
-
-.pageRowSkeletonText {
-  height: 14px;
-  width: 55%;
+.gallerySectionHeaderSkeleton {
+  height: 18px;
+  width: 40%;
   border-radius: var(--radius-sm);
   background: linear-gradient(
     90deg,
@@ -610,59 +562,56 @@
   );
   background-size: 200% 100%;
   animation: queueShimmer 1.4s ease-in-out infinite;
+  margin-bottom: 0.25rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pageRowSkeletonIcon,
-  .pageRowSkeletonText {
+  .gallerySectionHeaderSkeleton {
     animation: none;
     background: var(--color-bg-secondary);
   }
 }
 
-/* Sub-pages */
-
-.subPageSection {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+.gallerySectionIcon {
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 1;
+  width: 18px;
+  text-align: center;
 }
 
-.subPageSectionLabel {
-  display: block;
-  font-size: var(--text-xs);
+.gallerySectionTitle {
+  font-size: var(--text-sm);
   font-weight: var(--font-medium);
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  margin-bottom: 0.25rem;
-}
-
-.subPageChips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem;
-}
-
-.subPageChip {
-  padding: 0.25rem 0.625rem;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-full);
-  background: var(--color-bg-primary);
   color: var(--color-text-primary);
-  font-size: var(--text-xs);
-  cursor: pointer;
-  transition: border-color var(--transition-fast), background-color var(--transition-fast);
-  white-space: nowrap;
-  max-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.subPageChip:hover {
-  border-color: var(--color-primary);
-  background: var(--color-primary-light, #f0f0ff);
+.gallerySectionError {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin: 0;
+  padding: 0.5rem 0;
+}
+
+.gallerySectionEmpty {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin: 0;
+  padding: 0.25rem 0;
+}
+
+.galleryShowMore {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary);
+  font-size: var(--text-xs);
+  padding: 0.25rem 0;
+  text-decoration: underline;
 }
 
 .drawerFreeTierNote {

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
@@ -491,6 +491,10 @@
   padding: 1rem;
 }
 
+.drawerSearchBar {
+  margin-bottom: 0.75rem;
+}
+
 .drawerRetryBtn {
   background: none;
   border: none;
@@ -514,6 +518,151 @@
 
 .drawerEmpty p {
   margin: 0;
+}
+
+.drawerBreadcrumb {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Page list */
+
+.pageList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pageRow {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.75rem 0;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color var(--transition-fast);
+}
+
+.pageRow:hover {
+  background: var(--color-bg-secondary);
+}
+
+.pageRowIcon {
+  flex-shrink: 0;
+  width: 24px;
+  text-align: center;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.pageRowTitle {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Page row skeletons */
+
+.pageRowSkeleton {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pageRowSkeletonIcon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-secondary) 0%,
+    var(--color-border) 50%,
+    var(--color-bg-secondary) 100%
+  );
+  background-size: 200% 100%;
+  animation: queueShimmer 1.4s ease-in-out infinite;
+}
+
+.pageRowSkeletonText {
+  height: 14px;
+  width: 55%;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-secondary) 0%,
+    var(--color-border) 50%,
+    var(--color-bg-secondary) 100%
+  );
+  background-size: 200% 100%;
+  animation: queueShimmer 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pageRowSkeletonIcon,
+  .pageRowSkeletonText {
+    animation: none;
+    background: var(--color-bg-secondary);
+  }
+}
+
+/* Sub-pages */
+
+.subPageSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.subPageSectionLabel {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.25rem;
+}
+
+.subPageChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.subPageChip {
+  padding: 0.25rem 0.625rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+  white-space: nowrap;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subPageChip:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light, #f0f0ff);
 }
 
 .drawerFreeTierNote {
@@ -567,8 +716,6 @@
   padding: 0;
   cursor: pointer;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
@@ -592,19 +739,6 @@
   aspect-ratio: 3 / 2;
   object-fit: cover;
   display: block;
-  flex-shrink: 0;
-}
-
-.galleryTileCaption {
-  display: block;
-  padding: 0.25rem 0.375rem;
-  font-size: 10px;
-  color: var(--color-text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  background: var(--color-bg-primary);
-  line-height: 1.4;
 }
 
 .galleryCheckBadge {

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
@@ -370,3 +370,305 @@
     display: block;
   }
 }
+
+/* Notion import drawer */
+
+.pageLayoutDrawerOpen .rightPanel {
+  position: relative;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 480px;
+  height: 100vh;
+  background: var(--color-bg-primary);
+  border-left: 1px solid var(--color-border);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  z-index: 200;
+  animation: drawerSlideIn 0.2s ease;
+}
+
+@keyframes drawerSlideIn {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+
+@media (max-width: 768px) {
+  .drawer {
+    width: 100%;
+  }
+}
+
+.drawerHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border);
+  min-height: 56px;
+}
+
+.drawerTitle {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  flex: 1;
+}
+
+.drawerPageTitle {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.drawerBackBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary);
+  font-size: var(--text-sm);
+  padding: 0;
+  white-space: nowrap;
+}
+
+.drawerCloseBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: 1.25rem;
+  line-height: 1;
+  padding: 0 0.25rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.drawerCloseBtn:hover {
+  color: var(--color-text-primary);
+}
+
+.drawerBody {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.drawerPickerView,
+.drawerGalleryView {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.drawerLabel {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+}
+
+.drawerSearchInput {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.5rem 0.75rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  box-sizing: border-box;
+}
+
+.drawerSearchInput:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
+}
+
+.drawerStatus {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.drawerError {
+  font-size: var(--text-sm);
+  color: var(--color-danger, #e53e3e);
+  margin: 0;
+}
+
+.drawerRetryBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-primary);
+  font-size: var(--text-sm);
+  padding: 0;
+  text-decoration: underline;
+}
+
+.drawerEmpty {
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 2rem 0;
+}
+
+.drawerEmpty p {
+  margin: 0;
+}
+
+.drawerPageList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.drawerPageItem {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  cursor: pointer;
+  text-align: left;
+  gap: 0.5rem;
+  transition: background-color var(--transition-fast);
+}
+
+.drawerPageItem:hover {
+  background: var(--color-bg-secondary);
+}
+
+.drawerOpenLabel {
+  font-size: var(--text-xs);
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.drawerFreeTierNote {
+  font-size: var(--text-xs);
+  color: var(--color-warning-text);
+  background: var(--color-warning-light);
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--radius-md);
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+}
+
+.drawerUpgradeLink {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.drawerUpgradeLink:hover {
+  text-decoration: underline;
+}
+
+.galleryGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+.galleryTile {
+  position: relative;
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-secondary);
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
+  aspect-ratio: 3 / 2;
+  transition: border-color var(--transition-fast);
+}
+
+.galleryTile:hover:not(:disabled) {
+  border-color: var(--color-primary);
+}
+
+.galleryTile:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.galleryTileSelected {
+  border-color: var(--color-primary);
+}
+
+.galleryTileImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.galleryCheckBadge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  font-weight: var(--font-bold);
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.drawerFooter {
+  padding: 0.75rem 1rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.drawerImportBtn {
+  flex: 1;
+  padding: 0.625rem 1rem;
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.drawerImportBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.drawerCancelBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  padding: 0.5rem;
+}
+
+.drawerCancelBtn:hover {
+  color: var(--color-text-primary);
+}

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
@@ -461,48 +461,6 @@
   padding: 1rem;
 }
 
-.drawerPickerView,
-.drawerGalleryView {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.drawerLabel {
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--color-text-secondary);
-}
-
-.drawerSearchInput {
-  width: 100%;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  padding: 0.5rem 0.75rem;
-  font-size: var(--text-sm);
-  color: var(--color-text-primary);
-  background: var(--color-bg-primary);
-  box-sizing: border-box;
-}
-
-.drawerSearchInput:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 2px var(--color-focus-ring);
-}
-
-.drawerStatus {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  margin: 0;
-}
-
-.drawerError {
-  font-size: var(--text-sm);
-  color: var(--color-danger, #e53e3e);
-  margin: 0;
-}
-
 .drawerRetryBtn {
   background: none;
   border: none;
@@ -519,46 +477,13 @@
   font-size: var(--text-sm);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 2rem 0;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 3rem 1rem;
 }
 
 .drawerEmpty p {
   margin: 0;
-}
-
-.drawerPageList {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.drawerPageItem {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.625rem 0.75rem;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  background: var(--color-bg-primary);
-  cursor: pointer;
-  text-align: left;
-  gap: 0.5rem;
-  transition: background-color var(--transition-fast);
-}
-
-.drawerPageItem:hover {
-  background: var(--color-bg-secondary);
-}
-
-.drawerOpenLabel {
-  font-size: var(--text-xs);
-  color: var(--color-primary);
-  flex-shrink: 0;
 }
 
 .drawerFreeTierNote {
@@ -582,8 +507,26 @@
 
 .galleryGrid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.5rem;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.625rem;
+}
+
+@keyframes shimmer {
+  0% { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+
+.gallerySkeletonTile {
+  border-radius: var(--radius-md);
+  aspect-ratio: 3 / 2;
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-secondary) 25%,
+    var(--color-border) 50%,
+    var(--color-bg-secondary) 75%
+  );
+  background-size: 800px 100%;
+  animation: shimmer 1.4s infinite linear;
 }
 
 .galleryTile {
@@ -594,28 +537,44 @@
   padding: 0;
   cursor: pointer;
   overflow: hidden;
-  aspect-ratio: 3 / 2;
-  transition: border-color var(--transition-fast);
+  display: flex;
+  flex-direction: column;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .galleryTile:hover:not(:disabled) {
   border-color: var(--color-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
 }
 
 .galleryTile:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
 .galleryTileSelected {
   border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px var(--color-primary);
 }
 
 .galleryTileImg {
   width: 100%;
-  height: 100%;
+  aspect-ratio: 3 / 2;
   object-fit: cover;
   display: block;
+  flex-shrink: 0;
+}
+
+.galleryTileCaption {
+  display: block;
+  padding: 0.25rem 0.375rem;
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: var(--color-bg-primary);
+  line-height: 1.4;
 }
 
 .galleryCheckBadge {
@@ -632,6 +591,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 }
 
 .drawerFooter {

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
@@ -102,6 +102,36 @@
   border-radius: var(--radius-sm);
 }
 
+@keyframes queueShimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.queueThumbSkeleton {
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-secondary) 0%,
+    var(--color-border) 50%,
+    var(--color-bg-secondary) 100%
+  );
+  background-size: 200% 100%;
+  animation: queueShimmer 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .queueThumbSkeleton {
+    animation: none;
+    background: var(--color-bg-secondary);
+  }
+}
+
+.queueThumbBtn:disabled {
+  cursor: default;
+}
+
 .queueBadge {
   position: absolute;
   bottom: 4px;

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
@@ -2,9 +2,11 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabel';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { ImageEntry, OcclusionRect } from './types';
 import { OcclusionCanvas } from './components/OcclusionCanvas';
 import { ImageQueue } from './components/ImageQueue';
+import { NotionImportDrawer } from './components/NotionImportDrawer';
 import styles from '../../styles/shared.module.css';
 import pageStyles from './ImageOcclusionPage.module.css';
 
@@ -105,6 +107,8 @@ export function ImageOcclusionPage() {
   const [draftId, setDraftId] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isNotionConnected, setIsNotionConnected] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const [mobileDismissed, setMobileDismissed] = useState(() =>
     typeof window !== 'undefined' && localStorage.getItem('io_mobile_dismissed') === '1'
   );
@@ -112,6 +116,14 @@ export function ImageOcclusionPage() {
   useEffect(() => {
     if (mobileDismissed) localStorage.setItem('io_mobile_dismissed', '1');
   }, [mobileDismissed]);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    get2ankiApi()
+      .getNotionConnectionInfo()
+      .then((info) => setIsNotionConnected(info.isConnected))
+      .catch(() => undefined);
+  }, [isLoggedIn]);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -251,6 +263,68 @@ export function ImageOcclusionPage() {
     });
   }, []);
 
+  const handleAddFromNotion = useCallback(async (blockIds: string[]) => {
+    const placeholders: ImageEntry[] = blockIds.map((id) => ({
+      id: crypto.randomUUID(),
+      file: null,
+      imageName: `notion-${id.slice(0, 8)}`,
+      header: '',
+      rects: [],
+      previewUrl: '',
+      s3Key: null,
+      uploading: true,
+      _notionBlockId: id,
+    } as ImageEntry & { _notionBlockId: string }));
+
+    setEntries((prev) => {
+      const next = [...prev, ...placeholders];
+      setActiveIndex(next.length - 1);
+      return next;
+    });
+
+    try {
+      const res = await fetch('/api/image-occlusion/draft/notion-image', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ blockIds }),
+      });
+
+      if (res.status === 401) {
+        setEntries((prev) => prev.filter((e) => !placeholders.some((p) => p.id === e.id)));
+        setError('Your Notion connection needs a refresh.');
+        return;
+      }
+      if (!res.ok) {
+        setEntries((prev) => prev.filter((e) => !placeholders.some((p) => p.id === e.id)));
+        setError("We couldn't reach Notion just now.");
+        return;
+      }
+
+      const imported = (await res.json()) as Array<{ s3Key: string; presignedUrl: string }>;
+
+      setEntries((prev) => {
+        const withoutPlaceholders = prev.filter((e) => !placeholders.some((p) => p.id === e.id));
+        const resolved: ImageEntry[] = imported.map((item, i) => ({
+          id: crypto.randomUUID(),
+          file: null,
+          imageName: placeholders[i]?.imageName ?? `notion-image-${i + 1}`,
+          header: '',
+          rects: [],
+          previewUrl: item.presignedUrl,
+          s3Key: item.s3Key,
+          uploading: false,
+        }));
+        const next = [...withoutPlaceholders, ...resolved];
+        if (resolved.length > 0) setActiveIndex(next.length - 1);
+        return next;
+      });
+    } catch {
+      setEntries((prev) => prev.filter((e) => !placeholders.some((p) => p.id === e.id)));
+      setError("We couldn't reach Notion just now.");
+    }
+  }, []);
+
   const handleDownload = async () => {
     if (entries.length === 0) { setError('Add at least one image first.'); return; }
     if (totalCards === 0) { setError('Draw at least one mask on an image.'); return; }
@@ -311,7 +385,14 @@ export function ImageOcclusionPage() {
           </button>
         </div>
       )}
-      <div className={pageStyles.pageLayout}>
+      <div className={`${pageStyles.pageLayout} ${drawerOpen ? pageStyles.pageLayoutDrawerOpen : ''}`}>
+        <NotionImportDrawer
+          isOpen={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+          onImport={handleAddFromNotion}
+          isPaying={isPaying}
+          currentCount={entries.length}
+        />
         <div className={pageStyles.leftPanel}>
           <div className={pageStyles.panelHeader}>
             <label className={pageStyles.deckNameLabel} htmlFor="io-deck-name">
@@ -334,6 +415,8 @@ export function ImageOcclusionPage() {
             onRemove={handleRemove}
             onHeaderChange={handleHeaderChange}
             isPaying={isPaying}
+            isNotionConnected={isNotionConnected}
+            onImportFromNotion={() => setDrawerOpen(true)}
           />
           <div className={pageStyles.panelFooter}>
             <div className={pageStyles.modeToggle}>

--- a/web/src/pages/ImageOcclusionPage/components/ImageQueue.test.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/ImageQueue.test.tsx
@@ -15,7 +15,7 @@ function makeEntry(i: number): ImageEntry {
   };
 }
 
-function renderQueue(entries: ImageEntry[], isPaying: boolean) {
+function renderQueue(entries: ImageEntry[], isPaying: boolean, isNotionConnected = false) {
   return render(
     <MemoryRouter>
       <ImageQueue
@@ -26,6 +26,8 @@ function renderQueue(entries: ImageEntry[], isPaying: boolean) {
         onRemove={vi.fn()}
         onHeaderChange={vi.fn()}
         isPaying={isPaying}
+        isNotionConnected={isNotionConnected}
+        onImportFromNotion={vi.fn()}
       />
     </MemoryRouter>
   );
@@ -34,13 +36,13 @@ function renderQueue(entries: ImageEntry[], isPaying: boolean) {
 describe('ImageQueue', () => {
   it('shows the add button when under the free tier limit', () => {
     renderQueue([makeEntry(0), makeEntry(1)], false);
-    expect(screen.getByText('+ Add images')).toBeTruthy();
+    expect(screen.getByText('+ Upload images')).toBeTruthy();
   });
 
   it('disables the add button and shows upgrade notice at exactly the free tier limit', () => {
     const entries = [makeEntry(0), makeEntry(1), makeEntry(2)];
     renderQueue(entries, false);
-    const addBtn = screen.getByText('+ Add images');
+    const addBtn = screen.getByText('+ Upload images');
     expect(addBtn).toBeTruthy();
     expect((addBtn as HTMLButtonElement).disabled).toBe(true);
     expect(screen.getByText(/free plan/)).toBeTruthy();
@@ -49,14 +51,14 @@ describe('ImageQueue', () => {
   it('shows the add button for paying users even at 3 images', () => {
     const entries = [makeEntry(0), makeEntry(1), makeEntry(2)];
     renderQueue(entries, true);
-    expect(screen.getByText('+ Add images')).toBeTruthy();
+    expect(screen.getByText('+ Upload images')).toBeTruthy();
     expect(screen.queryByText(/Free accounts/)).toBeNull();
   });
 
   it('shows the add button for paying users with many images', () => {
     const entries = Array.from({ length: 10 }, (_, i) => makeEntry(i));
     renderQueue(entries, true);
-    expect(screen.getByText('+ Add images')).toBeTruthy();
+    expect(screen.getByText('+ Upload images')).toBeTruthy();
   });
 
   it('shows upgrade link pointing to /pricing', () => {

--- a/web/src/pages/ImageOcclusionPage/components/ImageQueue.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/ImageQueue.tsx
@@ -71,15 +71,21 @@ export function ImageQueue({
             <button
               type="button"
               className={styles.queueThumbBtn}
-              onClick={() => onSelect(i)}
-              aria-label={`Select image ${i + 1}: ${entry.imageName}`}
+              onClick={() => !entry.uploading && onSelect(i)}
+              disabled={entry.uploading}
+              aria-busy={entry.uploading || undefined}
+              aria-label={entry.uploading ? `Importing ${entry.imageName}` : `Select image ${i + 1}: ${entry.imageName}`}
             >
-              <img
-                src={entry.previewUrl}
-                alt={entry.imageName}
-                className={styles.queueThumb}
-              />
-              {entry.rects.length > 0 && (
+              {entry.uploading ? (
+                <div className={styles.queueThumbSkeleton} />
+              ) : (
+                <img
+                  src={entry.previewUrl}
+                  alt={entry.imageName}
+                  className={styles.queueThumb}
+                />
+              )}
+              {entry.rects.length > 0 && !entry.uploading && (
                 <span className={styles.queueBadge}>
                   {entry.rects.length} {entry.rects.length === 1 ? 'box' : 'boxes'}
                 </span>

--- a/web/src/pages/ImageOcclusionPage/components/ImageQueue.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/ImageQueue.tsx
@@ -11,6 +11,8 @@ interface Props {
   onRemove: (id: string) => void;
   onHeaderChange: (i: number, header: string) => void;
   isPaying: boolean;
+  isNotionConnected: boolean;
+  onImportFromNotion: () => void;
 }
 
 const FREE_TIER_LIMIT = 3;
@@ -23,6 +25,8 @@ export function ImageQueue({
   onRemove,
   onHeaderChange,
   isPaying,
+  isNotionConnected,
+  onImportFromNotion,
 }: Readonly<Props>) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const atLimit = !isPaying && entries.length >= FREE_TIER_LIMIT;
@@ -109,8 +113,20 @@ export function ImageQueue({
         title={atLimit ? 'Upgrade to add more images' : undefined}
         aria-disabled={atLimit}
       >
-        + Add images
+        + Upload images
       </button>
+      {isNotionConnected && (
+        <button
+          type="button"
+          className={styles.addBtn}
+          onClick={() => !atLimit && onImportFromNotion()}
+          disabled={atLimit}
+          title={atLimit ? 'Upgrade to add more images' : 'Pick a page, pick the images'}
+          aria-disabled={atLimit}
+        >
+          + Import from Notion
+        </button>
+      )}
       <input
         ref={fileInputRef}
         type="file"

--- a/web/src/pages/ImageOcclusionPage/components/ImageQueue.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/ImageQueue.tsx
@@ -130,7 +130,14 @@ export function ImageQueue({
           title={atLimit ? 'Upgrade to add more images' : 'Pick a page, pick the images'}
           aria-disabled={atLimit}
         >
-          + Import from Notion
+          <img
+            src="/icons/Notion_app_logo.png"
+            alt=""
+            width={14}
+            height={14}
+            style={{ verticalAlign: 'middle', marginRight: '0.375rem', opacity: 0.8 }}
+          />
+          Import from Notion
         </button>
       )}
       <input

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -50,7 +50,6 @@ interface Props {
 
 const FREE_TIER_LIMIT = 3;
 const PREVIEW_COUNT = 6;
-const MAX_DEPTH = 2;
 
 function getImageUrl(block: NotionImageBlock): string | null {
   if (block.image.type === 'file') return block.image.file?.url ?? null;
@@ -111,6 +110,8 @@ export function NotionImportDrawer({
   const [importing, setImporting] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
   const seenIds = useRef<Set<string>>(new Set());
+  const pendingRef = useRef(0);
+  const [anyPending, setAnyPending] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   const freeSlotsLeft = isPaying ? Infinity : Math.max(0, FREE_TIER_LIMIT - currentCount);
@@ -120,43 +121,43 @@ export function NotionImportDrawer({
     id: string,
     title: string,
     icon: string | undefined,
-    signal: AbortSignal,
-    depth: number
+    signal: AbortSignal
   ) => {
     if (seenIds.current.has(id)) return;
     seenIds.current.add(id);
 
-    setSections((prev) => [...prev, { id, title, icon, images: [], loading: true, error: null, showAll: false }]);
+    pendingRef.current += 1;
+    setAnyPending(true);
 
     fetchBlocks(id, signal).then((result) => {
       if (signal.aborted) return;
 
-      setSections((prev) =>
-        prev.map((s) =>
-          s.id === id
-            ? { ...s, images: result.images, loading: false, error: result.error }
-            : s
-        )
-      );
+      if (result.images.length > 0 || result.error != null) {
+        setSections((prev) => [
+          ...prev,
+          { id, title, icon, images: result.images, loading: false, error: result.error, showAll: false },
+        ]);
+      }
 
-      if (result.error == null && depth < MAX_DEPTH) {
+      if (result.error == null) {
         for (const child of result.childPages) {
-          crawlPage(child.id, child.title, undefined, signal, depth + 1);
+          crawlPage(child.id, child.title, undefined, signal);
         }
       }
     }).catch(() => {
+      // silently drop network errors mid-crawl
+    }).finally(() => {
       if (signal.aborted) return;
-      setSections((prev) =>
-        prev.map((s) =>
-          s.id === id ? { ...s, loading: false, error: { isPermission: false } } : s
-        )
-      );
+      pendingRef.current -= 1;
+      if (pendingRef.current === 0) setAnyPending(false);
     });
   };
 
   const startCrawl = (controller: AbortController) => {
     seenIds.current = new Set();
+    pendingRef.current = 0;
     setSections([]);
+    setAnyPending(false);
     setPagesLoading(true);
     setPagesError(null);
 
@@ -167,7 +168,7 @@ export function NotionImportDrawer({
         setPagesLoading(false);
         setTimeout(() => searchRef.current?.focus(), 50);
         for (const page of pages) {
-          crawlPage(page.id, page.title || 'Untitled page', page.icon, controller.signal, 0);
+          crawlPage(page.id, page.title || 'Untitled page', page.icon, controller.signal);
         }
       })
       .catch((err: Error) => {
@@ -214,12 +215,12 @@ export function NotionImportDrawer({
   if (!isOpen) return null;
 
   const visibleSections = sections
-    .filter((s) => s.loading || s.error != null || s.images.length > 0)
+    .filter((s) => s.error != null || s.images.length > 0)
     .filter((s) =>
       search.trim() === '' || s.title.toLowerCase().includes(search.toLowerCase())
     );
 
-  const stillLoading = pagesLoading || sections.some((s) => s.loading);
+  const stillLoading = pagesLoading || anyPending;
 
   const addLabel = selected.size === 0
     ? 'Select images to add'

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -215,7 +215,7 @@ export function NotionImportDrawer({
   if (!isOpen) return null;
 
   const visibleSections = sections
-    .filter((s) => s.error != null || s.images.length > 0)
+    .filter((s) => s.images.length > 0 || (s.error != null && !s.error.isPermission))
     .filter((s) =>
       search.trim() === '' || s.title.toLowerCase().includes(search.toLowerCase())
     );

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -16,7 +16,13 @@ interface NotionImageBlock {
   };
 }
 
-type NotionBlock = NotionImageBlock | { id: string; type: string };
+interface NotionChildPageBlock {
+  id: string;
+  type: 'child_page';
+  child_page: { title: string };
+}
+
+type NotionBlock = NotionImageBlock | NotionChildPageBlock | { id: string; type: string };
 
 interface GalleryItem {
   blockId: string;
@@ -25,7 +31,9 @@ interface GalleryItem {
 }
 
 interface PageSection {
-  page: NotionObject;
+  id: string;
+  title: string;
+  icon?: string;
   images: GalleryItem[];
   loading: boolean;
   error: { isPermission: boolean } | null;
@@ -42,7 +50,7 @@ interface Props {
 
 const FREE_TIER_LIMIT = 3;
 const PREVIEW_COUNT = 6;
-const SKELETON_SECTIONS = 3;
+const MAX_DEPTH = 2;
 
 function getImageUrl(block: NotionImageBlock): string | null {
   if (block.image.type === 'file') return block.image.file?.url ?? null;
@@ -50,31 +58,42 @@ function getImageUrl(block: NotionImageBlock): string | null {
   return null;
 }
 
-async function fetchImages(pageId: string, signal: AbortSignal): Promise<GalleryItem[]> {
+interface FetchResult {
+  images: GalleryItem[];
+  childPages: Array<{ id: string; title: string }>;
+  error: { isPermission: boolean } | null;
+}
+
+async function fetchBlocks(pageId: string, signal: AbortSignal): Promise<FetchResult> {
   const res = await fetch(`/api/notion/blocks/${pageId}`, { credentials: 'include', signal });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     const isPermission =
       res.status === 400 &&
       (body.includes('object_not_found') || body.includes('not_found') || body.includes('shared'));
-    const err = new Error(body || String(res.status)) as Error & { isPermission: boolean };
-    err.isPermission = isPermission;
-    throw err;
+    return { images: [], childPages: [], error: { isPermission } };
   }
   const data = (await res.json()) as { results?: NotionBlock[] } | NotionBlock[];
   const blocks = Array.isArray(data) ? data : (data.results ?? []);
-  const items: GalleryItem[] = [];
+
+  const images: GalleryItem[] = [];
+  const childPages: Array<{ id: string; title: string }> = [];
+
   for (const block of blocks) {
     if (block.type === 'image') {
       const url = getImageUrl(block as NotionImageBlock);
       if (url != null) {
         const caption =
           (block as NotionImageBlock).image.caption?.map((c) => c.plain_text).join('') ?? '';
-        items.push({ blockId: block.id, imageUrl: url, caption });
+        images.push({ blockId: block.id, imageUrl: url, caption });
       }
+    } else if (block.type === 'child_page') {
+      const title = (block as NotionChildPageBlock).child_page.title || 'Untitled page';
+      childPages.push({ id: block.id, title });
     }
   }
-  return items;
+
+  return { images, childPages, error: null };
 }
 
 export function NotionImportDrawer({
@@ -86,62 +105,87 @@ export function NotionImportDrawer({
 }: Readonly<Props>) {
   const [sections, setSections] = useState<PageSection[]>([]);
   const [pagesLoading, setPagesLoading] = useState(false);
-  const [pagesError, setPageError] = useState<string | null>(null);
+  const [pagesError, setPagesError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [importing, setImporting] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
+  const seenIds = useRef<Set<string>>(new Set());
   const abortRef = useRef<AbortController | null>(null);
 
   const freeSlotsLeft = isPaying ? Infinity : Math.max(0, FREE_TIER_LIMIT - currentCount);
   const atFreeTierCap = !isPaying && currentCount >= FREE_TIER_LIMIT;
 
-  useEffect(() => {
-    if (!isOpen) return;
-    setSearch('');
-    setSelected(new Set());
-    setSections([]);
-    setPageError(null);
-    setPagesLoading(true);
+  const crawlPage = (
+    id: string,
+    title: string,
+    icon: string | undefined,
+    signal: AbortSignal,
+    depth: number
+  ) => {
+    if (seenIds.current.has(id)) return;
+    seenIds.current.add(id);
 
-    const controller = new AbortController();
-    abortRef.current = controller;
+    setSections((prev) => [...prev, { id, title, icon, images: [], loading: true, error: null, showAll: false }]);
+
+    fetchBlocks(id, signal).then((result) => {
+      if (signal.aborted) return;
+
+      setSections((prev) =>
+        prev.map((s) =>
+          s.id === id
+            ? { ...s, images: result.images, loading: false, error: result.error }
+            : s
+        )
+      );
+
+      if (result.error == null && depth < MAX_DEPTH) {
+        for (const child of result.childPages) {
+          crawlPage(child.id, child.title, undefined, signal, depth + 1);
+        }
+      }
+    }).catch(() => {
+      if (signal.aborted) return;
+      setSections((prev) =>
+        prev.map((s) =>
+          s.id === id ? { ...s, loading: false, error: { isPermission: false } } : s
+        )
+      );
+    });
+  };
+
+  const startCrawl = (controller: AbortController) => {
+    seenIds.current = new Set();
+    setSections([]);
+    setPagesLoading(true);
+    setPagesError(null);
 
     get2ankiApi()
       .searchTopLevelPages('')
       .then((pages) => {
         if (controller.signal.aborted) return;
         setPagesLoading(false);
-        setSections(pages.map((page) => ({ page, images: [], loading: true, error: null, showAll: false })));
         setTimeout(() => searchRef.current?.focus(), 50);
-
         for (const page of pages) {
-          fetchImages(page.id, controller.signal)
-            .then((images) => {
-              if (controller.signal.aborted) return;
-              setSections((prev) =>
-                prev.map((s) => (s.page.id === page.id ? { ...s, images, loading: false } : s))
-              );
-            })
-            .catch((err: Error & { isPermission?: boolean }) => {
-              if (controller.signal.aborted) return;
-              setSections((prev) =>
-                prev.map((s) =>
-                  s.page.id === page.id
-                    ? { ...s, loading: false, error: { isPermission: err.isPermission === true } }
-                    : s
-                )
-              );
-            });
+          crawlPage(page.id, page.title || 'Untitled page', page.icon, controller.signal, 0);
         }
       })
       .catch((err: Error) => {
         if (controller.signal.aborted) return;
-        setPageError(err.message);
+        setPagesError(err.message);
         setPagesLoading(false);
       });
+  };
 
+  useEffect(() => {
+    if (!isOpen) return;
+    setSearch('');
+    setSelected(new Set());
+    const controller = new AbortController();
+    abortRef.current = controller;
+    startCrawl(controller);
     return () => controller.abort();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   const toggleImage = (blockId: string) => {
@@ -169,11 +213,13 @@ export function NotionImportDrawer({
 
   if (!isOpen) return null;
 
-  const filteredSections = sections
+  const visibleSections = sections
     .filter((s) => s.loading || s.error != null || s.images.length > 0)
     .filter((s) =>
-      search.trim() === '' || s.page.title.toLowerCase().includes(search.toLowerCase())
+      search.trim() === '' || s.title.toLowerCase().includes(search.toLowerCase())
     );
+
+  const stillLoading = pagesLoading || sections.some((s) => s.loading);
 
   const addLabel = selected.size === 0
     ? 'Select images to add'
@@ -189,19 +235,6 @@ export function NotionImportDrawer({
       </div>
 
       <div className={styles.drawerBody}>
-        {!pagesLoading && sections.length > 0 && (
-          <div className={`${sharedStyles.searchBarGroup} ${styles.drawerSearchBar}`}>
-            <input
-              ref={searchRef}
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search pages"
-              aria-label="Search pages"
-            />
-          </div>
-        )}
-
         {pagesError != null && (
           <div className={styles.drawerEmpty}>
             <p>Couldn't reach Notion. Try again in a moment.</p>
@@ -209,15 +242,10 @@ export function NotionImportDrawer({
               type="button"
               className={styles.drawerRetryBtn}
               onClick={() => {
-                setPageError(null);
-                setPagesLoading(true);
-                get2ankiApi()
-                  .searchTopLevelPages('')
-                  .then((pages) => {
-                    setSections(pages.map((p) => ({ page: p, images: [], loading: true, error: null, showAll: false })));
-                    setPagesLoading(false);
-                  })
-                  .catch((err: Error) => { setPageError(err.message); setPagesLoading(false); });
+                abortRef.current?.abort();
+                const controller = new AbortController();
+                abortRef.current = controller;
+                startCrawl(controller);
               }}
             >
               Try again
@@ -225,122 +253,136 @@ export function NotionImportDrawer({
           </div>
         )}
 
-        {pagesLoading && (
-          <div className={styles.gallerySections}>
-            {Array.from({ length: SKELETON_SECTIONS }).map((_, i) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <div key={i} className={styles.gallerySection}>
-                <div className={styles.gallerySectionHeaderSkeleton} aria-hidden="true" />
-                <div className={styles.galleryGrid}>
-                  {Array.from({ length: PREVIEW_COUNT }).map((__, j) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <div key={j} className={styles.gallerySkeletonTile} aria-hidden="true" />
-                  ))}
-                </div>
+        {!pagesLoading && pagesError == null && visibleSections.length === 0 && !stillLoading && (
+          <div className={styles.drawerEmpty}>
+            {search.trim().length > 0 ? (
+              <p>No pages match "<strong>{search}</strong>".</p>
+            ) : (
+              <>
+                <p>No images found in your shared pages.</p>
+                <p>Share a page with images in Notion, then come back here.</p>
+              </>
+            )}
+          </div>
+        )}
+
+        {(visibleSections.length > 0 || stillLoading) && (
+          <>
+            {visibleSections.length > 0 && (
+              <div className={`${sharedStyles.searchBarGroup} ${styles.drawerSearchBar}`}>
+                <input
+                  ref={searchRef}
+                  type="search"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search pages"
+                  aria-label="Search pages"
+                />
               </div>
-            ))}
-          </div>
-        )}
+            )}
 
-        {!pagesLoading && pagesError == null && filteredSections.length === 0 && sections.length === 0 && (
-          <div className={styles.drawerEmpty}>
-            <p>No pages shared with 2anki yet.</p>
-            <p>Share a page in Notion, then come back here.</p>
-          </div>
-        )}
+            {atFreeTierCap && (
+              <p className={styles.drawerFreeTierNote}>
+                Free plan: 3 images already added.{' '}
+                <a href="/pricing" className={styles.drawerUpgradeLink}>Upgrade for unlimited</a>
+              </p>
+            )}
 
-        {!pagesLoading && pagesError == null && filteredSections.length === 0 && sections.length > 0 && (
-          <div className={styles.drawerEmpty}>
-            <p>No pages match "<strong>{search}</strong>".</p>
-          </div>
-        )}
+            <div className={styles.gallerySections}>
+              {visibleSections.map((section) => {
+                const visible = section.showAll
+                  ? section.images
+                  : section.images.slice(0, PREVIEW_COUNT);
+                const hiddenCount = section.images.length - PREVIEW_COUNT;
 
-        {atFreeTierCap && sections.length > 0 && (
-          <p className={styles.drawerFreeTierNote}>
-            Free plan: 3 images already added.{' '}
-            <a href="/pricing" className={styles.drawerUpgradeLink}>Upgrade for unlimited</a>
-          </p>
-        )}
+                return (
+                  <div key={section.id} className={styles.gallerySection}>
+                    <div className={styles.gallerySectionHeader}>
+                      {section.icon != null && (
+                        <span className={styles.gallerySectionIcon}>
+                          <BlockIcon icon={section.icon} />
+                        </span>
+                      )}
+                      <span className={styles.gallerySectionTitle}>
+                        {section.title}
+                      </span>
+                    </div>
 
-        <div className={styles.gallerySections}>
-          {filteredSections.map((section) => {
-            const visible = section.showAll
-              ? section.images
-              : section.images.slice(0, PREVIEW_COUNT);
-            const hiddenCount = section.images.length - PREVIEW_COUNT;
+                    {section.loading && (
+                      <div className={styles.galleryGrid}>
+                        {Array.from({ length: PREVIEW_COUNT }).map((_, i) => (
+                          // eslint-disable-next-line react/no-array-index-key
+                          <div key={i} className={styles.gallerySkeletonTile} aria-hidden="true" />
+                        ))}
+                      </div>
+                    )}
 
-            return (
-              <div key={section.page.id} className={styles.gallerySection}>
-                <div className={styles.gallerySectionHeader}>
-                  <span className={styles.gallerySectionIcon}>
-                    <BlockIcon icon={section.page.icon} />
-                  </span>
-                  <span className={styles.gallerySectionTitle}>
-                    {section.page.title || 'Untitled page'}
-                  </span>
-                </div>
+                    {section.error != null && (
+                      <p className={styles.gallerySectionError}>
+                        {section.error.isPermission
+                          ? 'Not shared with 2anki. Share this page from Notion.'
+                          : "Couldn't load images."}
+                      </p>
+                    )}
 
-                {section.loading && (
+                    {visible.length > 0 && (
+                      <div className={styles.galleryGrid}>
+                        {visible.map((item) => {
+                          const isSelected = selected.has(item.blockId);
+                          const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
+                          return (
+                            <button
+                              key={item.blockId}
+                              type="button"
+                              className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
+                              onClick={() => !atLimit && toggleImage(item.blockId)}
+                              disabled={atLimit && !isSelected}
+                              aria-pressed={isSelected}
+                              title={item.caption || undefined}
+                            >
+                              <img
+                                src={item.imageUrl}
+                                alt={item.caption || 'Notion image'}
+                                className={styles.galleryTileImg}
+                              />
+                              {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {!section.showAll && hiddenCount > 0 && (
+                      <button
+                        type="button"
+                        className={styles.galleryShowMore}
+                        onClick={() =>
+                          setSections((prev) =>
+                            prev.map((s) => (s.id === section.id ? { ...s, showAll: true } : s))
+                          )
+                        }
+                      >
+                        Show {hiddenCount} more {hiddenCount === 1 ? 'image' : 'images'}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+
+              {stillLoading && (
+                <div className={styles.gallerySection} aria-label="Loading more pages">
+                  <div className={styles.gallerySectionHeaderSkeleton} aria-hidden="true" />
                   <div className={styles.galleryGrid}>
                     {Array.from({ length: PREVIEW_COUNT }).map((_, i) => (
                       // eslint-disable-next-line react/no-array-index-key
                       <div key={i} className={styles.gallerySkeletonTile} aria-hidden="true" />
                     ))}
                   </div>
-                )}
-
-                {section.error != null && (
-                  <p className={styles.gallerySectionError}>
-                    {section.error.isPermission
-                      ? 'Not shared with 2anki. Share this page from Notion.'
-                      : "Couldn't load images."}
-                  </p>
-                )}
-
-                {visible.length > 0 && (
-                  <div className={styles.galleryGrid}>
-                    {visible.map((item) => {
-                      const isSelected = selected.has(item.blockId);
-                      const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
-                      return (
-                        <button
-                          key={item.blockId}
-                          type="button"
-                          className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
-                          onClick={() => !atLimit && toggleImage(item.blockId)}
-                          disabled={atLimit && !isSelected}
-                          aria-pressed={isSelected}
-                          title={item.caption || undefined}
-                        >
-                          <img
-                            src={item.imageUrl}
-                            alt={item.caption || 'Notion image'}
-                            className={styles.galleryTileImg}
-                          />
-                          {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-
-                {!section.showAll && hiddenCount > 0 && (
-                  <button
-                    type="button"
-                    className={styles.galleryShowMore}
-                    onClick={() =>
-                      setSections((prev) =>
-                        prev.map((s) => (s.page.id === section.page.id ? { ...s, showAll: true } : s))
-                      )
-                    }
-                  >
-                    Show {hiddenCount} more {hiddenCount === 1 ? 'image' : 'images'}
-                  </button>
-                )}
-              </div>
-            );
-          })}
-        </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
       </div>
 
       <div className={styles.drawerFooter}>

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -62,9 +62,24 @@ function getImageUrl(block: NotionImageBlock): string | null {
   return null;
 }
 
+class NotionPageError extends Error {
+  constructor(
+    message: string,
+    readonly isPermission: boolean
+  ) {
+    super(message);
+  }
+}
+
 async function fetchPageContents(pageId: string, signal: AbortSignal): Promise<PageContents> {
   const res = await fetch(`/api/notion/blocks/${pageId}`, { credentials: 'include', signal });
-  if (!res.ok) throw new Error(`${res.status}`);
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    const isPermission =
+      res.status === 400 &&
+      (body.includes('object_not_found') || body.includes('not_found') || body.includes('shared'));
+    throw new NotionPageError(body || String(res.status), isPermission);
+  }
   const data = (await res.json()) as { results?: NotionBlock[] } | NotionBlock[];
   const blocks = Array.isArray(data) ? data : (data.results ?? []);
 
@@ -102,7 +117,7 @@ export function NotionImportDrawer({
   const [search, setSearch] = useState('');
   const [contents, setContents] = useState<PageContents | null>(null);
   const [contentsLoading, setContentsLoading] = useState(false);
-  const [contentsError, setContentsError] = useState<string | null>(null);
+  const [contentsError, setContentsError] = useState<{ message: string; isPermission: boolean } | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [importing, setImporting] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -159,7 +174,8 @@ export function NotionImportDrawer({
       })
       .catch((err: Error) => {
         if (controller.signal.aborted) return;
-        setContentsError(err.message);
+        const isPermission = err instanceof NotionPageError && err.isPermission;
+        setContentsError({ message: err.message, isPermission });
         setContentsLoading(false);
       });
   };
@@ -184,7 +200,8 @@ export function NotionImportDrawer({
         })
         .catch((err: Error) => {
           if (controller.signal.aborted) return;
-          setContentsError(err.message);
+          const isPermission = err instanceof NotionPageError && err.isPermission;
+          setContentsError({ message: err.message, isPermission });
           setContentsLoading(false);
         });
       return { kind: 'page', stack };
@@ -345,14 +362,30 @@ export function NotionImportDrawer({
 
             {contentsError != null && (
               <div className={styles.drawerEmpty}>
-                <p>Couldn't reach Notion. Try again in a moment.</p>
-                <button
-                  type="button"
-                  className={styles.drawerRetryBtn}
-                  onClick={() => currentPage != null && navigateTo(currentPage)}
-                >
-                  Try again
-                </button>
+                {contentsError.isPermission ? (
+                  <>
+                    <p>This page isn't shared with 2anki.</p>
+                    <p>Open Notion, find the page, and share it with the 2anki integration.</p>
+                    <button
+                      type="button"
+                      className={styles.drawerRetryBtn}
+                      onClick={navigateBack}
+                    >
+                      ← Back to pages
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <p>Couldn't reach Notion. Try again in a moment.</p>
+                    <button
+                      type="button"
+                      className={styles.drawerRetryBtn}
+                      onClick={() => currentPage != null && navigateTo(currentPage)}
+                    >
+                      Try again
+                    </button>
+                  </>
+                )}
               </div>
             )}
 

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -16,13 +16,7 @@ interface NotionImageBlock {
   };
 }
 
-interface NotionChildPageBlock {
-  id: string;
-  type: 'child_page';
-  child_page: { title: string };
-}
-
-type NotionBlock = NotionImageBlock | NotionChildPageBlock | { id: string; type: string };
+type NotionBlock = NotionImageBlock | { id: string; type: string };
 
 interface GalleryItem {
   blockId: string;
@@ -30,20 +24,13 @@ interface GalleryItem {
   caption: string;
 }
 
-interface PageEntry {
-  id: string;
-  title: string;
-  icon?: string;
-}
-
-interface PageContents {
+interface PageSection {
+  page: NotionObject;
   images: GalleryItem[];
-  subPages: PageEntry[];
+  loading: boolean;
+  error: { isPermission: boolean } | null;
+  showAll: boolean;
 }
-
-type DrawerView =
-  | { kind: 'pages' }
-  | { kind: 'page'; stack: PageEntry[] };
 
 interface Props {
   isOpen: boolean;
@@ -54,7 +41,8 @@ interface Props {
 }
 
 const FREE_TIER_LIMIT = 3;
-const SKELETON_COUNT = 6;
+const PREVIEW_COUNT = 6;
+const SKELETON_SECTIONS = 3;
 
 function getImageUrl(block: NotionImageBlock): string | null {
   if (block.image.type === 'file') return block.image.file?.url ?? null;
@@ -62,45 +50,31 @@ function getImageUrl(block: NotionImageBlock): string | null {
   return null;
 }
 
-class NotionPageError extends Error {
-  constructor(
-    message: string,
-    readonly isPermission: boolean
-  ) {
-    super(message);
-  }
-}
-
-async function fetchPageContents(pageId: string, signal: AbortSignal): Promise<PageContents> {
+async function fetchImages(pageId: string, signal: AbortSignal): Promise<GalleryItem[]> {
   const res = await fetch(`/api/notion/blocks/${pageId}`, { credentials: 'include', signal });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     const isPermission =
       res.status === 400 &&
       (body.includes('object_not_found') || body.includes('not_found') || body.includes('shared'));
-    throw new NotionPageError(body || String(res.status), isPermission);
+    const err = new Error(body || String(res.status)) as Error & { isPermission: boolean };
+    err.isPermission = isPermission;
+    throw err;
   }
   const data = (await res.json()) as { results?: NotionBlock[] } | NotionBlock[];
   const blocks = Array.isArray(data) ? data : (data.results ?? []);
-
-  const images: GalleryItem[] = [];
-  const subPages: PageEntry[] = [];
-
+  const items: GalleryItem[] = [];
   for (const block of blocks) {
     if (block.type === 'image') {
       const url = getImageUrl(block as NotionImageBlock);
       if (url != null) {
         const caption =
           (block as NotionImageBlock).image.caption?.map((c) => c.plain_text).join('') ?? '';
-        images.push({ blockId: block.id, imageUrl: url, caption });
+        items.push({ blockId: block.id, imageUrl: url, caption });
       }
-    } else if (block.type === 'child_page') {
-      const title = (block as NotionChildPageBlock).child_page.title || 'Untitled page';
-      subPages.push({ id: block.id, title });
     }
   }
-
-  return { images, subPages };
+  return items;
 }
 
 export function NotionImportDrawer({
@@ -110,14 +84,10 @@ export function NotionImportDrawer({
   isPaying,
   currentCount,
 }: Readonly<Props>) {
-  const [view, setView] = useState<DrawerView>({ kind: 'pages' });
-  const [pages, setPages] = useState<NotionObject[]>([]);
+  const [sections, setSections] = useState<PageSection[]>([]);
   const [pagesLoading, setPagesLoading] = useState(false);
-  const [pagesError, setPagesError] = useState<string | null>(null);
+  const [pagesError, setPageError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
-  const [contents, setContents] = useState<PageContents | null>(null);
-  const [contentsLoading, setContentsLoading] = useState(false);
-  const [contentsError, setContentsError] = useState<{ message: string; isPermission: boolean } | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [importing, setImporting] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -128,85 +98,51 @@ export function NotionImportDrawer({
 
   useEffect(() => {
     if (!isOpen) return;
-    setView({ kind: 'pages' });
     setSearch('');
-    setContents(null);
-    setContentsError(null);
     setSelected(new Set());
+    setSections([]);
+    setPageError(null);
     setPagesLoading(true);
-    setPagesError(null);
+
     const controller = new AbortController();
     abortRef.current = controller;
+
     get2ankiApi()
       .searchTopLevelPages('')
-      .then((data) => {
+      .then((pages) => {
         if (controller.signal.aborted) return;
-        setPages(data);
         setPagesLoading(false);
+        setSections(pages.map((page) => ({ page, images: [], loading: true, error: null, showAll: false })));
         setTimeout(() => searchRef.current?.focus(), 50);
+
+        for (const page of pages) {
+          fetchImages(page.id, controller.signal)
+            .then((images) => {
+              if (controller.signal.aborted) return;
+              setSections((prev) =>
+                prev.map((s) => (s.page.id === page.id ? { ...s, images, loading: false } : s))
+              );
+            })
+            .catch((err: Error & { isPermission?: boolean }) => {
+              if (controller.signal.aborted) return;
+              setSections((prev) =>
+                prev.map((s) =>
+                  s.page.id === page.id
+                    ? { ...s, loading: false, error: { isPermission: err.isPermission === true } }
+                    : s
+                )
+              );
+            });
+        }
       })
       .catch((err: Error) => {
         if (controller.signal.aborted) return;
-        setPagesError(err.message);
+        setPageError(err.message);
         setPagesLoading(false);
       });
+
     return () => controller.abort();
   }, [isOpen]);
-
-  const navigateTo = (entry: PageEntry) => {
-    abortRef.current?.abort();
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    setView((prev) => {
-      const stack = prev.kind === 'page' ? [...prev.stack, entry] : [entry];
-      return { kind: 'page', stack };
-    });
-    setContents(null);
-    setContentsError(null);
-    setContentsLoading(true);
-
-    fetchPageContents(entry.id, controller.signal)
-      .then((data) => {
-        if (controller.signal.aborted) return;
-        setContents(data);
-        setContentsLoading(false);
-      })
-      .catch((err: Error) => {
-        if (controller.signal.aborted) return;
-        const isPermission = err instanceof NotionPageError && err.isPermission;
-        setContentsError({ message: err.message, isPermission });
-        setContentsLoading(false);
-      });
-  };
-
-  const navigateBack = () => {
-    abortRef.current?.abort();
-    setView((prev) => {
-      if (prev.kind !== 'page') return prev;
-      if (prev.stack.length <= 1) return { kind: 'pages' };
-      const stack = prev.stack.slice(0, -1);
-      const parent = stack[stack.length - 1];
-      const controller = new AbortController();
-      abortRef.current = controller;
-      setContents(null);
-      setContentsError(null);
-      setContentsLoading(true);
-      fetchPageContents(parent.id, controller.signal)
-        .then((data) => {
-          if (controller.signal.aborted) return;
-          setContents(data);
-          setContentsLoading(false);
-        })
-        .catch((err: Error) => {
-          if (controller.signal.aborted) return;
-          const isPermission = err instanceof NotionPageError && err.isPermission;
-          setContentsError({ message: err.message, isPermission });
-          setContentsLoading(false);
-        });
-      return { kind: 'page', stack };
-    });
-  };
 
   const toggleImage = (blockId: string) => {
     setSelected((prev) => {
@@ -233,10 +169,9 @@ export function NotionImportDrawer({
 
   if (!isOpen) return null;
 
-  const currentPage = view.kind === 'page' ? view.stack[view.stack.length - 1] : null;
-  const filteredPages = search.trim() === ''
-    ? pages
-    : pages.filter((p) => p.title.toLowerCase().includes(search.toLowerCase()));
+  const filteredSections = search.trim() === ''
+    ? sections
+    : sections.filter((s) => s.page.title.toLowerCase().includes(search.toLowerCase()));
 
   const addLabel = selected.size === 0
     ? 'Select images to add'
@@ -245,213 +180,169 @@ export function NotionImportDrawer({
   return (
     <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Import from Notion">
       <div className={styles.drawerHeader}>
-        {view.kind === 'page' ? (
-          <>
-            <button type="button" className={styles.drawerBackBtn} onClick={navigateBack}>
-              ← Pages
-            </button>
-            <span className={styles.drawerBreadcrumb} title={currentPage?.title ?? ''}>
-              {currentPage?.title ?? 'Untitled page'}
-            </span>
-          </>
-        ) : (
-          <span className={styles.drawerTitle}>Import from Notion</span>
-        )}
+        <span className={styles.drawerTitle}>Import from Notion</span>
         <button type="button" className={styles.drawerCloseBtn} onClick={onClose} aria-label="Close">
           ×
         </button>
       </div>
 
       <div className={styles.drawerBody}>
-        {view.kind === 'pages' && (
-          <>
-            <div className={`${sharedStyles.searchBarGroup} ${styles.drawerSearchBar}`}>
-              <input
-                ref={searchRef}
-                type="search"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder="Search pages"
-                aria-label="Search pages"
-              />
-            </div>
-
-            {pagesLoading && (
-              <ul className={styles.pageList} aria-label="Loading pages">
-                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <li key={i} className={styles.pageRowSkeleton} aria-hidden="true">
-                    <div className={styles.pageRowSkeletonIcon} />
-                    <div className={styles.pageRowSkeletonText} />
-                  </li>
-                ))}
-              </ul>
-            )}
-
-            {pagesError != null && (
-              <div className={styles.drawerEmpty}>
-                <p>Couldn't reach Notion. Try again in a moment.</p>
-                <button
-                  type="button"
-                  className={styles.drawerRetryBtn}
-                  onClick={() => {
-                    setPagesError(null);
-                    setPagesLoading(true);
-                    get2ankiApi()
-                      .searchTopLevelPages('')
-                      .then((data) => { setPages(data); setPagesLoading(false); })
-                      .catch((err: Error) => { setPagesError(err.message); setPagesLoading(false); });
-                  }}
-                >
-                  Try again
-                </button>
-              </div>
-            )}
-
-            {!pagesLoading && pagesError == null && filteredPages.length === 0 && (
-              <div className={styles.drawerEmpty}>
-                {search.trim().length > 0 ? (
-                  <p>No pages match "<strong>{search}</strong>".</p>
-                ) : (
-                  <>
-                    <p>No pages shared with 2anki yet.</p>
-                    <p>Share a page in Notion, then come back here.</p>
-                  </>
-                )}
-              </div>
-            )}
-
-            {!pagesLoading && pagesError == null && filteredPages.length > 0 && (
-              <ul className={styles.pageList}>
-                {filteredPages.map((page) => (
-                  <li key={page.id}>
-                    <button
-                      type="button"
-                      className={styles.pageRow}
-                      onClick={() => navigateTo({ id: page.id, title: page.title || 'Untitled page', icon: page.icon })}
-                    >
-                      <span className={styles.pageRowIcon}>
-                        <BlockIcon icon={page.icon} />
-                      </span>
-                      <span className={styles.pageRowTitle}>{page.title || 'Untitled page'}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </>
+        {!pagesLoading && sections.length > 0 && (
+          <div className={`${sharedStyles.searchBarGroup} ${styles.drawerSearchBar}`}>
+            <input
+              ref={searchRef}
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search pages"
+              aria-label="Search pages"
+            />
+          </div>
         )}
 
-        {view.kind === 'page' && (
-          <>
-            {atFreeTierCap && (
-              <p className={styles.drawerFreeTierNote}>
-                Free plan: 3 images already added.{' '}
-                <a href="/pricing" className={styles.drawerUpgradeLink}>Upgrade for unlimited</a>
-              </p>
-            )}
+        {pagesError != null && (
+          <div className={styles.drawerEmpty}>
+            <p>Couldn't reach Notion. Try again in a moment.</p>
+            <button
+              type="button"
+              className={styles.drawerRetryBtn}
+              onClick={() => {
+                setPageError(null);
+                setPagesLoading(true);
+                get2ankiApi()
+                  .searchTopLevelPages('')
+                  .then((pages) => {
+                    setSections(pages.map((p) => ({ page: p, images: [], loading: true, error: null, showAll: false })));
+                    setPagesLoading(false);
+                  })
+                  .catch((err: Error) => { setPageError(err.message); setPagesLoading(false); });
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        )}
 
-            {contentsLoading && (
-              <div className={styles.galleryGrid}>
-                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <div key={i} className={styles.gallerySkeletonTile} aria-hidden="true" />
-                ))}
+        {pagesLoading && (
+          <div className={styles.gallerySections}>
+            {Array.from({ length: SKELETON_SECTIONS }).map((_, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <div key={i} className={styles.gallerySection}>
+                <div className={styles.gallerySectionHeaderSkeleton} aria-hidden="true" />
+                <div className={styles.galleryGrid}>
+                  {Array.from({ length: PREVIEW_COUNT }).map((__, j) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <div key={j} className={styles.gallerySkeletonTile} aria-hidden="true" />
+                  ))}
+                </div>
               </div>
-            )}
+            ))}
+          </div>
+        )}
 
-            {contentsError != null && (
-              <div className={styles.drawerEmpty}>
-                {contentsError.isPermission ? (
-                  <>
-                    <p>This page isn't shared with 2anki.</p>
-                    <p>Open Notion, find the page, and share it with the 2anki integration.</p>
-                    <button
-                      type="button"
-                      className={styles.drawerRetryBtn}
-                      onClick={navigateBack}
-                    >
-                      ← Back to pages
-                    </button>
-                  </>
-                ) : (
-                  <>
-                    <p>Couldn't reach Notion. Try again in a moment.</p>
-                    <button
-                      type="button"
-                      className={styles.drawerRetryBtn}
-                      onClick={() => currentPage != null && navigateTo(currentPage)}
-                    >
-                      Try again
-                    </button>
-                  </>
+        {!pagesLoading && pagesError == null && filteredSections.length === 0 && sections.length === 0 && (
+          <div className={styles.drawerEmpty}>
+            <p>No pages shared with 2anki yet.</p>
+            <p>Share a page in Notion, then come back here.</p>
+          </div>
+        )}
+
+        {!pagesLoading && pagesError == null && filteredSections.length === 0 && sections.length > 0 && (
+          <div className={styles.drawerEmpty}>
+            <p>No pages match "<strong>{search}</strong>".</p>
+          </div>
+        )}
+
+        {atFreeTierCap && sections.length > 0 && (
+          <p className={styles.drawerFreeTierNote}>
+            Free plan: 3 images already added.{' '}
+            <a href="/pricing" className={styles.drawerUpgradeLink}>Upgrade for unlimited</a>
+          </p>
+        )}
+
+        <div className={styles.gallerySections}>
+          {filteredSections.map((section) => {
+            const visible = section.showAll
+              ? section.images
+              : section.images.slice(0, PREVIEW_COUNT);
+            const hiddenCount = section.images.length - PREVIEW_COUNT;
+
+            return (
+              <div key={section.page.id} className={styles.gallerySection}>
+                <div className={styles.gallerySectionHeader}>
+                  <span className={styles.gallerySectionIcon}>
+                    <BlockIcon icon={section.page.icon} />
+                  </span>
+                  <span className={styles.gallerySectionTitle}>
+                    {section.page.title || 'Untitled page'}
+                  </span>
+                </div>
+
+                {section.loading && (
+                  <div className={styles.galleryGrid}>
+                    {Array.from({ length: PREVIEW_COUNT }).map((_, i) => (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <div key={i} className={styles.gallerySkeletonTile} aria-hidden="true" />
+                    ))}
+                  </div>
                 )}
-              </div>
-            )}
 
-            {!contentsLoading && contentsError == null && contents != null && (
-              <>
-                {contents.subPages.length > 0 && (
-                  <div className={styles.subPageSection}>
-                    <span className={styles.subPageSectionLabel}>Sub-pages</span>
-                    <div className={styles.subPageChips}>
-                      {contents.subPages.map((sp) => (
+                {section.error != null && (
+                  <p className={styles.gallerySectionError}>
+                    {section.error.isPermission
+                      ? 'Not shared with 2anki. Share this page from Notion.'
+                      : "Couldn't load images."}
+                  </p>
+                )}
+
+                {!section.loading && section.error == null && section.images.length === 0 && (
+                  <p className={styles.gallerySectionEmpty}>No images on this page.</p>
+                )}
+
+                {visible.length > 0 && (
+                  <div className={styles.galleryGrid}>
+                    {visible.map((item) => {
+                      const isSelected = selected.has(item.blockId);
+                      const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
+                      return (
                         <button
-                          key={sp.id}
+                          key={item.blockId}
                           type="button"
-                          className={styles.subPageChip}
-                          onClick={() => navigateTo(sp)}
+                          className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
+                          onClick={() => !atLimit && toggleImage(item.blockId)}
+                          disabled={atLimit && !isSelected}
+                          aria-pressed={isSelected}
+                          title={item.caption || undefined}
                         >
-                          {sp.title}
+                          <img
+                            src={item.imageUrl}
+                            alt={item.caption || 'Notion image'}
+                            className={styles.galleryTileImg}
+                          />
+                          {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
                         </button>
-                      ))}
-                    </div>
+                      );
+                    })}
                   </div>
                 )}
 
-                {contents.images.length === 0 && contents.subPages.length === 0 && (
-                  <div className={styles.drawerEmpty}>
-                    <p>No images on this page.</p>
-                  </div>
+                {!section.showAll && hiddenCount > 0 && (
+                  <button
+                    type="button"
+                    className={styles.galleryShowMore}
+                    onClick={() =>
+                      setSections((prev) =>
+                        prev.map((s) => (s.page.id === section.page.id ? { ...s, showAll: true } : s))
+                      )
+                    }
+                  >
+                    Show {hiddenCount} more {hiddenCount === 1 ? 'image' : 'images'}
+                  </button>
                 )}
-
-                {contents.images.length === 0 && contents.subPages.length > 0 && null}
-
-                {contents.images.length > 0 && (
-                  <>
-                    {contents.subPages.length > 0 && (
-                      <span className={styles.subPageSectionLabel}>Images on this page</span>
-                    )}
-                    <div className={styles.galleryGrid}>
-                      {contents.images.map((item) => {
-                        const isSelected = selected.has(item.blockId);
-                        const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
-                        return (
-                          <button
-                            key={item.blockId}
-                            type="button"
-                            className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
-                            onClick={() => !atLimit && toggleImage(item.blockId)}
-                            disabled={atLimit && !isSelected}
-                            aria-pressed={isSelected}
-                            title={item.caption || undefined}
-                          >
-                            <img
-                              src={item.imageUrl}
-                              alt={item.caption || 'Notion image'}
-                              className={styles.galleryTileImg}
-                            />
-                            {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </>
-                )}
-              </>
-            )}
-          </>
-        )}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       <div className={styles.drawerFooter}>

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -110,7 +110,14 @@ async function fetchBlocks(blockId: string, signal: AbortSignal): Promise<FetchR
     }
   }
 
-  return { images, childPages, error: null };
+  const seenBlockIds = new Set<string>();
+  const dedupedImages = images.filter((item) => {
+    if (seenBlockIds.has(item.blockId)) return false;
+    seenBlockIds.add(item.blockId);
+    return true;
+  });
+
+  return { images: dedupedImages, childPages, error: null };
 }
 
 export function NotionImportDrawer({
@@ -128,6 +135,7 @@ export function NotionImportDrawer({
   const [importing, setImporting] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
   const seenIds = useRef<Set<string>>(new Set());
+  const seenImageIds = useRef<Set<string>>(new Set());
   const pendingRef = useRef(0);
   const [anyPending, setAnyPending] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -150,10 +158,16 @@ export function NotionImportDrawer({
     fetchBlocks(id, signal).then((result) => {
       if (signal.aborted) return;
 
-      if (result.images.length > 0 || result.error != null) {
+      const uniqueImages = result.images.filter((item) => {
+        if (seenImageIds.current.has(item.blockId)) return false;
+        seenImageIds.current.add(item.blockId);
+        return true;
+      });
+
+      if (uniqueImages.length > 0 || result.error != null) {
         setSections((prev) => [
           ...prev,
-          { id, title, icon, images: result.images, loading: false, error: result.error, showAll: false },
+          { id, title, icon, images: uniqueImages, loading: false, error: result.error, showAll: false },
         ]);
       }
 
@@ -173,6 +187,7 @@ export function NotionImportDrawer({
 
   const startCrawl = (controller: AbortController) => {
     seenIds.current = new Set();
+    seenImageIds.current = new Set();
     pendingRef.current = 0;
     setSections([]);
     setAnyPending(false);

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -169,9 +169,11 @@ export function NotionImportDrawer({
 
   if (!isOpen) return null;
 
-  const filteredSections = search.trim() === ''
-    ? sections
-    : sections.filter((s) => s.page.title.toLowerCase().includes(search.toLowerCase()));
+  const filteredSections = sections
+    .filter((s) => s.loading || s.error != null || s.images.length > 0)
+    .filter((s) =>
+      search.trim() === '' || s.page.title.toLowerCase().includes(search.toLowerCase())
+    );
 
   const addLabel = selected.size === 0
     ? 'Select images to add'
@@ -293,10 +295,6 @@ export function NotionImportDrawer({
                       ? 'Not shared with 2anki. Share this page from Notion.'
                       : "Couldn't load images."}
                   </p>
-                )}
-
-                {!section.loading && section.error == null && section.images.length === 0 && (
-                  <p className={styles.gallerySectionEmpty}>No images on this page.</p>
                 )}
 
                 {visible.length > 0 && (

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
-import NotionObject from '../../../lib/interfaces/NotionObject';
 import styles from '../ImageOcclusionPage.module.css';
 
 interface NotionBlock {
@@ -14,6 +13,13 @@ interface NotionBlock {
   };
 }
 
+interface GalleryItem {
+  blockId: string;
+  imageUrl: string;
+  caption: string;
+  pageTitle: string;
+}
+
 interface Props {
   isOpen: boolean;
   onClose: () => void;
@@ -23,7 +29,6 @@ interface Props {
 }
 
 const FREE_TIER_LIMIT = 3;
-const DEBOUNCE_MS = 350;
 
 function getBlockImageUrl(block: NotionBlock): string | null {
   if (block.type !== 'image' || block.image == null) return null;
@@ -32,94 +37,78 @@ function getBlockImageUrl(block: NotionBlock): string | null {
   return null;
 }
 
-function getBlockCaption(block: NotionBlock): string {
-  return block.image?.caption?.map((c) => c.plain_text).join('') ?? '';
+async function loadAllImages(signal: AbortSignal): Promise<GalleryItem[]> {
+  const pages = await get2ankiApi().searchTopLevelPages('');
+  if (signal.aborted) return [];
+
+  const pageResults = await Promise.allSettled(
+    pages.map(async (page) => {
+      const res = await fetch(`/api/notion/blocks/${page.id}`, {
+        credentials: 'include',
+        signal,
+      });
+      if (!res.ok) return [];
+      const blocks = (await res.json()) as NotionBlock[];
+      return blocks
+        .filter((b) => b.type === 'image')
+        .map<GalleryItem>((b) => ({
+          blockId: b.id,
+          imageUrl: getBlockImageUrl(b) ?? '',
+          caption: b.image?.caption?.map((c) => c.plain_text).join('') ?? '',
+          pageTitle: page.title,
+        }))
+        .filter((item) => item.imageUrl !== '');
+    })
+  );
+
+  return pageResults.flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
 }
 
-export function NotionImportDrawer({ isOpen, onClose, onImport, isPaying, currentCount }: Readonly<Props>) {
-  const [query, setQuery] = useState('');
-  const [pages, setPages] = useState<NotionObject[]>([]);
-  const [pagesLoading, setPagesLoading] = useState(false);
-  const [pagesError, setPagesError] = useState<string | null>(null);
-
-  const [selectedPage, setSelectedPage] = useState<NotionObject | null>(null);
-  const [blocks, setBlocks] = useState<NotionBlock[]>([]);
-  const [blocksLoading, setBlocksLoading] = useState(false);
-  const [blocksError, setBlocksError] = useState<string | null>(null);
-
+export function NotionImportDrawer({
+  isOpen,
+  onClose,
+  onImport,
+  isPaying,
+  currentCount,
+}: Readonly<Props>) {
+  const [items, setItems] = useState<GalleryItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [importing, setImporting] = useState(false);
 
-  const inputRef = useRef<HTMLInputElement>(null);
-
   const freeSlotsLeft = isPaying ? Infinity : Math.max(0, FREE_TIER_LIMIT - currentCount);
-  const maxSelect = isPaying ? selected.size + 999 : freeSlotsLeft;
-
-  useEffect(() => {
-    if (isOpen) {
-      setQuery('');
-      setPages([]);
-      setPagesError(null);
-      setSelectedPage(null);
-      setBlocks([]);
-      setSelected(new Set());
-      setTimeout(() => inputRef.current?.focus(), 50);
-    }
-  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
-    let cancelled = false;
-    setPagesLoading(true);
-    setPagesError(null);
-    const timer = setTimeout(() => {
-      get2ankiApi()
-        .searchTopLevelPages(query)
-        .then((data) => {
-          if (cancelled) return;
-          setPages(data);
-          setPagesLoading(false);
-        })
-        .catch((err: Error) => {
-          if (cancelled) return;
-          setPagesError(err.message);
-          setPagesLoading(false);
-        });
-    }, DEBOUNCE_MS);
-    return () => {
-      cancelled = true;
-      clearTimeout(timer);
-    };
-  }, [query, isOpen]);
-
-  const handleSelectPage = (page: NotionObject) => {
-    setSelectedPage(page);
-    setBlocks([]);
-    setBlocksError(null);
+    setItems([]);
     setSelected(new Set());
-    setBlocksLoading(true);
-    fetch(`/api/notion/blocks/${page.id}`, { credentials: 'include' })
-      .then((r) => {
-        if (!r.ok) throw new Error(`${r.status}`);
-        return r.json() as Promise<NotionBlock[]>;
-      })
+    setError(null);
+    setLoading(true);
+
+    const controller = new AbortController();
+    loadAllImages(controller.signal)
       .then((data) => {
-        setBlocks(Array.isArray(data) ? data.filter((b) => b.type === 'image') : []);
-        setBlocksLoading(false);
+        if (controller.signal.aborted) return;
+        setItems(data);
+        setLoading(false);
       })
       .catch((err: Error) => {
-        setBlocksError(err.message);
-        setBlocksLoading(false);
+        if (controller.signal.aborted) return;
+        setError(err.message);
+        setLoading(false);
       });
-  };
 
-  const toggleBlock = (id: string) => {
+    return () => controller.abort();
+  }, [isOpen]);
+
+  const toggleItem = (blockId: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else if (next.size < maxSelect) {
-        next.add(id);
+      if (next.has(blockId)) {
+        next.delete(blockId);
+      } else if (isPaying || next.size < freeSlotsLeft) {
+        next.add(blockId);
       }
       return next;
     });
@@ -136,142 +125,111 @@ export function NotionImportDrawer({ isOpen, onClose, onImport, isPaying, curren
     }
   };
 
+  const handleRetry = () => {
+    setError(null);
+    setLoading(true);
+    const controller = new AbortController();
+    loadAllImages(controller.signal)
+      .then((data) => { setItems(data); setLoading(false); })
+      .catch((err: Error) => { setError(err.message); setLoading(false); });
+  };
+
   if (!isOpen) return null;
 
   const addLabel = selected.size === 0
-    ? 'Select images above'
+    ? 'Select images below'
     : `Add ${selected.size} ${selected.size === 1 ? 'image' : 'images'}`;
+
+  const atFreeTierCap = !isPaying && currentCount >= FREE_TIER_LIMIT;
 
   return (
     <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Import from Notion">
       <div className={styles.drawerHeader}>
-        {selectedPage == null ? (
-          <span className={styles.drawerTitle}>Import from Notion</span>
-        ) : (
-          <>
-            <button type="button" className={styles.drawerBackBtn} onClick={() => { setSelectedPage(null); setBlocks([]); setSelected(new Set()); }}>
-              ← Back to pages
-            </button>
-            <span className={styles.drawerPageTitle}>{selectedPage.title}</span>
-          </>
-        )}
-        <button type="button" className={styles.drawerCloseBtn} onClick={onClose} aria-label="Close">×</button>
+        <span className={styles.drawerTitle}>Import from Notion</span>
+        <button type="button" className={styles.drawerCloseBtn} onClick={onClose} aria-label="Close">
+          ×
+        </button>
       </div>
 
       <div className={styles.drawerBody}>
-        {selectedPage == null ? (
-          <div className={styles.drawerPickerView}>
-            <label htmlFor="notion-drawer-search" className={styles.drawerLabel}>
-              Search your Notion pages
-            </label>
-            <input
-              id="notion-drawer-search"
-              ref={inputRef}
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Type a page name"
-              className={styles.drawerSearchInput}
-            />
-            {pagesLoading && <p className={styles.drawerStatus}>Looking up your pages…</p>}
-            {pagesError != null && (
-              <p className={styles.drawerError}>
-                We couldn't reach Notion just now.{' '}
-                <button type="button" className={styles.drawerRetryBtn} onClick={() => setQuery((q) => q)}>
-                  Try again
-                </button>
-              </p>
-            )}
-            {!pagesLoading && pagesError == null && pages.length === 0 && query.trim().length > 0 && (
-              <p className={styles.drawerStatus}>
-                No pages match "{query}". Make sure the page is shared with 2anki.
-              </p>
-            )}
-            <ul className={styles.drawerPageList}>
-              {pages.map((page) => (
-                <li key={page.id}>
-                  <button
-                    type="button"
-                    className={styles.drawerPageItem}
-                    onClick={() => handleSelectPage(page)}
-                  >
-                    <span className={styles.drawerPageTitle}>{page.title}</span>
-                    <span className={styles.drawerOpenLabel}>Open</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
+        {loading && (
+          <div className={styles.galleryGrid}>
+            {Array.from({ length: 9 }).map((_, i) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <div key={i} className={styles.gallerySkeletonTile} aria-hidden="true" />
+            ))}
           </div>
-        ) : (
-          <div className={styles.drawerGalleryView}>
-            {blocksLoading && (
-              <p className={styles.drawerStatus}>Loading images from "{selectedPage.title}"…</p>
-            )}
-            {blocksError != null && (
-              <p className={styles.drawerError}>
-                We couldn't reach Notion just now.{' '}
-                <button type="button" className={styles.drawerRetryBtn} onClick={() => handleSelectPage(selectedPage)}>
-                  Try again
-                </button>
-              </p>
-            )}
-            {!blocksLoading && blocksError == null && blocks.length === 0 && (
-              <div className={styles.drawerEmpty}>
-                <p>No images on this page yet.</p>
-                <p>We only see images that live directly on the page — not links to outside files.</p>
-                <button type="button" className={styles.drawerRetryBtn} onClick={() => { setSelectedPage(null); setBlocks([]); }}>
-                  ← Pick a different page
-                </button>
-              </div>
-            )}
-            {!isPaying && freeSlotsLeft === 0 && (
+        )}
+
+        {error != null && (
+          <div className={styles.drawerEmpty}>
+            <p>We couldn't reach Notion just now.</p>
+            <button type="button" className={styles.drawerRetryBtn} onClick={handleRetry}>
+              Try again
+            </button>
+          </div>
+        )}
+
+        {!loading && error == null && items.length === 0 && (
+          <div className={styles.drawerEmpty}>
+            <p>No images found in your shared pages.</p>
+            <p>Add images directly to a Notion page and share that page with 2anki.</p>
+          </div>
+        )}
+
+        {!loading && error == null && items.length > 0 && (
+          <>
+            {atFreeTierCap && (
               <p className={styles.drawerFreeTierNote}>
                 You're on the free plan — 3 images already added.{' '}
-                <a href="/pricing" className={styles.drawerUpgradeLink}>Upgrade for unlimited</a>
+                <a href="/pricing" className={styles.drawerUpgradeLink}>
+                  Upgrade for unlimited
+                </a>
               </p>
             )}
             <div className={styles.galleryGrid}>
-              {blocks.map((block) => {
-                const imgUrl = getBlockImageUrl(block);
-                if (imgUrl == null) return null;
-                const caption = getBlockCaption(block);
-                const isSelected = selected.has(block.id);
+              {items.map((item) => {
+                const isSelected = selected.has(item.blockId);
                 const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
                 return (
                   <button
-                    key={block.id}
+                    key={item.blockId}
                     type="button"
                     className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
-                    onClick={() => !atLimit && toggleBlock(block.id)}
+                    onClick={() => !atLimit && toggleItem(item.blockId)}
                     disabled={atLimit && !isSelected}
                     aria-pressed={isSelected}
-                    title={caption || undefined}
                   >
-                    <img src={imgUrl} alt={caption || 'Notion image'} className={styles.galleryTileImg} />
+                    <img
+                      src={item.imageUrl}
+                      alt={item.caption || item.pageTitle}
+                      className={styles.galleryTileImg}
+                    />
                     {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
+                    <span className={styles.galleryTileCaption} title={item.pageTitle}>
+                      {item.pageTitle}
+                    </span>
                   </button>
                 );
               })}
             </div>
-          </div>
+          </>
         )}
       </div>
 
-      {selectedPage != null && (
-        <div className={styles.drawerFooter}>
-          <button
-            type="button"
-            className={styles.drawerImportBtn}
-            onClick={handleImport}
-            disabled={selected.size === 0 || importing}
-          >
-            {importing ? 'Importing…' : addLabel}
-          </button>
-          <button type="button" className={styles.drawerCancelBtn} onClick={onClose}>
-            Cancel
-          </button>
-        </div>
-      )}
+      <div className={styles.drawerFooter}>
+        <button
+          type="button"
+          className={styles.drawerImportBtn}
+          onClick={handleImport}
+          disabled={selected.size === 0 || importing || atFreeTierCap}
+        >
+          {importing ? 'Importing…' : addLabel}
+        </button>
+        <button type="button" className={styles.drawerCancelBtn} onClick={onClose}>
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -1,0 +1,277 @@
+import { useEffect, useRef, useState } from 'react';
+import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+import NotionObject from '../../../lib/interfaces/NotionObject';
+import styles from '../ImageOcclusionPage.module.css';
+
+interface NotionBlock {
+  id: string;
+  type: string;
+  image?: {
+    type: 'external' | 'file';
+    external?: { url: string };
+    file?: { url: string };
+    caption?: Array<{ plain_text: string }>;
+  };
+}
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onImport: (blockIds: string[]) => Promise<void>;
+  isPaying: boolean;
+  currentCount: number;
+}
+
+const FREE_TIER_LIMIT = 3;
+const DEBOUNCE_MS = 350;
+
+function getBlockImageUrl(block: NotionBlock): string | null {
+  if (block.type !== 'image' || block.image == null) return null;
+  if (block.image.type === 'file') return block.image.file?.url ?? null;
+  if (block.image.type === 'external') return block.image.external?.url ?? null;
+  return null;
+}
+
+function getBlockCaption(block: NotionBlock): string {
+  return block.image?.caption?.map((c) => c.plain_text).join('') ?? '';
+}
+
+export function NotionImportDrawer({ isOpen, onClose, onImport, isPaying, currentCount }: Readonly<Props>) {
+  const [query, setQuery] = useState('');
+  const [pages, setPages] = useState<NotionObject[]>([]);
+  const [pagesLoading, setPagesLoading] = useState(false);
+  const [pagesError, setPagesError] = useState<string | null>(null);
+
+  const [selectedPage, setSelectedPage] = useState<NotionObject | null>(null);
+  const [blocks, setBlocks] = useState<NotionBlock[]>([]);
+  const [blocksLoading, setBlocksLoading] = useState(false);
+  const [blocksError, setBlocksError] = useState<string | null>(null);
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [importing, setImporting] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const freeSlotsLeft = isPaying ? Infinity : Math.max(0, FREE_TIER_LIMIT - currentCount);
+  const maxSelect = isPaying ? selected.size + 999 : freeSlotsLeft;
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setPages([]);
+      setPagesError(null);
+      setSelectedPage(null);
+      setBlocks([]);
+      setSelected(new Set());
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setPagesLoading(true);
+    setPagesError(null);
+    const timer = setTimeout(() => {
+      get2ankiApi()
+        .searchTopLevelPages(query)
+        .then((data) => {
+          if (cancelled) return;
+          setPages(data);
+          setPagesLoading(false);
+        })
+        .catch((err: Error) => {
+          if (cancelled) return;
+          setPagesError(err.message);
+          setPagesLoading(false);
+        });
+    }, DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [query, isOpen]);
+
+  const handleSelectPage = (page: NotionObject) => {
+    setSelectedPage(page);
+    setBlocks([]);
+    setBlocksError(null);
+    setSelected(new Set());
+    setBlocksLoading(true);
+    fetch(`/api/notion/blocks/${page.id}`, { credentials: 'include' })
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json() as Promise<NotionBlock[]>;
+      })
+      .then((data) => {
+        setBlocks(Array.isArray(data) ? data.filter((b) => b.type === 'image') : []);
+        setBlocksLoading(false);
+      })
+      .catch((err: Error) => {
+        setBlocksError(err.message);
+        setBlocksLoading(false);
+      });
+  };
+
+  const toggleBlock = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else if (next.size < maxSelect) {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleImport = async () => {
+    if (selected.size === 0) return;
+    setImporting(true);
+    try {
+      await onImport(Array.from(selected));
+      onClose();
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const addLabel = selected.size === 0
+    ? 'Select images above'
+    : `Add ${selected.size} ${selected.size === 1 ? 'image' : 'images'}`;
+
+  return (
+    <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Import from Notion">
+      <div className={styles.drawerHeader}>
+        {selectedPage == null ? (
+          <span className={styles.drawerTitle}>Import from Notion</span>
+        ) : (
+          <>
+            <button type="button" className={styles.drawerBackBtn} onClick={() => { setSelectedPage(null); setBlocks([]); setSelected(new Set()); }}>
+              ← Back to pages
+            </button>
+            <span className={styles.drawerPageTitle}>{selectedPage.title}</span>
+          </>
+        )}
+        <button type="button" className={styles.drawerCloseBtn} onClick={onClose} aria-label="Close">×</button>
+      </div>
+
+      <div className={styles.drawerBody}>
+        {selectedPage == null ? (
+          <div className={styles.drawerPickerView}>
+            <label htmlFor="notion-drawer-search" className={styles.drawerLabel}>
+              Search your Notion pages
+            </label>
+            <input
+              id="notion-drawer-search"
+              ref={inputRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Type a page name"
+              className={styles.drawerSearchInput}
+            />
+            {pagesLoading && <p className={styles.drawerStatus}>Looking up your pages…</p>}
+            {pagesError != null && (
+              <p className={styles.drawerError}>
+                We couldn't reach Notion just now.{' '}
+                <button type="button" className={styles.drawerRetryBtn} onClick={() => setQuery((q) => q)}>
+                  Try again
+                </button>
+              </p>
+            )}
+            {!pagesLoading && pagesError == null && pages.length === 0 && query.trim().length > 0 && (
+              <p className={styles.drawerStatus}>
+                No pages match "{query}". Make sure the page is shared with 2anki.
+              </p>
+            )}
+            <ul className={styles.drawerPageList}>
+              {pages.map((page) => (
+                <li key={page.id}>
+                  <button
+                    type="button"
+                    className={styles.drawerPageItem}
+                    onClick={() => handleSelectPage(page)}
+                  >
+                    <span className={styles.drawerPageTitle}>{page.title}</span>
+                    <span className={styles.drawerOpenLabel}>Open</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className={styles.drawerGalleryView}>
+            {blocksLoading && (
+              <p className={styles.drawerStatus}>Loading images from "{selectedPage.title}"…</p>
+            )}
+            {blocksError != null && (
+              <p className={styles.drawerError}>
+                We couldn't reach Notion just now.{' '}
+                <button type="button" className={styles.drawerRetryBtn} onClick={() => handleSelectPage(selectedPage)}>
+                  Try again
+                </button>
+              </p>
+            )}
+            {!blocksLoading && blocksError == null && blocks.length === 0 && (
+              <div className={styles.drawerEmpty}>
+                <p>No images on this page yet.</p>
+                <p>We only see images that live directly on the page — not links to outside files.</p>
+                <button type="button" className={styles.drawerRetryBtn} onClick={() => { setSelectedPage(null); setBlocks([]); }}>
+                  ← Pick a different page
+                </button>
+              </div>
+            )}
+            {!isPaying && freeSlotsLeft === 0 && (
+              <p className={styles.drawerFreeTierNote}>
+                You're on the free plan — 3 images already added.{' '}
+                <a href="/pricing" className={styles.drawerUpgradeLink}>Upgrade for unlimited</a>
+              </p>
+            )}
+            <div className={styles.galleryGrid}>
+              {blocks.map((block) => {
+                const imgUrl = getBlockImageUrl(block);
+                if (imgUrl == null) return null;
+                const caption = getBlockCaption(block);
+                const isSelected = selected.has(block.id);
+                const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
+                return (
+                  <button
+                    key={block.id}
+                    type="button"
+                    className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
+                    onClick={() => !atLimit && toggleBlock(block.id)}
+                    disabled={atLimit && !isSelected}
+                    aria-pressed={isSelected}
+                    title={caption || undefined}
+                  >
+                    <img src={imgUrl} alt={caption || 'Notion image'} className={styles.galleryTileImg} />
+                    {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {selectedPage != null && (
+        <div className={styles.drawerFooter}>
+          <button
+            type="button"
+            className={styles.drawerImportBtn}
+            onClick={handleImport}
+            disabled={selected.size === 0 || importing}
+          >
+            {importing ? 'Importing…' : addLabel}
+          </button>
+          <button type="button" className={styles.drawerCancelBtn} onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -22,7 +22,10 @@ interface NotionChildPageBlock {
   child_page: { title: string };
 }
 
-type NotionBlock = NotionImageBlock | NotionChildPageBlock | { id: string; type: string };
+type NotionBlock =
+  | NotionImageBlock
+  | NotionChildPageBlock
+  | { id: string; type: string; has_children?: boolean };
 
 interface GalleryItem {
   blockId: string;
@@ -63,8 +66,8 @@ interface FetchResult {
   error: { isPermission: boolean } | null;
 }
 
-async function fetchBlocks(pageId: string, signal: AbortSignal): Promise<FetchResult> {
-  const res = await fetch(`/api/notion/blocks/${pageId}`, { credentials: 'include', signal });
+async function fetchBlocks(blockId: string, signal: AbortSignal): Promise<FetchResult> {
+  const res = await fetch(`/api/notion/blocks/${blockId}`, { credentials: 'include', signal });
   if (!res.ok) {
     const body = await res.text().catch(() => '');
     const isPermission =
@@ -77,6 +80,7 @@ async function fetchBlocks(pageId: string, signal: AbortSignal): Promise<FetchRe
 
   const images: GalleryItem[] = [];
   const childPages: Array<{ id: string; title: string }> = [];
+  const containerFetches: Promise<FetchResult>[] = [];
 
   for (const block of blocks) {
     if (block.type === 'image') {
@@ -89,6 +93,20 @@ async function fetchBlocks(pageId: string, signal: AbortSignal): Promise<FetchRe
     } else if (block.type === 'child_page') {
       const title = (block as NotionChildPageBlock).child_page.title || 'Untitled page';
       childPages.push({ id: block.id, title });
+    } else if (
+      block.type !== 'child_database' &&
+      (block as { has_children?: boolean }).has_children === true
+    ) {
+      // toggles, columns, callouts, synced blocks, etc. — recurse to find nested images
+      containerFetches.push(fetchBlocks(block.id, signal));
+    }
+  }
+
+  if (containerFetches.length > 0) {
+    const nested = await Promise.all(containerFetches);
+    for (const r of nested) {
+      images.push(...r.images);
+      childPages.push(...r.childPages);
     }
   }
 

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -48,7 +48,9 @@ async function loadAllImages(signal: AbortSignal): Promise<GalleryItem[]> {
         signal,
       });
       if (!res.ok) return [];
-      const blocks = (await res.json()) as NotionBlock[];
+      // getBlocks returns ListBlockChildrenResponse: { results: Block[], ... }
+      const data = (await res.json()) as { results?: NotionBlock[] } | NotionBlock[];
+      const blocks = Array.isArray(data) ? data : (data.results ?? []);
       return blocks
         .filter((b) => b.type === 'image')
         .map<GalleryItem>((b) => ({

--- a/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/NotionImportDrawer.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+import NotionObject from '../../../lib/interfaces/NotionObject';
+import { BlockIcon } from '../../SearchPage/components/BlockIcon';
+import sharedStyles from '../../../styles/shared.module.css';
 import styles from '../ImageOcclusionPage.module.css';
 
-interface NotionBlock {
+interface NotionImageBlock {
   id: string;
-  type: string;
-  image?: {
+  type: 'image';
+  image: {
     type: 'external' | 'file';
     external?: { url: string };
     file?: { url: string };
@@ -13,12 +16,34 @@ interface NotionBlock {
   };
 }
 
+interface NotionChildPageBlock {
+  id: string;
+  type: 'child_page';
+  child_page: { title: string };
+}
+
+type NotionBlock = NotionImageBlock | NotionChildPageBlock | { id: string; type: string };
+
 interface GalleryItem {
   blockId: string;
   imageUrl: string;
   caption: string;
-  pageTitle: string;
 }
+
+interface PageEntry {
+  id: string;
+  title: string;
+  icon?: string;
+}
+
+interface PageContents {
+  images: GalleryItem[];
+  subPages: PageEntry[];
+}
+
+type DrawerView =
+  | { kind: 'pages' }
+  | { kind: 'page'; stack: PageEntry[] };
 
 interface Props {
   isOpen: boolean;
@@ -29,41 +54,38 @@ interface Props {
 }
 
 const FREE_TIER_LIMIT = 3;
+const SKELETON_COUNT = 6;
 
-function getBlockImageUrl(block: NotionBlock): string | null {
-  if (block.type !== 'image' || block.image == null) return null;
+function getImageUrl(block: NotionImageBlock): string | null {
   if (block.image.type === 'file') return block.image.file?.url ?? null;
   if (block.image.type === 'external') return block.image.external?.url ?? null;
   return null;
 }
 
-async function loadAllImages(signal: AbortSignal): Promise<GalleryItem[]> {
-  const pages = await get2ankiApi().searchTopLevelPages('');
-  if (signal.aborted) return [];
+async function fetchPageContents(pageId: string, signal: AbortSignal): Promise<PageContents> {
+  const res = await fetch(`/api/notion/blocks/${pageId}`, { credentials: 'include', signal });
+  if (!res.ok) throw new Error(`${res.status}`);
+  const data = (await res.json()) as { results?: NotionBlock[] } | NotionBlock[];
+  const blocks = Array.isArray(data) ? data : (data.results ?? []);
 
-  const pageResults = await Promise.allSettled(
-    pages.map(async (page) => {
-      const res = await fetch(`/api/notion/blocks/${page.id}`, {
-        credentials: 'include',
-        signal,
-      });
-      if (!res.ok) return [];
-      // getBlocks returns ListBlockChildrenResponse: { results: Block[], ... }
-      const data = (await res.json()) as { results?: NotionBlock[] } | NotionBlock[];
-      const blocks = Array.isArray(data) ? data : (data.results ?? []);
-      return blocks
-        .filter((b) => b.type === 'image')
-        .map<GalleryItem>((b) => ({
-          blockId: b.id,
-          imageUrl: getBlockImageUrl(b) ?? '',
-          caption: b.image?.caption?.map((c) => c.plain_text).join('') ?? '',
-          pageTitle: page.title,
-        }))
-        .filter((item) => item.imageUrl !== '');
-    })
-  );
+  const images: GalleryItem[] = [];
+  const subPages: PageEntry[] = [];
 
-  return pageResults.flatMap((r) => (r.status === 'fulfilled' ? r.value : []));
+  for (const block of blocks) {
+    if (block.type === 'image') {
+      const url = getImageUrl(block as NotionImageBlock);
+      if (url != null) {
+        const caption =
+          (block as NotionImageBlock).image.caption?.map((c) => c.plain_text).join('') ?? '';
+        images.push({ blockId: block.id, imageUrl: url, caption });
+      }
+    } else if (block.type === 'child_page') {
+      const title = (block as NotionChildPageBlock).child_page.title || 'Untitled page';
+      subPages.push({ id: block.id, title });
+    }
+  }
+
+  return { images, subPages };
 }
 
 export function NotionImportDrawer({
@@ -73,38 +95,103 @@ export function NotionImportDrawer({
   isPaying,
   currentCount,
 }: Readonly<Props>) {
-  const [items, setItems] = useState<GalleryItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [view, setView] = useState<DrawerView>({ kind: 'pages' });
+  const [pages, setPages] = useState<NotionObject[]>([]);
+  const [pagesLoading, setPagesLoading] = useState(false);
+  const [pagesError, setPagesError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [contents, setContents] = useState<PageContents | null>(null);
+  const [contentsLoading, setContentsLoading] = useState(false);
+  const [contentsError, setContentsError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [importing, setImporting] = useState(false);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const freeSlotsLeft = isPaying ? Infinity : Math.max(0, FREE_TIER_LIMIT - currentCount);
+  const atFreeTierCap = !isPaying && currentCount >= FREE_TIER_LIMIT;
 
   useEffect(() => {
     if (!isOpen) return;
-    setItems([]);
+    setView({ kind: 'pages' });
+    setSearch('');
+    setContents(null);
+    setContentsError(null);
     setSelected(new Set());
-    setError(null);
-    setLoading(true);
-
+    setPagesLoading(true);
+    setPagesError(null);
     const controller = new AbortController();
-    loadAllImages(controller.signal)
+    abortRef.current = controller;
+    get2ankiApi()
+      .searchTopLevelPages('')
       .then((data) => {
         if (controller.signal.aborted) return;
-        setItems(data);
-        setLoading(false);
+        setPages(data);
+        setPagesLoading(false);
+        setTimeout(() => searchRef.current?.focus(), 50);
       })
       .catch((err: Error) => {
         if (controller.signal.aborted) return;
-        setError(err.message);
-        setLoading(false);
+        setPagesError(err.message);
+        setPagesLoading(false);
       });
-
     return () => controller.abort();
   }, [isOpen]);
 
-  const toggleItem = (blockId: string) => {
+  const navigateTo = (entry: PageEntry) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setView((prev) => {
+      const stack = prev.kind === 'page' ? [...prev.stack, entry] : [entry];
+      return { kind: 'page', stack };
+    });
+    setContents(null);
+    setContentsError(null);
+    setContentsLoading(true);
+
+    fetchPageContents(entry.id, controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setContents(data);
+        setContentsLoading(false);
+      })
+      .catch((err: Error) => {
+        if (controller.signal.aborted) return;
+        setContentsError(err.message);
+        setContentsLoading(false);
+      });
+  };
+
+  const navigateBack = () => {
+    abortRef.current?.abort();
+    setView((prev) => {
+      if (prev.kind !== 'page') return prev;
+      if (prev.stack.length <= 1) return { kind: 'pages' };
+      const stack = prev.stack.slice(0, -1);
+      const parent = stack[stack.length - 1];
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setContents(null);
+      setContentsError(null);
+      setContentsLoading(true);
+      fetchPageContents(parent.id, controller.signal)
+        .then((data) => {
+          if (controller.signal.aborted) return;
+          setContents(data);
+          setContentsLoading(false);
+        })
+        .catch((err: Error) => {
+          if (controller.signal.aborted) return;
+          setContentsError(err.message);
+          setContentsLoading(false);
+        });
+      return { kind: 'page', stack };
+    });
+  };
+
+  const toggleImage = (blockId: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(blockId)) {
@@ -127,94 +214,209 @@ export function NotionImportDrawer({
     }
   };
 
-  const handleRetry = () => {
-    setError(null);
-    setLoading(true);
-    const controller = new AbortController();
-    loadAllImages(controller.signal)
-      .then((data) => { setItems(data); setLoading(false); })
-      .catch((err: Error) => { setError(err.message); setLoading(false); });
-  };
-
   if (!isOpen) return null;
 
-  const addLabel = selected.size === 0
-    ? 'Select images below'
-    : `Add ${selected.size} ${selected.size === 1 ? 'image' : 'images'}`;
+  const currentPage = view.kind === 'page' ? view.stack[view.stack.length - 1] : null;
+  const filteredPages = search.trim() === ''
+    ? pages
+    : pages.filter((p) => p.title.toLowerCase().includes(search.toLowerCase()));
 
-  const atFreeTierCap = !isPaying && currentCount >= FREE_TIER_LIMIT;
+  const addLabel = selected.size === 0
+    ? 'Select images to add'
+    : `Add ${selected.size} ${selected.size === 1 ? 'image' : 'images'}`;
 
   return (
     <div className={styles.drawer} role="dialog" aria-modal="true" aria-label="Import from Notion">
       <div className={styles.drawerHeader}>
-        <span className={styles.drawerTitle}>Import from Notion</span>
+        {view.kind === 'page' ? (
+          <>
+            <button type="button" className={styles.drawerBackBtn} onClick={navigateBack}>
+              ← Pages
+            </button>
+            <span className={styles.drawerBreadcrumb} title={currentPage?.title ?? ''}>
+              {currentPage?.title ?? 'Untitled page'}
+            </span>
+          </>
+        ) : (
+          <span className={styles.drawerTitle}>Import from Notion</span>
+        )}
         <button type="button" className={styles.drawerCloseBtn} onClick={onClose} aria-label="Close">
           ×
         </button>
       </div>
 
       <div className={styles.drawerBody}>
-        {loading && (
-          <div className={styles.galleryGrid}>
-            {Array.from({ length: 9 }).map((_, i) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <div key={i} className={styles.gallerySkeletonTile} aria-hidden="true" />
-            ))}
-          </div>
+        {view.kind === 'pages' && (
+          <>
+            <div className={`${sharedStyles.searchBarGroup} ${styles.drawerSearchBar}`}>
+              <input
+                ref={searchRef}
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search pages"
+                aria-label="Search pages"
+              />
+            </div>
+
+            {pagesLoading && (
+              <ul className={styles.pageList} aria-label="Loading pages">
+                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <li key={i} className={styles.pageRowSkeleton} aria-hidden="true">
+                    <div className={styles.pageRowSkeletonIcon} />
+                    <div className={styles.pageRowSkeletonText} />
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {pagesError != null && (
+              <div className={styles.drawerEmpty}>
+                <p>Couldn't reach Notion. Try again in a moment.</p>
+                <button
+                  type="button"
+                  className={styles.drawerRetryBtn}
+                  onClick={() => {
+                    setPagesError(null);
+                    setPagesLoading(true);
+                    get2ankiApi()
+                      .searchTopLevelPages('')
+                      .then((data) => { setPages(data); setPagesLoading(false); })
+                      .catch((err: Error) => { setPagesError(err.message); setPagesLoading(false); });
+                  }}
+                >
+                  Try again
+                </button>
+              </div>
+            )}
+
+            {!pagesLoading && pagesError == null && filteredPages.length === 0 && (
+              <div className={styles.drawerEmpty}>
+                {search.trim().length > 0 ? (
+                  <p>No pages match "<strong>{search}</strong>".</p>
+                ) : (
+                  <>
+                    <p>No pages shared with 2anki yet.</p>
+                    <p>Share a page in Notion, then come back here.</p>
+                  </>
+                )}
+              </div>
+            )}
+
+            {!pagesLoading && pagesError == null && filteredPages.length > 0 && (
+              <ul className={styles.pageList}>
+                {filteredPages.map((page) => (
+                  <li key={page.id}>
+                    <button
+                      type="button"
+                      className={styles.pageRow}
+                      onClick={() => navigateTo({ id: page.id, title: page.title || 'Untitled page', icon: page.icon })}
+                    >
+                      <span className={styles.pageRowIcon}>
+                        <BlockIcon icon={page.icon} />
+                      </span>
+                      <span className={styles.pageRowTitle}>{page.title || 'Untitled page'}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
         )}
 
-        {error != null && (
-          <div className={styles.drawerEmpty}>
-            <p>We couldn't reach Notion just now.</p>
-            <button type="button" className={styles.drawerRetryBtn} onClick={handleRetry}>
-              Try again
-            </button>
-          </div>
-        )}
-
-        {!loading && error == null && items.length === 0 && (
-          <div className={styles.drawerEmpty}>
-            <p>No images found in your shared pages.</p>
-            <p>Add images directly to a Notion page and share that page with 2anki.</p>
-          </div>
-        )}
-
-        {!loading && error == null && items.length > 0 && (
+        {view.kind === 'page' && (
           <>
             {atFreeTierCap && (
               <p className={styles.drawerFreeTierNote}>
-                You're on the free plan — 3 images already added.{' '}
-                <a href="/pricing" className={styles.drawerUpgradeLink}>
-                  Upgrade for unlimited
-                </a>
+                Free plan: 3 images already added.{' '}
+                <a href="/pricing" className={styles.drawerUpgradeLink}>Upgrade for unlimited</a>
               </p>
             )}
-            <div className={styles.galleryGrid}>
-              {items.map((item) => {
-                const isSelected = selected.has(item.blockId);
-                const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
-                return (
-                  <button
-                    key={item.blockId}
-                    type="button"
-                    className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
-                    onClick={() => !atLimit && toggleItem(item.blockId)}
-                    disabled={atLimit && !isSelected}
-                    aria-pressed={isSelected}
-                  >
-                    <img
-                      src={item.imageUrl}
-                      alt={item.caption || item.pageTitle}
-                      className={styles.galleryTileImg}
-                    />
-                    {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
-                    <span className={styles.galleryTileCaption} title={item.pageTitle}>
-                      {item.pageTitle}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
+
+            {contentsLoading && (
+              <div className={styles.galleryGrid}>
+                {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <div key={i} className={styles.gallerySkeletonTile} aria-hidden="true" />
+                ))}
+              </div>
+            )}
+
+            {contentsError != null && (
+              <div className={styles.drawerEmpty}>
+                <p>Couldn't reach Notion. Try again in a moment.</p>
+                <button
+                  type="button"
+                  className={styles.drawerRetryBtn}
+                  onClick={() => currentPage != null && navigateTo(currentPage)}
+                >
+                  Try again
+                </button>
+              </div>
+            )}
+
+            {!contentsLoading && contentsError == null && contents != null && (
+              <>
+                {contents.subPages.length > 0 && (
+                  <div className={styles.subPageSection}>
+                    <span className={styles.subPageSectionLabel}>Sub-pages</span>
+                    <div className={styles.subPageChips}>
+                      {contents.subPages.map((sp) => (
+                        <button
+                          key={sp.id}
+                          type="button"
+                          className={styles.subPageChip}
+                          onClick={() => navigateTo(sp)}
+                        >
+                          {sp.title}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {contents.images.length === 0 && contents.subPages.length === 0 && (
+                  <div className={styles.drawerEmpty}>
+                    <p>No images on this page.</p>
+                  </div>
+                )}
+
+                {contents.images.length === 0 && contents.subPages.length > 0 && null}
+
+                {contents.images.length > 0 && (
+                  <>
+                    {contents.subPages.length > 0 && (
+                      <span className={styles.subPageSectionLabel}>Images on this page</span>
+                    )}
+                    <div className={styles.galleryGrid}>
+                      {contents.images.map((item) => {
+                        const isSelected = selected.has(item.blockId);
+                        const atLimit = !isPaying && !isSelected && selected.size >= freeSlotsLeft;
+                        return (
+                          <button
+                            key={item.blockId}
+                            type="button"
+                            className={`${styles.galleryTile} ${isSelected ? styles.galleryTileSelected : ''}`}
+                            onClick={() => !atLimit && toggleImage(item.blockId)}
+                            disabled={atLimit && !isSelected}
+                            aria-pressed={isSelected}
+                            title={item.caption || undefined}
+                          >
+                            <img
+                              src={item.imageUrl}
+                              alt={item.caption || 'Notion image'}
+                              className={styles.galleryTileImg}
+                            />
+                            {isSelected && <span className={styles.galleryCheckBadge}>✓</span>}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </>
+                )}
+              </>
+            )}
           </>
         )}
       </div>


### PR DESCRIPTION
## What this does

Implements the spec from `Documentation/specs/notion-image-import-occlusion.md` end-to-end.

## Changes

**Server**
- `POST /api/image-occlusion/draft/notion-image` — accepts `{ blockIds: string[] }`, resolves each Notion image block server-side, downloads via `instrumentedAxios` (SSRF-safe), validates Content-Type + 10 MB cap, uploads to app S3, returns `[{ s3Key, presignedUrl }]` — same shape as local upload
- `ImportNotionImagesUseCase` — 6 unit tests: happy path, null token → 401, invalid UUID → 400, bad MIME skip, over-size skip, non-image block skip
- `IoDraftController.importFromNotion` validates request body and delegates; maps use-case status errors to HTTP codes
- `ImageOcclusionRouter` wires the new route with `RequireAuthentication` + `express.json()`

**Frontend**
- `NotionImportDrawer` — right-side 480 px drawer (full-screen mobile), debounced page search (350 ms via `searchTopLevelPages`), image gallery (`GET /api/notion/blocks/:id`, client-filters `type=image`), multi-select with free-tier slot cap, "Add N images" footer CTA
- `ImageQueue` — adds "+ Import from Notion" button (visible only when `isNotionConnected`); renamed "+ Add images" → "+ Upload images"
- `ImageOcclusionPage` — fetches Notion connection on mount, wires drawer open/close, `handleAddFromNotion` inserts spinner placeholders then resolves to real entries on server response

## Security
- `blockIds` validated as Notion UUIDs before SDK calls
- Notion file URLs consumed server-side only via `instrumentedAxios` — never proxied to client
- Content-Type validated against allowlist before S3 write
- 10 MB download cap enforced via `maxContentLength`
- Notion token not logged or returned in any response

## Pre-build spike note
The spec calls for verifying that `instrumentedAxios.get('notion', notionFileUrl)` succeeds from the prod box before merging. `notion` service in `instrumentedAxios` has `null` allowlist (any public HTTPS host allowed), so the download will succeed as long as the presigned S3 URL is still valid when the request hits the server. Recommend testing manually on prod before marking live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)