### PR TITLE
fix: pass redirect_uri to Notion token exchange

### DIFF
--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -631,7 +631,8 @@ const UserRouter = () => {
    */
   router.get('/api/users/auth/notion/init', (req, res) => {
     const clientId = process.env.NOTION_CLIENT_ID;
-    if (!clientId) {
+    const redirectUri = process.env.NOTION_REDIRECT_URI;
+    if (!clientId || !redirectUri) {
       return res.redirect('/login?error=notion_cancelled');
     }
     const nonce = crypto.randomBytes(16).toString('hex');
@@ -641,7 +642,7 @@ const UserRouter = () => {
       maxAge: 300_000,
     });
     const state = `login:${nonce}`;
-    const url = `https://api.notion.com/v1/oauth/authorize?owner=user&client_id=${clientId}&response_type=code&state=${encodeURIComponent(state)}`;
+    const url = `https://api.notion.com/v1/oauth/authorize?owner=user&client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&state=${encodeURIComponent(state)}`;
     return res.redirect(url);
   });
 

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -13,6 +13,7 @@ beforeAll(() => {
   process.env.SECRET = SECRET;
   process.env.NOTION_CLIENT_ID = 'test-client-id';
   process.env.NOTION_CLIENT_SECRET = 'test-client-secret';
+  process.env.NOTION_REDIRECT_URI = 'http://localhost:2020/api/notion/connect';
 });
 
 const mockedAxios = instrumentedAxios as jest.Mocked<typeof instrumentedAxios>;

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -168,13 +168,14 @@ class AuthenticationService {
   } | null> {
     const clientId = process.env.NOTION_CLIENT_ID;
     const clientSecret = process.env.NOTION_CLIENT_SECRET;
-    if (!clientId || !clientSecret) return null;
+    const redirectUri = process.env.NOTION_REDIRECT_URI;
+    if (!clientId || !clientSecret || !redirectUri) return null;
 
     try {
       const result = await instrumentedAxios.post<{ [key: string]: unknown }>(
         'notion',
         'https://api.notion.com/v1/oauth/token',
-        { grant_type: 'authorization_code', code },
+        { grant_type: 'authorization_code', code, redirect_uri: redirectUri },
         {
           auth: { username: clientId, password: clientSecret },
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Problem

When `redirect_uri` is included in the Notion OAuth authorization URL, Notion also requires it in the token exchange call. The previous fix added it to the auth URL but not to the `POST /oauth/token` request, so the code exchange silently failed and users were redirected to `/login?error=notion_cancelled`.

## Fix

Add `redirect_uri: process.env.NOTION_REDIRECT_URI` to the token exchange body in `AuthenticationService.loginWithNotion`. Also gates on `NOTION_REDIRECT_URI` being set (returns `null` early if missing).

## Test

Updated `AuthenticationService.test.ts` to set `NOTION_REDIRECT_URI` in `beforeAll` — 19/19 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)