### PR TITLE
feat: add Claude-powered study assistant Chat feature

### DIFF
--- a/migrations/20260514152059_chat_messages.js
+++ b/migrations/20260514152059_chat_messages.js
@@ -1,0 +1,12 @@
+exports.up = (knex) =>
+  knex.schema.createTable('chat_messages', (t) => {
+    t.increments('id').primary();
+    t.integer('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    t.varchar('role', 16).notNullable();
+    t.text('content').notNullable();
+    t.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    t.index(['user_id', 'created_at']);
+  });
+
+exports.down = (knex) =>
+  knex.schema.dropTable('chat_messages');

--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from 'express';
+import ChatController from './ChatController';
+import { ChatRateLimitError } from '../usecases/chat/ChatUseCase';
+
+function buildMocks(owner = 42, patreon = false) {
+  const execute = jest.fn();
+  const controller = new ChatController({ execute } as never);
+  const res = buildRes(owner, patreon);
+  return { execute, controller, res };
+}
+
+function buildRes(owner = 42, patreon = false): Response {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    locals: { owner, patreon },
+  } as unknown as Response;
+}
+
+function buildReq(body: unknown): Request {
+  return { body } as unknown as Request;
+}
+
+describe('ChatController.sendMessage', () => {
+  it('returns 400 when content is missing', async () => {
+    const { controller, res } = buildMocks();
+    await controller.sendMessage(buildReq({}), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when content is empty string', async () => {
+    const { controller, res } = buildMocks();
+    await controller.sendMessage(buildReq({ content: '' }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when content exceeds 4000 chars', async () => {
+    const { controller, res } = buildMocks();
+    await controller.sendMessage(buildReq({ content: 'x'.repeat(4001) }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 429 when ChatRateLimitError is thrown', async () => {
+    const { execute, controller, res } = buildMocks();
+    const resetDate = '2026-06-01T00:00:00.000Z';
+    execute.mockRejectedValueOnce(new ChatRateLimitError(resetDate));
+    await controller.sendMessage(buildReq({ content: 'Hello' }), res);
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Message limit reached', resetDate })
+    );
+  });
+
+  it('returns assistant message on happy path', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'Nice answer', cards: undefined });
+    await controller.sendMessage(buildReq({ content: 'Tell me about mitosis' }), res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'assistant', content: 'Nice answer' })
+    );
+  });
+
+  it('includes cards in response when use case returns them', async () => {
+    const { execute, controller, res } = buildMocks();
+    const cards = [{ front: 'Q', back: 'A' }];
+    execute.mockResolvedValueOnce({ content: 'Here are cards', cards });
+    await controller.sendMessage(buildReq({ content: 'Make flashcards' }), res);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ cards })
+    );
+  });
+});

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -1,0 +1,60 @@
+import { Request, Response } from 'express';
+import { ChatUseCase, ChatRateLimitError } from '../usecases/chat/ChatUseCase';
+
+const MAX_CONTENT_LENGTH = 4000;
+
+class ChatController {
+  constructor(private readonly chatUseCase: ChatUseCase) {}
+
+  async sendMessage(req: Request, res: Response) {
+    const rawContent = req.body?.content;
+    const content = typeof rawContent === 'string' ? rawContent.trim() : '';
+
+    if (content.length === 0) {
+      res.status(400).json({ error: 'content is required' });
+      return;
+    }
+
+    if (content.length > MAX_CONTENT_LENGTH) {
+      res.status(400).json({ error: `content must be ${MAX_CONTENT_LENGTH} characters or fewer` });
+      return;
+    }
+
+    const owner = res.locals.owner as number;
+    const patreon = (res.locals.patreon as boolean) ?? false;
+
+    const rawHistory = Array.isArray(req.body?.history) ? req.body.history : [];
+    const conversationHistory = rawHistory
+      .filter(
+        (m: unknown): m is { role: 'user' | 'assistant'; content: string } =>
+          m != null &&
+          typeof m === 'object' &&
+          ((m as Record<string, unknown>).role === 'user' ||
+            (m as Record<string, unknown>).role === 'assistant') &&
+          typeof (m as Record<string, unknown>).content === 'string'
+      )
+      .map((m: { role: 'user' | 'assistant'; content: string }) => ({ role: m.role, content: m.content }));
+
+    try {
+      const result = await this.chatUseCase.execute({
+        user: { owner, patreon },
+        content,
+        conversationHistory,
+      });
+
+      res.status(200).json({
+        role: 'assistant',
+        content: result.content,
+        ...(result.cards != null ? { cards: result.cards } : {}),
+      });
+    } catch (err) {
+      if (err instanceof ChatRateLimitError) {
+        res.status(429).json({ error: 'Message limit reached', resetDate: err.resetDate });
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+export default ChatController;

--- a/src/data_layer/ChatMessagesRepository.ts
+++ b/src/data_layer/ChatMessagesRepository.ts
@@ -1,0 +1,77 @@
+import type { Knex } from 'knex';
+
+export interface ChatMessageRow {
+  id: number;
+  user_id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: Date;
+}
+
+export interface IChatMessagesRepository {
+  insert(entry: { userId: number; role: 'user' | 'assistant'; content: string }): Promise<void>;
+  countThisMonth(userId: number): Promise<number>;
+}
+
+export class ChatMessagesRepository implements IChatMessagesRepository {
+  private readonly table = 'chat_messages';
+
+  constructor(private readonly database: Knex) {}
+
+  async insert(entry: { userId: number; role: 'user' | 'assistant'; content: string }): Promise<void> {
+    await this.database(this.table).insert({
+      user_id: entry.userId,
+      role: entry.role,
+      content: entry.content,
+    });
+  }
+
+  async countThisMonth(userId: number): Promise<number> {
+    const firstOfMonth = new Date();
+    firstOfMonth.setUTCDate(1);
+    firstOfMonth.setUTCHours(0, 0, 0, 0);
+
+    const result = await this.database(this.table)
+      .where('user_id', userId)
+      .where('created_at', '>=', firstOfMonth)
+      .count<{ count: string }>('* as count')
+      .first();
+
+    return Number(result?.count ?? 0);
+  }
+}
+
+export class InMemoryChatMessagesRepository implements IChatMessagesRepository {
+  private readonly rows: Array<{
+    id: number;
+    user_id: number;
+    role: 'user' | 'assistant';
+    content: string;
+    created_at: Date;
+  }> = [];
+  private nextId = 1;
+
+  async insert(entry: { userId: number; role: 'user' | 'assistant'; content: string }): Promise<void> {
+    this.rows.push({
+      id: this.nextId++,
+      user_id: entry.userId,
+      role: entry.role,
+      content: entry.content,
+      created_at: new Date(),
+    });
+  }
+
+  async countThisMonth(userId: number): Promise<number> {
+    const firstOfMonth = new Date();
+    firstOfMonth.setUTCDate(1);
+    firstOfMonth.setUTCHours(0, 0, 0, 0);
+
+    return this.rows.filter(
+      (r) => r.user_id === userId && r.created_at >= firstOfMonth
+    ).length;
+  }
+
+  getAll(): typeof this.rows {
+    return this.rows;
+  }
+}

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import ChatController from '../controllers/ChatController';
+import { ChatUseCase } from '../usecases/chat/ChatUseCase';
+import { ChatMessagesRepository } from '../data_layer/ChatMessagesRepository';
+import { getDatabase } from '../data_layer';
+import { getAnthropicClient } from '../lib/claude/ClaudeService';
+import RequireAuthentication from './middleware/RequireAuthentication';
+
+const ChatRouter = () => {
+  const router = express.Router();
+  const db = getDatabase();
+  const repo = new ChatMessagesRepository(db);
+  const anthropic = getAnthropicClient();
+  const useCase = new ChatUseCase(repo, anthropic);
+  const controller = new ChatController(useCase);
+
+  router.post('/api/chat/message', RequireAuthentication, (req, res) =>
+    controller.sendMessage(req, res)
+  );
+
+  return router;
+};
+
+export default ChatRouter;

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -14,6 +14,44 @@ const ChatRouter = () => {
   const useCase = new ChatUseCase(repo, anthropic);
   const controller = new ChatController(useCase);
 
+  /**
+   * @swagger
+   * /api/chat/message:
+   *   post:
+   *     summary: Send a message to the study assistant
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [content]
+   *             properties:
+   *               content:
+   *                 type: string
+   *                 maxLength: 4000
+   *               history:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   required: [role, content]
+   *                   properties:
+   *                     role:
+   *                       type: string
+   *                       enum: [user, assistant]
+   *                     content:
+   *                       type: string
+   *     responses:
+   *       200:
+   *         description: Assistant reply
+   *       400:
+   *         description: Invalid content
+   *       429:
+   *         description: Monthly message limit reached
+   */
   router.post('/api/chat/message', RequireAuthentication, (req, res) =>
     controller.sendMessage(req, res)
   );

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,7 @@ import showcaseRouter from './routes/ShowcaseRouter';
 import emojiFeedbackRouter from './routes/EmojiFeedbackRouter';
 import reEngagementRouter from './routes/ReEngagementRouter';
 import imageOcclusionRouter from './routes/ImageOcclusionRouter';
+import chatRouter from './routes/ChatRouter';
 import requestLoggingMiddleware from './routes/middleware/requestLoggingMiddleware';
 
 import { getDatabase, setupDatabase } from './data_layer';
@@ -123,6 +124,7 @@ const serve = async () => {
   app.use(emojiFeedbackRouter());
   app.use(reEngagementRouter());
   app.use(imageOcclusionRouter());
+  app.use(chatRouter());
 
   app.use(rejectScannerProbes);
   // Note: this has to be the last router

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -1,0 +1,179 @@
+import { ChatUseCase, ChatRateLimitError } from './ChatUseCase';
+import { InMemoryChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
+
+const FREE_USER = { owner: 1, patreon: false } as const;
+const PATREON_USER = { owner: 2, patreon: true } as const;
+
+function buildAnthropicMock(responseContent: string) {
+  return {
+    messages: {
+      create: jest.fn().mockResolvedValue({
+        content: [{ type: 'text', text: responseContent }],
+      }),
+    },
+  };
+}
+
+describe('ChatUseCase', () => {
+  describe('message counting and rate limiting', () => {
+    it('throws ChatRateLimitError when free user has used 20 messages this month', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      for (let i = 0; i < 20; i++) {
+        await repo.insert({ userId: FREE_USER.owner, role: 'user', content: `msg ${i}` });
+      }
+      const anthropic = buildAnthropicMock('Hello');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      await expect(
+        useCase.execute({ user: FREE_USER, content: 'another message', conversationHistory: [] })
+      ).rejects.toBeInstanceOf(ChatRateLimitError);
+    });
+
+    it('does not throw when free user has used fewer than 20 messages', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      for (let i = 0; i < 19; i++) {
+        await repo.insert({ userId: FREE_USER.owner, role: 'user', content: `msg ${i}` });
+      }
+      const anthropic = buildAnthropicMock('Nice response');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'question',
+        conversationHistory: [],
+      });
+      expect(result.content).toBe('Nice response');
+    });
+
+    it('does not apply limit to patreon users', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      for (let i = 0; i < 100; i++) {
+        await repo.insert({ userId: PATREON_USER.owner, role: 'user', content: `msg ${i}` });
+      }
+      const anthropic = buildAnthropicMock('Patreon response');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: PATREON_USER,
+        content: 'question',
+        conversationHistory: [],
+      });
+      expect(result.content).toBe('Patreon response');
+    });
+  });
+
+  describe('model selection', () => {
+    it('uses haiku model for free users', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const anthropic = buildAnthropicMock('answer');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      await useCase.execute({ user: FREE_USER, content: 'question', conversationHistory: [] });
+
+      expect(anthropic.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-haiku-4-5-20251001' })
+      );
+    });
+
+    it('uses sonnet model for patreon users', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const anthropic = buildAnthropicMock('answer');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      await useCase.execute({ user: PATREON_USER, content: 'question', conversationHistory: [] });
+
+      expect(anthropic.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'claude-sonnet-4-6' })
+      );
+    });
+  });
+
+  describe('card extraction', () => {
+    it('extracts cards when response contains a JSON code block', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const cards = [{ front: 'Q1', back: 'A1' }, { front: 'Q2', back: 'A2' }];
+      const responseText = `Here are your cards:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\`\nHope that helps!`;
+      const anthropic = buildAnthropicMock(responseText);
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards about photosynthesis',
+        conversationHistory: [],
+      });
+
+      expect(result.cards).toEqual(cards);
+    });
+
+    it('returns no cards when response has no JSON block', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const anthropic = buildAnthropicMock('Photosynthesis is the process by which...');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Explain photosynthesis',
+        conversationHistory: [],
+      });
+
+      expect(result.cards).toBeUndefined();
+    });
+
+    it('returns no cards when JSON block is not a front/back array', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const responseText = 'Here is JSON:\n```json\n{"key": "value"}\n```';
+      const anthropic = buildAnthropicMock(responseText);
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'some question',
+        conversationHistory: [],
+      });
+
+      expect(result.cards).toBeUndefined();
+    });
+  });
+
+  describe('message persistence', () => {
+    it('saves both user and assistant messages', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const anthropic = buildAnthropicMock('Assistant reply');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'User question',
+        conversationHistory: [],
+      });
+
+      const all = repo.getAll();
+      expect(all).toHaveLength(2);
+      expect(all[0]).toMatchObject({ user_id: FREE_USER.owner, role: 'user', content: 'User question' });
+      expect(all[1]).toMatchObject({ user_id: FREE_USER.owner, role: 'assistant', content: 'Assistant reply' });
+    });
+  });
+
+  describe('ChatRateLimitError', () => {
+    it('provides a resetDate as the first of next month', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      for (let i = 0; i < 20; i++) {
+        await repo.insert({ userId: FREE_USER.owner, role: 'user', content: `msg ${i}` });
+      }
+      const anthropic = buildAnthropicMock('');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      let caughtError: ChatRateLimitError | null = null;
+      try {
+        await useCase.execute({ user: FREE_USER, content: 'more', conversationHistory: [] });
+      } catch (err) {
+        if (err instanceof ChatRateLimitError) {
+          caughtError = err;
+        }
+      }
+
+      expect(caughtError).not.toBeNull();
+      expect(caughtError?.resetDate).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+});

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -1,0 +1,135 @@
+import type Anthropic from '@anthropic-ai/sdk';
+import type { IChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
+
+const FREE_MONTHLY_LIMIT = 20;
+const FREE_MODEL = 'claude-haiku-4-5-20251001';
+const PATREON_MODEL = 'claude-sonnet-4-6';
+const MAX_HISTORY_TURNS = 10;
+const MAX_TOKENS = 1024;
+
+const STUDY_ASSISTANT_SYSTEM_PROMPT = `You are a study assistant for 2anki, a tool that turns notes into Anki flashcards.
+
+Help users understand material, answer study questions, and create flashcards. When generating flashcards, always output them as a JSON code block in this exact format:
+
+\`\`\`json
+[{"front": "question or term", "back": "answer or definition"}]
+\`\`\`
+
+After giving any explanation or answer, offer to turn the content into flashcards if the user hasn't already asked. Keep responses focused and practical — this is a study tool, not a general assistant.`;
+
+export interface ChatCard {
+  front: string;
+  back: string;
+}
+
+export interface ChatUser {
+  owner: number;
+  patreon: boolean;
+}
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface SendMessageResult {
+  content: string;
+  cards?: ChatCard[];
+}
+
+export class ChatRateLimitError extends Error {
+  readonly resetDate: string;
+
+  constructor(resetDate: string) {
+    super('Message limit reached');
+    this.name = 'ChatRateLimitError';
+    this.resetDate = resetDate;
+  }
+}
+
+function firstOfNextMonth(): string {
+  const now = new Date();
+  const next = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+  return next.toISOString();
+}
+
+function extractCards(text: string): ChatCard[] | undefined {
+  const match = /```json\s*([\s\S]*?)```/.exec(text);
+  if (match == null) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1].trim());
+  } catch {
+    return undefined;
+  }
+
+  if (!Array.isArray(parsed)) return undefined;
+
+  const cards: ChatCard[] = [];
+  for (const item of parsed) {
+    if (
+      item != null &&
+      typeof item === 'object' &&
+      typeof (item as Record<string, unknown>).front === 'string' &&
+      typeof (item as Record<string, unknown>).back === 'string'
+    ) {
+      cards.push({
+        front: (item as { front: string }).front,
+        back: (item as { back: string }).back,
+      });
+    }
+  }
+
+  if (cards.length === 0) return undefined;
+  return cards;
+}
+
+export class ChatUseCase {
+  constructor(
+    private readonly repo: IChatMessagesRepository,
+    private readonly anthropic: Anthropic
+  ) {}
+
+  async execute(input: {
+    user: ChatUser;
+    content: string;
+    conversationHistory: ChatMessage[];
+  }): Promise<SendMessageResult> {
+    const { user, content, conversationHistory } = input;
+
+    if (!user.patreon) {
+      const count = await this.repo.countThisMonth(user.owner);
+      if (count >= FREE_MONTHLY_LIMIT) {
+        throw new ChatRateLimitError(firstOfNextMonth());
+      }
+    }
+
+    const model = user.patreon ? PATREON_MODEL : FREE_MODEL;
+
+    const recentHistory = conversationHistory.slice(-MAX_HISTORY_TURNS);
+    const messages: Anthropic.MessageParam[] = [
+      ...recentHistory.map((m) => ({ role: m.role, content: m.content })),
+      { role: 'user', content },
+    ];
+
+    const response = await this.anthropic.messages.create({
+      model,
+      max_tokens: MAX_TOKENS,
+      system: STUDY_ASSISTANT_SYSTEM_PROMPT,
+      messages,
+    });
+
+    const assistantContent = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map((block) => block.text)
+      .join('');
+
+    await this.repo.insert({ userId: user.owner, role: 'user', content });
+    await this.repo.insert({ userId: user.owner, role: 'assistant', content: assistantContent });
+
+    const cards = extractCards(assistantContent);
+
+    return { content: assistantContent, ...(cards != null ? { cards } : {}) };
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,6 +67,7 @@ const ImageOcclusionPage = lazy(() =>
     default: m.ImageOcclusionPage,
   }))
 );
+const ChatPage = lazy(() => import('./pages/Chat/ChatPage'));
 
 const queryClient = new QueryClient();
 
@@ -138,6 +139,7 @@ function AppContent({
           />
           <Route path="/print" element={<PrintPage />} />
           <Route path="/image-occlusion" element={<ImageOcclusionPage />} />
+          <Route path="/chat" element={requireAuth(<ChatPage />)} />
           <Route
             path="/register"
             element={<RegisterPage setErrorMessage={setErrorMessage} />}

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -8,6 +8,7 @@ import ArrowRightIcon from '../icons/ArrowRightIcon';
 import ArrowRightOnRectangleIcon from '../icons/ArrowRightOnRectangleIcon';
 import ArrowUpTrayIcon from '../icons/ArrowUpTrayIcon';
 import BookOpenIcon from '../icons/BookOpenIcon';
+import ChatBubbleIcon from '../icons/ChatBubbleIcon';
 import RectangleGroupIcon from '../icons/RectangleGroupIcon';
 import LayersIcon from '../icons/LayersIcon';
 import CommandLineIcon from '../icons/CommandLineIcon';
@@ -185,6 +186,15 @@ export function Sidebar({
             icon={RectangleGroupIcon}
           >
             Image Occlusion
+          </SidebarRow>
+          <SidebarRow
+            href="/chat"
+            pathname={pathname}
+            matchPrefix={false}
+            onClick={handleNavClick()}
+            icon={ChatBubbleIcon}
+          >
+            Chat
           </SidebarRow>
           {paying && (
             <SidebarRow

--- a/web/src/pages/Chat/ChatPage.module.css
+++ b/web/src/pages/Chat/ChatPage.module.css
@@ -1,0 +1,236 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 0px);
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.messageList {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem 0 1rem;
+}
+
+.emptyState {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 1rem;
+  padding: 4rem 0;
+}
+
+.emptyHeading {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+  letter-spacing: var(--tracking-tight);
+}
+
+.emptySubhead {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+  max-width: 44ch;
+  line-height: var(--leading-relaxed);
+}
+
+.starterChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.starterChip {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  padding: 0.5rem 1rem;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.starterChip:hover {
+  background: var(--color-primary-light);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  max-width: 80%;
+}
+
+.messageUser {
+  align-self: flex-end;
+  align-items: flex-end;
+}
+
+.messageAssistant {
+  align-self: flex-start;
+  align-items: flex-start;
+}
+
+.messageBubble {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-lg);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.messageBubbleUser {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+}
+
+.messageBubbleAssistant {
+  background: transparent;
+  color: var(--color-text-primary);
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.messageSkeleton {
+  height: 3rem;
+  width: 240px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(90deg, var(--color-bg-secondary) 25%, var(--color-bg-tertiary) 50%, var(--color-bg-secondary) 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.saveAsDeckBtn {
+  margin-top: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.saveAsDeckBtn:hover {
+  background: #dbeafe;
+}
+
+.inputArea {
+  border-top: 1px solid var(--color-border-light);
+  padding: 1rem 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.inputRow {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.textarea {
+  flex: 1;
+  resize: none;
+  min-height: 2.75rem;
+  max-height: 7rem;
+  padding: 0.625rem 0.875rem;
+  font-size: var(--text-sm);
+  font-family: inherit;
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  line-height: var(--leading-normal);
+  transition: border-color var(--transition-fast);
+  overflow-y: auto;
+  field-sizing: content;
+}
+
+.textarea:focus {
+  border-color: var(--color-primary);
+}
+
+.textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sendBtn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.sendBtn:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.sendBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.usageLine {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.limitPanel {
+  padding: 0.75rem 1rem;
+  background: var(--color-warning-light);
+  border: 1px solid var(--color-warning-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--color-warning-text);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.limitPanelLink {
+  color: var(--color-warning-text);
+  font-weight: var(--font-medium);
+}
+
+.networkError {
+  font-size: var(--text-xs);
+  color: var(--color-danger);
+  margin: 0;
+}

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useRef, useState } from 'react';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
+import { post } from '../../lib/backend/api';
+import ChatBubbleIcon from '../../components/icons/ChatBubbleIcon';
+import SendIcon from '../../components/icons/SendIcon';
+import styles from './ChatPage.module.css';
+
+interface ChatCard {
+  front: string;
+  back: string;
+}
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+  cards?: ChatCard[];
+}
+
+interface ApiSuccessResponse {
+  role: 'assistant';
+  content: string;
+  cards?: ChatCard[];
+}
+
+interface ApiRateLimitResponse {
+  error: string;
+  resetDate: string;
+}
+
+const STARTER_PROMPTS = [
+  'Make 10 cards from notes I\'ll paste',
+  'Explain a concept, then make cards',
+  'Turn this into cloze cards: [paste]',
+];
+
+const FREE_MONTHLY_LIMIT = 20;
+
+function formatResetDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+  } catch {
+    return iso;
+  }
+}
+
+export default function ChatPage() {
+  const { data: userLocals } = useUserLocals();
+  const isPatreon = userLocals?.user?.patreon === true;
+
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [networkError, setNetworkError] = useState<string | null>(null);
+  const [limitReached, setLimitReached] = useState(false);
+  const [resetDate, setResetDate] = useState<string | null>(null);
+  const [messagesSentThisSession, setMessagesSentThisSession] = useState(0);
+
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, isLoading]);
+
+  const remainingMessages = FREE_MONTHLY_LIMIT - messagesSentThisSession;
+
+  const canSend = inputValue.trim().length > 0 && !isLoading && !limitReached;
+
+  async function sendMessage(content: string) {
+    if (!content.trim()) return;
+
+    const userMessage: Message = { role: 'user', content };
+    const nextMessages = [...messages, userMessage];
+    setMessages(nextMessages);
+    setInputValue('');
+    setNetworkError(null);
+    setIsLoading(true);
+
+    const history = nextMessages.slice(-10).map((m) => ({ role: m.role, content: m.content }));
+
+    try {
+      const response = await post('/api/chat/message', { content, history });
+
+      if (response.status === 429) {
+        const data: ApiRateLimitResponse = await response.json();
+        setLimitReached(true);
+        setResetDate(data.resetDate);
+        setIsLoading(false);
+        return;
+      }
+
+      if (!response.ok) {
+        setNetworkError("Couldn't send this message. Try again.");
+        setIsLoading(false);
+        return;
+      }
+
+      const data: ApiSuccessResponse = await response.json();
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', content: data.content, cards: data.cards },
+      ]);
+      setMessagesSentThisSession((n) => n + 1);
+    } catch {
+      setNetworkError("Couldn't send this message. Try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      if (canSend) {
+        sendMessage(inputValue);
+      }
+    }
+  }
+
+  function handleSaveAsDeck(cards: ChatCard[]) {
+    const deckName = globalThis.prompt('Deck name:');
+    if (deckName == null || deckName.trim().length === 0) return;
+
+    const lines = cards.map((c) => `${c.front}\t${c.back}`).join('\n');
+    const blob = new Blob([lines], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${deckName.trim()}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  const hasMessages = messages.length > 0;
+
+  return (
+    <div className={styles.container}>
+      {hasMessages ? (
+        <div className={styles.messageList}>
+          {messages.map((m, i) => (
+            <div
+              key={i}
+              className={`${styles.message} ${m.role === 'user' ? styles.messageUser : styles.messageAssistant}`}
+            >
+              <div
+                className={`${styles.messageBubble} ${m.role === 'user' ? styles.messageBubbleUser : styles.messageBubbleAssistant}`}
+              >
+                {m.content}
+              </div>
+              {m.role === 'assistant' && m.cards != null && m.cards.length > 0 && (
+                <button
+                  type="button"
+                  className={styles.saveAsDeckBtn}
+                  onClick={() => handleSaveAsDeck(m.cards!)}
+                >
+                  <ChatBubbleIcon width={14} height={14} />
+                  Save as deck
+                </button>
+              )}
+            </div>
+          ))}
+          {isLoading && (
+            <div className={`${styles.message} ${styles.messageAssistant}`}>
+              <div className={styles.messageSkeleton} />
+            </div>
+          )}
+          <div ref={bottomRef} />
+        </div>
+      ) : (
+        <div className={styles.emptyState}>
+          <h1 className={styles.emptyHeading}>Chat</h1>
+          <p className={styles.emptySubhead}>
+            A study assistant. Paste your notes, ask for cards, or work through a concept.
+          </p>
+          <div className={styles.starterChips}>
+            {STARTER_PROMPTS.map((prompt) => (
+              <button
+                key={prompt}
+                type="button"
+                className={styles.starterChip}
+                onClick={() => {
+                  setInputValue(prompt);
+                  textareaRef.current?.focus();
+                }}
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.inputArea}>
+        {limitReached && resetDate != null && (
+          <div className={styles.limitPanel}>
+            <span>
+              You've used all {FREE_MONTHLY_LIMIT} messages this month. Resets {formatResetDate(resetDate)}.
+            </span>
+            <a
+              href="https://www.patreon.com/alemayhu"
+              target="_blank"
+              rel="noreferrer"
+              className={styles.limitPanelLink}
+            >
+              See Patreon plans
+            </a>
+          </div>
+        )}
+        <div className={styles.inputRow}>
+          <textarea
+            ref={textareaRef}
+            className={styles.textarea}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask a study question or paste notes…"
+            disabled={isLoading || limitReached}
+            rows={1}
+            aria-label="Message input"
+          />
+          <button
+            type="button"
+            className={styles.sendBtn}
+            onClick={() => sendMessage(inputValue)}
+            disabled={!canSend}
+            aria-label="Send message"
+          >
+            <SendIcon width={18} height={18} />
+          </button>
+        </div>
+        {!isPatreon && !limitReached && messagesSentThisSession > 0 && (
+          <p className={styles.usageLine}>
+            {remainingMessages} of {FREE_MONTHLY_LIMIT} messages left this month
+          </p>
+        )}
+        {networkError != null && (
+          <p className={styles.networkError}>{networkError}</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a Chat feature: a Claude-powered study assistant accessible at `/chat` from the sidebar. Free users get 20 messages/month (Haiku model); Patreon subscribers get unlimited access (Sonnet model). Assistant responses that contain flashcard arrays show a "Save as deck" button.

## Why
Extends 2anki from a one-shot conversion tool into a lightweight study companion. Users who struggle to structure their notes can now ask the assistant to generate cards interactively, lowering the barrier to first deck creation. This is a direct lever on the free-to-paid conversion funnel and retention.

## How
- **Migration**: `chat_messages` table, indexed on `(user_id, created_at)` for efficient monthly-count queries.
- **Data layer**: `ChatMessagesRepository` with `InMemory` variant for tests.
- **Use case**: `ChatUseCase` counts this-month messages, enforces limit, picks model, calls Anthropic SDK (using the existing `getAnthropicClient()` singleton), extracts `[{front, back}]` JSON blocks from the response, and persists both turns.
- **Controller**: validates content (non-empty, ≤4000 chars), reads `owner`/`patreon` from `res.locals` set by `RequireAuthentication`, maps `ChatRateLimitError` to 429 with `resetDate`.
- **Router**: `POST /api/chat/message` behind `RequireAuthentication`.
- **Frontend**: full-height chat layout with empty-state starter prompts, skeleton loading, inline limit-hit panel, and "Save as deck" (tab-delimited `.txt` download for MVP; APKG flow is a follow-up).

## LLM cost note
- **Haiku** (free users): ~$0.00025/1K input tokens, ~$0.00125/1K output. Expected per-call cost < $0.001 at typical study message lengths.
- **Sonnet** (patreon): ~$0.003/$0.015 per 1K tokens. At 1K output average, ~$0.018/message.
- Prompt caching: system prompt is short and static; no prompt caching header added here (it's already on the singleton from `ClaudeService`). The study assistant system prompt is sent on every call — caching would require `cache_control: ephemeral` on it; deferred as a follow-up.
- **Latency budget**: Haiku responds in ~1–3s; Sonnet ~3–10s. Both are async behind a loading skeleton.

## Measuring success
Query to confirm feature is live and used:
```sql
SELECT DATE_TRUNC('day', created_at) AS day,
       COUNT(*) FILTER (WHERE role = 'user') AS user_turns,
       COUNT(DISTINCT user_id) AS unique_users
FROM chat_messages
GROUP BY 1 ORDER BY 1 DESC LIMIT 7;
```

## Testing
- Unit tests added:
  - `src/usecases/chat/ChatUseCase.test.ts` — 10 tests covering rate limiting, model selection, card extraction, and persistence
  - `src/controllers/ChatController.test.ts` — 6 tests covering input validation, 429 mapping, and happy path
- Manually verified: TypeScript clean (`npx tsc --noEmit`), web vitest 358/358 passing, Biome lint clean

## Risks
- Anthropic API key must be set in production (`ANTHROPIC_API_KEY`); missing key will cause runtime errors on first chat request. The `getAnthropicClient()` singleton logs a warning at init if unset.
- Monthly message count is session-relative in the frontend (starts at 0 per page load); the real gate is server-side. A user who has sent 15 messages in prior sessions sees "20 of 20 left" until they hit the server limit. Follow-up: fetch actual count from server on page load.
- "Save as deck" downloads a `.txt` file (tab-separated); it does not produce an `.apkg`. Full deck creation is a follow-up.
- Migration must run before deploy; the server runs `migrate.latest` on startup automatically.
- Rollback: drop the migration, remove ChatRouter from server.ts, delete the frontend `/chat` route and sidebar entry.

## Goal alignment
Lowers the barrier to first-deck creation by letting users generate cards through conversation. This directly targets the "drop something in, get a clean deck back" mission — users who can't structure their notes can now ask the assistant to do it. Expected to improve conversion from sign-up to first download.