### PR TITLE
fix(deploy): install puppeteer's Chrome binary on every deploy

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -38,6 +38,7 @@ jobs:
             git -C ${SERVER_DIR} clean -fd
 
             pnpm --dir ${SERVER_DIR} install --frozen-lockfile
+            pnpm --dir ${SERVER_DIR} exec puppeteer browsers install chrome
             pip install -r ${SERVER_DIR}/create_deck/requirements.txt
 
             pnpm --dir ${SERVER_DIR} run build


### PR DESCRIPTION
## Summary

PDF generation broke on prod after the puppeteer 24 → 25 bump merged in #2280. Root cause: pnpm blocks puppeteer's postinstall script (only `better-sqlite3` is in `onlyBuiltDependencies` per `.claude/rules/dependencies.md`), so the Chrome binary that puppeteer 25 pins was never downloaded — the cache at `~/.cache/puppeteer` still held the puppeteer-24-era `linux-148.0.7778.97`, and `ChromeLauncher.resolveExecutablePath` 500s.

This adds one line to the deploy script — `pnpm exec puppeteer browsers install chrome` — that runs right after `pnpm install`. The command is idempotent: it skips the download when the matching binary is already cached, so steady-state deploys pay nothing; it only does real work when puppeteer pins a new Chrome.

Not changing `onlyBuiltDependencies` because that would trigger a pnpm warning + security review for every contributor and CI run — a narrower deploy-only fix has less blast radius.

No user-visible behavior change — internal CI/deploy fix, no changelog entry.

## Test plan

- [ ] CI green
- [ ] After merge, the deploy workflow runs and the Chrome install step completes (visible in the SSH-action logs)
- [ ] PDF export at https://2anki.net/print returns 200 again

🤖 Generated with [Claude Code](https://claude.com/claude-code)