### PR TITLE
fix: allow re-converting a Notion page whose deck is already done

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -49,6 +49,12 @@ describe('NotionController', () => {
     canStart = true,
     withinLimit = true,
   }: { canStart?: boolean; withinLimit?: boolean } = {}) {
+    (JobRepository as unknown as { TERMINAL_STATUSES: string[] }).TERMINAL_STATUSES = [
+      'done',
+      'failed',
+      'cancelled',
+      'interrupted',
+    ];
     (JobRepository as unknown as jest.Mock).mockImplementation(() => ({}));
     (FindOrCreateJobUseCase as jest.Mock).mockImplementation(() => ({
       execute: jest.fn().mockResolvedValue({ id: 77, status: 'started' }),
@@ -201,7 +207,35 @@ describe('NotionController', () => {
       await controller.convert(req as express.Request, res as express.Response);
 
       expect(res.status).toHaveBeenCalledWith(202);
-      expect(res.json).toHaveBeenCalledWith({ jobId: 77 });
+      expect(res.json).toHaveBeenCalledWith({ jobId: 77, restarted: false });
+    });
+
+    it('returns restarted: true when re-converting a page whose job row is done', async () => {
+      (JobRepository as unknown as { TERMINAL_STATUSES: string[] }).TERMINAL_STATUSES = [
+        'done',
+        'failed',
+        'cancelled',
+        'interrupted',
+      ];
+      (JobRepository as unknown as jest.Mock).mockImplementation(() => ({}));
+      (FindOrCreateJobUseCase as jest.Mock).mockImplementation(() => ({
+        execute: jest.fn().mockResolvedValue({ id: 77, status: 'done' }),
+      }));
+      (CheckInProgressJobUseCase as jest.Mock).mockImplementation(() => ({
+        execute: jest.fn().mockResolvedValue(true),
+      }));
+      (CheckJobLimitUseCase as jest.Mock).mockImplementation(() => ({
+        execute: jest.fn().mockResolvedValue(true),
+      }));
+      (StartJobUseCase as jest.Mock).mockImplementation(() => ({
+        execute: jest.fn().mockResolvedValue(undefined),
+      }));
+      (performConversion as jest.Mock).mockResolvedValue(undefined);
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({ jobId: 77, restarted: true });
     });
 
     it('returns 409 when job is already in progress', async () => {

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -202,6 +202,8 @@ class NotionController {
         type: type || 'conversion',
       });
 
+      const restarted = JobRepository.TERMINAL_STATUSES.includes(job.status);
+
       const checkInProgress = new CheckInProgressJobUseCase(jobRepository);
       const canStart = await checkInProgress.execute(id, owner);
       if (!canStart) {
@@ -233,7 +235,7 @@ class NotionController {
         console.error('notion convert worker:', err);
       });
 
-      return res.status(202).json({ jobId: job.id });
+      return res.status(202).json({ jobId: job.id, restarted });
     } catch (err) {
       if (err instanceof InProgressJobError) {
         return res.status(409).json({ reason: 'already_in_progress' });

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -54,6 +54,18 @@ class JobRepository {
 
   static readonly TERMINAL_STATUSES = ['done', 'failed', 'cancelled', 'interrupted'];
 
+  async restartJob(id: string, owner: string): Promise<Jobs> {
+    const rows = await this.database(this.tableName)
+      .where({ object_id: id, owner })
+      .update({
+        status: 'started',
+        job_reason_failure: '',
+        last_edited_time: new Date(),
+      })
+      .returning('*');
+    return rows[0] as Jobs;
+  }
+
   async updateJobStatus(
     id: string,
     owner: string,

--- a/src/usecases/jobs/CheckInProgressJobUseCase.ts
+++ b/src/usecases/jobs/CheckInProgressJobUseCase.ts
@@ -1,5 +1,12 @@
 import JobRepository from '../../data_layer/JobRepository';
 
+const RESTARTABLE_STATUSES = new Set([
+  'started',
+  'failed',
+  'done',
+  'interrupted',
+]);
+
 export class CheckInProgressJobUseCase {
   constructor(private readonly jobRepository: JobRepository) {}
 
@@ -9,10 +16,6 @@ export class CheckInProgressJobUseCase {
       throw new Error('Job not found');
     }
 
-    if (job.status === 'started') {
-      return true;
-    }
-
-    return job.status === 'failed';
+    return RESTARTABLE_STATUSES.has(job.status);
   }
 }

--- a/src/usecases/jobs/StartJobUseCase.test.ts
+++ b/src/usecases/jobs/StartJobUseCase.test.ts
@@ -1,0 +1,85 @@
+import { StartJobUseCase } from './StartJobUseCase';
+import JobRepository from '../../data_layer/JobRepository';
+
+describe('StartJobUseCase', () => {
+  function makeRepo(
+    overrides: Partial<{
+      findJobById: jest.Mock;
+      updateJobStatus: jest.Mock;
+      restartJob: jest.Mock;
+    }> = {}
+  ): JobRepository {
+    return {
+      findJobById: jest.fn(),
+      updateJobStatus: jest.fn().mockResolvedValue({ id: 1, status: 'started' }),
+      restartJob: jest.fn().mockResolvedValue({ id: 1, status: 'started' }),
+      ...overrides,
+    } as unknown as JobRepository;
+  }
+
+  it('throws when the job is not found', async () => {
+    const repo = makeRepo({ findJobById: jest.fn().mockResolvedValue(null) });
+    const usecase = new StartJobUseCase(repo);
+
+    await expect(usecase.execute({ id: 'p1', owner: 'u1' })).rejects.toThrow(
+      'Job not found'
+    );
+  });
+
+  it('returns the row untouched when status is cancelled', async () => {
+    const cancelled = { id: 1, status: 'cancelled' };
+    const updateJobStatus = jest.fn();
+    const restartJob = jest.fn();
+    const repo = makeRepo({
+      findJobById: jest.fn().mockResolvedValue(cancelled),
+      updateJobStatus,
+      restartJob,
+    });
+    const usecase = new StartJobUseCase(repo);
+
+    const result = await usecase.execute({ id: 'p1', owner: 'u1' });
+
+    expect(result).toBe(cancelled);
+    expect(updateJobStatus).not.toHaveBeenCalled();
+    expect(restartJob).not.toHaveBeenCalled();
+  });
+
+  it.each(['done', 'failed', 'interrupted'])(
+    'dispatches to restartJob when status is terminal (%s)',
+    async (status) => {
+      const updateJobStatus = jest.fn();
+      const restartJob = jest
+        .fn()
+        .mockResolvedValue({ id: 1, status: 'started' });
+      const repo = makeRepo({
+        findJobById: jest.fn().mockResolvedValue({ id: 1, status }),
+        updateJobStatus,
+        restartJob,
+      });
+      const usecase = new StartJobUseCase(repo);
+
+      await usecase.execute({ id: 'p1', owner: 'u1' });
+
+      expect(restartJob).toHaveBeenCalledWith('p1', 'u1');
+      expect(updateJobStatus).not.toHaveBeenCalled();
+    }
+  );
+
+  it('uses updateJobStatus for a fresh (non-terminal) row', async () => {
+    const updateJobStatus = jest
+      .fn()
+      .mockResolvedValue({ id: 1, status: 'started' });
+    const restartJob = jest.fn();
+    const repo = makeRepo({
+      findJobById: jest.fn().mockResolvedValue({ id: 1, status: 'started' }),
+      updateJobStatus,
+      restartJob,
+    });
+    const usecase = new StartJobUseCase(repo);
+
+    await usecase.execute({ id: 'p1', owner: 'u1' });
+
+    expect(updateJobStatus).toHaveBeenCalledWith('p1', 'u1', 'started', '');
+    expect(restartJob).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/jobs/StartJobUseCase.ts
+++ b/src/usecases/jobs/StartJobUseCase.ts
@@ -21,6 +21,10 @@ export class StartJobUseCase {
       return job;
     }
 
+    if (JobRepository.TERMINAL_STATUSES.includes(job.status)) {
+      return this.jobRepository.restartJob(id, owner);
+    }
+
     return this.jobRepository.updateJobStatus(id, owner, 'started', '');
   }
 }

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
@@ -82,7 +82,10 @@ describe('SearchObjectEntry convert button', () => {
   });
 
   it('on 202: button becomes "In progress" (aria-disabled) and shows downloads link', async () => {
-    mockConvert.mockResolvedValue({ status: 202, json: async () => ({ jobId: 5 }) });
+    mockConvert.mockResolvedValue({
+      status: 202,
+      json: async () => ({ jobId: 5, restarted: false }),
+    });
 
     renderEntry();
     fireEvent.click(screen.getByRole('link', { name: 'Convert to Anki' }));
@@ -92,6 +95,23 @@ describe('SearchObjectEntry convert button', () => {
     });
 
     expect(screen.getByText(/Added to your downloads/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'view' })).toHaveAttribute('href', '/downloads');
+  });
+
+  it('on 202 with restarted: true: shows "Re-making your deck" copy instead', async () => {
+    mockConvert.mockResolvedValue({
+      status: 202,
+      json: async () => ({ jobId: 5, restarted: true }),
+    });
+
+    renderEntry();
+    fireEvent.click(screen.getByRole('link', { name: 'Convert to Anki' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Re-making your deck/)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/Added to your downloads/)).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'view' })).toHaveAttribute('href', '/downloads');
   });
 

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -40,6 +40,7 @@ function SearchObjectEntry(props: Readonly<Props>) {
   const navigate = useNavigate();
   const location = useLocation();
   const [status, setStatus] = useState<ConvertStatus>('idle');
+  const [restarted, setRestarted] = useState(false);
 
   const openRules = () => {
     const params = new URLSearchParams();
@@ -62,6 +63,8 @@ function SearchObjectEntry(props: Readonly<Props>) {
       .convert(id, getType(type), title)
       .then(async (response) => {
         if (response.status === 202) {
+          const body = await response.json().catch(() => null);
+          setRestarted(body?.restarted === true);
           setStatus('queued');
         } else if (response.status === 409) {
           setStatus('conflict');
@@ -91,7 +94,8 @@ function SearchObjectEntry(props: Readonly<Props>) {
       <div className={styles.objectActions}>
         {status === 'queued' && (
           <span className={styles.convertStatus}>
-            Added to your downloads — <Link to="/downloads">view</Link>
+            {restarted ? 'Re-making your deck — ' : 'Added to your downloads — '}
+            <Link to="/downloads">view</Link>
           </span>
         )}
         {status === 'paywall' && (

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Re-converting a Notion page you already converted now re-makes the deck', date: '2026-05-18' },
   { type: 'fix', title: 'Big Notion pages show up on Downloads while they convert', date: '2026-05-18' },
   { type: 'fix', title: 'Downloads page — one deck list with filters, source labels, and a fix for the empty state', date: '2026-05-18' },
   { type: 'fix', title: 'Download all as ZIP works again on multi-deck conversions', date: '2026-05-18' },


### PR DESCRIPTION
## Summary
Re-converting a Notion page that already has a done job row (deck sitting in Ready on `/downloads`) returned 409 + misleading "Already converting this page." copy. Two backend bugs interacting:

1. `CheckInProgressJobUseCase` only allowed restart of `started` / `failed` rows.
2. `JobRepository.updateJobStatus` has a `whereNotIn(TERMINAL_STATUSES)` guard that silently blocks flipping any terminal row → `started`.

Even fixing (1) alone leaves (2): `StartJobUseCase` returns `undefined`, the worker fires, the first thing it tries (`CreateJobWorkSpaceUseCase.updateJobStatus('step1_create_workspace')`) gets blocked by the same guard, the worker errors → `SetJobFailed` fires.

## Fix
- `CheckInProgressJobUseCase` — allow-set `{ started, failed, done, interrupted }`. `cancelled` stays blocked (pre-existing intentional no-op in `StartJobUseCase`).
- `JobRepository.restartJob(id, owner)` — new method that bypasses the terminal guard; clears `job_reason_failure` and resets `last_edited_time`.
- `StartJobUseCase` — pre-fetches the row; if status is terminal, calls `restartJob`; else `updateJobStatus` as before.
- `NotionController.convert` — captures `wasRestart` after `FindOrCreate` and returns `{ jobId, restarted }` in the 202.
- `SearchObjectEntry` — reads `restarted` and renders `Re-making your deck — view` instead of `Added to your downloads — view`.

## Trio agreement
Optimistic re-convert — no modal, no warning, no toast. `StorageHandler.uniqify` includes `Date.now()` in the S3 key so the previous `.apkg` is not destroyed on the rerun. Designer picked `Re-making your deck` (not `Re-converting`) because `convert` is internal vocab.

## Test plan
- [x] `pnpm test` — 1373 passed, no regressions
- [x] `pnpm exec tsc -p . --noEmit` clean
- [x] `pnpm --filter 2anki-web typecheck` clean
- [x] `pnpm --filter 2anki-web test --run` — 621 passed (added one for `Re-making your deck` copy variant)
- [x] `pnpm --filter 2anki-web lint` clean
- [x] New `StartJobUseCase.test.ts` covers dispatch to `restartJob` for done/failed/interrupted, no-op for cancelled, throw on not-found
- [x] `NotionController.test.ts` now asserts `restarted: false` on fresh row and `restarted: true` when re-converting a done row
- [ ] After deploy: re-convert a Notion page that's already in Ready → see it move to In progress on `/downloads` within one poll cycle

## Notes
- No DB migration. `jobs.type` and existing columns are sufficient.
- Concurrency: a double-click race exists pre-fix (two workers can both fire against the same row) but is not new with this change; flagged for a follow-up optimistic-lock follow-up rather than blocking this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->