### PR TITLE
fix: mask /chat and /ops from Hotjar recordings

### DIFF
--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -578,7 +578,7 @@ export default function ChatPage() {
         onDismiss={() => setShowConsentModal(false)}
       />
     )}
-    <div className={styles.layout}>
+    <div className={styles.layout} data-hj-suppress>
       <ConversationsSidebar
         conversations={conversations}
         activeId={activeConversationId}

--- a/web/src/pages/OpsPage/OpsLayout.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.tsx
@@ -26,7 +26,7 @@ export default function OpsLayout() {
   const fullPath = `${location.pathname}${location.search}`;
 
   return (
-    <main className={sharedStyles.pageWide}>
+    <main className={sharedStyles.pageWide} data-hj-suppress>
       <h1 className={sharedStyles.title}>Ops</h1>
       <nav aria-label="Ops sections" className={styles.tabs}>
         {TABS.map((tab) => {


### PR DESCRIPTION
## Summary
- Add `data-hj-suppress` on the chat layout root so messages, streaming text, conversation titles, card previews, and the composer are masked in Hotjar
- Add `data-hj-suppress` on the OpsLayout main so business metrics, customer messages, interviews, and the rest of the admin dashboard are masked

Hotjar's `data-hj-suppress` applies to every descendant, so each fix is a single attribute on the page root.

No changelog entry — privacy/observability hardening, no user-visible behavior change.

## Test plan
- [ ] Open `/chat`, inspect — `.layout` root has `data-hj-suppress`
- [ ] Open `/ops`, inspect — `main` has `data-hj-suppress`
- [ ] After deploy, verify in a fresh Hotjar recording that both surfaces render as masked rectangles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->