### PR TITLE
fix: Google Drive picks of native Docs fail with "appears to be empty"

### DIFF
--- a/src/controllers/Upload/helpers/handleGoogleDrive.test.ts
+++ b/src/controllers/Upload/helpers/handleGoogleDrive.test.ts
@@ -181,6 +181,35 @@ describe('handleGoogleDrive — native Google Apps mime types', () => {
     expect(reqFiles[0].originalname).toMatch(/\.pdf$/);
   });
 
+  it('derives size from the downloaded buffer, not the picker-reported sizeBytes', async () => {
+    const zeroSizeDoc = { ...baseDocFile, sizeBytes: 0 };
+    const req = makeReq([zeroSizeDoc]);
+    const res = makeRes();
+    const handleUpload = jest.fn();
+    mockedAxios.get.mockResolvedValue({
+      data: Buffer.from('<html><body><h1>hello</h1></body></html>'),
+    } as never);
+    await handleGoogleDrive(req, res as unknown as express.Response, handleUpload);
+    const reqFiles = (req as unknown as {
+      files: { size: number; buffer: Buffer }[];
+    }).files;
+    expect(reqFiles[0].size).toBeGreaterThan(0);
+    expect(Buffer.isBuffer(reqFiles[0].buffer)).toBe(true);
+    expect(handleUpload).toHaveBeenCalled();
+  });
+
+  it('requests arraybuffer responseType so bodies are not coerced to strings', async () => {
+    const req = makeReq([baseDocFile]);
+    const res = makeRes();
+    const handleUpload = jest.fn();
+    await handleGoogleDrive(req, res as unknown as express.Response, handleUpload);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'google_drive',
+      expect.any(String),
+      expect.objectContaining({ responseType: 'arraybuffer' })
+    );
+  });
+
   it('returns 400 and does not call handleUpload when googleDriveAuth is missing', async () => {
     const req = makeReq([basePdfFile], undefined);
     (req.body as Record<string, unknown>).googleDriveAuth = undefined;

--- a/src/controllers/Upload/helpers/handleGoogleDrive.ts
+++ b/src/controllers/Upload/helpers/handleGoogleDrive.ts
@@ -75,20 +75,21 @@ export async function handleGoogleDrive(
     req.files = await Promise.all(
       files.map(async (file) => {
         const { url, originalname } = resolveUrlAndName(file);
-        const contents = await instrumentedAxios.get(
+        const contents = await instrumentedAxios.get<ArrayBuffer>(
           'google_drive',
           url,
           {
             headers: {
               Authorization: `Bearer ${googleDriveAuth}`,
             },
-            responseType: 'blob',
+            responseType: 'arraybuffer',
           }
         );
+        const buffer = Buffer.from(contents.data);
         return {
           originalname,
-          size: file.sizeBytes,
-          buffer: contents.data,
+          size: buffer.length,
+          buffer,
         };
       })
     );


### PR DESCRIPTION
## What

Three bugs in `handleGoogleDrive.ts` that combined to break the new native-Doc export path shipped in #2309. Mirrors the working `handleDropbox.ts` pattern.

| Was | Now |
|---|---|
| `responseType: 'blob'` | `responseType: 'arraybuffer'` |
| `buffer: contents.data` | `buffer: Buffer.from(contents.data)` |
| `size: file.sizeBytes` | `size: buffer.length` |

## Why

A user picked a Google Doc named "2anki" after #2309 deployed. The server returned 400 with `"2anki.html" appears to be empty. Please re-export your file and try again.`

Root cause: the picker reports `sizeBytes: 0` for native Google Docs (they have no fixed byte size). `getUploadValidationError` checks `file.size === 0` and rejects before the parser sees the body. Even if size had been right, `responseType: 'blob'` is not valid in Node axios — it would have coerced the `text/html` body to a string, and the parser would have read garbage.

Pre-existing binary Drive picks worked because picker `sizeBytes` is non-zero for binary files. The `'blob'` typo silently worked-enough for binary content too.

## How

Match the Dropbox pattern exactly. `Buffer.from(arrayBuffer)` produces a real Node Buffer regardless of response Content-Type; `buffer.length` is correct for all paths.

## Testing

- `handleGoogleDrive.test.ts` (now 7 tests, was 5):
  - New: zero-`sizeBytes` native Doc produces non-zero size + real Buffer on the downstream file.
  - New: asserts `responseType: 'arraybuffer'` is in the request config.
  - Existing 5 tests still pass with no edits.

## Risks

- The same axios call is used for the pre-existing binary path. `Buffer.from(ArrayBuffer)` is a safe wrap for any binary content — no regression risk for PDFs etc.
- No changelog entry: the entry from #2309 ("Google Docs, Sheets, and Slides from your Drive turn straight into decks") becomes accurate once this lands.

## Goal alignment

Simpler/faster/more beautiful: yes — the "appears to be empty" error was the opposite of "drop something in, get a clean deck back". Toward scale: yes — Google Docs is the largest pool of cloud-native notes after PDFs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->