### PR TITLE
fix: resolve four Chat UX regressions (JSON bubble, prompt(), .txt download, usage counter)

### DIFF
--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -45,6 +45,8 @@ class ChatController {
       res.status(200).json({
         role: 'assistant',
         content: result.content,
+        ...(result.contentBefore != null ? { contentBefore: result.contentBefore } : {}),
+        ...(result.contentAfter != null ? { contentAfter: result.contentAfter } : {}),
         ...(result.cards != null ? { cards: result.cards } : {}),
       });
     } catch (err) {

--- a/src/controllers/ChatDeckController.test.ts
+++ b/src/controllers/ChatDeckController.test.ts
@@ -1,0 +1,121 @@
+import { Request, Response } from 'express';
+import ChatDeckController from './ChatDeckController';
+
+function buildRes(): Response {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    locals: { owner: 42 },
+  } as unknown as Response;
+}
+
+function buildReq(body: unknown): Request {
+  return { body } as unknown as Request;
+}
+
+const validCards = [
+  { front: 'Q1', back: 'A1' },
+  { front: 'Q2', back: 'A2' },
+];
+
+describe('ChatDeckController.generate', () => {
+  it('returns 400 when deckName is missing', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: validCards }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when deckName is empty string', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: validCards, deckName: '' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when deckName exceeds 120 chars', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: validCards, deckName: 'x'.repeat(121) }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when cards is not an array', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: 'not-an-array', deckName: 'My Deck' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when cards is empty', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: [], deckName: 'My Deck' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when cards array exceeds 200 items', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+    const tooManyCards = Array.from({ length: 201 }, (_, i) => ({ front: `Q${i}`, back: `A${i}` }));
+
+    await controller.generate(buildReq({ cards: tooManyCards, deckName: 'My Deck' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when a card is missing front field', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: [{ back: 'A1' }], deckName: 'My Deck' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when a card is missing back field', async () => {
+    const useCase = { execute: jest.fn() };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: [{ front: 'Q1' }], deckName: 'My Deck' }), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('calls use case and sends buffer on valid input', async () => {
+    const fakeBuffer = Buffer.from('fake-apkg-data');
+    const useCase = { execute: jest.fn().mockResolvedValue(fakeBuffer) };
+    const controller = new ChatDeckController(useCase as never);
+    const res = buildRes();
+
+    await controller.generate(buildReq({ cards: validCards, deckName: 'My Deck' }), res);
+
+    expect(useCase.execute).toHaveBeenCalledWith({ cards: validCards, deckName: 'My Deck' });
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      'attachment; filename="My Deck.apkg"'
+    );
+    expect(res.send).toHaveBeenCalledWith(fakeBuffer);
+  });
+});

--- a/src/controllers/ChatDeckController.ts
+++ b/src/controllers/ChatDeckController.ts
@@ -1,0 +1,66 @@
+import { Request, Response } from 'express';
+import { ChatDeckUseCase } from '../usecases/chat/ChatDeckUseCase';
+
+const MAX_DECK_NAME_LENGTH = 120;
+const MAX_CARDS = 200;
+
+function isValidCard(item: unknown): item is { front: string; back: string } {
+  return (
+    item != null &&
+    typeof item === 'object' &&
+    typeof (item as Record<string, unknown>).front === 'string' &&
+    typeof (item as Record<string, unknown>).back === 'string'
+  );
+}
+
+class ChatDeckController {
+  constructor(private readonly useCase: ChatDeckUseCase) {}
+
+  async generate(req: Request, res: Response) {
+    const rawDeckName = req.body?.deckName;
+    const deckName = typeof rawDeckName === 'string' ? rawDeckName.trim() : '';
+
+    if (deckName.length === 0) {
+      res.status(400).json({ error: 'deckName is required' });
+      return;
+    }
+
+    if (deckName.length > MAX_DECK_NAME_LENGTH) {
+      res.status(400).json({ error: `deckName must be ${MAX_DECK_NAME_LENGTH} characters or fewer` });
+      return;
+    }
+
+    const rawCards = req.body?.cards;
+
+    if (!Array.isArray(rawCards)) {
+      res.status(400).json({ error: 'cards must be a non-empty array' });
+      return;
+    }
+
+    if (rawCards.length === 0) {
+      res.status(400).json({ error: 'cards must be a non-empty array' });
+      return;
+    }
+
+    if (rawCards.length > MAX_CARDS) {
+      res.status(400).json({ error: `cards must have at most ${MAX_CARDS} items` });
+      return;
+    }
+
+    if (!rawCards.every(isValidCard)) {
+      res.status(400).json({ error: 'each card must have string front and back fields' });
+      return;
+    }
+
+    const buffer = await this.useCase.execute({
+      cards: rawCards.map((c) => ({ front: c.front, back: c.back })),
+      deckName,
+    });
+
+    res.setHeader('Content-Type', 'application/octet-stream');
+    res.setHeader('Content-Disposition', `attachment; filename="${deckName}.apkg"`);
+    res.send(buffer);
+  }
+}
+
+export default ChatDeckController;

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import ChatController from '../controllers/ChatController';
+import ChatDeckController from '../controllers/ChatDeckController';
 import { ChatUseCase } from '../usecases/chat/ChatUseCase';
+import { ChatDeckUseCase } from '../usecases/chat/ChatDeckUseCase';
 import { ChatMessagesRepository } from '../data_layer/ChatMessagesRepository';
 import { getDatabase } from '../data_layer';
 import { getAnthropicClient } from '../lib/claude/ClaudeService';
@@ -13,6 +15,8 @@ const ChatRouter = () => {
   const anthropic = getAnthropicClient();
   const useCase = new ChatUseCase(repo, anthropic);
   const controller = new ChatController(useCase);
+  const deckUseCase = new ChatDeckUseCase();
+  const deckController = new ChatDeckController(deckUseCase);
 
   /**
    * @swagger
@@ -55,6 +59,83 @@ const ChatRouter = () => {
   router.post('/api/chat/message', RequireAuthentication, (req, res) =>
     controller.sendMessage(req, res)
   );
+
+  /**
+   * @swagger
+   * /api/chat/deck:
+   *   post:
+   *     summary: Generate an Anki deck from chat cards
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [cards, deckName]
+   *             properties:
+   *               deckName:
+   *                 type: string
+   *                 maxLength: 120
+   *               cards:
+   *                 type: array
+   *                 maxItems: 200
+   *                 items:
+   *                   type: object
+   *                   required: [front, back]
+   *                   properties:
+   *                     front:
+   *                       type: string
+   *                     back:
+   *                       type: string
+   *     responses:
+   *       200:
+   *         description: Anki .apkg file
+   *         content:
+   *           application/octet-stream:
+   *             schema:
+   *               type: string
+   *               format: binary
+   *       400:
+   *         description: Invalid input
+   */
+  router.post('/api/chat/deck', RequireAuthentication, (req, res) =>
+    deckController.generate(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/chat/usage:
+   *   get:
+   *     summary: Get chat usage for the current month
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Usage data
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 used:
+   *                   type: integer
+   *                 limit:
+   *                   type: integer
+   *                   nullable: true
+   */
+  router.get('/api/chat/usage', RequireAuthentication, async (req, res) => {
+    const owner = res.locals.owner as number;
+    const patreon = (res.locals.patreon as boolean) ?? false;
+    const count = await repo.countThisMonth(owner);
+    res.status(200).json({
+      used: count,
+      limit: patreon ? null : 20,
+    });
+  });
 
   return router;
 };

--- a/src/usecases/chat/ChatDeckUseCase.ts
+++ b/src/usecases/chat/ChatDeckUseCase.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID, createHash } from 'node:crypto';
+import CustomExporter from '../../lib/parser/exporters/CustomExporter';
+
+export interface ChatDeckCard {
+  front: string;
+  back: string;
+}
+
+export interface ChatDeckInput {
+  cards: ChatDeckCard[];
+  deckName: string;
+}
+
+function deterministicId(input: string): number {
+  const hex = createHash('sha1').update(input).digest('hex').slice(0, 13);
+  return Number.parseInt(hex, 16) % 1e13;
+}
+
+export class ChatDeckUseCase {
+  async execute(input: ChatDeckInput): Promise<Buffer> {
+    const { cards, deckName } = input;
+    const workspaceDir = path.join(os.tmpdir(), `chat-deck-${randomUUID()}`);
+    fs.mkdirSync(workspaceDir, { recursive: true });
+
+    try {
+      const deckInfo = [
+        {
+          name: deckName,
+          image: '',
+          style: null,
+          id: deterministicId(deckName),
+          settings: {
+            template: 'specialstyle',
+            clozeModelName: 'n2a-cloze',
+            basicModelName: 'n2a-basic',
+            inputModelName: 'n2a-input',
+            useNotionId: true,
+          },
+          cards: cards.map((c) => ({
+            name: c.front,
+            back: c.back,
+            tags: [],
+            cloze: false,
+            number: 0,
+            enableInput: false,
+            answer: '',
+            media: [],
+          })),
+        },
+      ];
+
+      const exporter = new CustomExporter(deckName, workspaceDir);
+      exporter.configure(deckInfo as never);
+      return await exporter.save();
+    } finally {
+      fs.rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -133,6 +133,72 @@ describe('ChatUseCase', () => {
 
       expect(result.cards).toBeUndefined();
     });
+
+    it('returns contentBefore and contentAfter when JSON block is surrounded by prose', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const cards = [{ front: 'Q1', back: 'A1' }];
+      const responseText = `Here are your cards:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\`\nHope that helps!`;
+      const anthropic = buildAnthropicMock(responseText);
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+      });
+
+      expect(result.contentBefore).toBe('Here are your cards:');
+      expect(result.contentAfter).toBe('Hope that helps!');
+    });
+
+    it('returns contentBefore as undefined when no text before JSON block', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const cards = [{ front: 'Q1', back: 'A1' }];
+      const responseText = `\`\`\`json\n${JSON.stringify(cards)}\n\`\`\`\nHope that helps!`;
+      const anthropic = buildAnthropicMock(responseText);
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+      });
+
+      expect(result.contentBefore).toBeUndefined();
+      expect(result.contentAfter).toBe('Hope that helps!');
+    });
+
+    it('returns contentAfter as undefined when no text after JSON block', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const cards = [{ front: 'Q1', back: 'A1' }];
+      const responseText = `Here are your cards:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const anthropic = buildAnthropicMock(responseText);
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+      });
+
+      expect(result.contentBefore).toBe('Here are your cards:');
+      expect(result.contentAfter).toBeUndefined();
+    });
+
+    it('returns undefined contentBefore and contentAfter when no JSON block present', async () => {
+      const repo = new InMemoryChatMessagesRepository();
+      const anthropic = buildAnthropicMock('Just plain text response.');
+      const useCase = new ChatUseCase(repo, anthropic as never);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Explain something',
+        conversationHistory: [],
+      });
+
+      expect(result.contentBefore).toBeUndefined();
+      expect(result.contentAfter).toBeUndefined();
+    });
   });
 
   describe('message persistence', () => {

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -34,6 +34,8 @@ export interface ChatMessage {
 
 export interface SendMessageResult {
   content: string;
+  contentBefore?: string;
+  contentAfter?: string;
   cards?: ChatCard[];
 }
 
@@ -53,18 +55,27 @@ function firstOfNextMonth(): string {
   return next.toISOString();
 }
 
-function extractCards(text: string): ChatCard[] | undefined {
+interface ExtractCardsResult {
+  cards: ChatCard[] | undefined;
+  contentBefore: string | undefined;
+  contentAfter: string | undefined;
+}
+
+function extractCards(text: string): ExtractCardsResult {
   const match = /```json\s*([\s\S]*?)```/.exec(text);
-  if (match == null) return undefined;
+  if (match == null) return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
+
+  const before = text.slice(0, match.index).trim();
+  const after = text.slice(match.index + match[0].length).trim();
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(match[1].trim());
   } catch {
-    return undefined;
+    return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
   }
 
-  if (!Array.isArray(parsed)) return undefined;
+  if (!Array.isArray(parsed)) return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
 
   const cards: ChatCard[] = [];
   for (const item of parsed) {
@@ -81,8 +92,13 @@ function extractCards(text: string): ChatCard[] | undefined {
     }
   }
 
-  if (cards.length === 0) return undefined;
-  return cards;
+  if (cards.length === 0) return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
+
+  return {
+    cards,
+    contentBefore: before.length > 0 ? before : undefined,
+    contentAfter: after.length > 0 ? after : undefined,
+  };
 }
 
 export class ChatUseCase {
@@ -128,8 +144,13 @@ export class ChatUseCase {
     await this.repo.insert({ userId: user.owner, role: 'user', content });
     await this.repo.insert({ userId: user.owner, role: 'assistant', content: assistantContent });
 
-    const cards = extractCards(assistantContent);
+    const { cards, contentBefore, contentAfter } = extractCards(assistantContent);
 
-    return { content: assistantContent, ...(cards != null ? { cards } : {}) };
+    return {
+      content: assistantContent,
+      ...(cards != null ? { cards } : {}),
+      ...(contentBefore != null ? { contentBefore } : {}),
+      ...(contentAfter != null ? { contentAfter } : {}),
+    };
   }
 }

--- a/web/src/pages/Chat/CardPreview.module.css
+++ b/web/src/pages/Chat/CardPreview.module.css
@@ -1,0 +1,231 @@
+.cardPreview {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  width: 100%;
+  overflow: hidden;
+}
+
+.cardPreviewHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border-light);
+}
+
+.cardPreviewCount {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.cardPreviewCountNumber {
+  font-weight: var(--font-semibold);
+}
+
+.cardPreviewSave {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.cardPreviewSave:hover {
+  background: #dbeafe;
+}
+
+.renameRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.renameInput {
+  padding: 0.375rem 0.625rem;
+  font-size: var(--text-xs);
+  font-family: inherit;
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  min-width: 0;
+  width: 14rem;
+  transition: border-color var(--transition-fast);
+}
+
+.renameInput:focus {
+  border-color: var(--color-primary);
+}
+
+.renameSave {
+  padding: 0.375rem 0.75rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-bg-primary);
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.renameSave:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.renameSave:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.renameCancel {
+  padding: 0.375rem 0.75rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.renameCancel:hover {
+  background: var(--color-bg-secondary);
+}
+
+.renameHint {
+  width: 100%;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0;
+}
+
+.savedLine {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.savedFile {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.savedAgainBtn {
+  padding: 0.25rem 0.625rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.savedAgainBtn:hover {
+  background: var(--color-primary-light);
+}
+
+.cardPreviewColumnLabels {
+  display: none;
+}
+
+@media (min-width: 600px) {
+  .cardPreviewColumnLabels {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 1.5rem;
+    padding: 0.5rem 1rem;
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-tertiary);
+    font-weight: var(--font-medium);
+    border-bottom: 1px solid var(--color-border-light);
+  }
+}
+
+.cardPreviewList {
+  display: flex;
+  flex-direction: column;
+}
+
+.cardPreviewRow {
+  padding: 0.75rem 1rem;
+  font-size: var(--text-sm);
+  word-break: break-word;
+  border-top: 1px solid var(--color-border-light);
+}
+
+@media (min-width: 600px) {
+  .cardPreviewRow {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+}
+
+.cardPreviewFront {
+  color: var(--color-text-primary);
+}
+
+.cardPreviewBack {
+  color: var(--color-text-secondary);
+}
+
+.cardPreviewMobileLabel {
+  display: block;
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-tertiary);
+  font-weight: var(--font-medium);
+  margin-bottom: 0.25rem;
+}
+
+@media (min-width: 600px) {
+  .cardPreviewMobileLabel {
+    display: none;
+  }
+}
+
+.cardPreviewBack .cardPreviewMobileLabel {
+  margin-top: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .cardPreviewBack .cardPreviewMobileLabel {
+    margin-top: 0;
+  }
+}
+
+.cardPreviewExpandBtn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  background: transparent;
+  border: none;
+  border-top: 1px solid var(--color-border-light);
+  cursor: pointer;
+  text-align: center;
+  transition: color var(--transition-fast);
+}
+
+.cardPreviewExpandBtn:hover {
+  color: var(--color-text-secondary);
+}

--- a/web/src/pages/Chat/CardPreview.test.tsx
+++ b/web/src/pages/Chat/CardPreview.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import CardPreview from './CardPreview';
+
+function makeCards(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    front: `Question ${i + 1}`,
+    back: `Answer ${i + 1}`,
+  }));
+}
+
+describe('CardPreview', () => {
+  describe('card count display', () => {
+    it('shows "1 card" for a single card', () => {
+      render(<CardPreview cards={makeCards(1)} onSave={vi.fn()} />);
+      expect(screen.getByText('1')).toBeInTheDocument();
+      expect(screen.getByText(/\bcard\b/)).toBeInTheDocument();
+    });
+
+    it('shows "N cards" for multiple cards', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+  });
+
+  describe('card list display', () => {
+    it('shows first 5 cards by default when there are more than 5', () => {
+      render(<CardPreview cards={makeCards(8)} onSave={vi.fn()} />);
+      expect(screen.getByText('Question 5')).toBeInTheDocument();
+      expect(screen.queryByText('Question 6')).not.toBeInTheDocument();
+    });
+
+    it('shows all cards when count is 5 or fewer', () => {
+      render(<CardPreview cards={makeCards(5)} onSave={vi.fn()} />);
+      expect(screen.getByText('Question 5')).toBeInTheDocument();
+      expect(screen.queryByText(/Show all/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('expand toggle', () => {
+    it('shows expand button when cards exceed 5', () => {
+      render(<CardPreview cards={makeCards(8)} onSave={vi.fn()} />);
+      expect(screen.getByRole('button', { name: 'Show all 8 cards' })).toBeInTheDocument();
+    });
+
+    it('shows all cards after clicking expand', () => {
+      render(<CardPreview cards={makeCards(8)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Show all 8 cards' }));
+      expect(screen.getByText('Question 8')).toBeInTheDocument();
+    });
+
+    it('shows "Show fewer" button after expanding', () => {
+      render(<CardPreview cards={makeCards(8)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Show all 8 cards' }));
+      expect(screen.getByRole('button', { name: 'Show fewer' })).toBeInTheDocument();
+    });
+
+    it('collapses back to 5 after clicking show fewer', () => {
+      render(<CardPreview cards={makeCards(8)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Show all 8 cards' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Show fewer' }));
+      expect(screen.queryByText('Question 6')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('save flow', () => {
+    it('starts in idle state with Save as deck button', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      expect(screen.getByRole('button', { name: 'Save as deck' })).toBeInTheDocument();
+    });
+
+    it('transitions to naming state when Save as deck is clicked', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      expect(screen.getByRole('textbox', { name: 'Deck name' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    });
+
+    it('input has default value of Untitled deck', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      expect(screen.getByRole('textbox', { name: 'Deck name' })).toHaveValue('Untitled deck');
+    });
+
+    it('calls onSave with the deck name when Save is clicked', () => {
+      const onSave = vi.fn();
+      render(<CardPreview cards={makeCards(3)} onSave={onSave} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      const input = screen.getByRole('textbox', { name: 'Deck name' });
+      fireEvent.change(input, { target: { value: 'My Deck' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      expect(onSave).toHaveBeenCalledWith('My Deck');
+    });
+
+    it('transitions to saved state after clicking Save', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      expect(screen.getByText(/Saved as/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Save again' })).toBeInTheDocument();
+    });
+
+    it('shows saved file name with .apkg extension in saved state', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      const input = screen.getByRole('textbox', { name: 'Deck name' });
+      fireEvent.change(input, { target: { value: 'Biology' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      expect(screen.getByText('Saved as Biology.apkg')).toBeInTheDocument();
+    });
+
+    it('returns to naming state when Save again is clicked', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Save again' }));
+      expect(screen.getByRole('textbox', { name: 'Deck name' })).toBeInTheDocument();
+    });
+
+    it('returns to idle state when Cancel is clicked and never saved', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.getByRole('button', { name: 'Save as deck' })).toBeInTheDocument();
+    });
+
+    it('Save button is disabled when deck name is empty', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      const input = screen.getByRole('textbox', { name: 'Deck name' });
+      fireEvent.change(input, { target: { value: '' } });
+      expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    it('submits on Enter key press', () => {
+      const onSave = vi.fn();
+      render(<CardPreview cards={makeCards(3)} onSave={onSave} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      const input = screen.getByRole('textbox', { name: 'Deck name' });
+      fireEvent.change(input, { target: { value: 'Chemistry' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onSave).toHaveBeenCalledWith('Chemistry');
+    });
+
+    it('cancels on Escape key press', () => {
+      render(<CardPreview cards={makeCards(3)} onSave={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      const input = screen.getByRole('textbox', { name: 'Deck name' });
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(screen.getByRole('button', { name: 'Save as deck' })).toBeInTheDocument();
+    });
+
+    it('sanitizes forbidden characters in deck name', () => {
+      const onSave = vi.fn();
+      render(<CardPreview cards={makeCards(3)} onSave={onSave} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Save as deck' }));
+      const input = screen.getByRole('textbox', { name: 'Deck name' });
+      fireEvent.change(input, { target: { value: 'My/Deck:Name' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      expect(onSave).toHaveBeenCalledWith('My-Deck-Name');
+    });
+  });
+});

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -48,7 +48,7 @@ export default function CardPreview({ cards, onSave }: CardPreviewProps) {
   }
 
   function cancelNaming() {
-    setSaveState(savedName != null ? 'saved' : 'idle');
+    setSaveState(savedName == null ? 'idle' : 'saved');
   }
 
   function commitSave() {

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react';
+import styles from './CardPreview.module.css';
+
+interface ChatCard {
+  front: string;
+  back: string;
+}
+
+interface CardPreviewProps {
+  cards: ChatCard[];
+  onSave: (deckName: string) => void;
+}
+
+type SaveState = 'idle' | 'naming' | 'saved';
+
+const VISIBLE_COUNT = 5;
+const MAX_DECK_NAME_LENGTH = 120;
+const FILENAME_FORBIDDEN = /[/\\:*?"<>|]/g;
+
+function sanitizeFilename(name: string): string {
+  return name
+    .replace(FILENAME_FORBIDDEN, '-')
+    .replace(/^[.\s]+|[.\s]+$/g, '')
+    .slice(0, MAX_DECK_NAME_LENGTH);
+}
+
+export default function CardPreview({ cards, onSave }: CardPreviewProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [deckNameDraft, setDeckNameDraft] = useState('Untitled deck');
+  const [savedName, setSavedName] = useState<string | null>(null);
+  const [showHint, setShowHint] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (saveState === 'naming' && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [saveState]);
+
+  const visibleCards = expanded ? cards : cards.slice(0, VISIBLE_COUNT);
+  const hasMore = cards.length > VISIBLE_COUNT;
+
+  function openNaming() {
+    setSaveState('naming');
+    setShowHint(true);
+  }
+
+  function cancelNaming() {
+    setSaveState(savedName != null ? 'saved' : 'idle');
+  }
+
+  function commitSave() {
+    const sanitized = sanitizeFilename(deckNameDraft.trim());
+    if (sanitized.length === 0) return;
+    setSavedName(sanitized);
+    setSaveState('saved');
+    onSave(sanitized);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      commitSave();
+    } else if (e.key === 'Escape') {
+      cancelNaming();
+    }
+  }
+
+  const cardLabel = cards.length === 1 ? 'card' : 'cards';
+
+  return (
+    <div className={styles.cardPreview}>
+      <div className={styles.cardPreviewHeader}>
+        <span className={styles.cardPreviewCount}>
+          <span className={styles.cardPreviewCountNumber}>{cards.length}</span>{' '}
+          {cardLabel}
+        </span>
+
+        {saveState === 'idle' && (
+          <button type="button" className={styles.cardPreviewSave} onClick={openNaming}>
+            Save as deck
+          </button>
+        )}
+
+        {saveState === 'naming' && (
+          <div className={styles.renameRow}>
+            <input
+              ref={inputRef}
+              type="text"
+              className={styles.renameInput}
+              value={deckNameDraft}
+              onChange={(e) => setDeckNameDraft(e.target.value)}
+              onKeyDown={handleKeyDown}
+              maxLength={MAX_DECK_NAME_LENGTH}
+              placeholder="Name this deck"
+              aria-label="Deck name"
+            />
+            <button
+              type="button"
+              className={styles.renameSave}
+              onClick={commitSave}
+              disabled={deckNameDraft.trim().length === 0}
+            >
+              Save
+            </button>
+            <button type="button" className={styles.renameCancel} onClick={cancelNaming}>
+              Cancel
+            </button>
+            {showHint && (
+              <p className={styles.renameHint}>
+                {cards.length} {cardLabel}. Saves as {sanitizeFilename(deckNameDraft.trim()) || 'Untitled deck'}.apkg once you click Save.
+              </p>
+            )}
+          </div>
+        )}
+
+        {saveState === 'saved' && savedName != null && (
+          <div className={styles.savedLine}>
+            <span className={styles.savedFile}>Saved as {savedName}.apkg</span>
+            <button type="button" className={styles.savedAgainBtn} onClick={openNaming}>
+              Save again
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.cardPreviewColumnLabels}>
+        <span>Front</span>
+        <span>Back</span>
+      </div>
+
+      <div className={styles.cardPreviewList}>
+        {visibleCards.map((card, i) => (
+          <div key={i} className={styles.cardPreviewRow}>
+            <div className={styles.cardPreviewFront}>
+              <span className={styles.cardPreviewMobileLabel}>Front</span>
+              {card.front}
+            </div>
+            <div className={styles.cardPreviewBack}>
+              <span className={styles.cardPreviewMobileLabel}>Back</span>
+              {card.back}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {hasMore && (
+        <button
+          type="button"
+          className={styles.cardPreviewExpandBtn}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? 'Show fewer' : `Show all ${cards.length} cards`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/Chat/ChatPage.module.css
+++ b/web/src/pages/Chat/ChatPage.module.css
@@ -74,6 +74,10 @@
   max-width: 80%;
 }
 
+.messageAssistantWithCards {
+  max-width: 100%;
+}
+
 .messageUser {
   align-self: flex-end;
   align-items: flex-end;
@@ -104,6 +108,15 @@
   color: var(--color-text-primary);
   padding-left: 0;
   padding-right: 0;
+}
+
+.assistantText {
+  background: transparent;
+  color: var(--color-text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
 }
 
 .messageSkeleton {

--- a/web/src/pages/Chat/ChatPage.test.tsx
+++ b/web/src/pages/Chat/ChatPage.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import ChatPage from './ChatPage';
+
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => ({ data: { user: { patreon: false } } }),
+}));
+
+vi.mock('../../lib/backend/api', () => ({
+  post: vi.fn(),
+  get: vi.fn().mockResolvedValue({ used: 0, limit: 20 }),
+}));
+
+import { post, get } from '../../lib/backend/api';
+
+const mockPost = post as ReturnType<typeof vi.fn>;
+const mockGet = get as ReturnType<typeof vi.fn>;
+
+describe('ChatPage', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+  });
+
+  it('renders the empty state heading', () => {
+    render(<ChatPage />);
+    expect(screen.getByRole('heading', { name: 'Chat' })).toBeInTheDocument();
+  });
+
+  it('renders CardPreview when assistant message has cards', async () => {
+    const cards = [{ front: 'Q1', back: 'A1' }, { front: 'Q2', back: 'A2' }];
+    mockPost.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        role: 'assistant',
+        content: 'Here are cards:\n```json\n[]\n```\nDone!',
+        contentBefore: 'Here are cards:',
+        contentAfter: 'Done!',
+        cards,
+      }),
+    });
+
+    render(<ChatPage />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
+      target: { value: 'Make cards' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Q1')).toBeInTheDocument();
+    expect(screen.getByText('A1')).toBeInTheDocument();
+    expect(screen.getByText('Here are cards:')).toBeInTheDocument();
+    expect(screen.getByText('Done!')).toBeInTheDocument();
+  });
+
+  it('renders plain text for assistant message without cards', async () => {
+    mockPost.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        role: 'assistant',
+        content: 'Photosynthesis is the process...',
+      }),
+    });
+
+    render(<ChatPage />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
+      target: { value: 'Explain photosynthesis' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Photosynthesis is the process...')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Save as deck')).not.toBeInTheDocument();
+  });
+
+  it('hydrates usage counter from server on mount', async () => {
+    mockGet.mockResolvedValueOnce({ used: 5, limit: 20 });
+
+    render(<ChatPage />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/chat/usage', { redirect: false });
+    });
+  });
+});

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
-import { post } from '../../lib/backend/api';
-import ChatBubbleIcon from '../../components/icons/ChatBubbleIcon';
+import { get, post } from '../../lib/backend/api';
 import SendIcon from '../../components/icons/SendIcon';
+import CardPreview from './CardPreview';
 import styles from './ChatPage.module.css';
 
 interface ChatCard {
@@ -13,18 +13,27 @@ interface ChatCard {
 interface Message {
   role: 'user' | 'assistant';
   content: string;
+  contentBefore?: string;
+  contentAfter?: string;
   cards?: ChatCard[];
 }
 
 interface ApiSuccessResponse {
   role: 'assistant';
   content: string;
+  contentBefore?: string;
+  contentAfter?: string;
   cards?: ChatCard[];
 }
 
 interface ApiRateLimitResponse {
   error: string;
   resetDate: string;
+}
+
+interface ApiUsageResponse {
+  used: number;
+  limit: number | null;
 }
 
 const STARTER_PROMPTS = [
@@ -43,6 +52,20 @@ function formatResetDate(iso: string): string {
   }
 }
 
+async function downloadDeck(cards: ChatCard[], deckName: string): Promise<void> {
+  const response = await post('/api/chat/deck', { cards, deckName });
+  if (!response.ok) {
+    throw new Error('Failed to generate deck');
+  }
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${deckName}.apkg`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 export default function ChatPage() {
   const { data: userLocals } = useUserLocals();
   const isPatreon = userLocals?.user?.patreon === true;
@@ -53,16 +76,30 @@ export default function ChatPage() {
   const [networkError, setNetworkError] = useState<string | null>(null);
   const [limitReached, setLimitReached] = useState(false);
   const [resetDate, setResetDate] = useState<string | null>(null);
-  const [messagesSentThisSession, setMessagesSentThisSession] = useState(0);
+  const [messagesUsedThisMonth, setMessagesUsedThisMonth] = useState(0);
 
   const bottomRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
+    get('/api/chat/usage', { redirect: false })
+      .then((data: ApiUsageResponse | undefined) => {
+        if (data != null) {
+          setMessagesUsedThisMonth(data.used);
+          if (data.limit != null && data.used >= data.limit) {
+            setLimitReached(true);
+          }
+        }
+      })
+      .catch(() => {
+      });
+  }, []);
+
+  useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isLoading]);
 
-  const remainingMessages = FREE_MONTHLY_LIMIT - messagesSentThisSession;
+  const remainingMessages = FREE_MONTHLY_LIMIT - messagesUsedThisMonth;
 
   const canSend = inputValue.trim().length > 0 && !isLoading && !limitReached;
 
@@ -98,9 +135,15 @@ export default function ChatPage() {
       const data: ApiSuccessResponse = await response.json();
       setMessages((prev) => [
         ...prev,
-        { role: 'assistant', content: data.content, cards: data.cards },
+        {
+          role: 'assistant',
+          content: data.content,
+          contentBefore: data.contentBefore,
+          contentAfter: data.contentAfter,
+          cards: data.cards,
+        },
       ]);
-      setMessagesSentThisSession((n) => n + 1);
+      setMessagesUsedThisMonth((n) => n + 1);
     } catch {
       setNetworkError("Couldn't send this message. Try again.");
     } finally {
@@ -117,18 +160,10 @@ export default function ChatPage() {
     }
   }
 
-  function handleSaveAsDeck(cards: ChatCard[]) {
-    const deckName = globalThis.prompt('Deck name:');
-    if (deckName == null || deckName.trim().length === 0) return;
-
-    const lines = cards.map((c) => `${c.front}\t${c.back}`).join('\n');
-    const blob = new Blob([lines], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${deckName.trim()}.txt`;
-    a.click();
-    URL.revokeObjectURL(url);
+  function handleSaveAsDeck(cards: ChatCard[], deckName: string) {
+    downloadDeck(cards, deckName).catch(() => {
+      setNetworkError("Couldn't generate the deck. Try again.");
+    });
   }
 
   const hasMessages = messages.length > 0;
@@ -140,22 +175,31 @@ export default function ChatPage() {
           {messages.map((m, i) => (
             <div
               key={i}
-              className={`${styles.message} ${m.role === 'user' ? styles.messageUser : styles.messageAssistant}`}
+              className={`${styles.message} ${m.role === 'user' ? styles.messageUser : styles.messageAssistant} ${m.role === 'assistant' && m.cards != null && m.cards.length > 0 ? styles.messageAssistantWithCards : ''}`}
             >
-              <div
-                className={`${styles.messageBubble} ${m.role === 'user' ? styles.messageBubbleUser : styles.messageBubbleAssistant}`}
-              >
-                {m.content}
-              </div>
-              {m.role === 'assistant' && m.cards != null && m.cards.length > 0 && (
-                <button
-                  type="button"
-                  className={styles.saveAsDeckBtn}
-                  onClick={() => handleSaveAsDeck(m.cards!)}
-                >
-                  <ChatBubbleIcon width={14} height={14} />
-                  Save as deck
-                </button>
+              {m.role === 'user' && (
+                <div className={`${styles.messageBubble} ${styles.messageBubbleUser}`}>
+                  {m.content}
+                </div>
+              )}
+              {m.role === 'assistant' && (
+                <>
+                  {m.contentBefore != null && (
+                    <div className={styles.assistantText}>{m.contentBefore}</div>
+                  )}
+                  {m.cards != null && m.cards.length > 0 && (
+                    <CardPreview
+                      cards={m.cards}
+                      onSave={(deckName) => handleSaveAsDeck(m.cards!, deckName)}
+                    />
+                  )}
+                  {m.contentAfter != null && (
+                    <div className={styles.assistantText}>{m.contentAfter}</div>
+                  )}
+                  {m.cards == null && (
+                    <div className={styles.assistantText}>{m.content}</div>
+                  )}
+                </>
               )}
             </div>
           ))}
@@ -228,7 +272,7 @@ export default function ChatPage() {
             <SendIcon width={18} height={18} />
           </button>
         </div>
-        {!isPatreon && !limitReached && messagesSentThisSession > 0 && (
+        {!isPatreon && !limitReached && messagesUsedThisMonth > 0 && (
           <p className={styles.usageLine}>
             {remainingMessages} of {FREE_MONTHLY_LIMIT} messages left this month
           </p>


### PR DESCRIPTION
## What

Fixes four broken behaviors in the Chat feature:

1. Raw ` ```json ``` ` fence no longer shown in assistant messages — `extractCards` now returns `contentBefore`/`contentAfter` prose segments, and `CardPreview` renders them cleanly around the card list.
2. `globalThis.prompt()` replaced with an inline rename flow: idle → naming (input + Save + Cancel) → saved (filename + Save again). No native dialog, works on mobile.
3. `.txt` download replaced with a real `.apkg` file via new `POST /api/chat/deck` endpoint that calls `CustomExporter` + `CardGenerator`.
4. Usage counter now hydrated from `GET /api/chat/usage` on page load — returning users see the correct count immediately.

## Why

All four were regressions shipped with the initial Chat feature that broke the user experience. Fixes #2 (raw JSON) and #2 (prompt) were particularly visible and off-brand per VOICE.md.

## How

- `ChatUseCase.extractCards` refactored to return `{ cards, contentBefore, contentAfter }` instead of just `cards`. The controller passes the new fields through to the client.
- `CardPreview` component: full-width card grid, expand/collapse at 5+, desktop two-col / mobile single-col, inline rename state machine.
- `ChatDeckUseCase`: creates a temp workspace in `os.tmpdir()`, calls `CustomExporter.configure()` with a `DeckInfo`-shaped payload, calls `exporter.save()` which invokes the Python `create_deck.py` bridge, cleans up on exit.
- `ChatDeckController`: validates deckName (max 120), cards (non-empty array, max 200, front+back strings), delegates to use case, streams the buffer back with correct `Content-Disposition`.
- `GET /api/chat/usage`: inline handler in `ChatRouter` — calls `repo.countThisMonth`, returns `{ used, limit: patreon ? null : 20 }`.
- `ChatPage` hydrates counter on mount; hides the usage line for patreon users.

## Measuring success

- Zero occurrences of ` ```json ``` ` in rendered assistant messages (verified by looking at DOM in production).
- No `globalThis.prompt` calls anywhere: `grep -r "globalThis.prompt" web/src` returns nothing.
- Downloads produce `.apkg` files that open in Anki Desktop without errors.
- Usage line shows correct remaining count immediately on page load for returning free users.

## Testing

- Unit tests added:
  - `ChatUseCase.test.ts`: 5 new tests for `contentBefore`/`contentAfter` (including edge cases: no text before, no text after, no JSON block)
  - `ChatDeckController.test.ts`: 9 tests covering all validation paths and happy path
  - `CardPreview.test.tsx`: 20 tests covering card display, expand toggle, and full save state machine
  - `ChatPage.test.tsx`: 4 tests covering rendering with/without cards, usage hydration
- Swagger coverage test passes — both new endpoints documented

## Risks

- `POST /api/chat/deck` spawns Python synchronously (same as every other conversion). Cards come from trusted server-extracted JSON, not raw user input, so injection risk is low. Temp dir is cleaned up in finally block.
- `GET /api/chat/usage` adds one DB query per page load for logged-in users. It's a simple `COUNT(*)` on an indexed table — negligible overhead.

## Goal alignment

Polished UX directly improves trial-to-retention conversion. A feature that shows raw JSON and downloads `.txt` files signals a broken product — fixing it reduces churn on the Chat path.