### PR TITLE
fix: Google Drive picks fail with 404 — call setAppId on Picker

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
@@ -25,6 +25,7 @@ function buildBuilder(
 ) {
   const built = { setVisible: vi.fn() };
   const builder: Record<string, unknown> = {};
+  builder.setAppId = vi.fn().mockReturnValue(builder);
   builder.setOAuthToken = vi.fn().mockReturnValue(builder);
   builder.setDeveloperKey = vi.fn().mockReturnValue(builder);
   builder.addView = vi.fn().mockReturnValue(builder);
@@ -152,6 +153,17 @@ describe('useGooglePicker', () => {
       await expect(result.current.openPicker()).rejects.toThrow(
         /access_denied/
       );
+    });
+
+    it('calls setAppId with the project number derived from the client id', async () => {
+      process.env.REACT_APP_GOOGLE_CLIENT_ID =
+        '806855830059-abc123def.apps.googleusercontent.com';
+      const { builder } = stubGoogle((cb) => {
+        queueMicrotask(() => cb({ action: 'cancel' }));
+      });
+      const { result } = renderHook(() => useGooglePicker());
+      await result.current.openPicker();
+      expect(builder.setAppId).toHaveBeenCalledWith('806855830059');
     });
   });
 });

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
@@ -47,7 +47,7 @@ interface PickerBuilder {
   setDeveloperKey: (key: string) => PickerBuilder;
   setCallback: (cb: (data: PickerCallbackData) => void) => PickerBuilder;
   addView: (view: unknown) => PickerBuilder;
-  setAppId?: (id: string) => PickerBuilder;
+  setAppId: (id: string) => PickerBuilder;
   build: () => { setVisible: (visible: boolean) => void };
 }
 
@@ -204,6 +204,8 @@ export function useGooglePicker() {
     }
     inFlightRef.current = true;
 
+    const projectNumber = id.split('-')[0];
+
     return Promise.all([loadPicker(), loadIdentityServices()])
       .then(
         ([picker, oauth2]) =>
@@ -223,6 +225,7 @@ export function useGooglePicker() {
                 const view = new picker.DocsView();
                 view.setIncludeFolders(false);
                 const built = new picker.PickerBuilder()
+                  .setAppId(projectNumber)
                   .setOAuthToken(resp.access_token)
                   .setDeveloperKey(key)
                   .addView(view)

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Upload form: Google Drive picks convert into decks instead of erroring', date: '2026-05-16' },
   { type: 'feature', title: 'Upload form: pick a file from Google Drive in one click', date: '2026-05-16' },
   { type: 'feature', title: 'From Google Drive section on Downloads — see the files you picked from Drive and open any of them with one click', date: '2026-05-16' },
   { type: 'style', title: 'Upload form has tabs — Your computer and Dropbox sit side by side at the top of the page', date: '2026-05-15' },


### PR DESCRIPTION
## What
Adds \`.setAppId(projectNumber)\` to the Picker builder chain in \`useGooglePicker.ts\`. \`projectNumber\` is derived at runtime from the existing \`REACT_APP_GOOGLE_CLIENT_ID\` (numeric prefix of the client ID), so no new env var is needed.

## Why
With the \`drive.file\` OAuth scope (the narrowest, picked-files-only scope we chose in #2306), Google Picker only binds the picked file to *our* OAuth client when \`setAppId\` is called. Without it, the user can pick a file in the UI but the server's \`GET https://www.googleapis.com/drive/v3/files/<id>?alt=media\` with the bearer token returns **404 File not found**. Every Drive pick on prod was failing with "Error handling Google Drive files" until this fix.

Verified on prod logs:
\`\`\`
2|server   | google drive upload success
2|server   | POST /api/upload/google_drive 400
...
status: 404, message: "File not found: 1Gxh9TSApii4ErELl0jePIGUVMldsgSRe"
\`\`\`

## How
- One-line change in the builder chain: \`.setAppId(projectNumber)\` between the constructor and the rest of the chain.
- \`projectNumber\` is derived as \`clientId().split('-')[0]\` — the OAuth client ID has the shape \`<projectNumber>-<hash>.apps.googleusercontent.com\`. Engineer trio call: derive instead of adding a third env var, because two vars that must stay in sync is a deployment footgun.
- Test mock updated with a \`setAppId\` stub. Added an assertion that the derived project number reaches \`setAppId\`.
- Changelog entry added for the user-visible fix.

## Testing
- 6/6 \`useGooglePicker\` unit tests pass (was 5; +1 for the setAppId assertion).
- \`/check\`: server tsc clean, web typecheck clean, 484 Vitest tests pass, Biome lint clean.

## Risks
- Rollback: revert this commit. The tab returns to the broken state from before this PR, no other surface affected.
- The \`drive.file\` scope still requires the Picker API enabled on the GCP project (already enabled — Picker UI opens on prod).

## Trio synthesis
- **PM:** Ship the 1-line fix now. Severity high — 100% of Drive clicks fail post-#2306. Forward fix is cleaner than rolling back.
- **Designer:** Hide tab if env vars missing. No copy changes (generic error state is fine for a hotfix).
- **Engineer:** Derive project number from the OAuth client ID; no new env var. Insert \`setAppId\` in the chain. Mock needs the stub.
- **Conflict:** PM and Designer both assumed a new env var \`REACT_APP_GOOGLE_PROJECT_NUMBER\`. Engineer pointed out it's derivable. **Resolution:** derive it, no new env var, no drift risk.

## Goal alignment
Closes the deploy-blocking bug from #2306 so the Drive tab actually works for the user base that needs it. Critical for the 300K-user goal — without this fix, the Drive tab is visible but every click fails.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->