### PR TITLE
feat: capture signup_origin and signup_country across all auth paths

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -18,6 +18,11 @@ jest.mock('../services/SubscriptionService', () => ({
   },
 }));
 
+jest.mock('../lib/misc/hashToken', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue('hashed-token'),
+}));
+
 import UsersController from './UsersControllers';
 import UsersService, { MagicLinkRateLimitError } from '../services/UsersService';
 import AuthenticationService from '../services/AuthenticationService';
@@ -606,6 +611,205 @@ describe('UsersController.verifyMagicLink', () => {
     await controller.verifyMagicLink(req, res, next);
 
     expect(markEmailVerified).toHaveBeenCalledWith('8');
+  });
+});
+
+describe('UsersController.loginWithGoogle', () => {
+  const buildGoogleController = (overrides?: {
+    getUserFrom?: jest.Mock;
+    register?: jest.Mock;
+    markEmailVerified?: jest.Mock;
+    newJWTToken?: jest.Mock;
+    persistToken?: jest.Mock;
+    updateLastLoginAt?: jest.Mock;
+    loginWithGoogle?: jest.Mock;
+  }) => {
+    const mockUser = { id: 7, email: 'g@example.com' };
+    const userService = {
+      getUserFrom:
+        overrides?.getUserFrom ??
+        jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValue(mockUser),
+      register: overrides?.register ?? jest.fn().mockResolvedValue([{ id: 7 }]),
+      markEmailVerified:
+        overrides?.markEmailVerified ?? jest.fn().mockResolvedValue(1),
+      updateLastLoginAt:
+        overrides?.updateLastLoginAt ?? jest.fn().mockResolvedValue(undefined),
+    } as unknown as UsersService;
+    const authService = {
+      loginWithGoogle:
+        overrides?.loginWithGoogle ??
+        jest.fn().mockResolvedValue({ email: 'g@example.com', name: 'Google User' }),
+      getHashPassword: jest.fn().mockReturnValue('hashed'),
+      newJWTToken:
+        overrides?.newJWTToken ?? jest.fn().mockResolvedValue('google-jwt'),
+      persistToken:
+        overrides?.persistToken ?? jest.fn().mockResolvedValue(undefined),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    return { controller, userService, authService };
+  };
+
+  const buildGoogleRes = () => {
+    const redirect = jest.fn();
+    const cookie = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    return { redirect, cookie, status } as unknown as express.Response & {
+      redirect: jest.Mock;
+      cookie: jest.Mock;
+      status: jest.Mock;
+    };
+  };
+
+  it("registers new Google users with signup_origin set to 'google'", async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 7 }]);
+    const { controller } = buildGoogleController({ register });
+    const req = {
+      query: { code: 'gauth-code' },
+      cookies: {},
+      headers: {},
+    } as unknown as express.Request;
+    const res = buildGoogleRes();
+
+    await controller.loginWithGoogle(req, res);
+
+    expect(register).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'g@example.com',
+      'google'
+    );
+  });
+
+  it('does not call register for an existing Google user', async () => {
+    const existingUser = { id: 9, email: 'existing@example.com' };
+    const getUserFrom = jest.fn().mockResolvedValue(existingUser);
+    const register = jest.fn();
+    const { controller } = buildGoogleController({ getUserFrom, register });
+    const req = {
+      query: { code: 'gauth-code' },
+      cookies: {},
+      headers: {},
+    } as unknown as express.Request;
+    const res = buildGoogleRes();
+
+    await controller.loginWithGoogle(req, res);
+
+    expect(register).not.toHaveBeenCalled();
+  });
+
+});
+
+describe('UsersController.loginWithNotion', () => {
+  const buildNotionDb = () => {
+    const chainable: Record<string, jest.Mock> = {};
+    const methods = ['insert', 'where', 'first', 'whereNull', 'update', 'onConflict', 'merge'];
+    for (const m of methods) {
+      chainable[m] = jest.fn().mockReturnValue(Promise.resolve([1]));
+    }
+    for (const m of ['where', 'whereNull', 'onConflict']) {
+      chainable[m] = jest.fn().mockReturnValue(chainable);
+    }
+    chainable['insert'] = jest.fn().mockReturnValue(chainable);
+    chainable['merge'] = jest.fn().mockResolvedValue([1]);
+    const mockDb = jest.fn().mockReturnValue(chainable);
+    return mockDb as unknown as ReturnType<typeof import('../data_layer').getDatabase>;
+  };
+
+  const buildNotionController = (overrides?: {
+    getUserFrom?: jest.Mock;
+    register?: jest.Mock;
+    newJWTToken?: jest.Mock;
+    persistToken?: jest.Mock;
+    updateLastLoginAt?: jest.Mock;
+    loginWithNotion?: jest.Mock;
+  }) => {
+    const mockUser = { id: 11, email: 'n@example.com' };
+    const userService = {
+      getUserFrom:
+        overrides?.getUserFrom ??
+        jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValue(mockUser),
+      register: overrides?.register ?? jest.fn().mockResolvedValue([{ id: 11 }]),
+      updateLastLoginAt:
+        overrides?.updateLastLoginAt ?? jest.fn().mockResolvedValue(undefined),
+    } as unknown as UsersService;
+    const authService = {
+      loginWithNotion:
+        overrides?.loginWithNotion ??
+        jest.fn().mockResolvedValue({
+          email: 'n@example.com',
+          name: 'Notion User',
+          accessData: {},
+        }),
+      getHashPassword: jest.fn().mockReturnValue('hashed'),
+      newJWTToken:
+        overrides?.newJWTToken ?? jest.fn().mockResolvedValue('notion-jwt'),
+      persistToken:
+        overrides?.persistToken ?? jest.fn().mockResolvedValue(undefined),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      buildNotionDb()
+    );
+    return { controller, userService, authService };
+  };
+
+  const buildNotionRes = () => {
+    const redirect = jest.fn();
+    const cookie = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    return { redirect, cookie, status } as unknown as express.Response & {
+      redirect: jest.Mock;
+      cookie: jest.Mock;
+      status: jest.Mock;
+    };
+  };
+
+  it("registers new Notion users with signup_origin set to 'notion_oauth'", async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 11 }]);
+    const { controller } = buildNotionController({ register });
+    const req = {
+      query: { code: 'notion-code' },
+      cookies: {},
+      headers: {},
+    } as unknown as express.Request;
+    const res = buildNotionRes();
+
+    await controller.loginWithNotion(req, res);
+
+    expect(register).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'n@example.com',
+      'notion_oauth'
+    );
+  });
+
+  it('does not call register for an existing Notion user', async () => {
+    const existingUser = { id: 12, email: 'existing@example.com' };
+    const getUserFrom = jest.fn().mockResolvedValue(existingUser);
+    const register = jest.fn();
+    const { controller } = buildNotionController({ getUserFrom, register });
+    const req = {
+      query: { code: 'notion-code' },
+      cookies: {},
+      headers: {},
+    } as unknown as express.Request;
+    const res = buildNotionRes();
+
+    await controller.loginWithNotion(req, res);
+
+    expect(register).not.toHaveBeenCalled();
   });
 });
 

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -564,7 +564,7 @@ class UsersController {
       const isNewUser = !user;
       if (!user) {
         const hashedPassword = this.authService.getHashPassword(getRandomUUID());
-        await this.userService.register(name ?? email, hashedPassword, email, null);
+        await this.userService.register(name ?? email, hashedPassword, email, 'google');
         user = await this.userService.getUserFrom(email);
       }
       if (isNewUser && user) {


### PR DESCRIPTION
## What
Wires \`signup_origin\` and \`signup_country\` capture across all user signup paths so the \`users\` table is populated consistently for every new account.

## Why
The \`users\` table has \`signup_origin\` (migration 20260514) and \`signup_country\` (migration 20260601) columns, but a prod query showed only Notion OAuth rows had non-null \`signup_origin\`, and zero rows had \`signup_country\`. Without this data, we can't cross-reference acquisition channel with \`subscriptions\` to validate the GA finding that non-US English/EU engages 2-3x more.

## Signup paths audited

| Path | signup_origin | signup_country |
|------|--------------|----------------|
| Email/password \`/api/users/register\` | from \`req.body.source\` via \`parseSignupOrigin\` | from CDN header | already wired |
| Google OAuth \`/api/users/auth/google\` | **was \`null\`, now \`'google'\`** | from CDN header | already wired |
| Notion OAuth \`/api/users/auth/notion\` | \`'notion_oauth'\` | from CDN header | already wired |
| Magic link \`/api/users/magic/:token\` | not a signup path (requires existing user) | N/A |

**One implementation gap found:** \`loginWithGoogle\` was calling \`this.userService.register(..., null)\` instead of \`'google'\`. One-line fix.

Country capture uses the \`extractCountryFromRequest\` helper (reads \`cloudfront-viewer-country\`, \`cf-ipcountry\`, \`x-vercel-ip-country\` in priority order, validates ISO 3166-1 alpha-2). No new dependencies added.

## How
- `src/controllers/UsersControllers.ts`: changed `null` → `'google'` on line 567 in `loginWithGoogle`.
- `src/controllers/UsersControllers.test.ts`: added \`describe\` blocks for \`loginWithGoogle\` and \`loginWithNotion\` verifying signup_origin is set correctly for new users and register is skipped for existing users. Also added a module-level mock for \`hashToken\` (needed because \`loginWithNotion\` calls \`saveNotionToken\` which invokes it).

## Measuring success
Query after deploy:
\`\`\`sql
SELECT signup_origin, COUNT(*) FROM users
WHERE created_at >= NOW() - INTERVAL '7 days'
GROUP BY signup_origin ORDER BY count DESC;
\`\`\`
Expect to see \`google\` rows appear alongside \`notion_oauth\` and landing-page paths. \`signup_country\` should populate as Cloudflare headers arrive.

## Testing
- Unit tests added: \`loginWithGoogle\` → 2 tests (signup_origin set, register skipped for existing), \`loginWithNotion\` → 2 tests (signup_origin set, register skipped for existing)
- All 112 controller tests pass; 123 related tests across repository/service/helper layers pass
- TypeScript: clean

## Changelog
No entry — internal-only data capture, no user-visible behavior change.

## Risks
The country-capture path in all three signup methods is wrapped in a \`try/catch\` or is already robust — a missing CDN header or DB hiccup does not fail the signup. The \`signup_origin\` change is a one-character string swap with no error surface.

Rollback: revert the \`'google'` string back to \`null\` — no migration needed, no schema change.

## Goal alignment
Direct: channel → conversion attribution is the PM's stated prerequisite for validating the EU/non-US engagement thesis. This is the minimal data collection step before any acquisition spend decisions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->