### PR TITLE
docs: correct frontend dev port to 3000

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ touch .env
 pnpm dev
 ```
 
-The server starts on `http://localhost:2020` and the frontend on `http://localhost:5173`. For server-only work: `pnpm dev:server`.
+The server starts on `http://localhost:2020` and the frontend on `http://localhost:3000`. For server-only work: `pnpm dev:server`.
 
 ## How we develop
 

--- a/web/mock-server/README.md
+++ b/web/mock-server/README.md
@@ -10,7 +10,7 @@ The mock server runs on `http://localhost:2020` and provides mocked responses fo
 
 ## Security Considerations
 
-- **CORS Configuration**: Restricted to development origins only (`localhost:3000`, `localhost:5173`)
+- **CORS Configuration**: Restricted to development origins only (`localhost:3000`)
 - **Framework Fingerprinting**: X-Powered-By header disabled to prevent Express.js version disclosure
 - **Security Headers**: Additional security headers enabled (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, CSP)
 - **Environment Variables**: Use `MOCK_SERVER_ALLOWED_ORIGINS` to add custom origins (comma-separated)


### PR DESCRIPTION
## Summary
- README and mock-server README claimed the frontend runs on `http://localhost:5173` (Vite's default)
- Actual port is **3000**, pinned in `web/vite.config.ts:72`
- The mock-server CORS list also only allowed `localhost:3000`, not 5173

## Test plan
- [x] grepped repo for `5173` — no remaining references in source/docs
- [x] confirmed `vite.config.ts:72` is `port: 3000`
- [x] confirmed `web/mock-server/index.ts` allowlists only `localhost:3000` / `127.0.0.1:3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->