### PR TITLE
feat: add print options to PDF export

### DIFF
--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -8,6 +8,11 @@ import ApkgToNotionBlocksService from '../services/ApkgToNotionBlocksService';
 import PdfRenderService from '../services/PdfRenderService';
 import ExportApkgToPdfUseCase, {
   CardLimitExceededError,
+  DEFAULT_PDF_OPTIONS,
+  type Margins,
+  type Orientation,
+  type PaperSize,
+  type PdfOptions,
 } from '../usecases/apkg/ExportApkgToPdfUseCase';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
 import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParentPageUseCase';
@@ -60,6 +65,42 @@ function clampCursor(input: unknown): number {
 
 function isApkg(key: string): boolean {
   return /\.apkg$/i.test(key);
+}
+
+const BACKGROUND_COLOR_REGEX = /^#[0-9a-f]{6}$/i;
+const ALLOWED_PAPER_SIZES: PaperSize[] = ['A4', 'Letter', 'Legal'];
+const ALLOWED_ORIENTATIONS: Orientation[] = ['portrait', 'landscape'];
+const ALLOWED_MARGINS: Margins[] = ['narrow', 'normal', 'wide'];
+
+export function parsePdfOptions(body: Record<string, unknown>): PdfOptions | null {
+  const rawColor = body.backgroundColor;
+  if (typeof rawColor === 'string' && !BACKGROUND_COLOR_REGEX.test(rawColor)) {
+    return null;
+  }
+  const backgroundColor =
+    typeof rawColor === 'string' && BACKGROUND_COLOR_REGEX.test(rawColor)
+      ? rawColor
+      : DEFAULT_PDF_OPTIONS.backgroundColor;
+
+  const rawPaper = body.paperSize;
+  const paperSize: PaperSize =
+    typeof rawPaper === 'string' && (ALLOWED_PAPER_SIZES as string[]).includes(rawPaper)
+      ? (rawPaper as PaperSize)
+      : DEFAULT_PDF_OPTIONS.paperSize;
+
+  const rawOrientation = body.orientation;
+  const orientation: Orientation =
+    typeof rawOrientation === 'string' && (ALLOWED_ORIENTATIONS as string[]).includes(rawOrientation)
+      ? (rawOrientation as Orientation)
+      : DEFAULT_PDF_OPTIONS.orientation;
+
+  const rawMargins = body.margins;
+  const margins: Margins =
+    typeof rawMargins === 'string' && (ALLOWED_MARGINS as string[]).includes(rawMargins)
+      ? (rawMargins as Margins)
+      : DEFAULT_PDF_OPTIONS.margins;
+
+  return { backgroundColor, paperSize, orientation, margins };
 }
 
 class ApkgController {
@@ -173,6 +214,11 @@ class ApkgController {
         res.status(400).json({ message: 'File must be an .apkg file.' });
         return;
       }
+      const pdfOptions = parsePdfOptions(req.body as Record<string, unknown>);
+      if (pdfOptions == null) {
+        res.status(400).json({ message: 'Invalid background color. Use a six-digit hex value like #ffffff.' });
+        return;
+      }
       const fs = await import('node:fs/promises');
       let fileBuffer: Buffer;
       try {
@@ -184,7 +230,7 @@ class ApkgController {
         this.previewService,
         this.pdfRenderService
       );
-      const result = await useCase.execute(fileBuffer, isPaying(res.locals));
+      const result = await useCase.execute(fileBuffer, isPaying(res.locals), pdfOptions);
       const safeName = file.originalname
         .replace(/\.apkg$/i, '')
         .replace(/[^\w\s.-]/g, '_');

--- a/src/services/PdfRenderService.ts
+++ b/src/services/PdfRenderService.ts
@@ -1,10 +1,17 @@
 import puppeteer from 'puppeteer';
+import type { PdfOptions } from '../usecases/apkg/ExportApkgToPdfUseCase';
 
 const PDF_TIMEOUT_MS = 30_000;
 const MATHJAX_SETTLE_MS = 2_000;
 
+const MARGIN_VALUES: Record<string, string> = {
+  narrow: '0.5cm',
+  normal: '1cm',
+  wide: '2cm',
+};
+
 export default class PdfRenderService {
-  async renderHtml(html: string): Promise<Buffer> {
+  async renderHtml(html: string, options?: PdfOptions): Promise<Buffer> {
     const browser = await puppeteer.launch({
       headless: true,
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
@@ -28,10 +35,12 @@ export default class PdfRenderService {
         })`,
         { timeout: PDF_TIMEOUT_MS }
       );
+      const marginValue = MARGIN_VALUES[options?.margins ?? 'normal'] ?? '1cm';
       const pdf = await page.pdf({
-        format: 'A4',
+        format: options?.paperSize ?? 'A4',
+        landscape: options?.orientation === 'landscape',
         printBackground: true,
-        margin: { top: '1cm', right: '1cm', bottom: '1cm', left: '1cm' },
+        margin: { top: marginValue, right: marginValue, bottom: marginValue, left: marginValue },
         timeout: PDF_TIMEOUT_MS,
       });
       return Buffer.from(pdf);

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.test.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.test.ts
@@ -171,4 +171,59 @@ describe('ExportApkgToPdfUseCase', () => {
     const expectedBase64 = Buffer.from('fake-png-data').toString('base64');
     expect(htmlArg).toContain(`data:image/png;base64,${expectedBase64}`);
   });
+
+  it('uses white background by default', async () => {
+    const parsed = makeParsed(1);
+    const cards = [makeCard(1)];
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(1));
+    previewService.getCardsPage.mockReturnValueOnce({ cards, nextCursor: null, total: 1 });
+    pdfRenderService.renderHtml.mockResolvedValue(Buffer.from('%PDF'));
+
+    await useCase.execute(Buffer.from('fake-apkg'));
+
+    const htmlArg: string = pdfRenderService.renderHtml.mock.calls[0][0];
+    expect(htmlArg).toContain('background:#ffffff');
+  });
+
+  it('applies custom backgroundColor to the generated HTML body', async () => {
+    const parsed = makeParsed(1);
+    const cards = [makeCard(1)];
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(1));
+    previewService.getCardsPage.mockReturnValueOnce({ cards, nextCursor: null, total: 1 });
+    pdfRenderService.renderHtml.mockResolvedValue(Buffer.from('%PDF'));
+
+    await useCase.execute(Buffer.from('fake-apkg'), false, {
+      backgroundColor: '#1a2b3c',
+      paperSize: 'A4',
+      orientation: 'portrait',
+      margins: 'normal',
+    });
+
+    const htmlArg: string = pdfRenderService.renderHtml.mock.calls[0][0];
+    expect(htmlArg).toContain('background:#1a2b3c');
+  });
+
+  it('forwards print options to pdfRenderService.renderHtml', async () => {
+    const parsed = makeParsed(1);
+    const cards = [makeCard(1)];
+    previewService.parse.mockResolvedValue(parsed);
+    previewService.getMeta.mockReturnValue(makeMeta(1));
+    previewService.getCardsPage.mockReturnValueOnce({ cards, nextCursor: null, total: 1 });
+    pdfRenderService.renderHtml.mockResolvedValue(Buffer.from('%PDF'));
+
+    const options = {
+      backgroundColor: '#ffffff',
+      paperSize: 'Letter' as const,
+      orientation: 'landscape' as const,
+      margins: 'wide' as const,
+    };
+    await useCase.execute(Buffer.from('fake-apkg'), false, options);
+
+    expect(pdfRenderService.renderHtml).toHaveBeenCalledWith(
+      expect.any(String),
+      options
+    );
+  });
 });

--- a/src/usecases/apkg/ExportApkgToPdfUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToPdfUseCase.ts
@@ -136,7 +136,7 @@ window.MathJax = {
 </script>
 <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" async></script>`;
 
-function buildHtml(deckName: string, cards: RenderedCard[], parsed: ParsedApkg): string {
+function buildHtml(deckName: string, cards: RenderedCard[], parsed: ParsedApkg, backgroundColor: string): string {
   const rows = cards.map((card) => buildCardRow(card, parsed)).join('\n');
   return `<!DOCTYPE html>
 <html lang="en">
@@ -144,7 +144,7 @@ function buildHtml(deckName: string, cards: RenderedCard[], parsed: ParsedApkg):
 <meta charset="utf-8" />
 <title>${escapeHtml(deckName)}</title>
 <style>
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; margin: 0; padding: 0; background:${backgroundColor}; }
   h1 { font-size: 18px; margin: 16px 0 8px; }
   table { width: 100%; border-collapse: collapse; table-layout: fixed; }
   th { text-align: left; font-size: 12px; padding: 6px 10px; border-bottom: 2px solid #333; }
@@ -167,6 +167,24 @@ ${rows}
 </html>`;
 }
 
+export type PaperSize = 'A4' | 'Letter' | 'Legal';
+export type Orientation = 'portrait' | 'landscape';
+export type Margins = 'narrow' | 'normal' | 'wide';
+
+export interface PdfOptions {
+  backgroundColor: string;
+  paperSize: PaperSize;
+  orientation: Orientation;
+  margins: Margins;
+}
+
+export const DEFAULT_PDF_OPTIONS: PdfOptions = {
+  backgroundColor: '#ffffff',
+  paperSize: 'A4',
+  orientation: 'portrait',
+  margins: 'normal',
+};
+
 export interface ExportApkgToPdfResult {
   pdf: Buffer;
   deckName: string;
@@ -179,7 +197,11 @@ export default class ExportApkgToPdfUseCase {
     private readonly pdfRenderService: PdfRenderService
   ) {}
 
-  async execute(fileBuffer: Buffer, unlimitedAccess = false): Promise<ExportApkgToPdfResult> {
+  async execute(
+    fileBuffer: Buffer,
+    unlimitedAccess = false,
+    options: PdfOptions = DEFAULT_PDF_OPTIONS
+  ): Promise<ExportApkgToPdfResult> {
     const cacheKey = `pdf-export:${Date.now()}`;
     const parsed = await this.previewService.parse(cacheKey, fileBuffer);
     const meta = this.previewService.getMeta(parsed);
@@ -191,8 +213,8 @@ export default class ExportApkgToPdfUseCase {
     const cards = collectAllCards(this.previewService, parsed);
     const deckName =
       meta.decks.length > 0 ? meta.decks[0].fullName : 'Flashcards';
-    const html = buildHtml(deckName, cards, parsed);
-    const pdf = await this.pdfRenderService.renderHtml(html);
+    const html = buildHtml(deckName, cards, parsed, options.backgroundColor);
+    const pdf = await this.pdfRenderService.renderHtml(html, options);
     return { pdf, deckName, cardCount: cards.length };
   }
 }

--- a/web/src/pages/PrintPage/components/PrintForm.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.tsx
@@ -4,6 +4,9 @@ import formStyles from '../../UploadPage/components/UploadForm/UploadForm.module
 import styles from '../../../styles/shared.module.css';
 
 type PrintState = 'idle' | 'uploading' | 'done' | 'error';
+type PaperSize = 'A4' | 'Letter' | 'Legal';
+type Orientation = 'portrait' | 'landscape';
+type Margins = 'narrow' | 'normal' | 'wide';
 
 const WRONG_TYPE_MESSAGE =
   'This tool works with Anki deck files (.apkg). To turn notes into an Anki deck, use the Upload page.';
@@ -49,6 +52,10 @@ export default function PrintForm() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const submitRef = useRef<HTMLButtonElement>(null);
   const [dropHover, setDropHover] = useState(false);
+  const [backgroundColor, setBackgroundColor] = useState('#ffffff');
+  const [paperSize, setPaperSize] = useState<PaperSize>('A4');
+  const [orientation, setOrientation] = useState<Orientation>('portrait');
+  const [margins, setMargins] = useState<Margins>('normal');
 
   const resetForm = () => {
     setState('idle');
@@ -71,6 +78,10 @@ export default function PrintForm() {
 
     const formData = new FormData();
     formData.append('file', file);
+    formData.append('backgroundColor', backgroundColor);
+    formData.append('paperSize', paperSize);
+    formData.append('orientation', orientation);
+    formData.append('margins', margins);
 
     try {
       const response = await globalThis.fetch('/api/apkg/pdf', {
@@ -121,6 +132,56 @@ export default function PrintForm() {
 
   return (
     <form onSubmit={handleSubmit}>
+      <div className={styles.field} style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: '1rem', marginBottom: '1.25rem' }}>
+        <div>
+          <label htmlFor="print-paper-size" className={styles.fieldLabel}>Paper size</label>
+          <select
+            id="print-paper-size"
+            className={styles.select}
+            value={paperSize}
+            onChange={(e) => setPaperSize(e.target.value as PaperSize)}
+          >
+            <option value="A4">A4</option>
+            <option value="Letter">Letter</option>
+            <option value="Legal">Legal</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="print-orientation" className={styles.fieldLabel}>Orientation</label>
+          <select
+            id="print-orientation"
+            className={styles.select}
+            value={orientation}
+            onChange={(e) => setOrientation(e.target.value as Orientation)}
+          >
+            <option value="portrait">Portrait</option>
+            <option value="landscape">Landscape</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="print-margins" className={styles.fieldLabel}>Margins</label>
+          <select
+            id="print-margins"
+            className={styles.select}
+            value={margins}
+            onChange={(e) => setMargins(e.target.value as Margins)}
+          >
+            <option value="narrow">Narrow (0.5 cm)</option>
+            <option value="normal">Normal (1 cm)</option>
+            <option value="wide">Wide (2 cm)</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="print-bg-color" className={styles.fieldLabel}>Background color</label>
+          <input
+            id="print-bg-color"
+            type="color"
+            value={backgroundColor}
+            onChange={(e) => setBackgroundColor(e.target.value)}
+            style={{ display: 'block', width: '100%', height: '2.375rem', padding: '0.125rem 0.25rem', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-md)', cursor: 'pointer', background: 'var(--color-bg-primary)' }}
+          />
+        </div>
+      </div>
       <label
         htmlFor="print-file"
         className={`${formStyles.dropZone} ${

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Printable PDFs — pick background color, paper size (A4, Letter, Legal), orientation, and margins before you download', date: '2026-05-15' },
   { type: 'fix', title: 'Signup goes straight to your decks — no verification email to chase down, your address is confirmed the first time you use a sign-in link or password reset', date: '2026-05-15' },
   { type: 'fix', title: 'Notion mentions (people, dates, linked pages) appear as text in your cards instead of a JSON dump', date: '2026-05-15' },
   { type: 'fix', title: 'Downloaded Notion decks use the page title (or your custom deck name) as the filename', date: '2026-05-15' },


### PR DESCRIPTION
## What
Adds four user-configurable print options to the existing PDF export flow on the Print Page: background color (native color picker, default white), paper size (A4/Letter/Legal, default A4), orientation (portrait/landscape, default portrait), and margins (narrow 0.5 cm / normal 1 cm / wide 2 cm, default normal).

Controls render inline in a responsive grid above the drop zone. Defaults match today's behaviour exactly, so existing users see no change.

## Why
The PDF export flow was useful but inflexible — users printing for binders needed wider margins, users printing in dark-mode needed a non-white background, and users outside A4 regions needed Letter/Legal. This closes the gap without adding clicks for users who don't care.

## How
- `PdfOptions` type + `DEFAULT_PDF_OPTIONS` exported from `ExportApkgToPdfUseCase.ts`; the `execute` method accepts an optional third argument defaulting to those values.
- `buildHtml` now takes `backgroundColor` and inlines it on `<body style="background:...">`. The value is validated before it reaches this point so no re-escaping is needed.
- `PdfRenderService.renderHtml` accepts an optional `PdfOptions`; maps the `margins` enum to cm strings and toggles `landscape` mode in puppeteer's `page.pdf()` call.
- `parsePdfOptions(body)` in `ApkgController.ts` validates all four fields at the HTTP boundary: `backgroundColor` must match `/^#[0-9a-f]{6}$/i` or the handler returns 400; enum fields silently default when absent/invalid (they cannot produce XSS).
- `PrintForm.tsx` gains four controls (`<select>` × 3, `<input type="color">`) rendered in a CSS grid above the drop zone; values are appended to `FormData` before each upload call.

## Measuring success
Log line: no new instrumentation needed — the existing `console.error` in `exportPdf` will surface any failures. Measure via the existing PDF download count metric; an increase after ship confirms uptake. If `parsePdfOptions` rejects a bad `backgroundColor`, the server returns 400 and the form shows the generic error message.

## Testing
- Unit tests added: 3 new cases in `ExportApkgToPdfUseCase.test.ts`
  - default options produce `background:#ffffff` in generated HTML
  - custom `backgroundColor` is reflected in the HTML body style
  - options are forwarded to `pdfRenderService.renderHtml` as a second argument
- `parsePdfOptions` is a pure exported function and can be unit-tested; no new harness was fabricated for the controller path (consistent with existing pattern in this codebase)
- No Vitest for the form controls — they are purely presentational (select + color picker with `useState`); all 463 web tests still pass
- Manually verified: server tsc clean, web tsc clean, web vitest 463/463 green, Biome lint clean

## Changelog
`{ type: 'feature', title: 'Printable PDFs — pick background color, paper size (A4, Letter, Legal), orientation, and margins before you download', date: '2026-05-15' }`

## Risks
- **puppeteer `format` field**: puppeteer's `PDFOptions.format` accepts `'A4' | 'Letter' | 'Legal'` (and others) as strings matching our enum — confirmed against the puppeteer type definitions. No cast needed.
- **Rollback**: the `pdfOptions` parameter defaults to `DEFAULT_PDF_OPTIONS`, which replicates today's hardcoded values exactly. Reverting to the previous `execute(fileBuffer, unlimitedAccess)` call signature requires only removing the third argument — no migration, no DB change.
- sonar-scanner is not installed in this environment. Noted explicitly per CLAUDE.md. The two new user-controlled values that reach the HTML/puppeteer call both pass through strict validation first: `backgroundColor` via allowlist regex, enum values via `Array.includes`. No taint path to an unsanitized sink.

## Goal alignment
Makes the print-as-PDF flow more useful (binder margins, low-ink background, non-A4 paper) without adding steps for users who don't configure anything. Defaults are identical to today. Reduces friction for students printing study sheets — directly supports the 300K-user scale goal by improving retention of paying subscribers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->