### PR TITLE
fix: Notion token exchange — include redirect_uri (companion to #2349)

### DIFF
--- a/src/services/NotionService/NotionService.getAccessData.test.ts
+++ b/src/services/NotionService/NotionService.getAccessData.test.ts
@@ -1,0 +1,56 @@
+import { NotionService } from "./NotionService";
+import instrumentedAxios from "../observability/instrumentedAxios";
+import type { INotionRepository } from "../../data_layer/NotionRespository";
+
+jest.mock("../observability/instrumentedAxios");
+
+const mockedAxios = instrumentedAxios as jest.Mocked<typeof instrumentedAxios>;
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+	process.env.NOTION_CLIENT_ID = "client-abc";
+	process.env.NOTION_CLIENT_SECRET = "secret-xyz";
+	process.env.NOTION_REDIRECT_URI = "https://2anki.net/api/notion/connect";
+});
+
+afterEach(() => {
+	process.env = { ...ORIGINAL_ENV };
+	mockedAxios.post.mockReset();
+});
+
+function makeService() {
+	const stubRepo: INotionRepository = {
+		getNotionData: jest.fn().mockResolvedValue(null),
+		saveNotionToken: jest.fn().mockResolvedValue(true),
+		getNotionToken: jest.fn().mockResolvedValue(null),
+		deleteBlocksByOwner: jest.fn().mockResolvedValue(0),
+		deleteNotionData: jest.fn().mockResolvedValue(true),
+	};
+	return new NotionService(stubRepo);
+}
+
+test("posts redirect_uri to /v1/oauth/token so Notion accepts the exchange", async () => {
+	mockedAxios.post.mockResolvedValue({
+		data: { access_token: "tok", workspace_name: "Test", bot_id: "bot" },
+	} as Awaited<ReturnType<typeof mockedAxios.post>>);
+
+	await makeService().getAccessData("auth-code-123");
+
+	expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+	const [, url, body] = mockedAxios.post.mock.calls[0];
+	expect(url).toBe("https://api.notion.com/v1/oauth/token");
+	expect(body).toEqual({
+		grant_type: "authorization_code",
+		code: "auth-code-123",
+		redirect_uri: "https://2anki.net/api/notion/connect",
+	});
+});
+
+test("throws when NOTION_REDIRECT_URI is missing rather than POSTing an invalid request", () => {
+	delete process.env.NOTION_REDIRECT_URI;
+
+	expect(() => makeService().getAccessData("auth-code-123")).toThrow(
+		/Notion Connection Handler not configured/
+	);
+	expect(mockedAxios.post).not.toHaveBeenCalled();
+});

--- a/src/services/NotionService/NotionService.ts
+++ b/src/services/NotionService/NotionService.ts
@@ -259,6 +259,7 @@ export class NotionService {
       const data = {
         grant_type: 'authorization_code',
         code,
+        redirect_uri: uri,
       };
       const options = {
         auth: {


### PR DESCRIPTION
## Summary
- `NotionService.getAccessData` was POSTing `{ grant_type, code }` to `/v1/oauth/token` — missing `redirect_uri`. OAuth 2.0 requires the token exchange to repeat the same `redirect_uri` that was used in the authorize request.
- #2349 fixed the authorize step (added `redirect_uri` there). Once that shipped, Notion started rejecting the token exchange for the same reason. The controller catches the error and silently redirects to `/notion` — so the user sees the connect page again, still not connected. Exactly the reported symptom.
- This PR mirrors `AuthenticationService.ts:178`, which already passes `redirect_uri` to the same endpoint for the sign-in-with-Notion flow.

### Reported symptom (post-#2349)
> "the connect now goes to notion but I am still seeing https://2anki.net/notion ... 0/100 cards this month ... Connect your Notion workspace"

### Why trio was skipped
Continuation of the same hotfix as #2349. One-line OAuth-spec compliance, no product or UX decision.

## Test plan
- [x] `pnpm test src/services/NotionService/NotionService.getAccessData.test.ts` — 2/2 passing
  - asserts the token-exchange POST body contains `redirect_uri` matching `NOTION_REDIRECT_URI`
  - asserts the function refuses to POST when the env var is missing
- [x] `tsc --noEmit` clean
- [ ] Manual on prod after deploy: visit `/notion` → "Connect to Notion" → authorize on Notion → land back on `/notion` with workspace **connected** (sidebar shows workspace name, search works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2351"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->