### PR TITLE
fix: raw JSON cards, truncated responses, and ugly scrollbar

### DIFF
--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -5,15 +5,17 @@ const FREE_MONTHLY_LIMIT = 20;
 const FREE_MODEL = 'claude-haiku-4-5-20251001';
 const PATREON_MODEL = 'claude-sonnet-4-6';
 const MAX_HISTORY_TURNS = 10;
-const MAX_TOKENS = 1024;
+const MAX_TOKENS = 4096;
 
 const STUDY_ASSISTANT_SYSTEM_PROMPT = `You are a study assistant for 2anki, a tool that turns notes into Anki flashcards.
 
-Help users understand material, answer study questions, and create flashcards. When generating flashcards, always output them as a JSON code block in this exact format:
+Help users understand material, answer study questions, and create flashcards. When generating flashcards, you MUST wrap them in a JSON code block using EXACTLY this format — no exceptions:
 
 \`\`\`json
 [{"front": "question or term", "back": "answer or definition"}]
 \`\`\`
+
+Never output raw JSON without the code fence. Always include the opening \`\`\`json and closing \`\`\` markers.
 
 After giving any explanation or answer, offer to turn the content into flashcards if the user hasn't already asked. Keep responses focused and practical — this is a study tool, not a general assistant.`;
 
@@ -61,22 +63,14 @@ interface ExtractCardsResult {
   contentAfter: string | undefined;
 }
 
-function extractCards(text: string): ExtractCardsResult {
-  const match = /```json\s*([\s\S]*?)```/.exec(text);
-  if (match == null) return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
-
-  const before = text.slice(0, match.index).trim();
-  const after = text.slice(match.index + match[0].length).trim();
-
+function parseCardArray(raw: string): ChatCard[] | undefined {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(match[1].trim());
+    parsed = JSON.parse(raw.trim());
   } catch {
-    return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
+    return undefined;
   }
-
-  if (!Array.isArray(parsed)) return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
-
+  if (!Array.isArray(parsed)) return undefined;
   const cards: ChatCard[] = [];
   for (const item of parsed) {
     if (
@@ -91,14 +85,40 @@ function extractCards(text: string): ExtractCardsResult {
       });
     }
   }
+  return cards.length > 0 ? cards : undefined;
+}
 
-  if (cards.length === 0) return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
+function extractCards(text: string): ExtractCardsResult {
+  const fencedMatch = /```json\s*([\s\S]*?)```/.exec(text);
+  if (fencedMatch != null) {
+    const cards = parseCardArray(fencedMatch[1]);
+    if (cards != null) {
+      const before = text.slice(0, fencedMatch.index).trim();
+      const after = text.slice(fencedMatch.index + fencedMatch[0].length).trim();
+      return {
+        cards,
+        contentBefore: before.length > 0 ? before : undefined,
+        contentAfter: after.length > 0 ? after : undefined,
+      };
+    }
+  }
 
-  return {
-    cards,
-    contentBefore: before.length > 0 ? before : undefined,
-    contentAfter: after.length > 0 ? after : undefined,
-  };
+  // Fallback: detect a raw JSON array that starts with [{"front": ...}]
+  const rawMatch = /((?:^|\n)\s*)(\[\s*\{[\s\S]*\}\s*\])/.exec(text);
+  if (rawMatch != null) {
+    const cards = parseCardArray(rawMatch[2]);
+    if (cards != null) {
+      const before = text.slice(0, rawMatch.index).trim();
+      const after = text.slice(rawMatch.index + rawMatch[0].length).trim();
+      return {
+        cards,
+        contentBefore: before.length > 0 ? before : undefined,
+        contentAfter: after.length > 0 ? after : undefined,
+      };
+    }
+  }
+
+  return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
 }
 
 export class ChatUseCase {

--- a/web/src/pages/Chat/AssistantMarkdown.module.css
+++ b/web/src/pages/Chat/AssistantMarkdown.module.css
@@ -46,6 +46,7 @@
   background: var(--color-bg-tertiary);
   border-radius: var(--radius-md);
   overflow-x: auto;
+  overflow-y: hidden;
   font-size: 0.8125rem;
   line-height: var(--leading-normal);
 }

--- a/web/src/pages/Chat/ChatPage.module.css
+++ b/web/src/pages/Chat/ChatPage.module.css
@@ -14,6 +14,21 @@
   flex-direction: column;
   gap: 1rem;
   padding: 2rem 0 1rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.messageList::-webkit-scrollbar {
+  width: 4px;
+}
+
+.messageList::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.messageList::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: 2px;
 }
 
 .emptyState {

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -53,8 +53,10 @@ function formatResetDate(iso: string): string {
 }
 
 function visibleStreamingText(text: string): string {
-  const fenceIndex = text.indexOf('\n```json');
-  return fenceIndex === -1 ? text : text.slice(0, fenceIndex);
+  const fenceIndex = text.search(/(?:^|\n)```json/);
+  if (fenceIndex !== -1) return text.slice(0, fenceIndex);
+  const rawArrayIndex = text.search(/(?:^|\n)\s*\[\s*\{/);
+  return rawArrayIndex === -1 ? text : text.slice(0, rawArrayIndex);
 }
 
 async function downloadDeck(cards: ChatCard[], deckName: string): Promise<void> {
@@ -229,7 +231,7 @@ export default function ChatPage() {
     });
   }
 
-  const isCardStreaming = streamingText.includes('\n```json');
+  const isCardStreaming = /(?:^|\n)```json/.test(streamingText) || /(?:^|\n)\s*\[\s*\{/.test(streamingText);
 
   const hasMessages = messages.length > 0;
 


### PR DESCRIPTION
## Summary

Three bugs fixed in one pass:

**1. Cards showed as raw JSON instead of CardPreview**
The model sometimes outputs a raw `[{"front":...}]` array without the ` ```json ``` ` fence (especially when the user just says "yes"). `extractCards` only matched fenced blocks, so cards were never parsed and rendered as plain text. Added a fallback that detects raw JSON arrays directly. Also hardened the system prompt to be explicit that the fence is always required.

**2. Long card sets truncated mid-response**
`MAX_TOKENS = 1024` is too small for 20+ cards with detailed backs. Increased to 4096. The last card was cut off mid-sentence in the reproduction case.

**3. Ugly wide scrollbar on the message list**
The `.messageList` used the full native OS scrollbar (wide and intrusive on Windows). Now uses `scrollbar-width: thin` + 4px webkit overrides. Also added `overflow-y: hidden` on `.prose pre` to stop code blocks from growing their own vertical scrollbar.

**Bonus:** `visibleStreamingText` and `isCardStreaming` now recognise both fenced and raw-array patterns so the "Building cards" indicator fires correctly in both cases.

## Test plan

- [ ] `pnpm test src/usecases/chat/ChatUseCase.test.ts` — 14 pass
- [ ] `pnpm --filter 2anki-web test:run src/pages/Chat/` — 8 pass
- [ ] Manual: say "yes" to a card offer — cards render in `CardPreview`, no raw JSON visible
- [ ] Manual: ask for 20+ cards — full set completes without truncation
- [ ] Manual: scrollbar is thin and unobtrusive

🤖 Generated with [Claude Code](https://claude.com/claude-code)