### PR TITLE
feat: chat upload error CTA — deep-link from failed uploads to /chat

### DIFF
--- a/migrations/20260604000000_add_chat_consent_at.js
+++ b/migrations/20260604000000_add_chat_consent_at.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.table('users', (t) => {
+    t.timestamp('chat_consent_at', { useTz: true }).nullable();
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('users', (t) => {
+    t.dropColumn('chat_consent_at');
+  });
+};

--- a/src/controllers/ChatConsentController.test.ts
+++ b/src/controllers/ChatConsentController.test.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from 'express';
+import ChatConsentController from './ChatConsentController';
+
+function buildRes(owner = 1): Response {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    sendStatus: jest.fn().mockReturnThis(),
+    locals: { owner },
+  } as unknown as Response;
+}
+
+function buildReq(): Request {
+  return {} as unknown as Request;
+}
+
+describe('ChatConsentController.recordConsent', () => {
+  it('calls execute with the owner and returns 204', async () => {
+    const execute = jest.fn().mockResolvedValue(undefined);
+    const controller = new ChatConsentController({ execute } as never);
+    const res = buildRes(7);
+    await controller.recordConsent(buildReq(), res);
+    expect(execute).toHaveBeenCalledWith(7);
+    expect(res.sendStatus).toHaveBeenCalledWith(204);
+  });
+
+  it('propagates errors by rethrowing', async () => {
+    const execute = jest.fn().mockRejectedValue(new Error('DB down'));
+    const controller = new ChatConsentController({ execute } as never);
+    const res = buildRes(3);
+    await expect(controller.recordConsent(buildReq(), res)).rejects.toThrow('DB down');
+  });
+});

--- a/src/controllers/ChatConsentController.ts
+++ b/src/controllers/ChatConsentController.ts
@@ -1,0 +1,14 @@
+import { Request, Response } from 'express';
+import type { SetChatConsentUseCase } from '../usecases/chat/SetChatConsentUseCase';
+
+class ChatConsentController {
+  constructor(private readonly useCase: SetChatConsentUseCase) {}
+
+  async recordConsent(_req: Request, res: Response): Promise<void> {
+    const owner = res.locals.owner as number;
+    await this.useCase.execute(owner);
+    res.sendStatus(204);
+  }
+}
+
+export default ChatConsentController;

--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -5,7 +5,12 @@ import {
   ChatConversationNotFoundError,
 } from '../usecases/chat/ChatUseCase';
 
-function buildRes(owner = 42, patreon = false, subscriber = false): Response {
+function buildRes(
+  owner = 42,
+  patreon = false,
+  subscriber = false,
+  chatConsentAt: Date | null = new Date()
+): Response {
   return {
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
@@ -13,14 +18,19 @@ function buildRes(owner = 42, patreon = false, subscriber = false): Response {
     flushHeaders: jest.fn(),
     write: jest.fn(),
     end: jest.fn(),
-    locals: { owner, patreon, subscriber },
+    locals: { owner, patreon, subscriber, chat_consent_at: chatConsentAt },
   } as unknown as Response;
 }
 
-function buildMocks(owner = 42, patreon = false, subscriber = false) {
+function buildMocks(
+  owner = 42,
+  patreon = false,
+  subscriber = false,
+  chatConsentAt: Date | null = new Date()
+) {
   const execute = jest.fn();
   const controller = new ChatController({ execute } as never);
-  const res = buildRes(owner, patreon, subscriber);
+  const res = buildRes(owner, patreon, subscriber, chatConsentAt);
   return { execute, controller, res };
 }
 
@@ -59,6 +69,14 @@ function writtenEvents(res: Response): Array<{ event: string; data: unknown }> {
 }
 
 describe('ChatController.sendMessage', () => {
+  it('emits consent_required SSE error when chat_consent_at is null', async () => {
+    const { controller, res } = buildMocks(42, false, false, null);
+    await controller.sendMessage(buildReq({ content: 'Hello' }), res);
+    const events = writtenEvents(res);
+    expect(events).toContainEqual({ event: 'error', data: { type: 'consent_required' } });
+    expect(res.end).toHaveBeenCalled();
+  });
+
   it('returns 400 when content is missing', async () => {
     const { controller, res } = buildMocks();
     await controller.sendMessage(buildReq({}), res);

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -108,10 +108,24 @@ function emitChatError(res: Response, err: unknown): void {
   }
 }
 
+function hasConsented(locals: Record<string, unknown>): boolean {
+  return locals.chat_consent_at != null;
+}
+
 class ChatController {
   constructor(private readonly chatUseCase: ChatUseCase) {}
 
   async sendMessage(req: Request, res: Response) {
+    if (!hasConsented(res.locals as Record<string, unknown>)) {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.flushHeaders();
+      sseWrite(res, 'error', { type: 'consent_required' });
+      res.end();
+      return;
+    }
+
     const rawContent = req.body?.content;
     const content = typeof rawContent === 'string' ? rawContent.trim() : '';
 

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -200,6 +200,13 @@ class UsersRepository {
       .update({ signup_country: country });
   }
 
+  setChatConsentAt(userId: number): Promise<void> {
+    return this.database(this.table)
+      .where({ id: userId })
+      .update({ chat_consent_at: this.database.fn.now() })
+      .then(() => undefined);
+  }
+
   getSignupCountry(id: string | number): Promise<string | null> {
     return this.database(this.table)
       .where({ id })

--- a/src/data_layer/public/Users.ts
+++ b/src/data_layer/public/Users.ts
@@ -49,6 +49,8 @@ export default interface Users {
   cards_month_started_at: Date;
 
   signup_country: string | null;
+
+  chat_consent_at: Date | null;
 }
 
 /** Represents the initializer for the table public.users */
@@ -106,6 +108,8 @@ export interface UsersInitializer {
   cards_month_started_at?: Date;
 
   signup_country?: string | null;
+
+  chat_consent_at?: Date | null;
 }
 
 /** Represents the mutator for the table public.users */
@@ -153,4 +157,6 @@ export interface UsersMutator {
   cards_month_started_at?: Date;
 
   signup_country?: string | null;
+
+  chat_consent_at?: Date | null;
 }

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -1,13 +1,16 @@
 import express from 'express';
 import multer from 'multer';
 import ChatController from '../controllers/ChatController';
+import ChatConsentController from '../controllers/ChatConsentController';
 import ChatDeckController from '../controllers/ChatDeckController';
 import ConversationsController from '../controllers/ConversationsController';
 import { ChatUseCase } from '../usecases/chat/ChatUseCase';
+import { SetChatConsentUseCase } from '../usecases/chat/SetChatConsentUseCase';
 import { ChatDeckUseCase } from '../usecases/chat/ChatDeckUseCase';
 import { ConversationsUseCase } from '../usecases/chat/ConversationsUseCase';
 import { ChatMessagesRepository } from '../data_layer/ChatMessagesRepository';
 import { ConversationsRepository } from '../data_layer/ConversationsRepository';
+import UsersRepository from '../data_layer/UsersRepository';
 import { getDatabase } from '../data_layer';
 import { getAnthropicClient } from '../lib/claude/ClaudeService';
 import RequireAuthentication from './middleware/RequireAuthentication';
@@ -22,13 +25,32 @@ const ChatRouter = () => {
   const db = getDatabase();
   const messagesRepo = new ChatMessagesRepository(db);
   const conversationsRepo = new ConversationsRepository(db);
+  const usersRepo = new UsersRepository(db);
   const anthropic = getAnthropicClient();
   const useCase = new ChatUseCase(messagesRepo, conversationsRepo, anthropic);
   const controller = new ChatController(useCase);
+  const consentUseCase = new SetChatConsentUseCase(usersRepo);
+  const consentController = new ChatConsentController(consentUseCase);
   const deckUseCase = new ChatDeckUseCase();
   const deckController = new ChatDeckController(deckUseCase);
   const conversationsUseCase = new ConversationsUseCase(conversationsRepo);
   const conversationsController = new ConversationsController(conversationsUseCase);
+
+  /**
+   * @swagger
+   * /api/chat/consent:
+   *   post:
+   *     summary: Record chat consent for the authenticated user
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       204:
+   *         description: Consent recorded
+   */
+  router.post('/api/chat/consent', RequireAuthentication, (req, res) =>
+    consentController.recordConsent(req, res)
+  );
 
   /**
    * @swagger

--- a/src/routes/middleware/configureUserLocal.ts
+++ b/src/routes/middleware/configureUserLocal.ts
@@ -13,6 +13,7 @@ export async function configureUserLocal(
     res.locals.owner = user.owner;
     res.locals.patreon = user.patreon;
     res.locals.trial_started_at = user.trial_started_at ?? null;
+    res.locals.chat_consent_at = user.chat_consent_at ?? null;
     res.locals.subscriber = await authService.getIsSubscriber(
       database,
       user.email

--- a/src/usecases/chat/SetChatConsentUseCase.test.ts
+++ b/src/usecases/chat/SetChatConsentUseCase.test.ts
@@ -1,0 +1,25 @@
+import { SetChatConsentUseCase } from './SetChatConsentUseCase';
+
+interface FakeUsersRepository {
+  setChatConsentAt: jest.Mock;
+}
+
+function buildFakeRepo(): FakeUsersRepository {
+  return { setChatConsentAt: jest.fn().mockResolvedValue(undefined) };
+}
+
+describe('SetChatConsentUseCase', () => {
+  it('calls setChatConsentAt on the repository with the correct userId', async () => {
+    const repo = buildFakeRepo();
+    const useCase = new SetChatConsentUseCase(repo);
+    await useCase.execute(42);
+    expect(repo.setChatConsentAt).toHaveBeenCalledWith(42);
+  });
+
+  it('propagates repository errors', async () => {
+    const repo = buildFakeRepo();
+    repo.setChatConsentAt.mockRejectedValueOnce(new Error('DB error'));
+    const useCase = new SetChatConsentUseCase(repo);
+    await expect(useCase.execute(1)).rejects.toThrow('DB error');
+  });
+});

--- a/src/usecases/chat/SetChatConsentUseCase.ts
+++ b/src/usecases/chat/SetChatConsentUseCase.ts
@@ -1,0 +1,11 @@
+export interface IChatConsentRepository {
+  setChatConsentAt(userId: number): Promise<void>;
+}
+
+export class SetChatConsentUseCase {
+  constructor(private readonly usersRepo: IChatConsentRepository) {}
+
+  execute(userId: number): Promise<void> {
+    return this.usersRepo.setChatConsentAt(userId);
+  }
+}

--- a/web/src/components/ConsentModal/ConsentModal.module.css
+++ b/web/src/components/ConsentModal/ConsentModal.module.css
@@ -1,0 +1,12 @@
+.body {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-direction: column;
+}

--- a/web/src/components/ConsentModal/ConsentModal.module.css
+++ b/web/src/components/ConsentModal/ConsentModal.module.css
@@ -1,3 +1,21 @@
+.dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .body {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);

--- a/web/src/components/ConsentModal/ConsentModal.test.tsx
+++ b/web/src/components/ConsentModal/ConsentModal.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import '@testing-library/jest-dom';
+import ConsentModal from './ConsentModal';
+
+vi.mock('../../lib/backend/api', () => ({
+  post: vi.fn(),
+}));
+
+import { post } from '../../lib/backend/api';
+const mockPost = post as ReturnType<typeof vi.fn>;
+
+describe('ConsentModal', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  it('renders the consent heading', () => {
+    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: 'Chat sends your messages to Anthropic' })).toBeInTheDocument();
+  });
+
+  it('renders the body copy', () => {
+    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByText(/Your messages and any files you attach go to Anthropic/)).toBeInTheDocument();
+  });
+
+  it('renders the primary Start chatting button', () => {
+    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Start chatting' })).toBeInTheDocument();
+  });
+
+  it('renders the secondary Not now button', () => {
+    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Not now' })).toBeInTheDocument();
+  });
+
+  it('POSTs to /api/chat/consent and calls onAccept when primary button is clicked', async () => {
+    mockPost.mockResolvedValueOnce({ ok: true, status: 204 });
+    const onAccept = vi.fn();
+    render(<ConsentModal onAccept={onAccept} onDismiss={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Start chatting' }));
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/api/chat/consent', {});
+      expect(onAccept).toHaveBeenCalled();
+    });
+  });
+
+  it('calls onDismiss when Not now is clicked', () => {
+    const onDismiss = vi.fn();
+    render(<ConsentModal onAccept={vi.fn()} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('disables Start chatting button while posting', async () => {
+    let resolve!: (v: unknown) => void;
+    mockPost.mockReturnValueOnce(new Promise((res) => { resolve = res; }));
+    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Start chatting' }));
+    expect(screen.getByRole('button', { name: 'Start chatting' })).toBeDisabled();
+    resolve({ ok: true, status: 204 });
+  });
+});

--- a/web/src/components/ConsentModal/ConsentModal.tsx
+++ b/web/src/components/ConsentModal/ConsentModal.tsx
@@ -22,7 +22,7 @@ export default function ConsentModal({ onAccept, onDismiss }: Readonly<ConsentMo
   };
 
   return (
-    <div className={sharedStyles.modal} role="dialog" aria-modal="true" aria-labelledby="consent-heading">
+    <dialog open className={styles.dialog} aria-modal="true" aria-labelledby="consent-heading">
       <div className={sharedStyles.modalBackdrop} />
       <div className={sharedStyles.modalCardNarrow}>
         <div className={sharedStyles.modalHeader}>
@@ -54,6 +54,6 @@ export default function ConsentModal({ onAccept, onDismiss }: Readonly<ConsentMo
           </div>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/web/src/components/ConsentModal/ConsentModal.tsx
+++ b/web/src/components/ConsentModal/ConsentModal.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { post } from '../../lib/backend/api';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './ConsentModal.module.css';
+
+interface ConsentModalProps {
+  onAccept: () => void;
+  onDismiss: () => void;
+}
+
+export default function ConsentModal({ onAccept, onDismiss }: Readonly<ConsentModalProps>) {
+  const [pending, setPending] = useState(false);
+
+  const handleAccept = async () => {
+    setPending(true);
+    try {
+      await post('/api/chat/consent', {});
+      onAccept();
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className={sharedStyles.modal} role="dialog" aria-modal="true" aria-labelledby="consent-heading">
+      <div className={sharedStyles.modalBackdrop} />
+      <div className={sharedStyles.modalCardNarrow}>
+        <div className={sharedStyles.modalHeader}>
+          <h2 id="consent-heading" className={sharedStyles.modalHeaderTitle}>
+            Chat sends your messages to Anthropic
+          </h2>
+        </div>
+        <div className={sharedStyles.modalBody}>
+          <p className={styles.body}>
+            Your messages and any files you attach go to Anthropic to generate replies. They aren't used to train models. 20 messages a month on the free plan.
+          </p>
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+              onClick={handleAccept}
+              disabled={pending}
+            >
+              Start chatting
+            </button>
+            <button
+              type="button"
+              className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}
+              onClick={onDismiss}
+              disabled={pending}
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/backend/getUserLocals.ts
+++ b/web/src/lib/backend/getUserLocals.ts
@@ -14,7 +14,7 @@ interface GetUserLocalsResponse {
     };
   };
   linked_email: string;
-  user?: Users & { ankify_welcome_seen?: boolean; trial_started_at?: string | null; email_verified?: boolean; signup_country?: string | null };
+  user?: Users & { ankify_welcome_seen?: boolean; trial_started_at?: string | null; email_verified?: boolean; signup_country?: string | null; chat_consent_at?: string | null };
   features?: {
     kiUI: boolean;
     ops?: boolean;

--- a/web/src/pages/Chat/ChatPage.test.tsx
+++ b/web/src/pages/Chat/ChatPage.test.tsx
@@ -1,12 +1,26 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ChatPage from './ChatPage';
 
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
+function renderChatPage(path = '/chat') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/chat" element={<ChatPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 vi.mock('../../lib/hooks/useUserLocals', () => ({
-  useUserLocals: () => ({ data: { user: { patreon: false } } }),
+  useUserLocals: () => ({
+    data: { user: { patreon: false, chat_consent_at: '2026-01-01T00:00:00.000Z' } },
+    refetch: vi.fn(),
+  }),
 }));
 
 vi.mock('../../lib/backend/api', () => ({
@@ -44,7 +58,7 @@ describe('ChatPage', () => {
   });
 
   it('renders the empty state heading', () => {
-    render(<ChatPage />);
+    renderChatPage();
     expect(screen.getByRole('heading', { name: 'Chat' })).toBeInTheDocument();
   });
 
@@ -64,7 +78,7 @@ describe('ChatPage', () => {
       ])
     );
 
-    render(<ChatPage />);
+    renderChatPage();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
       target: { value: 'Make cards' },
@@ -88,7 +102,7 @@ describe('ChatPage', () => {
       ])
     );
 
-    render(<ChatPage />);
+    renderChatPage();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
       target: { value: 'Explain photosynthesis' },
@@ -115,7 +129,7 @@ describe('ChatPage', () => {
     });
     mockPost.mockResolvedValueOnce({ ok: true, status: 200, body: stream });
 
-    render(<ChatPage />);
+    renderChatPage();
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
       target: { value: 'Make cards' },
     });
@@ -144,7 +158,7 @@ describe('ChatPage', () => {
   });
 
   it('does not collapse short user messages', async () => {
-    render(<ChatPage />);
+    renderChatPage();
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
       target: { value: 'Short message' },
     });
@@ -153,7 +167,7 @@ describe('ChatPage', () => {
   });
 
   it('collapses long user messages and shows expand toggle', () => {
-    render(<ChatPage />);
+    renderChatPage();
     const longContent = 'x'.repeat(601);
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
       target: { value: longContent },
@@ -163,7 +177,7 @@ describe('ChatPage', () => {
   });
 
   it('toggles long message between collapsed and expanded', () => {
-    render(<ChatPage />);
+    renderChatPage();
     const longContent = 'x'.repeat(601);
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
       target: { value: longContent },
@@ -179,7 +193,7 @@ describe('ChatPage', () => {
   it('hydrates usage counter from server on mount', async () => {
     mockGet.mockResolvedValueOnce({ used: 5, limit: 20 });
 
-    render(<ChatPage />);
+    renderChatPage();
 
     await waitFor(() => {
       expect(mockGet).toHaveBeenCalledWith('/api/chat/usage', { redirect: false });
@@ -187,12 +201,12 @@ describe('ChatPage', () => {
   });
 
   it('shows paperclip button in the composer', () => {
-    render(<ChatPage />);
+    renderChatPage();
     expect(screen.getByRole('button', { name: 'Attach files' })).toBeInTheDocument();
   });
 
   it('shows chip when a valid file is attached via input', async () => {
-    render(<ChatPage />);
+    renderChatPage();
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['%PDF-1.4'], 'lecture.pdf', { type: 'application/pdf' });
     Object.defineProperty(input, 'files', { value: [file], configurable: true });
@@ -204,7 +218,7 @@ describe('ChatPage', () => {
   });
 
   it('shows error when file type is not allowed', async () => {
-    render(<ChatPage />);
+    renderChatPage();
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['data'], 'document.docx', { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
     Object.defineProperty(input, 'files', { value: [file], configurable: true });
@@ -216,7 +230,7 @@ describe('ChatPage', () => {
   });
 
   it('removes chip when the remove button is clicked', async () => {
-    render(<ChatPage />);
+    renderChatPage();
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['%PDF-1.4'], 'notes.pdf', { type: 'application/pdf' });
     Object.defineProperty(input, 'files', { value: [file], configurable: true });
@@ -241,7 +255,7 @@ describe('ChatPage', () => {
       ])
     );
 
-    render(<ChatPage />);
+    renderChatPage();
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     const file = new File(['%PDF-1.4'], 'slides.pdf', { type: 'application/pdf' });
     Object.defineProperty(input, 'files', { value: [file], configurable: true });
@@ -267,10 +281,48 @@ describe('ChatPage', () => {
       return Promise.resolve({ conversations: [] });
     });
 
-    render(<ChatPage />);
+    renderChatPage();
 
     await waitFor(() => {
       expect(screen.getByText('1 message left this month — your next send uses it')).toBeInTheDocument();
     });
+  });
+});
+
+describe('ChatPage — query-param handling', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+  });
+
+  it('pre-fills input with filename from query param when from=upload', async () => {
+    renderChatPage('/chat?from=upload&filename=Biology.epub');
+    await waitFor(() => {
+      const textarea = screen.getByRole('textbox', { name: 'Message input' }) as HTMLTextAreaElement;
+      expect(textarea.value).toBe('I tried to convert Biology.epub and got stuck. What can I do?');
+    });
+  });
+
+  it('falls back to "this file" when filename param is absent', async () => {
+    renderChatPage('/chat?from=upload');
+    await waitFor(() => {
+      const textarea = screen.getByRole('textbox', { name: 'Message input' }) as HTMLTextAreaElement;
+      expect(textarea.value).toBe('I tried to convert this file and got stuck. What can I do?');
+    });
+  });
+
+  it('hides starter chips when from=upload', () => {
+    renderChatPage('/chat?from=upload&filename=Notes.pdf');
+    expect(screen.queryByText("Make 10 cards from notes I'll paste")).not.toBeInTheDocument();
+  });
+
+  it('shows starter chips when no from param', () => {
+    renderChatPage('/chat');
+    expect(screen.getByText("Make 10 cards from notes I'll paste")).toBeInTheDocument();
+  });
+
+  it('renders the upload empty-state subhead when from=upload', () => {
+    renderChatPage('/chat?from=upload');
+    expect(screen.getByText("Tell me what's in your file — I'll help you get cards out of it.")).toBeInTheDocument();
   });
 });

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { get, post, postMultipart, patch, del } from '../../lib/backend/api';
+import ConsentModal from '../../components/ConsentModal/ConsentModal';
 import SendIcon from '../../components/icons/SendIcon';
 import AssistantMarkdown from './AssistantMarkdown';
 import CardPreview from './CardPreview';
@@ -31,7 +33,7 @@ interface ApiDonePayload {
 }
 
 interface ApiErrorPayload {
-  type: 'rate_limit' | 'server_error' | 'conversation_not_found';
+  type: 'rate_limit' | 'server_error' | 'conversation_not_found' | 'consent_required';
   resetDate?: string;
 }
 
@@ -145,15 +147,24 @@ function truncateName(name: string, max: number): string {
 }
 
 export default function ChatPage() {
-  const { data: userLocals } = useUserLocals();
+  const { data: userLocals, refetch: refetchUserLocals } = useUserLocals();
   const isPatreon = userLocals?.user?.patreon === true;
+  const hasConsented = userLocals?.user?.chat_consent_at != null;
+  const [showConsentModal, setShowConsentModal] = useState(false);
+
+  const [searchParams] = useSearchParams();
+  const cameFromUpload = searchParams.get('from') === 'upload';
+  const uploadFilename = searchParams.get('filename');
+  const prefilledPrompt = cameFromUpload
+    ? `I tried to convert ${uploadFilename ?? 'this file'} and got stuck. What can I do?`
+    : '';
 
   const [conversations, setConversations] = useState<ConversationSummary[]>([]);
   const [activeConversationId, setActiveConversationId] = useState<number | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [expandedUserMessages, setExpandedUserMessages] = useState<Set<number>>(new Set());
   const [streamingText, setStreamingText] = useState('');
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState(prefilledPrompt);
   const [isLoading, setIsLoading] = useState(false);
   const [networkError, setNetworkError] = useState<string | null>(null);
   const [limitReached, setLimitReached] = useState(false);
@@ -490,6 +501,8 @@ export default function ChatPage() {
             } else if (err.type === 'conversation_not_found') {
               setNetworkError('This conversation is gone. Start a new one.');
               setActiveConversationId(null);
+            } else if (err.type === 'consent_required') {
+              setShowConsentModal(true);
             } else {
               setNetworkError("Couldn't send this message. Try again.");
             }
@@ -555,6 +568,16 @@ export default function ChatPage() {
   const hasMessages = messages.length > 0;
 
   return (
+    <>
+    {(showConsentModal || (!hasConsented && userLocals != null)) && (
+      <ConsentModal
+        onAccept={async () => {
+          await refetchUserLocals();
+          setShowConsentModal(false);
+        }}
+        onDismiss={() => setShowConsentModal(false)}
+      />
+    )}
     <div className={styles.layout}>
       <ConversationsSidebar
         conversations={conversations}
@@ -640,23 +663,27 @@ export default function ChatPage() {
           <div className={styles.emptyState}>
             <h1 className={styles.emptyHeading}>Chat</h1>
             <p className={styles.emptySubhead}>
-              A study assistant. Paste your notes, ask for cards, or work through a concept.
+              {cameFromUpload
+                ? "Tell me what's in your file — I'll help you get cards out of it."
+                : 'A study assistant. Paste your notes, ask for cards, or work through a concept.'}
             </p>
-            <div className={styles.starterChips}>
-              {STARTER_PROMPTS.map((prompt) => (
-                <button
-                  key={prompt}
-                  type="button"
-                  className={styles.starterChip}
-                  onClick={() => {
-                    setInputValue(prompt);
-                    textareaRef.current?.focus();
-                  }}
-                >
-                  {prompt}
-                </button>
-              ))}
-            </div>
+            {!cameFromUpload && (
+              <div className={styles.starterChips}>
+                {STARTER_PROMPTS.map((prompt) => (
+                  <button
+                    key={prompt}
+                    type="button"
+                    className={styles.starterChip}
+                    onClick={() => {
+                      setInputValue(prompt);
+                      textareaRef.current?.focus();
+                    }}
+                  >
+                    {prompt}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         )}
 
@@ -802,5 +829,6 @@ export default function ChatPage() {
         </div>
       </div>
     </div>
+    </>
   );
 }

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -251,4 +251,52 @@ describe('UploadForm analytics events', () => {
 
     expect(gtag).not.toHaveBeenCalledWith('event', 'conversion_success');
   });
+
+  it('shows the chat CTA link in the error state', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 400,
+      text: () => Promise.resolve('Bad request'),
+      headers: new Headers({ 'Content-Type': 'text/plain' }),
+    }));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('a[href*="/chat"]')).not.toBeNull();
+    });
+    const link = container.querySelector('a[href*="/chat"]') as HTMLAnchorElement;
+    expect(link.textContent).toContain('Stuck?');
+    expect(link.href).toContain('from=upload');
+  });
+
+  it('shows the chat CTA link in the empty-deck state', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'X-Card-Count': '0',
+      }),
+      blob: () => Promise.resolve(new Blob(['fake'])),
+    }));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('a[href*="/chat"]')).not.toBeNull();
+    });
+    const link = container.querySelector('a[href*="/chat"]') as HTMLAnchorElement;
+    expect(link.textContent).toContain('Stuck?');
+    expect(link.href).toContain('from=upload');
+    expect(link.href).toContain('reason=empty');
+  });
 });

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -698,6 +698,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
           >
             Try a different file
           </button>
+          <Link to={chatCtaHref('empty')} className={formStyles.resetLink}>
+            Stuck? Ask Claude about this file →
+          </Link>
         </div>
       </div>
     );
@@ -755,6 +758,16 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     </div>
   );
 
+  const currentFilename = (): string =>
+    driveFilename ?? dropboxFilename ?? displayFilename(fileInputRef.current);
+
+  const chatCtaHref = (reason: 'error' | 'empty' | 'unsupported'): string => {
+    const filename = currentFilename();
+    const params = new URLSearchParams({ from: 'upload', reason });
+    if (filename) params.set('filename', filename);
+    return `/chat?${params.toString()}`;
+  };
+
   const renderErrorState = () => (
     <div className={formStyles.stateContent}>
       <WarningIcon className={formStyles.iconError} />
@@ -770,6 +783,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       >
         Try again
       </button>
+      <Link to={chatCtaHref('error')} className={formStyles.resetLink}>
+        Stuck? Ask Claude about this file →
+      </Link>
     </div>
   );
 

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: "Stuck on an upload? Open a chat to figure out what to do with the file", date: '2026-05-16' },
   { type: 'fix', title: 'Google Docs from your Drive convert with headings, bullets, and tables intact', date: '2026-05-16' },
   { type: 'feature', title: 'Google Docs, Sheets, and Slides from your Drive turn straight into decks', date: '2026-05-16' },
   { type: 'fix', title: 'Upload form: Google Drive picks convert into decks instead of erroring', date: '2026-05-16' },


### PR DESCRIPTION
## What

When an upload fails or produces an empty deck, a tertiary link now appears below the primary action: **"Stuck? Ask Claude about this file →"**. Clicking it navigates to `/chat?from=upload&filename=<file>&reason=<error|empty>`, where ChatPage pre-fills the textarea with a contextual prompt and skips the starter-prompt chips. First-time chat users see a one-time consent modal before the first message.

## Why

Failed uploads are a silent exit: the user hits a dead end with no path forward. Linking directly to chat with the filename pre-loaded recovers those sessions and routes users toward the 20-message/month chat funnel — the segment most likely to upgrade. Ties to the 300K-user growth goal by plugging the largest bounce point in the conversion flow.

## How

**Server (3 commits):**
- Migration: `users.chat_consent_at timestamptz nullable` — records when a user first consents to chat.
- `SetChatConsentUseCase` + `ChatConsentController` → `POST /api/chat/consent` (authenticated, returns 204).
- `configureUserLocal` exposes `chat_consent_at` via `res.locals`.
- `ChatController.sendMessage` rejects with SSE `{type: 'consent_required'}` when `chat_consent_at == null`.

**Web (3 commits):**
- `ConsentModal` component — one-time modal shown when `chat_consent_at == null`. POSTs to `/api/chat/consent`, calls `refetchUserLocals` on accept.
- `ChatPage` — reads `useSearchParams`; when `from=upload`, pre-fills textarea with "I tried to convert {filename}...", hides STARTER_PROMPTS chips, shows alternate empty-state subhead. Shows `ConsentModal` for un-consented users.
- `UploadForm` — `renderErrorState` and `renderEmptyDeckState` each get a Link to `/chat?from=upload&filename=...&reason=error|empty`.

## Measuring success

DB query after 7 days:
```sql
SELECT
  COUNT(*) FILTER (WHERE source = 'upload') AS upload_chat_sessions,
  COUNT(*) AS total_chat_sessions
FROM chat_conversations
WHERE created_at >= NOW() - INTERVAL '7 days';
```

Engagement target: ≥10% of upload-error sessions click the CTA and send at least one message.

No analytics events wired in this PR — no analytics layer exists yet. Flagged as follow-up.

## Testing

- Unit tests added:
  - Server: `SetChatConsentUseCase.test.ts` (2), `ChatConsentController.test.ts` (2), `ChatController.test.ts` (+1 consent_required gate test, existing 63 updated for new default)
  - Web: `ConsentModal.test.tsx` (7 tests), `ChatPage.test.tsx` (+5 query-param tests, existing updated for MemoryRouter), `UploadForm.test.tsx` (+2 CTA tests)
- `npx tsc --noEmit` — clean
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web test` — 508 passed
- `pnpm --filter 2anki-web lint` — clean
- Server Jest — 68 new/updated tests pass

## Changelog

`"Stuck on an upload? Open a chat to figure out what to do with the file"` — added to `web/src/pages/WhatsNewPage/changelog.ts`.

## Risks

- `chat_consent_at` column: migration is additive (nullable), no data loss. Rollback: drop column.
- Consent gate in `sendMessage`: all users without `chat_consent_at` get `consent_required` SSE; the modal re-prompts on next load. No data loss.
- `Users.ts` kanel types updated manually (no live DB in CI env); kanel will regenerate on next `pnpm kanel` run. The added fields match exactly what the migration adds.

## Goal alignment

Every bounced upload is an acquired user lost. The chat CTA turns dead ends into recovery sessions and feeds the 20-message/month funnel — the segment most likely to convert to paid. Directly serves the 300K-user growth goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->