### PR TITLE
chore: require a changelog entry before merge

### DIFF
--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -48,8 +48,9 @@ When given a spec or issue:
 5. **Write the failing test first.**
 6. **Implement.** Smallest viable change. No drive-by refactors.
 7. **Answer: how will we measure this worked?** Name the specific log line, metric, or query that will confirm the behavior in production. Add instrumentation alongside the implementation — not as a follow-up ticket.
-8. **Run `/check`** — parallel tsc + web typecheck + web vitest. Everything green before pushing.
-9. **Open the PR.** Title uses a conventional commit prefix (`fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`) followed by an imperative summary.
+8. **Changelog entry.** If a real user would notice this change, add a line to `web/src/pages/WhatsNewPage/changelog.ts` in the same PR. User voice, no implementation details — see CLAUDE.md > Changelog. If the PR is internal-only, say so in the PR body so reviewers don't ask.
+9. **Run `/check`** — parallel tsc + web typecheck + web vitest. Everything green before pushing.
+10. **Open the PR.** Title uses a conventional commit prefix (`fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`) followed by an imperative summary.
 
 ### When the work originated from a draft spec PR
 
@@ -80,6 +81,9 @@ Specific log, metric, or query that confirms this worked in production.
 ## Testing
 - Unit tests added: ...
 - Manually verified: ...
+
+## Changelog
+The exact line added to `web/src/pages/WhatsNewPage/changelog.ts`, or "No entry — internal-only, no user-visible change."
 
 ## Risks
 What could break. Rollback plan if relevant.

--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -5,16 +5,19 @@ argument-hint: optional date range, e.g. "last 14 days"
 
 Use the `pm` agent (with help from `designer` for tone).
 
+This is the **batch / backfill** tool — it builds blog and SEO copy from a window of merged PRs. Per-PR changelog entries belong in `web/src/pages/WhatsNewPage/changelog.ts` and are added in the PR that ships the change (see CLAUDE.md > Changelog). By the time `/changelog` runs, those entries should already exist; this command consolidates them into distribution copy.
+
 1. Pull merged PRs from the last $ARGUMENTS (default: 14 days). Use `gh pr list --state merged --search "merged:>=YYYY-MM-DD"`.
-2. Group by user-visible category:
+2. Cross-reference `web/src/pages/WhatsNewPage/changelog.ts` for entries dated in that window — they are the curated user-voice source. Note any merged user-visible PR that does not have an entry and flag it explicitly so the gap can be backfilled.
+3. Group by user-visible category:
    - **New** — net-new features
    - **Improved** — enhancements to existing features
    - **Fixed** — bug fixes worth mentioning
    - **Behind the scenes** — perf/infra (only mention if user-perceptible)
 
-3. Write each entry in user voice — what the user can now do, not what we changed. Bad: "Refactored Notion image extractor." Good: "Notion pages with embedded images now convert reliably even when an image fails to load."
+4. Write each entry in user voice — what the user can now do, not what we changed. Follow the conventions in CLAUDE.md > Changelog (sentence case, no trailing period, ~120 chars, no hedge filler, no implementation details). Bad: "Refactored Notion image extractor." Good: "Notion pages with embedded images convert even when one image fails to load."
 
-4. Output two formats:
+5. Output two formats:
    - **Short** (in-app changelog modal, ~150 words)
    - **Long** (blog post draft, ~600 words, SEO-aware — title with target keyword, H2 sections, one screenshot placeholder per feature)
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -33,8 +33,9 @@ When `$ARGUMENTS` is a PR number or URL (or you can find a draft PR titled `spec
    git commit -m "chore: remove implemented spec for <feature name>" \
      -m "Spec text preserved in git history: git log -p -- Documentation/specs/<slug>.md"
    ```
-6. Run `/check` (parallel tsc + web typecheck + web vitest + web lint). All green before flipping the PR.
-7. Graduate the PR from draft to ready, and rename the title to match the implementation prefix:
+6. **Add a changelog entry if this PR changes user-visible behavior.** See CLAUDE.md > Changelog for the rules (file path, when to add, voice). One line, user-facing prose — no implementation details. If you can't write the entry without referencing internal code, the PR probably doesn't need one. Commit as `chore: add changelog entry for <feature>`.
+7. Run `/check` (parallel tsc + web typecheck + web vitest + web lint). All green before flipping the PR.
+8. Graduate the PR from draft to ready, and rename the title to match the implementation prefix:
    ```
    gh pr edit <n> --title "<type>: <feature name>"   # feat: / fix: / refactor: / ...
    gh pr ready <n>
@@ -43,6 +44,7 @@ When `$ARGUMENTS` is a PR number or URL (or you can find a draft PR titled `spec
 
 Before merging:
 - All checks green.
+- Changelog entry added if the PR is user-visible (or explicit note in the PR body that no entry is warranted).
 - If user-facing, ping the `designer` agent for a review pass.
 - If the change touches auth, payments, or external-API integration, run `/security-review` first.
 - Note goal alignment in the PR body (per `CLAUDE.md`).
@@ -54,7 +56,7 @@ If `$ARGUMENTS` is a raw spec (pasted body or a path to a `.md` file with no ass
 1. Read the spec.
 2. Follow the engineer workflow above.
 3. Suggest a branch name. Format: `<type>/<short-slug>` using a conventional commit prefix (`fix/`, `feat/`, `chore/`, `refactor/`, `test/`). Do **not** use `docs/` for an implementation branch.
-4. Once confirmed, create the branch, commit in logical chunks, run `/check`, then open the PR (not draft) with `gh pr create` using the engineer template.
+4. Once confirmed, create the branch, commit in logical chunks. If the work changes user-visible behavior, add a changelog entry per CLAUDE.md > Changelog (separate `chore: add changelog entry …` commit). Run `/check`, then open the PR (not draft) with `gh pr create` using the engineer template.
 
 In this path there is no spec file in the repo to remove — skip the spec-cleanup commit.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,48 @@ Specs live in `Documentation/specs/` only while a feature is in flight. Workflow
 
 Do not open a separate implementation PR alongside a spec PR. Do not let `Documentation/specs/` collect specs for already-shipped work.
 
+## Changelog
+
+User-visible changes ship with a changelog entry in the **same PR**. The entry lands in `web/src/pages/WhatsNewPage/changelog.ts` and renders in the in-app "What's New" page.
+
+**When to add an entry.** Add one if a real user would notice the change. Don't add one if they wouldn't.
+
+| Commit type | Entry? |
+| --- | --- |
+| `feat:` — new feature or new capability | Yes |
+| `fix:` — bug a user could hit | Yes |
+| `revert:` — undoing something users could see | Yes, otherwise no |
+| `perf:` — only if the user perceives the speedup | Yes, otherwise no |
+| `style:` — UI change a user would notice | Yes, otherwise no |
+| `refactor:`, `chore:`, `test:`, `ci:`, `build:`, internal `docs:` | No |
+| Bumping a dependency that doesn't change behavior | No |
+
+If you can't write the entry without referencing internal files, classes, or refactors, the PR probably doesn't warrant one. State that explicitly in the PR body ("no changelog entry — internal refactor, no user-visible behavior change") rather than going silent.
+
+**How to write the entry.** Follow `VOICE.md`. The reader is a busy learner skimming the What's New page — they want to know what they can do now that they couldn't before, or which bug stopped affecting them. The conventions below match the existing entries in `changelog.ts`; new lines must match the file, not drift from it.
+
+- User voice, not engineering voice. What changed *for the user*, not what we changed in the code.
+- Specific over generic. Name the surface, the file format, the count — whatever makes the entry useful. If you have a number, use the number; don't write "about twice as fast" when you don't.
+- No implementation details. No file names, class names, library names, commit shas, ticket numbers, "we refactored X", "we migrated Y". The user does not care and shouldn't have to.
+- **Sentence case. No trailing period.** Matches every line in the current file. A trailing period on a one-line entry reads like an essay.
+- One line, ~120 characters max. No multi-sentence entries.
+- Start with the surface or the noun (the deck, the upload, password reset, sign in with Notion), not "Added"/"Fixed"/"Now". The type tag already says `feature`/`fix`; repeating it in prose is noise.
+- No hedge filler that implies prior brokenness: avoid "actually", "finally", "now properly", "no longer broken". These tell the user the thing was bad before — which most of them never noticed.
+- The em-dash is for adding specifics ("Theme switcher — light, dark, gold, and purple"), not for explaining a fix ("— no more waiting"). Don't apologize on the same line.
+
+Good vs bad:
+
+| Bad (don't ship this) | Good (ship this) |
+| --- | --- |
+| Refactored Notion image extractor | Notion pages with embedded images convert even when one image fails to load |
+| Fixed bug in EmailService | Password reset emails arrive within seconds |
+| Migrated S3 client to v3 SDK | (no entry — internal-only) |
+| Improved performance | Large Notion exports convert in about half the time |
+| Added `useDeckSettings` hook | (no entry — internal-only) |
+| Added auto-login on registration | Signed in automatically after creating your account |
+
+**The `/changelog` slash command** is the batch tool for backfilling a window of merged PRs into blog/SEO content. It is not a substitute for the per-PR entry — by the time `/changelog` runs, the entry should already be in the file.
+
 ## Slash commands (`.claude/commands/` and `.claude/skills/`)
 
 - `/trio` — force a trio review on any task.


### PR DESCRIPTION
## What
Make the per-PR changelog entry part of the merge checklist, and encode the voice rules so future entries don't drift from the file.

## Why
`web/src/pages/WhatsNewPage/changelog.ts` is the piece of release metadata users see. Two failure modes were happening:
1. The entry gets forgotten — the PR merges and the user-facing surface stays silent about a real change.
2. The entry gets written, but in engineering language ("Refactored …", "Migrated …", "Fixed bug in EmailService") that means nothing to a learner skimming the What's New page.

The fix is two changes in tandem: a checklist step in `/implement` and `engineer.md` so the entry is not optional, and a Changelog section in `CLAUDE.md` that names the threshold and the voice rules in one place — so an agent (or human) writing the next entry can match the existing 35 without rediscovering the conventions.

## How
**`CLAUDE.md` — new Changelog section** (between Spec lifecycle and Slash commands):
- Threshold table: `feat:`, `fix:`, user-visible `revert:` → yes. `perf:`/`style:` only if user-perceptible. `refactor:`/`chore:`/`test:`/`ci:`/`build:`/internal `docs:`/dep bumps → no.
- "How to write" pulled from VOICE.md and the live changelog file: sentence case, no trailing period, ~120 chars, start with the noun, no hedge filler (\"actually\", \"finally\", \"now properly\"), no em-dash apologies, no implementation details.
- Good-vs-bad examples table.

**`.claude/commands/implement.md`** — adds the changelog step in both the primary (take-over-the-draft-PR) path and the fallback path. New row in the \"before merging\" checklist.

**`.claude/agents/engineer.md`** — adds workflow step 8 (\"Changelog entry\") and a \"Changelog\" row in the PR description template — the entry (or \"no entry — internal-only\") is now visible in every PR body.

**`.claude/commands/changelog.md`** — reframed as the batch / backfill tool that consolidates already-written per-PR entries into blog/SEO content, not a substitute for the per-PR step. Now cross-references `changelog.ts` and flags any user-visible merged PR that's missing an entry.

## Measuring success
- Open the next 10 merged user-visible PRs in `gh pr list --state merged`. Each one should have either a one-line entry in `web/src/pages/WhatsNewPage/changelog.ts` dated within a day of merge, or a sentence in the PR body explaining why no entry is warranted.
- A spot-check on tone: no new entry in `changelog.ts` should contain a banned word (\"actually\", \"finally\", \"awesome\", \"oops\") or a trailing period.

## Testing
- Docs / markdown only — `/check` (tsc/typecheck/vitest/lint) has nothing to catch.
- Designer agent reviewed the Changelog section against VOICE.md and the live `changelog.ts`. Three example rewrites and one threshold gap (`revert:`) were folded into this commit.

## Changelog
No entry — internal-only tooling, no user-visible change. (Per the rule this PR introduces.)

## Risks
- A rule the agent is supposed to enforce is only as strong as the agent reading it. If `/implement` is skipped (raw \`git\` workflow), the entry can still be forgotten. The PR-template row is the backstop — a reviewer should see the missing/empty Changelog section before approving. If forgetting continues to be a problem after this lands, the next step is a check-merge-status hook that fails if `changelog.ts` has no entry on the merging commit when the PR title starts with \`feat:\`/\`fix:\`/user-visible \`revert:\`.

## Goal alignment
Indirect — keeps the user-facing release surface honest. Users who can see what's new come back; users who get a silent product don't notice the work and don't return. Cheap to ship, durable payoff.