### PR TITLE
fix: pass cards disable only the clicked button while redirecting

### DIFF
--- a/web/src/pages/PricingPage/components/PassCards.test.tsx
+++ b/web/src/pages/PricingPage/components/PassCards.test.tsx
@@ -56,7 +56,7 @@ describe('PassCards', () => {
     expect(onWeekPass).toHaveBeenCalledOnce();
   });
 
-  it('shows Redirecting… and disables both buttons when dayPassPending', () => {
+  it('disables only the Day Pass button when dayPassPending', () => {
     render(
       <PassCards
         onDayPass={vi.fn()}
@@ -66,10 +66,10 @@ describe('PassCards', () => {
       />
     );
     expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Get Week Pass' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Get Week Pass' })).toBeEnabled();
   });
 
-  it('shows Redirecting… and disables both buttons when weekPassPending', () => {
+  it('disables only the Week Pass button when weekPassPending', () => {
     render(
       <PassCards
         onDayPass={vi.fn()}
@@ -78,7 +78,7 @@ describe('PassCards', () => {
         weekPassPending={true}
       />
     );
-    expect(screen.getByRole('button', { name: 'Get Day Pass' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Get Day Pass' })).toBeEnabled();
     expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
   });
 

--- a/web/src/pages/PricingPage/components/PassCards.tsx
+++ b/web/src/pages/PricingPage/components/PassCards.tsx
@@ -45,7 +45,7 @@ export function PassCards({
           benefits={PASS_BENEFITS}
           onAction={onDayPass}
           actionLabel={dayPassPending ? 'Redirecting…' : 'Get Day Pass'}
-          actionDisabled={dayPassPending || weekPassPending}
+          actionDisabled={dayPassPending}
           caption="Starts the moment you pay"
         />
         <PricingCard
@@ -57,7 +57,7 @@ export function PassCards({
           benefits={PASS_BENEFITS}
           onAction={onWeekPass}
           actionLabel={weekPassPending ? 'Redirecting…' : 'Get Week Pass'}
-          actionDisabled={dayPassPending || weekPassPending}
+          actionDisabled={weekPassPending}
           caption="Starts the moment you pay"
         />
       </div>


### PR DESCRIPTION
## Summary

- Day Pass and Week Pass cards previously shared a single disabled gate (`dayPassPending || weekPassPending`), so clicking one card grayed out both. Looked like the pricing page broke even though only the clicked button was actually doing anything.
- Each card's `actionDisabled` now keys only on its own pending state — the other card stays enabled and clickable.
- The risk this previously guarded (clicking the second pass during the first redirect) is small in practice: the page is one navigation away from leaving for Stripe, and at worst the user ends up at Stripe for the second pass they clicked, which is what they wanted.

No changelog entry — the Day Pass / Week Pass launch entry from earlier today already covers the feature, and this is a transient-state polish that most users wouldn't have consciously noticed.

## Test plan

- [x] `pnpm --filter 2anki-web test` (577/577 green; PassCards tests updated to assert the new isolated-disable behavior)
- [x] `pnpm --filter 2anki-web typecheck`
- [x] `pnpm --filter 2anki-web lint`
- [ ] Visual: click Day Pass on /pricing — only that button shows "Redirecting…" and is disabled; Week Pass stays enabled. Same in reverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->