### PR TITLE
docs: catch What's New modal up to May 15 (13 entries)

### DIFF
--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,19 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Downloaded decks keep their original filename — accents, kanji, Cyrillic, and Arabic now arrive intact instead of mangled', date: '2026-05-15' },
+  { type: 'fix', title: 'Saved deck names stick instead of being overwritten by the Notion page title on reload', date: '2026-05-15' },
+  { type: 'feature', title: 'Card options moved into the sidebar — your saved pages and defaults live in one place', date: '2026-05-14' },
+  { type: 'feature', title: 'Email verification on signup so password resets and deck delivery actually reach you', date: '2026-05-14' },
+  { type: 'feature', title: 'Chat answers stream as Claude writes them — no more waiting for the full reply', date: '2026-05-14' },
+  { type: 'feature', title: 'Chat assistant now formats replies as Markdown — code blocks, lists, headings render properly', date: '2026-05-14' },
+  { type: 'feature', title: 'Paid plans: paste long notes into chat without the old length cap, and long pastes collapse so the thread stays readable', date: '2026-05-14' },
+  { type: 'style', title: 'Every transactional email now opens with the 2anki mascot and renders cleanly in dark mode and on mobile', date: '2026-05-14' },
+  { type: 'fix', title: 'Chat: cards render cleanly while streaming — no raw JSON flashes, no truncated replies', date: '2026-05-14' },
+  { type: 'fix', title: 'Chat scrolls with you while streaming and stops fighting you when you scroll up to read', date: '2026-05-14' },
+  { type: 'fix', title: 'Uploads with accents, Chinese, Japanese, or Arabic in the filename now go through', date: '2026-05-14' },
+  { type: 'fix', title: 'My Decks no longer shows the upgrade banner once you have paid, and the price displays correctly', date: '2026-05-14' },
+  { type: 'fix', title: 'Hardened Google sign-in — every login is now signature-verified', date: '2026-05-14' },
   { type: 'feature', title: 'Image occlusion: draw masks on any image and export native Anki 23.10 cards — source images pull straight from Notion', date: '2026-05-14' },
   { type: 'feature', title: 'Chat study assistant: ask Claude questions about any deck and download the conversation as a .txt file', date: '2026-05-14' },
   { type: 'feature', title: 'Sign in with Notion: one-click login alongside Google and email', date: '2026-05-14' },


### PR DESCRIPTION
## Summary

- Adds 13 entries to `web/src/pages/WhatsNewPage/changelog.ts` covering the 15 user-relevant PRs merged after #2230 (the prior snapshot at 2026-05-14T14:14Z) — skips the one docs/internal PR.
- Pure data-file change. No code, no tests, no migration. Same `ChangelogEntry` shape as existing entries.
- Newest-first ordering preserved.

## Trio review

- **PM** drafted entries + a 600-word blog seed for distribution.
- **Designer** ran a parallel tone pass — caught "Phase 1", "SSE", "JWKS" leaking into user-facing copy.
- **Engineer** flagged that PM's card-options sidebar wording (*"pick a deck and tune its settings without leaving the page"*) misrepresented PR #2211 — it's a dedicated `/card-options` page, not an inline panel. Rewritten to *"your saved pages and defaults live in one place"*.

Other resolutions: split non-ASCII filename fix into upload-symptom + download-symptom (felt as different bugs), kept chat fixes as two entries (render quality vs. scroll behaviour), bundled the chat input cap + collapse into one entry, bundled `/downloads` pricing fixes into one entry.

## Goal alignment

Path to 300K depends on returning users. The What's New modal is the cheapest "we're alive and shipping" signal we have — landing this catches the surface up to actual reality after a heavy two days of shipping. Specifically calls out the non-ASCII filename fix, which most directly serves the global user base we are trying to grow into.

## Spanish translation priority (out-of-band)

If the Spanish pass picks three:
1. Card options sidebar (every paying user touches this)
2. Email verification on signup (every new account hits this)
3. Non-ASCII filename fix (largest impact for non-English users — exactly the audience translation serves)

## Test plan

- [ ] CI: web typecheck passes (string-array data; same union types as existing entries)
- [ ] Visual: open `/whats-new` in dev, confirm the 13 new entries render at the top with correct date grouping and type icons
- [ ] Spot-check copy renders correctly for entries containing em dashes, apostrophes, and non-Latin words ("kanji", "Cyrillic")

🤖 Generated with [Claude Code](https://claude.com/claude-code)