### PR TITLE
feat: render markdown in chat assistant messages

### DIFF
--- a/web/src/pages/Chat/AssistantMarkdown.module.css
+++ b/web/src/pages/Chat/AssistantMarkdown.module.css
@@ -1,0 +1,90 @@
+.prose {
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  word-break: break-word;
+}
+
+.prose > :first-child { margin-top: 0; }
+.prose > :last-child  { margin-bottom: 0; }
+
+.prose p {
+  margin: 0 0 0.5rem;
+}
+
+.prose strong { font-weight: var(--font-semibold); }
+.prose em     { font-style: italic; }
+
+.prose ul,
+.prose ol {
+  margin: 0.25rem 0 0.5rem;
+  padding-left: 1.25rem;
+}
+.prose li { margin: 0.125rem 0; }
+.prose li > p { margin: 0; }
+
+.prose h1,
+.prose h2,
+.prose h3 {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  line-height: var(--leading-snug);
+  margin: 0.75rem 0 0.25rem;
+}
+
+.prose code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8125rem;
+  background: var(--color-bg-secondary);
+  padding: 0.05rem 0.3rem;
+  border-radius: var(--radius-sm);
+}
+
+.prose pre {
+  margin: 0.5rem 0;
+  padding: 0.75rem 0.875rem;
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-md);
+  overflow-x: auto;
+  font-size: 0.8125rem;
+  line-height: var(--leading-normal);
+}
+
+.prose pre code {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-size: inherit;
+}
+
+.prose hr {
+  border: 0;
+  border-top: 1px solid var(--color-border-light);
+  margin: 0.75rem 0;
+}
+
+.prose a {
+  color: var(--color-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.prose blockquote {
+  margin: 0.5rem 0;
+  padding-left: 0.75rem;
+  border-left: 2px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.prose table {
+  font-variant-numeric: tabular-nums;
+  border-collapse: collapse;
+  margin: 0.5rem 0;
+}
+
+.prose th,
+.prose td {
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--color-border-light);
+  text-align: left;
+}

--- a/web/src/pages/Chat/AssistantMarkdown.test.tsx
+++ b/web/src/pages/Chat/AssistantMarkdown.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import AssistantMarkdown from './AssistantMarkdown';
+
+describe('AssistantMarkdown', () => {
+  it('renders bold markdown as <strong>', () => {
+    render(<AssistantMarkdown>{'**bold text**'}</AssistantMarkdown>);
+    expect(screen.getByText('bold text').tagName).toBe('STRONG');
+  });
+
+  it('does not inject <script> tags from model output', () => {
+    const { container } = render(
+      <AssistantMarkdown>{'hello <script>alert(1)</script> world'}</AssistantMarkdown>
+    );
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('strips javascript: hrefs from links', () => {
+    const { container } = render(
+      <AssistantMarkdown>{'[click me](javascript:alert(1))'}</AssistantMarkdown>
+    );
+    const link = container.querySelector('a');
+    expect(link?.getAttribute('href')).toBeNull();
+  });
+
+  it('opens https links in a new tab with rel=noopener', () => {
+    render(<AssistantMarkdown>{'[2anki](https://2anki.net)'}</AssistantMarkdown>);
+    const link = screen.getByRole('link', { name: '2anki' });
+    expect(link.getAttribute('href')).toBe('https://2anki.net');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+});

--- a/web/src/pages/Chat/AssistantMarkdown.tsx
+++ b/web/src/pages/Chat/AssistantMarkdown.tsx
@@ -1,0 +1,26 @@
+import ReactMarkdown, { type Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import styles from './AssistantMarkdown.module.css';
+
+const components: Components = {
+  a: ({ href, children, ...rest }) => {
+    const safe = href != null && (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('mailto:'));
+    return (
+      <a href={safe ? href : undefined} target="_blank" rel="noopener noreferrer" {...rest}>
+        {children}
+      </a>
+    );
+  },
+};
+
+const plugins = [remarkGfm];
+
+export default function AssistantMarkdown({ children }: { children: string }) {
+  return (
+    <div className={styles.prose}>
+      <ReactMarkdown remarkPlugins={plugins} components={components}>
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/web/src/pages/Chat/ChatPage.module.css
+++ b/web/src/pages/Chat/ChatPage.module.css
@@ -110,15 +110,6 @@
   padding-right: 0;
 }
 
-.assistantText {
-  background: transparent;
-  color: var(--color-text-primary);
-  white-space: pre-wrap;
-  word-break: break-word;
-  font-size: var(--text-sm);
-  line-height: var(--leading-relaxed);
-}
-
 .messageSkeleton {
   height: 3rem;
   width: 240px;

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { get, post } from '../../lib/backend/api';
 import SendIcon from '../../components/icons/SendIcon';
+import AssistantMarkdown from './AssistantMarkdown';
 import CardPreview from './CardPreview';
 import styles from './ChatPage.module.css';
 
@@ -185,7 +186,7 @@ export default function ChatPage() {
               {m.role === 'assistant' && (
                 <>
                   {m.contentBefore != null && (
-                    <div className={styles.assistantText}>{m.contentBefore}</div>
+                    <AssistantMarkdown>{m.contentBefore}</AssistantMarkdown>
                   )}
                   {m.cards != null && m.cards.length > 0 && (
                     <CardPreview
@@ -194,10 +195,10 @@ export default function ChatPage() {
                     />
                   )}
                   {m.contentAfter != null && (
-                    <div className={styles.assistantText}>{m.contentAfter}</div>
+                    <AssistantMarkdown>{m.contentAfter}</AssistantMarkdown>
                   )}
                   {m.cards == null && (
-                    <div className={styles.assistantText}>{m.content}</div>
+                    <AssistantMarkdown>{m.content}</AssistantMarkdown>
                   )}
                 </>
               )}


### PR DESCRIPTION
## Summary

- AI responses were showing raw `**bold**`, `- bullets`, and `---` dividers as literal text instead of rendered HTML
- Added `AssistantMarkdown` component using `react-markdown` + `remark-gfm` (already installed — no new deps)
- Replaced all three assistant text render sites in `ChatPage.tsx`; user messages stay plain text
- No `rehype-raw` — model output is untrusted; `javascript:` hrefs are stripped; safe links open `target="_blank" rel="noopener noreferrer"`
- Removed the now-unused `.assistantText` CSS rule; new chat-tuned prose styles in `AssistantMarkdown.module.css`

## Test plan

- [x] Run `pnpm --filter 2anki-web test src/pages/Chat/AssistantMarkdown.test.tsx` — 4 tests: bold renders as `<strong>`, `<script>` injection blocked, `javascript:` href stripped, safe https link opens in new tab
- [x] Open Chat in dev, send a message — verify bold, lists, code blocks, and `---` dividers render correctly
- [x] Verify user message bubbles still show plain text (no markdown processing on input echo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)