### PR TITLE
fix: Auto Sync — pricing link, naming, sidebar gate, and docs

### DIFF
--- a/Documentation/ankify/README.md
+++ b/Documentation/ankify/README.md
@@ -1,6 +1,6 @@
 # Ankify (in 2anki/server)
 
-Hosted Anki + Notion ↔ Anki sync, ported from the standalone `2anki/ankify` prototype into 2anki/server proper. All routes and UI are gated behind the email allowlist defined in `src/lib/constants.ts` (`ANKIFY_ALLOWLIST_EMAILS`).
+Auto Sync — Notion → Anki sync, ported from the standalone `2anki/ankify` prototype into 2anki/server proper. All routes and UI are gated behind the email allowlist defined in `src/lib/constants.ts` (`ANKIFY_ALLOWLIST_EMAILS`).
 
 ## State at PR #2042 merge
 

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -366,7 +366,7 @@ class UsersController {
         .status(200)
         .json({ ok: true, alreadyRequested: result.alreadyRequested ?? false });
     } catch (error) {
-      console.error('Hosted Anki access request failed', error);
+      console.error('Auto Sync access request failed', error);
       return res.status(500).json({ message: 'Could not send request' });
     }
   }

--- a/src/lib/ankify/FEATURE.md
+++ b/src/lib/ankify/FEATURE.md
@@ -1,4 +1,4 @@
-# ankify — bidirectional Notion ↔ Anki sync
+# ankify — Notion → Anki sync
 
 Background-job factories and pure helpers for the Ankify product (separate from the one-shot conversion path). No HTTP, no SQL, no third-party SDK clients here — those live in `src/services/ankify/`.
 

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -170,15 +170,15 @@ class EmailService implements IEmailService {
     const msg = {
       to: SUPPORT_EMAIL_ADDRESS,
       from: DEFAULT_SENDER,
-      subject: 'Hosted Anki access request',
-      text: `User ${userId} <${userEmail}> requested access to Hosted Anki.`,
+      subject: 'Auto Sync access request',
+      text: `User ${userId} <${userEmail}> requested access to Auto Sync.`,
       replyTo: userEmail,
     };
     try {
       await sgMail.send(msg);
       return { didSend: true };
     } catch (e) {
-      console.error('Error sending Hosted Anki access request email', e);
+      console.error('Error sending Auto Sync access request email', e);
       return { didSend: false, error: e as Error };
     }
   }

--- a/src/services/NotionService/NotionService.ts
+++ b/src/services/NotionService/NotionService.ts
@@ -81,7 +81,7 @@ export class NotionService {
     if (!token) {
       throw new Error(APIErrorCode.Unauthorized);
     }
-    return new NotionAPIWrapper(token!, owner, this.blocksCacheRepository);
+    return new NotionAPIWrapper(token, owner, this.blocksCacheRepository);
   };
 
   tryGetNotionAPI = async (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,7 +119,7 @@ function AppContent({
         error={error}
         isLoggedIn={isLoggedIn}
         email={data?.user?.email}
-        locals={data?.locals == null ? data?.locals : { ...data.locals, trial_started_at: data?.user?.trial_started_at ?? null }}
+        locals={data?.locals == null ? data?.locals : { ...data.locals, trial_started_at: data?.user?.trial_started_at ?? null, autoSyncActive: data?.autoSyncActive === true }}
         features={data?.features}
       >
         <Routes>

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -16,6 +16,7 @@ interface SidebarRenderOpts {
   pathname?: string;
   patreon?: boolean;
   subscriber?: boolean;
+  autoSyncActive?: boolean;
   kiUI?: boolean;
   ops?: boolean;
   email?: string | null;
@@ -26,6 +27,7 @@ function renderSidebar({
   pathname = '/upload',
   patreon = false,
   subscriber = false,
+  autoSyncActive = false,
   kiUI = false,
   ops = false,
   email = 'alexander@alemayhu.com',
@@ -35,7 +37,7 @@ function renderSidebar({
     <MemoryRouter initialEntries={[pathname]}>
       <Sidebar
         email={email}
-        locals={{ patreon, subscriber }}
+        locals={{ patreon, subscriber, autoSyncActive }}
         features={{ kiUI, ops }}
         onLogOut={onLogOut}
       />
@@ -105,15 +107,23 @@ describe('Sidebar convert group', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('hides Auto Sync when the user does not have patreon access', () => {
+  it('hides Auto Sync from a subscriber without Auto Sync access', () => {
     renderSidebar({ subscriber: true });
     expect(
       screen.queryByRole('link', { name: 'Auto Sync' })
     ).not.toBeInTheDocument();
   });
 
-  it('shows Auto Sync when the user has patreon access', () => {
+  it('shows Auto Sync for a Lifetime (Patreon) user', () => {
     renderSidebar({ patreon: true });
+    expect(screen.getByRole('link', { name: 'Auto Sync' })).toHaveAttribute(
+      'href',
+      '/ankify'
+    );
+  });
+
+  it('shows Auto Sync for an Auto Sync subscriber', () => {
+    renderSidebar({ subscriber: true, autoSyncActive: true });
     expect(screen.getByRole('link', { name: 'Auto Sync' })).toHaveAttribute(
       'href',
       '/ankify'

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -83,6 +83,7 @@ function useTrialCountdown(trialStartedAt: string | null | undefined): string | 
 export interface SidebarLocals {
   patreon?: boolean;
   subscriber?: boolean;
+  autoSyncActive?: boolean;
   trial_started_at?: string | null;
   passExpiresAt?: string | null;
   passKind?: '24h' | '7d' | null;
@@ -182,7 +183,8 @@ export function Sidebar({
   const navigate = useNavigate();
   const theme = useTheme();
   const logoSrc = theme === 'light' ? '/mascot/navbar-logo.png' : '/mascot/Notion 1.png';
-  const showAnkify = locals?.patreon === true;
+  const showAnkify =
+    locals?.patreon === true || locals?.autoSyncActive === true;
   const paying = isPayingUser(locals);
   const showPricing = !paying;
   const showKi = features?.kiUI === true;

--- a/web/src/pages/DocsPage/content/help/limits.md
+++ b/web/src/pages/DocsPage/content/help/limits.md
@@ -71,9 +71,8 @@ Free covers the conversion paths most people need: drag in a file, get a deck ba
 | Account features (history, favorites, templates) | sign-in required | ✓ | ✓ |
 | AI-generated flashcards (Claude) | — | ✓ | ✓ |
 | Chat (study assistant) | 20 msg / mo | Unlimited | Unlimited |
-| Notion sync | — | — | ✓ |
 | Long-term deck storage | 24 h | active sub | indefinite |
-| Hosted Anki | — | — | ✓ |
+| Auto Sync (Notion → Anki) | — | $30/mo add-on | ✓ |
 
 See the [pricing page](/pricing) for the current plan list. Privacy details — what we read, what we don't — are on the [privacy policy](/documentation/reference/privacy).
 

--- a/web/src/pages/LandingPage/copy/notion.ts
+++ b/web/src/pages/LandingPage/copy/notion.ts
@@ -22,7 +22,7 @@ const notionCopy: LandingCopy = {
     },
     {
       q: 'Will it sync when I edit the Notion page later?',
-      a: 'A one-time conversion is a snapshot. Re-paste the link to make a fresh deck. If you want changes to flow automatically, see Hosted Anki on the pricing page — it polls Notion every few minutes.',
+      a: 'A one-time conversion is a snapshot. Re-paste the link to make a fresh deck. If you want changes to flow automatically, see Auto Sync on the pricing page — it polls Notion every few minutes.',
     },
   ],
 };

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -170,10 +170,10 @@ describe('PricingPage Auto Sync card', () => {
     });
   });
 
-  it('shows Learn how it works link', () => {
+  it('shows How sync works link', () => {
     renderAt('/pricing', { isLoggedIn: true });
-    const link = screen.getByRole('link', { name: 'Learn how it works' });
+    const link = screen.getByRole('link', { name: 'How sync works' });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', 'https://2anki.net/docs/auto-sync');
+    expect(link).toHaveAttribute('href', '/documentation/sync/how-it-works');
   });
 });

--- a/web/src/pages/PricingPage/components/AutoSyncCard.tsx
+++ b/web/src/pages/PricingPage/components/AutoSyncCard.tsx
@@ -10,7 +10,7 @@ const AUTO_SYNC_BENEFITS = [
   'Cancel anytime',
 ];
 
-const LEARN_MORE_HREF = 'https://2anki.net/docs/auto-sync';
+const LEARN_MORE_HREF = '/documentation/sync/how-it-works';
 
 interface AutoSyncCardProps {
   showNewBadge: boolean;

--- a/web/src/pages/PricingPage/components/PricingCard.tsx
+++ b/web/src/pages/PricingPage/components/PricingCard.tsx
@@ -128,7 +128,7 @@ export function PricingCard({
           {caption != null && <p className={styles.cardCaption}>{caption}</p>}
           {learnMoreHref != null && (
             <a href={learnMoreHref} className={styles.cardLearnMore} target="_blank" rel="noopener noreferrer">
-              Learn how it works
+              How sync works
             </a>
           )}
         </div>

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,9 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Auto Sync — "How sync works" on the pricing page opens the docs', date: '2026-05-17' },
+  { type: 'fix', title: 'Auto Sync appears in the sidebar for $30/mo subscribers, not only Lifetime accounts', date: '2026-05-17' },
+  { type: 'fix', title: 'Auto Sync is the name everywhere — pricing page, Notion FAQ, and limits table', date: '2026-05-17' },
   { type: 'fix', title: 'Escape closes settings, feedback, cancellation, and template-preview modals — and returns focus to the button that opened them', date: '2026-05-17' },
   { type: 'fix', title: 'Image occlusion toolbar buttons are reachable by screen readers — each tool announces its name', date: '2026-05-17' },
   { type: 'fix', title: 'Refresh button on My Decks shows its icon again', date: '2026-05-17' },


### PR DESCRIPTION
## Summary

Cleanup pass around the Auto Sync product after spotting a 404 on the pricing card.

- **Pricing page** — "Learn how it works" on the Auto Sync card linked to `https://2anki.net/docs/auto-sync` (404). Now points to `/documentation/sync/how-it-works` (a real doc). Label changed to **"How sync works"** to match the doc title (per VOICE.md — specific over generic).
- **Naming** — renamed user-facing "Hosted Anki" → "Auto Sync" across the Notion FAQ, limits table, staff access-request email, and dev docs. Internal symbols (`requestHostedAnkiAccess`, `users.hosted_anki_requested_at`) intentionally left alone — renaming the column needs a Knex migration, separate PR.
- **Sidebar gate bug** — the "Auto Sync" sidebar row was only shown for `patreon === true` (Lifetime). A user who paid $30/mo for Auto Sync via Stripe would not see the row. Now also checks `autoSyncActive`, which the `/users/debug/locals` endpoint already returns.
- **Limits table** — collapsed the duplicate "Notion sync" / "Auto Sync" rows (same product), marked the Subscription column as "\$30/mo add-on" since the table previously implied Lifetime-only, switched the arrow from `↔` to `→` (sync is one-way Notion → Anki).
- **Small Sonar nit** — dropped a redundant `token!` non-null assertion in `NotionService.ts` (TS already narrows after the `!token` throw above it).

## Changelog

Three entries added in `web/src/pages/WhatsNewPage/changelog.ts`.

## Sonar

Not run locally — change is mostly copy/href + a one-line gate condition. The new conditional logic is trivial enough that I'm comfortable pushing without a local sonar pass; happy to fix anything CI flags.

## Not in this PR (follow-ups worth flagging)

- The sync doc at `/documentation/sync/how-it-works` still has a "private alpha — only enabled for the project owner" warning callout. Either the alpha gate comes off, or Auto Sync isn't ready to be on the pricing page at \$30/mo. Worth deciding before the next deploy.
- A SonarCloud nit was raised in conversation about `NotionAPIWrapper.ts:46` — `blocksCache` should be `readonly`. That symbol does not exist on `main` (likely a finding from a different feature branch). Not fixed here.

## Test plan

- [x] `pnpm --filter 2anki-web typecheck` — clean
- [x] `pnpm --filter 2anki-web test` — 581/581 (added one Sidebar test for the new gate)
- [x] `pnpm test src/controllers/UsersControllers` — 27/27
- [x] `pnpm test src/services/NotionService/NotionService` — 10/10
- [ ] Visual check on /pricing — Auto Sync card → click "How sync works" → lands on /documentation/sync/how-it-works
- [ ] Visual check on sidebar for a \$30/mo Auto Sync subscriber — Auto Sync row visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->