### PR TITLE
ci: speed up checks and DRY up the install pipeline

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,34 @@
+name: Setup
+description: Install pnpm + Node, restore caches, run pnpm install --frozen-lockfile
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 22.20.0
+    - name: Resolve pnpm store path
+      shell: bash
+      run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+    - name: Cache pnpm store
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-
+    - name: Cache node_modules
+      id: modules-cache
+      uses: actions/cache@v5
+      with:
+        path: |
+          node_modules
+          web/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+    - name: Install
+      if: steps.modules-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile
+      env:
+        CI: true

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -10,29 +10,17 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build (22.20.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22.20.0
-      - name: Cache node_modules
-        id: modules-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            web/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-        env:
-          CI: true
+      - uses: ./.github/actions/setup
       - name: Build
         run: pnpm build
         env:
@@ -44,23 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22.20.0
-      - name: Cache node_modules
-        id: modules-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            web/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-        env:
-          CI: true
+      - uses: ./.github/actions/setup
       - name: Test
         run: pnpm test
         env:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,11 +5,16 @@ on:
     paths:
       - 'web/**'
       - '.github/workflows/web.yml'
+      - '.github/actions/setup/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -17,23 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22.20.0
-      - name: Cache node_modules
-        id: modules-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            web/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-        env:
-          CI: true
+      - uses: ./.github/actions/setup
       - name: Lint
         run: pnpm --filter 2anki-web lint
         env:
@@ -44,23 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22.20.0
-      - name: Cache node_modules
-        id: modules-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            web/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-        env:
-          CI: true
+      - uses: ./.github/actions/setup
       - name: Typecheck
         run: pnpm --filter 2anki-web typecheck
         env:
@@ -82,23 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22.20.0
-      - name: Cache node_modules
-        id: modules-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            web/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-        env:
-          CI: true
+      - uses: ./.github/actions/setup
       - name: Test
         run: pnpm --filter 2anki-web test
         env:
@@ -106,25 +63,12 @@ jobs:
 
   playwright:
     name: playwright (22.20.0)
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22.20.0
-      - name: Cache node_modules
-        id: modules-cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            web/node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: Install
-        if: steps.modules-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v5


### PR DESCRIPTION
## Summary

Three changes to cut the wait between push and green, motivated by today's dev-loop friction during the consolidated dependabot PR rebase + puppeteer-25 firefighting.

1. **`concurrency.cancel-in-progress`** on Server and Web. Force-pushing during iteration currently leaves the previous run finishing on its own runner. Now the new push cancels the old run.
2. **Skip Playwright on dependabot[bot] pushes** — second-slowest web job (~70s) and dep bumps almost never break e2e flows. Server `test` already does this; this mirrors the pattern.
3. **Composite action `./.github/actions/setup`** for the pnpm-install boilerplate that was repeated across all 6 jobs. Also adds a pnpm content-addressable store cache with `restore-keys`, so on lockfile-changing PRs the install partially restores instead of redownloading every package — roughly **60s → 15s** for install when `node_modules` cache misses.

Net effect for a typical dependabot PR: wall-clock should drop from ~85s to ~45-50s, and superseded runs stop hogging runners.

No user-visible behavior change — internal CI improvement, no changelog entry.

## Test plan

- [ ] CI green on this PR (validates the composite action resolves and all 6 jobs still pass)
- [ ] After merge, push a small code change to a new branch and confirm install step times improve on the next dep-bump PR
- [ ] Confirm Playwright is **skipped** (not failing) on the next dependabot push

🤖 Generated with [Claude Code](https://claude.com/claude-code)