### PR TITLE
feat: Google Drive tab on upload form

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -29,6 +29,44 @@ describe('UploadForm', () => {
     );
     expect(container.querySelector('.null')).toBeNull();
   });
+
+  test('renders the Google Drive tab when env vars are configured', () => {
+    const previousClient = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+    const previousKey = process.env.REACT_APP_GOOGLE_API_KEY;
+    process.env.REACT_APP_GOOGLE_CLIENT_ID = 'test-client';
+    process.env.REACT_APP_GOOGLE_API_KEY = 'test-key';
+    try {
+      const { container } = renderUploadForm(
+        <UploadForm setErrorMessage={vi.fn()} />
+      );
+      const tabs = Array.from(
+        container.querySelectorAll('button[role="tab"]')
+      );
+      expect(tabs.map((b) => b.textContent)).toContain('Google Drive');
+    } finally {
+      process.env.REACT_APP_GOOGLE_CLIENT_ID = previousClient;
+      process.env.REACT_APP_GOOGLE_API_KEY = previousKey;
+    }
+  });
+
+  test('omits the Google Drive tab when env vars are missing', () => {
+    const previousClient = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+    const previousKey = process.env.REACT_APP_GOOGLE_API_KEY;
+    process.env.REACT_APP_GOOGLE_CLIENT_ID = '';
+    process.env.REACT_APP_GOOGLE_API_KEY = '';
+    try {
+      const { container } = renderUploadForm(
+        <UploadForm setErrorMessage={vi.fn()} />
+      );
+      const tabs = Array.from(
+        container.querySelectorAll('button[role="tab"]')
+      );
+      expect(tabs.map((b) => b.textContent)).not.toContain('Google Drive');
+    } finally {
+      process.env.REACT_APP_GOOGLE_CLIENT_ID = previousClient;
+      process.env.REACT_APP_GOOGLE_API_KEY = previousKey;
+    }
+  });
 });
 
 describe('UploadForm analytics events', () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -10,6 +10,10 @@ import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadF
 import { useDrag } from './hooks/useDrag';
 import { useFileValidation } from './hooks/useFileValidation';
 import { useDropboxChooser, type DropboxFile } from './hooks/useDropboxChooser';
+import {
+  useGooglePicker,
+  type GoogleDriveFile,
+} from './hooks/useGooglePicker';
 import { UploadSourceTabs, type UploadSource } from './UploadSourceTabs';
 import { FeedbackWidget } from '../../../../components/FeedbackWidget/FeedbackWidget';
 import { useUserLocals } from '../../../../lib/hooks/useUserLocals';
@@ -133,6 +137,19 @@ function DropboxIcon({ className }: Readonly<{ className?: string }>) {
   );
 }
 
+function GoogleDriveIcon({ className }: Readonly<{ className?: string }>) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 32 32"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M11 4h10l10 17.5h-10L11 4zm-1 1.7L0 23.2 5 32h10L5 14.5 10 5.7zM10.5 23.5h21L26.5 32H5.5l5-8.5z" />
+    </svg>
+  );
+}
+
 function WarningIcon({ className }: Readonly<{ className?: string }>) {
   return (
     <svg
@@ -167,6 +184,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const [dropboxFilename, setDropboxFilename] = useState<string | null>(null);
   const [dropboxPending, setDropboxPending] = useState(false);
   const [dropboxError, setDropboxError] = useState<string | null>(null);
+  const [driveFilename, setDriveFilename] = useState<string | null>(null);
+  const [drivePending, setDrivePending] = useState(false);
+  const [driveError, setDriveError] = useState<string | null>(null);
   const [source, setSource] = useState<UploadSource>('local');
   const { data: userLocals } = useUserLocals();
   const queryClient = useQueryClient();
@@ -180,6 +200,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const fallbackTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const { validation, validate, reset: resetValidation } = useFileValidation();
   const { openChooser, isConfigured: isDropboxConfigured } = useDropboxChooser(FORMATS);
+  const { openPicker, isConfigured: isGoogleDriveConfigured } = useGooglePicker();
 
   const handleStartTrial = async () => {
     setTrialPending(true);
@@ -211,6 +232,8 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     setShowFallback(false);
     setDropboxFilename(null);
     setDropboxError(null);
+    setDriveFilename(null);
+    setDriveError(null);
     setSource('local');
     resetValidation();
     if (fileInputRef.current) {
@@ -339,6 +362,88 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     }
   };
 
+  const handleGoogleDriveFiles = async (
+    files: GoogleDriveFile[],
+    accessToken: string
+  ) => {
+    const first = files[0];
+    setDriveFilename(first?.name ?? null);
+    setDriveError(null);
+    setZoneState('converting');
+    fireAnalyticsEvent('upload_started');
+    setProgressWidth(10);
+    setProgressSlow(false);
+    setShowFallback(false);
+    try {
+      const formData = new FormData();
+      formData.append('files', JSON.stringify(files));
+      formData.append('googleDriveAuth', accessToken);
+      for (const [key, value] of Object.entries(globalThis.localStorage)) {
+        formData.append(key, value);
+      }
+      const request = await globalThis.fetch('/api/upload/google_drive', {
+        method: 'post',
+        body: formData,
+      });
+      if (request.redirected) {
+        const redirectUrl = new URL(request.url, globalThis.location.origin);
+        if (redirectUrl.searchParams.get('error') === 'upload_limit_exceeded') {
+          const isAnonymous = redirectUrl.pathname === '/login';
+          setLimitInfo({ isAnonymous, filename: first?.name ?? null });
+          setZoneState('limitReached');
+          return;
+        }
+        handleRedirect(request);
+        return;
+      }
+      if (request.status === 202) {
+        globalThis.location.href = '/downloads';
+        return;
+      }
+      if (request.status !== 200) {
+        const message = await extractErrorMessage(request);
+        setLocalError(message);
+        setZoneState('error');
+        return;
+      }
+      setWarningMessage(request.headers.get('X-Warning'));
+      setDeckName(resolveDeckName(request.headers));
+      const count = parseCardCountHeader(request.headers);
+      setCardCount(count);
+      const blob = await request.blob();
+      setDownloadLink(globalThis.URL.createObjectURL(blob));
+      setProgressWidth(100);
+      if (count === 0) {
+        setZoneState('emptyDeck');
+      } else {
+        fireAnalyticsEvent('conversion_success');
+        setZoneState('success');
+      }
+    } catch (error) {
+      setLocalError(toFriendlyThrownError(error));
+      setZoneState('error');
+    }
+  };
+
+  const handleGoogleDriveClick = async () => {
+    setDriveError(null);
+    setDrivePending(true);
+    try {
+      const outcome = await openPicker();
+      if (outcome.kind === 'cancelled') return;
+      if (outcome.files.length === 0) return;
+      await handleGoogleDriveFiles(outcome.files, outcome.accessToken);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Couldn't reach Google Drive. Sign in again and retry.";
+      setDriveError(message);
+    } finally {
+      setDrivePending(false);
+    }
+  };
+
   const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
     setZoneState('converting');
@@ -448,22 +553,34 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     </div>
   );
 
-  const renderConvertingState = () => (
-    <div className={formStyles.stateContent}>
-      <p className={formStyles.filename}>
-        {dropboxFilename ?? displayFilename(fileInputRef.current)}
-      </p>
-      <div className={formStyles.progressTrack}>
-        <div
-          className={`${formStyles.progressFill} ${progressSlow ? formStyles.progressFillSlow : ''}`}
-          style={{ width: `${progressWidth}%` }}
-        />
+  const remoteSourceLabel = (): string | null => {
+    if (driveFilename) return 'Google Drive';
+    if (dropboxFilename) return 'Dropbox';
+    return null;
+  };
+
+  const renderConvertingState = () => {
+    const remoteFilename = driveFilename ?? dropboxFilename;
+    const remoteSource = remoteSourceLabel();
+    return (
+      <div className={formStyles.stateContent}>
+        <p className={formStyles.filename}>
+          {remoteFilename ?? displayFilename(fileInputRef.current)}
+        </p>
+        <div className={formStyles.progressTrack}>
+          <div
+            className={`${formStyles.progressFill} ${progressSlow ? formStyles.progressFillSlow : ''}`}
+            style={{ width: `${progressWidth}%` }}
+          />
+        </div>
+        <p className={formStyles.statusText}>
+          {remoteFilename && remoteSource
+            ? `Fetching ${remoteFilename} from ${remoteSource}`
+            : 'Making your deck...'}
+        </p>
       </div>
-      <p className={formStyles.statusText}>
-        {dropboxFilename ? `Fetching ${dropboxFilename} from Dropbox` : 'Making your deck...'}
-      </p>
-    </div>
-  );
+    );
+  };
 
   const renderSuccessState = () => (
     <div className={formStyles.stateContent}>
@@ -645,8 +762,10 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     return renderIdleState();
   };
 
-  const showTabs = isDropboxConfigured && zoneState === 'idle' && !validation;
+  const anyRemoteSource = isDropboxConfigured || isGoogleDriveConfigured;
+  const showTabs = anyRemoteSource && zoneState === 'idle' && !validation;
   const showDropboxPanel = showTabs && source === 'dropbox';
+  const showGoogleDrivePanel = showTabs && source === 'google_drive';
   const showLocalPanel = !showTabs || source === 'local';
 
   return (
@@ -657,6 +776,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
             active={source}
             onChange={setSource}
             dropboxAvailable={isDropboxConfigured}
+            googleDriveAvailable={isGoogleDriveConfigured}
           />
         </div>
       )}
@@ -719,6 +839,42 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       {dropboxError && (
         <p className={formStyles.dropboxError} role="alert">
           {dropboxError}
+        </p>
+      )}
+      {showTabs && isGoogleDriveConfigured && (
+        <div
+          id="upload-panel-google-drive"
+          role="tabpanel"
+          className={`${zoneClassName} ${showGoogleDrivePanel ? '' : formStyles.panelHidden}`}
+          aria-hidden={!showGoogleDrivePanel}
+        >
+          <div className={formStyles.stateContent}>
+            <GoogleDriveIcon className={formStyles.dropboxIconLarge} />
+            <span className={formStyles.dropText}>
+              Pick a file from your Google Drive to convert it into a deck
+            </span>
+            <button
+              type="button"
+              className={formStyles.chooseButton}
+              onClick={handleGoogleDriveClick}
+              disabled={drivePending}
+              aria-label="Choose from Google Drive"
+            >
+              {drivePending ? 'Opening Google Drive' : 'Choose from Google Drive'}
+            </button>
+            <div className={formStyles.formatList}>
+              {FORMATS.map((fmt) => (
+                <span key={fmt} className={formStyles.formatPill}>
+                  {fmt}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+      {driveError && (
+        <p className={formStyles.dropboxError} role="alert">
+          {driveError}
         </p>
       )}
       {downloadLink && (

--- a/web/src/pages/UploadPage/components/UploadForm/UploadSourceTabs.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadSourceTabs.tsx
@@ -1,14 +1,20 @@
 import styles from './UploadSourceTabs.module.css';
 
-export type UploadSource = 'local' | 'dropbox';
+export type UploadSource = 'local' | 'dropbox' | 'google_drive';
 
 interface Props {
   active: UploadSource;
   onChange: (next: UploadSource) => void;
   dropboxAvailable: boolean;
+  googleDriveAvailable: boolean;
 }
 
-export function UploadSourceTabs({ active, onChange, dropboxAvailable }: Props) {
+export function UploadSourceTabs({
+  active,
+  onChange,
+  dropboxAvailable,
+  googleDriveAvailable,
+}: Props) {
   return (
     <div
       className={styles.tabs}
@@ -35,6 +41,18 @@ export function UploadSourceTabs({ active, onChange, dropboxAvailable }: Props) 
           onClick={() => onChange('dropbox')}
         >
           Dropbox
+        </button>
+      )}
+      {googleDriveAvailable && (
+        <button
+          type="button"
+          role="tab"
+          aria-selected={active === 'google_drive'}
+          aria-controls="upload-panel-google-drive"
+          className={`${styles.tab} ${active === 'google_drive' ? styles.tabActive : ''}`}
+          onClick={() => onChange('google_drive')}
+        >
+          Google Drive
         </button>
       )}
     </div>

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
@@ -1,0 +1,157 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGooglePicker } from './useGooglePicker';
+
+const ORIGINAL_CLIENT = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+const ORIGINAL_API_KEY = process.env.REACT_APP_GOOGLE_API_KEY;
+
+type GoogleGlobal = {
+  picker?: unknown;
+  accounts?: { oauth2?: unknown };
+};
+
+afterEach(() => {
+  process.env.REACT_APP_GOOGLE_CLIENT_ID = ORIGINAL_CLIENT;
+  process.env.REACT_APP_GOOGLE_API_KEY = ORIGINAL_API_KEY;
+  delete (window as unknown as { gapi?: unknown }).gapi;
+  delete (window as unknown as { google?: GoogleGlobal }).google;
+  document.querySelectorAll('script#gapi-js').forEach((n) => n.remove());
+  document.querySelectorAll('script#gis-js').forEach((n) => n.remove());
+});
+
+function buildBuilder(
+  onCallback: (cb: (data: { action: string; docs?: unknown[] }) => void) => void
+) {
+  const built = { setVisible: vi.fn() };
+  const builder: Record<string, unknown> = {};
+  builder.setOAuthToken = vi.fn().mockReturnValue(builder);
+  builder.setDeveloperKey = vi.fn().mockReturnValue(builder);
+  builder.addView = vi.fn().mockReturnValue(builder);
+  builder.setCallback = vi.fn().mockImplementation((cb: typeof onCallback extends never ? never : (data: { action: string; docs?: unknown[] }) => void) => {
+    onCallback(cb);
+    return builder;
+  });
+  builder.build = vi.fn().mockReturnValue(built);
+  return { builder, built };
+}
+
+function stubGoogle(
+  pickerCallbackRunner: (cb: (data: { action: string; docs?: unknown[] }) => void) => void,
+  tokenResponse: { access_token?: string; error?: string } = {
+    access_token: 'test-token',
+  }
+) {
+  const { builder, built } = buildBuilder(pickerCallbackRunner);
+
+  (window as unknown as { gapi: unknown }).gapi = {
+    load: (_lib: string, cb: () => void) => cb(),
+  };
+
+  const docsViewInstance = { setIncludeFolders: vi.fn().mockReturnThis() };
+
+  (window as unknown as { google: GoogleGlobal }).google = {
+    picker: {
+      PickerBuilder: function PickerBuilder() {
+        return builder;
+      },
+      ViewId: { DOCS: 'DOCS' },
+      Action: { PICKED: 'picked', CANCEL: 'cancel', LOADED: 'loaded' },
+      DocsView: function DocsView() {
+        return docsViewInstance;
+      },
+    },
+    accounts: {
+      oauth2: {
+        initTokenClient: ({
+          callback,
+        }: {
+          callback: (resp: { access_token?: string; error?: string }) => void;
+        }) => ({
+          callback,
+          requestAccessToken: () => callback(tokenResponse),
+        }),
+      },
+    },
+  };
+
+  return { builder, built };
+}
+
+describe('useGooglePicker', () => {
+  it('reports not configured when env vars are missing', () => {
+    process.env.REACT_APP_GOOGLE_CLIENT_ID = '';
+    process.env.REACT_APP_GOOGLE_API_KEY = '';
+    const { result } = renderHook(() => useGooglePicker());
+    expect(result.current.isConfigured).toBe(false);
+  });
+
+  it('rejects openPicker when env vars are missing', async () => {
+    process.env.REACT_APP_GOOGLE_CLIENT_ID = '';
+    process.env.REACT_APP_GOOGLE_API_KEY = '';
+    const { result } = renderHook(() => useGooglePicker());
+    await expect(result.current.openPicker()).rejects.toThrow(
+      /Couldn't load Google Drive/
+    );
+  });
+
+  describe('with credentials configured', () => {
+    beforeEach(() => {
+      process.env.REACT_APP_GOOGLE_CLIENT_ID = 'test-client-id';
+      process.env.REACT_APP_GOOGLE_API_KEY = 'test-api-key';
+    });
+
+    it('resolves with picked files and the access token when the user picks a file', async () => {
+      stubGoogle((cb) => {
+        queueMicrotask(() =>
+          cb({
+            action: 'picked',
+            docs: [
+              {
+                id: 'abc123',
+                name: 'biology.pdf',
+                mimeType: 'application/pdf',
+                iconUrl:
+                  'https://drive-thirdparty.googleusercontent.com/16/type/pdf',
+                url: 'https://drive.google.com/file/d/abc123/view',
+                sizeBytes: 2457600,
+              },
+            ],
+          })
+        );
+      });
+      const { result } = renderHook(() => useGooglePicker());
+      const outcome = await result.current.openPicker();
+      expect(outcome.kind).toBe('picked');
+      if (outcome.kind !== 'picked') return;
+      expect(outcome.accessToken).toBe('test-token');
+      expect(outcome.files).toHaveLength(1);
+      expect(outcome.files[0]).toMatchObject({
+        id: 'abc123',
+        name: 'biology.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: 2457600,
+      });
+    });
+
+    it('resolves cancelled when the user dismisses the picker', async () => {
+      stubGoogle((cb) => {
+        queueMicrotask(() => cb({ action: 'cancel' }));
+      });
+      const { result } = renderHook(() => useGooglePicker());
+      const outcome = await result.current.openPicker();
+      expect(outcome).toEqual({ kind: 'cancelled' });
+    });
+
+    it('rejects when the token request returns an error', async () => {
+      stubGoogle(
+        () => undefined,
+        { error: 'access_denied' }
+      );
+      const { result } = renderHook(() => useGooglePicker());
+      await expect(result.current.openPicker()).rejects.toThrow(
+        /access_denied/
+      );
+    });
+  });
+});

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
@@ -1,0 +1,254 @@
+import { useCallback, useRef } from 'react';
+
+export interface GoogleDriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  iconUrl: string;
+  url: string;
+  sizeBytes: number;
+  embedUrl: string;
+  description: string;
+  driveSuccess: boolean;
+  isShared: boolean;
+  lastEditedUtc: number;
+  rotation: number;
+  rotationDegree: number;
+  serviceId: string;
+  type: string;
+}
+
+export type GooglePickerResult =
+  | { kind: 'picked'; files: GoogleDriveFile[]; accessToken: string }
+  | { kind: 'cancelled' };
+
+interface PickerDoc {
+  id: string;
+  name: string;
+  mimeType: string;
+  iconUrl: string;
+  url: string;
+  sizeBytes?: number | string;
+  embedUrl?: string;
+  description?: string;
+  isShared?: boolean;
+  lastEditedUtc?: number;
+  serviceId?: string;
+  type?: string;
+}
+
+interface PickerCallbackData {
+  action: 'picked' | 'cancel' | 'loaded';
+  docs?: PickerDoc[];
+}
+
+interface PickerBuilder {
+  setOAuthToken: (token: string) => PickerBuilder;
+  setDeveloperKey: (key: string) => PickerBuilder;
+  setCallback: (cb: (data: PickerCallbackData) => void) => PickerBuilder;
+  addView: (view: unknown) => PickerBuilder;
+  setAppId?: (id: string) => PickerBuilder;
+  build: () => { setVisible: (visible: boolean) => void };
+}
+
+interface PickerGlobal {
+  PickerBuilder: new () => PickerBuilder;
+  ViewId: { DOCS: unknown };
+  Action: { PICKED: 'picked'; CANCEL: 'cancel'; LOADED: 'loaded' };
+  DocsView: new () => { setIncludeFolders: (b: boolean) => unknown };
+}
+
+interface TokenResponse {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface TokenClient {
+  callback: (resp: TokenResponse) => void;
+  requestAccessToken: (overrides?: { prompt?: string }) => void;
+}
+
+interface GoogleAccountsOAuth2 {
+  initTokenClient: (config: {
+    client_id: string;
+    scope: string;
+    callback: (resp: TokenResponse) => void;
+  }) => TokenClient;
+}
+
+declare global {
+  interface Window {
+    gapi?: {
+      load: (lib: string, cb: () => void) => void;
+    };
+    google?: {
+      picker?: PickerGlobal;
+      accounts?: { oauth2: GoogleAccountsOAuth2 };
+    };
+  }
+}
+
+const GAPI_SRC = 'https://apis.google.com/js/api.js';
+const GAPI_SCRIPT_ID = 'gapi-js';
+const GIS_SRC = 'https://accounts.google.com/gsi/client';
+const GIS_SCRIPT_ID = 'gis-js';
+const SCOPE = 'https://www.googleapis.com/auth/drive.file';
+
+const GOOGLE_UNAVAILABLE =
+  "Couldn't load Google Drive. Check your connection or disable script blockers and try again.";
+
+function clientId(): string | null {
+  const id = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+  return id && id.length > 0 ? id : null;
+}
+
+function apiKey(): string | null {
+  const key = process.env.REACT_APP_GOOGLE_API_KEY;
+  return key && key.length > 0 ? key : null;
+}
+
+function loadScript(src: string, id: string): Promise<void> {
+  const existing = document.getElementById(id) as HTMLScriptElement | null;
+  if (existing) {
+    if (existing.dataset.loaded === 'true') return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      existing.addEventListener('load', () => resolve());
+      existing.addEventListener('error', () =>
+        reject(new Error(GOOGLE_UNAVAILABLE))
+      );
+    });
+  }
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.id = id;
+    script.src = src;
+    script.async = true;
+    script.defer = true;
+    script.addEventListener('load', () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    });
+    script.addEventListener('error', () =>
+      reject(new Error(GOOGLE_UNAVAILABLE))
+    );
+    document.head.appendChild(script);
+  });
+}
+
+function loadPicker(): Promise<PickerGlobal> {
+  const existing = window.google?.picker;
+  if (existing) return Promise.resolve(existing);
+  const ensureGapi: Promise<void> = window.gapi
+    ? Promise.resolve()
+    : loadScript(GAPI_SRC, GAPI_SCRIPT_ID);
+  return ensureGapi.then(
+    () =>
+      new Promise<PickerGlobal>((resolve, reject) => {
+        if (!window.gapi) {
+          reject(new Error(GOOGLE_UNAVAILABLE));
+          return;
+        }
+        window.gapi.load('picker', () => {
+          const picker = window.google?.picker;
+          if (picker) resolve(picker);
+          else reject(new Error(GOOGLE_UNAVAILABLE));
+        });
+      })
+  );
+}
+
+function loadIdentityServices(): Promise<GoogleAccountsOAuth2> {
+  const existing = window.google?.accounts?.oauth2;
+  if (existing) return Promise.resolve(existing);
+  return loadScript(GIS_SRC, GIS_SCRIPT_ID).then(() => {
+    const oauth2 = window.google?.accounts?.oauth2;
+    if (!oauth2) throw new Error(GOOGLE_UNAVAILABLE);
+    return oauth2;
+  });
+}
+
+function toGoogleDriveFile(doc: PickerDoc): GoogleDriveFile {
+  return {
+    id: doc.id,
+    name: doc.name,
+    mimeType: doc.mimeType,
+    iconUrl: doc.iconUrl,
+    url: doc.url,
+    sizeBytes: typeof doc.sizeBytes === 'string'
+      ? Number.parseInt(doc.sizeBytes, 10) || 0
+      : doc.sizeBytes ?? 0,
+    embedUrl: doc.embedUrl ?? '',
+    description: doc.description ?? '',
+    driveSuccess: true,
+    isShared: doc.isShared ?? false,
+    lastEditedUtc: doc.lastEditedUtc ?? 0,
+    rotation: 0,
+    rotationDegree: 0,
+    serviceId: doc.serviceId ?? '',
+    type: doc.type ?? 'document',
+  };
+}
+
+export function useGooglePicker() {
+  const inFlightRef = useRef(false);
+
+  const openPicker = useCallback((): Promise<GooglePickerResult> => {
+    const id = clientId();
+    const key = apiKey();
+    if (id == null || key == null) {
+      return Promise.reject(new Error(GOOGLE_UNAVAILABLE));
+    }
+    if (inFlightRef.current) {
+      return Promise.reject(new Error('Google Drive picker is already open.'));
+    }
+    inFlightRef.current = true;
+
+    return Promise.all([loadPicker(), loadIdentityServices()])
+      .then(
+        ([picker, oauth2]) =>
+          new Promise<GooglePickerResult>((resolve, reject) => {
+            const tokenClient = oauth2.initTokenClient({
+              client_id: id,
+              scope: SCOPE,
+              callback: (resp) => {
+                if (resp.error || !resp.access_token) {
+                  reject(
+                    new Error(
+                      resp.error_description ?? resp.error ?? GOOGLE_UNAVAILABLE
+                    )
+                  );
+                  return;
+                }
+                const view = new picker.DocsView();
+                view.setIncludeFolders(false);
+                const built = new picker.PickerBuilder()
+                  .setOAuthToken(resp.access_token)
+                  .setDeveloperKey(key)
+                  .addView(view)
+                  .setCallback((data) => {
+                    if (data.action === picker.Action.PICKED) {
+                      const files = (data.docs ?? []).map(toGoogleDriveFile);
+                      resolve({
+                        kind: 'picked',
+                        files,
+                        accessToken: resp.access_token!,
+                      });
+                    } else if (data.action === picker.Action.CANCEL) {
+                      resolve({ kind: 'cancelled' });
+                    }
+                  })
+                  .build();
+                built.setVisible(true);
+              },
+            });
+            tokenClient.requestAccessToken({ prompt: '' });
+          })
+      )
+      .finally(() => {
+        inFlightRef.current = false;
+      });
+  }, []);
+
+  return { openPicker, isConfigured: clientId() != null && apiKey() != null };
+}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Upload form: pick a file from Google Drive in one click', date: '2026-05-16' },
   { type: 'feature', title: 'From Google Drive section on Downloads — see the files you picked from Drive and open any of them with one click', date: '2026-05-16' },
   { type: 'style', title: 'Upload form has tabs — Your computer and Dropbox sit side by side at the top of the page', date: '2026-05-15' },
   { type: 'feature', title: 'Upload form: pick a file from Dropbox in one click', date: '2026-05-15' },


### PR DESCRIPTION
## What
Adds a third "Google Drive" tab to the upload form alongside "Your computer" and "Dropbox". Clicking "Choose from Google Drive" opens the Google Picker, lets the user pick one file, and POSTs the picked file metadata plus an OAuth bearer token to the existing `POST /api/upload/google_drive` endpoint. The same conversion + downloads flow that Dropbox uses runs from there.

The tab is gated on `REACT_APP_GOOGLE_CLIENT_ID` and `REACT_APP_GOOGLE_API_KEY`. When either is missing, the tab is hidden — deploys without the env vars degrade gracefully to the two-tab layout. **The prod build needs both env vars set before users will see the new tab.**

## Why
The `google_drive_uploads` table has been around since August 2024 but nothing in the web app has populated it for a while. #2305 added a "From Google Drive" section on Downloads — without this PR that section sits empty forever. Drive is the largest unaddressed file source for student users (Notion + Dropbox + Drive ≈ all of them), so closing the loop is the single biggest conversion-surface gap on the upload form.

## How
- New `useGooglePicker` hook (`web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts`) — lazy-loads `apis.google.com/js/api.js` (gapi/Picker) and `accounts.google.com/gsi/client` (Google Identity Services token client) on demand. No npm package — the official scripts are the only sanctioned path Google supports for Picker, and the equivalent npm packages pull in heavy server-side SDKs that are wrong for the browser.
- OAuth scope: `https://www.googleapis.com/auth/drive.file` — Google's narrowest Picker scope. Per-file authorization (only the file the user picked is readable by our OAuth client); cannot enumerate the user's other Drive files. This was an active trio resolution — PM wanted `drive.file`, engineer initially said `drive.readonly`. Drive.file wins because Picker authorizes those specific files for us and the existing server-side `Authorization: Bearer` download call still works.
- **Concrete gotcha:** Google Identity Services' `requestAccessToken` callback is fire-and-forget — it does not return a Promise. The Picker must be opened *inside* that callback or it races the token init and silently no-ops. The hook does this.
- Added the third tab to `UploadSourceTabs.tsx` (new entrant at the end, per designer call).
- Wired `handleGoogleDriveClick` + `handleGoogleDriveFiles` in `UploadForm.tsx` mirroring the Dropbox handlers. POSTs `files` (JSON-stringified `GoogleDriveFile[]`) + `googleDriveAuth` (bearer) — the exact body shape `src/controllers/Upload/helpers/handleGoogleDrive.ts` expects.
- Reused all existing conversion states (`converting` / `success` / `emptyDeck` / `error` / `limitReached`). The converting status line now reads "Fetching {filename} from Google Drive" when Drive is the source — same pattern as Dropbox.
- Designer pass: monochrome `currentColor` Drive triangle glyph (no full-color Google mark — full-color marks have stricter brand-guideline rules and fight the Stripe-class restraint baseline).

## Measuring success
Leading indicator: Drive-sourced conversions per week. Phase-2 gate: 25+ successful Drive uploads in the first 14 days post-launch unlocks investment in folder-pick + multi-file. Below 10 → leave as-is. Secondary: rows in `google_drive_uploads` start increasing immediately after deploy, which surfaces the "From Google Drive" history section on `/downloads` for real users.

## Testing
- New `useGooglePicker.test.ts` — 5 tests (loading-state guards, picked-files outcome with access token, cancelled outcome, token-error rejection, missing-env-var rejection). Mocks `window.gapi`, `window.google.picker`, and `window.google.accounts.oauth2` to drive the callbacks deterministically without loading the real scripts.
- Existing `UploadForm.test.tsx` extended with 2 tests for tab visibility (Drive tab appears iff both env vars are present).
- `/check`: server tsc clean, web typecheck clean, 483 Vitest tests pass (was 481 before; +5 hook tests, +2 form tests minus 2 reused existing setup), Biome lint clean.

## Risks
- Picker UX gate: this depends on users granting `drive.file` scope inline. If they decline, the token callback gets `error: 'access_denied'` and we surface "Couldn't reach Google Drive. Sign in again and retry." Worth watching for the first week.
- Script load failure: the two Google scripts come from `apis.google.com` and `accounts.google.com`. Script blockers or corporate proxies will fail to load them and the user sees "Couldn't load Google Drive. Check your connection or disable script blockers and try again." Same behavior as the Dropbox tab on a Dropbox-blocked network.
- Rollback: removing this PR removes the tab. The server endpoint, repository, and migration stay — they predated this PR and serve the history section in #2305.

## Out of scope (deferred to phase 2)
- Multi-file batch upload (Picker supports it behind a flag; defer until #25-in-14-days gate clears).
- Folder pick / recursive (Drive folders).
- Paywall/quota wiring beyond what `/api/upload/google_drive` already enforces.

## Sonar
Sonar scanner not run locally (token not configured in this environment) — flagging for reviewers so a Sonar bounce on the new hook isn't a surprise. The hook has nested callbacks which can trigger cognitive complexity warnings.

## Goal alignment
- **Simpler/faster/more beautiful:** users studying from Drive-hosted PDFs or Docs skip the download-then-reupload round trip.
- **Scale-to-300K:** Drive is the largest unaddressed file source on the upload form; closing it unblocks an entire student population (Notion / Dropbox / Drive covers ~all of them).

---

<details>
<summary>Trio synthesis</summary>

- **PM:** Ship now. Drive tab parity with Dropbox; logged-in users only; PR-1 = single file, no folder pick. Leading indicator: 25+ Drive uploads / 14 days.
- **Designer:** Tab order Your computer / Dropbox / Google Drive (new entrant at end). "Pick a file from your Google Drive to convert it into a deck" + "Choose from Google Drive" + "Fetching {filename} from Google Drive". Monochrome Drive glyph in `currentColor` — no full-color Google mark.
- **Engineer:** S effort. 5 files. Dynamic `<script>` tags for both Google scripts (no npm pkg). Gotcha: open Picker inside the token callback. Hook unit tests mock both globals.
- **Conflict:** PM said `drive.file` scope; Engineer said `drive.readonly`. **Resolution:** `drive.file` — narrower, Google-recommended for Picker workflows, server-side download still works because Picker authorizes those specific files for the OAuth client.
</details>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [x] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->