### PR TITLE
fix: load saved deckName instead of masking with Notion page title (#1319)

### DIFF
--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -2,6 +2,8 @@ import { IServiceSettings } from '../../services/SettingsService';
 import CardOptionsController from './CardOptionsController';
 import { SettingsInitializer } from '../../data_layer/public/Settings';
 
+const FAKE_SAVED_PAYLOAD = { deckName: 'My Custom Deck', template: 'specialstyle' };
+
 class FakeSettingsService implements IServiceSettings {
   create(settings: SettingsInitializer): Promise<number[]> {
     return Promise.resolve([]);
@@ -14,7 +16,7 @@ class FakeSettingsService implements IServiceSettings {
     return Promise.resolve({
       object_id: '1',
       owner: '1',
-      payload: 'payload',
+      payload: FAKE_SAVED_PAYLOAD,
     });
   }
 
@@ -40,6 +42,35 @@ function testDefaultSettings(
   const defaultOptions = settingsController.getDefaultCardOptions(type);
   expect(defaultOptions).toStrictEqual(expectedOptions);
 }
+
+describe('CardOptionsController.findSetting', () => {
+  function makeMockFindRes() {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ send: jest.fn() });
+    return { locals: {}, json, status } as unknown as import('express').Response;
+  }
+
+  it('returns the inner payload object, not the full DB row', async () => {
+    const controller = new CardOptionsController(new FakeSettingsService());
+    const req = { params: { id: 'page-123' } } as unknown as import('express').Request;
+    const res = makeMockFindRes();
+    await controller.findSetting(req, res);
+    expect(res.json).toHaveBeenCalledWith({ payload: FAKE_SAVED_PAYLOAD });
+  });
+
+  it('returns null payload when no settings are found', async () => {
+    class EmptySettingsService extends FakeSettingsService {
+      getById(_id: string): Promise<SettingsInitializer> {
+        return Promise.resolve(null as unknown as SettingsInitializer);
+      }
+    }
+    const controller = new CardOptionsController(new EmptySettingsService());
+    const req = { params: { id: 'page-unknown' } } as unknown as import('express').Request;
+    const res = makeMockFindRes();
+    await controller.findSetting(req, res);
+    expect(res.json).toHaveBeenCalledWith({ payload: null });
+  });
+});
 
 describe('CardOptionsController.listSettings', () => {
   function makeMockRes(owner: string) {

--- a/src/controllers/CardOptionsController/CardOptionsController.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.ts
@@ -57,7 +57,7 @@ class CardOptionsController {
 
     try {
       const storedSettings = await this.service.getById(id);
-      return res.json({ payload: storedSettings });
+      return res.json({ payload: storedSettings?.payload ?? null });
     } catch (error) {
       console.info('Get setting failed');
       console.error(error);


### PR DESCRIPTION
## What

`GET /api/settings/find/:id` was sending the full DB row wrapped as `{ payload: { id, owner, object_id, payload: { deckName: ... }, ... } }`. The frontend's `applyPayload` unpacked one level to get `result.payload` — which was the full row — then checked `Object.hasOwn(fullRow, 'deckName')`. Since `deckName` lives inside `fullRow.payload`, the check always returned false and no server-saved settings were ever applied to the CardOptionsForm.

The one-line fix: `res.json({ payload: storedSettings?.payload ?? null })` — unwrap the JSONB column before sending.

## Why

Closes #1319. Users set a custom deck name in the CardOptions modal, saved it, reopened the form, and found it reverted to the Notion page title. The root cause was that the `findSetting` endpoint double-wrapped the response, so `applyPayload` in the frontend never received the actual settings dict.

## How

The bug was in `CardOptionsController.findSetting`. `SettingsRepository.getById` returns the full DB row (`.returning()` is a no-op on Knex SELECT queries). The controller previously sent the full row as `payload`, but the frontend expected the flat JSONB dict (`{ deckName, template, ... }`).

The frontend's `applyPayload` was already correct — it iterates keys and calls setters when the key is present. With the controller fixed, the saved `deckName` overwrites the temporary `pageTitle` placeholder set while the async fetch was in flight.

The secondary bug (export path hard-coding page title) is not present — `BuildDeckForJobUseCase` already reads `settings.deckName` at line 63 with `settings.deckName || bl.firstPageTitle || id`. Once settings load correctly, exports will use the saved name.

## Measuring success

After deploy, `GET /api/settings/find/:id` responses will have `payload` as a flat dict. In prod logs: `find settings <id>` should be followed by the form correctly displaying the saved deck name on reopen. Confirm by checking the network tab in DevTools — the response should be `{ "payload": { "deckName": "My Custom Name", ... } }` not `{ "payload": { "id": ..., "payload": ... } }`.

## Testing

- Server unit tests added: `CardOptionsController.findSetting` — two cases:
  1. Returns the inner payload object (not the full DB row)
  2. Returns `null` payload when no settings found
- Server tests: 9/9 passing
- Web typecheck: clean
- Web vitest: 397/397 passing (58 files)
- Web lint (Biome): no issues

## Risks

This changes the response shape of `GET /api/settings/find/:id`. Any client that was accidentally reading `result.payload.payload` would need to update — but nothing else reads this endpoint besides `Backend.getSettings`. That method already expects the flat settings dict per its return type `Settings['payload']` (`{ [key: string]: string }`). The contract was always meant to return the flat dict; this makes it actually do so.

Rollback: revert the one-line change in `CardOptionsController.ts` if any regression appears.

## Goal alignment

Returning users who set custom deck names now get them back on form reopen — directly reduces friction in the conversion flow, moving us toward the 300K-user goal by fixing a silent data-loss bug that would erode user trust.

Closes #1319