### PR TITLE
chore(claude): engineer auto-enters worktree on auth/payments/migration paths

### DIFF
--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -37,6 +37,20 @@ Flag the riskiest assumption explicitly. Propose the smallest spike, shadow call
 
 The request path is layered: `routes/` → `controllers/` → `usecases/` → `services/` → `data_layer/`. Each layer has its own CLAUDE.md — read it before editing files in that layer. Don't skip layers (e.g. controllers calling data_layer directly).
 
+## Mandatory worktree paths
+
+Before the first `Edit`, `Write`, or `Bash` command that mutates files, check the task's affected paths against the trigger list below. If any path matches, call `EnterWorktree` first — no exceptions, no override flag. This is the safety floor. If no path matches, proceed normally in the main checkout.
+
+**Trigger paths** (any match → `EnterWorktree` required):
+
+- `src/services/AuthenticationService/**`
+- `src/services/StripeService/**`
+- `src/lib/Token.ts`
+- `migrations/**`
+- Any path matching `**/auth/**` or `**/payments/**` (case-insensitive)
+
+**Why:** Reverting a worktree is free; reverting a bad edit on the orchestrator's main checkout costs a force-revert and may require a re-deploy. The cost of `EnterWorktree` is seconds; the cost of a botched auth or payments change on main is hours.
+
 ## Workflow
 
 When given a spec or issue:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Every PR is checked against both — does it make the experience simpler/faster/
 ## Working speed
 
 - For research spanning 3+ queries (where is X defined, what touches Y), spawn `Agent(subagent_type=Explore)`. If the result isn't immediately needed, run it with `run_in_background: true` and keep editing.
-- For risky changes (auth, payments, migrations, deploy pipeline), use `EnterWorktree` — reverting a worktree is free.
+- For risky changes (auth, payments, migrations, deploy pipeline), **must** use `EnterWorktree` — reverting a worktree is free. See `.claude/agents/engineer.md` for the enforced path list.
 - For "wait until X" (long builds, CI, deploys baking on prod), use `ScheduleWakeup` (270s if cache-warm matters, 1200s+ for genuine waits). Never busy-poll with sleep.
 - After deploys to 2anki.net, run `/deploy-status` to confirm the box is healthy.
 - If you keep approving the same read-only Bash commands, suggest `/fewer-permission-prompts`.


### PR DESCRIPTION
## What
Promote the worktree rule for the engineer agent from SHOULD to MUST. Adds a "Mandatory worktree paths" section to `.claude/agents/engineer.md` listing the exact path globs that require `EnterWorktree` before the first mutating edit, and updates `CLAUDE.md` line 64 to match.

## Why
The current wording is a guideline. We want the next engineer invocation to do the right thing without the user having to remember. Reverting a worktree is free; reverting a bad edit to auth/payments/migrations on the main checkout costs a force-revert and may require a re-deploy.

## How
Two markdown edits:
- `.claude/agents/engineer.md` — new section between "## Architecture" and "## Workflow" with the trigger path list (`src/services/AuthenticationService/**`, `src/services/StripeService/**`, `src/lib/Token.ts`, `migrations/**`, and any `**/auth/**` or `**/payments/**` case-insensitive match) plus the enforcement rule.
- `CLAUDE.md` — line 64 changed from "use" to "**must** use", with a cross-reference to the engineer agent file.

## Measuring success
Next engineer invocation against an auth/payments/migration path opens a worktree before any `Edit` or `Write`. Observable in the conversation transcript and in `git worktree list` output during those tasks.

## Testing
- Confirmed `pnpm typecheck` passes after the markdown changes.
- Reviewed both diffs for ambiguity in the trigger list — no overlapping/conflicting globs.
- Skipped runtime e2e per the spec — agent-definition edit only.

## Changelog
No entry — internal-only agent configuration change, no user-visible behavior change.

## Risks
None to the running product. The behavior change applies to the engineer subagent's workflow only. If the trigger list is too narrow, future auth/payments work could still land on the main checkout — easy to expand the globs in a follow-up.

## Goal alignment
Indirectly: prevents force-reverts that block deploys, which protects velocity on changes that move us toward 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->