### PR TITLE
fix: Dropbox upload returns 0 cards (worker buffer rewrap)

### DIFF
--- a/src/controllers/Upload/helpers/handleDropbox.ts
+++ b/src/controllers/Upload/helpers/handleDropbox.ts
@@ -48,20 +48,10 @@ export async function handleDropbox(
         const contents = await instrumentedAxios.get<ArrayBuffer>('dropbox', file.link, {
           responseType: 'arraybuffer',
         });
-        const buffer = Buffer.from(contents.data);
-        console.info('[handleDropbox] fetched', {
-          name: file.name,
-          expectedBytes: file.bytes,
-          actualBytes: buffer.length,
-          status: contents.status,
-          contentType: contents.headers['content-type'],
-          contentLength: contents.headers['content-length'],
-          firstBytes: buffer.subarray(0, 200).toString('utf8'),
-        });
         return {
           originalname: file.name,
           size: file.bytes,
-          buffer,
+          buffer: Buffer.from(contents.data),
         };
       })
     );

--- a/src/controllers/Upload/helpers/handleDropbox.ts
+++ b/src/controllers/Upload/helpers/handleDropbox.ts
@@ -48,10 +48,20 @@ export async function handleDropbox(
         const contents = await instrumentedAxios.get<ArrayBuffer>('dropbox', file.link, {
           responseType: 'arraybuffer',
         });
+        const buffer = Buffer.from(contents.data);
+        console.info('[handleDropbox] fetched', {
+          name: file.name,
+          expectedBytes: file.bytes,
+          actualBytes: buffer.length,
+          status: contents.status,
+          contentType: contents.headers['content-type'],
+          contentLength: contents.headers['content-length'],
+          firstBytes: buffer.subarray(0, 200).toString('utf8'),
+        });
         return {
           originalname: file.name,
           size: file.bytes,
-          buffer: Buffer.from(contents.data),
+          buffer,
         };
       })
     );

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -26,11 +26,10 @@ interface GenerationData {
  */
 function getFileContents(file: UploadedFile): Buffer {
   if (!file.path) {
-    return file.buffer;
+    return Buffer.from(file.buffer);
   }
 
   try {
-    // Check if a file exists before trying to read it
     if (fs.existsSync(file.path)) {
       return fs.readFileSync(file.path);
     }
@@ -39,7 +38,7 @@ function getFileContents(file: UploadedFile): Buffer {
     console.error(`Error reading file at path: ${file.path}`, error);
   }
 
-  return file.buffer;
+  return Buffer.from(file.buffer);
 }
 
 /**


### PR DESCRIPTION
## What

\`Buffer\` instances built in the main thread arrive in the worker as plain \`Uint8Array\`. Downstream parser code calls \`.toString()\` expecting UTF-8-decoded text; \`Uint8Array.toString()\` returns a comma-joined number list, so HTML parses to zero toggles and the conversion reports "Could not create a deck using your file(s) and rules".

## Why

Diagnosed by adding a temporary log in \`handleDropbox\`: the axios fetch was returning the exact file (26648 bytes, \`text/html; charset=utf-8\`, valid \`<html>…</html>\` payload). Bytes reached the server intact. The corruption only manifests once those bytes cross the \`worker_threads\` boundary, because \`Buffer\` is a Node-only subclass that doesn't round-trip through structured clone.

The multer path is unaffected — multer stores to disk, the worker reads via \`fs.readFileSync\`, and the resulting buffer never crosses a thread boundary. Only the in-memory upload paths (Dropbox, Google Drive) carry a pre-built buffer.

## How

One-line fix in \`src/usecases/uploads/worker.ts\` \`getFileContents\`: wrap \`file.buffer\` with \`Buffer.from()\`. Buffer.from a Buffer is a no-op cost; Buffer.from a Uint8Array gives back a real Buffer. The downstream \`.toString()\` then hits Buffer's UTF-8 decoder as intended.

Also strips the temporary \`console.info\` debug log from \`handleDropbox\`.

## Risks

- Affects every upload that goes through the worker. Local multer uploads stay on the disk-read branch (unchanged). Dropbox / Google Drive uploads now get a Buffer-wrapped buffer.
- No new dependencies.

## Test plan

- [ ] Deploy to prod, pick the same Notion HTML file via Dropbox, conversion produces a non-zero apkg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->