### PR TITLE
fix(web): tighten recovery boundary copy and reload helper

### DIFF
--- a/web/src/components/LocalDataRecoveryBoundary/LocalDataRecoveryBoundary.tsx
+++ b/web/src/components/LocalDataRecoveryBoundary/LocalDataRecoveryBoundary.tsx
@@ -30,14 +30,15 @@ export class LocalDataRecoveryBoundary extends React.Component<
     this.props.onError?.(error, errorInfo);
   }
 
+  private readonly defaultReload = () => window.location.reload();
+
   private readonly reloadPage = () => {
-    const reload = this.props.reloadPage ?? (() => globalThis.location.reload());
-    reload();
+    (this.props.reloadPage ?? this.defaultReload)();
   };
 
   private readonly resetLocalData = () => {
     try {
-      globalThis.localStorage.clear();
+      window.localStorage.clear();
     } catch {
       this.setState({ resetFailed: true });
       return;
@@ -54,7 +55,7 @@ export class LocalDataRecoveryBoundary extends React.Component<
             <header className={styles.pageHeader}>
               <h1 className={styles.title}>2anki could not finish loading</h1>
               <p className={styles.subtitle}>
-                Something saved in this browser is out of date. Reset it to
+                Stored data from a past version is breaking this page. Reset to
                 recover.
               </p>
             </header>

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,7 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
-  { type: 'fix', title: 'If 2anki gets stuck loading, reset stale browser data from the recovery screen', date: '2026-05-17' },
+  { type: 'fix', title: 'Recovery screen — reset stale browser data when 2anki gets stuck loading', date: '2026-05-17' },
   { type: 'fix', title: 'Auto Sync — "How sync works" on the pricing page opens the docs', date: '2026-05-17' },
   { type: 'fix', title: 'Auto Sync appears in the sidebar for $30/mo subscribers, not only Lifetime accounts', date: '2026-05-17' },
   { type: 'fix', title: 'Auto Sync is the name everywhere — pricing page, Notion FAQ, and limits table', date: '2026-05-17' },


### PR DESCRIPTION
## Summary
- Changelog entry leads with the surface (`Recovery screen — …`) to match VOICE.md
- Subtitle names *what* is wrong ("Stored data from a past version is breaking this page") instead of the vague "Something saved … is out of date"
- Extract `defaultReload` helper and switch `globalThis.location` / `globalThis.localStorage` to `window.*` for consistency with the rest of `web/src/`

Follow-ups from the #2347 review.

## Test plan
- [x] `pnpm --filter 2anki-web test:run` (584 passed)
- [x] `pnpm --filter 2anki-web typecheck`
- [x] `pnpm --filter 2anki-web lint`
- [ ] Trigger a render error in dev and confirm the recovery screen renders + reset clears localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->