### PR TITLE
docs(sync): drop private-alpha references — Auto Sync is shipping

### DIFF
--- a/web/src/pages/DocsPage/content/sync/how-it-works.md
+++ b/web/src/pages/DocsPage/content/sync/how-it-works.md
@@ -5,10 +5,6 @@ description: Edit a Notion page, get the updated deck — without re-uploading.
 
 Sync watches the Notion pages you've subscribed and keeps a matching deck up to date in Anki. When you edit a page in Notion, the next sync run picks up the changes and updates the deck — same deck name, same card IDs, no re-import drama.
 
-:::warning
-Sync is in private alpha. Today it's only enabled for the project owner's account while we shake out the data flow. Email [alexander@alemayhu.com](mailto:alexander@alemayhu.com) if you'd like to be on the early-access list.
-:::
-
 ## What sync does
 
 - Watches the Notion pages you mark for sync.
@@ -18,10 +14,10 @@ Sync is in private alpha. Today it's only enabled for the project owner's accoun
 
 ## Setting up sync on a page
 
-You'll do this from the **Ankify** area on 2anki.net once it's open to your account:
+You'll do this from the **Auto Sync** area on 2anki.net:
 
 1. Connect Notion (if you haven't already — see [Connect Notion in 5 minutes](/documentation/start-here/connect-notion)).
-2. Open the **Ankify** dashboard and pick a Notion page to subscribe.
+2. Open the **Auto Sync** dashboard and pick a Notion page to subscribe.
 3. Confirm the deck name. The deck is created the first time sync runs.
 4. Open Anki on the device that will hold the synced deck and let 2anki connect through AnkiConnect.
 
@@ -36,6 +32,6 @@ A background job polls your subscribed pages, diffs them against what's already 
 
 ## Free vs paid
 
-Sync is a paid feature (during private alpha it's gated by an allowlist; once it ships broadly, an active subscription will be required). The conversion features that ship today — Connect Notion + download deck, plus file uploads — stay free.
+Auto Sync is a paid feature — $30/mo, or included with a Lifetime account. The conversion features that ship today — Connect Notion + download deck, plus file uploads — stay free.
 
 See the [pricing page](/pricing) for current plans, and [When sync gets stuck](/documentation/sync/troubleshooting) if a sync isn't running.


### PR DESCRIPTION
## Summary

The pricing page sells Auto Sync at \$30/mo, but `web/src/pages/DocsPage/content/sync/how-it-works.md` still said "private alpha — only enabled for the project owner". Anyone clicking through "How sync works" from the pricing card was reading a contradiction. This brings the doc up to date with what we're actually selling.

## Changed

- Removed the `:::warning` callout block.
- Dropped the "once it's open to your account" hedge in the setup-steps intro.
- Rewrote the "Free vs paid" paragraph to name the actual plans (Auto Sync subscription \$30/mo, or Lifetime) instead of "during private alpha it's gated by an allowlist; once it ships broadly...".
- Renamed visible "Ankify" labels in the doc body to "Auto Sync" so the doc matches what users see in the sidebar. The route stays `/ankify`.

## Not changed

- No changelog entry — doc cleanup, no product behavior change.
- No code, no internal symbol renames.

## Test plan

- [x] `pnpm --filter 2anki-web typecheck` — clean
- [x] `pnpm --filter 2anki-web test` — 581/581 (no regression in DocsPage MDX rendering)
- [ ] Visual check on /documentation/sync/how-it-works after deploy — callout gone, body reads consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->