### PR TITLE
fix: downloaded templates open as their own deck in Anki, not Default

### DIFF
--- a/src/lib/templates/exportNoteTypeToApkg.test.ts
+++ b/src/lib/templates/exportNoteTypeToApkg.test.ts
@@ -1,6 +1,17 @@
 import { unzipSync, strFromU8 } from 'fflate';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const initSqlJs = require('sql.js');
 
 import { exportNoteTypeToApkg, AnkiNoteType } from './exportNoteTypeToApkg';
+
+async function readDecksJson(apkg: Buffer): Promise<Record<string, { id: number; name: string }>> {
+  const entries = unzipSync(new Uint8Array(apkg));
+  const SQL = await initSqlJs();
+  const db = new SQL.Database(entries['collection.anki2']);
+  const res = db.exec('SELECT decks FROM col');
+  db.close();
+  return JSON.parse(res[0].values[0][0] as string);
+}
 
 const basicNoteType: AnkiNoteType = {
   id: 1000000000000,
@@ -57,5 +68,29 @@ describe('exportNoteTypeToApkg', () => {
     });
 
     expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  it('names the deck "2anki::<noteType.name>" so cards do not land in Default on import', async () => {
+    const buffer = await exportNoteTypeToApkg(basicNoteType);
+    const decks = await readDecksJson(buffer);
+
+    const decksList = Object.values(decks);
+    expect(decksList).toHaveLength(1);
+    expect(decksList[0].name).toBe('2anki::Basic');
+    expect(decksList[0].id).not.toBe(1);
+  });
+
+  it('preserves the original template name casing and punctuation in the deck name', async () => {
+    const ornateNoteType: AnkiNoteType = {
+      ...basicNoteType,
+      name: 'Abhiyan Bhandari (Night Mode — Cloze)',
+    };
+
+    const buffer = await exportNoteTypeToApkg(ornateNoteType);
+    const decks = await readDecksJson(buffer);
+
+    expect(Object.values(decks)[0].name).toBe(
+      '2anki::Abhiyan Bhandari (Night Mode — Cloze)'
+    );
   });
 });

--- a/src/lib/templates/exportNoteTypeToApkg.ts
+++ b/src/lib/templates/exportNoteTypeToApkg.ts
@@ -110,11 +110,11 @@ function buildModel(noteType: AnkiNoteType, modelId: number, now: number) {
   };
 }
 
-function buildDeck(deckId: number, now: number) {
+function buildDeck(deckId: number, name: string, now: number) {
   return {
     [deckId]: {
       id: deckId,
-      name: 'Default',
+      name,
       desc: '',
       conf: 1,
       extendRev: 50,
@@ -255,10 +255,11 @@ export async function exportNoteTypeToApkg(
 
   const now = Math.floor(Date.now() / 1000);
   const modelId = noteType.id || Date.now();
-  const deckId = 1;
+  const deckId = Date.now() + 1;
+  const deckName = `2anki::${noteType.name}`;
 
   const model = buildModel(noteType, modelId, now);
-  const deck = buildDeck(deckId, now);
+  const deck = buildDeck(deckId, deckName, now);
   const conf = buildConf(deckId, modelId);
   const dconf = buildDconf(now);
 

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Downloaded note types land in their own deck in Anki, grouped under 2anki, instead of mixing into Default', date: '2026-05-16' },
   { type: 'fix', title: 'Abhiyan templates open in Anki without a missing-field error', date: '2026-05-16' },
   { type: 'feature', title: 'Auto Sync — Notion edits flow into Anki every 5 minutes, $30/mo, cancel anytime', date: '2026-05-16' },
   { type: 'feature', title: "Stuck on an upload? Open a chat to figure out what to do with the file", date: '2026-05-16' },


### PR DESCRIPTION
## Summary

- Template `.apkg` exports hardcoded the deck as `Default` (id `1`), so importing any downloadable template from 2anki.net dumped its cards into Anki's built-in Default deck mixed with whatever else the user was studying.
- Cards now land in `2anki::<Template name>` — nested under a single `2anki` parent in Anki's deck browser so multiple example imports stay tidy.
- Scope is the template-export path only (`src/lib/templates/exportNoteTypeToApkg.ts`). The Notion → Anki user-conversion pipeline names decks separately and is untouched.

## Why this format

Reported by Farah, an experienced template author, on 16 May: "every template make separate deck in anki". The trio surfaced two reasonable options — flat `<Template name>` vs nested `2anki::<Template name>`. Alexander picked nested so multiple example imports group under one collapsible parent, and the user can drag a child out if they want it standalone.

## Test plan

- [x] Targeted Jest run: `pnpm test src/lib/templates/exportNoteTypeToApkg.test.ts` — 18/18 pass, including new assertions that the generated `decks` JSON name is `2anki::<noteType.name>` and the deck id is not the reserved `1`.
- [x] Edge case: template name with punctuation (`Abhiyan Bhandari (Night Mode — Cloze)`) flows through verbatim.
- [x] Server tsc, web typecheck, web vitest (560/560), web lint all clean.
- [ ] Manual: download a template from `/templates`, import into Anki, confirm it appears under `2anki::<name>`.
- [ ] `sonar-scanner` not run locally (binary not installed in this sandbox) — flagging per `.claude/rules/sonar.md`. Diff is one function-signature change + tests + changelog, so risk of a Sonar bounce is low, but heads-up for reviewers.

## Notes

- Template names containing `/` will create nested decks in Anki (e.g. `Math / Science` becomes a `2anki::Math :: Science` sub-deck because `/` is a normal character but Anki uses `::` for hierarchy). No template currently does this; not worth pre-escaping.
- Existing users who previously imported a template have cards sitting in their Default deck with whatever review history they've built. Those stay where they are — the next download will produce a fresh deck under `2anki`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->