### PR TITLE
fix: chat consent modal closes after Start chatting

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -644,6 +644,77 @@ describe('UsersController.getLocals', () => {
     expect(payload.user.email_verified).toBe(true);
   });
 
+  it('surfaces chat_consent_at on the user object so the consent modal closes after accept', async () => {
+    const consentAt = new Date('2026-05-16T20:00:00.000Z');
+    const mockUser = {
+      id: 3,
+      email: 'c@example.com',
+      email_verified: true,
+      patreon: false,
+      ankify_welcome_seen: false,
+      trial_started_at: null,
+      hosted_anki_requested_at: null,
+      chat_consent_at: consentAt,
+      owner: 3,
+    };
+    const userService = {
+      getSubscriptionLinkedEmail: jest.fn().mockResolvedValue(null),
+    } as unknown as UsersService;
+    const authService = {
+      getUserFrom: jest.fn().mockResolvedValue(mockUser),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    const req = { cookies: { token: 'valid' } } as unknown as express.Request;
+    const res = {
+      locals: {},
+      json: jest.fn(),
+    } as unknown as express.Response & { json: jest.Mock };
+
+    await controller.getLocals(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.user.chat_consent_at).toEqual(consentAt);
+  });
+
+  it('defaults chat_consent_at to null when the user has not consented', async () => {
+    const mockUser = {
+      id: 4,
+      email: 'd@example.com',
+      email_verified: true,
+      patreon: false,
+      ankify_welcome_seen: false,
+      trial_started_at: null,
+      hosted_anki_requested_at: null,
+      chat_consent_at: null,
+      owner: 4,
+    };
+    const userService = {
+      getSubscriptionLinkedEmail: jest.fn().mockResolvedValue(null),
+    } as unknown as UsersService;
+    const authService = {
+      getUserFrom: jest.fn().mockResolvedValue(mockUser),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    const req = { cookies: { token: 'valid' } } as unknown as express.Request;
+    const res = {
+      locals: {},
+      json: jest.fn(),
+    } as unknown as express.Response & { json: jest.Mock };
+
+    await controller.getLocals(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.user.chat_consent_at).toBeNull();
+  });
+
   it('defaults email_verified to false when user has no value', async () => {
     const mockUser = {
       id: 2,

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -285,6 +285,7 @@ class UsersController {
         ankify_welcome_seen: user?.ankify_welcome_seen ?? false,
         trial_started_at: user?.trial_started_at ?? null,
         signup_country: signupCountry,
+        chat_consent_at: user?.chat_consent_at ?? null,
       },
       locals,
       linked_email: linkedEmail,

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Chat — Start chatting closes the consent prompt and drops you straight into the conversation', date: '2026-05-16' },
   { type: 'feature', title: 'Day Pass and Week Pass — pay once for unlimited conversions over 24 hours or 1 week', date: '2026-05-16' },
   { type: 'fix', title: 'Editing an Official note type opens the editor instead of showing Template not found', date: '2026-05-16' },
   { type: 'fix', title: 'Picking a downloaded 2anki note type in Anki\'s Add Card dialog pre-selects its matching deck', date: '2026-05-16' },


### PR DESCRIPTION
## Summary

- Clicking **Start chatting** on `/chat` did nothing — the consent prompt stayed on top of the chat and re-rendered after every accept attempt. Prod log on 16 May showed the same user clicking it four times in 10 seconds, each one a clean `POST /api/chat/consent → 204`.
- Root cause: `GET /api/users/debug/locals` built a `user` payload that omitted `chat_consent_at` (`src/controllers/UsersControllers.ts:278-295`). The frontend reads `userLocals?.user?.chat_consent_at` to compute `hasConsented` (`web/src/pages/Chat/ChatPage.tsx:152`); the field was always `undefined`, so the modal gate `(!hasConsented && userLocals != null)` re-opened the dialog on every render.
- Fix: surface `user.chat_consent_at` on the response, defaulting to `null`. Two regression tests pin the field on the payload — one for the consented case, one for the not-yet-consented case.
- Changelog entry added to `What's New` since every non-consented user on `/chat` was affected.

## Test plan

- [x] `pnpm test src/controllers/UsersControllers.test.ts` — 27/27 (25 existing + 2 new)
- [x] `npx tsc --noEmit` clean
- [ ] Visual on prod after deploy: hit `/chat` while logged-out-of-consent, click **Start chatting**, confirm modal closes and the composer is focusable
- [ ] Visual: reload `/chat` after accepting — modal does NOT reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->