### PR TITLE
feat: chat composer drafts per conversation (PR-2)

### DIFF
--- a/migrations/20260529000000_conversation_drafts.js
+++ b/migrations/20260529000000_conversation_drafts.js
@@ -1,0 +1,9 @@
+exports.up = (knex) =>
+  knex.schema.alterTable('conversations', (t) => {
+    t.text('draft_content').nullable().defaultTo(null);
+  });
+
+exports.down = (knex) =>
+  knex.schema.alterTable('conversations', (t) => {
+    t.dropColumn('draft_content');
+  });

--- a/src/controllers/ConversationsController.test.ts
+++ b/src/controllers/ConversationsController.test.ts
@@ -140,6 +140,81 @@ describe('ConversationsController', () => {
     });
   });
 
+  describe('saveDraft', () => {
+    it('returns 400 when content is missing', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'work' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.saveDraft(
+        buildReq({ params: { id: String(id) }, body: {} }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('accepts a string draft and returns 204', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'work' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.saveDraft(
+        buildReq({ params: { id: String(id) }, body: { content: 'in-progress' } }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+
+    it('accepts null content to clear the draft', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'work' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.saveDraft(
+        buildReq({ params: { id: String(id) }, body: { content: null } }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+
+    it('returns 400 when content is over the size cap', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 42, title: 'work' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.saveDraft(
+        buildReq({
+          params: { id: String(id) },
+          body: { content: 'x'.repeat(100_001) },
+        }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 when the conversation belongs to another user', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const id = await repo.create({ userId: 99, title: 'theirs' });
+      const controller = new ConversationsController(new ConversationsUseCase(repo));
+      const res = buildRes(42);
+
+      await controller.saveDraft(
+        buildReq({ params: { id: String(id) }, body: { content: 'sneaky' } }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
   describe('delete', () => {
     it('returns 204 on success', async () => {
       const repo = new InMemoryConversationsRepository();

--- a/src/controllers/ConversationsController.ts
+++ b/src/controllers/ConversationsController.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from 'express';
-import { ConversationsUseCase, InvalidTitleError } from '../usecases/chat/ConversationsUseCase';
+import {
+  ConversationsUseCase,
+  InvalidTitleError,
+  InvalidDraftError,
+} from '../usecases/chat/ConversationsUseCase';
 
 function parseConversationId(raw: unknown): number | null {
   if (typeof raw !== 'string') return null;
@@ -38,6 +42,7 @@ class ConversationsController {
     res.status(200).json({
       id: conv.id,
       title: conv.title,
+      draft: conv.draft,
       createdAt: conv.created_at.toISOString(),
       updatedAt: conv.updated_at.toISOString(),
       messages: conv.messages.map((m) => ({
@@ -78,6 +83,43 @@ class ConversationsController {
     } catch (err) {
       if (err instanceof InvalidTitleError) {
         res.status(400).json({ error: 'title must be 1 to 120 characters' });
+        return;
+      }
+      throw err;
+    }
+  }
+
+  async saveDraft(req: Request, res: Response): Promise<void> {
+    const owner = res.locals.owner as number;
+    const id = parseConversationId(req.params.id);
+    if (id == null) {
+      res.status(400).json({ error: 'invalid conversation id' });
+      return;
+    }
+    const rawContent = req.body?.content;
+    let content: string | null;
+    if (rawContent === null) {
+      content = null;
+    } else if (typeof rawContent === 'string') {
+      content = rawContent;
+    } else {
+      res.status(400).json({ error: 'content must be a string or null' });
+      return;
+    }
+    try {
+      const updated = await this.useCase.saveDraft({
+        userId: owner,
+        conversationId: id,
+        content,
+      });
+      if (!updated) {
+        res.status(404).json({ error: 'conversation not found' });
+        return;
+      }
+      res.status(204).end();
+    } catch (err) {
+      if (err instanceof InvalidDraftError) {
+        res.status(400).json({ error: 'draft is too long' });
         return;
       }
       throw err;

--- a/src/data_layer/ConversationsRepository.ts
+++ b/src/data_layer/ConversationsRepository.ts
@@ -4,6 +4,7 @@ export interface ConversationRow {
   id: number;
   user_id: number;
   title: string;
+  draft_content: string | null;
   created_at: Date;
   updated_at: Date;
   deleted_at: Date | null;
@@ -18,6 +19,7 @@ export interface ConversationSummary {
 export interface ConversationWithMessages {
   id: number;
   title: string;
+  draft: string | null;
   created_at: Date;
   updated_at: Date;
   messages: Array<{
@@ -35,6 +37,11 @@ export interface IConversationsRepository {
   rename(input: { userId: number; conversationId: number; title: string }): Promise<boolean>;
   softDelete(input: { userId: number; conversationId: number }): Promise<boolean>;
   touch(input: { userId: number; conversationId: number }): Promise<void>;
+  saveDraft(input: {
+    userId: number;
+    conversationId: number;
+    content: string | null;
+  }): Promise<boolean>;
 }
 
 export class ConversationsRepository implements IConversationsRepository {
@@ -85,6 +92,7 @@ export class ConversationsRepository implements IConversationsRepository {
     return {
       id: conv.id,
       title: conv.title,
+      draft: conv.draft_content ?? null,
       created_at: conv.created_at,
       updated_at: conv.updated_at,
       messages,
@@ -120,6 +128,18 @@ export class ConversationsRepository implements IConversationsRepository {
       .whereNull('deleted_at')
       .update({ updated_at: this.database.fn.now() });
   }
+
+  async saveDraft(input: {
+    userId: number;
+    conversationId: number;
+    content: string | null;
+  }): Promise<boolean> {
+    const updated = await this.database(this.table)
+      .where({ id: input.conversationId, user_id: input.userId })
+      .whereNull('deleted_at')
+      .update({ draft_content: input.content });
+    return updated > 0;
+  }
 }
 
 export class InMemoryConversationsRepository implements IConversationsRepository {
@@ -142,6 +162,7 @@ export class InMemoryConversationsRepository implements IConversationsRepository
       id,
       user_id: input.userId,
       title: input.title,
+      draft_content: null,
       created_at: now,
       updated_at: now,
       deleted_at: null,
@@ -174,6 +195,7 @@ export class InMemoryConversationsRepository implements IConversationsRepository
     return {
       id: conv.id,
       title: conv.title,
+      draft: conv.draft_content ?? null,
       created_at: conv.created_at,
       updated_at: conv.updated_at,
       messages,
@@ -211,6 +233,19 @@ export class InMemoryConversationsRepository implements IConversationsRepository
       (r) => r.id === input.conversationId && r.user_id === input.userId && r.deleted_at == null
     );
     if (conv != null) conv.updated_at = new Date();
+  }
+
+  async saveDraft(input: {
+    userId: number;
+    conversationId: number;
+    content: string | null;
+  }): Promise<boolean> {
+    const conv = this.rows.find(
+      (r) => r.id === input.conversationId && r.user_id === input.userId && r.deleted_at == null
+    );
+    if (conv == null) return false;
+    conv.draft_content = input.content;
+    return true;
   }
 
   recordMessage(entry: {

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -235,6 +235,43 @@ const ChatRouter = () => {
     conversationsController.delete(req, res)
   );
 
+  /**
+   * @swagger
+   * /api/chat/conversations/{id}/draft:
+   *   patch:
+   *     summary: Save the in-progress draft for a conversation
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema: { type: integer }
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [content]
+   *             properties:
+   *               content:
+   *                 type: string
+   *                 nullable: true
+   *                 maxLength: 100000
+   *     responses:
+   *       204:
+   *         description: Draft saved (or cleared if content is null)
+   *       400:
+   *         description: Invalid input
+   *       404:
+   *         description: Conversation not found
+   */
+  router.patch('/api/chat/conversations/:id/draft', RequireAuthentication, (req, res) =>
+    conversationsController.saveDraft(req, res)
+  );
+
   return router;
 };
 

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -236,6 +236,31 @@ describe('ChatUseCase', () => {
     });
   });
 
+  describe('draft auto-clear', () => {
+    it('clears the conversation draft after a successful assistant reply', async () => {
+      const { conversationsRepo, useCase } = buildUseCase('reply');
+      const id = await conversationsRepo.create({ userId: FREE_USER.owner, title: 'With draft' });
+      await conversationsRepo.saveDraft({
+        userId: FREE_USER.owner,
+        conversationId: id,
+        content: 'half-typed prompt',
+      });
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'final prompt',
+        conversationHistory: [],
+        conversationId: id,
+      });
+
+      const conv = await conversationsRepo.findForUser({
+        userId: FREE_USER.owner,
+        conversationId: id,
+      });
+      expect(conv?.draft).toBeNull();
+    });
+  });
+
   describe('conversation management', () => {
     it('creates a new conversation when no conversationId is provided', async () => {
       const { conversationsRepo, useCase } = buildUseCase('reply');

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -218,6 +218,11 @@ export class ChatUseCase {
       content: assistantContent,
     });
     await this.conversationsRepo.touch({ userId: user.owner, conversationId });
+    await this.conversationsRepo.saveDraft({
+      userId: user.owner,
+      conversationId,
+      content: null,
+    });
 
     const { cards, contentBefore, contentAfter } = extractCards(assistantContent);
 

--- a/src/usecases/chat/ConversationsUseCase.test.ts
+++ b/src/usecases/chat/ConversationsUseCase.test.ts
@@ -1,4 +1,8 @@
-import { ConversationsUseCase, InvalidTitleError } from './ConversationsUseCase';
+import {
+  ConversationsUseCase,
+  InvalidTitleError,
+  InvalidDraftError,
+} from './ConversationsUseCase';
 import { InMemoryConversationsRepository } from '../../data_layer/ConversationsRepository';
 
 const USER_A = 1;
@@ -154,6 +158,72 @@ describe('ConversationsUseCase', () => {
       const id = await repo.create({ userId: USER_B, title: 'theirs' });
 
       const ok = await useCase.rename({ userId: USER_A, conversationId: id, title: 'mine now' });
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('saveDraft', () => {
+    it('stores the draft on the conversation', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'Working' });
+
+      const ok = await useCase.saveDraft({
+        userId: USER_A,
+        conversationId: id,
+        content: 'half-typed message',
+      });
+
+      expect(ok).toBe(true);
+      const view = await useCase.get({ userId: USER_A, conversationId: id });
+      expect(view?.draft).toBe('half-typed message');
+    });
+
+    it('treats an empty string as null (clears the draft)', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'Working' });
+      await useCase.saveDraft({ userId: USER_A, conversationId: id, content: 'hello' });
+
+      await useCase.saveDraft({ userId: USER_A, conversationId: id, content: '' });
+
+      const view = await useCase.get({ userId: USER_A, conversationId: id });
+      expect(view?.draft).toBeNull();
+    });
+
+    it('clears the draft when content is null', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'Working' });
+      await useCase.saveDraft({ userId: USER_A, conversationId: id, content: 'hello' });
+
+      await useCase.saveDraft({ userId: USER_A, conversationId: id, content: null });
+
+      const view = await useCase.get({ userId: USER_A, conversationId: id });
+      expect(view?.draft).toBeNull();
+    });
+
+    it('rejects drafts over the 100 000 char cap', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'Working' });
+
+      await expect(
+        useCase.saveDraft({ userId: USER_A, conversationId: id, content: 'x'.repeat(100_001) })
+      ).rejects.toBeInstanceOf(InvalidDraftError);
+    });
+
+    it('returns false when saving to another user\'s conversation', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_B, title: 'Theirs' });
+
+      const ok = await useCase.saveDraft({
+        userId: USER_A,
+        conversationId: id,
+        content: 'sneaky',
+      });
+
       expect(ok).toBe(false);
     });
   });

--- a/src/usecases/chat/ConversationsUseCase.ts
+++ b/src/usecases/chat/ConversationsUseCase.ts
@@ -27,9 +27,19 @@ export interface ConversationMessageView {
 export interface ConversationView {
   id: number;
   title: string;
+  draft: string | null;
   created_at: Date;
   updated_at: Date;
   messages: ConversationMessageView[];
+}
+
+const MAX_DRAFT_LENGTH = 100_000;
+
+export class InvalidDraftError extends Error {
+  constructor() {
+    super('Invalid draft');
+    this.name = 'InvalidDraftError';
+  }
 }
 
 function hydrateMessages(
@@ -65,10 +75,35 @@ export class ConversationsUseCase {
     return {
       id: conv.id,
       title: conv.title,
+      draft: conv.draft,
       created_at: conv.created_at,
       updated_at: conv.updated_at,
       messages: hydrateMessages(conv),
     };
+  }
+
+  async saveDraft(input: {
+    userId: number;
+    conversationId: number;
+    content: string | null;
+  }): Promise<boolean> {
+    let normalised: string | null;
+    if (input.content == null) {
+      normalised = null;
+    } else {
+      if (typeof input.content !== 'string') {
+        throw new InvalidDraftError();
+      }
+      if (input.content.length > MAX_DRAFT_LENGTH) {
+        throw new InvalidDraftError();
+      }
+      normalised = input.content.length === 0 ? null : input.content;
+    }
+    return this.repo.saveDraft({
+      userId: input.userId,
+      conversationId: input.conversationId,
+      content: normalised,
+    });
   }
 
   async rename(input: {

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -57,10 +57,13 @@ interface ApiConversationDetailMessage {
 interface ApiConversationDetailResponse {
   id: number;
   title: string;
+  draft: string | null;
   createdAt: string;
   updatedAt: string;
   messages: ApiConversationDetailMessage[];
 }
+
+const DRAFT_DEBOUNCE_MS = 500;
 
 const STARTER_PROMPTS = [
   'Make 10 cards from notes I\'ll paste',
@@ -118,6 +121,7 @@ export default function ChatPage() {
   const bottomRef = useRef<HTMLDivElement>(null);
   const messageListRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const lastSavedDraftRef = useRef<string>('');
 
   useEffect(() => {
     get('/api/chat/usage', { redirect: false })
@@ -153,6 +157,24 @@ export default function ChatPage() {
     }
   }, [messages, isLoading, streamingText]);
 
+  useEffect(() => {
+    if (activeConversationId == null) return;
+    if (inputValue === lastSavedDraftRef.current) return;
+    const conversationId = activeConversationId;
+    const draft = inputValue;
+    const handle = setTimeout(() => {
+      patch(`/api/chat/conversations/${conversationId}/draft`, {
+        content: draft.length === 0 ? null : draft,
+      })
+        .then(() => {
+          lastSavedDraftRef.current = draft;
+        })
+        .catch(() => {
+        });
+    }, DRAFT_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [inputValue, activeConversationId]);
+
   const remainingMessages = FREE_MONTHLY_LIMIT - messagesUsedThisMonth;
 
   const canSend = inputValue.trim().length > 0 && !isLoading && !limitReached;
@@ -178,6 +200,8 @@ export default function ChatPage() {
     setExpandedUserMessages(new Set());
     setStreamingText('');
     setNetworkError(null);
+    setInputValue('');
+    lastSavedDraftRef.current = '';
     try {
       const data = (await get(`/api/chat/conversations/${id}`, { redirect: false })) as
         | ApiConversationDetailResponse
@@ -192,6 +216,10 @@ export default function ChatPage() {
           ...(m.contentAfter == null ? {} : { contentAfter: m.contentAfter }),
         }))
       );
+      if (data.draft != null && data.draft.length > 0) {
+        setInputValue(data.draft);
+        lastSavedDraftRef.current = data.draft;
+      }
     } catch {
       setNetworkError("Couldn't load this conversation.");
     }
@@ -321,6 +349,7 @@ export default function ChatPage() {
             setStreamingText('');
             setMessagesUsedThisMonth((n) => n + 1);
             setActiveConversationId(result.conversationId);
+            lastSavedDraftRef.current = '';
             const provisionalTitle =
               content.length > 60 ? `${content.slice(0, 60).trimEnd()}…` : content;
             upsertConversation(result.conversationId, provisionalTitle);


### PR DESCRIPTION
## Summary

PR-2 of the chat-history series. The composer's in-progress text now survives reloads and navigation for **existing conversations**. New-chat drafts (before any message is sent) stay as ephemeral React state — the trio explicitly scoped that case out to keep this PR small; revisit if support tickets surface it.

## What changes

- **Schema:** new `conversations.draft_content` (text, nullable). Single column on the existing row, no separate table.
- **Repo:** `ConversationsRepository.saveDraft(userId, conversationId, content)` — null clears.
- **Use case:** normalises empty string → null and caps content at 100 000 chars (matches the premium message cap, since drafts will often be exactly the content the user's about to send).
- **API:**
  - `GET /api/chat/conversations/:id` now includes `draft` in the response.
  - `PATCH /api/chat/conversations/:id/draft` saves or clears the draft. Body: `{ content: string | null }`.
- **Auto-clear:** `ChatUseCase.execute` clears the draft right after a successful assistant reply, so the client doesn't need to issue a separate clear call.
- **Frontend:** on selecting a saved conversation, the composer hydrates from `conversation.draft`. Input changes debounce a PATCH (500ms) when an active conversation is selected. Skips the call when content hasn't changed since the last save.

## Test plan

- [ ] Open a saved conversation. Type a few characters into the composer. Reload. Confirm the same text is restored.
- [ ] Type, then click another conversation. Reload. Switch back. Confirm the text is still there.
- [ ] Send a message. Confirm the draft is cleared on both the page and on reload (server auto-clears).
- [ ] Click "New chat" — confirm the composer is empty (no cross-conversation bleed).
- [ ] Try to PATCH a draft on another user's conversation id. Confirm 404.

## Out of scope (later PRs)

Folders, pins, file attachments, model picker, tone presets, temporary chat. Tracked in the trio plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)