### PR TITLE
fix: a11y/UX pass — modal focus-trap, skip link, drop-zone focus

### DIFF
--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -300,3 +300,25 @@
     z-index: 30;
   }
 }
+
+.skipLink {
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 100;
+  padding: 0.5rem 1rem;
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
+  border-radius: 0 0 var(--radius-md) 0;
+  text-decoration: none;
+  font-weight: var(--font-medium);
+  transform: translateY(-100%);
+  transition: transform var(--transition-fast);
+}
+
+.skipLink:focus,
+.skipLink:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}

--- a/web/src/components/AppShell/SidebarLayout.tsx
+++ b/web/src/components/AppShell/SidebarLayout.tsx
@@ -39,6 +39,9 @@ export function SidebarLayout({
 
   return (
     <div className={styles.shell} data-shell>
+      <a href="#main-content" className={styles.skipLink}>
+        Skip to content
+      </a>
       <Sidebar
         email={email}
         locals={locals}
@@ -68,7 +71,7 @@ export function SidebarLayout({
           passKind={locals?.passKind}
         />
         {error && <ErrorPresenter error={error} />}
-        <main className={sharedStyles.flexGrow}>
+        <main id="main-content" className={sharedStyles.flexGrow}>
           <Suspense fallback={<SkeletonPage rows={5} />}>{children}</Suspense>
         </main>
       </div>

--- a/web/src/components/FeedbackWidget/FeedbackModal.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackModal.tsx
@@ -19,9 +19,6 @@ export function FeedbackModal({ isActive, onClose }: Readonly<Props>) {
       ref={dialogRef}
       className={sharedStyles.dialog}
       aria-labelledby="feedback-modal-title"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
     >
       <div className={sharedStyles.modalCardNarrow}>
         <div className={sharedStyles.modalHeader}>

--- a/web/src/components/FeedbackWidget/FeedbackModal.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackModal.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { useLocation } from 'react-router-dom';
 
+import { useDialog } from '../../lib/hooks/useDialog';
 import sharedStyles from '../../styles/shared.module.css';
 import { FeedbackWidget } from './FeedbackWidget';
 
@@ -11,21 +12,18 @@ interface Props {
 
 export function FeedbackModal({ isActive, onClose }: Readonly<Props>) {
   const { pathname } = useLocation();
+  const dialogRef = useDialog(isActive, onClose);
 
   return createPortal(
-    <div className={isActive ? sharedStyles.modal : sharedStyles.modalHidden}>
-      <button
-        type="button"
-        className={sharedStyles.modalBackdrop}
-        onClick={onClose}
-        aria-label="Close feedback"
-      />
-      <div
-        className={sharedStyles.modalCardNarrow}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="feedback-modal-title"
-      >
+    <dialog
+      ref={dialogRef}
+      className={sharedStyles.dialog}
+      aria-labelledby="feedback-modal-title"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className={sharedStyles.modalCardNarrow}>
         <div className={sharedStyles.modalHeader}>
           <div id="feedback-modal-title" className={sharedStyles.modalHeaderTitle}>
             Send feedback
@@ -43,7 +41,7 @@ export function FeedbackModal({ isActive, onClose }: Readonly<Props>) {
           <FeedbackWidget page={pathname} onSubmitted={onClose} />
         </section>
       </div>
-    </div>,
+    </dialog>,
     document.body
   );
 }

--- a/web/src/components/modals/SettingsModal/SettingsModal.tsx
+++ b/web/src/components/modals/SettingsModal/SettingsModal.tsx
@@ -38,9 +38,6 @@ function SettingsModal({
       ref={dialogRef}
       className={sharedStyles.dialog}
       aria-labelledby="settings-modal-title"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClickClose();
-      }}
     >
       <div className={sharedStyles.modalCard}>
         <div className={sharedStyles.modalHeader}>

--- a/web/src/components/modals/SettingsModal/SettingsModal.tsx
+++ b/web/src/components/modals/SettingsModal/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { SyntheticEvent } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { ErrorHandlerType } from '../../errors/helpers/getErrorMessage';
 import { getVisibleText } from '../../../lib/text/getVisibleText';
+import { useDialog } from '../../../lib/hooks/useDialog';
 import { CardOptionsForm } from '../../CardOptionsForm/CardOptionsForm';
 import sharedStyles from '../../../styles/shared.module.css';
 import styles from './SettingsModal.module.css';
@@ -30,20 +31,18 @@ function SettingsModal({
   params.set('returnTo', returnTo);
   const fullPageHref = `/card-options?${params.toString()}`;
 
+  const dialogRef = useDialog(isActive, () => onClickClose());
+
   return (
-    <div className={isActive ? sharedStyles.modal : sharedStyles.modalHidden}>
-      <button
-        type="button"
-        className={sharedStyles.modalBackdrop}
-        onClick={onClickClose}
-        aria-label="Close modal"
-      />
-      <div
-        className={sharedStyles.modalCard}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="settings-modal-title"
-      >
+    <dialog
+      ref={dialogRef}
+      className={sharedStyles.dialog}
+      aria-labelledby="settings-modal-title"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClickClose();
+      }}
+    >
+      <div className={sharedStyles.modalCard}>
         <div className={sharedStyles.modalHeader}>
           <div id="settings-modal-title" className={sharedStyles.modalHeaderTitle}>
             {getVisibleText('card.options')}
@@ -72,7 +71,7 @@ function SettingsModal({
           />
         </section>
       </div>
-    </div>
+    </dialog>
   );
 }
 

--- a/web/src/lib/hooks/useDialog.ts
+++ b/web/src/lib/hooks/useDialog.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+
+export function useDialog(isOpen: boolean, onClose: () => void) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (isOpen && !dialog.open) {
+      if (typeof dialog.showModal === 'function') {
+        dialog.showModal();
+      } else {
+        dialog.setAttribute('open', '');
+      }
+    } else if (!isOpen && dialog.open) {
+      if (typeof dialog.close === 'function') {
+        dialog.close();
+      } else {
+        dialog.removeAttribute('open');
+      }
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    const handleClose = () => onClose();
+    dialog.addEventListener('close', handleClose);
+    return () => dialog.removeEventListener('close', handleClose);
+  }, [onClose]);
+
+  // jsdom doesn't implement native dialog Escape handling; only add the
+  // fallback listener when showModal is missing, to avoid double-firing
+  // onClose in real browsers.
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog || !isOpen) return;
+    if (typeof dialog.showModal === 'function') return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [isOpen, onClose]);
+
+  return ref;
+}

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -152,7 +152,7 @@
 .dangerTitle {
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
-  color: var(--color-danger);
+  color: var(--color-text-secondary);
   margin: 0 0 0.75rem;
 }
 

--- a/web/src/pages/AccountPage/components/CancellationSurveyModal.tsx
+++ b/web/src/pages/AccountPage/components/CancellationSurveyModal.tsx
@@ -41,9 +41,6 @@ export function CancellationSurveyModal({ mode, onConfirm, onClose }: Props) {
       ref={dialogRef}
       className={sharedStyles.dialog}
       aria-labelledby="cancellation-survey-title"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
     >
       <div className={sharedStyles.modalCardNarrow}>
         <div className={sharedStyles.modalHeader}>

--- a/web/src/pages/AccountPage/components/CancellationSurveyModal.tsx
+++ b/web/src/pages/AccountPage/components/CancellationSurveyModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { CancelMode } from '../../../lib/backend/cancelSubscription';
+import { useDialog } from '../../../lib/hooks/useDialog';
 import sharedStyles from '../../../styles/shared.module.css';
 import styles from '../AccountPage.module.css';
 
@@ -28,6 +29,7 @@ const MODE_LABELS: Record<CancelMode, string> = {
 export function CancellationSurveyModal({ mode, onConfirm, onClose }: Props) {
   const [reason, setReason] = useState<CancellationReason | ''>('');
   const [comment, setComment] = useState('');
+  const dialogRef = useDialog(true, onClose);
 
   const handleConfirm = () => {
     if (!reason) return;
@@ -35,19 +37,15 @@ export function CancellationSurveyModal({ mode, onConfirm, onClose }: Props) {
   };
 
   return (
-    <div className={sharedStyles.modal}>
-      <button
-        type="button"
-        className={sharedStyles.modalBackdrop}
-        onClick={onClose}
-        aria-label="Close"
-      />
-      <div
-        className={sharedStyles.modalCardNarrow}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="cancellation-survey-title"
-      >
+    <dialog
+      ref={dialogRef}
+      className={sharedStyles.dialog}
+      aria-labelledby="cancellation-survey-title"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className={sharedStyles.modalCardNarrow}>
         <div className={sharedStyles.modalHeader}>
           <span id="cancellation-survey-title" className={sharedStyles.modalHeaderTitle}>
             Before you go…
@@ -109,6 +107,6 @@ export function CancellationSurveyModal({ mode, onConfirm, onClose }: Props) {
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
+++ b/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { CardOptionsForm } from '../../components/CardOptionsForm/CardOptionsForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { useDialog } from '../../lib/hooks/useDialog';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './CardOptionsPage.module.css';
 
@@ -52,6 +53,7 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
   const [bulkError, setBulkError] = useState<string | null>(null);
   const [bulkSuccess, setBulkSuccess] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const bulkResetDialogRef = useDialog(confirmOpen, () => setConfirmOpen(false));
   const [bulkPending, setBulkPending] = useState(false);
 
   const pageId = params.get('pageId');
@@ -288,18 +290,14 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
         />
       </div>
 
-      <div
-        className={confirmOpen ? sharedStyles.modal : sharedStyles.modalHidden}
-        role="dialog"
-        aria-modal="true"
+      <dialog
+        ref={bulkResetDialogRef}
+        className={sharedStyles.dialog}
         aria-labelledby="bulk-reset-dialog-title"
+        onClick={(event) => {
+          if (event.target === event.currentTarget) setConfirmOpen(false);
+        }}
       >
-        <button
-          type="button"
-          className={sharedStyles.modalBackdrop}
-          onClick={() => setConfirmOpen(false)}
-          aria-label="Close"
-        />
         <div className={sharedStyles.modalCardNarrow}>
           <div className={sharedStyles.modalHeader}>
             <span
@@ -343,7 +341,7 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
             </button>
           </div>
         </div>
-      </div>
+      </dialog>
     </div>
   );
 }

--- a/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
+++ b/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
@@ -294,9 +294,6 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
         ref={bulkResetDialogRef}
         className={sharedStyles.dialog}
         aria-labelledby="bulk-reset-dialog-title"
-        onClick={(event) => {
-          if (event.target === event.currentTarget) setConfirmOpen(false);
-        }}
       >
         <div className={sharedStyles.modalCardNarrow}>
           <div className={sharedStyles.modalHeader}>

--- a/web/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -141,9 +141,6 @@ function PreviewModal({ starter, onClose }: Readonly<PreviewModalProps>) {
       ref={dialogRef}
       className={sharedStyles.dialog}
       aria-labelledby="note-type-preview-title"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
     >
       <div className={`${sharedStyles.modalCard} ${styles.dialog}`}>
         <div className={sharedStyles.modalHeader}>

--- a/web/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -10,6 +10,7 @@ import {
   getOfficialNoteTypes,
   getUserTemplates,
 } from '../../lib/backend/templates';
+import { useDialog } from '../../lib/hooks/useDialog';
 import sharedStyles from '../../styles/shared.module.css';
 import DownloadIcon from '../../components/icons/DownloadIcon';
 import PencilIcon from '../../components/icons/PencilIcon';
@@ -133,29 +134,18 @@ function PreviewModal({ starter, onClose }: Readonly<PreviewModalProps>) {
     () => buildPreviewDocument(starter.noteType, starter.previewData, 'back'),
     [starter]
   );
-
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  const dialogRef = useDialog(true, onClose);
 
   return (
-    <div className={sharedStyles.modal}>
-      <button
-        type="button"
-        className={sharedStyles.modalBackdrop}
-        onClick={onClose}
-        aria-label="Close preview"
-      />
-      <dialog
-        open
-        aria-modal="true"
-        aria-labelledby="note-type-preview-title"
-        className={`${sharedStyles.modalCard} ${styles.dialog}`}
-      >
+    <dialog
+      ref={dialogRef}
+      className={sharedStyles.dialog}
+      aria-labelledby="note-type-preview-title"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className={`${sharedStyles.modalCard} ${styles.dialog}`}>
         <div className={sharedStyles.modalHeader}>
           <h2
             id="note-type-preview-title"
@@ -196,8 +186,8 @@ function PreviewModal({ starter, onClose }: Readonly<PreviewModalProps>) {
             </div>
           </div>
         </div>
-      </dialog>
-    </div>
+      </div>
+    </dialog>
   );
 }
 

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -26,6 +26,11 @@
   background: var(--color-primary-light);
 }
 
+.dropZone:focus-within {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .dropZoneConverting {
   border-color: var(--color-primary);
   border-style: solid;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -843,10 +843,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const renderLiveStatus = (): string => {
     if (zoneState === 'converting') return 'Converting your file.';
     if (zoneState === 'success') {
-      const count = cardCount == null
-        ? ''
-        : `${cardCount} ${cardCount === 1 ? 'card' : 'cards'}`;
-      return `Your deck is ready${count ? ` — ${count}` : ''}.`;
+      if (cardCount == null) return 'Your deck is ready.';
+      const noun = cardCount === 1 ? 'card' : 'cards';
+      return `Your deck is ready — ${cardCount} ${noun}.`;
     }
     if (zoneState === 'emptyDeck') {
       return 'Conversion finished, but no cards were found.';

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -840,8 +840,29 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const showGoogleDrivePanel = showChips && source === 'google_drive';
   const showLocalPanel = !showChips || source === 'local';
 
+  const renderLiveStatus = (): string => {
+    if (zoneState === 'converting') return 'Converting your file.';
+    if (zoneState === 'success') {
+      const count = cardCount == null
+        ? ''
+        : `${cardCount} ${cardCount === 1 ? 'card' : 'cards'}`;
+      return `Your deck is ready${count ? ` — ${count}` : ''}.`;
+    }
+    if (zoneState === 'emptyDeck') {
+      return 'Conversion finished, but no cards were found.';
+    }
+    if (zoneState === 'error') return 'Conversion failed.';
+    if (zoneState === 'limitReached') {
+      return "You've reached your monthly limit.";
+    }
+    return '';
+  };
+
   return (
     <form encType="multipart/form-data" method="post" onSubmit={handleSubmit}>
+      <output aria-live="polite" className={sharedStyles.srOnly}>
+        {renderLiveStatus()}
+      </output>
       <label
         htmlFor="pakker"
         id="upload-panel-local"

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Escape closes settings, feedback, cancellation, and template-preview modals — and returns focus to the button that opened them', date: '2026-05-17' },
   { type: 'fix', title: 'Image occlusion toolbar buttons are reachable by screen readers — each tool announces its name', date: '2026-05-17' },
   { type: 'fix', title: 'Refresh button on My Decks shows its icon again', date: '2026-05-17' },
   { type: 'fix', title: 'Sign in and signup prompt your password manager to autofill and save credentials', date: '2026-05-17' },

--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -444,10 +444,13 @@
   border: none;
   background: transparent;
   color: inherit;
+  overflow: visible;
+}
+
+.dialog[open] {
   display: flex;
   align-items: center;
   justify-content: center;
-  overflow: visible;
 }
 
 .dialog::backdrop {

--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -432,6 +432,28 @@
   background: var(--color-backdrop);
 }
 
+.dialog {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: visible;
+}
+
+.dialog::backdrop {
+  background: var(--color-backdrop);
+}
+
 .modalCard {
   position: relative;
   background: var(--color-bg-primary);
@@ -1143,4 +1165,16 @@
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }


### PR DESCRIPTION
## Summary

PR A from the trio remainder list. Closes the last remaining WCAG blockers from the designer review. 13 files, +194/-78.

### 1. Modal `<dialog>` migration

Five consumers move from `<div className={sharedStyles.modal}>` to the HTML `<dialog>` element via a new `useDialog(isOpen, onClose)` hook (`web/src/lib/hooks/useDialog.ts`):

- `SettingsModal`
- `FeedbackModal`
- `CancellationSurveyModal`
- `TemplatesPage` `PreviewModal` (was the hybrid `<div>` + `<dialog open>` shape)
- `CardOptionsPage` bulk-reset confirm

Real browsers now get **focus trap**, **escape-to-close**, **return-focus-to-trigger**, top-layer rendering (no z-index races), and native `::backdrop` styling. PR #2344 added the ARIA attributes (announcement layer); this is the behavior layer.

The hook falls back to `set/removeAttribute('open')` in jsdom (where `showModal()` isn't implemented), and only registers a manual Escape listener when `showModal` is missing, so real browsers don't double-fire `onClose`.

### 2. Drop-zone visible focus ring

`UploadForm` wraps the hidden file input in a `<label>`; `.dropZone:focus-within` now shows a 2px primary outline. Keyboard users can finally see where focus lives in the upload flow.

### 3. Skip-to-main-content link

New `.skipLink` in `AppShell.module.css` — visually hidden until focused, then slides in at top-left. Targets `id="main-content"` on the `<main>` in `SidebarLayout`. Keyboard users can bypass the sidebar's ~15 nav links per page.

### 4. `AccountDeletion` red-on-red de-emphasis

`.dangerTitle` was red on the same screen as the red warning notice and red Delete button — designer called it a "wall of danger." Heading is now `text-secondary`; the warning and button stay red because the action *is* irreversible.

### 5. `aria-live` status region on `UploadForm`

New `<output aria-live="polite">` inside the form, `.srOnly`-styled, that produces a one-line description of the current zone state ("Converting your file.", "Your deck is ready — 87 cards.", "Conversion failed.", etc.). Screen-reader users now hear what's happening when the visual state flips.

## Out of scope

- Type-scale shift (`--text-sm` 18→14px) — separate visual PR, your call when
- `window.confirm` → in-app modal for account deletion — depends on this PR landing (uses the new `<dialog>` infra). Can be next.

## Test plan

- [x] `pnpm typecheck` (web): clean
- [x] `pnpm lint` (web, Biome): clean
- [x] `pnpm test --run` (web): **577 / 577 pass**, 85 files. (TemplatesPage and CardOptionsPage initially failed because jsdom doesn't implement `HTMLDialogElement.showModal` — verified the fallback in `useDialog` makes them pass.)
- [ ] Visual after merge:
  - [ ] Open `/card-options` and click any page row → settings modal opens with focus trapped; Escape closes; focus returns to the trigger
  - [ ] Click the feedback widget icon → same behavior
  - [ ] `/account` → Cancel subscription → survey modal: same behavior
  - [ ] `/note-types` → click a template name → preview modal: same behavior
  - [ ] `/card-options` → "Reset all" → confirm modal: same behavior
  - [ ] Tab into the `/upload` dropzone → visible blue outline
  - [ ] First Tab on any page → "Skip to content" link slides in from top-left; activating jumps focus to main
  - [ ] `/account` → Danger zone heading is now muted gray instead of red
  - [ ] `/upload` with VoiceOver / NVDA → state changes announced ("Converting your file.", etc.)

## Changelog

Two entries — modal escape + focus return, and the existing image-occlusion line from a previous PR (untouched). Skip link / focus ring / aria-live are infrastructure invisible to most users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->