### PR TITLE
feat: ops conversions tab, latency percentiles, re-engagement, messages toggle, signup geography

### DIFF
--- a/src/controllers/ContactMessagesController.ts
+++ b/src/controllers/ContactMessagesController.ts
@@ -23,8 +23,13 @@ class ContactMessagesController {
     if (Number.isNaN(id)) {
       return res.status(400).json({ error: 'Invalid id' });
     }
+    const bodyValue = (req.body as { is_acknowledged?: unknown } | undefined)
+      ?.is_acknowledged;
+    const isAcknowledged = bodyValue === false ? false : true;
     const database = getDatabase();
-    await database('feedback').where({ id }).update({ is_acknowledged: true });
+    await database('feedback')
+      .where({ id })
+      .update({ is_acknowledged: isAcknowledged });
     return res.status(200).send();
   }
 }

--- a/src/data_layer/ObservabilityRepository.ts
+++ b/src/data_layer/ObservabilityRepository.ts
@@ -49,6 +49,14 @@ export interface ServiceErrorRateRow {
   errors: number;
 }
 
+export interface ServiceLatencyRow {
+  service: string;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  count: number;
+}
+
 export interface IObservabilityRepository {
   insertRequestLogs(rows: RequestLogRow[]): Promise<void>;
   insertOutboundCallLogs(rows: OutboundCallLogRow[]): Promise<void>;
@@ -61,6 +69,10 @@ export interface IObservabilityRepository {
     fromTime: Date,
     bucketSeconds: number
   ): Promise<OutboundCallBucketRow[]>;
+  outboundLatencyByService(
+    fromTime: Date,
+    limit: number
+  ): Promise<ServiceLatencyRow[]>;
   errorRateByRoute(fromTime: Date, limit: number): Promise<RouteErrorRateRow[]>;
   errorRateByService(
     fromTime: Date,
@@ -161,6 +173,41 @@ export class ObservabilityRepository implements IObservabilityRepository {
       (r: { bucket: Date; service: string; count: number }) => ({
         bucket: new Date(r.bucket),
         service: r.service,
+        count: Number(r.count),
+      })
+    );
+  }
+
+  async outboundLatencyByService(
+    fromTime: Date,
+    limit: number
+  ): Promise<ServiceLatencyRow[]> {
+    const result = await this.database.raw(
+      `SELECT
+         service,
+         percentile_disc(0.5) WITHIN GROUP (ORDER BY duration_ms)::int AS p50_ms,
+         percentile_disc(0.95) WITHIN GROUP (ORDER BY duration_ms)::int AS p95_ms,
+         percentile_disc(0.99) WITHIN GROUP (ORDER BY duration_ms)::int AS p99_ms,
+         COUNT(*)::int AS count
+       FROM ${this.outboundTable}
+       WHERE created_at >= ?
+       GROUP BY service
+       ORDER BY count DESC
+       LIMIT ?`,
+      [fromTime, limit]
+    );
+    return (result.rows ?? []).map(
+      (r: {
+        service: string;
+        p50_ms: number | null;
+        p95_ms: number | null;
+        p99_ms: number | null;
+        count: number;
+      }) => ({
+        service: r.service,
+        p50_ms: r.p50_ms == null ? 0 : Number(r.p50_ms),
+        p95_ms: r.p95_ms == null ? 0 : Number(r.p95_ms),
+        p99_ms: r.p99_ms == null ? 0 : Number(r.p99_ms),
         count: Number(r.count),
       })
     );

--- a/src/data_layer/ReEngagementFeedbackRepository.test.ts
+++ b/src/data_layer/ReEngagementFeedbackRepository.test.ts
@@ -1,0 +1,129 @@
+import { InMemoryReEngagementFeedbackRepository } from './ReEngagementFeedbackRepository';
+
+describe('InMemoryReEngagementFeedbackRepository', () => {
+  describe('countByReason', () => {
+    it('groups rows by stopped_reason and orders by count desc', async () => {
+      const repo = new InMemoryReEngagementFeedbackRepository();
+      const now = new Date('2026-05-09T12:00:00Z');
+      repo.insert({
+        stopped_reason: 'Switched to another tool',
+        content_type: 'pdf',
+        created_at: now,
+      });
+      repo.insert({
+        stopped_reason: 'Switched to another tool',
+        content_type: 'pdf',
+        created_at: now,
+      });
+      repo.insert({
+        stopped_reason: 'Switched to another tool',
+        content_type: 'notion',
+        created_at: now,
+      });
+      repo.insert({
+        stopped_reason: 'No longer studying',
+        content_type: 'pdf',
+        created_at: now,
+      });
+
+      const result = await repo.countByReason(
+        new Date('2026-01-01T00:00:00Z')
+      );
+
+      expect(result).toEqual([
+        { stopped_reason: 'Switched to another tool', count: 3 },
+        { stopped_reason: 'No longer studying', count: 1 },
+      ]);
+    });
+
+    it('excludes rows older than the since cutoff', async () => {
+      const repo = new InMemoryReEngagementFeedbackRepository();
+      repo.insert({
+        stopped_reason: 'Switched to another tool',
+        content_type: 'pdf',
+        created_at: new Date('2026-01-01T00:00:00Z'),
+      });
+      repo.insert({
+        stopped_reason: 'Switched to another tool',
+        content_type: 'pdf',
+        created_at: new Date('2026-05-01T00:00:00Z'),
+      });
+
+      const result = await repo.countByReason(
+        new Date('2026-04-01T00:00:00Z')
+      );
+
+      expect(result).toEqual([
+        { stopped_reason: 'Switched to another tool', count: 1 },
+      ]);
+    });
+
+    it('returns an empty array when nothing matches', async () => {
+      const repo = new InMemoryReEngagementFeedbackRepository();
+      const result = await repo.countByReason(new Date('2026-01-01T00:00:00Z'));
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('recentComments', () => {
+    it('returns only rows with non-empty comment, newest first, capped to limit', async () => {
+      const repo = new InMemoryReEngagementFeedbackRepository();
+      repo.insert({
+        stopped_reason: 'Other',
+        content_type: 'pdf',
+        comment: 'first',
+        created_at: new Date('2026-05-01T00:00:00Z'),
+      });
+      repo.insert({
+        stopped_reason: 'Other',
+        content_type: 'pdf',
+        comment: 'second',
+        created_at: new Date('2026-05-05T00:00:00Z'),
+      });
+      repo.insert({
+        stopped_reason: 'Other',
+        content_type: 'notion',
+        comment: 'third',
+        created_at: new Date('2026-05-09T00:00:00Z'),
+      });
+      repo.insert({
+        stopped_reason: 'No longer studying',
+        content_type: 'pdf',
+        created_at: new Date('2026-05-09T00:00:00Z'),
+      });
+      repo.insert({
+        stopped_reason: 'Other',
+        content_type: 'pdf',
+        comment: '',
+        created_at: new Date('2026-05-09T00:00:00Z'),
+      });
+
+      const result = await repo.recentComments(2);
+
+      expect(result).toEqual([
+        {
+          stopped_reason: 'Other',
+          content_type: 'notion',
+          comment: 'third',
+          created_at: '2026-05-09T00:00:00.000Z',
+        },
+        {
+          stopped_reason: 'Other',
+          content_type: 'pdf',
+          comment: 'second',
+          created_at: '2026-05-05T00:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('returns an empty array when no rows have a comment', async () => {
+      const repo = new InMemoryReEngagementFeedbackRepository();
+      repo.insert({
+        stopped_reason: 'No longer studying',
+        content_type: 'pdf',
+      });
+      const result = await repo.recentComments(20);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/data_layer/ReEngagementFeedbackRepository.ts
+++ b/src/data_layer/ReEngagementFeedbackRepository.ts
@@ -1,0 +1,137 @@
+import type { Knex } from 'knex';
+
+export interface ReEngagementReasonCount {
+  stopped_reason: string;
+  count: number;
+}
+
+export interface ReEngagementCommentEntry {
+  stopped_reason: string;
+  content_type: string;
+  comment: string;
+  created_at: string;
+}
+
+export interface IReEngagementFeedbackRepository {
+  countByReason(since: Date): Promise<ReEngagementReasonCount[]>;
+  recentComments(limit: number): Promise<ReEngagementCommentEntry[]>;
+}
+
+interface ReasonRow {
+  stopped_reason: string;
+  count: string | number;
+}
+
+interface CommentRow {
+  stopped_reason: string;
+  content_type: string;
+  comment: string;
+  created_at: Date | string;
+}
+
+const toIso = (value: Date | string): string =>
+  typeof value === 'string' ? value : value.toISOString();
+
+export class ReEngagementFeedbackRepository
+  implements IReEngagementFeedbackRepository
+{
+  private readonly table = 're_engagement_feedback';
+
+  constructor(private readonly database: Knex) {}
+
+  async countByReason(since: Date): Promise<ReEngagementReasonCount[]> {
+    const rows = await this.database(this.table)
+      .select('stopped_reason')
+      .count<ReasonRow[]>('* as count')
+      .where('created_at', '>=', since)
+      .groupBy('stopped_reason')
+      .orderBy('count', 'desc');
+    return rows.map((row) => ({
+      stopped_reason: row.stopped_reason,
+      count: Number(row.count),
+    }));
+  }
+
+  async recentComments(limit: number): Promise<ReEngagementCommentEntry[]> {
+    const rows = await this.database<CommentRow>(this.table)
+      .select('stopped_reason', 'content_type', 'comment', 'created_at')
+      .whereNotNull('comment')
+      .andWhere('comment', '!=', '')
+      .orderBy('created_at', 'desc')
+      .limit(limit);
+    return rows.map((row) => ({
+      stopped_reason: row.stopped_reason,
+      content_type: row.content_type,
+      comment: row.comment,
+      created_at: toIso(row.created_at),
+    }));
+  }
+}
+
+export class InMemoryReEngagementFeedbackRepository
+  implements IReEngagementFeedbackRepository
+{
+  private readonly rows: Array<{
+    stopped_reason: string;
+    content_type: string;
+    comment: string | null;
+    created_at: Date;
+  }> = [];
+
+  insert(row: {
+    stopped_reason: string;
+    content_type: string;
+    comment?: string | null;
+    created_at?: Date;
+  }): void {
+    this.rows.push({
+      stopped_reason: row.stopped_reason,
+      content_type: row.content_type,
+      comment: row.comment ?? null,
+      created_at: row.created_at ?? new Date(),
+    });
+  }
+
+  async countByReason(since: Date): Promise<ReEngagementReasonCount[]> {
+    const counts = new Map<string, number>();
+    for (const row of this.rows) {
+      if (row.created_at >= since) {
+        counts.set(
+          row.stopped_reason,
+          (counts.get(row.stopped_reason) ?? 0) + 1
+        );
+      }
+    }
+    return Array.from(counts.entries())
+      .map(([stopped_reason, count]) => ({ stopped_reason, count }))
+      .sort((a, b) => b.count - a.count);
+  }
+
+  async recentComments(limit: number): Promise<ReEngagementCommentEntry[]> {
+    return this.rows
+      .filter(
+        (
+          r
+        ): r is {
+          stopped_reason: string;
+          content_type: string;
+          comment: string;
+          created_at: Date;
+        } => r.comment != null && r.comment !== ''
+      )
+      .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+      .slice(0, limit)
+      .map((r) => ({
+        stopped_reason: r.stopped_reason,
+        content_type: r.content_type,
+        comment: r.comment,
+        created_at: r.created_at.toISOString(),
+      }));
+  }
+
+  clear(): void {
+    this.rows.length = 0;
+  }
+}
+
+export default ReEngagementFeedbackRepository;

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -4,6 +4,18 @@ import Users from './public/Users';
 import Subscriptions from './public/Subscriptions';
 import { isNewMonth } from '../lib/User/isNewMonth';
 
+export interface SignupCountryCount {
+  country: string;
+  count: number;
+}
+
+export interface ISignupCountryRepository {
+  countBySignupCountry(
+    since: Date,
+    limit: number
+  ): Promise<SignupCountryCount[]>;
+}
+
 class UsersRepository {
   table: string;
 
@@ -229,6 +241,24 @@ class UsersRepository {
       .count<{ signup_country: string; count: string }[]>('* as count')
       .groupBy('signup_country')
       .orderBy('count', 'desc');
+  }
+
+  async countBySignupCountry(
+    since: Date,
+    limit: number
+  ): Promise<{ country: string; count: number }[]> {
+    const rows = (await this.database(this.table)
+      .whereNotNull('signup_country')
+      .where('created_at', '>=', since)
+      .select('signup_country')
+      .count<{ signup_country: string; count: string }[]>('* as count')
+      .groupBy('signup_country')
+      .orderBy('count', 'desc')
+      .limit(limit)) as { signup_country: string; count: string }[];
+    return rows.map((row) => ({
+      country: row.signup_country,
+      count: Number(row.count),
+    }));
   }
 
   incrementCardUsage(id: string | number, cardCount: number) {

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -15,6 +15,8 @@ import { PerformanceMetricsService } from '../services/ops/PerformanceMetricsSer
 import { BusinessMetricsCacheRepository } from '../data_layer/BusinessMetricsCacheRepository';
 import { CancellationFeedbackRepository } from '../data_layer/CancellationFeedbackRepository';
 import { EmojiFeedbackRepository } from '../data_layer/EmojiFeedbackRepository';
+import { ReEngagementFeedbackRepository } from '../data_layer/ReEngagementFeedbackRepository';
+import UsersRepository from '../data_layer/UsersRepository';
 import { ShowcaseRepository } from '../data_layer/ShowcaseRepository';
 import DownloadRepository from '../data_layer/DownloadRepository';
 import NotionRepository from '../data_layer/NotionRespository';
@@ -37,6 +39,8 @@ const OpsRouter = () => {
     cacheRepository: new BusinessMetricsCacheRepository(database),
     cancellationRepository: new CancellationFeedbackRepository(database),
     emojiFeedbackRepository: new EmojiFeedbackRepository(database),
+    reengagementRepository: new ReEngagementFeedbackRepository(database),
+    signupCountryRepository: new UsersRepository(database),
   });
 
   const conversionMetricsService = new ConversionMetricsService(database);

--- a/src/routes/middleware/requestLoggingMiddleware.test.ts
+++ b/src/routes/middleware/requestLoggingMiddleware.test.ts
@@ -21,6 +21,7 @@ class FakeRepo implements IObservabilityRepository {
   aggregateInboundByStatusClass = async () => [];
   topRoutesByLatency = async () => [];
   aggregateOutboundByService = async () => [];
+  outboundLatencyByService = async () => [];
   errorRateByRoute = async () => [];
   errorRateByService = async () => [];
 }

--- a/src/services/observability/FEATURE.md
+++ b/src/services/observability/FEATURE.md
@@ -16,6 +16,7 @@ Express controllers used to call `axios.get(...)` directly with user-controlled 
 - `OBSERVABILITY_SERVICES` — frozen list. Adding a new outbound integration means **adding it here first**, then writing the wrapper.
 - `FIXED_HOST_ALLOWLIST` — per-service host pin. Set to `null` for services that need wildcard hosts (e.g. Notion's per-tenant CDNs); set to an explicit list for services that only ever talk to one or two endpoints.
 - `getObservabilitySink()` / `ObservabilitySinkInstance` — singleton sink. The query service (`ObservabilityQueryService`) reads from it.
+- `ObservabilityQueryService.getMetrics(window)` — read API for `/ops`. Aggregates inbound volume + route latency, outbound volume + per-service latency percentiles (p50/p95/p99), and route/service error rates over a `1h | 24h | 7d` window. Adding a new aggregation means extending `IObservabilityRepository`, the `OpsMetricsResponse` shape, and the engineering tab in one PR.
 
 ## Adding a new service
 

--- a/src/services/observability/ObservabilityQueryService.test.ts
+++ b/src/services/observability/ObservabilityQueryService.test.ts
@@ -12,12 +12,14 @@ import {
   OutboundCallBucketRow,
   RouteErrorRateRow,
   ServiceErrorRateRow,
+  ServiceLatencyRow,
 } from '../../data_layer/ObservabilityRepository';
 
 class StubRepo implements IObservabilityRepository {
   inboundBuckets: AggregatedRequestRow[] = [];
   routeLatency: RouteLatencyRow[] = [];
   outboundBuckets: OutboundCallBucketRow[] = [];
+  outboundLatency: ServiceLatencyRow[] = [];
   routeErrors: RouteErrorRateRow[] = [];
   serviceErrors: ServiceErrorRateRow[] = [];
   capturedFromTime: Date | null = null;
@@ -34,6 +36,8 @@ class StubRepo implements IObservabilityRepository {
   topRoutesByLatency = async (_fromTime: Date, _limit: number) => this.routeLatency;
   aggregateOutboundByService = async (_fromTime: Date, _bucketSeconds: number) =>
     this.outboundBuckets;
+  outboundLatencyByService = async (_fromTime: Date, _limit: number) =>
+    this.outboundLatency;
   errorRateByRoute = async (_fromTime: Date, _limit: number) => this.routeErrors;
   errorRateByService = async (_fromTime: Date, _limit: number) => this.serviceErrors;
 }
@@ -77,6 +81,10 @@ describe('ObservabilityQueryService', () => {
     ];
     repo.outboundBuckets = [
       { bucket: new Date('2026-05-09T10:00:00Z'), service: 'notion', count: 4 },
+    ];
+    repo.outboundLatency = [
+      { service: 'notion', p50_ms: 110, p95_ms: 460, p99_ms: 820, count: 250 },
+      { service: 'claude', p50_ms: 380, p95_ms: 1200, p99_ms: 2100, count: 90 },
     ];
     repo.routeErrors = [
       { method: 'GET', route: '/api/upload', total: 100, errors: 3 },
@@ -124,5 +132,9 @@ describe('ObservabilityQueryService', () => {
       total: 50,
       errors: 2,
     });
+    expect(result.outbound_latency_by_service).toEqual([
+      { service: 'notion', p50_ms: 110, p95_ms: 460, p99_ms: 820, count: 250 },
+      { service: 'claude', p50_ms: 380, p95_ms: 1200, p99_ms: 2100, count: 90 },
+    ]);
   });
 });

--- a/src/services/observability/ObservabilityQueryService.ts
+++ b/src/services/observability/ObservabilityQueryService.ts
@@ -22,6 +22,7 @@ export const OPS_METRICS_BUCKET_SECONDS_BY_WINDOW: Record<OpsMetricsWindow, numb
 const TOP_ROUTES_LIMIT = 15;
 const TOP_ROUTES_ERROR_LIMIT = 10;
 const TOP_SERVICES_ERROR_LIMIT = 5;
+const TOP_SERVICES_LATENCY_LIMIT = 10;
 
 export interface OpsMetricsBucketPoint {
   bucket: string;
@@ -56,6 +57,14 @@ export interface OpsMetricsServiceErrorPoint {
   errors: number;
 }
 
+export interface OpsMetricsServiceLatencyPoint {
+  service: string;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  count: number;
+}
+
 export interface OpsMetricsResponse {
   window: OpsMetricsWindow;
   bucket_seconds: number;
@@ -63,6 +72,7 @@ export interface OpsMetricsResponse {
   inbound_volume: OpsMetricsBucketPoint[];
   route_latency: OpsMetricsRouteLatencyPoint[];
   outbound_volume: OpsMetricsOutboundPoint[];
+  outbound_latency_by_service: OpsMetricsServiceLatencyPoint[];
   error_rate_by_route: OpsMetricsRouteErrorPoint[];
   error_rate_by_service: OpsMetricsServiceErrorPoint[];
 }
@@ -82,14 +92,24 @@ export class ObservabilityQueryService {
     const bucketSeconds = OPS_METRICS_BUCKET_SECONDS_BY_WINDOW[window];
     const fromTime = new Date(Date.now() - rangeMs);
 
-    const [inbound, latency, outbound, routeErrors, serviceErrors] =
-      await Promise.all([
-        this.repository.aggregateInboundByStatusClass(fromTime, bucketSeconds),
-        this.repository.topRoutesByLatency(fromTime, TOP_ROUTES_LIMIT),
-        this.repository.aggregateOutboundByService(fromTime, bucketSeconds),
-        this.repository.errorRateByRoute(fromTime, TOP_ROUTES_ERROR_LIMIT),
-        this.repository.errorRateByService(fromTime, TOP_SERVICES_ERROR_LIMIT),
-      ]);
+    const [
+      inbound,
+      latency,
+      outbound,
+      outboundLatency,
+      routeErrors,
+      serviceErrors,
+    ] = await Promise.all([
+      this.repository.aggregateInboundByStatusClass(fromTime, bucketSeconds),
+      this.repository.topRoutesByLatency(fromTime, TOP_ROUTES_LIMIT),
+      this.repository.aggregateOutboundByService(fromTime, bucketSeconds),
+      this.repository.outboundLatencyByService(
+        fromTime,
+        TOP_SERVICES_LATENCY_LIMIT
+      ),
+      this.repository.errorRateByRoute(fromTime, TOP_ROUTES_ERROR_LIMIT),
+      this.repository.errorRateByService(fromTime, TOP_SERVICES_ERROR_LIMIT),
+    ]);
 
     return {
       window,
@@ -110,6 +130,13 @@ export class ObservabilityQueryService {
       outbound_volume: outbound.map((row) => ({
         bucket: row.bucket.toISOString(),
         service: row.service,
+        count: row.count,
+      })),
+      outbound_latency_by_service: outboundLatency.map((row) => ({
+        service: row.service,
+        p50_ms: row.p50_ms,
+        p95_ms: row.p95_ms,
+        p99_ms: row.p99_ms,
         count: row.count,
       })),
       error_rate_by_route: routeErrors.map((row) => ({

--- a/src/services/observability/ObservabilitySink.test.ts
+++ b/src/services/observability/ObservabilitySink.test.ts
@@ -29,6 +29,7 @@ class FakeRepo implements IObservabilityRepository {
   aggregateInboundByStatusClass = async () => [];
   topRoutesByLatency = async () => [];
   aggregateOutboundByService = async () => [];
+  outboundLatencyByService = async () => [];
   errorRateByRoute = async () => [];
   errorRateByService = async () => [];
 }

--- a/src/services/observability/instrumentedAxios.test.ts
+++ b/src/services/observability/instrumentedAxios.test.ts
@@ -51,6 +51,7 @@ class FakeRepo implements IObservabilityRepository {
   aggregateInboundByStatusClass = async () => [];
   topRoutesByLatency = async () => [];
   aggregateOutboundByService = async () => [];
+  outboundLatencyByService = async () => [];
   errorRateByRoute = async () => [];
   errorRateByService = async () => [];
 }

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -19,6 +19,16 @@ import {
   IEmojiFeedbackRepository,
   InMemoryEmojiFeedbackRepository,
 } from '../../data_layer/EmojiFeedbackRepository';
+import {
+  IReEngagementFeedbackRepository,
+  InMemoryReEngagementFeedbackRepository,
+  ReEngagementCommentEntry,
+  ReEngagementReasonCount,
+} from '../../data_layer/ReEngagementFeedbackRepository';
+import {
+  ISignupCountryRepository,
+  SignupCountryCount,
+} from '../../data_layer/UsersRepository';
 
 export type BusinessMetricKey =
   | 'mrr_usd'
@@ -34,7 +44,10 @@ export type BusinessMetricKey =
   | 'cancellation_reasons_top'
   | 'cancellation_comments_recent'
   | 'emoji_feedback_ratings'
-  | 'emoji_feedback_comments';
+  | 'emoji_feedback_comments'
+  | 'reengagement_reasons_top'
+  | 'reengagement_comments_recent'
+  | 'signup_countries_90d';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -77,6 +90,9 @@ export interface BusinessMetricsResponse {
   cancellation_comments_recent: CancellationCommentEntry[] | null;
   emoji_feedback_ratings: EmojiFeedbackRatingCount[] | null;
   emoji_feedback_comments: EmojiFeedbackCommentEntry[] | null;
+  reengagement_reasons_top: ReEngagementReasonCount[] | null;
+  reengagement_comments_recent: ReEngagementCommentEntry[] | null;
+  signup_countries_90d: SignupCountryCount[] | null;
   as_of: string;
   cache_age_seconds: number;
   errors?: BusinessMetricError[];
@@ -87,6 +103,10 @@ export const CANCELLATION_REASONS_LOOKBACK_DAYS = 90;
 export const CANCELLATION_COMMENTS_LIMIT = 20;
 export const EMOJI_FEEDBACK_LOOKBACK_DAYS = 30;
 export const EMOJI_FEEDBACK_COMMENTS_LIMIT = 20;
+export const REENGAGEMENT_REASONS_LOOKBACK_DAYS = 90;
+export const REENGAGEMENT_COMMENTS_LIMIT = 20;
+export const SIGNUP_COUNTRIES_LOOKBACK_DAYS = 90;
+export const SIGNUP_COUNTRIES_LIMIT = 10;
 
 interface BusinessMetricsServiceDeps {
   stripeFactory?: () => Stripe;
@@ -94,6 +114,8 @@ interface BusinessMetricsServiceDeps {
   cacheRepository?: IBusinessMetricsCacheRepository;
   cancellationRepository?: ICancellationFeedbackRepository;
   emojiFeedbackRepository?: IEmojiFeedbackRepository;
+  reengagementRepository?: IReEngagementFeedbackRepository;
+  signupCountryRepository?: ISignupCountryRepository;
 }
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
@@ -135,6 +157,10 @@ export class BusinessMetricsService {
 
   private readonly emojiFeedbackRepository: IEmojiFeedbackRepository;
 
+  private readonly reengagementRepository: IReEngagementFeedbackRepository;
+
+  private readonly signupCountryRepository: ISignupCountryRepository | null;
+
   private allSubsPromise: Promise<NormalizedSubscription[]> | null = null;
 
   private invoicesPromise: Promise<NormalizedInvoice[]> | null = null;
@@ -150,6 +176,10 @@ export class BusinessMetricsService {
     this.emojiFeedbackRepository =
       deps.emojiFeedbackRepository ??
       new InMemoryEmojiFeedbackRepository();
+    this.reengagementRepository =
+      deps.reengagementRepository ??
+      new InMemoryReEngagementFeedbackRepository();
+    this.signupCountryRepository = deps.signupCountryRepository ?? null;
   }
 
   async getMetrics(): Promise<BusinessMetricsResponse> {
@@ -239,6 +269,38 @@ export class BusinessMetricsService {
             EMOJI_FEEDBACK_COMMENTS_LIMIT
           ),
       },
+      {
+        key: 'reengagement_reasons_top',
+        fetch: () =>
+          this.reengagementRepository.countByReason(
+            new Date(
+              now.getTime() -
+                REENGAGEMENT_REASONS_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
+            )
+          ),
+      },
+      {
+        key: 'reengagement_comments_recent',
+        fetch: () =>
+          this.reengagementRepository.recentComments(
+            REENGAGEMENT_COMMENTS_LIMIT
+          ),
+      },
+      ...(this.signupCountryRepository != null
+        ? [
+            {
+              key: 'signup_countries_90d' as BusinessMetricKey,
+              fetch: () =>
+                this.signupCountryRepository!.countBySignupCountry(
+                  new Date(
+                    now.getTime() -
+                      SIGNUP_COUNTRIES_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
+                  ),
+                  SIGNUP_COUNTRIES_LIMIT
+                ),
+            },
+          ]
+        : []),
     ];
 
     const usedEntries: BusinessMetricsCacheEntry[] = [];
@@ -301,6 +363,15 @@ export class BusinessMetricsService {
       ) as CancellationCommentEntry[] | null,
       emoji_feedback_ratings: valueByKey.get('emoji_feedback_ratings') as EmojiFeedbackRatingCount[] | null,
       emoji_feedback_comments: valueByKey.get('emoji_feedback_comments') as EmojiFeedbackCommentEntry[] | null,
+      reengagement_reasons_top: valueByKey.get(
+        'reengagement_reasons_top'
+      ) as ReEngagementReasonCount[] | null,
+      reengagement_comments_recent: valueByKey.get(
+        'reengagement_comments_recent'
+      ) as ReEngagementCommentEntry[] | null,
+      signup_countries_90d: valueByKey.has('signup_countries_90d')
+        ? (valueByKey.get('signup_countries_90d') as SignupCountryCount[] | null)
+        : null,
       as_of: now.toISOString(),
       cache_age_seconds: cacheAgeSeconds,
     };

--- a/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
+++ b/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
@@ -21,6 +21,9 @@ describe('GetBusinessMetricsUseCase', () => {
       cancellation_comments_recent: [],
       emoji_feedback_ratings: [],
       emoji_feedback_comments: [],
+      reengagement_reasons_top: [],
+      reengagement_comments_recent: [],
+      signup_countries_90d: [],
       as_of: '2026-05-09T14:32:07.000Z',
       cache_age_seconds: 412,
     };

--- a/src/usecases/ops/GetOpsMetricsUseCase.test.ts
+++ b/src/usecases/ops/GetOpsMetricsUseCase.test.ts
@@ -11,6 +11,7 @@ class StubRepo implements IObservabilityRepository {
   aggregateInboundByStatusClass = async () => [];
   topRoutesByLatency = async () => [];
   aggregateOutboundByService = async () => [];
+  outboundLatencyByService = async () => [];
   errorRateByRoute = async () => [];
   errorRateByService = async () => [];
 }
@@ -45,6 +46,7 @@ describe('GetOpsMetricsUseCase', () => {
       inbound_volume: [],
       route_latency: [],
       outbound_volume: [],
+      outbound_latency_by_service: [],
       error_rate_by_route: [],
       error_rate_by_service: [],
     } as OpsMetricsResponse;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,6 +50,7 @@ const AnkifyHistoryPage = lazy(
 const OpsLayout = lazy(() => import('./pages/OpsPage/OpsLayout'));
 const EngineeringTab = lazy(() => import('./pages/OpsPage/EngineeringTab'));
 const PerformanceTab = lazy(() => import('./pages/OpsPage/PerformanceTab'));
+const ConversionsTab = lazy(() => import('./pages/OpsPage/ConversionsTab'));
 const BusinessTab = lazy(() => import('./pages/OpsPage/BusinessTab'));
 const ShowcaseTab = lazy(() => import('./pages/OpsPage/ShowcaseTab'));
 const InterviewsTab = lazy(() => import('./pages/OpsPage/InterviewsTab'));
@@ -223,6 +224,7 @@ function AppContent({
           <Route path="/ops" element={requireAuth(<OpsLayout />)}>
             <Route index element={<EngineeringTab />} />
             <Route path="performance" element={<PerformanceTab />} />
+            <Route path="conversions" element={<ConversionsTab />} />
             <Route path="business" element={<BusinessTab />} />
             <Route path="showcase" element={<ShowcaseTab />} />
             <Route path="interviews" element={<InterviewsTab />} />

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -808,10 +808,18 @@ export class Backend {
     return get(`${this.baseURL}ops/contact-messages`);
   }
 
-  async acknowledgeContactMessage(id: number): Promise<void> {
+  async acknowledgeContactMessage(
+    id: number,
+    isAcknowledged = true
+  ): Promise<void> {
     const response = await fetch(
       `${this.baseURL}ops/contact-messages/${id}/acknowledge`,
-      { method: 'PATCH', credentials: 'include' }
+      {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_acknowledged: isAcknowledged }),
+      }
     );
     if (!response.ok) {
       throw new Error('Failed to acknowledge message');

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -70,6 +70,23 @@ const buildSampleMetrics = (
       created_at: '2026-05-08T12:00:00.000Z',
     },
   ],
+  reengagement_reasons_top: [
+    { stopped_reason: 'Switched to another tool', count: 6 },
+    { stopped_reason: 'No longer studying', count: 3 },
+  ],
+  reengagement_comments_recent: [
+    {
+      stopped_reason: 'Switched to another tool',
+      content_type: 'pdf',
+      comment: 'I moved to RemNote',
+      created_at: '2026-05-07T09:00:00.000Z',
+    },
+  ],
+  signup_countries_90d: [
+    { country: 'NO', count: 240 },
+    { country: 'DE', count: 180 },
+    { country: 'US', count: 95 },
+  ],
   as_of: '2026-05-09T14:32:07.000Z',
   cache_age_seconds: 412,
   ...overrides,
@@ -144,6 +161,15 @@ describe('BusinessTab', () => {
     expect(
       screen.getByText('Recent cancellation comments')
     ).toBeInTheDocument();
+    expect(
+      screen.getByText('Why people stop, last 90 days')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Recent re-engagement comments')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Signups by country, last 90 days')
+    ).toBeInTheDocument();
   });
 
   test('shows ChartPanel empty state when time-series arrays are empty', async () => {
@@ -159,6 +185,9 @@ describe('BusinessTab', () => {
           failed_payments_weekly: [],
           cancellation_reasons_top: [],
           cancellation_comments_recent: [],
+          reengagement_reasons_top: [],
+          reengagement_comments_recent: [],
+          signup_countries_90d: [],
         }),
     });
 
@@ -178,6 +207,15 @@ describe('BusinessTab', () => {
       screen.getByText('No cancellations recorded yet.')
     ).toBeInTheDocument();
     expect(screen.getByText('No free-text comments yet.')).toBeInTheDocument();
+    expect(
+      screen.getByText('No re-engagement feedback recorded yet.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('No re-engagement comments yet.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('No countries captured yet.')
+    ).toBeInTheDocument();
   });
 
   test('renders cancellation comment text from the response', async () => {

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -18,6 +18,9 @@ import EmojiFeedbackCommentsList from './charts/EmojiFeedbackCommentsList';
 import ConversionsChurnChart from './charts/ConversionsChurnChart';
 import FailedPaymentsWeeklyChart from './charts/FailedPaymentsWeeklyChart';
 import MrrTimeseriesChart from './charts/MrrTimeseriesChart';
+import ReEngagementCommentsList from './charts/ReEngagementCommentsList';
+import ReEngagementReasonsChart from './charts/ReEngagementReasonsChart';
+import SignupCountriesChart from './charts/SignupCountriesChart';
 import styles from './OpsPage.module.css';
 import { useBusinessMetrics } from './useBusinessMetrics';
 
@@ -129,95 +132,201 @@ export default function BusinessTab() {
         />
       </div>
 
-      <div className={styles.grid}>
-        <ChartPanel
-          title="MRR, last 90 days"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.mrr_timeseries?.length ?? 0) === 0}
-          emptyText="No MRR history yet."
-        >
-          <MrrTimeseriesChart points={visible?.mrr_timeseries ?? []} />
-        </ChartPanel>
+      <section
+        className={styles.section}
+        aria-labelledby="biz-section-revenue"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="biz-section-revenue" className={styles.sectionTitle}>
+            Revenue & subscriptions
+          </h2>
+          <p className={styles.sectionHint}>MRR, active subs, churn, failed payments</p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title="MRR, last 90 days"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.mrr_timeseries?.length ?? 0) === 0}
+            emptyText="No MRR history yet."
+          >
+            <MrrTimeseriesChart points={visible?.mrr_timeseries ?? []} />
+          </ChartPanel>
 
-        <ChartPanel
-          title="Active paying subs, last 90 days"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.active_subs_timeseries?.length ?? 0) === 0}
-          emptyText="No active-subs history yet."
-        >
-          <ActiveSubsTimeseriesChart
-            points={visible?.active_subs_timeseries ?? []}
-          />
-        </ChartPanel>
+          <ChartPanel
+            title="Active paying subs, last 90 days"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.active_subs_timeseries?.length ?? 0) === 0}
+            emptyText="No active-subs history yet."
+          >
+            <ActiveSubsTimeseriesChart
+              points={visible?.active_subs_timeseries ?? []}
+            />
+          </ChartPanel>
 
-        <ChartPanel
-          title="New vs churned, last 12 weeks"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.conversions_vs_churn_weekly?.length ?? 0) === 0}
-          emptyText="No subscription movements yet."
-        >
-          <ConversionsChurnChart
-            points={visible?.conversions_vs_churn_weekly ?? []}
-          />
-        </ChartPanel>
+          <ChartPanel
+            title="New vs churned, last 12 weeks"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.conversions_vs_churn_weekly?.length ?? 0) === 0}
+            emptyText="No subscription movements yet."
+          >
+            <ConversionsChurnChart
+              points={visible?.conversions_vs_churn_weekly ?? []}
+            />
+          </ChartPanel>
 
-        <ChartPanel
-          title="Failed payments, last 12 weeks"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.failed_payments_weekly?.length ?? 0) === 0}
-          emptyText="No failed payments in this window."
-        >
-          <FailedPaymentsWeeklyChart
-            points={visible?.failed_payments_weekly ?? []}
-          />
-        </ChartPanel>
+          <ChartPanel
+            title="Failed payments, last 12 weeks"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.failed_payments_weekly?.length ?? 0) === 0}
+            emptyText="No failed payments in this window."
+          >
+            <FailedPaymentsWeeklyChart
+              points={visible?.failed_payments_weekly ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
 
-        <ChartPanel
-          title="Why users cancel, last 90 days"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.cancellation_reasons_top?.length ?? 0) === 0}
-          emptyText="No cancellations recorded yet."
-        >
-          <CancellationReasonsChart
-            points={visible?.cancellation_reasons_top ?? []}
-          />
-        </ChartPanel>
+      <section
+        className={styles.section}
+        aria-labelledby="biz-section-cancellations"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="biz-section-cancellations" className={styles.sectionTitle}>
+            Why users cancel
+          </h2>
+          <p className={styles.sectionHint}>Cancel-survey reasons and comments</p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title="Why users cancel, last 90 days"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.cancellation_reasons_top?.length ?? 0) === 0}
+            emptyText="No cancellations recorded yet."
+          >
+            <CancellationReasonsChart
+              points={visible?.cancellation_reasons_top ?? []}
+            />
+          </ChartPanel>
 
-        <ChartPanel
-          title="Recent cancellation comments"
-          subtitle="Latest free-text feedback from the cancel survey"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.cancellation_comments_recent?.length ?? 0) === 0}
-          emptyText="No free-text comments yet."
-        >
-          <CancellationCommentsList
-            points={visible?.cancellation_comments_recent ?? []}
-          />
-        </ChartPanel>
+          <ChartPanel
+            title="Recent cancellation comments"
+            subtitle="Latest free-text feedback from the cancel survey"
+            isLoading={showInitialSkeleton}
+            isEmpty={
+              (visible?.cancellation_comments_recent?.length ?? 0) === 0
+            }
+            emptyText="No free-text comments yet."
+          >
+            <CancellationCommentsList
+              points={visible?.cancellation_comments_recent ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
 
-        <ChartPanel
-          title="Emoji feedback, last 30 days"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.emoji_feedback_ratings?.length ?? 0) === 0}
-          emptyText="No emoji feedback yet."
-        >
-          <EmojiFeedbackChart
-            points={visible?.emoji_feedback_ratings ?? []}
-          />
-        </ChartPanel>
+      <section
+        className={styles.section}
+        aria-labelledby="biz-section-reengagement"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="biz-section-reengagement" className={styles.sectionTitle}>
+            Re-engagement feedback
+          </h2>
+          <p className={styles.sectionHint}>
+            Why people stop engaging after a re-engagement email
+          </p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title="Why people stop, last 90 days"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.reengagement_reasons_top?.length ?? 0) === 0}
+            emptyText="No re-engagement feedback recorded yet."
+          >
+            <ReEngagementReasonsChart
+              points={visible?.reengagement_reasons_top ?? []}
+            />
+          </ChartPanel>
 
-        <ChartPanel
-          title="Recent feedback comments"
-          subtitle="Latest text feedback from the emoji widget"
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.emoji_feedback_comments?.length ?? 0) === 0}
-          emptyText="No feedback comments yet."
-        >
-          <EmojiFeedbackCommentsList
-            points={visible?.emoji_feedback_comments ?? []}
-          />
-        </ChartPanel>
-      </div>
+          <ChartPanel
+            title="Recent re-engagement comments"
+            subtitle="Latest free-text feedback after a re-engagement email"
+            isLoading={showInitialSkeleton}
+            isEmpty={
+              (visible?.reengagement_comments_recent?.length ?? 0) === 0
+            }
+            emptyText="No re-engagement comments yet."
+          >
+            <ReEngagementCommentsList
+              points={visible?.reengagement_comments_recent ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
+
+      <section
+        className={styles.section}
+        aria-labelledby="biz-section-emoji"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="biz-section-emoji" className={styles.sectionTitle}>
+            Emoji feedback
+          </h2>
+          <p className={styles.sectionHint}>
+            Ratings and comments from the in-app emoji widget
+          </p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title="Emoji feedback, last 30 days"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.emoji_feedback_ratings?.length ?? 0) === 0}
+            emptyText="No emoji feedback yet."
+          >
+            <EmojiFeedbackChart
+              points={visible?.emoji_feedback_ratings ?? []}
+            />
+          </ChartPanel>
+
+          <ChartPanel
+            title="Recent feedback comments"
+            subtitle="Latest text feedback from the emoji widget"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.emoji_feedback_comments?.length ?? 0) === 0}
+            emptyText="No feedback comments yet."
+          >
+            <EmojiFeedbackCommentsList
+              points={visible?.emoji_feedback_comments ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
+
+      <section
+        className={styles.section}
+        aria-labelledby="biz-section-geography"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="biz-section-geography" className={styles.sectionTitle}>
+            Geography
+          </h2>
+          <p className={styles.sectionHint}>Where new signups come from</p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title="Signups by country, last 90 days"
+            subtitle="Top 10 by signup count · ISO country codes"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.signup_countries_90d?.length ?? 0) === 0}
+            emptyText="No countries captured yet."
+          >
+            <SignupCountriesChart
+              points={visible?.signup_countries_90d ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
     </>
   );
 }

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -9,6 +9,7 @@ import {
   formatUsd,
 } from './businessHelpers';
 import { BusinessMetricsResponse } from './businessTypes';
+import MetricCard, { formatNumberOrDash } from './MetricCard';
 import ActiveSubsTimeseriesChart from './charts/ActiveSubsTimeseriesChart';
 import CancellationCommentsList from './charts/CancellationCommentsList';
 import CancellationReasonsChart from './charts/CancellationReasonsChart';
@@ -24,26 +25,6 @@ import SignupCountriesChart from './charts/SignupCountriesChart';
 import styles from './OpsPage.module.css';
 import { useBusinessMetrics } from './useBusinessMetrics';
 
-interface MetricCardProps {
-  title: string;
-  value: string;
-  footnote?: string;
-}
-
-function MetricCard({ title, value, footnote }: Readonly<MetricCardProps>) {
-  return (
-    <section className={`${sharedStyles.surface} ${styles.card}`}>
-      <h2 className={styles.cardTitle}>{title}</h2>
-      <p className={styles.cardValue}>{value}</p>
-      {footnote != null && <p className={styles.cardFootnote}>{footnote}</p>}
-    </section>
-  );
-}
-
-const formatNumberOrDash = (
-  value: number | null,
-  format: (n: number) => string
-): string => (value == null ? '—' : format(value));
 
 const buildMrrFootnote = (
   asOf: string | null,

--- a/web/src/pages/OpsPage/ContactMessagesTab.tsx
+++ b/web/src/pages/OpsPage/ContactMessagesTab.tsx
@@ -18,10 +18,12 @@ export default function ContactMessagesTab() {
       .finally(() => setLoading(false));
   }, []);
 
-  async function handleAcknowledge(id: number) {
-    await get2ankiApi().acknowledgeContactMessage(id);
+  async function handleToggle(id: number, nextValue: boolean) {
+    await get2ankiApi().acknowledgeContactMessage(id, nextValue);
     setMessages((prev) =>
-      prev.map((m) => (m.id === id ? { ...m, is_acknowledged: true } : m))
+      prev.map((m) =>
+        m.id === id ? { ...m, is_acknowledged: nextValue } : m
+      )
     );
   }
 
@@ -39,43 +41,33 @@ export default function ContactMessagesTab() {
     );
   }
 
-  const unread = messages.filter((m) => !m.is_acknowledged);
-  const read = messages.filter((m) => m.is_acknowledged);
+  const unreadCount = messages.filter((m) => !m.is_acknowledged).length;
 
   return (
     <div className={styles.contactMessages}>
-      {unread.length > 0 && (
-        <section>
-          <h2 className={sharedStyles.sectionTitle}>
-            Unread ({unread.length})
-          </h2>
-          <ul className={styles.messageList}>
-            {unread.map((m) => (
-              <MessageCard key={m.id} message={m} onAcknowledge={handleAcknowledge} />
-            ))}
-          </ul>
-        </section>
-      )}
-      {read.length > 0 && (
-        <section>
-          <h2 className={sharedStyles.sectionTitle}>Read ({read.length})</h2>
-          <ul className={styles.messageList}>
-            {read.map((m) => (
-              <MessageCard key={m.id} message={m} onAcknowledge={handleAcknowledge} />
-            ))}
-          </ul>
-        </section>
-      )}
+      <header className={styles.sectionHeader}>
+        <h2 className={styles.sectionTitle}>
+          Messages — {unreadCount} unread of {messages.length}
+        </h2>
+        <p className={styles.sectionHint}>
+          Acknowledged messages stay in the list, faded.
+        </p>
+      </header>
+      <ul className={styles.messageList}>
+        {messages.map((m) => (
+          <MessageCard key={m.id} message={m} onToggle={handleToggle} />
+        ))}
+      </ul>
     </div>
   );
 }
 
 interface MessageCardProps {
   message: ContactMessage;
-  onAcknowledge: (id: number) => void;
+  onToggle: (id: number, nextValue: boolean) => void;
 }
 
-function MessageCard({ message, onAcknowledge }: Readonly<MessageCardProps>) {
+function MessageCard({ message, onToggle }: Readonly<MessageCardProps>) {
   const attachments: string[] = (() => {
     try {
       return message.attachments ? JSON.parse(message.attachments) : [];
@@ -85,10 +77,11 @@ function MessageCard({ message, onAcknowledge }: Readonly<MessageCardProps>) {
   })();
 
   const date = new Date(message.created_at).toLocaleString();
+  const acked = message.is_acknowledged;
 
   return (
     <li
-      className={`${styles.messageCard} ${message.is_acknowledged ? styles.messageCardRead : ''}`}
+      className={`${styles.messageCard} ${acked ? styles.messageCardRead : ''}`}
     >
       <div className={styles.messageHeader}>
         <div>
@@ -109,23 +102,24 @@ function MessageCard({ message, onAcknowledge }: Readonly<MessageCardProps>) {
           {attachments.join(', ')}
         </p>
       )}
-      {!message.is_acknowledged && (
-        <div className={styles.messageActions}>
-          <button
-            type="button"
-            className={sharedStyles.btnSecondary}
-            onClick={() => onAcknowledge(message.id)}
-          >
-            Mark as read
-          </button>
+      <div className={styles.messageActions}>
+        <button
+          type="button"
+          className={sharedStyles.btnSmall}
+          aria-pressed={acked}
+          onClick={() => onToggle(message.id, !acked)}
+        >
+          {acked ? 'Acknowledged' : 'Mark as read'}
+        </button>
+        {!acked && (
           <a
             href={`mailto:${message.email}?subject=Re: your message to 2anki`}
             className={sharedStyles.btnPrimary}
           >
             Reply
           </a>
-        </div>
-      )}
+        )}
+      </div>
     </li>
   );
 }

--- a/web/src/pages/OpsPage/ConversionsTab.test.tsx
+++ b/web/src/pages/OpsPage/ConversionsTab.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ConversionsTab from './ConversionsTab';
+import { ConversionMetricsResponse } from './conversionTypes';
+
+const renderTab = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ConversionsTab />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+const buildSampleMetrics = (
+  overrides: Partial<ConversionMetricsResponse> = {}
+): ConversionMetricsResponse => ({
+  free_conversions_7d: 824,
+  paid_conversions_7d: 137,
+  free_conversion_success_rate_7d: 91.4,
+  paid_conversion_success_rate_7d: 96.2,
+  conversion_errors_7d_top_reasons: [
+    { reason: 'Notion timeout', count: 12 },
+    { reason: 'Parser crash', count: 5 },
+  ],
+  failed_conversions_weekly: Array.from({ length: 12 }).map((_, i) => ({
+    week: `2026-02-${String((i % 28) + 1).padStart(2, '0')}`,
+    count: i % 4,
+  })),
+  ...overrides,
+});
+
+describe('ConversionsTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('renders volume and success-rate cards from the response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => buildSampleMetrics(),
+    });
+
+    renderTab();
+
+    await waitFor(() => expect(screen.getByText('824')).toBeInTheDocument());
+    expect(screen.getByText('Free conversions')).toBeInTheDocument();
+    expect(screen.getByText('137')).toBeInTheDocument();
+    expect(screen.getByText('Paid conversions')).toBeInTheDocument();
+    expect(screen.getByText('91.4%')).toBeInTheDocument();
+    expect(screen.getByText('Free success rate')).toBeInTheDocument();
+    expect(screen.getByText('96.2%')).toBeInTheDocument();
+    expect(screen.getByText('Paid success rate')).toBeInTheDocument();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/conversion/metrics',
+      expect.objectContaining({ credentials: 'include' })
+    );
+  });
+
+  test('renders failure panel titles', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => buildSampleMetrics(),
+    });
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Top failure reasons, last 7 days')
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.getByText('Failed conversions, last 12 weeks')
+    ).toBeInTheDocument();
+  });
+
+  test('shows ChartPanel empty state when failure arrays are empty', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () =>
+        buildSampleMetrics({
+          conversion_errors_7d_top_reasons: [],
+          failed_conversions_weekly: [],
+        }),
+    });
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('No failed conversions in this window.').length
+      ).toBeGreaterThan(0)
+    );
+  });
+
+  test('renders em-dash for null metric values', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () =>
+        buildSampleMetrics({
+          free_conversion_success_rate_7d: null,
+          paid_conversion_success_rate_7d: null,
+        }),
+    });
+
+    renderTab();
+
+    await waitFor(() => expect(screen.getByText('824')).toBeInTheDocument());
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('shows the alert banner when the request fails', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({}),
+    });
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/\/api\/ops\/conversion\/metrics failed/i)
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByText(/Last good data shown below/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/OpsPage/ConversionsTab.tsx
+++ b/web/src/pages/OpsPage/ConversionsTab.tsx
@@ -9,29 +9,9 @@ import { ConversionMetricsResponse } from './conversionTypes';
 import ChartPanel from './charts/ChartPanel';
 import FailedConversionsWeeklyChart from './charts/FailedConversionsWeeklyChart';
 import FailureReasonsChart from './charts/FailureReasonsChart';
+import MetricCard, { formatNumberOrDash } from './MetricCard';
 import styles from './OpsPage.module.css';
 import { useConversionMetrics } from './useConversionMetrics';
-
-interface MetricCardProps {
-  title: string;
-  value: string;
-  footnote?: string;
-}
-
-function MetricCard({ title, value, footnote }: Readonly<MetricCardProps>) {
-  return (
-    <section className={`${sharedStyles.surface} ${styles.card}`}>
-      <h2 className={styles.cardTitle}>{title}</h2>
-      <p className={styles.cardValue}>{value}</p>
-      {footnote != null && <p className={styles.cardFootnote}>{footnote}</p>}
-    </section>
-  );
-}
-
-const formatNumberOrDash = (
-  value: number | null,
-  format: (n: number) => string
-): string => (value == null ? '—' : format(value));
 
 export default function ConversionsTab() {
   const { data, error, isLoading } = useConversionMetrics();

--- a/web/src/pages/OpsPage/ConversionsTab.tsx
+++ b/web/src/pages/OpsPage/ConversionsTab.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import {
+  formatInteger,
+  formatPercentOneDecimal,
+} from './businessHelpers';
+import { ConversionMetricsResponse } from './conversionTypes';
+import ChartPanel from './charts/ChartPanel';
+import FailedConversionsWeeklyChart from './charts/FailedConversionsWeeklyChart';
+import FailureReasonsChart from './charts/FailureReasonsChart';
+import styles from './OpsPage.module.css';
+import { useConversionMetrics } from './useConversionMetrics';
+
+interface MetricCardProps {
+  title: string;
+  value: string;
+  footnote?: string;
+}
+
+function MetricCard({ title, value, footnote }: Readonly<MetricCardProps>) {
+  return (
+    <section className={`${sharedStyles.surface} ${styles.card}`}>
+      <h2 className={styles.cardTitle}>{title}</h2>
+      <p className={styles.cardValue}>{value}</p>
+      {footnote != null && <p className={styles.cardFootnote}>{footnote}</p>}
+    </section>
+  );
+}
+
+const formatNumberOrDash = (
+  value: number | null,
+  format: (n: number) => string
+): string => (value == null ? '—' : format(value));
+
+export default function ConversionsTab() {
+  const { data, error, isLoading } = useConversionMetrics();
+  const [lastSnapshot, setLastSnapshot] =
+    useState<ConversionMetricsResponse | null>(null);
+
+  useEffect(() => {
+    if (data != null) {
+      setLastSnapshot(data);
+    }
+  }, [data]);
+
+  const visible = data ?? lastSnapshot;
+  const showInitialSkeleton = isLoading && visible == null;
+
+  return (
+    <>
+      {error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          /api/ops/conversion/metrics failed: {error.message}. Last good data
+          shown below.
+        </div>
+      )}
+
+      <section className={styles.section} aria-labelledby="conv-section-volume">
+        <header className={styles.sectionHeader}>
+          <h2 id="conv-section-volume" className={styles.sectionTitle}>
+            Volume, last 7 days
+          </h2>
+          <p className={styles.sectionHint}>Completed conversions by tier</p>
+        </header>
+        <div className={styles.cardGrid}>
+          <MetricCard
+            title="Free conversions"
+            value={formatNumberOrDash(
+              visible?.free_conversions_7d ?? null,
+              formatInteger
+            )}
+          />
+          <MetricCard
+            title="Paid conversions"
+            value={formatNumberOrDash(
+              visible?.paid_conversions_7d ?? null,
+              formatInteger
+            )}
+          />
+        </div>
+      </section>
+
+      <section
+        className={styles.section}
+        aria-labelledby="conv-section-success"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="conv-section-success" className={styles.sectionTitle}>
+            Success rate, last 7 days
+          </h2>
+          <p className={styles.sectionHint}>
+            done ÷ (done + failed) for `conversion` jobs
+          </p>
+        </header>
+        <div className={styles.cardGrid}>
+          <MetricCard
+            title="Free success rate"
+            value={formatNumberOrDash(
+              visible?.free_conversion_success_rate_7d ?? null,
+              formatPercentOneDecimal
+            )}
+          />
+          <MetricCard
+            title="Paid success rate"
+            value={formatNumberOrDash(
+              visible?.paid_conversion_success_rate_7d ?? null,
+              formatPercentOneDecimal
+            )}
+          />
+        </div>
+      </section>
+
+      <section
+        className={styles.section}
+        aria-labelledby="conv-section-failures"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="conv-section-failures" className={styles.sectionTitle}>
+            Failures
+          </h2>
+          <p className={styles.sectionHint}>What is breaking and how often</p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title="Top failure reasons, last 7 days"
+            subtitle="From jobs.job_reason_failure · top 10"
+            isLoading={showInitialSkeleton}
+            isEmpty={
+              (visible?.conversion_errors_7d_top_reasons?.length ?? 0) === 0
+            }
+            emptyText="No failed conversions in this window."
+          >
+            <FailureReasonsChart
+              points={visible?.conversion_errors_7d_top_reasons ?? []}
+            />
+          </ChartPanel>
+
+          <ChartPanel
+            title="Failed conversions, last 12 weeks"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.failed_conversions_weekly?.length ?? 0) === 0}
+            emptyText="No failed conversions in this window."
+          >
+            <FailedConversionsWeeklyChart
+              points={visible?.failed_conversions_weekly ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/EngineeringTab.tsx
+++ b/web/src/pages/OpsPage/EngineeringTab.tsx
@@ -125,56 +125,84 @@ export default function EngineeringTab() {
         </div>
       )}
 
-      <div className={styles.grid}>
-        <ChartPanel
-          title={`Inbound requests, ${suffix}`}
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.inbound_volume.length ?? 0) === 0}
-          emptyText="No requests in this window."
-        >
-          <InboundVolumeChart
-            points={visible?.inbound_volume ?? []}
-            window={window}
-          />
-        </ChartPanel>
+      <section className={styles.section} aria-labelledby="ops-section-inbound">
+        <header className={styles.sectionHeader}>
+          <h2 id="ops-section-inbound" className={styles.sectionTitle}>
+            Inbound
+          </h2>
+          <p className={styles.sectionHint}>Traffic hitting the server</p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title={`Inbound requests, ${suffix}`}
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.inbound_volume.length ?? 0) === 0}
+            emptyText="No requests in this window."
+          >
+            <InboundVolumeChart
+              points={visible?.inbound_volume ?? []}
+              window={window}
+            />
+          </ChartPanel>
 
-        <ChartPanel
-          title={`Latency by route, ${suffix}`}
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.route_latency.length ?? 0) === 0}
-          emptyText="No requests in this window."
-        >
-          <LatencyByRouteChart points={visible?.route_latency ?? []} />
-        </ChartPanel>
+          <ChartPanel
+            title={`Latency by route, ${suffix}`}
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.route_latency.length ?? 0) === 0}
+            emptyText="No requests in this window."
+          >
+            <LatencyByRouteChart points={visible?.route_latency ?? []} />
+          </ChartPanel>
+        </div>
+      </section>
 
-        <ChartPanel
-          title={`Outbound calls by service, ${suffix}`}
-          isLoading={showInitialSkeleton}
-          isEmpty={(visible?.outbound_volume.length ?? 0) === 0}
-          emptyText="No outbound calls in this window."
-        >
-          <OutboundByServiceChart
-            points={visible?.outbound_volume ?? []}
-            window={window}
-          />
-        </ChartPanel>
+      <section className={styles.section} aria-labelledby="ops-section-outbound">
+        <header className={styles.sectionHeader}>
+          <h2 id="ops-section-outbound" className={styles.sectionTitle}>
+            Outbound
+          </h2>
+          <p className={styles.sectionHint}>Calls we make to third parties</p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title={`Outbound calls by service, ${suffix}`}
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.outbound_volume.length ?? 0) === 0}
+            emptyText="No outbound calls in this window."
+          >
+            <OutboundByServiceChart
+              points={visible?.outbound_volume ?? []}
+              window={window}
+            />
+          </ChartPanel>
+        </div>
+      </section>
 
-        <ChartPanel
-          title={`Error rate, ${suffix}`}
-          subtitle="% non-2xx · top 10 routes / top 5 services"
-          isLoading={showInitialSkeleton}
-          isEmpty={
-            (visible?.error_rate_by_route.length ?? 0) === 0 &&
-            (visible?.error_rate_by_service.length ?? 0) === 0
-          }
-          emptyText="No errors in this window."
-        >
-          <ErrorRateChart
-            routes={visible?.error_rate_by_route ?? []}
-            services={visible?.error_rate_by_service ?? []}
-          />
-        </ChartPanel>
-      </div>
+      <section className={styles.section} aria-labelledby="ops-section-errors">
+        <header className={styles.sectionHeader}>
+          <h2 id="ops-section-errors" className={styles.sectionTitle}>
+            Errors
+          </h2>
+          <p className={styles.sectionHint}>Non-2xx responses</p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title={`Error rate, ${suffix}`}
+            subtitle="% non-2xx · top 10 routes / top 5 services"
+            isLoading={showInitialSkeleton}
+            isEmpty={
+              (visible?.error_rate_by_route.length ?? 0) === 0 &&
+              (visible?.error_rate_by_service.length ?? 0) === 0
+            }
+            emptyText="No errors in this window."
+          >
+            <ErrorRateChart
+              routes={visible?.error_rate_by_route ?? []}
+              services={visible?.error_rate_by_service ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
     </>
   );
 }

--- a/web/src/pages/OpsPage/EngineeringTab.tsx
+++ b/web/src/pages/OpsPage/EngineeringTab.tsx
@@ -10,6 +10,7 @@ import ChartPanel from './charts/ChartPanel';
 import InboundVolumeChart from './charts/InboundVolumeChart';
 import LatencyByRouteChart from './charts/LatencyByRouteChart';
 import OutboundByServiceChart from './charts/OutboundByServiceChart';
+import OutboundLatencyTable from './charts/OutboundLatencyTable';
 import ErrorRateChart from './charts/ErrorRateChart';
 
 const WINDOW_LABEL: Record<OpsMetricsWindow, string> = {
@@ -33,6 +34,7 @@ const hasAnyData = (response: OpsMetricsResponse | undefined): boolean => {
     response.inbound_volume.length > 0 ||
     response.route_latency.length > 0 ||
     response.outbound_volume.length > 0 ||
+    (response.outbound_latency_by_service?.length ?? 0) > 0 ||
     response.error_rate_by_route.length > 0 ||
     response.error_rate_by_service.length > 0
   );
@@ -173,6 +175,20 @@ export default function EngineeringTab() {
             <OutboundByServiceChart
               points={visible?.outbound_volume ?? []}
               window={window}
+            />
+          </ChartPanel>
+
+          <ChartPanel
+            title={`Latency by service, ${suffix}`}
+            subtitle="p50 / p95 / p99 over duration_ms · top 10 services"
+            isLoading={showInitialSkeleton}
+            isEmpty={
+              (visible?.outbound_latency_by_service?.length ?? 0) === 0
+            }
+            emptyText="No outbound calls in this window."
+          >
+            <OutboundLatencyTable
+              rows={visible?.outbound_latency_by_service ?? []}
             />
           </ChartPanel>
         </div>

--- a/web/src/pages/OpsPage/MetricCard.test.tsx
+++ b/web/src/pages/OpsPage/MetricCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import MetricCard, { formatNumberOrDash } from './MetricCard';
+
+describe('MetricCard', () => {
+  test('renders title and value', () => {
+    render(<MetricCard title="MRR" value="$4,820" />);
+    expect(screen.getByText('MRR')).toBeInTheDocument();
+    expect(screen.getByText('$4,820')).toBeInTheDocument();
+  });
+
+  test('renders the footnote when provided', () => {
+    render(
+      <MetricCard
+        title="MRR"
+        value="$4,820"
+        footnote="as of 14:32 (cache 412s old)"
+      />
+    );
+    expect(
+      screen.getByText('as of 14:32 (cache 412s old)')
+    ).toBeInTheDocument();
+  });
+
+  test('omits the footnote element when not provided', () => {
+    const { container } = render(<MetricCard title="MRR" value="$4,820" />);
+    expect(container.querySelectorAll('p')).toHaveLength(1);
+  });
+});
+
+describe('formatNumberOrDash', () => {
+  test('returns em-dash for null', () => {
+    expect(formatNumberOrDash(null, (n) => `${n}`)).toBe('—');
+  });
+
+  test('applies the formatter for non-null values', () => {
+    expect(formatNumberOrDash(42, (n) => `$${n}`)).toBe('$42');
+  });
+
+  test('treats zero as a real value, not absent', () => {
+    expect(formatNumberOrDash(0, (n) => `${n}`)).toBe('0');
+  });
+});

--- a/web/src/pages/OpsPage/MetricCard.tsx
+++ b/web/src/pages/OpsPage/MetricCard.tsx
@@ -1,0 +1,27 @@
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+
+interface MetricCardProps {
+  title: string;
+  value: string;
+  footnote?: string;
+}
+
+export default function MetricCard({
+  title,
+  value,
+  footnote,
+}: Readonly<MetricCardProps>) {
+  return (
+    <section className={`${sharedStyles.surface} ${styles.card}`}>
+      <h2 className={styles.cardTitle}>{title}</h2>
+      <p className={styles.cardValue}>{value}</p>
+      {footnote != null && <p className={styles.cardFootnote}>{footnote}</p>}
+    </section>
+  );
+}
+
+export const formatNumberOrDash = (
+  value: number | null,
+  format: (n: number) => string
+): string => (value == null ? '—' : format(value));

--- a/web/src/pages/OpsPage/OpsLayout.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.tsx
@@ -9,6 +9,7 @@ const PAGE_TITLE = 'Ops · 2anki';
 const TABS = [
   { to: '/ops', label: 'Engineering', match: (path: string) => path === '/ops' || path.startsWith('/ops?') },
   { to: '/ops/performance', label: 'Performance', match: (path: string) => path.startsWith('/ops/performance') },
+  { to: '/ops/conversions', label: 'Conversions', match: (path: string) => path.startsWith('/ops/conversions') },
   { to: '/ops/business', label: 'Business', match: (path: string) => path.startsWith('/ops/business') },
   { to: '/ops/showcase', label: 'Showcase', match: (path: string) => path.startsWith('/ops/showcase') },
   { to: '/ops/interviews', label: 'Interviews', match: (path: string) => path.startsWith('/ops/interviews') },

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -134,6 +134,32 @@
   }
 }
 
+.section {
+  margin-bottom: 1.5rem;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 0.625rem;
+  margin: 0 0 0.625rem;
+}
+
+.sectionTitle {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  margin: 0;
+}
+
+.sectionHint {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0;
+}
+
 .panel {
   display: flex;
   flex-direction: column;

--- a/web/src/pages/OpsPage/PerformanceTab.tsx
+++ b/web/src/pages/OpsPage/PerformanceTab.tsx
@@ -4,6 +4,7 @@ import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
 import { usePerformanceMetrics } from './usePerformanceMetrics';
 import ChartPanel from './charts/ChartPanel';
+import { formatCount } from './opsHelpers';
 import {
   JobDurationPercentiles,
   PerformanceMetricsResponse,
@@ -14,11 +15,6 @@ const formatMs = (value: number | null): string => {
   if (value == null) return '—';
   if (value < 1000) return `${value} ms`;
   return `${(value / 1000).toFixed(2)} s`;
-};
-
-const formatCount = (n: number): string => {
-  if (n < 10_000) return String(n);
-  return n.toLocaleString('en', { useGrouping: true }).replaceAll(',', ' ');
 };
 
 const STATUS_COLORS: Record<string, string> = {

--- a/web/src/pages/OpsPage/businessTypes.ts
+++ b/web/src/pages/OpsPage/businessTypes.ts
@@ -12,7 +12,10 @@ export type BusinessMetricKey =
   | 'cancellation_reasons_top'
   | 'cancellation_comments_recent'
   | 'emoji_feedback_ratings'
-  | 'emoji_feedback_comments';
+  | 'emoji_feedback_comments'
+  | 'reengagement_reasons_top'
+  | 'reengagement_comments_recent'
+  | 'signup_countries_90d';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -63,6 +66,23 @@ export interface EmojiFeedbackCommentPoint {
   created_at: string;
 }
 
+export interface ReEngagementReasonPoint {
+  stopped_reason: string;
+  count: number;
+}
+
+export interface ReEngagementCommentPoint {
+  stopped_reason: string;
+  content_type: string;
+  comment: string;
+  created_at: string;
+}
+
+export interface SignupCountryPoint {
+  country: string;
+  count: number;
+}
+
 export interface BusinessMetricsResponse {
   mrr_usd: number | null;
   net_new_mrr_mtd_usd: number | null;
@@ -78,6 +98,9 @@ export interface BusinessMetricsResponse {
   cancellation_comments_recent: CancellationCommentPoint[] | null;
   emoji_feedback_ratings: EmojiFeedbackRatingPoint[] | null;
   emoji_feedback_comments: EmojiFeedbackCommentPoint[] | null;
+  reengagement_reasons_top: ReEngagementReasonPoint[] | null;
+  reengagement_comments_recent: ReEngagementCommentPoint[] | null;
+  signup_countries_90d: SignupCountryPoint[] | null;
   as_of: string;
   cache_age_seconds: number;
   errors?: BusinessMetricError[];

--- a/web/src/pages/OpsPage/charts/FailedConversionsWeeklyChart.test.tsx
+++ b/web/src/pages/OpsPage/charts/FailedConversionsWeeklyChart.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import FailedConversionsWeeklyChart from './FailedConversionsWeeklyChart';
+
+describe('FailedConversionsWeeklyChart', () => {
+  test('renders without crashing when given weekly points', () => {
+    const { container } = render(
+      <FailedConversionsWeeklyChart
+        points={Array.from({ length: 4 }).map((_, i) => ({
+          week: `2026-04-${String(7 + i * 7).padStart(2, '0')}`,
+          count: i,
+        }))}
+      />
+    );
+
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  test('renders without crashing on an empty list', () => {
+    const { container } = render(<FailedConversionsWeeklyChart points={[]} />);
+
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/web/src/pages/OpsPage/charts/FailedConversionsWeeklyChart.tsx
+++ b/web/src/pages/OpsPage/charts/FailedConversionsWeeklyChart.tsx
@@ -1,0 +1,76 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipContentProps,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { FailedConversionsWeekPoint } from '../conversionTypes';
+import { formatWeekLabel } from '../businessHelpers';
+import {
+  AXIS_STROKE,
+  AXIS_TICK_STYLE,
+  GRID_STROKE,
+  SERIES_RED,
+  TIME_SERIES_CHART_MARGIN,
+  TOOLTIP_CURSOR_FILL,
+} from './timeSeriesChartHelpers';
+import TimeSeriesTooltipShell, {
+  TimeSeriesTooltipRow,
+} from './TimeSeriesTooltipShell';
+
+interface FailedConversionsWeeklyChartProps {
+  points: FailedConversionsWeekPoint[];
+}
+
+interface WeekRow {
+  week: string;
+  label: string;
+  count: number;
+}
+
+const buildRows = (points: FailedConversionsWeekPoint[]): WeekRow[] =>
+  points.map((point) => ({
+    week: point.week,
+    label: formatWeekLabel(point.week),
+    count: point.count,
+  }));
+
+function FailedConversionsTooltip({ active, payload }: TooltipContentProps) {
+  if (!active || payload == null || payload.length === 0) return null;
+  const row = payload[0].payload as WeekRow;
+  return (
+    <TimeSeriesTooltipShell title={row.label}>
+      <TimeSeriesTooltipRow label="failed" value={row.count.toLocaleString()} />
+    </TimeSeriesTooltipShell>
+  );
+}
+
+export default function FailedConversionsWeeklyChart({
+  points,
+}: Readonly<FailedConversionsWeeklyChartProps>) {
+  const data = buildRows(points);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} margin={TIME_SERIES_CHART_MARGIN}>
+        <CartesianGrid stroke={GRID_STROKE} vertical={false} />
+        <XAxis dataKey="label" tick={AXIS_TICK_STYLE} stroke={AXIS_STROKE} />
+        <YAxis
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          allowDecimals={false}
+        />
+        <Tooltip
+          content={FailedConversionsTooltip}
+          cursor={TOOLTIP_CURSOR_FILL}
+        />
+        <Bar dataKey="count" fill={SERIES_RED} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web/src/pages/OpsPage/charts/FailureReasonsChart.test.tsx
+++ b/web/src/pages/OpsPage/charts/FailureReasonsChart.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import FailureReasonsChart from './FailureReasonsChart';
+
+describe('FailureReasonsChart', () => {
+  test('renders without crashing when given points', () => {
+    const { container } = render(
+      <FailureReasonsChart
+        points={[
+          { reason: 'Notion timeout', count: 12 },
+          { reason: 'Parser crash', count: 5 },
+        ]}
+      />
+    );
+
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  test('renders without crashing on an empty list', () => {
+    const { container } = render(<FailureReasonsChart points={[]} />);
+
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/web/src/pages/OpsPage/charts/FailureReasonsChart.tsx
+++ b/web/src/pages/OpsPage/charts/FailureReasonsChart.tsx
@@ -1,0 +1,83 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipContentProps,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { ConversionErrorCount } from '../conversionTypes';
+import TimeSeriesTooltipShell, {
+  TimeSeriesTooltipRow,
+} from './TimeSeriesTooltipShell';
+import {
+  AXIS_STROKE,
+  AXIS_TICK_STYLE,
+  GRID_STROKE,
+  SERIES_RED,
+  TOOLTIP_CURSOR_FILL,
+} from './timeSeriesChartHelpers';
+
+interface FailureReasonsChartProps {
+  points: ConversionErrorCount[];
+}
+
+interface ReasonRow {
+  reason: string;
+  count: number;
+}
+
+const buildRows = (points: ConversionErrorCount[]): ReasonRow[] =>
+  points.map((point) => ({ reason: point.reason, count: point.count }));
+
+function ReasonsTooltip({ active, payload }: TooltipContentProps) {
+  if (!active || payload == null || payload.length === 0) return null;
+  const row = payload[0].payload as ReasonRow;
+  return (
+    <TimeSeriesTooltipShell title={row.reason}>
+      <TimeSeriesTooltipRow
+        label="failures"
+        value={row.count.toLocaleString()}
+      />
+    </TimeSeriesTooltipShell>
+  );
+}
+
+const HORIZONTAL_MARGIN = {
+  top: 8,
+  right: 16,
+  left: 0,
+  bottom: 0,
+} as const;
+
+export default function FailureReasonsChart({
+  points,
+}: Readonly<FailureReasonsChartProps>) {
+  const data = buildRows(points);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} layout="vertical" margin={HORIZONTAL_MARGIN}>
+        <CartesianGrid stroke={GRID_STROKE} horizontal={false} />
+        <XAxis
+          type="number"
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          allowDecimals={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="reason"
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          width={160}
+        />
+        <Tooltip content={ReasonsTooltip} cursor={TOOLTIP_CURSOR_FILL} />
+        <Bar dataKey="count" fill={SERIES_RED} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web/src/pages/OpsPage/charts/OutboundLatencyTable.test.tsx
+++ b/web/src/pages/OpsPage/charts/OutboundLatencyTable.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import OutboundLatencyTable from './OutboundLatencyTable';
+
+describe('OutboundLatencyTable', () => {
+  test('renders one row per service with percentile cells', () => {
+    render(
+      <OutboundLatencyTable
+        rows={[
+          { service: 'notion', p50_ms: 110, p95_ms: 460, p99_ms: 820, count: 250 },
+          { service: 'claude', p50_ms: 380, p95_ms: 1200, p99_ms: 2100, count: 90 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('notion')).toBeInTheDocument();
+    expect(screen.getByText('claude')).toBeInTheDocument();
+    expect(screen.getByText('110 ms')).toBeInTheDocument();
+    expect(screen.getByText('460 ms')).toBeInTheDocument();
+    expect(screen.getByText('1.20 s')).toBeInTheDocument();
+    expect(screen.getByText('2.10 s')).toBeInTheDocument();
+  });
+
+  test('formats counts of 10 000+ with a thin space separator', () => {
+    render(
+      <OutboundLatencyTable
+        rows={[
+          { service: 'notion', p50_ms: 80, p95_ms: 200, p99_ms: 500, count: 12450 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('12 450')).toBeInTheDocument();
+  });
+
+  test('renders an empty body when given no rows', () => {
+    const { container } = render(<OutboundLatencyTable rows={[]} />);
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(0);
+  });
+});

--- a/web/src/pages/OpsPage/charts/OutboundLatencyTable.tsx
+++ b/web/src/pages/OpsPage/charts/OutboundLatencyTable.tsx
@@ -1,3 +1,4 @@
+import { formatCount } from '../opsHelpers';
 import { OpsMetricsServiceLatencyPoint } from '../opsTypes';
 import styles from '../OpsPage.module.css';
 
@@ -8,11 +9,6 @@ interface OutboundLatencyTableProps {
 const formatMs = (value: number): string => {
   if (value < 1000) return `${value} ms`;
   return `${(value / 1000).toFixed(2)} s`;
-};
-
-const formatCount = (n: number): string => {
-  if (n < 10_000) return String(n);
-  return n.toLocaleString('en', { useGrouping: true }).replaceAll(',', ' ');
 };
 
 export default function OutboundLatencyTable({

--- a/web/src/pages/OpsPage/charts/OutboundLatencyTable.tsx
+++ b/web/src/pages/OpsPage/charts/OutboundLatencyTable.tsx
@@ -1,0 +1,45 @@
+import { OpsMetricsServiceLatencyPoint } from '../opsTypes';
+import styles from '../OpsPage.module.css';
+
+interface OutboundLatencyTableProps {
+  rows: OpsMetricsServiceLatencyPoint[];
+}
+
+const formatMs = (value: number): string => {
+  if (value < 1000) return `${value} ms`;
+  return `${(value / 1000).toFixed(2)} s`;
+};
+
+const formatCount = (n: number): string => {
+  if (n < 10_000) return String(n);
+  return n.toLocaleString('en', { useGrouping: true }).replaceAll(',', ' ');
+};
+
+export default function OutboundLatencyTable({
+  rows,
+}: Readonly<OutboundLatencyTableProps>) {
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Service</th>
+          <th>p50</th>
+          <th>p95</th>
+          <th>p99</th>
+          <th>Calls</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.service}>
+            <td>{row.service}</td>
+            <td className={styles.numeric}>{formatMs(row.p50_ms)}</td>
+            <td className={styles.numeric}>{formatMs(row.p95_ms)}</td>
+            <td className={styles.numeric}>{formatMs(row.p99_ms)}</td>
+            <td className={styles.numeric}>{formatCount(row.count)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/web/src/pages/OpsPage/charts/ReEngagementCommentsList.test.tsx
+++ b/web/src/pages/OpsPage/charts/ReEngagementCommentsList.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import ReEngagementCommentsList from './ReEngagementCommentsList';
+
+describe('ReEngagementCommentsList', () => {
+  test('renders each comment with reason + content_type and body', () => {
+    render(
+      <ReEngagementCommentsList
+        points={[
+          {
+            stopped_reason: 'Switched to another tool',
+            content_type: 'pdf',
+            comment: 'I moved to RemNote',
+            created_at: '2026-05-07T09:00:00.000Z',
+          },
+          {
+            stopped_reason: 'No longer studying',
+            content_type: 'notion',
+            comment: 'Done with my exam',
+            created_at: '2026-05-05T10:00:00.000Z',
+          },
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByText('Switched to another tool · pdf')
+    ).toBeInTheDocument();
+    expect(screen.getByText('I moved to RemNote')).toBeInTheDocument();
+    expect(
+      screen.getByText('No longer studying · notion')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Done with my exam')).toBeInTheDocument();
+  });
+
+  test('renders an empty list when given no points', () => {
+    const { container } = render(<ReEngagementCommentsList points={[]} />);
+    expect(container.querySelectorAll('li')).toHaveLength(0);
+  });
+});

--- a/web/src/pages/OpsPage/charts/ReEngagementCommentsList.tsx
+++ b/web/src/pages/OpsPage/charts/ReEngagementCommentsList.tsx
@@ -1,0 +1,38 @@
+import { ReEngagementCommentPoint } from '../businessTypes';
+import styles from '../OpsPage.module.css';
+
+interface ReEngagementCommentsListProps {
+  points: ReEngagementCommentPoint[];
+}
+
+const formatDate = (iso: string): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  });
+};
+
+export default function ReEngagementCommentsList({
+  points,
+}: Readonly<ReEngagementCommentsListProps>) {
+  return (
+    <ul className={styles.commentList}>
+      {points.map((point, idx) => (
+        <li key={`${point.created_at}-${idx}`} className={styles.commentItem}>
+          <div className={styles.commentMeta}>
+            <span className={styles.commentReason}>
+              {point.stopped_reason} · {point.content_type}
+            </span>
+            <span className={styles.commentDate}>
+              {formatDate(point.created_at)}
+            </span>
+          </div>
+          <p className={styles.commentBody}>{point.comment}</p>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/pages/OpsPage/charts/ReEngagementReasonsChart.test.tsx
+++ b/web/src/pages/OpsPage/charts/ReEngagementReasonsChart.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import ReEngagementReasonsChart from './ReEngagementReasonsChart';
+
+describe('ReEngagementReasonsChart', () => {
+  test('renders without crashing when given points', () => {
+    const { container } = render(
+      <ReEngagementReasonsChart
+        points={[
+          { stopped_reason: 'Switched to another tool', count: 6 },
+          { stopped_reason: 'No longer studying', count: 3 },
+        ]}
+      />
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  test('renders without crashing on an empty list', () => {
+    const { container } = render(<ReEngagementReasonsChart points={[]} />);
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/web/src/pages/OpsPage/charts/ReEngagementReasonsChart.tsx
+++ b/web/src/pages/OpsPage/charts/ReEngagementReasonsChart.tsx
@@ -1,0 +1,83 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipContentProps,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { ReEngagementReasonPoint } from '../businessTypes';
+import TimeSeriesTooltipShell, {
+  TimeSeriesTooltipRow,
+} from './TimeSeriesTooltipShell';
+import {
+  AXIS_STROKE,
+  AXIS_TICK_STYLE,
+  GRID_STROKE,
+  SERIES_RED,
+  TOOLTIP_CURSOR_FILL,
+} from './timeSeriesChartHelpers';
+
+interface ReEngagementReasonsChartProps {
+  points: ReEngagementReasonPoint[];
+}
+
+interface ReasonRow {
+  stopped_reason: string;
+  count: number;
+}
+
+const buildRows = (points: ReEngagementReasonPoint[]): ReasonRow[] =>
+  points.map((point) => ({
+    stopped_reason: point.stopped_reason,
+    count: point.count,
+  }));
+
+function ReasonsTooltip({ active, payload }: TooltipContentProps) {
+  if (!active || payload == null || payload.length === 0) return null;
+  const row = payload[0].payload as ReasonRow;
+  return (
+    <TimeSeriesTooltipShell title={row.stopped_reason}>
+      <TimeSeriesTooltipRow label="stops" value={row.count.toLocaleString()} />
+    </TimeSeriesTooltipShell>
+  );
+}
+
+const HORIZONTAL_MARGIN = {
+  top: 8,
+  right: 16,
+  left: 0,
+  bottom: 0,
+} as const;
+
+export default function ReEngagementReasonsChart({
+  points,
+}: Readonly<ReEngagementReasonsChartProps>) {
+  const data = buildRows(points);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={data} layout="vertical" margin={HORIZONTAL_MARGIN}>
+        <CartesianGrid stroke={GRID_STROKE} horizontal={false} />
+        <XAxis
+          type="number"
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          allowDecimals={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="stopped_reason"
+          tick={AXIS_TICK_STYLE}
+          stroke={AXIS_STROKE}
+          width={160}
+        />
+        <Tooltip content={ReasonsTooltip} cursor={TOOLTIP_CURSOR_FILL} />
+        <Bar dataKey="count" fill={SERIES_RED} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/web/src/pages/OpsPage/charts/SignupCountriesChart.test.tsx
+++ b/web/src/pages/OpsPage/charts/SignupCountriesChart.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import SignupCountriesChart from './SignupCountriesChart';
+
+describe('SignupCountriesChart', () => {
+  test('renders one row per country with its count', () => {
+    render(
+      <SignupCountriesChart
+        points={[
+          { country: 'NO', count: 240 },
+          { country: 'DE', count: 180 },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('NO')).toBeInTheDocument();
+    expect(screen.getByText('DE')).toBeInTheDocument();
+    expect(screen.getByText('240')).toBeInTheDocument();
+    expect(screen.getByText('180')).toBeInTheDocument();
+  });
+
+  test('renders the "+N others" tail row when othersCount > 0', () => {
+    render(
+      <SignupCountriesChart
+        points={[{ country: 'NO', count: 100 }]}
+        othersCount={42}
+      />
+    );
+
+    expect(screen.getByText('+42 others')).toBeInTheDocument();
+  });
+
+  test('omits the tail row when othersCount is 0', () => {
+    render(<SignupCountriesChart points={[{ country: 'NO', count: 100 }]} />);
+    expect(screen.queryByText(/others/)).toBeNull();
+  });
+
+  test('renders an empty list when given no points and no others', () => {
+    const { container } = render(<SignupCountriesChart points={[]} />);
+    expect(container.querySelectorAll('li')).toHaveLength(0);
+  });
+
+  test('formats counts of 10 000+ with a thin space separator', () => {
+    render(
+      <SignupCountriesChart points={[{ country: 'US', count: 12450 }]} />
+    );
+    expect(screen.getByText('12 450')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/OpsPage/charts/SignupCountriesChart.tsx
+++ b/web/src/pages/OpsPage/charts/SignupCountriesChart.tsx
@@ -1,0 +1,57 @@
+import { SignupCountryPoint } from '../businessTypes';
+import styles from '../OpsPage.module.css';
+
+interface SignupCountriesChartProps {
+  points: SignupCountryPoint[];
+  othersCount?: number;
+}
+
+const COUNTRY_BAR_COLOR = '#3b82f6';
+
+const formatCount = (n: number): string => {
+  if (n < 10_000) return String(n);
+  return n.toLocaleString('en', { useGrouping: true }).replaceAll(',', ' ');
+};
+
+export default function SignupCountriesChart({
+  points,
+  othersCount = 0,
+}: Readonly<SignupCountriesChartProps>) {
+  const max = Math.max(
+    1,
+    ...points.map((row) => row.count),
+    othersCount
+  );
+
+  return (
+    <ul className={styles.statusList} aria-label="Signup country breakdown">
+      {points.map((row) => {
+        const pct = (row.count / max) * 100;
+        return (
+          <li key={row.country} className={styles.statusRow}>
+            <span className={styles.statusLabel}>{row.country}</span>
+            <span className={styles.statusBarWrap}>
+              <span
+                className={styles.statusBar}
+                style={{
+                  width: `${pct}%`,
+                  backgroundColor: COUNTRY_BAR_COLOR,
+                }}
+              />
+            </span>
+            <span className={styles.numeric}>{formatCount(row.count)}</span>
+          </li>
+        );
+      })}
+      {othersCount > 0 && (
+        <li className={styles.statusRow}>
+          <span className={`${styles.statusLabel} ${styles.numericMuted}`}>
+            +{othersCount} others
+          </span>
+          <span className={styles.statusBarWrap} />
+          <span className={styles.numericMuted}>—</span>
+        </li>
+      )}
+    </ul>
+  );
+}

--- a/web/src/pages/OpsPage/charts/SignupCountriesChart.tsx
+++ b/web/src/pages/OpsPage/charts/SignupCountriesChart.tsx
@@ -1,4 +1,5 @@
 import { SignupCountryPoint } from '../businessTypes';
+import { formatCount } from '../opsHelpers';
 import styles from '../OpsPage.module.css';
 
 interface SignupCountriesChartProps {
@@ -7,11 +8,6 @@ interface SignupCountriesChartProps {
 }
 
 const COUNTRY_BAR_COLOR = '#3b82f6';
-
-const formatCount = (n: number): string => {
-  if (n < 10_000) return String(n);
-  return n.toLocaleString('en', { useGrouping: true }).replaceAll(',', ' ');
-};
 
 export default function SignupCountriesChart({
   points,

--- a/web/src/pages/OpsPage/conversionTypes.test.ts
+++ b/web/src/pages/OpsPage/conversionTypes.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+
+import type {
+  ConversionErrorCount,
+  ConversionMetricsResponse,
+  FailedConversionsWeekPoint,
+} from './conversionTypes';
+
+describe('conversionTypes', () => {
+  test('shapes accept the response contract returned by /api/ops/conversion/metrics', () => {
+    const reason: ConversionErrorCount = { reason: 'Notion timeout', count: 3 };
+    const week: FailedConversionsWeekPoint = { week: '2026-05-04', count: 1 };
+    const response: ConversionMetricsResponse = {
+      free_conversions_7d: 10,
+      paid_conversions_7d: 2,
+      free_conversion_success_rate_7d: 80,
+      paid_conversion_success_rate_7d: 95,
+      conversion_errors_7d_top_reasons: [reason],
+      failed_conversions_weekly: [week],
+    };
+
+    expect(response.free_conversions_7d).toBe(10);
+    expect(response.conversion_errors_7d_top_reasons?.[0].reason).toBe(
+      'Notion timeout'
+    );
+    expect(response.failed_conversions_weekly?.[0].week).toBe('2026-05-04');
+  });
+
+  test('null fields are assignable for every nullable metric', () => {
+    const response: ConversionMetricsResponse = {
+      free_conversions_7d: null,
+      paid_conversions_7d: null,
+      free_conversion_success_rate_7d: null,
+      paid_conversion_success_rate_7d: null,
+      conversion_errors_7d_top_reasons: null,
+      failed_conversions_weekly: null,
+    };
+    expect(response.free_conversions_7d).toBeNull();
+    expect(response.failed_conversions_weekly).toBeNull();
+  });
+});

--- a/web/src/pages/OpsPage/conversionTypes.ts
+++ b/web/src/pages/OpsPage/conversionTypes.ts
@@ -1,0 +1,18 @@
+export interface ConversionErrorCount {
+  reason: string;
+  count: number;
+}
+
+export interface FailedConversionsWeekPoint {
+  week: string;
+  count: number;
+}
+
+export interface ConversionMetricsResponse {
+  free_conversions_7d: number | null;
+  paid_conversions_7d: number | null;
+  free_conversion_success_rate_7d: number | null;
+  paid_conversion_success_rate_7d: number | null;
+  conversion_errors_7d_top_reasons: ConversionErrorCount[] | null;
+  failed_conversions_weekly: FailedConversionsWeekPoint[] | null;
+}

--- a/web/src/pages/OpsPage/opsHelpers.ts
+++ b/web/src/pages/OpsPage/opsHelpers.ts
@@ -57,6 +57,11 @@ export const formatBucketLabel = (
 export const formatClock = (date: Date): string =>
   `${padTwo(date.getHours())}:${padTwo(date.getMinutes())}:${padTwo(date.getSeconds())}`;
 
+export const formatCount = (n: number): string => {
+  if (n < 10_000) return String(n);
+  return n.toLocaleString('en', { useGrouping: true }).replaceAll(',', ' ');
+};
+
 export interface InboundBucketRow {
   bucket: string;
   '2xx': number;

--- a/web/src/pages/OpsPage/opsTypes.ts
+++ b/web/src/pages/OpsPage/opsTypes.ts
@@ -35,6 +35,14 @@ export interface OpsMetricsServiceErrorPoint {
   errors: number;
 }
 
+export interface OpsMetricsServiceLatencyPoint {
+  service: string;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  count: number;
+}
+
 export interface OpsMetricsResponse {
   window: OpsMetricsWindow;
   bucket_seconds: number;
@@ -42,6 +50,7 @@ export interface OpsMetricsResponse {
   inbound_volume: OpsMetricsBucketPoint[];
   route_latency: OpsMetricsRouteLatencyPoint[];
   outbound_volume: OpsMetricsOutboundPoint[];
+  outbound_latency_by_service: OpsMetricsServiceLatencyPoint[];
   error_rate_by_route: OpsMetricsRouteErrorPoint[];
   error_rate_by_service: OpsMetricsServiceErrorPoint[];
 }

--- a/web/src/pages/OpsPage/useConversionMetrics.test.ts
+++ b/web/src/pages/OpsPage/useConversionMetrics.test.ts
@@ -1,0 +1,74 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useConversionMetrics } from './useConversionMetrics';
+
+const wrap = (client: QueryClient) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+
+describe('useConversionMetrics', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('calls /api/ops/conversion/metrics with credentials and returns the payload', async () => {
+    const payload = {
+      free_conversions_7d: 10,
+      paid_conversions_7d: 2,
+      free_conversion_success_rate_7d: 80,
+      paid_conversion_success_rate_7d: 95,
+      conversion_errors_7d_top_reasons: [],
+      failed_conversions_weekly: [],
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => payload,
+    });
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => useConversionMetrics(), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(payload));
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/conversion/metrics',
+      expect.objectContaining({ credentials: 'include' })
+    );
+  });
+
+  test('surfaces a thrown error when the response is not ok', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({}),
+    });
+
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => useConversionMetrics(), {
+      wrapper: wrap(client),
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe('500 Internal Server Error');
+  });
+});

--- a/web/src/pages/OpsPage/useConversionMetrics.ts
+++ b/web/src/pages/OpsPage/useConversionMetrics.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { ConversionMetricsResponse } from './conversionTypes';
+
+const REFRESH_MS = 30_000;
+
+const fetchConversionMetrics =
+  async (): Promise<ConversionMetricsResponse> => {
+    const response = await fetch('/api/ops/conversion/metrics', {
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  };
+
+export const useConversionMetrics = () => {
+  return useQuery<ConversionMetricsResponse, Error>({
+    queryKey: ['ops-conversion-metrics'],
+    queryFn: fetchConversionMetrics,
+    refetchInterval: REFRESH_MS,
+    refetchOnWindowFocus: true,
+  });
+};


### PR DESCRIPTION
## Summary

Internal `/ops` dashboard upgrades. All routes are gated by `RequireOpsAccess` — no customer-facing changes, no changelog entry.

**Conversions tab (new)** — consumes the previously-orphaned `/api/ops/conversion/metrics`: free vs paid 7d volume, success rates, top failure reasons, 12-week failed-conversion trend.

**Engineering > Outbound — latency percentiles** — per-service p50/p95/p99 over `outbound_call_logs.duration_ms` (top 10) via `percentile_disc` bound to the active window. EngineeringTab now grouped into Inbound / Outbound / Errors sections.

**Messages — bidirectional ack toggle** — `is_acknowledged` is now a `aria-pressed` toggle. Single merged list (no more unread/read split); acked rows stay in place, faded. `ContactMessagesController.acknowledge` accepts `is_acknowledged` in the body so the same PATCH flips both ways.

**Business > Re-engagement feedback (new)** — `ReEngagementFeedbackRepository` mirrors the cancellation pattern (`countByReason` / `recentComments`); wired into `BusinessMetricsService` via the existing 15-min cache. New section with reasons bar + recent comments list.

**Business > Geography (new)** — top-10 signup countries over 90 days via `UsersRepository.countBySignupCountry(since, limit)`. Lives on Business (cached) rather than Performance (real-time) to keep the existing 7d query independent.

**Layout** — BusinessTab and EngineeringTab grouped into labeled sections so they stay legible as more panels land.

**Shared bits** — `formatCount` lifted to `opsHelpers.ts`; `MetricCard` + `formatNumberOrDash` extracted to a shared component.

## Test plan

- [x] `pnpm --filter 2anki-web typecheck` — green
- [x] `pnpm --filter 2anki-web test -- --run` — full suite passing (incl. new colocated tests for Conversions, MetricCard, OutboundLatencyTable, ReEngagement charts, SignupCountriesChart)
- [x] `pnpm --filter 2anki-web lint` — clean
- [x] Server `tsc --noEmit` + affected server tests (Observability, BusinessMetrics, ReEngagementFeedback) — green
- [x] CI on latest commit — all SUCCESS (Playwright, Web lint/build/test, Snyk)
- [x] `/security-review` — no findings
- [x] SonarCloud duplication hotspots cleared (largest: ConversionsTab 13.0% / 20 lines, SignupCountriesChart 27.6% / 16 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)