### PR TITLE
fix: serve 503 when web/build/index.html is missing during deploy

### DIFF
--- a/src/controllers/IndexController/IndexController.ts
+++ b/src/controllers/IndexController/IndexController.ts
@@ -4,7 +4,7 @@ import AuthenticationService from '../../services/AuthenticationService';
 import TokenRepository from '../../data_layer/TokenRepository';
 import UsersRepository from '../../data_layer/UsersRepository';
 import { configureUserLocal } from '../../routes/middleware/configureUserLocal';
-import { getIndexFileContents } from './getIndexFileContents';
+import { sendIndex } from './sendIndex';
 import { getDefaultEmailService } from '../../services/EmailService/EmailService';
 
 class IndexController {
@@ -15,7 +15,7 @@ class IndexController {
       new UsersRepository(database)
     );
     configureUserLocal(request, response, authService, database).then(() => {
-      response.send(getIndexFileContents());
+      sendIndex(response);
     });
   }
 

--- a/src/controllers/IndexController/getIndexFileContents.test.ts
+++ b/src/controllers/IndexController/getIndexFileContents.test.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { getIndexFileContents } from './getIndexFileContents';
+
+jest.mock('../../lib/constants', () => {
+  const tmpRoot = require('os').tmpdir();
+  const tmpBuild = require('path').join(
+    tmpRoot,
+    `index-contents-test-${process.pid}-${Date.now()}`
+  );
+  return { BUILD_DIR: tmpBuild };
+});
+
+const { BUILD_DIR } = jest.requireMock('../../lib/constants') as {
+  BUILD_DIR: string;
+};
+
+describe('getIndexFileContents', () => {
+  beforeEach(() => {
+    fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  });
+
+  it('returns the file contents when index.html exists', () => {
+    fs.mkdirSync(BUILD_DIR, { recursive: true });
+    fs.writeFileSync(
+      path.join(BUILD_DIR, 'index.html'),
+      '<html>hello</html>',
+      'utf8'
+    );
+
+    expect(getIndexFileContents()).toBe('<html>hello</html>');
+  });
+
+  it('returns null when index.html is missing (deploy race)', () => {
+    expect(getIndexFileContents()).toBeNull();
+  });
+
+  it('returns null when build directory itself is missing', () => {
+    expect(fs.existsSync(BUILD_DIR)).toBe(false);
+    expect(getIndexFileContents()).toBeNull();
+  });
+});

--- a/src/controllers/IndexController/getIndexFileContents.ts
+++ b/src/controllers/IndexController/getIndexFileContents.ts
@@ -2,8 +2,14 @@ import path from 'path';
 import fs from 'fs';
 import { BUILD_DIR } from '../../lib/constants';
 
-export const getIndexFileContents = () => {
+export const getIndexFileContents = (): string | null => {
   const indexFilePath = path.join(BUILD_DIR, 'index.html');
-  const contents = fs.readFileSync(indexFilePath, 'utf8');
-  return contents;
+  try {
+    return fs.readFileSync(indexFilePath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw err;
+  }
 };

--- a/src/controllers/IndexController/sendIndex.test.ts
+++ b/src/controllers/IndexController/sendIndex.test.ts
@@ -1,0 +1,45 @@
+import { Response } from 'express';
+
+import { sendIndex } from './sendIndex';
+import { getIndexFileContents } from './getIndexFileContents';
+
+jest.mock('./getIndexFileContents');
+
+const mockedGet = getIndexFileContents as jest.MockedFunction<
+  typeof getIndexFileContents
+>;
+
+function buildResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe('sendIndex', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it('sends the html with default 200 status when the build exists', () => {
+    mockedGet.mockReturnValue('<html>ready</html>');
+    const res = buildResponse();
+
+    sendIndex(res);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith('<html>ready</html>');
+  });
+
+  it('responds 503 with Retry-After when the build is mid-deploy', () => {
+    mockedGet.mockReturnValue(null);
+    const res = buildResponse();
+
+    sendIndex(res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.set).toHaveBeenCalledWith('Retry-After', '5');
+    expect(res.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/controllers/IndexController/sendIndex.ts
+++ b/src/controllers/IndexController/sendIndex.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import { getIndexFileContents } from './getIndexFileContents';
+
+const BUILD_PENDING_BODY =
+  'The site is being updated. Refresh in a few seconds.';
+
+export const sendIndex = (response: express.Response) => {
+  const html = getIndexFileContents();
+  if (html == null) {
+    response.set('Retry-After', '5');
+    return response.status(503).send(BUILD_PENDING_BODY);
+  }
+  return response.send(html);
+};

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 
-import { getIndexFileContents } from '../IndexController/getIndexFileContents';
+import { sendIndex } from '../IndexController/sendIndex';
 import type AuthenticationService from '../../services/AuthenticationService';
 import type UsersService from '../../services/UsersService';
 import { extractTokenFromCookies } from './extractTokenFromCookies';
@@ -23,7 +23,7 @@ export class StripeController {
     const token = extractTokenFromCookies(cookies);
 
     if (!token) {
-      return res.send(getIndexFileContents());
+      return sendIndex(res);
     }
 
     const loggedInUser = await this.authService.getUserFrom(token);
@@ -45,7 +45,7 @@ export class StripeController {
       }
     }
 
-    res.send(getIndexFileContents());
+    sendIndex(res);
   }
 
   async checkSubscriptionStatus(req: express.Request, res: express.Response) {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -8,7 +8,7 @@ import UsersService from '../services/UsersService';
 import { getRedirect } from './helpers/getRedirect';
 import { parseSignupOrigin } from './helpers/parseSignupOrigin';
 
-import { getIndexFileContents } from './IndexController/getIndexFileContents';
+import { sendIndex } from './IndexController/sendIndex';
 import { getRandomUUID } from '../shared/helpers/getRandomUUID';
 import SubscriptionService from '../services/SubscriptionService';
 import { OPS_OWNER_EMAIL } from '../routes/middleware/RequireOpsAccess';
@@ -212,7 +212,7 @@ class UsersController {
       const token = req.params.id;
       const isValid = await this.authService.isValidToken(token);
       if (isValid) {
-        return res.send(getIndexFileContents());
+        return sendIndex(res);
       }
       return res.redirect('/login');
     } catch (err) {
@@ -529,7 +529,7 @@ class UsersController {
   async checkUser(req: express.Request, res: express.Response) {
     const user = await this.authService.getUserFrom(req.cookies.token);
     if (!user) {
-      res.send(getIndexFileContents());
+      sendIndex(res);
     } else {
       res.redirect(getRedirect(req));
     }

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Loading the site during an update shows a brief "updating" notice instead of a server error', date: '2026-05-17' },
   { type: 'fix', title: 'Recovery screen — reset stale browser data when 2anki gets stuck loading', date: '2026-05-17' },
   { type: 'fix', title: 'Auto Sync — "How sync works" on the pricing page opens the docs', date: '2026-05-17' },
   { type: 'fix', title: 'Auto Sync appears in the sidebar for $30/mo subscribers, not only Lifetime accounts', date: '2026-05-17' },


### PR DESCRIPTION
## What

When `web/build/index.html` is missing on disk, every route that serves the SPA shell (`/`, `/reset/:id`, `/successful-checkout`, `/check-user`) now responds with **503 + `Retry-After: 5`** and a short "site is being updated" body instead of a 500. The four call sites all go through a new `sendIndex(res)` helper; `getIndexFileContents()` swallows `ENOENT` and returns `null` so the helper can decide.

## Why

After the morning of 2026-05-17 deploys (#2345 / #2346 / #2348), prod logs showed two consecutive `ENOENT … web/build/index.html` errors at the top of the window — the very first user(s) after the deploy got a 500.

Root cause is the build's own gap, not workflow ordering: when `pnpm --filter 2anki-web build` runs on the prod box, Vite empties `web/build/` before it writes the new bundle. The previous pm2 process is still serving traffic during that gap, and `getIndexFileContents` did `fs.readFileSync` — so any request to `/` during the build crashed with ENOENT.

Issue #2354 proposed two fixes:
1. **Reorder the workflow** — already true. `deploy.2anki.net.yml` runs the web build to completion before `pm2 restart`. So the spec's "single-line ordering change" is a no-op against the actual workflow.
2. **Defensive read** — this PR. The race window is real (it just lives inside the build step, not after `pm2 restart`), and a 503 with `Retry-After` is the right shape for the browser to recover automatically.

## How

- `getIndexFileContents()` now returns `string | null` — catches `ENOENT` only, rethrows anything else.
- New `sendIndex(res)` colocated with it: sends 200 + html on hit, 503 + `Retry-After: 5` + short body on null.
- Replaced `res.send(getIndexFileContents())` at all 4 call sites (`IndexController`, `StripeController` x2, `UsersControllers` x2). No call site does anything more than render the shell.

## Measuring success

- After next deploy, no `ENOENT … index.html` lines in `pm2 logs server`. Any residual ones are wrapped — the controller can't blow up because the read no longer throws on ENOENT.
- If the race ever fires, the user sees the "site is being updated" message and a refresh works (browsers respect `Retry-After` for soft retries; modern browsers retry SPAs automatically).

## Testing

- `src/controllers/IndexController/getIndexFileContents.test.ts` — 3 cases (file present, file missing, directory missing).
- `src/controllers/IndexController/sendIndex.test.ts` — 2 cases (sends html on hit, 503 + Retry-After on miss).
- `pnpm test src/controllers/IndexController src/controllers/StripeController src/controllers/UsersControllers` → 39 passed.
- `pnpm typecheck`, web typecheck, web lint, web vitest (580 tests) — all green.

## Risks

- The build directory could be missing for reasons *other* than a deploy race (e.g. server started without ever running `pnpm --filter 2anki-web build`). In that case users now see a 503 forever instead of 500 forever — same severity, slightly more helpful body.
- I did *not* change the deploy workflow. A follow-up could move the web build to a staging dir + atomic rename to close the race entirely — out of scope for this fix because (a) the spec asks for the defensive read and (b) the staging swap is a riskier shell change.

## Goal alignment

- **Simplest, fastest experience**: a 503 with "refresh in a few seconds" is recoverable; a 500 is a dead end. New users hitting `/` for the first time during a deploy don't get a broken first impression.
- **Scale to 300K+**: deploy frequency increases as the team grows. The race window grows with build time. This change makes the window safe regardless of how slow a future build gets.

Refs #2354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->