### PR TITLE
feat: re-engagement email — clicks, rewrite, scheduler cleanup

### DIFF
--- a/src/controllers/Upload/DropboxController.test.ts
+++ b/src/controllers/Upload/DropboxController.test.ts
@@ -32,6 +32,7 @@ function makeController(
     getUploadsByOwner: jest.fn().mockResolvedValue([]),
     findByIdAndOwner: jest.fn().mockResolvedValue(null),
     update: jest.fn().mockResolvedValue([]),
+    getLastUploadForUser: jest.fn().mockResolvedValue(null),
   };
   const notionRepository: INotionRepository = {
     getNotionData: jest.fn().mockResolvedValue({ owner: 1, token: '...' } as NotionTokens),

--- a/src/controllers/Upload/GoogleDriveController.test.ts
+++ b/src/controllers/Upload/GoogleDriveController.test.ts
@@ -31,6 +31,7 @@ function makeController(
     getUploadsByOwner: jest.fn().mockResolvedValue([]),
     findByIdAndOwner: jest.fn().mockResolvedValue(null),
     update: jest.fn().mockResolvedValue([]),
+    getLastUploadForUser: jest.fn().mockResolvedValue(null),
   };
   const notionRepository: INotionRepository = {
     getNotionData: jest.fn().mockResolvedValue({ owner: 1, token: '...' } as NotionTokens),

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -45,6 +45,9 @@ describe('Upload file', () => {
       ): Promise<Uploads[]> {
         return Promise.resolve([]);
       },
+      getLastUploadForUser: function (_userId: number) {
+        return Promise.resolve(null);
+      },
     };
     const notionRepository: INotionRepository = {
       getNotionData: function (owner: string | number): Promise<NotionTokens> {

--- a/src/data_layer/InactivityEmailRepository.ts
+++ b/src/data_layer/InactivityEmailRepository.ts
@@ -3,12 +3,18 @@ import type { Knex } from 'knex';
 export interface IInactivityEmailRepository {
   getUsersToNotify(limit?: number): Promise<Array<{ id: number; name: string; email: string }>>;
   recordSend(userId: number, token: string): Promise<void>;
+  findByToken(token: string): Promise<{ id: number; userId: number } | null>;
 }
 
 interface UserRow {
   id: number;
   name: string;
   email: string;
+}
+
+interface InactivityEmailRow {
+  id: number;
+  user_id: number;
 }
 
 export class InactivityEmailRepository implements IInactivityEmailRepository {
@@ -56,6 +62,17 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
   async recordSend(userId: number, token: string): Promise<void> {
     await this.database(this.table).insert({ user_id: userId, token });
   }
+
+  async findByToken(token: string): Promise<{ id: number; userId: number } | null> {
+    const row = await this.database<InactivityEmailRow>(this.table)
+      .select('id', 'user_id')
+      .where({ token })
+      .first();
+    if (row == null) {
+      return null;
+    }
+    return { id: row.id, userId: row.user_id };
+  }
 }
 
 export class InMemoryInactivityEmailRepository
@@ -64,6 +81,8 @@ export class InMemoryInactivityEmailRepository
   private usersToReturn: Array<{ id: number; name: string; email: string }> =
     [];
   private readonly sentUserIds = new Set<number>();
+  private emails: Array<{ id: number; userId: number; token: string }> = [];
+  private nextId = 1;
 
   seedUsers(users: Array<{ id: number; name: string; email: string }>): void {
     this.usersToReturn = users;
@@ -75,8 +94,18 @@ export class InMemoryInactivityEmailRepository
     return this.usersToReturn.filter((u) => !this.sentUserIds.has(u.id)).slice(0, limit);
   }
 
-  async recordSend(userId: number, _token: string): Promise<void> {
+  async recordSend(userId: number, token: string): Promise<void> {
+    const id = this.nextId++;
+    this.emails.push({ id, userId, token });
     this.sentUserIds.add(userId);
+  }
+
+  async findByToken(token: string): Promise<{ id: number; userId: number } | null> {
+    const found = this.emails.find((e) => e.token === token);
+    if (found == null) {
+      return null;
+    }
+    return { id: found.id, userId: found.userId };
   }
 
   getSentUserIds(): ReadonlySet<number> {
@@ -86,6 +115,8 @@ export class InMemoryInactivityEmailRepository
   clear(): void {
     this.usersToReturn = [];
     this.sentUserIds.clear();
+    this.emails = [];
+    this.nextId = 1;
   }
 }
 

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -1,6 +1,11 @@
 import { Knex } from 'knex';
 import Uploads from './public/Uploads';
 
+export interface LastUpload {
+  filename: string;
+  created_at: Date;
+}
+
 export interface IUploadRepository {
   deleteUpload(owner: number, key: string): Promise<number>;
   getUploadsByOwner(owner: number): Promise<Uploads[]>;
@@ -11,6 +16,7 @@ export interface IUploadRepository {
     key: string,
     size_mb: number
   ): Promise<Uploads[]>;
+  getLastUploadForUser(userId: number): Promise<LastUpload | null>;
 }
 class UploadRepository implements IUploadRepository {
   private readonly table = 'uploads';
@@ -61,6 +67,19 @@ class UploadRepository implements IUploadRepository {
       key,
       size_mb,
     });
+  }
+
+  async getLastUploadForUser(userId: number): Promise<LastUpload | null> {
+    const row = await this.database<Uploads>(this.table)
+      .select('filename', 'created_at')
+      .where({ owner: userId })
+      .whereNotNull('filename')
+      .orderBy('created_at', 'desc')
+      .first();
+    if (row == null || row.filename == null || row.created_at == null) {
+      return null;
+    }
+    return { filename: row.filename, created_at: row.created_at };
   }
 }
 

--- a/src/lib/inactivity/jobs/scheduleInactivityWarnings.ts
+++ b/src/lib/inactivity/jobs/scheduleInactivityWarnings.ts
@@ -1,11 +1,12 @@
 import type { SendInactivityWarningsUseCase } from '../../../usecases/ops/SendInactivityWarningsUseCase';
+import type { EventsSink } from '../../../services/events/EventsSink';
 
 export const INACTIVITY_WARNING_DAILY_LIMIT = 100;
 export const INACTIVITY_WARNING_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 export const scheduleInactivityWarnings = (
   useCase: SendInactivityWarningsUseCase,
-  options: { intervalMs?: number; limit?: number } = {}
+  options: { intervalMs?: number; limit?: number; eventsSink?: EventsSink } = {}
 ): NodeJS.Timeout => {
   const intervalMs = options.intervalMs ?? INACTIVITY_WARNING_INTERVAL_MS;
   const limit = options.limit ?? INACTIVITY_WARNING_DAILY_LIMIT;
@@ -14,10 +15,18 @@ export const scheduleInactivityWarnings = (
     try {
       const result = await useCase.execute(false, limit);
       console.info(`[inactivity-warnings] sent ${result.count} warning(s)`);
+      if (options.eventsSink != null) {
+        options.eventsSink.record({
+          name: 'email_batch_sent',
+          props: { campaign: 'inactivity', count: result.count },
+        });
+      }
     } catch (error) {
       console.error('[inactivity-warnings] daily job failed:', error);
     }
   };
 
-  return setInterval(tick, intervalMs);
+  const handle = setInterval(tick, intervalMs);
+  handle.unref();
+  return handle;
 };

--- a/src/lib/reengagement/jobs/scheduleReEngagementEmails.test.ts
+++ b/src/lib/reengagement/jobs/scheduleReEngagementEmails.test.ts
@@ -1,0 +1,77 @@
+import { scheduleReEngagementEmails, RE_ENGAGEMENT_INTERVAL_MS } from './scheduleReEngagementEmails';
+import type { IReEngagementRepository } from '../../../data_layer/ReEngagementRepository';
+import type { IEmailService } from '../../../services/EmailService/EmailService';
+import type { EventsSink } from '../../../services/events/EventsSink';
+
+jest.mock('../../../lib/storage/jobs/helpers/sendReEngagementEmails', () => ({
+  sendReEngagementEmails: jest.fn().mockResolvedValue({ count: 0 }),
+}));
+
+import { sendReEngagementEmails } from '../../storage/jobs/helpers/sendReEngagementEmails';
+
+const mockRepo = {} as IReEngagementRepository;
+const mockEmailService = {} as IEmailService;
+
+function makeSink(): jest.Mocked<Pick<EventsSink, 'record'>> {
+  return { record: jest.fn() };
+}
+
+describe('scheduleReEngagementEmails', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('fires sendReEngagementEmails after one interval', async () => {
+    const sink = makeSink();
+    const handle = scheduleReEngagementEmails(mockRepo, mockEmailService, sink as unknown as EventsSink, { intervalMs: 1000 });
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(sendReEngagementEmails).toHaveBeenCalledTimes(1);
+    clearInterval(handle);
+  });
+
+  it('does not fire before the interval elapses', () => {
+    const sink = makeSink();
+    const handle = scheduleReEngagementEmails(mockRepo, mockEmailService, sink as unknown as EventsSink, { intervalMs: 1000 });
+
+    jest.advanceTimersByTime(999);
+
+    expect(sendReEngagementEmails).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('emits email_batch_sent with campaign=reengagement and the returned count', async () => {
+    (sendReEngagementEmails as jest.Mock).mockResolvedValueOnce({ count: 7 });
+    const sink = makeSink();
+    const handle = scheduleReEngagementEmails(mockRepo, mockEmailService, sink as unknown as EventsSink, { intervalMs: 1000 });
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(sink.record).toHaveBeenCalledWith({
+      name: 'email_batch_sent',
+      props: { campaign: 'reengagement', count: 7 },
+    });
+    clearInterval(handle);
+  });
+
+  it('catches errors thrown by sendReEngagementEmails without rethrowing', async () => {
+    (sendReEngagementEmails as jest.Mock).mockRejectedValueOnce(new Error('db down'));
+    const sink = makeSink();
+    const handle = scheduleReEngagementEmails(mockRepo, mockEmailService, sink as unknown as EventsSink, { intervalMs: 1000 });
+
+    jest.advanceTimersByTime(1000);
+    await expect(Promise.resolve()).resolves.toBeUndefined();
+
+    expect(sink.record).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('uses RE_ENGAGEMENT_INTERVAL_MS as the default interval', () => {
+    expect(RE_ENGAGEMENT_INTERVAL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/reengagement/jobs/scheduleReEngagementEmails.ts
+++ b/src/lib/reengagement/jobs/scheduleReEngagementEmails.ts
@@ -1,0 +1,32 @@
+import type { IReEngagementRepository } from '../../../data_layer/ReEngagementRepository';
+import type { IEmailService } from '../../../services/EmailService/EmailService';
+import type { EventsSink } from '../../../services/events/EventsSink';
+import { sendReEngagementEmails } from '../../storage/jobs/helpers/sendReEngagementEmails';
+
+export const RE_ENGAGEMENT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export const scheduleReEngagementEmails = (
+  repo: IReEngagementRepository,
+  emailService: IEmailService,
+  eventsSink: EventsSink,
+  options: { intervalMs?: number } = {}
+): NodeJS.Timeout => {
+  const intervalMs = options.intervalMs ?? RE_ENGAGEMENT_INTERVAL_MS;
+
+  const tick = async () => {
+    try {
+      const { count } = await sendReEngagementEmails(repo, emailService);
+      console.info(`[re-engagement] sent ${count} email(s)`);
+      eventsSink.record({
+        name: 'email_batch_sent',
+        props: { campaign: 'reengagement', count },
+      });
+    } catch (error) {
+      console.error('[re-engagement] daily job failed:', error);
+    }
+  };
+
+  const handle = setInterval(tick, intervalMs);
+  handle.unref();
+  return handle;
+};

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
@@ -104,7 +104,7 @@ describe('sendReEngagementEmails', () => {
       .mockRejectedValueOnce(new Error('SendGrid error'))
       .mockResolvedValueOnce(undefined);
 
-    await expect(sendReEngagementEmails(repo, emailService)).resolves.toBeUndefined();
+    await expect(sendReEngagementEmails(repo, emailService)).resolves.toMatchObject({ count: expect.any(Number) });
     expect(emailService.sendReEngagementEmail).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.ts
@@ -6,16 +6,20 @@ import type { IEmailService } from '../../../../services/EmailService/EmailServi
 export async function sendReEngagementEmails(
   repo: IReEngagementRepository,
   emailService: IEmailService
-): Promise<void> {
+): Promise<{ count: number }> {
   const users = await repo.getUsersToEmail();
 
+  let count = 0;
   for (const user of users) {
     const token = crypto.randomBytes(32).toString('hex');
     await repo.recordSend(user.id, token);
     try {
       await emailService.sendReEngagementEmail(user.email, user.name, token);
+      count++;
     } catch (error) {
       console.error(`[re-engagement] failed to email user ${user.id}:`, error);
     }
   }
+
+  return { count };
 }

--- a/src/routes/EmailRedirectRouter.test.ts
+++ b/src/routes/EmailRedirectRouter.test.ts
@@ -1,0 +1,145 @@
+import express from 'express';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import type { IInactivityEmailRepository } from '../data_layer/InactivityEmailRepository';
+import type { IReEngagementRepository } from '../data_layer/ReEngagementRepository';
+import type { EventsSink } from '../services/events/EventsSink';
+
+const mockInactivityRepo: jest.Mocked<Pick<IInactivityEmailRepository, 'findByToken'>> = {
+  findByToken: jest.fn().mockResolvedValue(null),
+};
+
+const mockReEngagementRepo: jest.Mocked<Pick<IReEngagementRepository, 'findByToken'>> = {
+  findByToken: jest.fn().mockResolvedValue(null),
+};
+
+const mockSink: jest.Mocked<Pick<EventsSink, 'record'>> = {
+  record: jest.fn(),
+};
+
+jest.mock('../data_layer', () => ({ getDatabase: jest.fn() }));
+jest.mock('../data_layer/InactivityEmailRepository', () =>
+  jest.fn().mockImplementation(() => mockInactivityRepo)
+);
+jest.mock('../data_layer/ReEngagementRepository', () =>
+  jest.fn().mockImplementation(() => mockReEngagementRepo)
+);
+jest.mock('../services/events/eventsSinkInstance', () => ({
+  getEventsSink: jest.fn(() => mockSink),
+}));
+
+async function buildServer() {
+  const { default: EmailRedirectRouter } = await import('./EmailRedirectRouter');
+  const app = express();
+  app.use(EmailRedirectRouter());
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+describe('EmailRedirectRouter', () => {
+  let server: http.Server;
+  let url: string;
+
+  beforeAll(async () => {
+    process.env.DOMAIN = 'https://2anki.net';
+    ({ server, url } = await buildServer());
+  });
+
+  afterAll(() => server.close());
+
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('GET /r/email', () => {
+    it('redirects to / when to param is absent', async () => {
+      const res = await fetch(`${url}/r/email?t=abc&c=inactivity`, { redirect: 'manual' });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://2anki.net/');
+    });
+
+    it('redirects to allowed destination /upload', async () => {
+      const res = await fetch(`${url}/r/email?t=abc&c=inactivity&to=/upload`, { redirect: 'manual' });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://2anki.net/upload');
+    });
+
+    it('redirects to allowed destination /pricing', async () => {
+      const res = await fetch(`${url}/r/email?t=abc&c=inactivity&to=/pricing`, { redirect: 'manual' });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://2anki.net/pricing');
+    });
+
+    it('redirects to allowed destination /login', async () => {
+      const res = await fetch(`${url}/r/email?t=abc&c=inactivity&to=/login`, { redirect: 'manual' });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://2anki.net/login');
+    });
+
+    it('falls back to / for a disallowed destination', async () => {
+      const res = await fetch(`${url}/r/email?t=abc&c=inactivity&to=/evil`, { redirect: 'manual' });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://2anki.net/');
+    });
+
+    it('falls back to / when to is an absolute URL injection', async () => {
+      const res = await fetch(`${url}/r/email?t=abc&c=inactivity&to=https://evil.com`, { redirect: 'manual' });
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://2anki.net/');
+    });
+
+    it('records email_clicked with null user when inactivity token is unknown', async () => {
+      mockInactivityRepo.findByToken.mockResolvedValueOnce(null);
+      await fetch(`${url}/r/email?t=badtoken&c=inactivity&to=/upload`, { redirect: 'manual' });
+      expect(mockSink.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'email_clicked',
+          user_id: null,
+          props: expect.objectContaining({ campaign: 'inactivity', email_id: null }),
+        })
+      );
+    });
+
+    it('records email_clicked with user_id when inactivity token resolves', async () => {
+      mockInactivityRepo.findByToken.mockResolvedValueOnce({ id: 5, userId: 42 });
+      await fetch(`${url}/r/email?t=validtoken&c=inactivity&to=/upload`, { redirect: 'manual' });
+      expect(mockSink.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'email_clicked',
+          user_id: 42,
+          props: expect.objectContaining({ campaign: 'inactivity', email_id: 5 }),
+        })
+      );
+    });
+
+    it('records email_clicked with user_id when reengagement token resolves', async () => {
+      mockReEngagementRepo.findByToken.mockResolvedValueOnce({ id: 9, userId: 77 });
+      await fetch(`${url}/r/email?t=retoken&c=reengagement&to=/`, { redirect: 'manual' });
+      expect(mockSink.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'email_clicked',
+          user_id: 77,
+          props: expect.objectContaining({ campaign: 'reengagement', email_id: 9 }),
+        })
+      );
+    });
+
+    it('records email_clicked with null user when campaign param is missing', async () => {
+      await fetch(`${url}/r/email?t=sometoken&to=/upload`, { redirect: 'manual' });
+      expect(mockSink.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'email_clicked',
+          user_id: null,
+          props: expect.objectContaining({ campaign: 'unknown' }),
+        })
+      );
+    });
+
+    it('still redirects when token DB lookup throws', async () => {
+      mockInactivityRepo.findByToken.mockRejectedValueOnce(new Error('db down'));
+      const res = await fetch(`${url}/r/email?t=abc&c=inactivity&to=/upload`, { redirect: 'manual' });
+      expect(res.status).toBe(302);
+    });
+  });
+});

--- a/src/routes/EmailRedirectRouter.ts
+++ b/src/routes/EmailRedirectRouter.ts
@@ -10,6 +10,39 @@ const ALLOWED_EMAIL_DESTINATIONS = new Set(['/', '/upload', '/pricing', '/login'
 const EmailRedirectRouter = () => {
   const router = express.Router();
 
+  /**
+   * @swagger
+   * /r/email:
+   *   get:
+   *     summary: Email click redirect
+   *     description: |
+   *       Records an `email_clicked` analytics event then 302s the user to a
+   *       validated destination. Destination is checked against a static
+   *       allowlist (`/`, `/upload`, `/pricing`, `/login`); unknown values fall
+   *       back to `/`. Unknown or missing tokens record an anonymous click and
+   *       still redirect — never fails user-visibly.
+   *     tags: [Email]
+   *     parameters:
+   *       - in: query
+   *         name: t
+   *         schema:
+   *           type: string
+   *         description: Email token from inactivity_emails.token or re_engagement_emails.token
+   *       - in: query
+   *         name: c
+   *         schema:
+   *           type: string
+   *           enum: [inactivity, reengagement]
+   *         description: Campaign — disambiguates which table to resolve the token against
+   *       - in: query
+   *         name: to
+   *         schema:
+   *           type: string
+   *         description: Destination path (allowlisted); falls back to `/` if unknown
+   *     responses:
+   *       302:
+   *         description: Redirect to the resolved destination
+   */
   router.get('/r/email', async (req, res) => {
     const token = typeof req.query.t === 'string' ? req.query.t : null;
     const campaign = typeof req.query.c === 'string' ? req.query.c : null;

--- a/src/routes/EmailRedirectRouter.ts
+++ b/src/routes/EmailRedirectRouter.ts
@@ -1,0 +1,62 @@
+import express from 'express';
+
+import { getDatabase } from '../data_layer';
+import InactivityEmailRepository from '../data_layer/InactivityEmailRepository';
+import ReEngagementRepository from '../data_layer/ReEngagementRepository';
+import { getEventsSink } from '../services/events/eventsSinkInstance';
+
+const ALLOWED_EMAIL_DESTINATIONS = new Set(['/', '/upload', '/pricing', '/login']);
+
+const EmailRedirectRouter = () => {
+  const router = express.Router();
+
+  router.get('/r/email', async (req, res) => {
+    const token = typeof req.query.t === 'string' ? req.query.t : null;
+    const campaign = typeof req.query.c === 'string' ? req.query.c : null;
+    const rawDestination = typeof req.query.to === 'string' ? req.query.to : null;
+
+    const destination = rawDestination != null && ALLOWED_EMAIL_DESTINATIONS.has(rawDestination)
+      ? rawDestination
+      : '/';
+
+    const domain = process.env.DOMAIN ?? 'https://2anki.net';
+    const sink = getEventsSink();
+
+    let userId: number | null = null;
+    let emailId: number | null = null;
+
+    if (token != null && campaign != null) {
+      const database = getDatabase();
+
+      if (campaign === 'inactivity') {
+        const result = await new InactivityEmailRepository(database).findByToken(token).catch(() => null);
+        if (result != null) {
+          userId = result.userId;
+          emailId = result.id;
+        }
+      } else if (campaign === 'reengagement') {
+        const result = await new ReEngagementRepository(database).findByToken(token).catch(() => null);
+        if (result != null) {
+          userId = result.userId;
+          emailId = result.id;
+        }
+      }
+    }
+
+    sink.record({
+      name: 'email_clicked',
+      user_id: userId,
+      props: {
+        campaign: campaign ?? 'unknown',
+        email_id: emailId,
+        destination,
+      },
+    });
+
+    res.redirect(302, `${domain}${destination}`);
+  });
+
+  return router;
+};
+
+export default EmailRedirectRouter;

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ import contactMessagesRouter from './routes/ContactMessagesRouter';
 import showcaseRouter from './routes/ShowcaseRouter';
 import emojiFeedbackRouter from './routes/EmojiFeedbackRouter';
 import reEngagementRouter from './routes/ReEngagementRouter';
+import emailRedirectRouter from './routes/EmailRedirectRouter';
 import imageOcclusionRouter from './routes/ImageOcclusionRouter';
 import chatRouter from './routes/ChatRouter';
 import eventsRouter from './routes/EventsRouter';
@@ -58,8 +59,9 @@ import JobRepository from './data_layer/JobRepository';
 import { MagicTokenRepository } from './data_layer/MagicTokenRepository';
 import ReEngagementRepository from './data_layer/ReEngagementRepository';
 import InactivityEmailRepository from './data_layer/InactivityEmailRepository';
+import UploadRepository from './data_layer/UploadRespository';
 import { updateStripeSubscriptions } from './lib/storage/jobs/helpers/updateStripeSubscriptions';
-import { sendReEngagementEmails } from './lib/storage/jobs/helpers/sendReEngagementEmails';
+import { scheduleReEngagementEmails } from './lib/reengagement/jobs/scheduleReEngagementEmails';
 import { scheduleInactivityWarnings } from './lib/inactivity/jobs/scheduleInactivityWarnings';
 import { getDefaultEmailService } from './services/EmailService/EmailService';
 import { SendInactivityWarningsUseCase } from './usecases/ops/SendInactivityWarningsUseCase';
@@ -128,6 +130,7 @@ const serve = async () => {
   app.use(contactMessagesRouter());
   app.use(emojiFeedbackRouter());
   app.use(reEngagementRouter());
+  app.use(emailRedirectRouter());
   app.use(imageOcclusionRouter());
   app.use(chatRouter());
   app.use(eventsRouter());
@@ -172,7 +175,6 @@ const serve = async () => {
 
   const database = getDatabase();
   await setupDatabase(database);
-  getEventsSink();
   const interruptedCount = await new JobRepository(database).markInterruptedClaudeJobs();
   if (interruptedCount > 0) {
     console.info(`[startup] Marked ${interruptedCount} Claude job(s) as interrupted`);
@@ -191,18 +193,15 @@ const serve = async () => {
     });
   }
 
+  const eventsSink = getEventsSink();
   const reEngagementRepo = new ReEngagementRepository(database);
   const emailService = getDefaultEmailService();
-  const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-  setInterval(() => {
-    sendReEngagementEmails(reEngagementRepo, emailService).catch((error) => {
-      console.error('[re-engagement] daily job failed:', error);
-    });
-  }, ONE_DAY_MS);
+  scheduleReEngagementEmails(reEngagementRepo, emailService, eventsSink);
 
   const inactivityEmailRepo = new InactivityEmailRepository(database);
-  const sendInactivityWarningsUseCase = new SendInactivityWarningsUseCase(inactivityEmailRepo, emailService);
-  scheduleInactivityWarnings(sendInactivityWarningsUseCase);
+  const uploadRepo = new UploadRepository(database);
+  const sendInactivityWarningsUseCase = new SendInactivityWarningsUseCase(inactivityEmailRepo, emailService, uploadRepo);
+  scheduleInactivityWarnings(sendInactivityWarningsUseCase, { eventsSink });
 };
 
 serve();

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -56,7 +56,7 @@ export interface IEmailService {
     name: string,
     token: string
   ): Promise<void>;
-  sendInactivityWarningEmail(to: string): Promise<void>;
+  sendInactivityWarningEmail(to: string, token: string, lastConversion?: { deckName: string } | null): Promise<void>;
   sendAbandonedCheckoutRecoveryEmail(to: string): Promise<void>;
 }
 
@@ -257,9 +257,23 @@ class EmailService implements IEmailService {
     }
   }
 
-  async sendInactivityWarningEmail(to: string): Promise<void> {
+  async sendInactivityWarningEmail(
+    to: string,
+    token: string,
+    lastConversion?: { deckName: string } | null
+  ): Promise<void> {
     const domain = process.env.DOMAIN ?? 'https://2anki.net';
-    const markup = INACTIVITY_WARNING_TEMPLATE.replace('{{link}}', domain);
+
+    const hasConversion = lastConversion != null;
+    const bodyText = hasConversion
+      ? `Your last deck on 2anki was ${lastConversion.deckName}. If another exam or chapter is coming up, your account is ready — paste a Notion link or drop in a file and you'll have a deck in under a minute.`
+      : `You signed up for 2anki but haven't made a deck yet. When you're ready, paste a Notion link or drop in a file at 2anki.net and you'll have an Anki deck in under a minute.`;
+
+    const ctaUrl = `${domain}/r/email?t=${encodeURIComponent(token)}&c=inactivity&to=/upload`;
+
+    const markup = INACTIVITY_WARNING_TEMPLATE
+      .replace('{{bodyText}}', bodyText)
+      .replace('{{ctaUrl}}', ctaUrl);
 
     const $ = cheerio.load(markup);
     const text = $('body').text().replace(/\s+/g, ' ').trim();
@@ -267,7 +281,7 @@ class EmailService implements IEmailService {
     const msg = {
       to,
       from: this.defaultSender,
-      subject: 'Your 2anki account will be deleted soon',
+      subject: 'Your decks on 2anki — still here when you need them',
       text,
       html: markup,
       replyTo: 'support@2anki.net',
@@ -508,8 +522,8 @@ export class UnimplementedEmailService implements IEmailService {
     console.info('sendReEngagementEmail not handled', to, name, token);
   }
 
-  async sendInactivityWarningEmail(to: string): Promise<void> {
-    console.info('sendInactivityWarningEmail not handled', to);
+  async sendInactivityWarningEmail(to: string, token: string, lastConversion?: { deckName: string } | null): Promise<void> {
+    console.info('sendInactivityWarningEmail not handled', to, token, lastConversion);
   }
 
   async sendAbandonedCheckoutRecoveryEmail(to: string): Promise<void> {

--- a/src/services/EmailService/templates/inactivity-warning.html
+++ b/src/services/EmailService/templates/inactivity-warning.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="color-scheme" content="light dark" />
-  <title>2anki.net — Your account will be deleted soon</title>
+  <title>2anki.net — Your decks, still here when you need them</title>
   <style>
     @media (prefers-color-scheme: dark) {
       body { background-color: #1a1a1a !important; }
@@ -13,6 +13,7 @@
       .email-body p { color: #f9fafb !important; }
       .email-cta a { background-color: #60a5fa !important; }
       .email-footer { color: #6b7280 !important; border-top-color: #374151 !important; }
+      .email-muted { color: #6b7280 !important; }
     }
     @media only screen and (max-width: 600px) {
       .email-card { width: 100% !important; padding: 0 !important; }
@@ -34,14 +35,13 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <p style="margin: 0 0 16px;">You haven't signed in to 2anki in a while. We remove data from accounts that have been inactive for 6 months or more.</p>
-              <p style="margin: 0 0 16px;">If we don't hear from you in the next 14 days, your uploaded decks and files will be permanently deleted. This only affects data stored on 2anki.net — anything you've already downloaded to your computer or Anki app is safe.</p>
-              <p style="margin: 0 0 24px;">To keep your account, sign in once.</p>
+              <p style="margin: 0 0 16px;">{{bodyText}}</p>
+              <p style="margin: 0 0 24px;">If you only need it for one push — a Day Pass covers a full day of converting, a Week Pass covers a week. Pay once, no subscription.</p>
               <div style="text-align: center; margin: 0 0 24px;" class="email-cta">
-                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Log in</a>
+                <a href="{{ctaUrl}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Open 2anki</a>
               </div>
-              <p style="margin: 0 0 16px;">If you no longer need your account, you can ignore this email — we won't send another.</p>
-              <p style="margin: 0 0 16px;">Questions? Reply to this email.</p>
+              <p class="email-muted" style="margin: 0 0 16px; font-size: 13px; color: #6b7280;">One housekeeping note: accounts inactive for 6 months get cleaned up, and we'll remove your uploaded decks and files in 14 days if we don't see you. Anything already downloaded to Anki is safe. Signing in once keeps everything.</p>
+              <p style="margin: 0;">The 2anki Team</p>
             </td>
           </tr>
           <tr>

--- a/src/services/EmailService/templates/re-engagement.html
+++ b/src/services/EmailService/templates/re-engagement.html
@@ -46,6 +46,7 @@
                 <p class="video-caption" style="margin: 8px 0 0; font-size: 13px; color: #6b7280;">Watch how it works (60 sec)</p>
               </div>
               <p style="margin: 0 0 16px;">Paste a Notion page URL or upload a file at 2anki.net. You'll have an Anki deck in under a minute.</p>
+              <!-- Click tracking via /r/email deferred: /feedback/onboarding is a survey page, not a conversion destination, and is not in the allowed-destinations allowlist. -->
               <div style="text-align: center; margin: 24px 0;" class="email-cta">
                 <a href="{{surveyUrl}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Tell us what happened</a>
               </div>

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -11,6 +11,8 @@ export const KNOWN_EVENTS = new Set([
   'paywall_shown',
   'paywall_upgrade_clicked',
   'purchase',
+  'email_clicked',
+  'email_batch_sent',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -1,6 +1,7 @@
 import { SendInactivityWarningsUseCase } from './SendInactivityWarningsUseCase';
 import { InMemoryInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
 import type { IEmailService } from '../../services/EmailService/EmailService';
+import type { IUploadRepository, LastUpload } from '../../data_layer/UploadRespository';
 
 function makeEmailService(
   overrides: Partial<IEmailService> = {}
@@ -18,6 +19,16 @@ function makeEmailService(
     sendInactivityWarningEmail: jest.fn().mockResolvedValue(undefined),
     sendAbandonedCheckoutRecoveryEmail: jest.fn().mockResolvedValue(undefined),
     ...overrides,
+  };
+}
+
+function makeUploadRepo(lastUpload: LastUpload | null = null): jest.Mocked<IUploadRepository> {
+  return {
+    deleteUpload: jest.fn(),
+    getUploadsByOwner: jest.fn(),
+    findByIdAndOwner: jest.fn(),
+    update: jest.fn(),
+    getLastUploadForUser: jest.fn().mockResolvedValue(lastUpload),
   };
 }
 
@@ -79,8 +90,8 @@ describe('SendInactivityWarningsUseCase', () => {
 
       expect(result).toEqual({ count: 2, dryRun: false });
       expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledTimes(2);
-      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith('alice@example.com');
-      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith('bob@example.com');
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith('alice@example.com', expect.any(String), null);
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith('bob@example.com', expect.any(String), null);
       expect(repo.getSentUserIds()).toEqual(new Set([1, 2]));
     });
 
@@ -125,6 +136,55 @@ describe('SendInactivityWarningsUseCase', () => {
       expect(result).toEqual({ count: 2, dryRun: false });
       expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledTimes(2);
       expect(repo.getSentUserIds().size).toBe(2);
+    });
+  });
+
+  describe('lastConversion lookup', () => {
+    it('passes deckName derived from filename when user has a prior upload', async () => {
+      repo.seedUsers([{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+      const emailService = makeEmailService();
+      const uploadsRepo = makeUploadRepo({
+        filename: 'Biochemistry Chapter 4.html',
+        created_at: new Date('2026-01-01'),
+      });
+      const useCase = new SendInactivityWarningsUseCase(repo, emailService, uploadsRepo);
+
+      await useCase.execute(false);
+
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith(
+        'alice@example.com',
+        expect.any(String),
+        { deckName: 'Biochemistry Chapter 4' }
+      );
+    });
+
+    it('passes null lastConversion when user has no prior upload', async () => {
+      repo.seedUsers([{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+      const emailService = makeEmailService();
+      const uploadsRepo = makeUploadRepo(null);
+      const useCase = new SendInactivityWarningsUseCase(repo, emailService, uploadsRepo);
+
+      await useCase.execute(false);
+
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith(
+        'alice@example.com',
+        expect.any(String),
+        null
+      );
+    });
+
+    it('falls back to null lastConversion when no uploadsRepo is provided', async () => {
+      repo.seedUsers([{ id: 1, name: 'Alice', email: 'alice@example.com' }]);
+      const emailService = makeEmailService();
+      const useCase = new SendInactivityWarningsUseCase(repo, emailService);
+
+      await useCase.execute(false);
+
+      expect(emailService.sendInactivityWarningEmail).toHaveBeenCalledWith(
+        'alice@example.com',
+        expect.any(String),
+        null
+      );
     });
   });
 });

--- a/src/usecases/ops/SendInactivityWarningsUseCase.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.ts
@@ -1,16 +1,31 @@
 import type { IInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
+import type { IUploadRepository } from '../../data_layer/UploadRespository';
 import type { IEmailService } from '../../services/EmailService/EmailService';
+import path from 'node:path';
 
 export interface SendInactivityWarningsResult {
   count: number;
   dryRun: boolean;
 }
 
+class NoOpUploadRepository implements IUploadRepository {
+  deleteUpload(): Promise<number> { return Promise.resolve(0); }
+  getUploadsByOwner(): Promise<never[]> { return Promise.resolve([]); }
+  findByIdAndOwner(): Promise<null> { return Promise.resolve(null); }
+  update(): Promise<never[]> { return Promise.resolve([]); }
+  getLastUploadForUser(): Promise<null> { return Promise.resolve(null); }
+}
+
 export class SendInactivityWarningsUseCase {
+  private readonly uploadsRepo: IUploadRepository;
+
   constructor(
     private readonly repo: IInactivityEmailRepository,
-    private readonly emailService: IEmailService
-  ) {}
+    private readonly emailService: IEmailService,
+    uploadsRepo?: IUploadRepository
+  ) {
+    this.uploadsRepo = uploadsRepo ?? new NoOpUploadRepository();
+  }
 
   async execute(dryRun: boolean, limit = 500): Promise<SendInactivityWarningsResult> {
     const users = await this.repo.getUsersToNotify(limit);
@@ -21,9 +36,14 @@ export class SendInactivityWarningsUseCase {
 
     let sent = 0;
     for (const user of users) {
-      await this.repo.recordSend(user.id, crypto.randomUUID());
+      const token = crypto.randomUUID();
+      await this.repo.recordSend(user.id, token);
       try {
-        await this.emailService.sendInactivityWarningEmail(user.email);
+        const lastUpload = await this.uploadsRepo.getLastUploadForUser(user.id);
+        const lastConversion = lastUpload != null
+          ? { deckName: path.basename(lastUpload.filename, path.extname(lastUpload.filename)) }
+          : null;
+        await this.emailService.sendInactivityWarningEmail(user.email, token, lastConversion);
         sent++;
       } catch (error) {
         console.error(`[inactivity] failed to email user ${user.id}:`, error);

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Inactivity email shows your last deck name and a Day Pass option for one-time converting', date: '2026-05-17' },
   { type: 'fix', title: 'Loading the site during an update shows a brief "updating" notice instead of a server error', date: '2026-05-17' },
   { type: 'fix', title: 'Recovery screen — reset stale browser data when 2anki gets stuck loading', date: '2026-05-17' },
   { type: 'fix', title: 'Auto Sync — "How sync works" on the pricing page opens the docs', date: '2026-05-17' },


### PR DESCRIPTION
## Summary

Track D bundle — three tightly coupled pieces shipped as one PR per the trio synthesis. Sets up re-engagement as a measurable growth lever for the "I finished what I needed" cancellation cohort (47% of churn — task completion, not dissatisfaction).

### 1. Email click measurement
- New `email_clicked` and `email_batch_sent` events in `KNOWN_EVENTS`.
- New `GET /r/email` route — records click via `EventsSink`, then 302s to destination.
- **CWE-601 mitigation:** `to` is validated against a static allowlist (`/`, `/upload`, `/pricing`, `/login`). Unknown values fall back to `/`.
- `c` (campaign) param disambiguates token-to-user lookup between `inactivity_emails` and `re_engagement_emails`. Missing/unknown token records an anonymous click and still redirects.
- Adds `InactivityEmailRepository.findByToken` — was missing.

### 2. Scheduler refactor + batch volume signal
- New `src/lib/reengagement/jobs/scheduleReEngagementEmails.ts` mirrors the inactivity scheduler.
- `sendReEngagementEmails` now returns `{ count }`; both schedulers emit `email_batch_sent` after each batch.
- Removes the top-level `setInterval` in `server.ts:197-205` — fixes the existing `.claude/rules/code-quality.md` violation.

### 3. Inactivity email rewrite
- Subject: **Your decks on 2anki — still here when you need them** (was: _Your 2anki account will be deleted soon_).
- Body picks one of two designer-approved variants based on whether the user has a prior conversion (`getLastUploadForUser` lookup).
- **Day Pass / Week Pass mention** as a quiet secondary paragraph — pay-once products fit the exam-cycle usage shape; subscription would not.
- Deletion warning demoted to 13px muted-gray under the CTA, not the headline.
- CTA **Open 2anki** wraps through `/r/email?…` for click tracking.

### Intentional non-goals
- Re-engagement template body copy untouched — different audience (never-converted), pricing mention would poison the survey signal. CTA URL also left as-is because `/feedback/onboarding` isn't in the redirect allowlist — deferred.
- **3mo "next exam coming" trigger** deferred to a follow-up PR — needs a new `last_upload_at` column and a second cron entry.
- No CTR dashboard, no unsubscribe footer, no token expiry.

## Test plan
- [ ] CI green: server typecheck, server tests, web build, web tests, web lint, SonarCloud, Playwright
- [ ] Manually verify `/r/email?t=…&c=inactivity&to=/upload` 302s correctly and records an `email_clicked` event
- [ ] `/r/email?to=/evil.example.com` falls back to `/` (CWE-601 check)
- [ ] Send a test inactivity email to a user with a prior upload — verify deck name renders
- [ ] Send a test inactivity email to a user with no prior upload — verify fallback copy renders
- [ ] After deploy: query `SELECT name, count(*) FROM events WHERE name IN ('email_clicked','email_batch_sent') AND created_at >= NOW() - INTERVAL '7 days' GROUP BY name;`

## Success metric (PM)
30-day reactivation rate = users who upload at least once within 30 days of inactivity email send ÷ users emailed. Target: **8% at 4 weeks**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->