### PR TITLE
fix: pin archiver to v7 so bulk download works again

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,6 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/test/'],
   moduleNameMapper: {
     '^puppeteer$': '<rootDir>/src/test/mocks/puppeteer.ts',
-    '^archiver$': '<rootDir>/src/test/mocks/archiver.ts',
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@sendgrid/mail": "^8.1.3",
     "@types/express-session": "^1.18.1",
     "@types/swagger-ui-express": "^4.1.8",
-    "archiver": "^8.0.0",
+    "archiver": "~7.0.1",
     "aws-sdk": "^2.1502.0",
     "axios": "^1.13.5",
     "bcryptjs": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8
       archiver:
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ~7.0.1
+        version: 7.0.1
       aws-sdk:
         specifier: ^2.1502.0
         version: 2.1693.0
@@ -3320,9 +3320,13 @@ packages:
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
-  archiver@8.0.0:
-    resolution: {integrity: sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==}
-    engines: {node: '>=18'}
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -3811,9 +3815,9 @@ packages:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
-  compress-commons@7.0.1:
-    resolution: {integrity: sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==}
-    engines: {node: '>=18'}
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -3921,9 +3925,9 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
-  crc32-stream@7.0.1:
-    resolution: {integrity: sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==}
-    engines: {node: '>=18'}
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -5123,10 +5127,6 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-stream@4.0.1:
-    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
-    engines: {node: '>=18'}
-
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
@@ -5966,6 +5966,10 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -6698,9 +6702,8 @@ packages:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  readdir-glob@3.0.0:
-    resolution: {integrity: sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==}
-    engines: {node: '>=18'}
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -7945,9 +7948,9 @@ packages:
     engines: {node: '>=8.0.0'}
     hasBin: true
 
-  zip-stream@7.0.5:
-    resolution: {integrity: sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==}
-    engines: {node: '>=18'}
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -11506,17 +11509,25 @@ snapshots:
 
   append-field@1.0.0: {}
 
-  archiver@8.0.0:
+  archiver-utils@5.0.2:
     dependencies:
-      async: 3.2.6
-      buffer-crc32: 1.0.0
-      is-stream: 4.0.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
       lazystream: 1.0.1
+      lodash: 4.18.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
-      readdir-glob: 3.0.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
       tar-stream: 3.1.8
-      zip-stream: 7.0.5
+      zip-stream: 6.0.1
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -12061,11 +12072,11 @@ snapshots:
 
   commander@9.5.0: {}
 
-  compress-commons@7.0.1:
+  compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
-      crc32-stream: 7.0.1
-      is-stream: 4.0.1
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
@@ -12163,7 +12174,7 @@ snapshots:
 
   crc-32@1.2.2: {}
 
-  crc32-stream@7.0.1:
+  crc32-stream@6.0.0:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
@@ -13460,8 +13471,6 @@ snapshots:
 
   is-stream@2.0.1: {}
 
-  is-stream@4.0.1: {}
-
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
@@ -14750,6 +14759,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.13
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.3
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.0.3
@@ -15509,9 +15522,9 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
-  readdir-glob@3.0.0:
+  readdir-glob@1.1.3:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 5.1.9
 
   readdirp@3.6.0:
     dependencies:
@@ -16840,10 +16853,10 @@ snapshots:
     optionalDependencies:
       commander: 9.5.0
 
-  zip-stream@7.0.5:
+  zip-stream@6.0.1:
     dependencies:
-      compress-commons: 7.0.1
-      normalize-path: 3.0.0
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
       readable-stream: 4.7.0
 
   zod@3.25.76: {}

--- a/src/controllers/DownloadController.test.ts
+++ b/src/controllers/DownloadController.test.ts
@@ -1,5 +1,9 @@
 import DownloadController from './DownloadController';
 import { Request, Response } from 'express';
+import { Writable } from 'stream';
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
 
 function mockResponse(): Response {
   const headers: Record<string, string> = {};
@@ -86,5 +90,70 @@ describe('DownloadController.getFile', () => {
       'Content-Disposition',
       "attachment; filename=\"owner-1234-uuid.apkg\"; filename*=UTF-8''owner-1234-uuid.apkg"
     );
+  });
+});
+
+describe('DownloadController.getBulkDownload', () => {
+  let workspaceBase: string;
+  let originalWorkspaceBase: string | undefined;
+
+  beforeEach(() => {
+    workspaceBase = fs.mkdtempSync(path.join(os.tmpdir(), 'bulk-test-'));
+    originalWorkspaceBase = process.env.WORKSPACE_BASE;
+    process.env.WORKSPACE_BASE = workspaceBase;
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceBase, { recursive: true, force: true });
+    if (originalWorkspaceBase === undefined) {
+      delete process.env.WORKSPACE_BASE;
+    } else {
+      process.env.WORKSPACE_BASE = originalWorkspaceBase;
+    }
+  });
+
+  function streamingResponse(): { res: Response; chunks: Buffer[]; done: Promise<void> } {
+    const chunks: Buffer[] = [];
+    let resolveDone!: () => void;
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve;
+    });
+
+    const sink = new Writable({
+      write(chunk, _enc, cb) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        cb();
+      },
+    });
+    sink.on('finish', () => resolveDone());
+
+    const res = Object.assign(sink, {
+      headersSent: false,
+      setHeader: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    }) as unknown as Response;
+
+    return { res, chunks, done };
+  }
+
+  it('streams a zip archive of the .apkg files in the workspace', async () => {
+    const id = 'workspace-with-decks';
+    const workspace = path.join(workspaceBase, id);
+    fs.mkdirSync(workspace);
+    fs.writeFileSync(path.join(workspace, 'deck-one.apkg'), 'fake-apkg-one');
+    fs.writeFileSync(path.join(workspace, 'deck-two.apkg'), 'fake-apkg-two');
+
+    const controller = new DownloadController(makeService() as any);
+    const req = { params: { id } } as unknown as Request;
+    const { res, chunks, done } = streamingResponse();
+
+    controller.getBulkDownload(req, res);
+    await done;
+
+    expect((res.status as jest.Mock)).not.toHaveBeenCalledWith(500);
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/zip');
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(Buffer.concat(chunks).subarray(0, 2).toString()).toBe('PK');
   });
 });

--- a/src/test/mocks/archiver.ts
+++ b/src/test/mocks/archiver.ts
@@ -1,7 +1,0 @@
-const archiver = () => {
-  throw new Error(
-    'archiver mock invoked in tests. The download path is exercised end-to-end via the real package outside Jest.'
-  );
-};
-
-export default archiver;

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Download all as ZIP works again on multi-deck conversions', date: '2026-05-18' },
   { type: 'fix', title: 'Inactivity email shows your last deck name and a Day Pass option for one-time converting', date: '2026-05-17' },
   { type: 'fix', title: 'Loading the site during an update shows a brief "updating" notice instead of a server error', date: '2026-05-17' },
   { type: 'fix', title: 'Recovery screen — reset stale browser data when 2anki gets stuck loading', date: '2026-05-17' },


### PR DESCRIPTION
## Summary

- `archiver@8.0.0` was a breaking ESM-only rewrite. Our `DownloadController.getBulkDownload` calls the v7 factory `archiver('zip', { zlib: { level: 9 } })`, which no longer exists in v8 — runtime throws `(0, archiver_1.default) is not a function` on every bulk-download request.
- Pinning to `~7.0.1` (last v7 release, plain CJS) restores the API the controller is written against. No source changes needed in the controller itself.
- Adds a controller test that actually streams a zip from a tmpdir and asserts the `PK` zip-magic header. Drops `src/test/mocks/archiver.ts` (the stub that hid the breakage in Jest).

## Why this slipped past CI

The breaking change landed in a dependabot bump. The mock at `src/test/mocks/archiver.ts` plus the `moduleNameMapper` entry in `jest.config.js` (`'^archiver$' → mock`) meant every test would throw if it touched archiver, so no test actually exercised the path. The bulk-download feature has been 100% broken since the v8 bump entered the lockfile.

## Prod evidence (2026-05-17 UTC)

13 × 500 on `GET /download/:id/bulk` across 6 distinct download IDs. One iPad user retried 5 times in 5 seconds. The workspace `.apkg` files were intact on disk — only the zip wrapper crashed.

## Test plan

- [x] `pnpm test src/controllers/DownloadController.test.ts` → 5/5 pass
- [x] `pnpm test` (full server suite) → 1359/1375 pass (8 skipped, 8 todo, no failures)
- [x] `pnpm exec tsc -p . --noEmit` → clean
- [x] `pnpm --filter 2anki-web typecheck` → clean
- [x] `pnpm --filter 2anki-web test` → 599/599 pass
- [x] `pnpm --filter 2anki-web lint` → clean
- [ ] After deploy: confirm `GET /download/:id/bulk` returns a real zip on a multi-deck workspace

## Notes

- No SonarCloud run locally — change is a one-line dep pin plus one regression test, low complexity. Watching for any Sonar bounce on CI.
- Changelog entry added: `Download all as ZIP works again on multi-deck conversions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->