### PR TITLE
fix: restore verifyEmail error logging

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -319,6 +319,28 @@ describe('UsersController.verifyEmail', () => {
 
     expect(res.redirect).toHaveBeenCalledWith('/login?verify_error=expired');
   });
+
+  it('logs verifyEmail failures before forwarding them', async () => {
+    const error = new Error('magic token lookup failed');
+    const verifyMagicToken = jest.fn().mockRejectedValue(error);
+    const { controller } = buildVerifyEmailController({ verifyMagicToken });
+    const req = { params: { token: 'boom-tok' }, cookies: {} } as unknown as express.Request;
+    const res = buildVerifyEmailRes();
+    const next = jest.fn();
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      await controller.verifyEmail(req, res, next);
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(consoleError).toHaveBeenCalledWith('Email verification failed:', error);
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
 });
 
 describe('UsersController.requestMagicLink', () => {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -703,6 +703,7 @@ class UsersController {
       await this.userService.markEmailVerified(result.userId.toString());
       return res.redirect(`${base}?verified=1`);
     } catch (error) {
+      console.error('Email verification failed:', error);
       next(error);
     }
   }


### PR DESCRIPTION
## Summary
- restore the `verifyEmail` catch-block error log before forwarding to Express error handling
- add a regression test that asserts the underlying error is logged and passed to `next(error)`

Closes #2295

## Tests
- `src/controllers/UsersControllers.ts` and `src/controllers/UsersControllers.test.ts` parse successfully with the TypeScript parser
- source-level proof confirmed the controller contains `console.error('Email verification failed:', error)` and the regression test asserts that log + `next(error)` path

Not run: `pnpm test src/controllers/UsersControllers.test.ts` because both `git clone` and GitHub archive download for a full checkout were denied in this environment. The patch is intentionally small and includes the focused Jest regression test for project CI to run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->