### PR TITLE
feat: Dropbox chooser on upload form

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="Content-Security-Policy"
-    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
   <link rel="apple-touch-icon" href="/logo192.png" />
   <!--
       Notice the use of  in the tags above.

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -501,3 +501,53 @@
     flex-direction: column;
   }
 }
+
+.dropboxRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 1rem auto 0;
+  max-width: 800px;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+}
+
+.dropboxButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  background: transparent;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.dropboxButton:hover {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-text-tertiary);
+}
+
+.dropboxButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.dropboxIcon {
+  width: 1rem;
+  height: 1rem;
+  color: #0061fe;
+}
+
+.dropboxError {
+  margin: 0.5rem auto 0;
+  max-width: 800px;
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-error, #b00020);
+}

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, act } from '@testing-library/react';
+import { render, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -89,6 +89,64 @@ describe('UploadForm analytics events', () => {
     });
 
     expect(gtag).toHaveBeenCalledWith('event', 'conversion_success');
+  });
+
+  it('posts to /api/upload/dropbox when the chooser returns a file', async () => {
+    const previousKey = process.env.REACT_APP_DROPBOX_APP_KEY;
+    process.env.REACT_APP_DROPBOX_APP_KEY = 'test-key';
+    (window as unknown as { Dropbox?: unknown }).Dropbox = {
+      choose: ({ success }: { success: (files: unknown[]) => void }) => {
+        success([
+          {
+            id: 'id:1',
+            name: 'pharm.pdf',
+            bytes: 200,
+            icon: 'page_white_acrobat',
+            isDir: false,
+            link: 'https://dl.dropboxusercontent.com/x/pharm.pdf',
+            linkType: 'direct',
+          },
+        ]);
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': 'attachment; filename="deck.apkg"',
+        'X-Card-Count': '7',
+      }),
+      blob: () => Promise.resolve(new Blob(['fake'])),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const button = container.querySelector(
+      'button[aria-label="Choose from Dropbox"]'
+    ) as HTMLButtonElement;
+    expect(button).not.toBeNull();
+    await act(async () => {
+      button.click();
+    });
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.find(
+          (call) => call[0] === '/api/upload/dropbox'
+        )
+      ).toBeDefined()
+    );
+    const dropboxCall = fetchMock.mock.calls.find(
+      (call) => call[0] === '/api/upload/dropbox'
+    )!;
+    expect(dropboxCall[1]).toEqual(expect.objectContaining({ method: 'post' }));
+    const body = dropboxCall[1].body as FormData;
+    expect(JSON.parse(body.get('files') as string)).toEqual([
+      expect.objectContaining({ name: 'pharm.pdf', linkType: 'direct' }),
+    ]);
+
+    delete (window as unknown as { Dropbox?: unknown }).Dropbox;
+    process.env.REACT_APP_DROPBOX_APP_KEY = previousKey;
   });
 
   it('does not fire conversion_success when the deck is empty', async () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -9,6 +9,7 @@ import getHeadersFilename from '../../helpers/getHeadersFilename';
 import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadFileName';
 import { useDrag } from './hooks/useDrag';
 import { useFileValidation } from './hooks/useFileValidation';
+import { useDropboxChooser, type DropboxFile } from './hooks/useDropboxChooser';
 import { FeedbackWidget } from '../../../../components/FeedbackWidget/FeedbackWidget';
 import { useUserLocals } from '../../../../lib/hooks/useUserLocals';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
@@ -118,6 +119,19 @@ function CheckCircleIcon({ className }: Readonly<{ className?: string }>) {
   );
 }
 
+function DropboxIcon({ className }: Readonly<{ className?: string }>) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M8 4l8 5-8 5-8-5 8-5zm16 0l8 5-8 5-8-5 8-5zM0 19l8-5 8 5-8 5-8-5zm24-5l8 5-8 5-8-5 8-5zM8 26l8-5 8 5-8 5-8-5z" />
+    </svg>
+  );
+}
+
 function WarningIcon({ className }: Readonly<{ className?: string }>) {
   return (
     <svg
@@ -149,6 +163,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const [progressSlow, setProgressSlow] = useState(false);
   const [showFallback, setShowFallback] = useState(false);
   const [trialPending, setTrialPending] = useState(false);
+  const [dropboxFilename, setDropboxFilename] = useState<string | null>(null);
+  const [dropboxPending, setDropboxPending] = useState(false);
+  const [dropboxError, setDropboxError] = useState<string | null>(null);
   const { data: userLocals } = useUserLocals();
   const queryClient = useQueryClient();
   const showTrialButton =
@@ -160,6 +177,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const downloadRef = useRef<HTMLAnchorElement>(null);
   const fallbackTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const { validation, validate, reset: resetValidation } = useFileValidation();
+  const { openChooser, isConfigured: isDropboxConfigured } = useDropboxChooser(FORMATS);
 
   const handleStartTrial = async () => {
     setTrialPending(true);
@@ -189,6 +207,8 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     setProgressWidth(10);
     setProgressSlow(false);
     setShowFallback(false);
+    setDropboxFilename(null);
+    setDropboxError(null);
     resetValidation();
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
@@ -237,6 +257,84 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     }, 2000);
     return () => clearTimeout(timer);
   }, [zoneState]);
+
+  const handleDropboxFiles = async (files: DropboxFile[]) => {
+    const first = files[0];
+    setDropboxFilename(first?.name ?? null);
+    setDropboxError(null);
+    setZoneState('converting');
+    fireAnalyticsEvent('upload_started');
+    setProgressWidth(10);
+    setProgressSlow(false);
+    setShowFallback(false);
+    try {
+      const formData = new FormData();
+      formData.append('files', JSON.stringify(files));
+      for (const [key, value] of Object.entries(globalThis.localStorage)) {
+        formData.append(key, value);
+      }
+      const request = await globalThis.fetch('/api/upload/dropbox', {
+        method: 'post',
+        body: formData,
+      });
+      if (request.redirected) {
+        const redirectUrl = new URL(request.url, globalThis.location.origin);
+        if (redirectUrl.searchParams.get('error') === 'upload_limit_exceeded') {
+          const isAnonymous = redirectUrl.pathname === '/login';
+          setLimitInfo({ isAnonymous, filename: first?.name ?? null });
+          setZoneState('limitReached');
+          return;
+        }
+        handleRedirect(request);
+        return;
+      }
+      if (request.status === 202) {
+        globalThis.location.href = '/downloads';
+        return;
+      }
+      if (request.status !== 200) {
+        const message = await extractErrorMessage(request);
+        setLocalError(message);
+        setZoneState('error');
+        return;
+      }
+      setWarningMessage(request.headers.get('X-Warning'));
+      setDeckName(resolveDeckName(request.headers));
+      const count = parseCardCountHeader(request.headers);
+      setCardCount(count);
+      const blob = await request.blob();
+      setDownloadLink(globalThis.URL.createObjectURL(blob));
+      setProgressWidth(100);
+      if (count === 0) {
+        setZoneState('emptyDeck');
+      } else {
+        fireAnalyticsEvent('conversion_success');
+        setZoneState('success');
+      }
+    } catch (error) {
+      setLocalError(toFriendlyThrownError(error));
+      setZoneState('error');
+    }
+  };
+
+  const handleDropboxClick = async () => {
+    setDropboxError(null);
+    setDropboxPending(true);
+    try {
+      const outcome = await openChooser();
+      if (outcome.kind === 'cancelled') return;
+      if (outcome.files.length === 0) return;
+      await handleDropboxFiles(outcome.files);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Couldn't open Dropbox. Try again in a moment.";
+      setDropboxError(message);
+    } finally {
+      setDropboxPending(false);
+    }
+  };
 
   const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
@@ -350,7 +448,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const renderConvertingState = () => (
     <div className={formStyles.stateContent}>
       <p className={formStyles.filename}>
-        {displayFilename(fileInputRef.current)}
+        {dropboxFilename ?? displayFilename(fileInputRef.current)}
       </p>
       <div className={formStyles.progressTrack}>
         <div
@@ -358,7 +456,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
           style={{ width: `${progressWidth}%` }}
         />
       </div>
-      <p className={formStyles.statusText}>Making your deck...</p>
+      <p className={formStyles.statusText}>
+        {dropboxFilename ? `Fetching ${dropboxFilename} from Dropbox` : 'Making your deck...'}
+      </p>
     </div>
   );
 
@@ -563,6 +663,26 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
           }}
         />
       </label>
+      {isDropboxConfigured && zoneState === 'idle' && !validation && (
+        <div className={formStyles.dropboxRow}>
+          <span>or</span>
+          <button
+            type="button"
+            className={formStyles.dropboxButton}
+            onClick={handleDropboxClick}
+            disabled={dropboxPending}
+            aria-label="Choose from Dropbox"
+          >
+            <DropboxIcon className={formStyles.dropboxIcon} />
+            {dropboxPending ? 'Loading…' : 'Choose from Dropbox'}
+          </button>
+        </div>
+      )}
+      {dropboxError && (
+        <p className={formStyles.dropboxError} role="alert">
+          {dropboxError}
+        </p>
+      )}
       {downloadLink && (
         <a
           hidden

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useDropboxChooser.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useDropboxChooser.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDropboxChooser } from './useDropboxChooser';
+
+const ORIGINAL_KEY = process.env.REACT_APP_DROPBOX_APP_KEY;
+
+afterEach(() => {
+  process.env.REACT_APP_DROPBOX_APP_KEY = ORIGINAL_KEY;
+  delete (window as unknown as { Dropbox?: unknown }).Dropbox;
+  document.querySelectorAll('script#dropboxjs').forEach((node) => node.remove());
+});
+
+describe('useDropboxChooser', () => {
+  it('reports not configured when the app key is missing', () => {
+    process.env.REACT_APP_DROPBOX_APP_KEY = '';
+    const { result } = renderHook(() => useDropboxChooser(['.pdf']));
+    expect(result.current.isConfigured).toBe(false);
+  });
+
+  it('rejects openChooser when the app key is missing', async () => {
+    process.env.REACT_APP_DROPBOX_APP_KEY = '';
+    const { result } = renderHook(() => useDropboxChooser(['.pdf']));
+    await expect(result.current.openChooser()).rejects.toThrow(
+      /Couldn't load Dropbox/
+    );
+  });
+
+  describe('with a configured app key', () => {
+    beforeEach(() => {
+      process.env.REACT_APP_DROPBOX_APP_KEY = 'test-key';
+    });
+
+    it('resolves with picked files when the user chooses a file', async () => {
+      (window as unknown as { Dropbox?: unknown }).Dropbox = {
+        choose: ({ success }: { success: (files: unknown[]) => void }) => {
+          success([
+            {
+              id: 'id:1',
+              name: 'pharm.pdf',
+              bytes: 200,
+              icon: 'page_white_acrobat',
+              isDir: false,
+              link: 'https://dl.dropboxusercontent.com/x/pharm.pdf',
+              linkType: 'direct',
+            },
+          ]);
+        },
+      };
+      const { result } = renderHook(() => useDropboxChooser(['.pdf']));
+      let outcome: unknown;
+      await act(async () => {
+        outcome = await result.current.openChooser();
+      });
+      expect(outcome).toEqual({
+        kind: 'picked',
+        files: [
+          expect.objectContaining({ name: 'pharm.pdf', linkType: 'direct' }),
+        ],
+      });
+    });
+
+    it('resolves with cancelled when the user closes the chooser', async () => {
+      (window as unknown as { Dropbox?: unknown }).Dropbox = {
+        choose: ({ cancel }: { cancel?: () => void }) => cancel?.(),
+      };
+      const { result } = renderHook(() => useDropboxChooser(['.pdf']));
+      let outcome: unknown;
+      await act(async () => {
+        outcome = await result.current.openChooser();
+      });
+      expect(outcome).toEqual({ kind: 'cancelled' });
+    });
+
+    it('rejects when the SDK script fails to load', async () => {
+      const appendChildSpy = vi
+        .spyOn(document.head, 'appendChild')
+        .mockImplementation((node) => {
+          if ((node as HTMLScriptElement).id === 'dropboxjs') {
+            queueMicrotask(() => node.dispatchEvent(new Event('error')));
+          }
+          return node as unknown as Node;
+        });
+      const { result } = renderHook(() => useDropboxChooser(['.pdf']));
+      await expect(result.current.openChooser()).rejects.toThrow(
+        /Couldn't load Dropbox/
+      );
+      appendChildSpy.mockRestore();
+    });
+  });
+});

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useDropboxChooser.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useDropboxChooser.ts
@@ -1,0 +1,105 @@
+import { useCallback, useRef } from 'react';
+
+export interface DropboxFile {
+  id: string;
+  name: string;
+  bytes: number;
+  icon: string;
+  isDir: boolean;
+  link: string;
+  linkType: 'preview' | 'direct';
+}
+
+interface DropboxChooseOptions {
+  success: (files: DropboxFile[]) => void;
+  cancel?: () => void;
+  linkType?: 'preview' | 'direct';
+  multiselect?: boolean;
+  extensions?: string[];
+}
+
+interface DropboxGlobal {
+  choose: (options: DropboxChooseOptions) => void;
+}
+
+declare global {
+  interface Window {
+    Dropbox?: DropboxGlobal;
+  }
+}
+
+const SDK_SRC = 'https://www.dropbox.com/static/api/2/dropins.js';
+const SDK_SCRIPT_ID = 'dropboxjs';
+
+const SDK_UNAVAILABLE =
+  "Couldn't load Dropbox. Check your connection or disable script blockers and try again.";
+
+type ChooserResult =
+  | { kind: 'picked'; files: DropboxFile[] }
+  | { kind: 'cancelled' };
+
+function appKey(): string | null {
+  const key = process.env.REACT_APP_DROPBOX_APP_KEY;
+  return key && key.length > 0 ? key : null;
+}
+
+function loadSdk(key: string): Promise<DropboxGlobal> {
+  if (window.Dropbox) {
+    return Promise.resolve(window.Dropbox);
+  }
+  const existing = document.getElementById(SDK_SCRIPT_ID) as HTMLScriptElement | null;
+  if (existing) {
+    return new Promise((resolve, reject) => {
+      existing.addEventListener('load', () => {
+        if (window.Dropbox) resolve(window.Dropbox);
+        else reject(new Error(SDK_UNAVAILABLE));
+      });
+      existing.addEventListener('error', () => reject(new Error(SDK_UNAVAILABLE)));
+    });
+  }
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = SDK_SCRIPT_ID;
+    script.src = SDK_SRC;
+    script.setAttribute('data-app-key', key);
+    script.addEventListener('load', () => {
+      if (window.Dropbox) resolve(window.Dropbox);
+      else reject(new Error(SDK_UNAVAILABLE));
+    });
+    script.addEventListener('error', () => reject(new Error(SDK_UNAVAILABLE)));
+    document.head.appendChild(script);
+  });
+}
+
+export function useDropboxChooser(extensions: string[]) {
+  const loadingRef = useRef(false);
+
+  const openChooser = useCallback((): Promise<ChooserResult> => {
+    const key = appKey();
+    if (!key) {
+      return Promise.reject(new Error(SDK_UNAVAILABLE));
+    }
+    if (loadingRef.current) {
+      return Promise.reject(new Error('Dropbox chooser is already open.'));
+    }
+    loadingRef.current = true;
+    return loadSdk(key)
+      .then(
+        (sdk) =>
+          new Promise<ChooserResult>((resolve) => {
+            sdk.choose({
+              linkType: 'direct',
+              multiselect: false,
+              extensions,
+              success: (files) => resolve({ kind: 'picked', files }),
+              cancel: () => resolve({ kind: 'cancelled' }),
+            });
+          })
+      )
+      .finally(() => {
+        loadingRef.current = false;
+      });
+  }, [extensions]);
+
+  return { openChooser, isConfigured: appKey() != null };
+}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Upload form: pick a file from Dropbox in one click', date: '2026-05-15' },
   { type: 'feature', title: 'PDF export — pick paper size (A4, Letter, Legal), orientation, margins, and page color', date: '2026-05-15' },
   { type: 'fix', title: 'Signup goes straight to your decks — no verification email to chase down, your address is confirmed the first time you use a sign-in link or password reset', date: '2026-05-15' },
   { type: 'fix', title: 'Notion mentions (people, dates, linked pages) appear as text in your cards instead of a JSON dump', date: '2026-05-15' },


### PR DESCRIPTION
## What

Adds a "Choose from Dropbox" button under the existing file dropzone on `/upload`. Users can now pick a file from their Dropbox account without re-uploading it manually. The button is hidden unless `REACT_APP_DROPBOX_APP_KEY` is configured.

## Why

The server already exposes `POST /api/upload/dropbox` but no part of the React UI was calling it — the endpoint has been effectively orphaned. The in-flight #2300 PR ships a "From Dropbox" history section on `/downloads`, but without writes happening that section stays empty. This PR reconnects the pipe: pick a file from Dropbox → file is converted → row lands in `dropbox_uploads` → shows up in #2300's history section after it merges.

Mission fit: shortest path from "what I'm studying" to an Anki deck for users whose source files live in Dropbox.

## How

- `useDropboxChooser` hook lazy-loads the Dropbox SDK on first click. Avoids the Vite-doesn't-interpolate-`%REACT_APP_*%`-in-HTML problem entirely.
- `UploadForm` renders the chooser button inline below the dropzone, idle state only. POSTs the picked file as `multipart/form-data` with a `files` JSON field, matching the controller's existing `getFilesOrEmpty` parser.
- `web/index.html` CSP extended to allow `https://www.dropbox.com` so the SDK script is not blocked.
- Reuses the same convert-and-download response handling as the local-file submit path. Cancel = silent; SDK load failure = inline error string.

## Measuring success

Per PM (trio synthesis): count of `dropbox_uploads` rows created per day, segmented by whether the conversion succeeded. Target: ≥20 successful Dropbox-sourced conversions in the first 7 days post-ship.

## Testing

- Hook unit tests: SDK-missing case, picked-files resolves with correct shape, cancel resolves cleanly, SDK script load error rejects with user-safe message.
- UploadForm integration test: mocked `window.Dropbox.choose` triggers POST to `/api/upload/dropbox` with the expected `files` payload.
- `pnpm typecheck` + `pnpm test` (web) + server `tsc --noEmit` all green locally.

## Risks

- **CSP change.** Touches `script-src` in `web/index.html`. New allow-listed origin is `https://www.dropbox.com` only. No other directives change.
- **External-API integration** per CLAUDE.md, so `/security-review` should run before merge.
- Vite HTML env interpolation: avoided entirely by lazy-loading the SDK from JS, where `process.env.REACT_APP_DROPBOX_APP_KEY` interpolation already works via `vite.config.ts` `define`.

## Goal alignment

- Mission (simpler/faster): ~one click to pull a file from Dropbox vs download → re-upload.
- Scale (toward 300K): unblocks the Dropbox user cohort and feeds the history surface in #2300.

## Required before merge

- Set `REACT_APP_DROPBOX_APP_KEY` on the production build environment. The key is public (it's in the JS bundle) — the security boundary is the Dropbox-side allowed-domains list.
- Run `/security-review` (touches external-API integration + CSP).
- Rebase #2300 on top of this PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->