### PR TITLE
fix: scrollbar at right edge + smart auto-scroll

### DIFF
--- a/web/src/pages/Chat/ChatPage.module.css
+++ b/web/src/pages/Chat/ChatPage.module.css
@@ -2,18 +2,11 @@
   display: flex;
   flex-direction: column;
   height: calc(100vh - 0px);
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 0 1.5rem;
 }
 
 .messageList {
   flex: 1;
   overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 2rem 0 1rem;
   scrollbar-width: thin;
   scrollbar-color: var(--color-border) transparent;
 }
@@ -31,6 +24,15 @@
   border-radius: 2px;
 }
 
+.messageListInner {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .emptyState {
   flex: 1;
   display: flex;
@@ -39,7 +41,10 @@
   justify-content: center;
   text-align: center;
   gap: 1rem;
-  padding: 4rem 0;
+  padding: 4rem 1.5rem;
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .emptyHeading {
@@ -161,10 +166,13 @@
 
 .inputArea {
   border-top: 1px solid var(--color-border-light);
-  padding: 1rem 0 1.5rem;
+  padding: 1rem 1.5rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .inputRow {

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -88,6 +88,7 @@ export default function ChatPage() {
   const [messagesUsedThisMonth, setMessagesUsedThisMonth] = useState(0);
 
   const bottomRef = useRef<HTMLDivElement>(null);
+  const messageListRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -105,7 +106,12 @@ export default function ChatPage() {
   }, []);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: streamingText.length > 0 ? 'auto' : 'smooth' });
+    const el = messageListRef.current;
+    if (el == null) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom < 120) {
+      bottomRef.current?.scrollIntoView({ behavior: streamingText.length > 0 ? 'auto' : 'smooth' });
+    }
   }, [messages, isLoading, streamingText]);
 
   const remainingMessages = FREE_MONTHLY_LIMIT - messagesUsedThisMonth;
@@ -238,7 +244,8 @@ export default function ChatPage() {
   return (
     <div className={styles.container}>
       {hasMessages || isLoading ? (
-        <div className={styles.messageList}>
+        <div className={styles.messageList} ref={messageListRef}>
+          <div className={styles.messageListInner}>
           {messages.map((m, i) => (
             <div
               key={i}
@@ -305,6 +312,7 @@ export default function ChatPage() {
             </div>
           )}
           <div ref={bottomRef} />
+          </div>
         </div>
       ) : (
         <div className={styles.emptyState}>


### PR DESCRIPTION
## Summary

Two scroll fixes:

**Scrollbar position** — The scrollbar was appearing next to the 800px message container because `overflow-y: auto` was on the inner constrained div. Restructured layout so the scroll container spans the full available width (scrollbar now at the right edge of the screen), with a new `.messageListInner` wrapper centering the messages at max-width 800px. Same pattern Claude.ai uses.

**Auto-scroll behavior** — Previously scrolled to the bottom on every streaming token, making it impossible to scroll up and read while a response was generating. Now only auto-scrolls if the user is already within 120px of the bottom. Scroll up to read, and the stream stays where you left it.

## Test plan

- [ ] `pnpm --filter 2anki-web test:run src/pages/Chat/` — 8 pass  
- [ ] Manual: scrollbar appears at the far right edge of the content area
- [ ] Manual: can scroll up mid-stream and the view stays put; scroll back to bottom and it resumes following

🤖 Generated with [Claude Code](https://claude.com/claude-code)