### PR TITLE
fix: a11y pass — refresh icon, contrast, autoComplete, modal ARIA

### DIFF
--- a/web/src/components/FeedbackWidget/FeedbackModal.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackModal.tsx
@@ -20,9 +20,16 @@ export function FeedbackModal({ isActive, onClose }: Readonly<Props>) {
         onClick={onClose}
         aria-label="Close feedback"
       />
-      <div className={sharedStyles.modalCardNarrow}>
+      <div
+        className={sharedStyles.modalCardNarrow}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="feedback-modal-title"
+      >
         <div className={sharedStyles.modalHeader}>
-          <div className={sharedStyles.modalHeaderTitle}>Send feedback</div>
+          <div id="feedback-modal-title" className={sharedStyles.modalHeaderTitle}>
+            Send feedback
+          </div>
           <button
             type="button"
             aria-label="close"

--- a/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -63,6 +63,8 @@ function ForgotPasswordForm({ setError }: Readonly<ForgotPasswordProps>) {
                   }
                 }}
                 type="email"
+                autoComplete="email"
+                inputMode="email"
                 placeholder="Email address"
                 required
               />

--- a/web/src/components/forms/NewPasswordForm.tsx
+++ b/web/src/components/forms/NewPasswordForm.tsx
@@ -76,6 +76,7 @@ function NewPasswordForm({ setErrorMessage }: Readonly<Props>) {
                   setPassword(event.target.value);
                 }}
                 type="password"
+                autoComplete="new-password"
                 placeholder="New password"
                 required
               />
@@ -96,6 +97,7 @@ function NewPasswordForm({ setErrorMessage }: Readonly<Props>) {
                   setConfirmPassword(event.target.value);
                 }}
                 type="password"
+                autoComplete="new-password"
                 placeholder="Re-enter new password"
                 required
               />

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -108,6 +108,8 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
                   }
                 }}
                 type="email"
+                autoComplete="email"
+                inputMode="email"
                 placeholder="Email address"
                 required
                 name="email"
@@ -126,6 +128,7 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
                 onChange={(event) => setPassword(event.target.value)}
                 required
                 type="password"
+                autoComplete="new-password"
                 placeholder="Password"
                 aria-describedby="password-help"
               />

--- a/web/src/components/modals/SettingsModal/SettingsModal.tsx
+++ b/web/src/components/modals/SettingsModal/SettingsModal.tsx
@@ -38,9 +38,14 @@ function SettingsModal({
         onClick={onClickClose}
         aria-label="Close modal"
       />
-      <div className={sharedStyles.modalCard}>
+      <div
+        className={sharedStyles.modalCard}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-modal-title"
+      >
         <div className={sharedStyles.modalHeader}>
-          <div className={sharedStyles.modalHeaderTitle}>
+          <div id="settings-modal-title" className={sharedStyles.modalHeaderTitle}>
             {getVisibleText('card.options')}
           </div>
           <div className={styles.headerActions}>

--- a/web/src/pages/AccountPage/components/CancellationSurveyModal.tsx
+++ b/web/src/pages/AccountPage/components/CancellationSurveyModal.tsx
@@ -42,9 +42,14 @@ export function CancellationSurveyModal({ mode, onConfirm, onClose }: Props) {
         onClick={onClose}
         aria-label="Close"
       />
-      <div className={sharedStyles.modalCardNarrow}>
+      <div
+        className={sharedStyles.modalCardNarrow}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cancellation-survey-title"
+      >
         <div className={sharedStyles.modalHeader}>
-          <span className={sharedStyles.modalHeaderTitle}>
+          <span id="cancellation-survey-title" className={sharedStyles.modalHeaderTitle}>
             Before you go…
           </span>
           <button

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -14,6 +14,7 @@ import { UnfinishedJobsInfo } from './components/UnfinishedJobsInfo';
 import { PaywallBanner } from './components/PaywallBanner';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import RefreshIcon from '../../components/icons/RefreshIcon';
 import styles from './DownloadsPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 
@@ -85,7 +86,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
           disabled={refreshing || loading}
           aria-label="Refresh my decks"
         >
-          <i className="fa-solid fa-arrows-rotate" aria-hidden="true" />
+          <RefreshIcon />
           {refreshing ? 'Refreshing…' : 'Refresh'}
         </button>
       </div>

--- a/web/src/pages/DownloadsPage/components/ListJobs/ListJobs.module.css
+++ b/web/src/pages/DownloadsPage/components/ListJobs/ListJobs.module.css
@@ -2,7 +2,8 @@
   background-color: var(--color-bg-primary);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .table {

--- a/web/src/pages/DownloadsPage/components/ListJobs/RefreshButton.tsx
+++ b/web/src/pages/DownloadsPage/components/ListJobs/RefreshButton.tsx
@@ -1,4 +1,5 @@
 import styles from '../../../../styles/shared.module.css';
+import RefreshIcon from '../../../../components/icons/RefreshIcon';
 
 interface Prop {
   onRefresh: () => void;
@@ -8,11 +9,11 @@ export function RefreshButton({ onRefresh }: Readonly<Prop>) {
   return (
     <button
       onClick={() => onRefresh()}
-      aria-label="refresh"
+      aria-label="Refresh"
       type="button"
       className={styles.btnIcon}
     >
-      <i className="fa-solid fa-arrows-rotate" />
+      <RefreshIcon />
     </button>
   );
 }

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -87,6 +87,8 @@ function LoginForm() {
                       }
                     }}
                     type="email"
+                    autoComplete="email"
+                    inputMode="email"
                     placeholder="Email address"
                     required
                   />
@@ -140,6 +142,7 @@ function LoginForm() {
                   name="email"
                   value={email}
                   type="email"
+                  autoComplete="email"
                   readOnly
                 />
               </label>
@@ -168,6 +171,7 @@ function LoginForm() {
                   onChange={(event) => setPassword(event.target.value)}
                   required
                   type="password"
+                  autoComplete="current-password"
                   placeholder="Password"
                   autoFocus
                 />

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,8 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Refresh button on My Decks shows its icon again', date: '2026-05-17' },
+  { type: 'fix', title: 'Sign in and signup prompt your password manager to autofill and save credentials', date: '2026-05-17' },
   { type: 'fix', title: 'Homepage and limit messages match the pricing page — 100 cards per month, everywhere', date: '2026-05-17' },
   { type: 'fix', title: 'Chat — Start chatting closes the consent prompt and drops you straight into the conversation', date: '2026-05-16' },
   { type: 'feature', title: 'Day Pass and Week Pass — pay once for unlimited conversions over 24 hours or 1 week', date: '2026-05-16' },

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -1,11 +1,11 @@
 :root {
   --color-text-primary: #1f2937;
   --color-text-secondary: #6b7280;
-  --color-text-tertiary: #9ca3af;
+  --color-text-tertiary: #6b7280;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
-  --color-text-link: #3b82f6;
-  --color-text-link-hover: #2563eb;
+  --color-text-link: #2563eb;
+  --color-text-link-hover: #1d4ed8;
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f9fafb;
   --color-bg-tertiary: #f3f4f6;


### PR DESCRIPTION
## Summary

A11y findings from the designer trio review — the safe, additive ones. Skipped the structural items (modal `<dialog>` migration, drop-zone keyboard restructure, type-scale shift) — those get their own focused PRs so they can be reviewed independently.

### 1. Refresh icon, restored

`DownloadsPage.tsx` and `ListJobs/RefreshButton.tsx` were rendering `<i className="fa-solid fa-arrows-rotate" />`, but Font Awesome was never wired into the bundle — both buttons came up empty (one with a visible "Refresh" label and an invisible glyph, the other with *only* an `aria-label`, meaning it was effectively invisible for sighted users). Swapped both for the in-tree `RefreshIcon` SVG (`web/src/components/icons/RefreshIcon.tsx`).

### 2. Color tokens, WCAG AA contrast on white

| Token | Old | New | Old ratio | New ratio |
|---|---|---|---|---|
| `--color-text-link` | `#3b82f6` | `#2563eb` | 3.68:1 ❌ | 5.17:1 ✅ |
| `--color-text-link-hover` | `#2563eb` | `#1d4ed8` | — | — |
| `--color-text-tertiary` | `#9ca3af` | `#6b7280` | 2.85:1 ❌ | 4.55:1 ✅ |

`tertiary` now equals `secondary` — intentional. Stripe-class apps reserve "tertiary" for decorative-only states, but in our codebase it's used for real labels (sidebar identity, footer links, downloads table headers, the home-hero "Read the guide" line), so it has to pass AA. Restoring the visual hierarchy is a job for the deferred type-scale PR.

### 3. `autoComplete` + `inputMode` on auth forms

| Form | Field | Attr |
|---|---|---|
| `LoginForm` | email | `autoComplete="email"`, `inputMode="email"` |
| `LoginForm` | password | `autoComplete="current-password"` |
| `RegisterForm` | email | `autoComplete="email"`, `inputMode="email"` |
| `RegisterForm` | password | `autoComplete="new-password"` |
| `ForgotPasswordForm` | email | `autoComplete="email"`, `inputMode="email"` |
| `NewPasswordForm` | both | `autoComplete="new-password"` |

Password managers will surface saved credentials at sign-in, offer to save new ones at signup, and let users accept the strong-password suggestion on the reset flow. iOS will show the email-tuned keyboard on the email fields.

### 4. Modal ARIA

Three shared-modal consumers were missing the dialog ARIA — added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing at the header title:

- `SettingsModal` (`settings-modal-title`)
- `FeedbackModal` (`feedback-modal-title`)
- `CancellationSurveyModal` (`cancellation-survey-title`)

`ConsentModal` already had this (uses the HTML `<dialog>` element). Full focus-trap, escape-to-close, and return-focus-to-trigger handling is the separate `<dialog>`-migration PR.

### 5. Jobs table mobile overflow

`ListJobs.module.css` `.container` had `overflow: hidden`, which clipped the 5-column table on ≤640px viewports (the file-name and timestamp columns disappeared off the edge). Changed to `overflow-x: auto` / `overflow-y: hidden` — table scrolls horizontally on mobile, vertical clipping still preserves the rounded corners.

## Out of scope (separate PRs)

- **Modal `<dialog>` migration** — adding `role="dialog"` etc. announces the modal correctly, but real focus-trap + escape-to-close + return-focus-to-trigger needs the `<dialog>` element (or a focus-trap effect). Single dedicated PR.
- **Drop-zone keyboard accessibility** (`UploadForm.tsx`) — the current `<label>`-wraps-hidden-input pattern *is* focusable (the input is tabbable), but the focus ring is invisible. The fix is a `:focus-visible` CSS pass on the label, not a structural rewrite. Single dedicated PR.
- **Type-scale shift** (`--text-sm` 18px → 14px) — system-wide reflow; deserves its own PR with a visual review.
- **`window.confirm()` for logout / delete-account** — kept native; if you want themed modals there, separate PR.
- **Skip-to-main-content link** — small additive; can be folded into the modal `<dialog>` PR.

## Test plan

- [x] `pnpm typecheck` (web) — clean
- [x] `pnpm test --run` (web) — 577 pass, 85 files (one flake on first run, clean on rerun, unrelated to these changes)
- [x] `pnpm lint` (web, Biome) — clean
- [ ] Visual check after merge:
  - [ ] My Decks page — refresh button shows the circular-arrow icon, both in the header and in the per-job row
  - [ ] Links on white surfaces look darker (better contrast); use Lighthouse or Axe to confirm
  - [ ] iOS Safari: tap an email field → email-tuned keyboard appears
  - [ ] Open the settings modal with a screen reader → it announces as a dialog with the "Card options" title
  - [ ] Resize the My Decks page to 375px — the jobs table scrolls horizontally instead of clipping
  - [ ] Save a new password in a password manager when registering — manager prompts to save

## Changelog

Two entries added — the refresh-icon fix and the autoComplete prompt. The contrast bump and modal ARIA aren't user-noticeable to most users; they're hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->