### PR TITLE
fix: allow Google Picker scripts in CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="Content-Security-Policy"
-    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
   <link rel="apple-touch-icon" href="/logo192.png" />
   <!--
       Notice the use of  in the tags above.


### PR DESCRIPTION
## What
Adds \`https://apis.google.com\` and \`https://accounts.google.com\` to the \`script-src\` directive of the CSP meta tag in \`web/index.html\`. Required for the Google Drive upload tab from #2306 to function.

## Why
Browser console on prod after deploying #2306 showed:

\`\`\`
Loading the script 'https://apis.google.com/js/api.js' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com"
\`\`\`

Same violation for \`accounts.google.com/gsi/client\`. Both are required by the Picker / GIS flow that \`useGooglePicker\` lazy-loads.

## How
One-line addition to the existing CSP meta tag's \`script-src\`. No other directives needed — frame/connect/img directives are not set on this site, so the Picker iframe and XHR calls were never blocked.

## Testing
- Local: rebuild + smoke-test the upload form. Tab opens the Picker.
- Prod (after rebuild): browser console shows no CSP violations for the two Google origins.

## Risks
- Two new third-party script origins in script-src — both are Google-owned and serve the official Picker SDK; this is the same trust boundary as the existing Dropbox SDK allowance (\`www.dropbox.com\`).
- Rollback: revert this commit. The CSP returns to its prior shape; the Drive tab silently fails to load Picker, same as before this fix.

## Goal alignment
Unblocks #2306, which closes the empty "From Google Drive" history section #2305 introduced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->