### PR TITLE
fix: /downloads recovery loop — wrap job.created_at in Date for sortKey

### DIFF
--- a/web/src/pages/DownloadsPage/helpers/toDeckRows.test.ts
+++ b/web/src/pages/DownloadsPage/helpers/toDeckRows.test.ts
@@ -106,4 +106,15 @@ describe('toDeckRows — sorting', () => {
     const rows = toDeckRows([jobNoDate, jobWithDate], [], [], []);
     expect((rows[0] as { source: string; kind: string; job: JobResponse; sortKey: Date }).job.id).toBe(1);
   });
+
+  it('handles created_at when API returns it as an ISO string (not a Date)', () => {
+    const isoString = '2026-05-10T00:00:00.000Z';
+    const job = makeJob({
+      id: 1 as JobsId,
+      created_at: isoString as unknown as Date,
+    });
+    const rows = toDeckRows([job], [], [], []);
+    expect(rows[0].sortKey).toBeInstanceOf(Date);
+    expect(rows[0].sortKey.getTime()).toBe(new Date(isoString).getTime());
+  });
 });

--- a/web/src/pages/DownloadsPage/helpers/toDeckRows.ts
+++ b/web/src/pages/DownloadsPage/helpers/toDeckRows.ts
@@ -26,7 +26,7 @@ export function toDeckRows(
   const rows: DeckRow[] = [];
 
   for (const job of jobs) {
-    const sortKey = job.created_at ?? EPOCH;
+    const sortKey = job.created_at == null ? EPOCH : new Date(job.created_at);
     const source = jobSource(job.type);
     rows.push({ source, kind: 'job', job, sortKey });
   }


### PR DESCRIPTION
## Summary
Hotfix for an immediate prod regression introduced by #2374 (unified `/downloads`).

`JobResponse.created_at` is typed as `Date` by Kanel but the API serializes it as an ISO string in JSON. `toDeckRows()` used it directly as `sortKey`, then called `sortKey.getTime()` during sort. Strings don't have `getTime()` → every render of `/downloads` threw `TypeError` → the recovery boundary fired with the misleading "Reset local data" suggestion. Neither Reset nor Reload helped because the failure was in the code path, not the cache.

## Fix
One line: wrap `job.created_at` in `new Date()` when building `sortKey`, mirroring how upload/Dropbox/Drive rows already handled the string case.

## Test plan
- [x] Added a regression test in `toDeckRows.test.ts` that passes a string as `created_at` and asserts `sortKey instanceof Date` plus the parsed time.
- [x] 11/11 vitest tests pass.
- [ ] After deploy: `/downloads` loads without the recovery banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->