### PR TITLE
fix: ops Performance — slowest-jobs table overflow + clickable IDs

### DIFF
--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -184,6 +184,37 @@
   position: relative;
 }
 
+.chartFrameAuto {
+  width: 100%;
+  position: relative;
+  min-height: 220px;
+}
+
+.jobIdButton {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-primary);
+  cursor: pointer;
+  text-decoration: none;
+  font-variant-numeric: tabular-nums;
+}
+
+.jobIdButton:hover {
+  text-decoration: underline;
+}
+
+.jobIdButton:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.jobIdCopied {
+  color: var(--color-success, #16a34a);
+}
+
 .skeletonBar {
   width: 100%;
   height: 100%;

--- a/web/src/pages/OpsPage/PerformanceTab.tsx
+++ b/web/src/pages/OpsPage/PerformanceTab.tsx
@@ -20,8 +20,8 @@ function JobIdCell({ id }: Readonly<JobIdCellProps>) {
 
   useEffect(() => {
     if (!copied) return undefined;
-    const timer = window.setTimeout(() => setCopied(false), 1200);
-    return () => window.clearTimeout(timer);
+    const timer = setTimeout(() => setCopied(false), 1200);
+    return () => clearTimeout(timer);
   }, [copied]);
 
   const handleClick = useCallback(() => {

--- a/web/src/pages/OpsPage/PerformanceTab.tsx
+++ b/web/src/pages/OpsPage/PerformanceTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
@@ -10,6 +10,43 @@ import {
   PerformanceMetricsResponse,
   SignupCountryBreakdownItem,
 } from './performanceTypes';
+
+interface JobIdCellProps {
+  id: number;
+}
+
+function JobIdCell({ id }: Readonly<JobIdCellProps>) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return undefined;
+    const timer = window.setTimeout(() => setCopied(false), 1200);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  const handleClick = useCallback(() => {
+    const text = String(id);
+    if (navigator.clipboard?.writeText != null) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => setCopied(true))
+        .catch(() => setCopied(false));
+    }
+  }, [id]);
+
+  return (
+    <button
+      type="button"
+      className={`${styles.jobIdButton} ${copied ? styles.jobIdCopied : ''}`}
+      onClick={handleClick}
+      aria-label={`Copy job ID ${id} to clipboard`}
+      title={copied ? 'Copied' : 'Click to copy'}
+    >
+      #{id}
+      {copied ? ' ✓' : ''}
+    </button>
+  );
+}
 
 const formatMs = (value: number | null): string => {
   if (value == null) return '—';
@@ -113,7 +150,9 @@ const renderSlowestJobs = (
       <tbody>
         {rows.map((row) => (
           <tr key={row.id}>
-            <td className={styles.numericMuted}>#{row.id}</td>
+            <td className={styles.numericMuted}>
+              <JobIdCell id={row.id} />
+            </td>
             <td>{row.type ?? '—'}</td>
             <td className={styles.numeric}>{formatMs(row.duration_ms)}</td>
             <td className={styles.numeric}>
@@ -222,10 +261,11 @@ export default function PerformanceTab() {
 
         <ChartPanel
           title="Slowest 20 jobs, last 24h"
-          subtitle="Click an ID in pg to investigate"
+          subtitle="Click an ID to copy it for pg lookup"
           isLoading={isInitial}
           isEmpty={(data?.slowest_jobs_24h.length ?? 0) === 0}
           emptyText="No completed jobs in this window."
+          autoHeight
         >
           {data != null && renderSlowestJobs(data.slowest_jobs_24h)}
         </ChartPanel>

--- a/web/src/pages/OpsPage/charts/ChartPanel.test.tsx
+++ b/web/src/pages/OpsPage/charts/ChartPanel.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, test } from 'vitest';
+
+import ChartPanel from './ChartPanel';
+import styles from '../OpsPage.module.css';
+
+describe('ChartPanel', () => {
+  test('renders the loading skeleton when isLoading', () => {
+    const { container } = render(
+      <ChartPanel
+        title="Latency"
+        isLoading
+        isEmpty={false}
+        emptyText="No data"
+      >
+        <div>actual content</div>
+      </ChartPanel>
+    );
+    expect(container.querySelector(`.${styles.skeletonBar}`)).not.toBeNull();
+    expect(screen.queryByText('actual content')).toBeNull();
+  });
+
+  test('renders the empty state text when isEmpty and not loading', () => {
+    render(
+      <ChartPanel
+        title="Latency"
+        isLoading={false}
+        isEmpty
+        emptyText="No data in this window."
+      >
+        <div>actual content</div>
+      </ChartPanel>
+    );
+    expect(screen.getByText('No data in this window.')).toBeInTheDocument();
+    expect(screen.queryByText('actual content')).toBeNull();
+  });
+
+  test('renders children when not loading and not empty', () => {
+    render(
+      <ChartPanel
+        title="Latency"
+        isLoading={false}
+        isEmpty={false}
+        emptyText="No data"
+      >
+        <div>actual content</div>
+      </ChartPanel>
+    );
+    expect(screen.getByText('actual content')).toBeInTheDocument();
+  });
+
+  test('uses the fixed-height frame by default', () => {
+    const { container } = render(
+      <ChartPanel
+        title="Latency"
+        isLoading={false}
+        isEmpty={false}
+        emptyText="No data"
+      >
+        <div>x</div>
+      </ChartPanel>
+    );
+    expect(container.querySelector(`.${styles.chartFrame}`)).not.toBeNull();
+    expect(container.querySelector(`.${styles.chartFrameAuto}`)).toBeNull();
+  });
+
+  test('uses the auto-height frame when autoHeight is true', () => {
+    const { container } = render(
+      <ChartPanel
+        title="Slowest jobs"
+        isLoading={false}
+        isEmpty={false}
+        emptyText="No data"
+        autoHeight
+      >
+        <div>x</div>
+      </ChartPanel>
+    );
+    expect(container.querySelector(`.${styles.chartFrameAuto}`)).not.toBeNull();
+    expect(container.querySelector(`.${styles.chartFrame}`)).toBeNull();
+  });
+});

--- a/web/src/pages/OpsPage/charts/ChartPanel.tsx
+++ b/web/src/pages/OpsPage/charts/ChartPanel.tsx
@@ -9,6 +9,7 @@ interface ChartPanelProps {
   isLoading: boolean;
   isEmpty: boolean;
   emptyText: string;
+  autoHeight?: boolean;
   children: ReactNode;
 }
 
@@ -35,13 +36,15 @@ export default function ChartPanel({
   isLoading,
   isEmpty,
   emptyText,
+  autoHeight = false,
   children,
 }: Readonly<ChartPanelProps>) {
+  const frameClass = autoHeight ? styles.chartFrameAuto : styles.chartFrame;
   return (
     <section className={`${sharedStyles.surface} ${styles.panel}`}>
       <h2 className={styles.panelTitle}>{title}</h2>
       {subtitle != null && <p className={styles.panelSubtitle}>{subtitle}</p>}
-      <div className={styles.chartFrame}>{renderBody({ isLoading, isEmpty, emptyText, children })}</div>
+      <div className={frameClass}>{renderBody({ isLoading, isEmpty, emptyText, children })}</div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Two small Performance-tab fixes on `/ops/performance`. Internal-only — no changelog entry.

**1. Slowest-jobs table was bleeding outside the card.** The 20-row table was rendered inside a fixed 220px `.chartFrame`, so the bottom 15 rows overflowed beyond the panel boundary. Added an `autoHeight` prop on `ChartPanel` that switches to a new `.chartFrameAuto` class (no fixed height, `min-height: 220px` so the loading skeleton still has a footprint). Opted in only on this panel.

**2. The subtitle promised an action that didn't exist.** It said *"Click an ID in pg to investigate"* but clicking nothing. Job IDs are now buttons that copy the numeric ID to the clipboard via `navigator.clipboard.writeText`, with a transient ✓ marker and `aria-label` for screen readers. Subtitle updated to *"Click an ID to copy it for pg lookup"*.

## Test plan

- [x] `pnpm --filter 2anki-web typecheck` — green
- [x] `pnpm --filter 2anki-web test -- --run src/pages/OpsPage` — green (including new `ChartPanel.test.tsx`)
- [x] `pnpm --filter 2anki-web lint` — clean
- [x] Server `tsc --noEmit` — green
- [ ] Manual: load `/ops/performance`, confirm the slowest-jobs table renders inside the card; click a job ID, confirm clipboard receives the bare numeric ID and the ✓ marker fades after ~1.2 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->