### PR TITLE
fix: Auto Sync pricing card cleanup — surface errors, tighten copy

### DIFF
--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -411,13 +411,32 @@ export class Backend {
   }
 
   async startAutoSyncCheckout(): Promise<
-    { url: string } | { status: 'cap_reached' | 'already_subscribed' }
+    { url: string } | { status: 'cap_reached' | 'already_subscribed' | 'error' }
   > {
-    const response = await post(`${this.baseURL}checkout/auto-sync`, {});
-    if (response.status === 404) {
-      return { status: 'cap_reached' };
+    try {
+      const response = await post(`${this.baseURL}checkout/auto-sync`, {});
+      if (response.status === 404) {
+        return { status: 'cap_reached' };
+      }
+      if (!response.ok) {
+        return { status: 'error' };
+      }
+      const body = (await response.json().catch(() => null)) as
+        | { url?: string; status?: 'cap_reached' | 'already_subscribed' }
+        | null;
+      if (body == null) {
+        return { status: 'error' };
+      }
+      if (typeof body.url === 'string') {
+        return { url: body.url };
+      }
+      if (body.status === 'cap_reached' || body.status === 'already_subscribed') {
+        return { status: body.status };
+      }
+      return { status: 'error' };
+    } catch {
+      return { status: 'error' };
     }
-    return response.json();
   }
 
   async startTrial(): Promise<{

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -93,16 +93,7 @@ describe('PricingPage Auto Sync card', () => {
 
   it('shows waitlist caption for waitlisted user', () => {
     renderAt('/pricing', { isLoggedIn: true, hostedAnkiRequested: true });
-    expect(screen.getByText("You joined the waitlist — it's open now.")).toBeInTheDocument();
-  });
-
-  it('shows Unlimited caption for subscriber', () => {
-    renderAt('/pricing', {
-      isLoggedIn: true,
-      hostedAnkiRequested: false,
-    });
-    const caption = screen.queryByText('Upgrade from Unlimited — keep everything you have.');
-    expect(caption).not.toBeInTheDocument();
+    expect(screen.getByText('Waitlist is open — subscribe anytime.')).toBeInTheDocument();
   });
 
   it('shows Included in Lifetime plan caption for patreon user and hides price', () => {
@@ -113,6 +104,47 @@ describe('PricingPage Auto Sync card', () => {
   it('shows Join the waitlist when cap is reached', () => {
     renderAt('/pricing', { isLoggedIn: true, autoSyncCapReached: true });
     expect(screen.getByRole('button', { name: 'Join the waitlist' })).toBeInTheDocument();
+  });
+
+  it('shows the capacity caption when cap is reached', () => {
+    renderAt('/pricing', { isLoggedIn: true, autoSyncCapReached: true });
+    expect(
+      screen.getByText("We're at capacity — we'll email you when a seat opens.")
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces an inline error when checkout fails instead of redirecting', async () => {
+    mockStartAutoSyncCheckout.mockResolvedValue({ status: 'error' });
+    const originalHref = globalThis.location.href;
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: originalHref },
+    });
+
+    renderAt('/pricing', { isLoggedIn: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Subscribe' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Couldn't start checkout. Try again, or email support@2anki.net.")
+      ).toBeInTheDocument();
+    });
+    expect(globalThis.location.href).toBe(originalHref);
+  });
+
+  it('redirects to /ankify/setup when the user is already subscribed', async () => {
+    mockStartAutoSyncCheckout.mockResolvedValue({ status: 'already_subscribed' });
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+
+    renderAt('/pricing', { isLoggedIn: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Subscribe' }));
+
+    await waitFor(() => {
+      expect(globalThis.location.href).toBe('/ankify/setup');
+    });
   });
 
   it('shows Subscribed (disabled) when user already has Auto Sync', () => {

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -39,8 +39,7 @@ function isAutoSyncNewChipVisible(): boolean {
 function autoSyncCaption(
   patreon: boolean | null | undefined,
   autoSyncActive: boolean,
-  hostedAnkiRequested: boolean,
-  isUnlimitedSubscriber: boolean
+  hostedAnkiRequested: boolean
 ): string | undefined {
   if (patreon === true) {
     return 'Included in your Lifetime plan';
@@ -49,10 +48,7 @@ function autoSyncCaption(
     return undefined;
   }
   if (hostedAnkiRequested) {
-    return 'You joined the waitlist — it\'s open now.';
-  }
-  if (isUnlimitedSubscriber) {
-    return 'Upgrade from Unlimited — keep everything you have.';
+    return 'Waitlist is open — subscribe anytime.';
   }
   return undefined;
 }
@@ -75,6 +71,7 @@ export default function PricingPage({
   const lifetimeLink = getLifetimeLink();
   const [waitlistState, setWaitlistState] = useState<RequestState>('idle');
   const [trialState, setTrialState] = useState<RequestState>('idle');
+  const [subscribeError, setSubscribeError] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
   const fromPaywall = searchParams.get('source') === 'paywall-cancel';
   const fromContext = searchParams.get('from');
@@ -114,16 +111,21 @@ export default function PricingPage({
       globalThis.location.href = '/login?redirect=/pricing';
       return;
     }
-    try {
-      const result = await get2ankiApi().startAutoSyncCheckout();
-      if ('url' in result) {
-        globalThis.location.href = result.url;
-      } else if (result.status === 'cap_reached') {
-        await handleWaitlistRequest();
-      }
-    } catch {
-      globalThis.location.href = '/login?redirect=/pricing';
+    setSubscribeError(null);
+    const result = await get2ankiApi().startAutoSyncCheckout();
+    if ('url' in result) {
+      globalThis.location.href = result.url;
+      return;
     }
+    if (result.status === 'cap_reached') {
+      await handleWaitlistRequest();
+      return;
+    }
+    if (result.status === 'already_subscribed') {
+      globalThis.location.href = '/ankify/setup';
+      return;
+    }
+    setSubscribeError("Couldn't start checkout. Try again, or email support@2anki.net.");
   };
 
   const handleStartTrial = async () => {
@@ -141,12 +143,8 @@ export default function PricingPage({
     }
   };
 
-  const autoSyncCaptionText = autoSyncCaption(
-    patreon,
-    autoSyncActive,
-    hostedAnkiRequested,
-    false
-  );
+  const autoSyncCaptionText = subscribeError
+    ?? autoSyncCaption(patreon, autoSyncActive, hostedAnkiRequested);
 
   const showCapReached = autoSyncCapReached && !isLifetime && !autoSyncActive;
 

--- a/web/src/pages/PricingPage/components/AutoSyncCard.tsx
+++ b/web/src/pages/PricingPage/components/AutoSyncCard.tsx
@@ -83,7 +83,7 @@ export function AutoSyncCard({
         onAction={onWaitlist}
         actionLabel={waitlistLabel}
         actionDisabled={waitlistDisabled}
-        caption={caption}
+        caption={caption ?? "We're at capacity — we'll email you when a seat opens."}
         learnMoreHref={LEARN_MORE_HREF}
       />
     );

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,7 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
-  { type: 'feature', title: 'Auto Sync is live — Notion edits sync to Anki every 5 minutes, $30/mo, cancel anytime', date: '2026-05-16' },
+  { type: 'feature', title: 'Auto Sync — Notion edits flow into Anki every 5 minutes, $30/mo, cancel anytime', date: '2026-05-16' },
   { type: 'feature', title: "Stuck on an upload? Open a chat to figure out what to do with the file", date: '2026-05-16' },
   { type: 'fix', title: 'Google Docs from your Drive convert with headings, bullets, and tables intact', date: '2026-05-16' },
   { type: 'feature', title: 'Google Docs, Sheets, and Slides from your Drive turn straight into decks', date: '2026-05-16' },


### PR DESCRIPTION
## What

Five small follow-ups to the Auto Sync launch (#2324). All on the same surface (`PricingPage`), all under ~90 LOC of net change.

- **Surface real errors instead of silently bouncing through `/login`.** When `POST /api/checkout/auto-sync` returns a non-2xx or non-JSON body (Stripe permission error, 5xx, etc.), `startAutoSyncCheckout()` now returns `{ status: 'error' }` rather than letting `response.json()` throw upstream. The handler shows `"Couldn't start checkout. Try again, or email support@2anki.net."` in the card caption.
- **Handle `already_subscribed` at runtime.** Redirect to `/ankify/setup` instead of leaving the click as a no-op.
- **Drop the dead `isUnlimitedSubscriber` parameter** from `autoSyncCaption()`. Branch was never reached; caller hard-coded `false`. Designer flagged it in the post-impl review.
- **Replace apology-shaped waitlist caption.** `"You joined the waitlist — it's open now."` → `"Waitlist is open — subscribe anytime."` per VOICE.md (em-dash is for specifics, not for apologizing about prior brokenness).
- **Default the cap-reached caption.** `"We're at capacity — we'll email you when a seat opens."` so users understand why the CTA changed from `Subscribe` to `Join the waitlist`.
- **Tighten the changelog entry.** Drop the `is live` hedge.

## Why

The original Auto Sync PR (#2324) shipped with one real live-UX cliff and a handful of nits from the post-impl trio review.

The live cliff: when Stripe rejected the checkout session (the `rk_live_…x3u6bt` restricted key was missing `Checkout Sessions: Write` until we fixed the permission in the dashboard), the frontend's `try/catch` redirected to `/login?redirect=/pricing` → already logged in → bounce back to `/pricing`. User clicked Subscribe and "nothing happened." We caught it during the manual smoke-test post-deploy; if a real user had hit it first, we'd have lost them.

The nits came from the designer agent's post-impl review of #2324:
- the `You joined the waitlist — it's open now.` caption reads as apology;
- the `isUnlimitedSubscriber` branch was dead;
- the cap-reached state changed the CTA with no explanatory caption;
- the changelog entry leaned on `is live` hedge filler.

## How

| File | Change |
|---|---|
| `web/src/lib/backend/Backend.ts` | `startAutoSyncCheckout()` now wraps the call in try/catch, treats non-2xx as `{ status: 'error' }`, and parses the body defensively. Union type extended with `'error'`. |
| `web/src/pages/PricingPage/PricingPage.tsx` | New `subscribeError` state; handler sets it on `'error'` instead of redirecting. `'already_subscribed'` redirects to `/ankify/setup`. `autoSyncCaption()` loses the dead param. Waitlisted caption rewritten. |
| `web/src/pages/PricingPage/components/AutoSyncCard.tsx` | Cap-reached branch defaults `caption` to the new capacity message. |
| `web/src/pages/WhatsNewPage/changelog.ts` | Drop `is live` from the Auto Sync entry. |
| `web/src/pages/PricingPage/PricingPage.test.tsx` | Updated waitlist caption assertion; new tests for capacity caption, error surface, and `already_subscribed` redirect. Dropped the test asserting on the dead Unlimited-upgrade branch. |

## Measuring success

The pre-existing `auto_sync.checkout.*` log lines from #2324 still cover the server side. On the client side this PR is observable two ways:

1. The user-visible inline error caption is now an explicit string in the DOM; the support inbox is the canary (we expect lower volume of "Subscribe doesn't work" tickets once this lands).
2. Existing `auto_sync.checkout.error` shape (status returned by server) is unchanged; nothing here moves server telemetry.

## Testing

- `pnpm --filter 2anki-web test:run` — **555 passed**
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean (Biome, 537 files)
- `pnpm typecheck` — clean (server tsc)

New tests in `PricingPage.test.tsx`:
- `surfaces an inline error when checkout fails instead of redirecting`
- `redirects to /ankify/setup when the user is already subscribed`
- `shows the capacity caption when cap is reached`

## Changelog

No changelog entry — this is a polish PR on top of #2324 which already shipped the user-facing entry. The capacity caption + error message are new strings but they're recovery states users only see when something's already gone wrong, not a new capability.

## Risks

- **Behavior change for the `already_subscribed` runtime path.** Before, this branch was unreachable in practice (the card hides Subscribe via `isActive`). If the server returns `already_subscribed` for any reason a current Auto Sync user clicks Subscribe, they now end up at `/ankify/setup` — which is the right destination but is a redirect they didn't have before. Acceptable.
- **`startAutoSyncCheckout` no longer throws.** Any caller that relied on the `throw` is gone — only PricingPage uses it, and the new return shape covers every old throw case.

## Goal alignment

The live cliff was costing potential paying subscribers — anyone clicking Subscribe during the ~3-minute window between env vars going live and the Stripe permission being fixed got the silent bounce. This patch makes the failure mode legible so future Stripe rejections (rate limit, expired key, etc.) recover instead of dropping the user. Direct contribution to the +10 paying subscribers / $300 MRR target from #2324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->