### PR TITLE
fix: include NOTION_REDIRECT_URI in Notion login auth URL

### DIFF
--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -631,7 +631,8 @@ const UserRouter = () => {
    */
   router.get('/api/users/auth/notion/init', (req, res) => {
     const clientId = process.env.NOTION_CLIENT_ID;
-    if (!clientId) {
+    const redirectUri = process.env.NOTION_REDIRECT_URI;
+    if (!clientId || !redirectUri) {
       return res.redirect('/login?error=notion_cancelled');
     }
     const nonce = crypto.randomBytes(16).toString('hex');
@@ -641,7 +642,7 @@ const UserRouter = () => {
       maxAge: 300_000,
     });
     const state = `login:${nonce}`;
-    const url = `https://api.notion.com/v1/oauth/authorize?owner=user&client_id=${clientId}&response_type=code&state=${encodeURIComponent(state)}`;
+    const url = `https://api.notion.com/v1/oauth/authorize?owner=user&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&state=${encodeURIComponent(state)}`;
     return res.redirect(url);
   });
 


### PR DESCRIPTION
## Problem

Notion requires `redirect_uri` in the authorization URL when one is configured in the integration settings. The current prod code omits it, causing Notion to return "Missing or invalid redirect_uri" when users click "Continue with Notion".

## Fix

Reuse the existing `NOTION_REDIRECT_URI` env var (already registered in the Notion integration) in the login init URL. The callback still lands at `/api/notion/connect`, which the `state=login:nonce` handler forwards to `/api/users/auth/notion`.

No Notion dashboard changes needed — same registered URI, same flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)