### PR TITLE
perf(ci): roll Blacksmith to web and playwright runners

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,7 +32,7 @@ jobs:
   playwright:
     name: playwright (22.20.0)
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   lint:
     name: lint (22.20.0)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -30,7 +30,7 @@ jobs:
 
   build:
     name: build (22.20.0)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -52,7 +52,7 @@ jobs:
 
   test:
     name: test (22.20.0)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

- Expands the Blacksmith runner rollout beyond the `server.yml` pilot (PR #2286).
- Moves the `lint`, `build`, and `test` jobs in `web.yml` and the `playwright` job in `playwright.yml` from `ubuntu-latest` to `blacksmith`.
- `deploy.2anki.net.yml` stays on `ubuntu-latest` intentionally — it uses `appleboy/ssh-action` and the deploy path benefits from the known-good runner.

## Test plan

- [ ] Lint job runs green on Blacksmith
- [ ] Build job runs green on Blacksmith
- [ ] Web test job runs green on Blacksmith
- [ ] Playwright job runs green on Blacksmith
- [ ] Eyeball wall-clock numbers vs prior `ubuntu-latest` runs

No changelog entry — internal CI/runner change, no user-visible behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->