### PR TITLE
fix: hide /downloads upgrade footer for paying users, fix price

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -29,6 +29,12 @@ vi.mock('../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({}),
 }));
 
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => ({
+    data: { locals: { patreon: false, subscriber: false } },
+  }),
+}));
+
 type AnalyticsGlobals = {
   hj?: ReturnType<typeof vi.fn>;
   gtag?: ReturnType<typeof vi.fn>;

--- a/web/src/pages/DownloadsPage/components/FinishedJobs.test.tsx
+++ b/web/src/pages/DownloadsPage/components/FinishedJobs.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { FinishedJobs } from './FinishedJobs';
+import UserUpload from '../../../lib/interfaces/UserUpload';
+
+const mockUseUserLocals = vi.fn();
+vi.mock('../../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => mockUseUserLocals(),
+}));
+
+function buildUpload(overrides: Partial<UserUpload> = {}): UserUpload {
+  return {
+    id: 1,
+    key: 'deck-1.apkg',
+    filename: 'Pharmacology.apkg',
+    object_id: 'obj-1',
+    owner: 1,
+    created_at: new Date('2026-05-10T11:30:00Z'),
+    size: 1024,
+    ...overrides,
+  } as UserUpload;
+}
+
+function renderFinishedJobs() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <FinishedJobs
+          uploads={[buildUpload()]}
+          deleteUpload={vi.fn().mockResolvedValue(undefined)}
+          doneJobs={[]}
+          deleteJob={vi.fn()}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('FinishedJobs upgrade footer', () => {
+  beforeEach(() => {
+    mockUseUserLocals.mockReset();
+  });
+
+  it('shows the upgrade footer to free users at the canonical price', () => {
+    mockUseUserLocals.mockReturnValue({
+      data: { locals: { patreon: false, subscriber: false } },
+    });
+
+    renderFinishedJobs();
+
+    const link = screen.getByRole('link', {
+      name: /Upgrade to Unlimited — \$6 \/ mo, cancel anytime/,
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/pricing');
+    expect(screen.queryByText(/\$5\/month/)).not.toBeInTheDocument();
+  });
+
+  it('hides the upgrade footer for lifetime (patreon) users', () => {
+    mockUseUserLocals.mockReturnValue({
+      data: { locals: { patreon: true, subscriber: false } },
+    });
+
+    renderFinishedJobs();
+
+    expect(screen.queryByText(/Hitting the 100-card limit/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /Upgrade to Unlimited/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the upgrade footer for monthly subscribers', () => {
+    mockUseUserLocals.mockReturnValue({
+      data: { locals: { patreon: false, subscriber: true } },
+    });
+
+    renderFinishedJobs();
+
+    expect(screen.queryByText(/Hitting the 100-card limit/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
+++ b/web/src/pages/DownloadsPage/components/FinishedJobs.tsx
@@ -10,6 +10,12 @@ import EyeIcon from '../../../components/icons/EyeIcon';
 import TrashIcon from '../../../components/icons/TrashIcon';
 import SendToAnkifyButton from './SendToAnkifyButton';
 import { fireAnalyticsEvent } from '../../../lib/analytics/fireAnalyticsEvent';
+import { useUserLocals } from '../../../lib/hooks/useUserLocals';
+import { isPayingUser } from '../../../components/NavigationBar/helpers/getPlanLabel';
+import {
+  MONTHLY_PRICE,
+  MONTHLY_SUFFIX,
+} from '../../PricingPage/pricing.constants';
 import styles from '../DownloadsPage.module.css';
 import sharedStyles from '../../../styles/shared.module.css';
 
@@ -24,6 +30,8 @@ interface Prop {
 
 export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }: Prop) {
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
+  const { data } = useUserLocals();
+  const showUpgradeFooter = !isPayingUser(data?.locals);
 
   const uploadObjectIds = new Set((uploads ?? []).map((u) => u.object_id));
   const uniqueDoneJobs = doneJobs.filter((j) => !uploadObjectIds.has(j.object_id));
@@ -163,10 +171,15 @@ export function FinishedJobs({ uploads, deleteUpload, doneJobs = [], deleteJob }
           </tbody>
         </table>
         </div>
-        <div className={styles.upgradeFooter}>
-          Hitting the 100-card limit?{' '}
-          <Link to="/pricing">Upgrade to Unlimited — $5/month, cancel anytime →</Link>
-        </div>
+        {showUpgradeFooter && (
+          <div className={styles.upgradeFooter}>
+            Hitting the 100-card limit?{' '}
+            <Link to="/pricing">
+              Upgrade to Unlimited — {MONTHLY_PRICE} {MONTHLY_SUFFIX}, cancel
+              anytime →
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Lifetime (`patreon`) and monthly (`subscriber`) users were seeing the "Hitting the 100-card limit? Upgrade to Unlimited — \$5/month…" footer at the bottom of the /downloads Ready-to-Download card. The footer in `FinishedJobs.tsx` was rendered unconditionally.
- The price was hand-typed as `\$5/month` but the canonical source (`web/src/pages/PricingPage/pricing.constants.ts`) is `\$6 / mo`. `PaywallBanner.tsx` already uses the constant; this footer hadn't been updated.

Fix:
- Gate the footer with `isPayingUser(locals)` from `useUserLocals` (same helper used by `getPlanLabel`).
- Render the price as `{MONTHLY_PRICE} {MONTHLY_SUFFIX}`, matching `PaywallBanner`.
- Add `FinishedJobs.test.tsx` covering free / patreon / subscriber cases — including an assertion that `\$5/month` is no longer in the DOM.

## Test plan

- [x] `pnpm --filter 2anki-web test FinishedJobs.test` — 3/3 pass
- [x] `pnpm --filter 2anki-web lint` — clean
- [x] Visual check on /downloads as a lifetime user (footer hidden)
- [x] Visual check on /downloads as a free user (footer shown, reads "\$6 / mo")

🤖 Generated with [Claude Code](https://claude.com/claude-code)