### PR TITLE
refactor: extract PersistStripeSessionUseCase, inject controller deps

### DIFF
--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -1,13 +1,7 @@
 import express from 'express';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
 import { StripeController } from './StripeController';
-
-jest.mock('../../data_layer', () => ({
-  getDatabase: jest.fn().mockReturnValue({}),
-}));
-
-jest.mock('../../services/EmailService/EmailService', () => ({
-  getDefaultEmailService: jest.fn().mockReturnValue({}),
-}));
 
 jest.mock('./extractTokenFromCookies', () => ({
   extractTokenFromCookies: jest.fn(),
@@ -17,41 +11,84 @@ jest.mock('../../services/SubscriptionService', () => ({
   getUserActiveSubscriptions: jest.fn(),
 }));
 
-jest.mock('../../lib/integrations/stripe', () => ({
-  getStripe: jest.fn().mockReturnValue({
-    checkout: {
-      sessions: {
-        retrieve: jest.fn(),
-      },
-    },
-    subscriptions: {
-      retrieve: jest.fn(),
-    },
-    customers: {
-      retrieve: jest.fn(),
-    },
-  }),
-  updateStoreSubscription: jest.fn().mockResolvedValue(undefined),
-}));
-
-jest.mock('../../services/AuthenticationService');
-jest.mock('../../data_layer/TokenRepository');
-jest.mock('../../data_layer/UsersRepository');
-jest.mock('../../services/UsersService');
 jest.mock('../IndexController/getIndexFileContents', () => ({
   getIndexFileContents: jest.fn().mockReturnValue('<html/>'),
 }));
 
 import { extractTokenFromCookies } from './extractTokenFromCookies';
 import SubscriptionService from '../../services/SubscriptionService';
-import { getStripe, updateStoreSubscription } from '../../lib/integrations/stripe';
-import AuthenticationService from '../../services/AuthenticationService';
-import UsersService from '../../services/UsersService';
+import type AuthenticationService from '../../services/AuthenticationService';
+import type { UserWithOwner } from '../../services/AuthenticationService';
+import type UsersService from '../../services/UsersService';
+import type { PersistStripeSessionUseCase } from '../../usecases/checkout/PersistStripeSessionUseCase';
+import type Subscriptions from '../../data_layer/public/Subscriptions';
+import type { SubscriptionsId } from '../../data_layer/public/Subscriptions';
+import type { UsersId } from '../../data_layer/public/Users';
+
+type StripeMock = {
+  checkout: { sessions: { retrieve: jest.Mock } };
+};
 
 const mockedExtractToken = extractTokenFromCookies as jest.MockedFunction<typeof extractTokenFromCookies>;
 const mockedGetActiveSubscriptions = SubscriptionService.getUserActiveSubscriptions as jest.MockedFunction<typeof SubscriptionService.getUserActiveSubscriptions>;
-const mockedUpdateStoreSubscription = updateStoreSubscription as jest.MockedFunction<typeof updateStoreSubscription>;
-const mockedStripe = getStripe() as any;
+
+function buildUser(overrides: Partial<UserWithOwner> = {}): UserWithOwner {
+  return {
+    id: 1 as UsersId,
+    name: 'Test',
+    email: 'test@example.com',
+    password: '',
+    created_at: null,
+    updated_at: null,
+    reset_token: null,
+    patreon: false,
+    last_login_at: null,
+    hosted_anki_requested_at: null,
+    signup_origin: null,
+    ankify_welcome_seen: false,
+    trial_started_at: null,
+    card_options: null,
+    theme: null,
+    anki_web_acknowledged_at: null,
+    email_verified: false,
+    ai_template_generate_count: 0,
+    ai_template_modify_count: 0,
+    cards_used_this_month: 0,
+    cards_month_started_at: new Date(0),
+    signup_country: null,
+    chat_consent_at: null,
+    owner: 1,
+    ...overrides,
+  };
+}
+
+function buildSubscription(overrides: Partial<Subscriptions> = {}): Subscriptions {
+  return {
+    id: 1 as SubscriptionsId,
+    email: 'test@example.com',
+    active: true,
+    payload: {},
+    created_at: null,
+    updated_at: null,
+    linked_email: null,
+    ...overrides,
+  };
+}
+
+type SessionCustomerDetails = NonNullable<
+  StripeTypes.Checkout.Session['customer_details']
+>;
+
+function buildSession(
+  customerEmail: string | null
+): Pick<StripeTypes.Checkout.Session, 'customer_details'> {
+  return {
+    customer_details:
+      customerEmail == null
+        ? null
+        : ({ email: customerEmail } as SessionCustomerDetails),
+  };
+}
 
 function mockRequest(query: Record<string, string> = {}, cookies?: string): express.Request {
   return {
@@ -61,63 +98,77 @@ function mockRequest(query: Record<string, string> = {}, cookies?: string): expr
 }
 
 function mockResponse(): express.Response {
-  const res = {
+  return {
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
     send: jest.fn().mockReturnThis(),
   } as unknown as express.Response;
-  return res;
 }
 
-function setupAuthenticatedUser(user = { email: 'test@example.com', name: 'Test', patreon: false }) {
-  mockedExtractToken.mockReturnValue('abc');
-  (AuthenticationService as jest.MockedClass<typeof AuthenticationService>).prototype.getUserFrom = jest.fn().mockResolvedValue(user);
+interface ControllerHarness {
+  controller: StripeController;
+  authService: { getUserFrom: jest.Mock };
+  usersService: { updateSubScriptionEmailUsingPrimaryEmail: jest.Mock };
+  persistStripeSessionUseCase: { execute: jest.Mock };
+  stripe: StripeMock;
+}
+
+function buildController(): ControllerHarness {
+  const authService = {
+    getUserFrom: jest.fn(),
+  };
+  const usersService = {
+    updateSubScriptionEmailUsingPrimaryEmail: jest.fn(),
+  };
+  const persistStripeSessionUseCase = {
+    execute: jest.fn(),
+  };
+  const stripe: StripeMock = {
+    checkout: { sessions: { retrieve: jest.fn() } },
+  };
+  const controller = new StripeController(
+    authService as unknown as AuthenticationService,
+    usersService as unknown as UsersService,
+    persistStripeSessionUseCase as unknown as PersistStripeSessionUseCase,
+    stripe as unknown as Pick<StripeTypes, 'checkout'>
+  );
+  return { controller, authService, usersService, persistStripeSessionUseCase, stripe };
 }
 
 describe('StripeController', () => {
-  let controller: StripeController;
-
   beforeEach(() => {
-    controller = new StripeController();
     jest.clearAllMocks();
   });
 
   describe('checkSubscriptionStatus', () => {
-    it('returns hasActiveSubscription true when session_id is provided and session is paid', async () => {
-      setupAuthenticatedUser();
+    it('returns hasActiveSubscription true when session_id is provided and the use case reports paid', async () => {
+      const h = buildController();
+      mockedExtractToken.mockReturnValue('abc');
+      h.authService.getUserFrom.mockResolvedValue(buildUser());
       mockedGetActiveSubscriptions.mockResolvedValue([]);
-      mockedStripe.checkout.sessions.retrieve.mockResolvedValue({
-        payment_status: 'paid',
-        subscription: 'sub_123',
-      });
-      mockedStripe.subscriptions.retrieve.mockResolvedValue({
-        id: 'sub_123',
-        customer: 'cus_123',
-        status: 'active',
-      });
-      mockedStripe.customers.retrieve.mockResolvedValue({
-        id: 'cus_123',
-        email: 'test@example.com',
-      });
+      h.persistStripeSessionUseCase.execute.mockResolvedValue(true);
 
       const req = mockRequest({ session_id: 'cs_test_123' });
       const res = mockResponse();
 
-      await controller.checkSubscriptionStatus(req, res);
+      await h.controller.checkSubscriptionStatus(req, res);
 
+      expect(h.persistStripeSessionUseCase.execute).toHaveBeenCalledWith('cs_test_123');
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ hasActiveSubscription: true })
       );
     });
 
     it('returns hasActiveSubscription true when user has patreon flag', async () => {
-      setupAuthenticatedUser({ email: 'test@example.com', name: 'Test', patreon: true });
+      const h = buildController();
+      mockedExtractToken.mockReturnValue('abc');
+      h.authService.getUserFrom.mockResolvedValue(buildUser({ patreon: true }));
       mockedGetActiveSubscriptions.mockResolvedValue([]);
 
       const req = mockRequest();
       const res = mockResponse();
 
-      await controller.checkSubscriptionStatus(req, res);
+      await h.controller.checkSubscriptionStatus(req, res);
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ hasActiveSubscription: true })
@@ -125,13 +176,15 @@ describe('StripeController', () => {
     });
 
     it('returns hasActiveSubscription true when DB has active subscription', async () => {
-      setupAuthenticatedUser();
-      mockedGetActiveSubscriptions.mockResolvedValue([{ id: 1, email: 'test@example.com', active: true } as any]);
+      const h = buildController();
+      mockedExtractToken.mockReturnValue('abc');
+      h.authService.getUserFrom.mockResolvedValue(buildUser());
+      mockedGetActiveSubscriptions.mockResolvedValue([buildSubscription()]);
 
       const req = mockRequest();
       const res = mockResponse();
 
-      await controller.checkSubscriptionStatus(req, res);
+      await h.controller.checkSubscriptionStatus(req, res);
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ hasActiveSubscription: true })
@@ -139,13 +192,15 @@ describe('StripeController', () => {
     });
 
     it('returns hasActiveSubscription false when no subscription found anywhere', async () => {
-      setupAuthenticatedUser();
+      const h = buildController();
+      mockedExtractToken.mockReturnValue('abc');
+      h.authService.getUserFrom.mockResolvedValue(buildUser());
       mockedGetActiveSubscriptions.mockResolvedValue([]);
 
       const req = mockRequest();
       const res = mockResponse();
 
-      await controller.checkSubscriptionStatus(req, res);
+      await h.controller.checkSubscriptionStatus(req, res);
 
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ hasActiveSubscription: false })
@@ -154,63 +209,59 @@ describe('StripeController', () => {
   });
 
   describe('getSuccessfulCheckout', () => {
-    function setupStripeSession(stripeEmail: string) {
-      mockedStripe.checkout.sessions.retrieve.mockResolvedValue({
-        payment_status: 'paid',
-        subscription: 'sub_123',
-        customer_details: { email: stripeEmail },
-      });
-      mockedStripe.subscriptions.retrieve.mockResolvedValue({
-        id: 'sub_123',
-        customer: 'cus_123',
-        status: 'active',
-        cancel_at_period_end: false,
-      });
-      mockedStripe.customers.retrieve.mockResolvedValue({
-        id: 'cus_123',
-        email: stripeEmail,
-      });
+    function authedUser(h: ControllerHarness, email: string) {
+      mockedExtractToken.mockReturnValue('abc');
+      h.authService.getUserFrom.mockResolvedValue(buildUser({ email }));
     }
 
     it('persists the subscription before linking when emails differ', async () => {
-      setupAuthenticatedUser({ email: 'user@2anki.com', name: 'Test', patreon: false });
-      setupStripeSession('paypal@email.com');
-      (UsersService as jest.MockedClass<typeof UsersService>).prototype.updateSubScriptionEmailUsingPrimaryEmail = jest.fn().mockResolvedValue(1);
+      const h = buildController();
+      authedUser(h, 'user@2anki.com');
+      h.persistStripeSessionUseCase.execute.mockResolvedValue(true);
+      h.stripe.checkout.sessions.retrieve.mockResolvedValue(
+        buildSession('paypal@email.com')
+      );
+      h.usersService.updateSubScriptionEmailUsingPrimaryEmail.mockResolvedValue(1);
 
       const req = mockRequest({ session_id: 'cs_test_123' });
       const res = mockResponse();
 
-      await controller.getSuccessfulCheckout(req, res);
+      await h.controller.getSuccessfulCheckout(req, res);
 
-      expect(mockedUpdateStoreSubscription).toHaveBeenCalled();
-      expect((UsersService as jest.MockedClass<typeof UsersService>).prototype.updateSubScriptionEmailUsingPrimaryEmail)
-        .toHaveBeenCalledWith('paypal@email.com', 'user@2anki.com');
+      expect(h.persistStripeSessionUseCase.execute).toHaveBeenCalledWith('cs_test_123');
+      expect(h.usersService.updateSubScriptionEmailUsingPrimaryEmail).toHaveBeenCalledWith(
+        'paypal@email.com',
+        'user@2anki.com'
+      );
     });
 
     it('does not link when session email matches the logged-in email', async () => {
-      setupAuthenticatedUser({ email: 'user@2anki.com', name: 'Test', patreon: false });
-      setupStripeSession('user@2anki.com');
-      (UsersService as jest.MockedClass<typeof UsersService>).prototype.updateSubScriptionEmailUsingPrimaryEmail = jest.fn();
+      const h = buildController();
+      authedUser(h, 'user@2anki.com');
+      h.persistStripeSessionUseCase.execute.mockResolvedValue(true);
+      h.stripe.checkout.sessions.retrieve.mockResolvedValue(
+        buildSession('user@2anki.com')
+      );
 
       const req = mockRequest({ session_id: 'cs_test_123' });
       const res = mockResponse();
 
-      await controller.getSuccessfulCheckout(req, res);
+      await h.controller.getSuccessfulCheckout(req, res);
 
-      expect((UsersService as jest.MockedClass<typeof UsersService>).prototype.updateSubScriptionEmailUsingPrimaryEmail)
-        .not.toHaveBeenCalled();
+      expect(h.usersService.updateSubScriptionEmailUsingPrimaryEmail).not.toHaveBeenCalled();
     });
 
     it('serves the page without error when no token present', async () => {
-      mockedExtractToken.mockReturnValue(null as any);
+      const h = buildController();
+      mockedExtractToken.mockReturnValue(null);
 
       const req = mockRequest({ session_id: 'cs_test_123' });
       const res = mockResponse();
 
-      await controller.getSuccessfulCheckout(req, res);
+      await h.controller.getSuccessfulCheckout(req, res);
 
       expect(res.send).toHaveBeenCalled();
-      expect(mockedUpdateStoreSubscription).not.toHaveBeenCalled();
+      expect(h.persistStripeSessionUseCase.execute).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -1,50 +1,23 @@
 import express from 'express';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
 import { getIndexFileContents } from '../IndexController/getIndexFileContents';
-import { getDatabase } from '../../data_layer';
-import { getDefaultEmailService } from '../../services/EmailService/EmailService';
-import UsersRepository from '../../data_layer/UsersRepository';
-import UsersService from '../../services/UsersService';
-import TokenRepository from '../../data_layer/TokenRepository';
-import AuthenticationService from '../../services/AuthenticationService';
-import { getStripe, updateStoreSubscription } from '../../lib/integrations/stripe';
+import type AuthenticationService from '../../services/AuthenticationService';
+import type UsersService from '../../services/UsersService';
 import { extractTokenFromCookies } from './extractTokenFromCookies';
 import SubscriptionService from '../../services/SubscriptionService';
-import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
-import { Knex } from 'knex';
+import type { PersistStripeSessionUseCase } from '../../usecases/checkout/PersistStripeSessionUseCase';
 
-async function persistStripeSession(database: Knex, sessionId: string): Promise<boolean> {
-  const stripe = getStripe();
-  const session = await stripe.checkout.sessions.retrieve(sessionId);
-  if (session.payment_status !== 'paid') {
-    return false;
-  }
-  if (session.subscription) {
-    const subscriptionId = typeof session.subscription === 'string'
-      ? session.subscription
-      : session.subscription.id;
-    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
-    const customerId = typeof subscription.customer === 'string'
-      ? subscription.customer
-      : subscription.customer.id;
-    const customer = await stripe.customers.retrieve(customerId) as StripeTypes.Customer;
-    await updateStoreSubscription(database, customer, subscription);
-  }
-  return true;
-}
-
-async function getAuthenticatedUser(cookies: string | undefined) {
-  const token = extractTokenFromCookies(cookies);
-  if (!token) {
-    return null;
-  }
-  const database = getDatabase();
-  const userRepository = new UsersRepository(database);
-  const tokenRepository = new TokenRepository(database);
-  const authService = new AuthenticationService(tokenRepository, userRepository);
-  return authService.getUserFrom(token);
-}
+type StripeClient = Pick<StripeTypes, 'checkout'>;
 
 export class StripeController {
+  constructor(
+    private readonly authService: AuthenticationService,
+    private readonly usersService: UsersService,
+    private readonly persistStripeSessionUseCase: PersistStripeSessionUseCase,
+    private readonly stripe: StripeClient
+  ) {}
+
   async getSuccessfulCheckout(req: express.Request, res: express.Response) {
     const cookies = req.get('cookie');
     const token = extractTokenFromCookies(cookies);
@@ -53,30 +26,19 @@ export class StripeController {
       return res.send(getIndexFileContents());
     }
 
-    const database = getDatabase();
-    const emailService = getDefaultEmailService();
-    const userRepository = new UsersRepository(database);
-    const usersService = new UsersService(userRepository, emailService);
-    const tokenRepository = new TokenRepository(database);
-    const authService = new AuthenticationService(
-      tokenRepository,
-      userRepository
-    );
-
-    const loggedInUser = await authService.getUserFrom(token);
+    const loggedInUser = await this.authService.getUserFrom(token);
     const sessionId = req.query.session_id as string;
 
     if (loggedInUser && sessionId) {
       // Persist subscription before linking — without this, the link write is a
       // no-op when the webhook hasn't fired yet and the subscriptions row doesn't exist.
-      await persistStripeSession(database, sessionId);
+      await this.persistStripeSessionUseCase.execute(sessionId);
 
-      const stripe = getStripe();
-      const session = await stripe.checkout.sessions.retrieve(sessionId);
+      const session = await this.stripe.checkout.sessions.retrieve(sessionId);
       const email = session.customer_details?.email;
 
       if (loggedInUser.email !== email && email) {
-        await usersService.updateSubScriptionEmailUsingPrimaryEmail(
+        await this.usersService.updateSubScriptionEmailUsingPrimaryEmail(
           email.toLowerCase(),
           loggedInUser.email.toLowerCase()
         );
@@ -88,7 +50,8 @@ export class StripeController {
 
   async checkSubscriptionStatus(req: express.Request, res: express.Response) {
     try {
-      const user = await getAuthenticatedUser(req.get('cookie'));
+      const token = extractTokenFromCookies(req.get('cookie'));
+      const user = token ? await this.authService.getUserFrom(token) : null;
       if (!user) {
         return res.status(401).json({ authenticated: false, hasActiveSubscription: false });
       }
@@ -99,7 +62,7 @@ export class StripeController {
       if (!hasActiveSubscription) {
         const sessionId = req.query.session_id as string;
         if (sessionId) {
-          hasActiveSubscription = await persistStripeSession(getDatabase(), sessionId);
+          hasActiveSubscription = await this.persistStripeSessionUseCase.execute(sessionId);
         }
       }
 

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -10,6 +10,11 @@ import { getDatabase } from '../data_layer';
 import { StripeController } from '../controllers/StripeController/StripeController';
 import UsersRepository from '../data_layer/UsersRepository';
 import UserPassRepository, { type PassKind } from '../data_layer/UserPassRepository';
+import TokenRepository from '../data_layer/TokenRepository';
+import AuthenticationService from '../services/AuthenticationService';
+import UsersService from '../services/UsersService';
+import { getDefaultEmailService } from '../services/EmailService/EmailService';
+import { PersistStripeSessionUseCase } from '../usecases/checkout/PersistStripeSessionUseCase';
 import hashToken from '../lib/misc/hashToken';
 
 const DURATION_24H_MS = 24 * 60 * 60 * 1000;
@@ -17,7 +22,19 @@ const DURATION_7D_MS = 7 * 24 * 60 * 60 * 1000;
 
 const WebhooksRouter = () => {
   const router = express.Router();
-  const controller = new StripeController();
+  const database = getDatabase();
+  const stripe = getStripe();
+  const usersRepository = new UsersRepository(database);
+  const tokenRepository = new TokenRepository(database);
+  const authService = new AuthenticationService(tokenRepository, usersRepository);
+  const usersService = new UsersService(usersRepository, getDefaultEmailService());
+  const persistStripeSessionUseCase = new PersistStripeSessionUseCase(stripe, database);
+  const controller = new StripeController(
+    authService,
+    usersService,
+    persistStripeSessionUseCase,
+    stripe
+  );
 
   /**
    * @swagger

--- a/src/usecases/checkout/PersistStripeSessionUseCase.ts
+++ b/src/usecases/checkout/PersistStripeSessionUseCase.ts
@@ -1,0 +1,38 @@
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+import type { Knex } from 'knex';
+
+import { updateStoreSubscription } from '../../lib/integrations/stripe';
+
+type StripeClient = Pick<StripeTypes, 'checkout' | 'subscriptions' | 'customers'>;
+
+export class PersistStripeSessionUseCase {
+  constructor(
+    private readonly stripe: StripeClient,
+    private readonly database: Knex
+  ) {}
+
+  async execute(sessionId: string): Promise<boolean> {
+    const session = await this.stripe.checkout.sessions.retrieve(sessionId);
+    if (session.payment_status !== 'paid') {
+      return false;
+    }
+    if (session.subscription) {
+      const subscriptionId =
+        typeof session.subscription === 'string'
+          ? session.subscription
+          : session.subscription.id;
+      const subscription = await this.stripe.subscriptions.retrieve(subscriptionId);
+      const customerId =
+        typeof subscription.customer === 'string'
+          ? subscription.customer
+          : subscription.customer.id;
+      const customer = (await this.stripe.customers.retrieve(
+        customerId
+      )) as StripeTypes.Customer;
+      await updateStoreSubscription(this.database, customer, subscription);
+    }
+    return true;
+  }
+}
+
+export default PersistStripeSessionUseCase;


### PR DESCRIPTION
## Summary

PR C from the trio remainder list — the last engineer-flagged layering refactor. Closes the violation in `StripeController`:

> Controllers shouldn't touch `getDatabase` or construct repositories inline; business logic (Stripe session retrieve → updateSubscription) belongs in a use case, not a private function in the controller file.

## What changed

**New `src/usecases/checkout/PersistStripeSessionUseCase.ts`** — the sequence that lived in the file-scope `persistStripeSession` helper (retrieve Stripe checkout session → retrieve subscription → fetch customer → call `updateStoreSubscription`) now lives in a class with its Stripe client and Knex injected via constructor. Returns the same boolean.

**`StripeController` now takes four deps via constructor:**
- `AuthenticationService`
- `UsersService`
- `PersistStripeSessionUseCase`
- Stripe client (narrowed to `Pick<Stripe, 'checkout'>`)

No more `getDatabase()` calls in the controller. The internal `getAuthenticatedUser` helper that constructed three repositories inline is gone — `checkSubscriptionStatus` just calls `this.authService.getUserFrom(token)`.

**`WebhookRouter`** wires the dependency tree once at startup (database, stripe, repositories, services, use case) and passes the controller its four collaborators. Other handlers in WebhookRouter that still use `getDatabase()` inline are out of scope.

**`StripeController.test.ts` rewritten** to use constructor injection instead of `jest.mock('../../data_layer')` / `jest.mock('AuthenticationService')` / `jest.mock('UsersService')`. Tests wire their own typed test doubles via a `buildController()` factory. **No `as any` anywhere** — only `as unknown as X` at the test-double boundary (the canonical TypeScript escape hatch for partial mocks). The `UserWithOwner` and `Subscriptions` test factories are typed against the real interfaces.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test StripeController PersistStripeSession` — 7/7 pass
- [x] `pnpm test` — **1330 pass**, 8 skipped, 8 todo (matches `main` baseline)
- [x] Worktree used (per CLAUDE.md: payments path requires worktree)
- [ ] `/security-review` to follow on this PR before merge (per CLAUDE.md payments rule)
- [ ] After merge: SSH and watch a real checkout webhook fire — confirm `updateStoreSubscription` still receives the customer + subscription, the `subscriptions` row updates, and the cross-email link still works on `/successful-checkout`

## No behaviour change

Same Stripe calls, same DB writes via `updateStoreSubscription`, same response shapes. The refactor moves construction up one layer; the controller is now testable without mocking modules, and the layering rule (controllers → use cases → services → repositories → DB) is restored for this controller.

## Out of scope

- The remaining `getDatabase()` calls inside other `WebhookRouter` handlers — they each warrant their own use case extraction; separate PRs.
- The disputed `!user.patreon` / `!id` patterns and `ObjectAction alt=""` finding — declined as defensive code.
- AWS SDK v2 EOL upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->