### PR TITLE
perf(ci): pilot Blacksmith runner on server workflow

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   typecheck:
     name: typecheck (22.20.0)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -29,7 +29,7 @@ jobs:
   test:
     name: test (${{ matrix.shard }})
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Two-line swap on `server.yml`: `runs-on: ubuntu-latest` → `runs-on: blacksmith` for the `typecheck` and `test` matrix jobs. Web and Playwright workflows stay on GitHub-hosted runners for this pilot.

## Why server first

- Server jobs are pure CPU (`tsc -p . --noEmit`, `ts-jest` across a 3-shard matrix). Blacksmith's pitch is faster single-core hardware — those are exactly the workloads that benefit.
- Web jobs are mixed (Biome lint is I/O-light, Vitest with jsdom is heavier on memory than CPU, Playwright is browser-bound). Less obvious win, will pilot separately if server numbers are good.
- `appleboy/ssh-action` in `deploy.2anki.net.yml` is untouched — deploy stays on the known-good runner.

## Prereq before merge

The Blacksmith GitHub App needs to be installed on the `2anki` org and enabled for this repo. If it isn't, the jobs hang in "Waiting for a runner to pick up this job" — that's the failure mode to watch for.

If the org isn't onboarded yet:
- Sign up at https://app.blacksmith.sh (free tier: 3000 min/month, no card)
- Install the GitHub App on `2anki` org, select this repo
- Re-run this PR's checks

## Test plan

- [ ] Blacksmith GitHub App installed & enabled on this repo
- [ ] `typecheck (22.20.0)` job picks up a Blacksmith runner (visible in the job log header)
- [ ] All three `test (N/3)` shards green
- [ ] Wall-clock for the server workflow is lower than baseline (compare to the perf/ci-throughput merge run on `main`)
- [ ] No new failures on Sonar / Snyk caused by runner environment differences

## Rollback

One-line revert: change `blacksmith` back to `ubuntu-latest` on both jobs. No infra cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)