### PR TITLE
fix: encode non-ASCII filenames in Content-Disposition (RFC 5987)

### DIFF
--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -15,6 +15,7 @@ import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
 import { isPaying } from '../lib/isPaying';
+import { buildContentDisposition } from '../lib/buildContentDisposition';
 
 const MEDIA_CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',
@@ -188,10 +189,7 @@ class ApkgController {
         .replace(/\.apkg$/i, '')
         .replace(/[^\w\s.-]/g, '_');
       res.setHeader('Content-Type', 'application/pdf');
-      res.setHeader(
-        'Content-Disposition',
-        `attachment; filename="${safeName}.pdf"`
-      );
+      res.setHeader('Content-Disposition', buildContentDisposition(`${safeName}.pdf`));
       res.send(result.pdf);
     } catch (error) {
       if (error instanceof CardLimitExceededError) {

--- a/src/controllers/ChatDeckController.test.ts
+++ b/src/controllers/ChatDeckController.test.ts
@@ -114,7 +114,7 @@ describe('ChatDeckController.generate', () => {
     expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
     expect(res.setHeader).toHaveBeenCalledWith(
       'Content-Disposition',
-      'attachment; filename="My Deck.apkg"'
+      "attachment; filename=\"My Deck.apkg\"; filename*=UTF-8''My%20Deck.apkg"
     );
     expect(res.send).toHaveBeenCalledWith(fakeBuffer);
   });

--- a/src/controllers/ChatDeckController.ts
+++ b/src/controllers/ChatDeckController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { ChatDeckUseCase } from '../usecases/chat/ChatDeckUseCase';
+import { buildContentDisposition } from '../lib/buildContentDisposition';
 
 const MAX_DECK_NAME_LENGTH = 120;
 const MAX_CARDS = 200;
@@ -58,7 +59,7 @@ class ChatDeckController {
     });
 
     res.setHeader('Content-Type', 'application/octet-stream');
-    res.setHeader('Content-Disposition', `attachment; filename="${deckName}.apkg"`);
+    res.setHeader('Content-Disposition', buildContentDisposition(`${deckName}.apkg`));
     res.send(buffer);
   }
 }

--- a/src/controllers/DownloadController.test.ts
+++ b/src/controllers/DownloadController.test.ts
@@ -38,7 +38,7 @@ describe('DownloadController.getFile', () => {
     );
     expect(res.setHeader).toHaveBeenCalledWith(
       'Content-Disposition',
-      'attachment; filename="123-deck.apkg"'
+      "attachment; filename=\"123-deck.apkg\"; filename*=UTF-8''123-deck.apkg"
     );
   });
 
@@ -59,7 +59,7 @@ describe('DownloadController.getFile', () => {
     expect(res.send).toHaveBeenCalled();
     expect(res.setHeader).toHaveBeenCalledWith(
       'Content-Disposition',
-      'attachment; filename="123-deck.apkg"'
+      "attachment; filename=\"123-deck.apkg\"; filename*=UTF-8''123-deck.apkg"
     );
   });
 });

--- a/src/controllers/DownloadController.ts
+++ b/src/controllers/DownloadController.ts
@@ -6,6 +6,7 @@ import StorageHandler from '../lib/storage/StorageHandler';
 import DownloadService from '../services/DownloadService';
 import { canAccess } from '../lib/misc/canAccess';
 import { DownloadPage } from '../ui/pages/DownloadPage';
+import { buildContentDisposition } from '../lib/buildContentDisposition';
 
 class DownloadController {
   constructor(private service: DownloadService) {}
@@ -24,10 +25,7 @@ class DownloadController {
       if (body) {
         const filename = key.endsWith('.apkg') ? key : `${key}.apkg`;
         res.setHeader('Content-Type', 'application/octet-stream');
-        res.setHeader(
-          'Content-Disposition',
-          `attachment; filename="${filename}"`
-        );
+        res.setHeader('Content-Disposition', buildContentDisposition(filename));
         res.send(body);
       } else {
         throw new Error(`File not found: ${key}`);
@@ -119,10 +117,7 @@ class DownloadController {
       });
 
       res.setHeader('Content-Type', 'application/zip');
-      res.setHeader(
-        'Content-Disposition',
-        `attachment; filename="anki-decks-${id}.zip"`
-      );
+      res.setHeader('Content-Disposition', buildContentDisposition(`anki-decks-${id}.zip`));
 
       archive.pipe(res);
       ankiFiles.forEach((file) => {

--- a/src/controllers/ImageOcclusionController.ts
+++ b/src/controllers/ImageOcclusionController.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import express from "express";
 import { CreateImageOcclusionDeckUseCase, ImageOcclusionImage, OcclusionRect } from "../usecases/imageOcclusion/CreateImageOcclusionDeckUseCase";
+import { buildContentDisposition } from "../lib/buildContentDisposition";
 
 interface RawPoint { x: unknown; y: unknown; }
 interface RawRect { x: unknown; y: unknown; w: unknown; h: unknown; label?: unknown; shape?: unknown; points?: unknown; groupId?: unknown; }
@@ -52,7 +53,7 @@ class ImageOcclusionController {
       if (e.status === 403) { res.status(403).json({ message: e.message }); return; }
       throw err;
     } finally { for (const f of uploadedFiles) fs.unlink(f.path, () => undefined); }
-    res.setHeader("Content-Disposition", `attachment; filename="${path.basename(apkgPath)}"`);
+    res.setHeader("Content-Disposition", buildContentDisposition(path.basename(apkgPath)));
     res.setHeader("Content-Type", "application/octet-stream");
     const stream = fs.createReadStream(apkgPath);
     stream.on("end", () => { fs.unlink(apkgPath, () => undefined); });

--- a/src/lib/buildContentDisposition.test.ts
+++ b/src/lib/buildContentDisposition.test.ts
@@ -1,0 +1,65 @@
+import http from 'http';
+import { buildContentDisposition } from './buildContentDisposition';
+
+describe('buildContentDisposition', () => {
+  it('handles plain ASCII filename', () => {
+    expect(buildContentDisposition('report.apkg')).toBe(
+      "attachment; filename=\"report.apkg\"; filename*=UTF-8''report.apkg"
+    );
+  });
+
+  it('handles umlaut filename with ASCII fallback and percent-encoded filename*', () => {
+    const result = buildContentDisposition('Speicheldrüsen.apkg');
+    expect(result).toMatch(/^attachment; filename="Speicheldr_sen\.apkg"/);
+    expect(result).toContain("filename*=UTF-8''Speicheldr%C3%BCsen.apkg");
+  });
+
+  it('handles CJK filename', () => {
+    const result = buildContentDisposition('漢字.apkg');
+    expect(result).toMatch(/^attachment; filename="[^"]*"/);
+    expect(result).toContain("filename*=UTF-8''%E6%BC%A2%E5%AD%97.apkg");
+  });
+
+  it('handles Cyrillic filename', () => {
+    const result = buildContentDisposition('Здравствуйте.apkg');
+    expect(result).toMatch(/^attachment; filename="[^"]*"/);
+    expect(result).toContain("filename*=UTF-8''%D0%97%D0%B4%D1%80%D0%B0%D0%B2%D1%81%D1%82%D0%B2%D1%83%D0%B9%D1%82%D0%B5.apkg");
+  });
+
+  it('handles emoji filename', () => {
+    const result = buildContentDisposition('📚.apkg');
+    expect(result).toMatch(/^attachment; filename="[^"]*"/);
+    expect(result).toContain("filename*=UTF-8''%F0%9F%93%9A.apkg");
+  });
+
+  it('strips double-quotes from ASCII fallback to avoid breaking header parsing', () => {
+    const result = buildContentDisposition('Some "Quoted" Name.apkg');
+    expect(result).not.toMatch(/filename="[^"]*"[^;]/);
+    expect(result).toMatch(/filename="Some _Quoted_ Name\.apkg"/);
+    expect(result).toContain("filename*=UTF-8''Some%20%22Quoted%22%20Name.apkg");
+  });
+
+  it('strips backslash from ASCII fallback', () => {
+    const result = buildContentDisposition('path\\to\\file.apkg');
+    expect(result).toMatch(/filename="path_to_file\.apkg"/);
+    expect(result).toContain("filename*=UTF-8''path%5Cto%5Cfile.apkg");
+  });
+
+  it('produces a header value that is a legal HTTP header byte sequence', () => {
+    const inputs = [
+      'report.apkg',
+      'Speicheldrüsen.apkg',
+      '漢字.apkg',
+      'Здравствуйте.apkg',
+      '📚.apkg',
+      'Some "Quoted" Name.apkg',
+      'path\\to\\file.apkg',
+    ];
+    for (const input of inputs) {
+      const value = buildContentDisposition(input);
+      expect(() =>
+        http.validateHeaderValue('Content-Disposition', value)
+      ).not.toThrow();
+    }
+  });
+});

--- a/src/lib/buildContentDisposition.ts
+++ b/src/lib/buildContentDisposition.ts
@@ -1,0 +1,7 @@
+export function buildContentDisposition(filename: string): string {
+  const ascii = filename
+    .replace(/[^\x20-\x7E]/g, '_')
+    .replace(/["\\]/g, '_');
+  const encoded = encodeURIComponent(filename);
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${encoded}`;
+}


### PR DESCRIPTION
## What

Adds `buildContentDisposition()` in `src/lib/` and applies it at every `Content-Disposition` setter site that previously interpolated a user-controlled filename directly into the header string.

The helper emits two parameters per RFC 5987:
- `filename="<ascii-fallback>"` — quotes and backslashes replaced with `_` so the value is a well-formed quoted-string
- `filename*=UTF-8''<percent-encoded>` — the full Unicode name, percent-encoded; preferred by all modern browsers when both are present

## Why

Raw UTF-8 interpolation into `Content-Disposition` throws `TypeError: The header content contains invalid characters` in Node 22, and sent mangled latin1 names to browsers in older Node versions. Users in Europe and Asia (Japanese kanji, German umlauts, Cyrillic) received corrupted `.apkg` filenames on every download. Follow-up to #2247 — that fix handled upload-side filename matching; this fix handles the download response shape.

## How

One small pure helper with zero new dependencies (`encodeURIComponent` is stdlib). Applied at all five sites found via `grep -rn "Content-Disposition" src/ --include="*.ts"`:

| File | Line | Filename source |
|---|---|---|
| `src/controllers/DownloadController.ts` | 28 | S3 key (user-controlled) |
| `src/controllers/DownloadController.ts` | 122 | `anki-decks-${id}.zip` |
| `src/controllers/ApkgController.ts` | 192 | `file.originalname`-derived |
| `src/controllers/ImageOcclusionController.ts` | 55 | `path.basename(apkgPath)` |
| `src/controllers/ChatDeckController.ts` | 61 | user-supplied deck name |

## Measuring success

After deploy: any non-ASCII download (e.g. a deck named "漢字") should arrive in the browser with the correct filename. Verifiable by downloading a deck with a Japanese or German name and checking the saved filename in the OS. No new header-throw errors in `pm2 logs` for the download endpoints.

## Testing

- Unit tests added: `src/lib/buildContentDisposition.test.ts` — 8 cases covering ASCII, umlaut, CJK, Cyrillic, emoji, double-quote, backslash, and `http.validateHeaderValue` smoke for all inputs
- Controller tests updated: `DownloadController.test.ts` (2 assertions), `ChatDeckController.test.ts` (1 assertion)
- Manually verified: `pnpm test` — 23 tests pass; full `/check` (server tsc + web typecheck + web vitest + web lint) all green

## Risks

Browsers that only support `filename=` (IE 8 and older) will get the underscored ASCII fallback instead of the Unicode name — acceptable regression for an extremely small user segment. No rollback needed; the change is additive (adds `filename*` alongside the existing `filename=`).

## Goal alignment

EU and Asian learners are a large part of the 300K-user path. Corrupted filenames on download are a silent trust-breaker. This makes the experience correct for every script.