### PR TITLE
fix: add mock fixture for highlight-test-id to stop CI timeout

### DIFF
--- a/src/services/NotionService/_mock/payloads/ListBlockChildrenResponse/highlight-test-id.json
+++ b/src/services/NotionService/_mock/payloads/ListBlockChildrenResponse/highlight-test-id.json
@@ -1,0 +1,8 @@
+{
+    "object": "list",
+    "results": [],
+    "next_cursor": null,
+    "has_more": false,
+    "type": "block",
+    "block": {}
+}


### PR DESCRIPTION
## Summary

Fixes the failing Server CI on `main`. The BlockHandler test *"Highlighted text is rendered with background"* uses a synthetic block id (`highlight-test-id`) that has no fixture under `src/services/NotionService/_mock/payloads/ListBlockChildrenResponse/`. `MockNotionAPI.getBlocks` falls through to the real Notion client when no fixture exists, which on the GitHub Actions runner takes long enough to blow past the 10-second per-test timeout:

```
● Highlighted text is rendered with background
  thrown: "Exceeded timeout of 10000 ms for a test."
```

Run 25985625065 on `main` was red because of this. Locally the same call completes inside the timeout, which is why nobody caught it pre-merge.

The test asserts the toggle's *front* rendering (the `yellow_background` annotation → `<span style="background-color:#DFAB01">`). The back/children are irrelevant to the assertion. Adding an empty `ListBlockChildrenResponse` fixture short-circuits the real-API fallback and the test runs in deterministic time.

## Test plan

- [x] `pnpm test BlockHandler` — 23/23 pass (5 skipped, 6 todo), 18.2 s — same as before the failure, just no longer racing the timeout.
- [ ] CI to confirm: this PR's Server workflow should turn green, unblocking the deploy pipeline.

No FEATURE.md update — this is a test fixture, not a change to the service's responsibilities, public surface, or constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->