### PR TITLE
style: tighten PDF print options copy and color swatch

### DIFF
--- a/web/src/pages/PrintPage/components/PrintForm.tsx
+++ b/web/src/pages/PrintPage/components/PrintForm.tsx
@@ -172,14 +172,19 @@ export default function PrintForm() {
           </select>
         </div>
         <div>
-          <label htmlFor="print-bg-color" className={styles.fieldLabel}>Background color</label>
-          <input
-            id="print-bg-color"
-            type="color"
-            value={backgroundColor}
-            onChange={(e) => setBackgroundColor(e.target.value)}
-            style={{ display: 'block', width: '100%', height: '2.375rem', padding: '0.125rem 0.25rem', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-md)', cursor: 'pointer', background: 'var(--color-bg-primary)' }}
-          />
+          <label htmlFor="print-bg-color" className={styles.fieldLabel}>Page background</label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', height: '2.375rem' }}>
+            <input
+              id="print-bg-color"
+              type="color"
+              value={backgroundColor}
+              onChange={(e) => setBackgroundColor(e.target.value)}
+              style={{ width: '3rem', height: '2.375rem', padding: '0.125rem', border: '1px solid var(--color-border)', borderRadius: 'var(--radius-md)', cursor: 'pointer', background: 'var(--color-bg-primary)' }}
+            />
+            <span style={{ color: 'var(--color-text-secondary)', fontVariantNumeric: 'tabular-nums', fontSize: '0.875rem' }}>
+              {backgroundColor.toUpperCase()}
+            </span>
+          </div>
         </div>
       </div>
       <label

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,7 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
-  { type: 'feature', title: 'Printable PDFs — pick background color, paper size (A4, Letter, Legal), orientation, and margins before you download', date: '2026-05-15' },
+  { type: 'feature', title: 'PDF export — pick paper size (A4, Letter, Legal), orientation, margins, and page color', date: '2026-05-15' },
   { type: 'fix', title: 'Signup goes straight to your decks — no verification email to chase down, your address is confirmed the first time you use a sign-in link or password reset', date: '2026-05-15' },
   { type: 'fix', title: 'Notion mentions (people, dates, linked pages) appear as text in your cards instead of a JSON dump', date: '2026-05-15' },
   { type: 'fix', title: 'Downloaded Notion decks use the page title (or your custom deck name) as the filename', date: '2026-05-15' },


### PR DESCRIPTION
## What
Designer-pass polish on #2296.

- Changelog: `Printable PDFs — pick background color, paper size (A4, Letter, Legal), orientation, and margins before you download` → `PDF export — pick paper size (A4, Letter, Legal), orientation, margins, and page color`.
- Color swatch: full-width control → 3 rem swatch + muted tabular-nums hex readout (`#FFFFFF`).
- Field label: `Background color` → `Page background`.

## Why
Three things landed in #2296 that drifted from the existing in-product voice and the rest of the changelog file:

1. The feature is "PDF export" everywhere else in product; "Printable PDFs" reintroduces a second name.
2. `before you download` is filler — the reader of the What's New page already knows when settings apply.
3. A full-width native `<input type="color">` swatch alongside three selects reads visually heavier than the selects and breaks the restrained productivity-tool feel.

## How
- One-line edit in `web/src/pages/WhatsNewPage/changelog.ts`.
- Color picker wrapped in a flex row: 3 rem `<input type="color">` plus a `<span>` showing the uppercase hex in `--color-text-secondary`, tabular-nums for digit alignment.

## Testing
- `pnpm --filter 2anki-web typecheck` — green.
- `pnpm --filter 2anki-web lint` — green.
- Pure presentational change in a single component + a string; no logic to unit-test. No backend changes.

## Risks
None — defaults preserved, FormData wiring unchanged, validation untouched.

## Goal alignment
Mission: the print page is cleaner and the changelog reads consistently with the rest of the file. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->