### PR TITLE
perf: cache chat system prompt block

### DIFF
--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -410,6 +410,22 @@ describe('ChatUseCase', () => {
     });
   });
 
+  describe('system prompt caching', () => {
+    it('passes system as an array with a cache_control ephemeral block', async () => {
+      const { anthropic, useCase } = buildUseCase('answer');
+
+      await useCase.execute({ user: FREE_USER, content: 'question', conversationHistory: [] });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(Array.isArray(callArg.system)).toBe(true);
+      expect(callArg.system).toHaveLength(1);
+      expect(callArg.system[0]).toMatchObject({
+        type: 'text',
+        cache_control: { type: 'ephemeral' },
+      });
+    });
+  });
+
   describe('ChatRateLimitError', () => {
     it('provides a resetDate as the first of next month', async () => {
       const { messagesRepo, useCase } = buildUseCase('');

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -204,7 +204,7 @@ export class ChatUseCase {
     const stream = this.anthropic.messages.stream({
       model,
       max_tokens: MAX_TOKENS,
-      system: STUDY_ASSISTANT_SYSTEM_PROMPT,
+      system: [{ type: 'text', text: STUDY_ASSISTANT_SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } }],
       messages,
     });
 


### PR DESCRIPTION
## What
Changes the `system` argument in `ChatUseCase` from a plain string to a one-block array with `cache_control: { type: 'ephemeral' }`, enabling Anthropic prompt caching for the chat system prompt.

## Why
The `anthropic-beta: prompt-caching-2024-07-31` header was already set on every request via `getAnthropicClient()`, but the chat use case wasn't opting in — the system prompt (~330 tokens) was being re-ingested on every message turn. The conversion path in `ClaudeService.ts` already used this caching pattern. This is a follow-up cost optimization flagged during the slice 1 feasibility pass for PR #2319.

## How
Single-line change in `ChatUseCase.ts` line 207: wrap `STUDY_ASSISTANT_SYSTEM_PROMPT` in `[{ type: 'text', text: ..., cache_control: { type: 'ephemeral' } }]`. Matches the existing pattern at `ClaudeService.ts:359`.

## Measuring success
Anthropic usage dashboard: `cache_creation_input_tokens` and `cache_read_input_tokens` appear on chat requests (models `claude-haiku-4-5-20251001` and `claude-sonnet-4-6`). A cache hit reduces system-prompt ingestion cost by ~90% per turn. After deploy, verify cache read events appear on chat model requests in the Anthropic dashboard.

## Testing
- Unit test added: `ChatUseCase › system prompt caching › passes system as an array with a cache_control ephemeral block` — asserts `callArg.system` is an array of length 1 with `cache_control: { type: 'ephemeral' }` on the text block.
- All 121 existing ChatUseCase tests pass.
- server `npx tsc --noEmit` — clean.
- web tsc, web vitest (508 tests), web biome lint — all green.

## Changelog
No entry — internal cost optimization, no user-visible behavior change.

## Risks
- If Anthropic changes the system-array contract, this needs updating. Risk is very low; the conversion path has used this pattern stably.
- No rollback needed — falling back to a plain string is a one-line revert with zero user impact.

## Sonar
`SONAR_TOKEN` not configured in this environment. Change is a single-line parameter shape update with no new code paths, no user input, no taint surfaces — sonar bounce is not expected.

## Goal alignment
Reduces per-turn token costs as chat volume grows from the upload-error CTA shipped in PR #2319. Cost savings at scale directly support the 300K-user growth target by keeping per-user LLM cost in check without any behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->