### PR TITLE
fix: return to /upload after saving global card options

### DIFF
--- a/web/src/pages/CardOptionsPage/CardOptionsPage.test.tsx
+++ b/web/src/pages/CardOptionsPage/CardOptionsPage.test.tsx
@@ -9,9 +9,19 @@ vi.mock('../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => mockApi,
 }));
 
+const cardOptionsFormProps = vi.fn();
 vi.mock('../../components/CardOptionsForm/CardOptionsForm', () => ({
-  CardOptionsForm: () => <div data-testid="card-options-form" />,
+  CardOptionsForm: (props: Record<string, unknown>) => {
+    cardOptionsFormProps(props);
+    return <div data-testid="card-options-form" />;
+  },
 }));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 const mockApi = {
   listSettings: vi.fn(),
@@ -31,6 +41,8 @@ function renderPage(search = '') {
 describe('CardOptionsPage per-page list', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    cardOptionsFormProps.mockClear();
+    mockNavigate.mockClear();
     mockApi.listSettings.mockResolvedValue({ items: [] });
     mockApi.deleteSettings.mockResolvedValue(undefined);
     mockApi.deleteRules.mockResolvedValue(undefined);
@@ -176,6 +188,31 @@ describe('CardOptionsPage per-page list', () => {
       expect(mockApi.deleteAllUserSettings).toHaveBeenCalledTimes(1);
       expect(mockApi.listSettings).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('wires onSaved to return to /upload when arriving with ?returnTo=/upload', async () => {
+    renderPage('?returnTo=/upload');
+    await screen.findByTestId('card-options-form');
+    const props = cardOptionsFormProps.mock.calls.at(-1)?.[0] as { onSaved?: () => void };
+    expect(props.onSaved).toBeDefined();
+    props.onSaved!();
+    expect(mockNavigate).toHaveBeenCalledWith('/upload');
+  });
+
+  it('leaves onSaved undefined for direct nav to /card-options', async () => {
+    renderPage();
+    await screen.findByTestId('card-options-form');
+    const props = cardOptionsFormProps.mock.calls.at(-1)?.[0] as { onSaved?: () => void };
+    expect(props.onSaved).toBeUndefined();
+  });
+
+  it('keeps onSaved wired when viewing a specific page', async () => {
+    renderPage('?pageId=abc-123');
+    await screen.findByTestId('card-options-form');
+    const props = cardOptionsFormProps.mock.calls.at(-1)?.[0] as { onSaved?: () => void };
+    expect(props.onSaved).toBeDefined();
+    props.onSaved!();
+    expect(mockNavigate).toHaveBeenCalledWith('/upload');
   });
 
   it('shows error strip when bulk reset fails', async () => {

--- a/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
+++ b/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
@@ -56,7 +56,9 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
 
   const pageId = params.get('pageId');
   const pageTitle = params.get('title');
-  const returnTo = params.get('returnTo') ?? '/upload';
+  const returnToParam = params.get('returnTo');
+  const returnTo = returnToParam ?? '/upload';
+  const shouldReturnAfterSave = pageId != null || returnToParam != null;
 
   const goBack = () => navigate(returnTo);
 
@@ -282,8 +284,8 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
         <CardOptionsForm
           pageId={pageId}
           pageTitle={pageTitle}
-          onSaved={pageId == null ? undefined : goBack}
-          onReset={pageId == null ? undefined : goBack}
+          onSaved={shouldReturnAfterSave ? goBack : undefined}
+          onReset={shouldReturnAfterSave ? goBack : undefined}
           setError={setErrorMessage}
         />
       </div>

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -97,7 +97,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
       <UploadForm setErrorMessage={setErrorMessage} />
       <p className={pageStyles.settingsHint}>
         Change deck names, templates, and conversion defaults in{' '}
-        <Link to="/card-options">Settings</Link>.
+        <Link to="/card-options?returnTo=/upload">Settings</Link>.
       </p>
       <p className={pageStyles.footnote}>
         Your uploaded files are deleted after 2 hours.


### PR DESCRIPTION
## Summary
- /upload's "Settings" link now passes `?returnTo=/upload`
- `CardOptionsPage` wires the form's `onSaved` / `onReset` handlers whenever `?returnTo` is present, not only when editing a specific page
- Users who detour to settings mid-upload land back on /upload after Save; sidebar / direct-nav users keep the previous behavior (stay on settings)

Bug: clicking the Settings link from /upload, editing global defaults, then Save left the user stranded on /card-options. The page already had the `goBack` / `?returnTo` machinery for per-page edits — this PR widens the gate so the global view honors it too.

### Trio synthesis
- **PM**: query param `?from=upload`, silent redirect, only when from /upload.
- **Designer**: explicit "Save and return to upload" button label, scope to /upload + /downloads.
- **Engineer**: the `?returnTo=` query-param convention already exists in `SettingsModal.tsx`; reuse it.

Resolution: use the existing `?returnTo=/upload` param (engineer + PM win on mechanism — consistency, survives refresh). Scope to /upload only (engineer's analysis showed the safe-default falls into place). Button label change deferred — current label "Save defaults" is already specific; track as follow-up if user feedback warrants.

No changelog entry — this restores the expected flow rather than introducing new behavior the user needs to learn.

## Test plan
- [x] `web/src/pages/CardOptionsPage/CardOptionsPage.test.tsx` — 3 new tests cover `?returnTo=/upload`, `?pageId=…`, and bare nav cases
- [ ] Manual: from /upload click Settings → edit a deck-name field → Save → land on /upload
- [ ] Manual: from sidebar click Card options → edit → Save → stay on /card-options
- [ ] Manual: from per-page Rules → Card options (`?pageId=…`) → edit → Save → return to rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->