### PR TITLE
fix: link downloaded note types to their deck so Add Card pre-selects it

### DIFF
--- a/src/lib/templates/exportNoteTypeToApkg.test.ts
+++ b/src/lib/templates/exportNoteTypeToApkg.test.ts
@@ -4,13 +4,21 @@ const initSqlJs = require('sql.js');
 
 import { exportNoteTypeToApkg, AnkiNoteType } from './exportNoteTypeToApkg';
 
-async function readDecksJson(apkg: Buffer): Promise<Record<string, { id: number; name: string }>> {
+async function readColJson<T>(apkg: Buffer, column: 'decks' | 'models'): Promise<Record<string, T>> {
   const entries = unzipSync(new Uint8Array(apkg));
   const SQL = await initSqlJs();
   const db = new SQL.Database(entries['collection.anki2']);
-  const res = db.exec('SELECT decks FROM col');
+  const res = db.exec(`SELECT ${column} FROM col`);
   db.close();
   return JSON.parse(res[0].values[0][0] as string);
+}
+
+function readDecksJson(apkg: Buffer) {
+  return readColJson<{ id: number; name: string }>(apkg, 'decks');
+}
+
+function readModelsJson(apkg: Buffer) {
+  return readColJson<{ id: number; did: number | null }>(apkg, 'models');
 }
 
 const basicNoteType: AnkiNoteType = {
@@ -78,6 +86,15 @@ describe('exportNoteTypeToApkg', () => {
     expect(decksList).toHaveLength(1);
     expect(decksList[0].name).toBe('2anki::Basic');
     expect(decksList[0].id).not.toBe(1);
+  });
+
+  it('links the note type to its deck so Add Card pre-selects the matching deck', async () => {
+    const buffer = await exportNoteTypeToApkg(basicNoteType);
+    const [model] = Object.values(await readModelsJson(buffer));
+    const [deck] = Object.values(await readDecksJson(buffer));
+
+    expect(typeof model.did).toBe('number');
+    expect(model.did).toBe(deck.id);
   });
 
   it('preserves the original template name casing and punctuation in the deck name', async () => {

--- a/src/lib/templates/exportNoteTypeToApkg.ts
+++ b/src/lib/templates/exportNoteTypeToApkg.ts
@@ -64,7 +64,12 @@ function buildSchema(db: import('sql.js').Database) {
   `);
 }
 
-function buildModel(noteType: AnkiNoteType, modelId: number, now: number) {
+function buildModel(
+  noteType: AnkiNoteType,
+  modelId: number,
+  deckId: number,
+  now: number
+) {
   return {
     [modelId]: {
       id: modelId,
@@ -73,7 +78,7 @@ function buildModel(noteType: AnkiNoteType, modelId: number, now: number) {
       mod: now,
       usn: -1,
       sortf: 0,
-      did: null,
+      did: deckId,
       tmpls: noteType.tmpls.map((t) => ({
         name: t.name,
         ord: t.ord,
@@ -258,7 +263,7 @@ export async function exportNoteTypeToApkg(
   const deckId = Date.now() + 1;
   const deckName = `2anki::${noteType.name}`;
 
-  const model = buildModel(noteType, modelId, now);
+  const model = buildModel(noteType, modelId, deckId, now);
   const deck = buildDeck(deckId, deckName, now);
   const conf = buildConf(deckId, modelId);
   const dconf = buildDconf(now);

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Picking a downloaded 2anki note type in Anki\'s Add Card dialog pre-selects its matching deck', date: '2026-05-16' },
   { type: 'fix', title: 'Downloaded note types land in their own deck in Anki, grouped under 2anki, instead of mixing into Default', date: '2026-05-16' },
   { type: 'fix', title: 'Abhiyan templates open in Anki without a missing-field error', date: '2026-05-16' },
   { type: 'feature', title: 'Auto Sync — Notion edits flow into Anki every 5 minutes, $30/mo, cancel anytime', date: '2026-05-16' },


### PR DESCRIPTION
## Summary

- Follow-up to #2334. Template `.apkg` exports now create a deck per template, but the model's `did` field was still `null` — so picking one of our note types in Anki's **Add Card** dialog used whatever deck the user had selected last, not the matching `2anki::<Template name>` deck.
- Set `did: deckId` on the model JSON so Anki pre-selects the right deck.
- Per-template `did` on each `tmpls[n]` entry stays `null` — Anki 2.1+ ignores it.

## Why

Reported by Farah, the same template author who flagged the import-deck bug. Her screenshot shows our note types listed in Anki's "Choose Note Type" picker but the Deck field next to "Type" pointing at an unrelated deck. For a template author writing dozens of cards in a session, re-picking the deck every time is friction on the primary action.

## Trade-off (flagged for reviewers)

On re-import, Anki overwrites the model's `did`. A user who imported a template, then manually changed the Add Card default in their own collection, will have that preference reset on re-import. This affects the picker default only — no card data, scheduling, or review history is touched. Anki's model-merge behavior gives us no way to avoid this while still setting `did`. Acceptable: the default we set is the correct one for the common case, and the override is one click.

## Test plan

- [x] Targeted Jest: `pnpm test src/lib/templates/exportNoteTypeToApkg.test.ts` — 19/19 pass, including a new assertion that the generated model's `did` is numeric and equals the deck's `id`.
- [x] Server tsc, web typecheck, web lint all clean.
- [ ] Manual: download a template, import, open Add Card, pick the imported note type → confirm the Deck field jumps to `2anki::<Template name>`.
- [ ] Sonar-scanner not run locally (binary not installed in this sandbox). Diff is one function-signature change + one test + changelog; low Sonar risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->