### PR TITLE
feat: reset saved settings on /card-options and /rules

### DIFF
--- a/src/controllers/ParserRulesController.test.ts
+++ b/src/controllers/ParserRulesController.test.ts
@@ -13,6 +13,7 @@ describe('ParserRulesController', () => {
     service = {
       createRule: jest.fn(),
       getById: jest.fn(),
+      deleteRule: jest.fn(),
     } as any;
     controller = new RulesController(service);
     req = {
@@ -71,5 +72,65 @@ describe('ParserRulesController', () => {
       res as express.Response
     );
     expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('RulesController.deleteRule', () => {
+  let service: ParserRulesService;
+  let controller: RulesController;
+  let req: Partial<express.Request>;
+  let res: Partial<express.Response>;
+
+  beforeEach(() => {
+    service = {
+      createRule: jest.fn(),
+      getById: jest.fn(),
+      deleteRule: jest.fn(),
+    } as any;
+    controller = new RulesController(service);
+    req = { params: { id: 'page-abc' } };
+    res = {
+      send: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      locals: { owner: 'owner1' },
+    };
+    jest.spyOn(getOwnerModule, 'getOwner').mockReturnValue('owner1');
+  });
+
+  it('calls deleteRule with id and owner and returns 204', async () => {
+    (service.deleteRule as jest.Mock).mockResolvedValue(1);
+
+    await controller.deleteRule(
+      req as express.Request,
+      res as express.Response
+    );
+
+    expect(service.deleteRule).toHaveBeenCalledWith('page-abc', 'owner1');
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it('returns 204 even when no row is found (idempotent)', async () => {
+    (service.deleteRule as jest.Mock).mockResolvedValue(0);
+
+    await controller.deleteRule(
+      req as express.Request,
+      res as express.Response
+    );
+
+    expect(res.status).toHaveBeenCalledWith(204);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    req.params = {};
+
+    await controller.deleteRule(
+      req as express.Request,
+      res as express.Response
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(service.deleteRule).not.toHaveBeenCalled();
   });
 });

--- a/src/controllers/ParserRulesController.ts
+++ b/src/controllers/ParserRulesController.ts
@@ -39,6 +39,17 @@ class RulesController {
       res.status(200).json();
     }
   }
+
+  async deleteRule(req: Request, res: Response) {
+    const { id } = req.params;
+
+    if (!id) {
+      return res.status(400).send();
+    }
+
+    await this.service.deleteRule(id, getOwner(res));
+    res.status(204).send();
+  }
 }
 
 export default RulesController;

--- a/src/controllers/UserPreferencesController.test.ts
+++ b/src/controllers/UserPreferencesController.test.ts
@@ -10,6 +10,7 @@ function buildMocks(userId = 1) {
     locals: { owner: userId },
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
   } as unknown as Response;
   return { repo, controller, res };
 }
@@ -97,6 +98,29 @@ describe('UserPreferencesController.patch', () => {
     await controller.patch(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe('UserPreferencesController.deleteCardOptions', () => {
+  it('returns 204 and nulls cardOptions while preserving theme and ankiWebAcknowledgedAt', async () => {
+    const { repo, controller, res } = buildMocks(10);
+    await repo.patch(10, { theme: 'dark', cardOptions: { deckName: 'Old' } });
+
+    await controller.deleteCardOptions({} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.json).not.toHaveBeenCalled();
+    const stored = await repo.get(10);
+    expect(stored.cardOptions).toBeNull();
+    expect(stored.theme).toBe('dark');
+  });
+
+  it('is idempotent when cardOptions is already null', async () => {
+    const { controller, res } = buildMocks(11);
+
+    await controller.deleteCardOptions({} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(204);
   });
 });
 

--- a/src/controllers/UserPreferencesController.ts
+++ b/src/controllers/UserPreferencesController.ts
@@ -4,6 +4,7 @@ import type { IUserPreferencesRepository } from '../data_layer/UserPreferencesRe
 import { GetUserPreferencesUseCase } from '../usecases/GetUserPreferencesUseCase';
 import { PatchUserPreferencesUseCase } from '../usecases/PatchUserPreferencesUseCase';
 import { MigrateUserPreferencesUseCase } from '../usecases/MigrateUserPreferencesUseCase';
+import { DeleteUserPreferencesCardOptionsUseCase } from '../usecases/UserPreferences/DeleteUserPreferencesCardOptionsUseCase';
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -39,11 +40,13 @@ export class UserPreferencesController {
   private readonly getUseCase: GetUserPreferencesUseCase;
   private readonly patchUseCase: PatchUserPreferencesUseCase;
   private readonly migrateUseCase: MigrateUserPreferencesUseCase;
+  private readonly deleteCardOptionsUseCase: DeleteUserPreferencesCardOptionsUseCase;
 
   constructor(repo: IUserPreferencesRepository) {
     this.getUseCase = new GetUserPreferencesUseCase(repo);
     this.patchUseCase = new PatchUserPreferencesUseCase(repo);
     this.migrateUseCase = new MigrateUserPreferencesUseCase(repo);
+    this.deleteCardOptionsUseCase = new DeleteUserPreferencesCardOptionsUseCase(repo);
   }
 
   async get(_req: Request, res: Response): Promise<void> {
@@ -66,5 +69,11 @@ export class UserPreferencesController {
     const userId = res.locals.owner as number;
     const prefs = await this.migrateUseCase.execute({ userId, cardOptions, theme, ankiWebAcknowledgedAt });
     res.status(200).json(prefs);
+  }
+
+  async deleteCardOptions(_req: Request, res: Response): Promise<void> {
+    const userId = res.locals.owner as number;
+    await this.deleteCardOptionsUseCase.execute(userId);
+    res.status(204).send();
   }
 }

--- a/src/data_layer/ParserRulesRepository.ts
+++ b/src/data_layer/ParserRulesRepository.ts
@@ -34,6 +34,12 @@ class ParserRulesRepository {
       .returning('*')
       .first();
   }
+
+  deleteByObjectId(objectId: string, owner: string): Promise<number> {
+    return this.database(this.tableName)
+      .where({ object_id: objectId, owner })
+      .del();
+  }
 }
 
 export default ParserRulesRepository;

--- a/src/data_layer/UserPreferencesRepository.ts
+++ b/src/data_layer/UserPreferencesRepository.ts
@@ -23,6 +23,7 @@ export interface IUserPreferencesRepository {
   get(userId: number): Promise<UserPreferences>;
   patch(userId: number, prefs: Partial<UserPreferences>): Promise<UserPreferences>;
   migrate(userId: number, prefs: Partial<UserPreferences>): Promise<UserPreferences>;
+  clearCardOptions(userId: number): Promise<UserPreferences>;
 }
 
 const ALLOWED_CARD_OPTION_KEYS = new Set([
@@ -102,6 +103,11 @@ export class UserPreferencesRepository implements IUserPreferencesRepository {
     }
     return this.get(userId);
   }
+
+  async clearCardOptions(userId: number): Promise<UserPreferences> {
+    await this.database('users').where({ id: userId }).update({ card_options: null });
+    return this.get(userId);
+  }
 }
 
 function laterOf(a: string | null, b: string): string {
@@ -136,6 +142,13 @@ export class InMemoryUserPreferencesRepository implements IUserPreferencesReposi
       theme: current.theme ?? prefs.theme ?? null,
       ankiWebAcknowledgedAt: current.ankiWebAcknowledgedAt ?? prefs.ankiWebAcknowledgedAt ?? null,
     };
+    this.store.set(userId, next);
+    return next;
+  }
+
+  async clearCardOptions(userId: number): Promise<UserPreferences> {
+    const current = await this.get(userId);
+    const next: UserPreferences = { ...current, cardOptions: null };
     this.store.set(userId, next);
     return next;
   }

--- a/src/routes/ParserRulesRouter.ts
+++ b/src/routes/ParserRulesRouter.ts
@@ -145,6 +145,10 @@ const ParserRulesRouter = () => {
     controller.createRule(req, res)
   );
 
+  router.delete('/api/rules/:id', RequireAuthentication, (req, res) =>
+    controller.deleteRule(req, res)
+  );
+
   return router;
 };
 

--- a/src/routes/ParserRulesRouter.ts
+++ b/src/routes/ParserRulesRouter.ts
@@ -145,6 +145,39 @@ const ParserRulesRouter = () => {
     controller.createRule(req, res)
   );
 
+  /**
+   * @swagger
+   * /api/rules/{id}:
+   *   delete:
+   *     summary: Delete parser rule
+   *     description: Remove the parser rule row for the given object ID, scoped to the authenticated owner. Idempotent — returns 204 whether or not a row was deleted.
+   *     tags: [Parser Rules]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Object ID whose parser rule should be removed
+   *     responses:
+   *       204:
+   *         description: Parser rule deleted (or did not exist)
+   *       400:
+   *         description: Missing object ID
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   *       401:
+   *         description: Authentication required
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   */
   router.delete('/api/rules/:id', RequireAuthentication, (req, res) =>
     controller.deleteRule(req, res)
   );

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -704,6 +704,12 @@ const UserRouter = () => {
     (req, res) => userPreferencesController.migrate(req, res)
   );
 
+  router.delete(
+    '/api/users/me/preferences/card-options',
+    RequireAuthentication,
+    (req, res) => userPreferencesController.deleteCardOptions(req, res)
+  );
+
   return router;
 };
 

--- a/src/services/ParserRulesService.ts
+++ b/src/services/ParserRulesService.ts
@@ -10,6 +10,10 @@ class ParserRulesService {
   getById(id: string) {
     return this.repository.getById(id);
   }
+
+  deleteRule(id: string, owner: string): Promise<number> {
+    return this.repository.deleteByObjectId(id, owner);
+  }
 }
 
 export default ParserRulesService;

--- a/src/usecases/UserPreferences/DeleteUserPreferencesCardOptionsUseCase.ts
+++ b/src/usecases/UserPreferences/DeleteUserPreferencesCardOptionsUseCase.ts
@@ -1,0 +1,9 @@
+import type { IUserPreferencesRepository, UserPreferences } from '../../data_layer/UserPreferencesRepository';
+
+export class DeleteUserPreferencesCardOptionsUseCase {
+  constructor(private readonly repo: IUserPreferencesRepository) {}
+
+  execute(userId: number): Promise<UserPreferences> {
+    return this.repo.clearCardOptions(userId);
+  }
+}

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -298,6 +298,13 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
     const resetStore = async () => {
       if (pageId) {
         await get2ankiApi().deleteSettings(pageId);
+      } else {
+        try {
+          await get2ankiApi().resetUserCardOptions();
+        } catch {
+          setError(new Error("Couldn't reset card options. Try again."));
+          return;
+        }
       }
       if (options) clearStoredCardOptions(options);
       localStorage.removeItem('page-emoji');
@@ -415,24 +422,31 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
       </div>
     );
 
+    const showResetButton = !hideActions && pageId == null;
+    const showSaveButton = !hideActions && isDirty;
+
     return (
       <div className={fieldStyles.form}>
-        {!hideActions && isDirty && (
+        {(showResetButton || showSaveButton) && (
           <div className={fieldStyles.saveBar}>
-            <button
-              type="button"
-              className={`${sharedStyles.btnSecondary} ${fieldStyles.actionButton}`}
-              onClick={resetStore}
-            >
-              Reset to 2anki defaults
-            </button>
-            <button
-              type="button"
-              className={`${sharedStyles.btnPrimary} ${fieldStyles.actionButton}`}
-              onClick={onSubmit}
-            >
-              Save defaults
-            </button>
+            {showResetButton && (
+              <button
+                type="button"
+                className={`${sharedStyles.btnSecondary} ${fieldStyles.actionButton}`}
+                onClick={resetStore}
+              >
+                Reset to defaults
+              </button>
+            )}
+            {showSaveButton && (
+              <button
+                type="button"
+                className={`${sharedStyles.btnPrimary} ${fieldStyles.actionButton}`}
+                onClick={onSubmit}
+              >
+                Save defaults
+              </button>
+            )}
           </div>
         )}
 

--- a/web/src/lib/backend/Backend.test.ts
+++ b/web/src/lib/backend/Backend.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Backend } from './Backend';
-import * as api from './api';
 import { JobsId } from '../../schemas/public/Jobs';
+import * as api from './api';
+import { Backend } from './Backend';
 
 // Mock the api module
 vi.mock('./api', () => ({
@@ -72,7 +72,9 @@ describe('Backend', () => {
 
     it('should handle 409 Conflict with default message', async () => {
       const mockResponse = createMockResponse(409, false, 'Conflict');
-      (mockResponse as any).json = vi.fn().mockRejectedValue(new Error('Invalid JSON'));
+      (mockResponse as any).json = vi
+        .fn()
+        .mockRejectedValue(new Error('Invalid JSON'));
       vi.mocked(api.del).mockResolvedValue(mockResponse);
 
       await expect(backend.deleteJob(123 as JobsId)).rejects.toThrow(
@@ -81,7 +83,11 @@ describe('Backend', () => {
     });
 
     it('should handle other HTTP errors', async () => {
-      const mockResponse = createMockResponse(500, false, 'Internal Server Error');
+      const mockResponse = createMockResponse(
+        500,
+        false,
+        'Internal Server Error'
+      );
       vi.mocked(api.del).mockResolvedValue(mockResponse);
 
       await expect(backend.deleteJob(123 as JobsId)).rejects.toThrow(
@@ -164,6 +170,60 @@ describe('Backend', () => {
       expect(api.post).toHaveBeenCalledWith(
         expect.stringContaining('upload/jobs/abc-123/restart'),
         {}
+      );
+    });
+  });
+
+  describe('resetUserCardOptions', () => {
+    it('calls DELETE on the card-options endpoint', async () => {
+      const mockResponse = createMockResponse(204, true);
+      vi.mocked(api.del).mockResolvedValue(mockResponse);
+
+      await expect(backend.resetUserCardOptions()).resolves.toBeUndefined();
+      expect(api.del).toHaveBeenCalledWith(
+        '/api/users/me/preferences/card-options'
+      );
+    });
+
+    it('throws on non-2xx response', async () => {
+      const mockResponse = createMockResponse(
+        500,
+        false,
+        'Internal Server Error'
+      );
+      vi.mocked(api.del).mockResolvedValue(mockResponse);
+
+      await expect(backend.resetUserCardOptions()).rejects.toThrow(
+        'Failed to reset card options: 500'
+      );
+    });
+
+    it('resolves when response is null', async () => {
+      vi.mocked(api.del).mockResolvedValue(null);
+
+      await expect(backend.resetUserCardOptions()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('deleteRules', () => {
+    it('calls DELETE on the rules endpoint with the page id', async () => {
+      const mockResponse = createMockResponse(204, true);
+      vi.mocked(api.del).mockResolvedValue(mockResponse);
+
+      await expect(backend.deleteRules('page-xyz')).resolves.toBeUndefined();
+      expect(api.del).toHaveBeenCalledWith('/api/rules/page-xyz');
+    });
+
+    it('throws on non-2xx response', async () => {
+      const mockResponse = createMockResponse(
+        500,
+        false,
+        'Internal Server Error'
+      );
+      vi.mocked(api.del).mockResolvedValue(mockResponse);
+
+      await expect(backend.deleteRules('page-xyz')).rejects.toThrow(
+        'Failed to delete rules: 500'
       );
     });
   });

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -1,22 +1,17 @@
-import Cookies from 'universal-cookie';
-
 import { getNotionObjectTitle } from 'get-notion-object-title';
-import { 
-  NotionDatabase, 
-  NotionPage 
-} from '../../generated/data-contracts';
+import Cookies from 'universal-cookie';
+import { NotionDatabase, NotionPage } from '../../generated/data-contracts';
+import JobResponse from '../../schemas/public/JobResponse';
+import { JobsId } from '../../schemas/public/Jobs';
+import { cancelPendingSync } from '../data_layer/userPreferencesSync';
+import AnkifyClient from '../interfaces/AnkifyClient';
+import { ConnectionInfo } from '../interfaces/ConnectionInfo';
 import NotionObject from '../interfaces/NotionObject';
 import UserUpload from '../interfaces/UserUpload';
-import AnkifyClient from '../interfaces/AnkifyClient';
-
-import { JobsId } from '../../schemas/public/Jobs';
-import JobResponse from '../../schemas/public/JobResponse';
-import { ConnectionInfo } from '../interfaces/ConnectionInfo';
 import isOfflineMode from '../isOfflineMode';
 import getObjectIcon, { ObjectIcon } from '../notion/getObjectIcon';
 import { Rules, Settings } from '../types';
 import { del, get, getLoginURL, post } from './api';
-import { cancelPendingSync } from '../data_layer/userPreferencesSync';
 import { getResourceUrl } from './getResourceUrl';
 import { CONFLICT, OK } from './http';
 
@@ -49,7 +44,9 @@ export class Backend {
     globalThis.location.href = '/';
   }
 
-  async resendVerificationEmail(): Promise<{ ok: true } | { ok: true; alreadyVerified: true }> {
+  async resendVerificationEmail(): Promise<
+    { ok: true } | { ok: true; alreadyVerified: true }
+  > {
     const response = await post(`${this.baseURL}users/resend-verification`, {});
     if (!response.ok) {
       throw new Error(`${response.status}`);
@@ -113,7 +110,25 @@ export class Backend {
     });
   }
 
-  async listSettings(): Promise<{ items: { pageId: string; title: string | null; updatedAt: string | null }[] }> {
+  async resetUserCardOptions(): Promise<void> {
+    const response = await del(
+      `${this.baseURL}users/me/preferences/card-options`
+    );
+    if (response != null && !response.ok) {
+      throw new Error(`Failed to reset card options: ${response.status}`);
+    }
+  }
+
+  async deleteRules(pageId: string): Promise<void> {
+    const response = await del(`${this.baseURL}rules/${pageId}`);
+    if (response != null && !response.ok) {
+      throw new Error(`Failed to delete rules: ${response.status}`);
+    }
+  }
+
+  async listSettings(): Promise<{
+    items: { pageId: string; title: string | null; updatedAt: string | null }[];
+  }> {
     const result = await get(`${this.baseURL}settings/list`);
     if (!result) {
       return { items: [] };
@@ -321,9 +336,7 @@ export class Backend {
     return post(`${this.baseURL}users/magic-link`, { email, purpose });
   }
 
-  async validateMagicToken(
-    token: string
-  ): Promise<Response> {
+  async validateMagicToken(token: string): Promise<Response> {
     const response = await fetch(`${this.baseURL}users/magic/${token}`, {
       credentials: 'include',
     });
@@ -376,7 +389,11 @@ export class Backend {
     await post(`${this.baseURL}users/debug/ankify-welcome-seen`, {});
   }
 
-  async startTrial(): Promise<{ ok: boolean; reason?: string; trialExpiresAt?: string }> {
+  async startTrial(): Promise<{
+    ok: boolean;
+    reason?: string;
+    trialExpiresAt?: string;
+  }> {
     const response = await post(`${this.baseURL}users/start-trial`, {});
     if (!response.ok) {
       const error = await response.json().catch(() => ({ ok: false }));
@@ -523,9 +540,7 @@ export class Backend {
   }
 
   async deleteAnkifySubscription(id: number): Promise<void> {
-    const response = await del(
-      `${this.baseURL}ankify/subscriptions/${id}`
-    );
+    const response = await del(`${this.baseURL}ankify/subscriptions/${id}`);
     if (!response?.ok) {
       throw new Error('Failed to delete subscription');
     }
@@ -548,7 +563,9 @@ export class Backend {
       const body = await response
         .json()
         .catch(() => ({ message: response.statusText }));
-      const error = new Error(body.message ?? 'Failed to update deck') as Error & {
+      const error = new Error(
+        body.message ?? 'Failed to update deck'
+      ) as Error & {
         status?: number;
         retryAfterSeconds?: number;
       };
@@ -572,9 +589,7 @@ export class Backend {
       created_at: string;
     }>
   > {
-    const result = await get(
-      `${this.baseURL}ankify/conflicts?status=pending`
-    );
+    const result = await get(`${this.baseURL}ankify/conflicts?status=pending`);
     return result ?? [];
   }
 

--- a/web/src/pages/RulesPage/RulesPage.test.tsx
+++ b/web/src/pages/RulesPage/RulesPage.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import RulesPage from './RulesPage';
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => mockApi,
+}));
+
+vi.mock('../../components/CardOptionsForm/CardOptionsForm', () => ({
+  CardOptionsForm: vi.fn((_props: unknown, _ref: unknown) => (
+    <div data-testid="card-options-form" />
+  )),
+}));
+
+const mockApi = {
+  getRules: vi.fn(),
+  getFavorites: vi.fn(),
+  deleteRules: vi.fn(),
+  deleteSettings: vi.fn(),
+  addFavorite: vi.fn(),
+  deleteFavorite: vi.fn(),
+};
+
+function renderPage(id = 'page-abc') {
+  return render(
+    <MemoryRouter initialEntries={[`/rules/${id}`]}>
+      <Routes>
+        <Route
+          path="/rules/:id"
+          element={<RulesPage setErrorMessage={vi.fn()} />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('RulesPage reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getRules.mockResolvedValue(null);
+    mockApi.getFavorites.mockResolvedValue([]);
+    mockApi.deleteRules.mockResolvedValue(undefined);
+    mockApi.deleteSettings.mockResolvedValue(undefined);
+  });
+
+  it('shows the Reset to defaults button', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Reset to defaults' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('calls deleteRules and deleteSettings when Reset to defaults is clicked', async () => {
+    renderPage('page-xyz');
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Reset to defaults' })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to defaults' }));
+
+    await waitFor(() => {
+      expect(mockApi.deleteRules).toHaveBeenCalledWith('page-xyz');
+      expect(mockApi.deleteSettings).toHaveBeenCalledWith('page-xyz');
+    });
+  });
+});

--- a/web/src/pages/RulesPage/RulesPage.tsx
+++ b/web/src/pages/RulesPage/RulesPage.tsx
@@ -92,6 +92,7 @@ export default function RulesPage({ setErrorMessage }: Readonly<Props>) {
   const [favorite, setFavorite] = useState<boolean>(false);
   const [isTogglingFavorite, setIsTogglingFavorite] = useState(false);
   const [initialSnapshot, setInitialSnapshot] = useState('');
+  const [isResetting, setIsResetting] = useState(false);
 
   const cardOptionsRef = useRef<CardOptionsFormHandle>(null);
 
@@ -149,6 +150,32 @@ export default function RulesPage({ setErrorMessage }: Readonly<Props>) {
       cancelled = true;
     };
   }, [id]);
+
+  const resetAll = async () => {
+    if (isResetting) return;
+    setIsResetting(true);
+    try {
+      await Promise.all([
+        get2ankiApi().deleteRules(id),
+        get2ankiApi().deleteSettings(id),
+      ]);
+      setRules(defaultRules);
+      setTags(defaultRules.tags_is);
+      setSendEmail(defaultRules.email_notification);
+      setInitialSnapshot(
+        snapshot(
+          defaultRules,
+          defaultRules.tags_is,
+          defaultRules.email_notification
+        )
+      );
+      await cardOptionsRef.current?.reset();
+    } catch (error) {
+      setErrorMessage(error);
+    } finally {
+      setIsResetting(false);
+    }
+  };
 
   const goBack = () => navigate(returnTo);
 
@@ -356,6 +383,14 @@ export default function RulesPage({ setErrorMessage }: Readonly<Props>) {
             />
 
             <div className={styles.saveBar}>
+              <button
+                type="button"
+                className={`${sharedStyles.btnSecondary} ${styles.actionButton}`}
+                onClick={resetAll}
+                disabled={isSaving || isResetting}
+              >
+                {isResetting ? 'Resetting' : 'Reset to defaults'}
+              </button>
               <button
                 type="button"
                 className={`${sharedStyles.btnSecondary} ${styles.actionButton}`}


### PR DESCRIPTION
## Summary

- Implements Phase 1 of the spec at [`Documentation/specs/reset-card-options.md`](https://github.com/2anki/server/blob/main/Documentation/specs/reset-card-options.md) (PR #2248), bundled with the per-page rules reset that came up after the spec landed.
- Adds two server-side delete endpoints, both owner-scoped and idempotent.
- Wires the existing CardOptionsForm reset button to actually clear the server-persisted user defaults, and adds a bulk "Reset to defaults" button on /rules.

## What changed

**Server**
- `DELETE /api/users/me/preferences/card-options` — nulls `users.card_options` for the authenticated user. `theme` and `ankiWebAcknowledgedAt` untouched. 204 even when already null.
- `DELETE /api/rules/:id` — removes the per-page `parser_rules` row. Owner check is in the `WHERE` clause (`{ object_id, owner }`) so cross-user mutation is impossible even if middleware were bypassed.
- New `DeleteUserPreferencesCardOptionsUseCase` orchestrates the call.
- Repository methods on real and `InMemory*` impls; controller-level tests against the in-memory repo.

**Web**
- `Backend.resetUserCardOptions()` and `Backend.deleteRules(pageId)`.
- `CardOptionsForm`: on the user-defaults path (`pageId == null`) the **Reset to defaults** button is visible even when the form isn't dirty (so the affordance is discoverable). `resetStore` now also clears the server-persisted defaults via the new endpoint.
- `RulesPage`: new bulk **Reset to defaults** button calls `deleteRules` + `deleteSettings` in parallel and resets the embedded `CardOptionsForm`.
- Inline error per VOICE.md on failure (`Couldn't reset card options. Try again.`).

## Scope deferred

The spec calls for a 5-second undo toast. There is no Toast primitive in the codebase today, and the spec explicitly allowed this: shipping the core round-trip cleanly beats half-built toast scaffolding. If the leading indicator (50+ resets/week within 30 days) confirms demand, the toast lands with the Phase 2 Settings page.

## Goal alignment

A returning user who feels locked into stale settings either re-imports elsewhere or stops using the tool. A visible reset lowers the cost of experimentation — directly serves retention on the path to 300K.

## Test plan

- [x] Server jest: 47/47 pass on the touched controllers and repository
- [x] Web vitest: 404/404 pass (one pre-existing unhandled `setTimeout` error in `AnkifyPage.test.tsx` mock — unrelated, exists on `main`)
- [x] Web typecheck: clean
- [x] Web lint (Biome): clean
- [x] Server tsc build: clean
- [ ] Manual: on `/card-options`, click **Reset to defaults**, refresh — defaults should persist (no reanimation from server)
- [ ] Manual: on `/rules/:id`, click **Reset to defaults**, refresh — both rules and per-page card options should be cleared
- [ ] Manual: 401 when unauthenticated (verify by hitting endpoints with no cookie)

## Notes

- Includes a small drive-by Biome auto-format on `Backend.ts` (import reorder, line wrapping) — touched the file anyway, accepted the formatter's pass to keep diff noise contained to one PR.
- Engineer agent (this session's automated worker) did the implementation; a Claude-runtime crash interrupted the commit/push/PR phase. Verified all checks green and ship-ready before recovering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)