### PR TITLE
fix: remove undeclared fields from Abhiyan templates

### DIFF
--- a/src/services/officialTemplates.test.ts
+++ b/src/services/officialTemplates.test.ts
@@ -61,4 +61,41 @@ describe('getOfficialTemplates', () => {
     const raw = templates.find((t) => t.id === 'official-no-style-basic');
     expect(raw?.noteType.css).toBe('');
   });
+
+  it('only references fields that exist on the note type', () => {
+    const ankiBuiltinTokens = new Set(['FrontSide']);
+    const failures: string[] = [];
+    for (const template of templates) {
+      const declared = new Set(template.noteType.flds.map((f) => f.name));
+      for (const tmpl of template.noteType.tmpls) {
+        for (const ref of extractFieldRefs(tmpl.qfmt + tmpl.afmt)) {
+          if (ankiBuiltinTokens.has(ref)) continue;
+          if (declared.has(ref)) continue;
+          failures.push(
+            `${template.id}: references {{${ref}}} but flds are [${[...declared].join(', ')}]`,
+          );
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
 });
+
+function extractFieldRefs(html: string): string[] {
+  const refs: string[] = [];
+  const tokenPattern = /\{\{([^{}]+)\}\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = tokenPattern.exec(html)) !== null) {
+    let name = match[1].trim();
+    if (name.startsWith('#') || name.startsWith('/') || name.startsWith('^')) {
+      name = name.slice(1).trim();
+    }
+    const colonIdx = name.indexOf(':');
+    if (colonIdx !== -1) {
+      name = name.slice(colonIdx + 1).trim();
+    }
+    if (name === '') continue;
+    refs.push(name);
+  }
+  return refs;
+}

--- a/src/templates/abhiyan_basic_front.html
+++ b/src/templates/abhiyan_basic_front.html
@@ -23,8 +23,7 @@
         {{#Tags}}
         <div class="tags row">{{Tags}}</div>{{/Tags}}
         <div class="question row">
-            {{#text2 image}}
-            <div class="image">{{text2 image}}</div>{{/text2 image}} {{Front}}
+            {{Front}}
         </div>
     </div>
 </div>
@@ -32,7 +31,5 @@
 <div class="note backonly">
     <div class="back k">
         <div class="row">{{Back}}</div>
-        {{#explanation}}
-        <div class="explanation row">{{explanation}}</div>{{/explanation}}
     </div>
 </div>

--- a/src/templates/abhiyan_cloze_back.html
+++ b/src/templates/abhiyan_cloze_back.html
@@ -23,8 +23,7 @@
         {{#Tags}}
         <div class="tags row">{{Tags}}</div>{{/Tags}}
         <div class="question row">
-            {{#text2 image}}
-            <div class="image">{{text2 image}}</div>{{/text2 image}} {{cloze:Text}}
+            {{cloze:Text}}
         </div>
     </div>
 </div>

--- a/src/templates/abhiyan_cloze_front.html
+++ b/src/templates/abhiyan_cloze_front.html
@@ -24,8 +24,7 @@
         {{#Tags}}
         <div class="tags row">{{Tags}}</div>{{/Tags}}
         <div class="question row">
-            {{#text2 image}}
-            <div class="image">{{text2 image}}</div>{{/text2 image}} {{cloze:Text}}
+            {{cloze:Text}}
         </div>
     </div>
 </div>

--- a/src/templates/abhiyan_input_front.html
+++ b/src/templates/abhiyan_input_front.html
@@ -23,8 +23,7 @@
         {{#Tags}}
         <div class="tags row">{{Tags}}</div>{{/Tags}}
         <div class="question row">
-            {{#text2 image}}
-            <div class="image">{{text2 image}}</div>{{/text2 image}}{{Front}}<br>{{type:Input}}
+            {{Front}}<br>{{type:Input}}
         </div>
     </div>
 </div>
@@ -32,7 +31,5 @@
 <div class="note backonly">
     <div class="back k">
         <div class="row">{{Back}}</div>
-        {{#explanation}}
-        <div class="explanation row">{{explanation}}</div>{{/explanation}}
     </div>
 </div>

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Abhiyan templates open in Anki without a missing-field error', date: '2026-05-16' },
   { type: 'feature', title: 'Auto Sync — Notion edits flow into Anki every 5 minutes, $30/mo, cancel anytime', date: '2026-05-16' },
   { type: 'feature', title: "Stuck on an upload? Open a chat to figure out what to do with the file", date: '2026-05-16' },
   { type: 'fix', title: 'Google Docs from your Drive convert with headings, bullets, and tables intact', date: '2026-05-16' },


### PR DESCRIPTION
## Summary
- Removes `{{#text2 image}}` and `{{#explanation}}` references from four Abhiyan Night Mode templates. Those fields are not declared on the templates' note types, so Anki's preview validator rejected every deck built from them (`Found '{{#text2 image}}', but there is no field called 'text2 image'`).
- Adds a regression test in `officialTemplates.test.ts` that asserts every `{{field}}` reference in every registered starter's `qfmt`/`afmt` resolves against the template's declared `flds` (allowlisting `FrontSide` as an Anki built-in). Prevents the bug class from shipping again.
- Adds a What's New entry: `Abhiyan templates open in Anki without a missing-field error`.

## Why now
A creator hired to record a 2anki marketing video chose the Abhiyan cloze template, generated a deck, opened it in Anki, hit the validator error, and could not finish recording. Same bug applies to anyone who picked the basic or cloze variants of the Night Mode template.

## Trio review (per CLAUDE.md trio policy)
- **PM:** ship patch now + file follow-up issues; add changelog entry; check sibling templates for the same pattern (caught the `explanation` references during this PR).
- **Designer:** removal is visually safe — cloze body, tags, and `Extra` block still render; no orphan CSS. Original intent was an inline image — that should come back as a real `Image` field in a follow-up rather than as a placeholder here.
- **Engineer:** wider scope than initially briefed (4 files, not 2); recommended adding the field-resolves-against-flds test in this PR — done.

## Follow-ups (not in this PR)
- Reintroduce a real `Image` field + conditional block on the Abhiyan note types so the night-mode templates can show inline images again.
- Extend field-vs-flds validation to user-authored templates in the in-app editor, with a save-time error surfaced before the deck is generated.

## Sonar
Not run locally — this PR is template HTML edits + a small test helper (no controller/use-case/component changes). Will rely on CI's SonarCloud check.

## Test plan
- [x] `pnpm test src/services/officialTemplates.test.ts` — 21/21 passing, including the new assertion across all 11 starters
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm --filter 2anki-web typecheck` — clean
- [x] `pnpm --filter 2anki-web lint` — clean (Biome)
- [x] `pnpm --filter 2anki-web test` — 560/560 passing
- [ ] Manual: pick the Abhiyan Night Mode template in the Note Types page, download, and confirm Anki opens the preview without the missing-field error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->