### PR TITLE
fix: editor loads Official templates instead of Template not found

### DIFF
--- a/web/src/pages/TemplatesPage/EditorPage.test.tsx
+++ b/web/src/pages/TemplatesPage/EditorPage.test.tsx
@@ -141,6 +141,7 @@ describe('EditorPage (edit)', () => {
     vi.spyOn(templatesApi, 'getDefaultNoteTypes').mockResolvedValue([
       sampleStarter,
     ]);
+    vi.spyOn(templatesApi, 'getOfficialNoteTypes').mockResolvedValue([]);
     vi.spyOn(templatesApi, 'getUserTemplates').mockResolvedValue({
       templates: [],
       hiddenIds: [],
@@ -184,5 +185,21 @@ describe('EditorPage (edit)', () => {
     vi.spyOn(templatesApi, 'getDefaultNoteTypes').mockResolvedValue([]);
     renderEditor('edit', '/templates/edit/missing-id');
     expect(await screen.findByText(/template not found/i)).toBeInTheDocument();
+  });
+
+  it('loads a starter that lives only in the official set', async () => {
+    const officialStarter: NoteTypeStarter = {
+      ...sampleStarter,
+      id: 'official-only-notion-basic',
+      name: 'Only Notion (Basic)',
+    };
+    vi.spyOn(templatesApi, 'getDefaultNoteTypes').mockResolvedValue([]);
+    vi.spyOn(templatesApi, 'getOfficialNoteTypes').mockResolvedValue([
+      officialStarter,
+    ]);
+    renderEditor('edit', `/templates/edit/${officialStarter.id}`);
+    expect(
+      await screen.findByDisplayValue('Only Notion (Basic)')
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/TemplatesPage/EditorPage.tsx
+++ b/web/src/pages/TemplatesPage/EditorPage.tsx
@@ -11,6 +11,7 @@ import {
   aiModifyNoteType,
   downloadNoteTypeApkg,
   getDefaultNoteTypes,
+  getOfficialNoteTypes,
   getUserTemplates,
   saveUserTemplate,
 } from '../../lib/backend/templates';
@@ -223,11 +224,12 @@ function AIGenerateSection({ onGenerated }: Readonly<AIGenerateSectionProps>) {
 }
 
 async function findStarter(id: string): Promise<NoteTypeStarter | null> {
-  const [defaults, user] = await Promise.all([
+  const [defaults, official, user] = await Promise.all([
     getDefaultNoteTypes().catch(() => []),
+    getOfficialNoteTypes().catch(() => []),
     getUserTemplates().catch(() => ({ templates: [], hiddenIds: [] })),
   ]);
-  const all = [...defaults, ...user.templates];
+  const all = [...user.templates, ...official, ...defaults];
   return all.find((s) => s.id === id) ?? null;
 }
 

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Editing an Official note type opens the editor instead of showing Template not found', date: '2026-05-16' },
   { type: 'fix', title: 'Picking a downloaded 2anki note type in Anki\'s Add Card dialog pre-selects its matching deck', date: '2026-05-16' },
   { type: 'fix', title: 'Downloaded note types land in their own deck in Anki, grouped under 2anki, instead of mixing into Default', date: '2026-05-16' },
   { type: 'fix', title: 'Abhiyan templates open in Anki without a missing-field error', date: '2026-05-16' },


### PR DESCRIPTION
## Summary

Production regression: clicking **Edit** on any Official 2anki note type (e.g. `Only Notion (Basic)`, `n2a-basic`, `cloze-modern`) returned "Template not found".

**Root cause:** `TemplatesPage.tsx:218` fetches three sources to populate the gallery — defaults + official + user. `EditorPage.tsx`'s `findStarter` only fetched two — defaults + user. Every Official template id fell through to `null` in the editor lookup and rendered the not-found state.

**Fix:** Add `getOfficialNoteTypes()` to the lookup. Re-ordered so user templates take precedence on id collisions (matches the gallery's de-dup order at `TemplatesPage.tsx:229-232`).

## Test plan

- [x] `pnpm test --run src/pages/TemplatesPage/EditorPage.test.tsx` — 10/10 pass, including a new regression test that loads a starter present only in the official set.
- [x] Web typecheck, web lint clean.
- [ ] Manual: on prod after deploy, click Edit on `Only Notion (Basic)`, `Only Notion (Cloze)`, `Raw Note (no style)` — confirm editor opens with the template's name in the title field, not "Template not found".

## Why this slipped through

The existing test for "Template not found" only checked a fabricated `missing-id`, never an id that *should* exist via the official endpoint. New test covers the gap.

Not bundled with #2334 / #2336 because this is in a different file (`EditorPage.tsx`) and a different surface (gallery click → edit, not download/import). It's the same product area (note-type templates) but a separate regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->