### PR TITLE
fix: align free-plan limit copy and rewrite post-checkout page

### DIFF
--- a/web/src/components/TopMessage/TopMessage.tsx
+++ b/web/src/components/TopMessage/TopMessage.tsx
@@ -19,7 +19,7 @@ function TopMessage() {
     return (
       <div className={styles.alertDanger}>
         <p>
-          You&apos;ve reached your conversion limit.{' '}
+          You&apos;ve reached your monthly limit.{' '}
           <Link to="/pricing">Upgrade</Link> to convert more.
         </p>
       </div>

--- a/web/src/components/errors/helpers/getErrorMessage.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.ts
@@ -80,7 +80,7 @@ export function classifyError(error: unknown): FriendlyError {
 
   if (lower.includes('upload_limit') || lower.includes('upload limit')) {
     return {
-      title: "You've reached your conversion limit.",
+      title: "You've reached your monthly limit.",
       detail: 'Upgrade at /pricing to convert more decks.',
     };
   }

--- a/web/src/pages/AccountPage/AccountPage.tsx
+++ b/web/src/pages/AccountPage/AccountPage.tsx
@@ -60,8 +60,7 @@ export default function AccountPage() {
           aria-live="polite"
         >
           <p>
-            <strong>Thanks for subscribing!</strong> Your plan is active —
-            you can see the details below.
+            <strong>Subscribed.</strong> Your plan details are below.
           </p>
           <button
             type="button"

--- a/web/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
+++ b/web/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
@@ -14,7 +14,7 @@ interface Prop {
 export function DeleteAccountPage({ setError }: Readonly<Prop>) {
   const [count, setCount] = React.useState(0);
   const [isDeleting, setIsDeleting] = React.useState(false);
-  const deleteButtonText = count === 0 ? 'Delete' : 'I am sure!';
+  const deleteButtonText = count === 0 ? 'Delete' : 'Yes, delete account';
 
   const handleDelete = async () => {
     if (count < 1) {
@@ -53,7 +53,7 @@ export function DeleteAccountPage({ setError }: Readonly<Prop>) {
 
         {isDeleting && (
           <div className={sharedStyles.infoBox}>
-            Deleting your account and cancelling subscriptions...
+            Deleting your account and cancelling subscriptions
           </div>
         )}
 
@@ -63,7 +63,7 @@ export function DeleteAccountPage({ setError }: Readonly<Prop>) {
           type="button"
           disabled={isDeleting}
         >
-          {isDeleting ? 'Deleting...' : deleteButtonText}
+          {isDeleting ? 'Deleting' : deleteButtonText}
         </button>
         <p
           className={`${sharedStyles.smallDescription} ${sharedStyles.marginTopLg}`}

--- a/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
+++ b/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
@@ -14,13 +14,12 @@ export function EmptyDownloadsSection({ hasActiveJobs, uploads }: Readonly<Prop>
   return (
     <div className={styles.card}>
       <div className={styles.empty}>
-        <div className={styles.emptyIcon}>📭</div>
         <p className={styles.emptyTitle}>No decks yet</p>
         <p className={styles.emptyDescription}>
           Paste a Notion link or upload a file to make your first deck.
         </p>
         <Link to="/notion" className={styles.emptyLink}>
-          Make your first deck
+          Make a deck
         </Link>
       </div>
     </div>

--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -40,7 +40,7 @@ describe('HomePage (anonymous)', () => {
 
   it('shows free tier info and open source in the hero', () => {
     renderHome();
-    expect(screen.getByText(/100 cards per conversion/i)).toBeInTheDocument();
+    expect(screen.getByText(/100 cards per month/i)).toBeInTheDocument();
     expect(screen.getByText(/open source/i)).toBeInTheDocument();
   });
 

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -138,7 +138,7 @@ export function HomePage({
         </p>
         <UploadForm setErrorMessage={setErrorMessage} />
         <div className={styles.heroFooter}>
-          <span>Free up to 100 cards per conversion</span>
+          <span>Free up to 100 cards per month</span>
           <span className={styles.footerDot} aria-hidden="true" />
           <a
             href="https://github.com/2anki/server"

--- a/web/src/pages/HomePage/components/HomePageLoggedInHeader.tsx
+++ b/web/src/pages/HomePage/components/HomePageLoggedInHeader.tsx
@@ -6,7 +6,7 @@ export function HomePageLoggedInHeader() {
   const title = data?.user?.name;
   return (
     <h2 className={styles.subHeading}>
-      Welcome back{title ? `, ${title}!` : ''}
+      Welcome back{title ? `, ${title}` : ''}
     </h2>
   );
 }

--- a/web/src/pages/SuccessfulCheckout/components/SuccessContent.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/SuccessContent.tsx
@@ -15,37 +15,23 @@ export const SuccessContent = ({ timeoutReached }: SuccessContentProps) => {
       <h1 className={styles.title}>Your payment has been confirmed</h1>
 
       <p>
-        Your payment has been successfully processed. To access your newly
-        unlocked features and start using our service, you will need to either
-        log in to your existing account or create a new one.
+        To start using your new features, log in or create an account with the{' '}
+        <strong>same email address</strong> you used at checkout.
       </p>
 
       <UserActionCards />
 
       <p>
-        <strong>Important Note:</strong>
+        <strong>Used a different email for payment?</strong>
       </p>
       <p>
-        To ensure a smooth experience, please ensure you log in or register
-        using the <strong>same email address</strong> you used during your
-        payment.
-      </p>
-
-      <p>
-        In case you use different email addresses (e.g., Gmail for daily use and
-        web.de for payments), you can still link them after logging in. Head
-        over to your Settings page for more information:{' '}
-        <a href={settingsLink}>{settingsLink}</a>
+        You can link payment and login emails from your{' '}
+        <a href={settingsLink}>settings page</a> after signing in.
       </p>
 
       <p>
-        <strong>
-          Having trouble logging in with the email used for payment?
-        </strong>
-        {
-          " Don't worry, we're here to help! Feel free to reach out to on eamil via this link: "
-        }
-        <a href={supportLink}>email link</a>.
+        Having trouble logging in? Email{' '}
+        <a href={supportLink}>support@2anki.net</a>.
       </p>
 
       <TimeoutWarning show={timeoutReached} />

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -717,7 +717,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const renderLimitState = () => (
     <div className={formStyles.limitContent}>
       <p className={formStyles.limitTitle}>
-        You've reached the free conversion limit
+        You've reached your monthly limit
       </p>
       <p className={formStyles.limitDescription}>
         {limitInfo?.isAnonymous

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Homepage and limit messages match the pricing page — 100 cards per month, everywhere', date: '2026-05-17' },
   { type: 'fix', title: 'Chat — Start chatting closes the consent prompt and drops you straight into the conversation', date: '2026-05-16' },
   { type: 'feature', title: 'Day Pass and Week Pass — pay once for unlimited conversions over 24 hours or 1 week', date: '2026-05-16' },
   { type: 'fix', title: 'Editing an Official note type opens the editor instead of showing Template not found', date: '2026-05-16' },


### PR DESCRIPTION
## Summary

User-facing copy fixes from the PM trio review.

**The big one — limit-message alignment.** The homepage hero said *"Free up to 100 cards per conversion"* while the pricing page, the monthly-limit banner, and the upload-form gate all said *"100 cards per month"*. A user who read the hero and then got blocked at 100 cards over the course of a month would feel bait-and-switched. Now every surface speaks the same line:

| Surface | Before | After |
|---|---|---|
| Homepage hero | Free up to 100 cards per conversion | Free up to 100 cards per month |
| TopMessage banner | You've reached your conversion limit | You've reached your monthly limit |
| UploadForm limit gate | You've reached the free conversion limit | You've reached your monthly limit |
| `getErrorMessage` upload_limit | You've reached your conversion limit. | You've reached your monthly limit. |

**Post-checkout page rewrite.** `/successful-checkout` had a typo (*"to on eamil"*), banned voice (*"Don't worry, we're here to help! Feel free to reach out…"*), and Title Case *"Important Note"*. Rewrote the body — same structure (h1 → what to do → action cards → email-mismatch help → support fallback), no fake warmth, no typo, sentence case throughout. Same `UserActionCards` and `TimeoutWarning` components.

**Voice sweep on adjacent surfaces** (exclamations, ellipsis, casing):

- `HomePageLoggedInHeader` — dropped the `!` after the user's name
- `AccountPage` post-subscribe banner — *"Thanks for subscribing! Your plan is active — you can see the details below."* → *"Subscribed. Your plan details are below."*
- `DeleteAccountPage` — *"I am sure!"* confirm → *"Yes, delete account"*. Dropped literal `...` from *"Deleting..."* and *"Deleting your account and cancelling subscriptions..."* per VOICE.md
- `EmptyDownloadsSection` — dropped the 📭 emoji (no emoji in product UI per VOICE.md banned-words table); CTA *"Make your first deck"* → *"Make a deck"*

## Out of scope

These were flagged in the trio review but not in this PR — separate sweeps if you want them:

- `SubscriptionManagement` Title Case headings + literal `...` loaders
- `MagicLinkPage` and `FeedbackWidget` literal `...` loaders
- `AboutPage` *"Get started"* → specific CTA
- `TierSection` stale fallback content (and possibly dead component)
- Thousands-separator sweep (1,000 → 1 000) per VOICE.md numbers section
- Anonymous-user trial-on-registration product change (real product call, not copy)

## Test plan

- [x] `pnpm typecheck` (web) — clean
- [x] `pnpm test --run` (web) — 577 pass, 85 files
- [x] `pnpm lint` (web, Biome) — clean
- [x] `HomePage.test.tsx` assertion updated to match the new hero string
- [ ] Visual check after merge:
  - [ ] Homepage hero shows new line
  - [ ] Upload past the limit shows the new limit copy on the form gate
  - [ ] Hit `/upload?error=upload_limit_exceeded` → TopMessage shows new line
  - [ ] `/successful-checkout` renders the rewritten body
  - [ ] `/account` post-subscribe banner shows new line
  - [ ] `/delete-account` → click Delete → second button reads "Yes, delete account"
  - [ ] `/downloads` empty state has no envelope emoji and CTA reads "Make a deck"

## Out of scope / not run

- `sonar-scanner` not run locally (no token configured). Changes are text-only — extremely low risk of new findings.

## Changelog

One entry added — the limit-message alignment is the one user-visible bug this PR closes. The other items are voice polish that users wouldn't write home about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->