### PR TITLE
fix: chat deck — cloze cards, ordering, deck ID

### DIFF
--- a/src/usecases/chat/ChatDeckUseCase.test.ts
+++ b/src/usecases/chat/ChatDeckUseCase.test.ts
@@ -1,0 +1,37 @@
+import { looksLikeCloze } from './ChatDeckUseCase';
+
+describe('looksLikeCloze', () => {
+  it('returns true for a single cloze marker', () => {
+    expect(looksLikeCloze('Paris is the capital of {{c1::France}}')).toBe(true);
+  });
+
+  it('returns true for multi-digit cloze numbers', () => {
+    expect(looksLikeCloze('{{c12::elephant}} memory')).toBe(true);
+  });
+
+  it('returns true when more than one cloze marker is present', () => {
+    expect(
+      looksLikeCloze('{{c1::mitochondria}} is the {{c2::powerhouse}} of the cell')
+    ).toBe(true);
+  });
+
+  it('returns true when the marker is embedded in HTML', () => {
+    expect(looksLikeCloze('<p>What is <b>{{c1::Paris}}</b>?</p>')).toBe(true);
+  });
+
+  it('returns false on plain Q/A text', () => {
+    expect(looksLikeCloze('What is the capital of France?')).toBe(false);
+  });
+
+  it('returns false when only the opening braces are present', () => {
+    expect(looksLikeCloze('Render {{ as braces}}')).toBe(false);
+  });
+
+  it('returns false when cloze marker has no digit', () => {
+    expect(looksLikeCloze('{{c::Paris}} broken syntax')).toBe(false);
+  });
+
+  it('returns false on an empty string', () => {
+    expect(looksLikeCloze('')).toBe(false);
+  });
+});

--- a/src/usecases/chat/ChatDeckUseCase.ts
+++ b/src/usecases/chat/ChatDeckUseCase.ts
@@ -14,9 +14,15 @@ export interface ChatDeckInput {
   deckName: string;
 }
 
-function deterministicId(input: string): number {
-  const hex = createHash('sha1').update(input).digest('hex').slice(0, 13);
+function randomDeckId(): number {
+  const hex = createHash('sha1').update(randomUUID()).digest('hex').slice(0, 13);
   return Number.parseInt(hex, 16) % 1e13;
+}
+
+const CLOZE_PATTERN = /\{\{c\d+::/;
+
+export function looksLikeCloze(front: string): boolean {
+  return CLOZE_PATTERN.test(front);
 }
 
 export class ChatDeckUseCase {
@@ -31,20 +37,20 @@ export class ChatDeckUseCase {
           name: deckName,
           image: '',
           style: null,
-          id: deterministicId(deckName),
+          id: randomDeckId(),
           settings: {
             template: 'specialstyle',
             clozeModelName: 'n2a-cloze',
             basicModelName: 'n2a-basic',
             inputModelName: 'n2a-input',
-            useNotionId: true,
+            useNotionId: false,
           },
-          cards: cards.map((c) => ({
+          cards: cards.map((c, index) => ({
             name: c.front,
             back: c.back,
             tags: [],
-            cloze: false,
-            number: 0,
+            cloze: looksLikeCloze(c.front),
+            number: index,
             enableInput: false,
             answer: '',
             media: [],


### PR DESCRIPTION
## Summary

You flagged that cloze deletion cards from `/chat` weren't real cloze note types. A full review of `ChatDeckUseCase` surfaced three "surprises" that this PR bundles, since they all live in that one file.

### Bugs fixed

1. **Cloze cards downgraded to Basic.** `cloze: false` was hard-coded on every chat-generated card. The Python packager requires both `card.cloze === true` **and** `{{c` in the front; the second was met but the first never was. Now we detect `{{cN::` in the front and set the flag accordingly.

2. **All cards shared `number: 0`.** That value feeds genanki's `sort_field`. The Anki browser shows every card with sort-field "0" → ordering becomes effectively random. Now uses the array index.

3. **Same-name deck collisions.** `id: deterministicId(deckName)` made every regeneration of a same-named deck land with the same Anki deck id, silently merging into the user's existing deck on import. Switched to a random id per call so each `/api/chat/deck` call is its own deck.

### Also

- Dropped the dead `useNotionId: true` flag. Chat cards never carry a `notionId` so the Python branch never fired. Cosmetic, but misleading.

### Deferred (not in this PR)

- **HTML sanitization of AI-emitted card content.** Self-XSS at worst; the recipient-on-deck-share concern is the Anki ecosystem contract, not a 2anki bug.
- **`.trim()` on AI-emitted front/back.** Cosmetic.

## Test plan

- [ ] On staging, ask `/chat` to generate cloze cards (e.g. "make 5 cloze cards on photosynthesis"). Download the .apkg. Open in Anki. Confirm cards are the **Cloze** note type, not Basic.
- [ ] Generate a non-cloze deck. Confirm cards are still **Basic**.
- [ ] Generate two decks with the same name. Confirm they import as two separate decks in Anki, not merged.
- [ ] In Anki Browse, sort by **Sort Field**. Confirm cards are no longer all "0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)