### PR TITLE
feat: chat conversation history + sidebar (PR-1)

### DIFF
--- a/migrations/20260528000000_conversations.js
+++ b/migrations/20260528000000_conversations.js
@@ -1,0 +1,27 @@
+exports.up = async (knex) => {
+  await knex.schema.createTable('conversations', (t) => {
+    t.increments('id').primary();
+    t.integer('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    t.text('title').notNullable();
+    t.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    t.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    t.timestamp('deleted_at', { useTz: true }).nullable();
+    t.index(['user_id', 'deleted_at', 'updated_at']);
+  });
+
+  await knex.schema.alterTable('chat_messages', (t) => {
+    t.integer('conversation_id')
+      .nullable()
+      .references('id')
+      .inTable('conversations')
+      .onDelete('CASCADE');
+    t.index(['conversation_id', 'created_at']);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('chat_messages', (t) => {
+    t.dropColumn('conversation_id');
+  });
+  await knex.schema.dropTable('conversations');
+};

--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from 'express';
 import ChatController from './ChatController';
-import { ChatRateLimitError } from '../usecases/chat/ChatUseCase';
+import {
+  ChatRateLimitError,
+  ChatConversationNotFoundError,
+} from '../usecases/chat/ChatUseCase';
 
 function buildRes(owner = 42, patreon = false, subscriber = false): Response {
   return {
@@ -103,5 +106,54 @@ describe('ChatController.sendMessage', () => {
     await controller.sendMessage(buildReq({ content: 'Make flashcards' }), res);
     const events = writtenEvents(res);
     expect(events).toContainEqual({ event: 'done', data: expect.objectContaining({ cards }) });
+  });
+
+  it('passes conversationId from body through to the use case', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 7 });
+    await controller.sendMessage(
+      buildReq({ content: 'Hi', conversationId: 7 }),
+      res
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: 7 })
+    );
+  });
+
+  it('rejects non-positive or non-integer conversationId values by sending null', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+    await controller.sendMessage(
+      buildReq({ content: 'Hi', conversationId: 'abc' }),
+      res
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationId: null })
+    );
+  });
+
+  it('emits conversationId in done event', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'reply', conversationId: 42 });
+    await controller.sendMessage(buildReq({ content: 'Hi' }), res);
+    const events = writtenEvents(res);
+    expect(events).toContainEqual({
+      event: 'done',
+      data: expect.objectContaining({ conversationId: 42 }),
+    });
+  });
+
+  it('sends conversation_not_found error event when use case throws ChatConversationNotFoundError', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockRejectedValueOnce(new ChatConversationNotFoundError());
+    await controller.sendMessage(
+      buildReq({ content: 'Hi', conversationId: 999 }),
+      res
+    );
+    const events = writtenEvents(res);
+    expect(events).toContainEqual({
+      event: 'error',
+      data: { type: 'conversation_not_found' },
+    });
   });
 });

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -1,11 +1,25 @@
 import { Request, Response } from 'express';
-import { ChatUseCase, ChatRateLimitError } from '../usecases/chat/ChatUseCase';
+import {
+  ChatUseCase,
+  ChatRateLimitError,
+  ChatConversationNotFoundError,
+} from '../usecases/chat/ChatUseCase';
 
 const MAX_CONTENT_LENGTH = 4000;
 const MAX_CONTENT_LENGTH_PREMIUM = 100_000;
 
 function sseWrite(res: Response, event: string, data: unknown): void {
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+function parseConversationId(raw: unknown): number | null {
+  if (raw == null) return null;
+  if (typeof raw === 'number' && Number.isSafeInteger(raw) && raw > 0) return raw;
+  if (typeof raw === 'string' && /^[1-9]\d*$/.test(raw)) {
+    const n = Number(raw);
+    return Number.isSafeInteger(n) ? n : null;
+  }
+  return null;
 }
 
 class ChatController {
@@ -31,6 +45,8 @@ class ChatController {
       return;
     }
 
+    const conversationId = parseConversationId(req.body?.conversationId);
+
     const rawHistory = Array.isArray(req.body?.history) ? req.body.history : [];
     const conversationHistory = rawHistory
       .filter(
@@ -53,11 +69,13 @@ class ChatController {
         user: { owner, patreon: isPremium },
         content,
         conversationHistory,
+        conversationId,
         onToken: (text) => sseWrite(res, 'token', text),
       });
 
       sseWrite(res, 'done', {
         content: result.content,
+        conversationId: result.conversationId,
         ...(result.cards != null ? { cards: result.cards } : {}),
         ...(result.contentBefore != null ? { contentBefore: result.contentBefore } : {}),
         ...(result.contentAfter != null ? { contentAfter: result.contentAfter } : {}),
@@ -65,6 +83,8 @@ class ChatController {
     } catch (err) {
       if (err instanceof ChatRateLimitError) {
         sseWrite(res, 'error', { type: 'rate_limit', resetDate: err.resetDate });
+      } else if (err instanceof ChatConversationNotFoundError) {
+        sseWrite(res, 'error', { type: 'conversation_not_found' });
       } else {
         sseWrite(res, 'error', { type: 'server_error' });
       }

--- a/src/controllers/ConversationsController.test.ts
+++ b/src/controllers/ConversationsController.test.ts
@@ -1,0 +1,166 @@
+import { Request, Response } from 'express';
+import ConversationsController from './ConversationsController';
+import { ConversationsUseCase, InvalidTitleError } from '../usecases/chat/ConversationsUseCase';
+import { InMemoryConversationsRepository } from '../data_layer/ConversationsRepository';
+
+function buildRes(owner = 42): Response {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    end: jest.fn().mockReturnThis(),
+    locals: { owner },
+  } as unknown as Response;
+}
+
+function buildReq(input: { params?: Record<string, string>; body?: unknown }): Request {
+  return {
+    params: input.params ?? {},
+    body: input.body,
+  } as unknown as Request;
+}
+
+describe('ConversationsController', () => {
+  describe('list', () => {
+    it('returns the user\'s conversations sorted by use case order', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const a = await repo.create({ userId: 42, title: 'First' });
+      const b = await repo.create({ userId: 42, title: 'Second' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.list(buildReq({}), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        conversations: [
+          expect.objectContaining({ id: b, title: 'Second' }),
+          expect.objectContaining({ id: a, title: 'First' }),
+        ],
+      });
+    });
+  });
+
+  describe('get', () => {
+    it('returns 400 for invalid id', async () => {
+      const controller = new ConversationsController(
+        new ConversationsUseCase(new InMemoryConversationsRepository())
+      );
+      const res = buildRes();
+
+      await controller.get(buildReq({ params: { id: 'abc' } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 when conversation belongs to another user', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 99, title: 'theirs' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.get(buildReq({ params: { id: String(id) } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns the conversation with messages', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'mine' });
+      repo.recordMessage({ userId: 42, conversationId: id, role: 'user', content: 'hi' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.get(buildReq({ params: { id: String(id) } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id,
+          title: 'mine',
+          messages: [
+            expect.objectContaining({ role: 'user', content: 'hi' }),
+          ],
+        })
+      );
+    });
+  });
+
+  describe('rename', () => {
+    it('returns 400 when title missing', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'old' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.rename(buildReq({ params: { id: String(id) }, body: {} }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 400 when title is empty after trimming', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'old' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.rename(
+        buildReq({ params: { id: String(id) }, body: { title: '   ' } }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 204 on rename success', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'old' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.rename(
+        buildReq({ params: { id: String(id) }, body: { title: 'new' } }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+
+    it('returns 404 when conversation belongs to another user', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 99, title: 'theirs' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.rename(
+        buildReq({ params: { id: String(id) }, body: { title: 'mine' } }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('delete', () => {
+    it('returns 204 on success', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'gone' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.delete(buildReq({ params: { id: String(id) } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+
+    it('returns 404 when conversation belongs to another user', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 99, title: 'theirs' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.delete(buildReq({ params: { id: String(id) } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+});

--- a/src/controllers/ConversationsController.ts
+++ b/src/controllers/ConversationsController.ts
@@ -1,0 +1,100 @@
+import { Request, Response } from 'express';
+import { ConversationsUseCase, InvalidTitleError } from '../usecases/chat/ConversationsUseCase';
+
+function parseConversationId(raw: unknown): number | null {
+  if (typeof raw !== 'string') return null;
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+class ConversationsController {
+  constructor(private readonly useCase: ConversationsUseCase) {}
+
+  async list(req: Request, res: Response): Promise<void> {
+    const owner = res.locals.owner as number;
+    const items = await this.useCase.list(owner);
+    res.status(200).json({
+      conversations: items.map((c) => ({
+        id: c.id,
+        title: c.title,
+        updatedAt: c.updated_at.toISOString(),
+      })),
+    });
+  }
+
+  async get(req: Request, res: Response): Promise<void> {
+    const owner = res.locals.owner as number;
+    const id = parseConversationId(req.params.id);
+    if (id == null) {
+      res.status(400).json({ error: 'invalid conversation id' });
+      return;
+    }
+    const conv = await this.useCase.get({ userId: owner, conversationId: id });
+    if (conv == null) {
+      res.status(404).json({ error: 'conversation not found' });
+      return;
+    }
+    res.status(200).json({
+      id: conv.id,
+      title: conv.title,
+      createdAt: conv.created_at.toISOString(),
+      updatedAt: conv.updated_at.toISOString(),
+      messages: conv.messages.map((m) => ({
+        id: m.id,
+        role: m.role,
+        content: m.content,
+        createdAt: m.created_at.toISOString(),
+      })),
+    });
+  }
+
+  async rename(req: Request, res: Response): Promise<void> {
+    const owner = res.locals.owner as number;
+    const id = parseConversationId(req.params.id);
+    if (id == null) {
+      res.status(400).json({ error: 'invalid conversation id' });
+      return;
+    }
+    const rawTitle = req.body?.title;
+    if (typeof rawTitle !== 'string') {
+      res.status(400).json({ error: 'title is required' });
+      return;
+    }
+    try {
+      const updated = await this.useCase.rename({
+        userId: owner,
+        conversationId: id,
+        title: rawTitle,
+      });
+      if (!updated) {
+        res.status(404).json({ error: 'conversation not found' });
+        return;
+      }
+      res.status(204).end();
+    } catch (err) {
+      if (err instanceof InvalidTitleError) {
+        res.status(400).json({ error: 'title must be 1 to 120 characters' });
+        return;
+      }
+      throw err;
+    }
+  }
+
+  async delete(req: Request, res: Response): Promise<void> {
+    const owner = res.locals.owner as number;
+    const id = parseConversationId(req.params.id);
+    if (id == null) {
+      res.status(400).json({ error: 'invalid conversation id' });
+      return;
+    }
+    const deleted = await this.useCase.delete({ userId: owner, conversationId: id });
+    if (!deleted) {
+      res.status(404).json({ error: 'conversation not found' });
+      return;
+    }
+    res.status(204).end();
+  }
+}
+
+export default ConversationsController;

--- a/src/data_layer/ChatMessagesRepository.ts
+++ b/src/data_layer/ChatMessagesRepository.ts
@@ -3,13 +3,21 @@ import type { Knex } from 'knex';
 export interface ChatMessageRow {
   id: number;
   user_id: number;
+  conversation_id: number | null;
   role: 'user' | 'assistant';
   content: string;
   created_at: Date;
 }
 
+export interface ChatMessageInsert {
+  userId: number;
+  conversationId: number | null;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 export interface IChatMessagesRepository {
-  insert(entry: { userId: number; role: 'user' | 'assistant'; content: string }): Promise<void>;
+  insert(entry: ChatMessageInsert): Promise<void>;
   countThisMonth(userId: number): Promise<number>;
 }
 
@@ -18,9 +26,10 @@ export class ChatMessagesRepository implements IChatMessagesRepository {
 
   constructor(private readonly database: Knex) {}
 
-  async insert(entry: { userId: number; role: 'user' | 'assistant'; content: string }): Promise<void> {
+  async insert(entry: ChatMessageInsert): Promise<void> {
     await this.database(this.table).insert({
       user_id: entry.userId,
+      conversation_id: entry.conversationId,
       role: entry.role,
       content: entry.content,
     });
@@ -45,16 +54,18 @@ export class InMemoryChatMessagesRepository implements IChatMessagesRepository {
   private readonly rows: Array<{
     id: number;
     user_id: number;
+    conversation_id: number | null;
     role: 'user' | 'assistant';
     content: string;
     created_at: Date;
   }> = [];
   private nextId = 1;
 
-  async insert(entry: { userId: number; role: 'user' | 'assistant'; content: string }): Promise<void> {
+  async insert(entry: ChatMessageInsert): Promise<void> {
     this.rows.push({
       id: this.nextId++,
       user_id: entry.userId,
+      conversation_id: entry.conversationId,
       role: entry.role,
       content: entry.content,
       created_at: new Date(),

--- a/src/data_layer/ConversationsRepository.ts
+++ b/src/data_layer/ConversationsRepository.ts
@@ -1,0 +1,231 @@
+import type { Knex } from 'knex';
+
+export interface ConversationRow {
+  id: number;
+  user_id: number;
+  title: string;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+}
+
+export interface ConversationSummary {
+  id: number;
+  title: string;
+  updated_at: Date;
+}
+
+export interface ConversationWithMessages {
+  id: number;
+  title: string;
+  created_at: Date;
+  updated_at: Date;
+  messages: Array<{
+    id: number;
+    role: 'user' | 'assistant';
+    content: string;
+    created_at: Date;
+  }>;
+}
+
+export interface IConversationsRepository {
+  create(input: { userId: number; title: string }): Promise<number>;
+  listForUser(userId: number): Promise<ConversationSummary[]>;
+  findForUser(input: { userId: number; conversationId: number }): Promise<ConversationWithMessages | null>;
+  rename(input: { userId: number; conversationId: number; title: string }): Promise<boolean>;
+  softDelete(input: { userId: number; conversationId: number }): Promise<boolean>;
+  touch(input: { userId: number; conversationId: number }): Promise<void>;
+}
+
+export class ConversationsRepository implements IConversationsRepository {
+  private readonly table = 'conversations';
+
+  constructor(private readonly database: Knex) {}
+
+  async create(input: { userId: number; title: string }): Promise<number> {
+    const [row] = await this.database(this.table)
+      .insert({ user_id: input.userId, title: input.title })
+      .returning<{ id: number }[]>('id');
+    return row.id;
+  }
+
+  async listForUser(userId: number): Promise<ConversationSummary[]> {
+    const rows = await this.database(this.table)
+      .select('id', 'title', 'updated_at')
+      .where('user_id', userId)
+      .whereNull('deleted_at')
+      .orderBy('updated_at', 'desc');
+    return rows.map((r) => ({
+      id: r.id as number,
+      title: r.title as string,
+      updated_at: r.updated_at as Date,
+    }));
+  }
+
+  async findForUser(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<ConversationWithMessages | null> {
+    const conv = await this.database(this.table)
+      .where({ id: input.conversationId, user_id: input.userId })
+      .whereNull('deleted_at')
+      .first<ConversationRow | undefined>();
+    if (conv == null) return null;
+
+    const messages = await this.database('chat_messages')
+      .where({ conversation_id: input.conversationId, user_id: input.userId })
+      .orderBy('created_at', 'asc')
+      .select<{
+        id: number;
+        role: 'user' | 'assistant';
+        content: string;
+        created_at: Date;
+      }[]>('id', 'role', 'content', 'created_at');
+
+    return {
+      id: conv.id,
+      title: conv.title,
+      created_at: conv.created_at,
+      updated_at: conv.updated_at,
+      messages,
+    };
+  }
+
+  async rename(input: {
+    userId: number;
+    conversationId: number;
+    title: string;
+  }): Promise<boolean> {
+    const updated = await this.database(this.table)
+      .where({ id: input.conversationId, user_id: input.userId })
+      .whereNull('deleted_at')
+      .update({ title: input.title, updated_at: this.database.fn.now() });
+    return updated > 0;
+  }
+
+  async softDelete(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<boolean> {
+    const updated = await this.database(this.table)
+      .where({ id: input.conversationId, user_id: input.userId })
+      .whereNull('deleted_at')
+      .update({ deleted_at: this.database.fn.now() });
+    return updated > 0;
+  }
+
+  async touch(input: { userId: number; conversationId: number }): Promise<void> {
+    await this.database(this.table)
+      .where({ id: input.conversationId, user_id: input.userId })
+      .whereNull('deleted_at')
+      .update({ updated_at: this.database.fn.now() });
+  }
+}
+
+export class InMemoryConversationsRepository implements IConversationsRepository {
+  private readonly rows: ConversationRow[] = [];
+  private readonly messages: Array<{
+    id: number;
+    user_id: number;
+    conversation_id: number | null;
+    role: 'user' | 'assistant';
+    content: string;
+    created_at: Date;
+  }> = [];
+  private nextId = 1;
+  private nextMessageId = 1;
+
+  async create(input: { userId: number; title: string }): Promise<number> {
+    const now = new Date();
+    const id = this.nextId++;
+    this.rows.push({
+      id,
+      user_id: input.userId,
+      title: input.title,
+      created_at: now,
+      updated_at: now,
+      deleted_at: null,
+    });
+    return id;
+  }
+
+  async listForUser(userId: number): Promise<ConversationSummary[]> {
+    return this.rows
+      .filter((r) => r.user_id === userId && r.deleted_at == null)
+      .sort((a, b) => {
+        const t = b.updated_at.getTime() - a.updated_at.getTime();
+        return t !== 0 ? t : b.id - a.id;
+      })
+      .map((r) => ({ id: r.id, title: r.title, updated_at: r.updated_at }));
+  }
+
+  async findForUser(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<ConversationWithMessages | null> {
+    const conv = this.rows.find(
+      (r) => r.id === input.conversationId && r.user_id === input.userId && r.deleted_at == null
+    );
+    if (conv == null) return null;
+    const messages = this.messages
+      .filter((m) => m.conversation_id === input.conversationId && m.user_id === input.userId)
+      .sort((a, b) => a.created_at.getTime() - b.created_at.getTime())
+      .map((m) => ({ id: m.id, role: m.role, content: m.content, created_at: m.created_at }));
+    return {
+      id: conv.id,
+      title: conv.title,
+      created_at: conv.created_at,
+      updated_at: conv.updated_at,
+      messages,
+    };
+  }
+
+  async rename(input: {
+    userId: number;
+    conversationId: number;
+    title: string;
+  }): Promise<boolean> {
+    const conv = this.rows.find(
+      (r) => r.id === input.conversationId && r.user_id === input.userId && r.deleted_at == null
+    );
+    if (conv == null) return false;
+    conv.title = input.title;
+    conv.updated_at = new Date();
+    return true;
+  }
+
+  async softDelete(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<boolean> {
+    const conv = this.rows.find(
+      (r) => r.id === input.conversationId && r.user_id === input.userId && r.deleted_at == null
+    );
+    if (conv == null) return false;
+    conv.deleted_at = new Date();
+    return true;
+  }
+
+  async touch(input: { userId: number; conversationId: number }): Promise<void> {
+    const conv = this.rows.find(
+      (r) => r.id === input.conversationId && r.user_id === input.userId && r.deleted_at == null
+    );
+    if (conv != null) conv.updated_at = new Date();
+  }
+
+  recordMessage(entry: {
+    userId: number;
+    conversationId: number | null;
+    role: 'user' | 'assistant';
+    content: string;
+  }): void {
+    this.messages.push({
+      id: this.nextMessageId++,
+      user_id: entry.userId,
+      conversation_id: entry.conversationId,
+      role: entry.role,
+      content: entry.content,
+      created_at: new Date(),
+    });
+  }
+}

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -1,9 +1,12 @@
 import express from 'express';
 import ChatController from '../controllers/ChatController';
 import ChatDeckController from '../controllers/ChatDeckController';
+import ConversationsController from '../controllers/ConversationsController';
 import { ChatUseCase } from '../usecases/chat/ChatUseCase';
 import { ChatDeckUseCase } from '../usecases/chat/ChatDeckUseCase';
+import { ConversationsUseCase } from '../usecases/chat/ConversationsUseCase';
 import { ChatMessagesRepository } from '../data_layer/ChatMessagesRepository';
+import { ConversationsRepository } from '../data_layer/ConversationsRepository';
 import { getDatabase } from '../data_layer';
 import { getAnthropicClient } from '../lib/claude/ClaudeService';
 import RequireAuthentication from './middleware/RequireAuthentication';
@@ -11,12 +14,15 @@ import RequireAuthentication from './middleware/RequireAuthentication';
 const ChatRouter = () => {
   const router = express.Router();
   const db = getDatabase();
-  const repo = new ChatMessagesRepository(db);
+  const messagesRepo = new ChatMessagesRepository(db);
+  const conversationsRepo = new ConversationsRepository(db);
   const anthropic = getAnthropicClient();
-  const useCase = new ChatUseCase(repo, anthropic);
+  const useCase = new ChatUseCase(messagesRepo, conversationsRepo, anthropic);
   const controller = new ChatController(useCase);
   const deckUseCase = new ChatDeckUseCase();
   const deckController = new ChatDeckController(deckUseCase);
+  const conversationsUseCase = new ConversationsUseCase(conversationsRepo);
+  const conversationsController = new ConversationsController(conversationsUseCase);
 
   /**
    * @swagger
@@ -37,6 +43,9 @@ const ChatRouter = () => {
    *               content:
    *                 type: string
    *                 maxLength: 4000
+   *               conversationId:
+   *                 type: integer
+   *                 nullable: true
    *               history:
    *                 type: array
    *                 items:
@@ -131,12 +140,100 @@ const ChatRouter = () => {
     const owner = res.locals.owner as number;
     const patreon = (res.locals.patreon as boolean) ?? false;
     const subscriber = (res.locals.subscriber as boolean) ?? false;
-    const count = await repo.countThisMonth(owner);
+    const count = await messagesRepo.countThisMonth(owner);
     res.status(200).json({
       used: count,
       limit: patreon || subscriber ? null : 20,
     });
   });
+
+  /**
+   * @swagger
+   * /api/chat/conversations:
+   *   get:
+   *     summary: List the user's chat conversations
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Conversation summaries, newest first
+   */
+  router.get('/api/chat/conversations', RequireAuthentication, (req, res) =>
+    conversationsController.list(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/chat/conversations/{id}:
+   *   get:
+   *     summary: Load a conversation and its messages
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema: { type: integer }
+   *     responses:
+   *       200:
+   *         description: Conversation with messages
+   *       404:
+   *         description: Conversation not found
+   *   patch:
+   *     summary: Rename a conversation
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema: { type: integer }
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [title]
+   *             properties:
+   *               title:
+   *                 type: string
+   *                 maxLength: 120
+   *     responses:
+   *       204:
+   *         description: Renamed
+   *       400:
+   *         description: Invalid title
+   *       404:
+   *         description: Conversation not found
+   *   delete:
+   *     summary: Soft-delete a conversation
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema: { type: integer }
+   *     responses:
+   *       204:
+   *         description: Deleted
+   *       404:
+   *         description: Conversation not found
+   */
+  router.get('/api/chat/conversations/:id', RequireAuthentication, (req, res) =>
+    conversationsController.get(req, res)
+  );
+  router.patch('/api/chat/conversations/:id', RequireAuthentication, (req, res) =>
+    conversationsController.rename(req, res)
+  );
+  router.delete('/api/chat/conversations/:id', RequireAuthentication, (req, res) =>
+    conversationsController.delete(req, res)
+  );
 
   return router;
 };

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -1,5 +1,10 @@
-import { ChatUseCase, ChatRateLimitError } from './ChatUseCase';
+import {
+  ChatUseCase,
+  ChatRateLimitError,
+  ChatConversationNotFoundError,
+} from './ChatUseCase';
 import { InMemoryChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
+import { InMemoryConversationsRepository } from '../../data_layer/ConversationsRepository';
 
 const FREE_USER = { owner: 1, patreon: false } as const;
 const PATREON_USER = { owner: 2, patreon: true } as const;
@@ -18,15 +23,26 @@ function buildAnthropicMock(responseContent: string) {
   };
 }
 
+function buildUseCase(responseContent: string) {
+  const messagesRepo = new InMemoryChatMessagesRepository();
+  const conversationsRepo = new InMemoryConversationsRepository();
+  const anthropic = buildAnthropicMock(responseContent);
+  const useCase = new ChatUseCase(messagesRepo, conversationsRepo, anthropic as never);
+  return { messagesRepo, conversationsRepo, anthropic, useCase };
+}
+
 describe('ChatUseCase', () => {
   describe('message counting and rate limiting', () => {
     it('throws ChatRateLimitError when free user has used 20 messages this month', async () => {
-      const repo = new InMemoryChatMessagesRepository();
+      const { messagesRepo, useCase } = buildUseCase('Hello');
       for (let i = 0; i < 20; i++) {
-        await repo.insert({ userId: FREE_USER.owner, role: 'user', content: `msg ${i}` });
+        await messagesRepo.insert({
+          userId: FREE_USER.owner,
+          conversationId: null,
+          role: 'user',
+          content: `msg ${i}`,
+        });
       }
-      const anthropic = buildAnthropicMock('Hello');
-      const useCase = new ChatUseCase(repo, anthropic as never);
 
       await expect(
         useCase.execute({ user: FREE_USER, content: 'another message', conversationHistory: [] })
@@ -34,12 +50,15 @@ describe('ChatUseCase', () => {
     });
 
     it('does not throw when free user has used fewer than 20 messages', async () => {
-      const repo = new InMemoryChatMessagesRepository();
+      const { messagesRepo, useCase } = buildUseCase('Nice response');
       for (let i = 0; i < 19; i++) {
-        await repo.insert({ userId: FREE_USER.owner, role: 'user', content: `msg ${i}` });
+        await messagesRepo.insert({
+          userId: FREE_USER.owner,
+          conversationId: null,
+          role: 'user',
+          content: `msg ${i}`,
+        });
       }
-      const anthropic = buildAnthropicMock('Nice response');
-      const useCase = new ChatUseCase(repo, anthropic as never);
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -50,12 +69,15 @@ describe('ChatUseCase', () => {
     });
 
     it('does not apply limit to patreon users', async () => {
-      const repo = new InMemoryChatMessagesRepository();
+      const { messagesRepo, useCase } = buildUseCase('Patreon response');
       for (let i = 0; i < 100; i++) {
-        await repo.insert({ userId: PATREON_USER.owner, role: 'user', content: `msg ${i}` });
+        await messagesRepo.insert({
+          userId: PATREON_USER.owner,
+          conversationId: null,
+          role: 'user',
+          content: `msg ${i}`,
+        });
       }
-      const anthropic = buildAnthropicMock('Patreon response');
-      const useCase = new ChatUseCase(repo, anthropic as never);
 
       const result = await useCase.execute({
         user: PATREON_USER,
@@ -68,9 +90,7 @@ describe('ChatUseCase', () => {
 
   describe('model selection', () => {
     it('uses haiku model for free users', async () => {
-      const repo = new InMemoryChatMessagesRepository();
-      const anthropic = buildAnthropicMock('answer');
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { anthropic, useCase } = buildUseCase('answer');
 
       await useCase.execute({ user: FREE_USER, content: 'question', conversationHistory: [] });
 
@@ -80,9 +100,7 @@ describe('ChatUseCase', () => {
     });
 
     it('uses sonnet model for patreon users', async () => {
-      const repo = new InMemoryChatMessagesRepository();
-      const anthropic = buildAnthropicMock('answer');
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { anthropic, useCase } = buildUseCase('answer');
 
       await useCase.execute({ user: PATREON_USER, content: 'question', conversationHistory: [] });
 
@@ -94,11 +112,9 @@ describe('ChatUseCase', () => {
 
   describe('card extraction', () => {
     it('extracts cards when response contains a JSON code block', async () => {
-      const repo = new InMemoryChatMessagesRepository();
       const cards = [{ front: 'Q1', back: 'A1' }, { front: 'Q2', back: 'A2' }];
       const responseText = `Here are your cards:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\`\nHope that helps!`;
-      const anthropic = buildAnthropicMock(responseText);
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { useCase } = buildUseCase(responseText);
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -110,9 +126,7 @@ describe('ChatUseCase', () => {
     });
 
     it('returns no cards when response has no JSON block', async () => {
-      const repo = new InMemoryChatMessagesRepository();
-      const anthropic = buildAnthropicMock('Photosynthesis is the process by which...');
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { useCase } = buildUseCase('Photosynthesis is the process by which...');
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -124,10 +138,8 @@ describe('ChatUseCase', () => {
     });
 
     it('returns no cards when JSON block is not a front/back array', async () => {
-      const repo = new InMemoryChatMessagesRepository();
       const responseText = 'Here is JSON:\n```json\n{"key": "value"}\n```';
-      const anthropic = buildAnthropicMock(responseText);
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { useCase } = buildUseCase(responseText);
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -139,11 +151,9 @@ describe('ChatUseCase', () => {
     });
 
     it('returns contentBefore and contentAfter when JSON block is surrounded by prose', async () => {
-      const repo = new InMemoryChatMessagesRepository();
       const cards = [{ front: 'Q1', back: 'A1' }];
       const responseText = `Here are your cards:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\`\nHope that helps!`;
-      const anthropic = buildAnthropicMock(responseText);
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { useCase } = buildUseCase(responseText);
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -156,11 +166,9 @@ describe('ChatUseCase', () => {
     });
 
     it('returns contentBefore as undefined when no text before JSON block', async () => {
-      const repo = new InMemoryChatMessagesRepository();
       const cards = [{ front: 'Q1', back: 'A1' }];
       const responseText = `\`\`\`json\n${JSON.stringify(cards)}\n\`\`\`\nHope that helps!`;
-      const anthropic = buildAnthropicMock(responseText);
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { useCase } = buildUseCase(responseText);
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -173,11 +181,9 @@ describe('ChatUseCase', () => {
     });
 
     it('returns contentAfter as undefined when no text after JSON block', async () => {
-      const repo = new InMemoryChatMessagesRepository();
       const cards = [{ front: 'Q1', back: 'A1' }];
       const responseText = `Here are your cards:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
-      const anthropic = buildAnthropicMock(responseText);
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { useCase } = buildUseCase(responseText);
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -190,9 +196,7 @@ describe('ChatUseCase', () => {
     });
 
     it('returns undefined contentBefore and contentAfter when no JSON block present', async () => {
-      const repo = new InMemoryChatMessagesRepository();
-      const anthropic = buildAnthropicMock('Just plain text response.');
-      const useCase = new ChatUseCase(repo, anthropic as never);
+      const { useCase } = buildUseCase('Just plain text response.');
 
       const result = await useCase.execute({
         user: FREE_USER,
@@ -206,32 +210,139 @@ describe('ChatUseCase', () => {
   });
 
   describe('message persistence', () => {
-    it('saves both user and assistant messages', async () => {
-      const repo = new InMemoryChatMessagesRepository();
-      const anthropic = buildAnthropicMock('Assistant reply');
-      const useCase = new ChatUseCase(repo, anthropic as never);
+    it('saves both user and assistant messages with the same conversation_id', async () => {
+      const { messagesRepo, useCase } = buildUseCase('Assistant reply');
 
-      await useCase.execute({
+      const result = await useCase.execute({
         user: FREE_USER,
         content: 'User question',
         conversationHistory: [],
       });
 
-      const all = repo.getAll();
+      const all = messagesRepo.getAll();
       expect(all).toHaveLength(2);
-      expect(all[0]).toMatchObject({ user_id: FREE_USER.owner, role: 'user', content: 'User question' });
-      expect(all[1]).toMatchObject({ user_id: FREE_USER.owner, role: 'assistant', content: 'Assistant reply' });
+      expect(all[0]).toMatchObject({
+        user_id: FREE_USER.owner,
+        role: 'user',
+        content: 'User question',
+        conversation_id: result.conversationId,
+      });
+      expect(all[1]).toMatchObject({
+        user_id: FREE_USER.owner,
+        role: 'assistant',
+        content: 'Assistant reply',
+        conversation_id: result.conversationId,
+      });
+    });
+  });
+
+  describe('conversation management', () => {
+    it('creates a new conversation when no conversationId is provided', async () => {
+      const { conversationsRepo, useCase } = buildUseCase('reply');
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Hello there',
+        conversationHistory: [],
+      });
+
+      const list = await conversationsRepo.listForUser(FREE_USER.owner);
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe(result.conversationId);
+    });
+
+    it('auto-titles the new conversation from the first user message', async () => {
+      const { conversationsRepo, useCase } = buildUseCase('reply');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'Explain mitosis briefly please',
+        conversationHistory: [],
+      });
+
+      const list = await conversationsRepo.listForUser(FREE_USER.owner);
+      expect(list[0].title).toBe('Explain mitosis briefly please');
+    });
+
+    it('truncates long auto-titles with an ellipsis', async () => {
+      const { conversationsRepo, useCase } = buildUseCase('reply');
+      const longInput =
+        'This is a very long opening user message that absolutely will exceed the auto title cap of sixty characters by a wide margin.';
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: longInput,
+        conversationHistory: [],
+      });
+
+      const list = await conversationsRepo.listForUser(FREE_USER.owner);
+      expect(list[0].title.length).toBeLessThanOrEqual(61);
+      expect(list[0].title.endsWith('…')).toBe(true);
+    });
+
+    it('reuses an existing conversation when a valid conversationId is provided', async () => {
+      const { conversationsRepo, messagesRepo, useCase } = buildUseCase('reply');
+      const existingId = await conversationsRepo.create({
+        userId: FREE_USER.owner,
+        title: 'Already here',
+      });
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'follow-up',
+        conversationHistory: [],
+        conversationId: existingId,
+      });
+
+      expect(result.conversationId).toBe(existingId);
+      const all = messagesRepo.getAll();
+      expect(all.every((m) => m.conversation_id === existingId)).toBe(true);
+      const list = await conversationsRepo.listForUser(FREE_USER.owner);
+      expect(list).toHaveLength(1);
+    });
+
+    it('throws ChatConversationNotFoundError when the conversationId does not exist', async () => {
+      const { useCase } = buildUseCase('reply');
+
+      await expect(
+        useCase.execute({
+          user: FREE_USER,
+          content: 'nope',
+          conversationHistory: [],
+          conversationId: 9999,
+        })
+      ).rejects.toBeInstanceOf(ChatConversationNotFoundError);
+    });
+
+    it('throws ChatConversationNotFoundError when the conversationId belongs to another user', async () => {
+      const { conversationsRepo, useCase } = buildUseCase('reply');
+      const theirs = await conversationsRepo.create({
+        userId: PATREON_USER.owner,
+        title: 'Theirs',
+      });
+
+      await expect(
+        useCase.execute({
+          user: FREE_USER,
+          content: 'sneaky',
+          conversationHistory: [],
+          conversationId: theirs,
+        })
+      ).rejects.toBeInstanceOf(ChatConversationNotFoundError);
     });
   });
 
   describe('ChatRateLimitError', () => {
     it('provides a resetDate as the first of next month', async () => {
-      const repo = new InMemoryChatMessagesRepository();
+      const { messagesRepo, useCase } = buildUseCase('');
       for (let i = 0; i < 20; i++) {
-        await repo.insert({ userId: FREE_USER.owner, role: 'user', content: `msg ${i}` });
+        await messagesRepo.insert({
+          userId: FREE_USER.owner,
+          conversationId: null,
+          role: 'user',
+          content: `msg ${i}`,
+        });
       }
-      const anthropic = buildAnthropicMock('');
-      const useCase = new ChatUseCase(repo, anthropic as never);
 
       let caughtError: ChatRateLimitError | null = null;
       try {

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -1,11 +1,13 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import type { IChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
+import type { IConversationsRepository } from '../../data_layer/ConversationsRepository';
 
 const FREE_MONTHLY_LIMIT = 20;
 const FREE_MODEL = 'claude-haiku-4-5-20251001';
 const PATREON_MODEL = 'claude-sonnet-4-6';
 const MAX_HISTORY_TURNS = 10;
 const MAX_TOKENS = 4096;
+const AUTO_TITLE_MAX_LENGTH = 60;
 
 const STUDY_ASSISTANT_SYSTEM_PROMPT = `You are a study assistant for 2anki, a tool that turns notes into Anki flashcards.
 
@@ -36,9 +38,17 @@ export interface ChatMessage {
 
 export interface SendMessageResult {
   content: string;
+  conversationId: number;
   contentBefore?: string;
   contentAfter?: string;
   cards?: ChatCard[];
+}
+
+function buildAutoTitle(firstMessage: string): string {
+  const trimmed = firstMessage.replace(/\s+/g, ' ').trim();
+  if (trimmed.length === 0) return 'New conversation';
+  if (trimmed.length <= AUTO_TITLE_MAX_LENGTH) return trimmed;
+  return `${trimmed.slice(0, AUTO_TITLE_MAX_LENGTH).trimEnd()}…`;
 }
 
 export class ChatRateLimitError extends Error {
@@ -121,9 +131,17 @@ function extractCards(text: string): ExtractCardsResult {
   return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
 }
 
+export class ChatConversationNotFoundError extends Error {
+  constructor() {
+    super('Conversation not found');
+    this.name = 'ChatConversationNotFoundError';
+  }
+}
+
 export class ChatUseCase {
   constructor(
-    private readonly repo: IChatMessagesRepository,
+    private readonly messagesRepo: IChatMessagesRepository,
+    private readonly conversationsRepo: IConversationsRepository,
     private readonly anthropic: Anthropic
   ) {}
 
@@ -131,15 +149,33 @@ export class ChatUseCase {
     user: ChatUser;
     content: string;
     conversationHistory: ChatMessage[];
+    conversationId?: number | null;
     onToken?: (text: string) => void;
   }): Promise<SendMessageResult> {
     const { user, content, conversationHistory, onToken } = input;
 
     if (!user.patreon) {
-      const count = await this.repo.countThisMonth(user.owner);
+      const count = await this.messagesRepo.countThisMonth(user.owner);
       if (count >= FREE_MONTHLY_LIMIT) {
         throw new ChatRateLimitError(firstOfNextMonth());
       }
+    }
+
+    let conversationId: number;
+    if (input.conversationId != null) {
+      const existing = await this.conversationsRepo.findForUser({
+        userId: user.owner,
+        conversationId: input.conversationId,
+      });
+      if (existing == null) {
+        throw new ChatConversationNotFoundError();
+      }
+      conversationId = existing.id;
+    } else {
+      conversationId = await this.conversationsRepo.create({
+        userId: user.owner,
+        title: buildAutoTitle(content),
+      });
     }
 
     const model = user.patreon ? PATREON_MODEL : FREE_MODEL;
@@ -150,7 +186,12 @@ export class ChatUseCase {
       { role: 'user', content },
     ];
 
-    await this.repo.insert({ userId: user.owner, role: 'user', content });
+    await this.messagesRepo.insert({
+      userId: user.owner,
+      conversationId,
+      role: 'user',
+      content,
+    });
 
     const stream = this.anthropic.messages.stream({
       model,
@@ -170,12 +211,19 @@ export class ChatUseCase {
       .map((block) => block.text)
       .join('');
 
-    await this.repo.insert({ userId: user.owner, role: 'assistant', content: assistantContent });
+    await this.messagesRepo.insert({
+      userId: user.owner,
+      conversationId,
+      role: 'assistant',
+      content: assistantContent,
+    });
+    await this.conversationsRepo.touch({ userId: user.owner, conversationId });
 
     const { cards, contentBefore, contentAfter } = extractCards(assistantContent);
 
     return {
       content: assistantContent,
+      conversationId,
       ...(cards != null ? { cards } : {}),
       ...(contentBefore != null ? { contentBefore } : {}),
       ...(contentAfter != null ? { contentAfter } : {}),

--- a/src/usecases/chat/ConversationsUseCase.test.ts
+++ b/src/usecases/chat/ConversationsUseCase.test.ts
@@ -1,0 +1,133 @@
+import { ConversationsUseCase, InvalidTitleError } from './ConversationsUseCase';
+import { InMemoryConversationsRepository } from '../../data_layer/ConversationsRepository';
+
+const USER_A = 1;
+const USER_B = 2;
+
+describe('ConversationsUseCase', () => {
+  describe('list', () => {
+    it('returns only the calling user\'s conversations, newest first', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+
+      const first = await repo.create({ userId: USER_A, title: 'First' });
+      const second = await repo.create({ userId: USER_A, title: 'Second' });
+      await repo.create({ userId: USER_B, title: 'Theirs' });
+
+      const list = await useCase.list(USER_A);
+      expect(list.map((c) => c.id)).toEqual([second, first]);
+    });
+
+    it('excludes soft-deleted conversations', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+
+      const keep = await repo.create({ userId: USER_A, title: 'Keep' });
+      const drop = await repo.create({ userId: USER_A, title: 'Drop' });
+      await repo.softDelete({ userId: USER_A, conversationId: drop });
+
+      const list = await useCase.list(USER_A);
+      expect(list.map((c) => c.id)).toEqual([keep]);
+    });
+  });
+
+  describe('get', () => {
+    it('returns null for another user\'s conversation', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+
+      const id = await repo.create({ userId: USER_B, title: 'Theirs' });
+      const result = await useCase.get({ userId: USER_A, conversationId: id });
+
+      expect(result).toBeNull();
+    });
+
+    it('returns the conversation with ordered messages', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+
+      const id = await repo.create({ userId: USER_A, title: 'Conversation' });
+      repo.recordMessage({ userId: USER_A, conversationId: id, role: 'user', content: 'hello' });
+      repo.recordMessage({ userId: USER_A, conversationId: id, role: 'assistant', content: 'hi' });
+
+      const result = await useCase.get({ userId: USER_A, conversationId: id });
+      expect(result?.messages).toEqual([
+        expect.objectContaining({ role: 'user', content: 'hello' }),
+        expect.objectContaining({ role: 'assistant', content: 'hi' }),
+      ]);
+    });
+  });
+
+  describe('rename', () => {
+    it('rejects empty titles', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'old' });
+
+      await expect(
+        useCase.rename({ userId: USER_A, conversationId: id, title: '   ' })
+      ).rejects.toBeInstanceOf(InvalidTitleError);
+    });
+
+    it('rejects overly long titles', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'old' });
+
+      await expect(
+        useCase.rename({ userId: USER_A, conversationId: id, title: 'x'.repeat(121) })
+      ).rejects.toBeInstanceOf(InvalidTitleError);
+    });
+
+    it('updates the title when valid', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'old' });
+
+      const ok = await useCase.rename({ userId: USER_A, conversationId: id, title: '  fresh title  ' });
+      expect(ok).toBe(true);
+      const conv = await useCase.get({ userId: USER_A, conversationId: id });
+      expect(conv?.title).toBe('fresh title');
+    });
+
+    it('returns false when renaming another user\'s conversation', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_B, title: 'theirs' });
+
+      const ok = await useCase.rename({ userId: USER_A, conversationId: id, title: 'mine now' });
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('delete', () => {
+    it('soft-deletes the conversation', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'gone' });
+
+      const ok = await useCase.delete({ userId: USER_A, conversationId: id });
+      expect(ok).toBe(true);
+      expect(await useCase.list(USER_A)).toEqual([]);
+    });
+
+    it('returns false when deleting another user\'s conversation', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_B, title: 'theirs' });
+
+      const ok = await useCase.delete({ userId: USER_A, conversationId: id });
+      expect(ok).toBe(false);
+    });
+
+    it('returns false on the second delete', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'gone' });
+
+      await useCase.delete({ userId: USER_A, conversationId: id });
+      const second = await useCase.delete({ userId: USER_A, conversationId: id });
+      expect(second).toBe(false);
+    });
+  });
+});

--- a/src/usecases/chat/ConversationsUseCase.ts
+++ b/src/usecases/chat/ConversationsUseCase.ts
@@ -1,0 +1,42 @@
+import type { IConversationsRepository, ConversationSummary, ConversationWithMessages } from '../../data_layer/ConversationsRepository';
+
+const MAX_TITLE_LENGTH = 120;
+
+export class InvalidTitleError extends Error {
+  constructor() {
+    super('Invalid title');
+    this.name = 'InvalidTitleError';
+  }
+}
+
+export class ConversationsUseCase {
+  constructor(private readonly repo: IConversationsRepository) {}
+
+  list(userId: number): Promise<ConversationSummary[]> {
+    return this.repo.listForUser(userId);
+  }
+
+  get(input: { userId: number; conversationId: number }): Promise<ConversationWithMessages | null> {
+    return this.repo.findForUser(input);
+  }
+
+  async rename(input: {
+    userId: number;
+    conversationId: number;
+    title: string;
+  }): Promise<boolean> {
+    const trimmed = input.title.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_TITLE_LENGTH) {
+      throw new InvalidTitleError();
+    }
+    return this.repo.rename({
+      userId: input.userId,
+      conversationId: input.conversationId,
+      title: trimmed,
+    });
+  }
+
+  delete(input: { userId: number; conversationId: number }): Promise<boolean> {
+    return this.repo.softDelete(input);
+  }
+}

--- a/web/src/lib/backend/api.ts
+++ b/web/src/lib/backend/api.ts
@@ -50,6 +50,17 @@ export const post = async (url: string, body: unknown) =>
     body: JSON.stringify(body),
   });
 
+export const patch = async (url: string, body: unknown) =>
+  fetch(url, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
 const DEFAULT_GET_OPTIONS: ClientSideOptions = { redirect: true };
 
 export const get = async (

--- a/web/src/pages/Chat/ChatPage.module.css
+++ b/web/src/pages/Chat/ChatPage.module.css
@@ -1,7 +1,16 @@
+.layout {
+  display: flex;
+  flex-direction: row;
+  height: calc(100vh - 0px);
+  min-height: 0;
+}
+
 .container {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 0px);
+  flex: 1;
+  min-width: 0;
+  height: 100%;
 }
 
 .messageList {

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
-import { get, post } from '../../lib/backend/api';
+import { get, post, patch, del } from '../../lib/backend/api';
 import SendIcon from '../../components/icons/SendIcon';
 import AssistantMarkdown from './AssistantMarkdown';
 import CardPreview from './CardPreview';
+import ConversationsSidebar, {
+  ConversationSummary,
+} from './ConversationsSidebar';
 import styles from './ChatPage.module.css';
 
 interface ChatCard {
@@ -21,19 +24,39 @@ interface Message {
 
 interface ApiDonePayload {
   content: string;
+  conversationId: number;
   contentBefore?: string;
   contentAfter?: string;
   cards?: ChatCard[];
 }
 
 interface ApiErrorPayload {
-  type: 'rate_limit' | 'server_error';
+  type: 'rate_limit' | 'server_error' | 'conversation_not_found';
   resetDate?: string;
 }
 
 interface ApiUsageResponse {
   used: number;
   limit: number | null;
+}
+
+interface ApiConversationsResponse {
+  conversations: ConversationSummary[];
+}
+
+interface ApiConversationDetailMessage {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  createdAt: string;
+}
+
+interface ApiConversationDetailResponse {
+  id: number;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  messages: ApiConversationDetailMessage[];
 }
 
 const STARTER_PROMPTS = [
@@ -77,6 +100,8 @@ export default function ChatPage() {
   const { data: userLocals } = useUserLocals();
   const isPatreon = userLocals?.user?.patreon === true;
 
+  const [conversations, setConversations] = useState<ConversationSummary[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<number | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [expandedUserMessages, setExpandedUserMessages] = useState<Set<number>>(new Set());
   const [streamingText, setStreamingText] = useState('');
@@ -106,6 +131,17 @@ export default function ChatPage() {
   }, []);
 
   useEffect(() => {
+    get('/api/chat/conversations', { redirect: false })
+      .then((data: ApiConversationsResponse | undefined) => {
+        if (data != null && Array.isArray(data.conversations)) {
+          setConversations(data.conversations);
+        }
+      })
+      .catch(() => {
+      });
+  }, []);
+
+  useEffect(() => {
     const el = messageListRef.current;
     if (el == null) return;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
@@ -117,6 +153,86 @@ export default function ChatPage() {
   const remainingMessages = FREE_MONTHLY_LIMIT - messagesUsedThisMonth;
 
   const canSend = inputValue.trim().length > 0 && !isLoading && !limitReached;
+
+  function upsertConversation(id: number, title: string): void {
+    setConversations((prev) => {
+      const updatedAt = new Date().toISOString();
+      const existing = prev.find((c) => c.id === id);
+      if (existing != null) {
+        return [
+          { ...existing, title, updatedAt },
+          ...prev.filter((c) => c.id !== id),
+        ];
+      }
+      return [{ id, title, updatedAt }, ...prev];
+    });
+  }
+
+  async function handleSelectConversation(id: number) {
+    if (id === activeConversationId) return;
+    setActiveConversationId(id);
+    setMessages([]);
+    setExpandedUserMessages(new Set());
+    setStreamingText('');
+    setNetworkError(null);
+    try {
+      const data = (await get(`/api/chat/conversations/${id}`, { redirect: false })) as
+        | ApiConversationDetailResponse
+        | undefined;
+      if (data == null) return;
+      setMessages(
+        data.messages.map((m) => ({ role: m.role, content: m.content }))
+      );
+    } catch {
+      setNetworkError("Couldn't load this conversation.");
+    }
+  }
+
+  function handleNewConversation() {
+    setActiveConversationId(null);
+    setMessages([]);
+    setExpandedUserMessages(new Set());
+    setStreamingText('');
+    setNetworkError(null);
+    setInputValue('');
+    textareaRef.current?.focus();
+  }
+
+  async function handleRenameConversation(id: number, title: string) {
+    const previous = conversations;
+    setConversations((prev) =>
+      prev.map((c) => (c.id === id ? { ...c, title } : c))
+    );
+    try {
+      const response = await patch(`/api/chat/conversations/${id}`, { title });
+      if (!response.ok) {
+        setConversations(previous);
+        setNetworkError("Couldn't rename this conversation.");
+      }
+    } catch {
+      setConversations(previous);
+      setNetworkError("Couldn't rename this conversation.");
+    }
+  }
+
+  async function handleDeleteConversation(id: number) {
+    const previous = conversations;
+    setConversations((prev) => prev.filter((c) => c.id !== id));
+    if (id === activeConversationId) {
+      handleNewConversation();
+    }
+    try {
+      const response = await del(`/api/chat/conversations/${id}`, { redirect: false });
+      if (response == null) return;
+      if (!response.ok) {
+        setConversations(previous);
+        setNetworkError("Couldn't delete this conversation.");
+      }
+    } catch {
+      setConversations(previous);
+      setNetworkError("Couldn't delete this conversation.");
+    }
+  }
 
   async function sendMessage(content: string) {
     if (!content.trim()) return;
@@ -132,7 +248,11 @@ export default function ChatPage() {
     const history = nextMessages.slice(-10).map((m) => ({ role: m.role, content: m.content }));
 
     try {
-      const response = await post('/api/chat/message', { content, history });
+      const response = await post('/api/chat/message', {
+        content,
+        history,
+        conversationId: activeConversationId,
+      });
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({})) as { error?: string };
@@ -191,11 +311,18 @@ export default function ChatPage() {
             ]);
             setStreamingText('');
             setMessagesUsedThisMonth((n) => n + 1);
+            setActiveConversationId(result.conversationId);
+            const provisionalTitle =
+              content.length > 60 ? `${content.slice(0, 60).trimEnd()}…` : content;
+            upsertConversation(result.conversationId, provisionalTitle);
           } else if (eventType === 'error') {
             const err = JSON.parse(data) as ApiErrorPayload;
             if (err.type === 'rate_limit') {
               setLimitReached(true);
               if (err.resetDate != null) setResetDate(err.resetDate);
+            } else if (err.type === 'conversation_not_found') {
+              setNetworkError('This conversation is gone. Start a new one.');
+              setActiveConversationId(null);
             } else {
               setNetworkError("Couldn't send this message. Try again.");
             }
@@ -242,148 +369,158 @@ export default function ChatPage() {
   const hasMessages = messages.length > 0;
 
   return (
-    <div className={styles.container}>
-      {hasMessages || isLoading ? (
-        <div className={styles.messageList} ref={messageListRef}>
-          <div className={styles.messageListInner}>
-          {messages.map((m, i) => (
-            <div
-              key={i}
-              className={`${styles.message} ${m.role === 'user' ? styles.messageUser : styles.messageAssistant} ${m.role === 'assistant' && m.cards != null && m.cards.length > 0 ? styles.messageAssistantWithCards : ''}`}
-            >
-              {m.role === 'user' && (() => {
-                const isLong = m.content.length > 600 || m.content.split('\n').length > 12;
-                const isExpanded = expandedUserMessages.has(i);
-                return (
-                  <>
-                    <div
-                      className={`${styles.messageBubble} ${styles.messageBubbleUser} ${isLong ? styles.userBubbleCollapsible : ''} ${isLong && !isExpanded ? styles.userBubbleClamped : ''}`}
-                    >
-                      {m.content}
-                    </div>
-                    {isLong && (
-                      <button
-                        type="button"
-                        className={styles.expandToggle}
-                        onClick={() => toggleUserMessage(i)}
-                        aria-expanded={isExpanded}
+    <div className={styles.layout}>
+      <ConversationsSidebar
+        conversations={conversations}
+        activeId={activeConversationId}
+        onSelect={handleSelectConversation}
+        onNew={handleNewConversation}
+        onRename={handleRenameConversation}
+        onDelete={handleDeleteConversation}
+      />
+      <div className={styles.container}>
+        {hasMessages || isLoading ? (
+          <div className={styles.messageList} ref={messageListRef}>
+            <div className={styles.messageListInner}>
+            {messages.map((m, i) => (
+              <div
+                key={i}
+                className={`${styles.message} ${m.role === 'user' ? styles.messageUser : styles.messageAssistant} ${m.role === 'assistant' && m.cards != null && m.cards.length > 0 ? styles.messageAssistantWithCards : ''}`}
+              >
+                {m.role === 'user' && (() => {
+                  const isLong = m.content.length > 600 || m.content.split('\n').length > 12;
+                  const isExpanded = expandedUserMessages.has(i);
+                  return (
+                    <>
+                      <div
+                        className={`${styles.messageBubble} ${styles.messageBubbleUser} ${isLong ? styles.userBubbleCollapsible : ''} ${isLong && !isExpanded ? styles.userBubbleClamped : ''}`}
                       >
-                        {isExpanded ? 'Show less' : 'Show full message'}
-                      </button>
+                        {m.content}
+                      </div>
+                      {isLong && (
+                        <button
+                          type="button"
+                          className={styles.expandToggle}
+                          onClick={() => toggleUserMessage(i)}
+                          aria-expanded={isExpanded}
+                        >
+                          {isExpanded ? 'Show less' : 'Show full message'}
+                        </button>
+                      )}
+                    </>
+                  );
+                })()}
+                {m.role === 'assistant' && (
+                  <>
+                    {m.contentBefore != null && (
+                      <AssistantMarkdown>{m.contentBefore}</AssistantMarkdown>
+                    )}
+                    {m.cards != null && m.cards.length > 0 && (
+                      <CardPreview
+                        cards={m.cards}
+                        onSave={(deckName) => handleSaveAsDeck(m.cards!, deckName)}
+                      />
+                    )}
+                    {m.contentAfter != null && (
+                      <AssistantMarkdown>{m.contentAfter}</AssistantMarkdown>
+                    )}
+                    {m.cards == null && (
+                      <AssistantMarkdown>{m.content}</AssistantMarkdown>
                     )}
                   </>
-                );
-              })()}
-              {m.role === 'assistant' && (
-                <>
-                  {m.contentBefore != null && (
-                    <AssistantMarkdown>{m.contentBefore}</AssistantMarkdown>
-                  )}
-                  {m.cards != null && m.cards.length > 0 && (
-                    <CardPreview
-                      cards={m.cards}
-                      onSave={(deckName) => handleSaveAsDeck(m.cards!, deckName)}
-                    />
-                  )}
-                  {m.contentAfter != null && (
-                    <AssistantMarkdown>{m.contentAfter}</AssistantMarkdown>
-                  )}
-                  {m.cards == null && (
-                    <AssistantMarkdown>{m.content}</AssistantMarkdown>
-                  )}
-                </>
-              )}
+                )}
+              </div>
+            ))}
+            {isLoading && (
+              <div className={`${styles.message} ${styles.messageAssistant}`}>
+                {streamingText.length > 0 ? (
+                  <>
+                    <AssistantMarkdown isStreaming={!isCardStreaming}>
+                      {visibleStreamingText(streamingText)}
+                    </AssistantMarkdown>
+                    {isCardStreaming && (
+                      <span className={styles.buildingCards}>Building cards</span>
+                    )}
+                  </>
+                ) : (
+                  <div className={styles.messageSkeleton} />
+                )}
+              </div>
+            )}
+            <div ref={bottomRef} />
             </div>
-          ))}
-          {isLoading && (
-            <div className={`${styles.message} ${styles.messageAssistant}`}>
-              {streamingText.length > 0 ? (
-                <>
-                  <AssistantMarkdown isStreaming={!isCardStreaming}>
-                    {visibleStreamingText(streamingText)}
-                  </AssistantMarkdown>
-                  {isCardStreaming && (
-                    <span className={styles.buildingCards}>Building cards</span>
-                  )}
-                </>
-              ) : (
-                <div className={styles.messageSkeleton} />
-              )}
+          </div>
+        ) : (
+          <div className={styles.emptyState}>
+            <h1 className={styles.emptyHeading}>Chat</h1>
+            <p className={styles.emptySubhead}>
+              A study assistant. Paste your notes, ask for cards, or work through a concept.
+            </p>
+            <div className={styles.starterChips}>
+              {STARTER_PROMPTS.map((prompt) => (
+                <button
+                  key={prompt}
+                  type="button"
+                  className={styles.starterChip}
+                  onClick={() => {
+                    setInputValue(prompt);
+                    textareaRef.current?.focus();
+                  }}
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className={styles.inputArea}>
+          {limitReached && resetDate != null && (
+            <div className={styles.limitPanel}>
+              <span>
+                You've used all {FREE_MONTHLY_LIMIT} messages this month. Resets {formatResetDate(resetDate)}.
+              </span>
+              <a
+                href="https://www.patreon.com/alemayhu"
+                target="_blank"
+                rel="noreferrer"
+                className={styles.limitPanelLink}
+              >
+                See Patreon plans
+              </a>
             </div>
           )}
-          <div ref={bottomRef} />
-          </div>
-        </div>
-      ) : (
-        <div className={styles.emptyState}>
-          <h1 className={styles.emptyHeading}>Chat</h1>
-          <p className={styles.emptySubhead}>
-            A study assistant. Paste your notes, ask for cards, or work through a concept.
-          </p>
-          <div className={styles.starterChips}>
-            {STARTER_PROMPTS.map((prompt) => (
-              <button
-                key={prompt}
-                type="button"
-                className={styles.starterChip}
-                onClick={() => {
-                  setInputValue(prompt);
-                  textareaRef.current?.focus();
-                }}
-              >
-                {prompt}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-
-      <div className={styles.inputArea}>
-        {limitReached && resetDate != null && (
-          <div className={styles.limitPanel}>
-            <span>
-              You've used all {FREE_MONTHLY_LIMIT} messages this month. Resets {formatResetDate(resetDate)}.
-            </span>
-            <a
-              href="https://www.patreon.com/alemayhu"
-              target="_blank"
-              rel="noreferrer"
-              className={styles.limitPanelLink}
+          <div className={styles.inputRow}>
+            <textarea
+              ref={textareaRef}
+              className={styles.textarea}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Ask a study question or paste notes…"
+              disabled={isLoading || limitReached}
+              rows={1}
+              aria-label="Message input"
+            />
+            <button
+              type="button"
+              className={styles.sendBtn}
+              onClick={() => sendMessage(inputValue)}
+              disabled={!canSend}
+              aria-label="Send message"
             >
-              See Patreon plans
-            </a>
+              <SendIcon width={18} height={18} />
+            </button>
           </div>
-        )}
-        <div className={styles.inputRow}>
-          <textarea
-            ref={textareaRef}
-            className={styles.textarea}
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="Ask a study question or paste notes…"
-            disabled={isLoading || limitReached}
-            rows={1}
-            aria-label="Message input"
-          />
-          <button
-            type="button"
-            className={styles.sendBtn}
-            onClick={() => sendMessage(inputValue)}
-            disabled={!canSend}
-            aria-label="Send message"
-          >
-            <SendIcon width={18} height={18} />
-          </button>
+          {!isPatreon && !limitReached && messagesUsedThisMonth > 0 && (
+            <p className={styles.usageLine}>
+              {remainingMessages} of {FREE_MONTHLY_LIMIT} messages left this month
+            </p>
+          )}
+          {networkError != null && (
+            <p className={styles.networkError}>{networkError}</p>
+          )}
         </div>
-        {!isPatreon && !limitReached && messagesUsedThisMonth > 0 && (
-          <p className={styles.usageLine}>
-            {remainingMessages} of {FREE_MONTHLY_LIMIT} messages left this month
-          </p>
-        )}
-        {networkError != null && (
-          <p className={styles.networkError}>{networkError}</p>
-        )}
       </div>
     </div>
   );

--- a/web/src/pages/Chat/ConversationsSidebar.module.css
+++ b/web/src/pages/Chat/ConversationsSidebar.module.css
@@ -1,0 +1,179 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 260px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--color-border-light);
+  padding: 1rem 0.75rem;
+  gap: 0.75rem;
+  background: var(--color-bg-secondary);
+  overflow-y: auto;
+}
+
+.newChatBtn {
+  appearance: none;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  text-align: left;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.newChatBtn:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-primary);
+}
+
+.empty {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0;
+  padding: 0.5rem 0.25rem;
+  line-height: var(--leading-relaxed);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-md);
+  position: relative;
+}
+
+.item:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.itemActive {
+  background: var(--color-bg-tertiary);
+}
+
+.itemMain {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.125rem;
+  padding: 0.5rem 0.625rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  min-width: 0;
+}
+
+.itemTitle {
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.itemMeta {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.renameInput {
+  flex: 1;
+  padding: 0.5rem 0.625rem;
+  font-size: var(--text-sm);
+  font-family: inherit;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  outline: none;
+  min-width: 0;
+}
+
+.menuWrapper {
+  position: relative;
+}
+
+.menuTrigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  margin-right: 0.25rem;
+  background: transparent;
+  border: none;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  opacity: 0;
+  transition: opacity var(--transition-fast), background var(--transition-fast);
+}
+
+.item:hover .menuTrigger,
+.menuTrigger[aria-expanded='true'] {
+  opacity: 1;
+}
+
+.menuTrigger:hover {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+}
+
+.menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 0.25rem;
+  min-width: 140px;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  z-index: 10;
+  padding: 0.25rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.menuItem {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.375rem 0.625rem;
+  font-size: var(--text-sm);
+  background: transparent;
+  border: none;
+  color: var(--color-text-primary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.menuItem:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.menuItemDanger {
+  color: var(--color-danger);
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    display: none;
+  }
+}

--- a/web/src/pages/Chat/ConversationsSidebar.tsx
+++ b/web/src/pages/Chat/ConversationsSidebar.tsx
@@ -1,0 +1,186 @@
+import { useState, useRef, useEffect } from 'react';
+import styles from './ConversationsSidebar.module.css';
+
+export interface ConversationSummary {
+  id: number;
+  title: string;
+  updatedAt: string;
+}
+
+interface Props {
+  conversations: ConversationSummary[];
+  activeId: number | null;
+  onSelect: (id: number) => void;
+  onNew: () => void;
+  onRename: (id: number, title: string) => void;
+  onDelete: (id: number) => void;
+}
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const diffMs = Date.now() - then;
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export default function ConversationsSidebar({
+  conversations,
+  activeId,
+  onSelect,
+  onNew,
+  onRename,
+  onDelete,
+}: Props) {
+  const [menuOpenFor, setMenuOpenFor] = useState<number | null>(null);
+  const [renamingId, setRenamingId] = useState<number | null>(null);
+  const [renameDraft, setRenameDraft] = useState('');
+  const menuRef = useRef<HTMLDivElement>(null);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (menuOpenFor == null) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current != null && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpenFor(null);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [menuOpenFor]);
+
+  useEffect(() => {
+    if (renamingId != null) {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    }
+  }, [renamingId]);
+
+  function startRename(id: number, currentTitle: string) {
+    setRenamingId(id);
+    setRenameDraft(currentTitle);
+    setMenuOpenFor(null);
+  }
+
+  function commitRename(id: number) {
+    const next = renameDraft.trim();
+    if (next.length > 0) {
+      onRename(id, next);
+    }
+    setRenamingId(null);
+    setRenameDraft('');
+  }
+
+  function cancelRename() {
+    setRenamingId(null);
+    setRenameDraft('');
+  }
+
+  return (
+    <aside className={styles.sidebar} aria-label="Conversations">
+      <button
+        type="button"
+        className={styles.newChatBtn}
+        onClick={onNew}
+      >
+        New chat
+      </button>
+
+      {conversations.length === 0 ? (
+        <p className={styles.empty}>No conversations yet. Start one below.</p>
+      ) : (
+        <ul className={styles.list}>
+          {conversations.map((c) => {
+            const isActive = c.id === activeId;
+            const isRenaming = c.id === renamingId;
+            return (
+              <li
+                key={c.id}
+                className={`${styles.item} ${isActive ? styles.itemActive : ''}`}
+              >
+                {isRenaming ? (
+                  <input
+                    ref={renameInputRef}
+                    type="text"
+                    className={styles.renameInput}
+                    value={renameDraft}
+                    onChange={(e) => setRenameDraft(e.target.value)}
+                    onBlur={() => commitRename(c.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        commitRename(c.id);
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cancelRename();
+                      }
+                    }}
+                    aria-label="Conversation title"
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    className={styles.itemMain}
+                    onClick={() => onSelect(c.id)}
+                    title={c.title}
+                  >
+                    <span className={styles.itemTitle}>{c.title}</span>
+                    <span className={styles.itemMeta}>{formatRelativeTime(c.updatedAt)}</span>
+                  </button>
+                )}
+
+                {!isRenaming && (
+                  <div className={styles.menuWrapper} ref={menuOpenFor === c.id ? menuRef : undefined}>
+                    <button
+                      type="button"
+                      className={styles.menuTrigger}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMenuOpenFor((prev) => (prev === c.id ? null : c.id));
+                      }}
+                      aria-label={`Options for ${c.title}`}
+                      aria-haspopup="menu"
+                      aria-expanded={menuOpenFor === c.id}
+                    >
+                      <span aria-hidden="true">⋯</span>
+                    </button>
+
+                    {menuOpenFor === c.id && (
+                      <div className={styles.menu} role="menu">
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className={styles.menuItem}
+                          onClick={() => startRename(c.id, c.title)}
+                        >
+                          Rename
+                        </button>
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                          onClick={() => {
+                            setMenuOpenFor(null);
+                            onDelete(c.id);
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

PR-1 of the chat-history series voted on by the trio. Ships **only** persistence + a threads sidebar; folders, pins, model picker, tone, attachments, drafts, and temporary chat are deferred to follow-up PRs.

- New `conversations` table + nullable `chat_messages.conversation_id`
- ChatUseCase creates or reuses a conversation per request, auto-titles from the first user message, touches on assistant reply
- Conversation API: `GET /list`, `GET /:id`, `PATCH /:id` (rename), `DELETE /:id` (soft delete)
- ConversationsSidebar on `/chat` — 260px panel, "New chat" button, hover three-dot menu for rename/delete, hidden on mobile

## Why this shape

Per the trio synthesis on the original ask ("ship all of ChatGPT-feature-X in one PR"), bundling 9 features into one PR violates `One PR per feature` and produces something unreviewable. PR-1 is the load-bearing slice; the rest layers on top once we know users return.

**Success metric:** 7-day return-to-conversation rate ≥ 25%. If < 10%, history wasn't the unlock and we stop building chat infra.

## Test plan

- [ ] Send a message on `/chat` — confirm a row appears in the sidebar with the auto-title
- [ ] Reload — confirm the conversation persists and re-opens with full history
- [ ] Click "New chat" — confirm a fresh empty conversation
- [ ] Rename via the three-dot menu — confirm persistence after reload
- [ ] Delete — confirm the row disappears and a reload doesn't bring it back
- [ ] Mobile viewport — confirm the sidebar collapses and the composer is full-width
- [ ] Confirm free-tier 20 msg/month limit still triggers correctly
- [ ] Confirm Patreon users still get sonnet model + unlimited messages

## Follow-up PRs

- PR-2: server-side drafts (debounced `PATCH /:id/draft`)
- PR-3: file attachments (images + PDFs only — audio + "any file format" are out)
- Later, separately: folders, pins, model picker, tone, temporary chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)