### PR TITLE
fix: parse multipart-serialized chat history so attachments don't drop context

### DIFF
--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -248,3 +248,71 @@ describe('ChatController.sendMessage — file attachments', () => {
     );
   });
 });
+
+describe('ChatController.sendMessage — multipart history parsing', () => {
+  it('parses history when serialized as a JSON string by multer (multipart/form-data)', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+
+    const history = [
+      { role: 'user', content: 'previous question' },
+      { role: 'assistant', content: 'previous answer' },
+    ];
+
+    const file = makeFile({
+      mimetype: 'image/png',
+      originalname: 'diagram.png',
+      buffer: Buffer.concat([PNG_MAGIC, Buffer.alloc(20)]),
+    });
+
+    await controller.sendMessage(
+      buildReq(
+        { content: 'follow-up question', history: JSON.stringify(history) },
+        [file]
+      ),
+      res
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationHistory: [
+          { role: 'user', content: 'previous question' },
+          { role: 'assistant', content: 'previous answer' },
+        ],
+      })
+    );
+  });
+
+  it('returns an empty history when the multipart string is not valid JSON', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+
+    await controller.sendMessage(
+      buildReq({ content: 'Hi', history: 'not-json[' }),
+      res
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ conversationHistory: [] })
+    );
+  });
+
+  it('still accepts history as a real array (JSON request body)', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+
+    await controller.sendMessage(
+      buildReq({
+        content: 'Hi',
+        history: [{ role: 'user', content: 'prior' }],
+      }),
+      res
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationHistory: [{ role: 'user', content: 'prior' }],
+      })
+    );
+  });
+});

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -86,8 +86,16 @@ function isHistoryEntry(m: unknown): m is HistoryEntry {
 }
 
 function parseHistory(raw: unknown): HistoryEntry[] {
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(isHistoryEntry).map((m) => ({ role: m.role, content: m.content }));
+  let parsed: unknown = raw;
+  if (typeof raw === 'string') {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isHistoryEntry).map((m) => ({ role: m.role, content: m.content }));
 }
 
 function emitChatError(res: Response, err: unknown): void {


### PR DESCRIPTION
## Summary

When a chat request arrives as `multipart/form-data` (the user attached a file), multer serializes the `history` field to a JSON **string**. The previous `parseHistory` in `src/controllers/ChatController.ts` only accepted arrays via `Array.isArray(raw)`, so it silently returned `[]` for any chat turn that included an attachment — dropping all prior conversation context for that turn.

`parseHistory` now accepts both shapes:

- arrays (JSON request bodies, the existing path)
- JSON strings (multipart request bodies, the broken path)

Invalid JSON still collapses to an empty history, matching the existing fail-soft posture and satisfying the security rule on parsing untrusted input (try/catch around `JSON.parse`, then `isHistoryEntry` validates each entry's shape — CWE-20).

## Background

- Regression introduced by **PR #2262** (commit `f7e2d2edb706`), which added attachment support without handling FormData string-serialization of `history`.
- Catalogued as **P0 #13** in the chat roadmap added in PR #2265.

## Test plan

- [x] Added 3 tests in `src/controllers/ChatController.test.ts` under a new `multipart history parsing` describe block.
- [x] Verified the multipart-string test fails on the unfixed code with the expected diff (`conversationHistory: []` vs the expected 2-entry array), then passes after the fix.
- [x] All 23 tests in `ChatController.test.ts` green: `pnpm test src/controllers/ChatController.test.ts`.
- [ ] No browser/dev-server testing needed — controller-level unit test is the verifier.

## Notes

- No changelog entry needed at the controller-fix level — the user-visible improvement is "follow-up questions with attachments remember earlier messages in the conversation," which I'll leave for the reviewer to phrase if they want to bundle it into the next chat-area entry. Happy to add one inline if preferred.
- Sonar local run skipped — change is a 6-line diff in one function plus colocated tests; expect no new findings, but reviewer should expect the standard PR analysis to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)