### PR TITLE
fix: re-extract cards when loading a saved chat conversation

### DIFF
--- a/src/controllers/ConversationsController.ts
+++ b/src/controllers/ConversationsController.ts
@@ -45,6 +45,9 @@ class ConversationsController {
         role: m.role,
         content: m.content,
         createdAt: m.created_at.toISOString(),
+        ...(m.cards != null ? { cards: m.cards } : {}),
+        ...(m.contentBefore != null ? { contentBefore: m.contentBefore } : {}),
+        ...(m.contentAfter != null ? { contentAfter: m.contentAfter } : {}),
       })),
     });
   }

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -67,7 +67,7 @@ function firstOfNextMonth(): string {
   return next.toISOString();
 }
 
-interface ExtractCardsResult {
+export interface ExtractCardsResult {
   cards: ChatCard[] | undefined;
   contentBefore: string | undefined;
   contentAfter: string | undefined;
@@ -98,7 +98,7 @@ function parseCardArray(raw: string): ChatCard[] | undefined {
   return cards.length > 0 ? cards : undefined;
 }
 
-function extractCards(text: string): ExtractCardsResult {
+export function extractCards(text: string): ExtractCardsResult {
   const fencedMatch = /```json\s*([\s\S]*?)```/.exec(text);
   if (fencedMatch != null) {
     const cards = parseCardArray(fencedMatch[1]);

--- a/src/usecases/chat/ConversationsUseCase.test.ts
+++ b/src/usecases/chat/ConversationsUseCase.test.ts
@@ -56,6 +56,64 @@ describe('ConversationsUseCase', () => {
         expect.objectContaining({ role: 'assistant', content: 'hi' }),
       ]);
     });
+
+    it('hydrates cards from assistant messages that contain a JSON code block', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'Cards' });
+      repo.recordMessage({ userId: USER_A, conversationId: id, role: 'user', content: 'make cards' });
+      const assistantContent =
+        'Here are your cards:\n```json\n[{"front":"Q1","back":"A1"},{"front":"Q2","back":"A2"}]\n```\nHope that helps!';
+      repo.recordMessage({
+        userId: USER_A,
+        conversationId: id,
+        role: 'assistant',
+        content: assistantContent,
+      });
+
+      const result = await useCase.get({ userId: USER_A, conversationId: id });
+      const assistant = result?.messages.find((m) => m.role === 'assistant');
+      expect(assistant?.cards).toEqual([
+        { front: 'Q1', back: 'A1' },
+        { front: 'Q2', back: 'A2' },
+      ]);
+      expect(assistant?.contentBefore).toBe('Here are your cards:');
+      expect(assistant?.contentAfter).toBe('Hope that helps!');
+    });
+
+    it('does not attach cards to user messages even when their content has JSON', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'Mixed' });
+      repo.recordMessage({
+        userId: USER_A,
+        conversationId: id,
+        role: 'user',
+        content: 'Turn this into cards:\n```json\n[{"front":"X","back":"Y"}]\n```',
+      });
+
+      const result = await useCase.get({ userId: USER_A, conversationId: id });
+      const userMsg = result?.messages.find((m) => m.role === 'user');
+      expect((userMsg as { cards?: unknown }).cards).toBeUndefined();
+    });
+
+    it('leaves assistant messages without JSON cards untouched', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'Prose' });
+      repo.recordMessage({
+        userId: USER_A,
+        conversationId: id,
+        role: 'assistant',
+        content: 'Just a plain explanation.',
+      });
+
+      const result = await useCase.get({ userId: USER_A, conversationId: id });
+      const assistant = result?.messages.find((m) => m.role === 'assistant');
+      expect((assistant as { cards?: unknown }).cards).toBeUndefined();
+      expect((assistant as { contentBefore?: unknown }).contentBefore).toBeUndefined();
+      expect((assistant as { contentAfter?: unknown }).contentAfter).toBeUndefined();
+    });
   });
 
   describe('rename', () => {

--- a/src/usecases/chat/ConversationsUseCase.ts
+++ b/src/usecases/chat/ConversationsUseCase.ts
@@ -1,4 +1,9 @@
-import type { IConversationsRepository, ConversationSummary, ConversationWithMessages } from '../../data_layer/ConversationsRepository';
+import type {
+  IConversationsRepository,
+  ConversationSummary,
+  ConversationWithMessages,
+} from '../../data_layer/ConversationsRepository';
+import { extractCards, ChatCard } from './ChatUseCase';
 
 const MAX_TITLE_LENGTH = 120;
 
@@ -9,6 +14,41 @@ export class InvalidTitleError extends Error {
   }
 }
 
+export interface ConversationMessageView {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  created_at: Date;
+  cards?: ChatCard[];
+  contentBefore?: string;
+  contentAfter?: string;
+}
+
+export interface ConversationView {
+  id: number;
+  title: string;
+  created_at: Date;
+  updated_at: Date;
+  messages: ConversationMessageView[];
+}
+
+function hydrateMessages(
+  conv: ConversationWithMessages
+): ConversationMessageView[] {
+  return conv.messages.map((m) => {
+    if (m.role !== 'assistant') {
+      return m;
+    }
+    const { cards, contentBefore, contentAfter } = extractCards(m.content);
+    return {
+      ...m,
+      ...(cards != null ? { cards } : {}),
+      ...(contentBefore != null ? { contentBefore } : {}),
+      ...(contentAfter != null ? { contentAfter } : {}),
+    };
+  });
+}
+
 export class ConversationsUseCase {
   constructor(private readonly repo: IConversationsRepository) {}
 
@@ -16,8 +56,19 @@ export class ConversationsUseCase {
     return this.repo.listForUser(userId);
   }
 
-  get(input: { userId: number; conversationId: number }): Promise<ConversationWithMessages | null> {
-    return this.repo.findForUser(input);
+  async get(input: {
+    userId: number;
+    conversationId: number;
+  }): Promise<ConversationView | null> {
+    const conv = await this.repo.findForUser(input);
+    if (conv == null) return null;
+    return {
+      id: conv.id,
+      title: conv.title,
+      created_at: conv.created_at,
+      updated_at: conv.updated_at,
+      messages: hydrateMessages(conv),
+    };
   }
 
   async rename(input: {

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -49,6 +49,9 @@ interface ApiConversationDetailMessage {
   role: 'user' | 'assistant';
   content: string;
   createdAt: string;
+  cards?: ChatCard[];
+  contentBefore?: string;
+  contentAfter?: string;
 }
 
 interface ApiConversationDetailResponse {
@@ -181,7 +184,13 @@ export default function ChatPage() {
         | undefined;
       if (data == null) return;
       setMessages(
-        data.messages.map((m) => ({ role: m.role, content: m.content }))
+        data.messages.map((m) => ({
+          role: m.role,
+          content: m.content,
+          ...(m.cards != null ? { cards: m.cards } : {}),
+          ...(m.contentBefore != null ? { contentBefore: m.contentBefore } : {}),
+          ...(m.contentAfter != null ? { contentAfter: m.contentAfter } : {}),
+        }))
       );
     } catch {
       setNetworkError("Couldn't load this conversation.");

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -187,9 +187,9 @@ export default function ChatPage() {
         data.messages.map((m) => ({
           role: m.role,
           content: m.content,
-          ...(m.cards != null ? { cards: m.cards } : {}),
-          ...(m.contentBefore != null ? { contentBefore: m.contentBefore } : {}),
-          ...(m.contentAfter != null ? { contentAfter: m.contentAfter } : {}),
+          ...(m.cards == null ? {} : { cards: m.cards }),
+          ...(m.contentBefore == null ? {} : { contentBefore: m.contentBefore }),
+          ...(m.contentAfter == null ? {} : { contentAfter: m.contentAfter }),
         }))
       );
     } catch {


### PR DESCRIPTION
## The bug

Revisit a saved chat conversation from the sidebar and the assistant's card-generating reply renders as a raw JSON dump — no CardPreview, no **Save as deck** button. Screenshot from the report shows the literal `[{"front": ..., "back": ...}]` block flushed to the page.

## Why

`ChatUseCase` extracts the JSON cards block at send-time and emits `{cards, contentBefore, contentAfter}` on the SSE `done` event. That structured shape is what makes the card preview render. But `GET /api/chat/conversations/:id` was returning only the raw `content` for each message. On reload, the client fell back to rendering the entire message through `AssistantMarkdown`, JSON block and all.

## Fix

- Export `extractCards` from `ChatUseCase`.
- Run it inside `ConversationsUseCase.get` for each assistant message; user messages are intentionally untouched even when their content has JSON (so "Turn this into cards: …" pastes don't get treated as outputs).
- Pass `{cards, contentBefore, contentAfter}` through `ConversationsController` to the JSON response.
- Client now hydrates the same structured fields on conversation load.

No schema change. Existing rows benefit automatically — extraction runs on read.

## Test plan

- [ ] On staging, send a chat message that generates cards. Confirm CardPreview + Save button render.
- [ ] Reload the page, click the conversation in the sidebar. Confirm CardPreview + Save button render again (no raw JSON wall).
- [ ] Send a user message containing a literal JSON block. Confirm the **user** bubble still renders as plain text, no preview.
- [ ] Older assistant messages (sent before this fix) — reload + click; the JSON block in their content should now be parsed and rendered as cards retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)