### PR TITLE
fix: handle non-ASCII filenames in upload path (#2184)

### DIFF
--- a/src/lib/storage/types.test.ts
+++ b/src/lib/storage/types.test.ts
@@ -1,0 +1,35 @@
+import { isFileNameEqual } from './types';
+import type { File } from '../zip/zip';
+
+function file(name: string): File {
+  return { name };
+}
+
+describe('isFileNameEqual', () => {
+  it.each([
+    ['plain UTF-8 umlaut', 'Speicheldrüsen.zip', 'Speicheldrüsen.zip'],
+    ['CJK characters', '漢字.zip', '漢字.zip'],
+    ['Cyrillic', 'Здравствуйте.zip', 'Здравствуйте.zip'],
+    ['accented', 'café.html', 'café.html'],
+    ['emoji', '📚.zip', '📚.zip'],
+  ])('%s: matches when both sides are identical', (_label, fileName, name) => {
+    expect(isFileNameEqual(file(fileName), name)).toBe(true);
+  });
+
+  it('matches when the zip entry is UTF-8 but the name arrived double-encoded as latin1', () => {
+    expect(isFileNameEqual(file('Speicheldrüsen.zip'), 'SpeicheldrÃ¼sen.zip')).toBe(true);
+  });
+
+  it('matches when the file name is double-encoded but the name is clean UTF-8', () => {
+    expect(isFileNameEqual(file('SpeicheldrÃ¼sen.zip'), 'Speicheldrüsen.zip')).toBe(true);
+  });
+
+  it('does not throw and returns false for a truly malformed percent-encoded name', () => {
+    expect(() => isFileNameEqual(file('normal.zip'), 'bad%E0%A4%A.zip')).not.toThrow();
+    expect(isFileNameEqual(file('normal.zip'), 'bad%E0%A4%A.zip')).toBe(false);
+  });
+
+  it('returns false for clearly different names', () => {
+    expect(isFileNameEqual(file('one.zip'), 'two.zip')).toBe(false);
+  });
+});

--- a/src/lib/storage/types.ts
+++ b/src/lib/storage/types.ts
@@ -37,36 +37,32 @@ export interface Job {
   job_reason_failure?: string;
 }
 
-/**
- * Check if the file name is equal to the name
- * This can be used to find the contents of a file in the payload.
- * Due to encoding issues, we need to check both the encoded and decoded names
- *
- * @param file uploaded file from user
- * @param name name of the file
- * @returns true if the file name is equal to the name
- */
+function recoverLatin1(s: string): string {
+  return Buffer.from(s, 'latin1').toString('utf8');
+}
+
+function safeDecodeURIComponent(s: string): string {
+  try {
+    return global.decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
 export function isFileNameEqual(file: File, name: string) {
-  try {
-    // For backwards compatibility, we need to support the old way of parsing
-    const decodedName = global.decodeURIComponent(name);
-    if (file.name === decodedName) {
-      return true;
-    }
-  } catch (error) {
-    console.error(error);
-    console.debug('Failed to decode name');
+  if (file.name === name) {
+    return true;
   }
 
-  try {
-    const decodedFilename = global.decodeURIComponent(file.name);
-    const decodedName = global.decodeURIComponent(name);
+  const decodedFileName = safeDecodeURIComponent(file.name);
+  const decodedName = safeDecodeURIComponent(name);
 
-    return decodedFilename === decodedName;
-  } catch (error) {
-    console.error(error);
-    console.debug('Failed to decode names');
+  if (decodedFileName === decodedName) {
+    return true;
   }
 
-  return file.name === name;
+  const recoveredFileName = recoverLatin1(file.name);
+  const recoveredName = recoverLatin1(name);
+
+  return recoveredFileName === decodedName || decodedFileName === recoveredName;
 }


### PR DESCRIPTION
## What

Fixes a filename-matching failure that caused upload jobs to silently produce zero cards for filenames with non-ASCII characters (umlauts, CJK, Cyrillic, accents, emoji).

## Why

Closes #2184

EU and Asian users were blocked at the very first step: uploading a file. Jobs like 168411 (`SpeicheldrÃ¼sen.zip`) and 168394 failed with "No packages produced" because the file entry inside the zip could never be found.

The root cause: multer re-decodes the `Content-Disposition` filename using latin1 when the browser sends raw UTF-8 bytes without RFC 5987 percent-encoding. This turns `Speicheldrüsen.zip` into `SpeicheldrÃ¼sen.zip`. The zip entry itself is stored with the correct UTF-8 name. `isFileNameEqual` compared these two and returned false on all three paths, so `DeckParser.processFirstFile` found no file, produced an empty payload, and the job was marked failed.

The issue title said `TypeError: Invalid URL` — that is a paraphrase. The actual failure was a null `firstFile` → empty `payload` → "No packages produced". No `new URL()` call touches a user filename in this path.

## How

Added a latin1-recovery path to `isFileNameEqual` in `src/lib/storage/types.ts`:

```ts
Buffer.from(s, 'latin1').toString('utf8')
```

This converts the latin1 byte sequence `Ã¼` back to its UTF-8 origin `ü`. The recovery is only attempted when the direct string comparison and the `decodeURIComponent` comparison both fail, so the ASCII common case has no overhead.

Also extracted `safeDecodeURIComponent` to consolidate the try/catch (was duplicated twice in the original) and prevent `URIError` from propagating to callers with malformed percent sequences like `bad%E0%A4%A.zip`.

## Measuring success

Jobs with non-ASCII filenames should stop appearing with `job_reason_failure = 'No packages produced'`. Production query:

```sql
SELECT count(*) FROM jobs
WHERE job_reason_failure = 'No packages produced'
  AND title ~ '[^\x00-\x7F]'
  AND created_at > now() - interval '7 days';
```

Should trend to zero for new jobs after deploy.

## Testing

- Unit tests added: `src/lib/storage/types.test.ts` — 9 cases:
  - Plain UTF-8 umlaut, CJK, Cyrillic, accented, emoji (same-same matches)
  - Double-encoded latin1 → UTF-8 match (the exact bug case)
  - Reverse: double-encoded file.name vs clean name
  - Malformed percent sequence `bad%E0%A4%A.zip` — must not throw, must return false
  - Clearly different names return false
- All 9 pass; the two double-encoding cases were failing before the fix
- Server tsc: clean
- Web typecheck: clean
- Web vitest 397 tests: all pass
- Web Biome lint: clean

## Risks

The latin1 recovery adds a new match path. A false positive would require a filename that is valid latin1 and coincidentally decodes to the same UTF-8 as a different zip entry — extremely unlikely in practice.

Rollback: revert this commit. The symptom reverts to "No packages produced" for non-ASCII filenames, which is the current production behaviour.

## Goal alignment

EU and Asian users (umlauts, CJK, Cyrillic) are blocked at the upload step today. Fixing this removes a hard blocker for a significant user segment on the path to 300K users.

## Follow-up

`ApkgController` and `DownloadController` set `Content-Disposition` without RFC 5987 encoding (`filename*=UTF-8''...`). This affects the download side and is a separate bug — not in scope here.