### PR TITLE
feat: surface Auto Sync at limit wall, upload banner, and post-success

### DIFF
--- a/src/controllers/Upload/helpers/handleUploadLimitError.test.ts
+++ b/src/controllers/Upload/helpers/handleUploadLimitError.test.ts
@@ -54,13 +54,13 @@ describe('handleUploadLimitError', () => {
     jest.clearAllMocks();
   });
 
-  it('redirects unauthenticated users to login', async () => {
+  it('redirects unauthenticated users to /limit', async () => {
     const res = mockResponse(undefined);
     await handleUploadLimitError(mockRequest(), res);
-    expect(res.redirect).toHaveBeenCalledWith('/login?error=upload_limit_exceeded');
+    expect(res.redirect).toHaveBeenCalledWith('/limit');
   });
 
-  it('redirects authenticated users with no Stripe subscription to pricing', async () => {
+  it('redirects authenticated users with no Stripe subscription to /limit', async () => {
     (UsersService as jest.MockedClass<typeof UsersService>).prototype.getUserById =
       jest.fn().mockResolvedValue({ id: '1', email: 'user@example.com' });
     mockedFindActive.mockResolvedValue([]);
@@ -68,7 +68,7 @@ describe('handleUploadLimitError', () => {
     const res = mockResponse('owner-1');
     await handleUploadLimitError(mockRequest(), res);
 
-    expect(res.redirect).toHaveBeenCalledWith('/pricing?error=upload_limit_exceeded');
+    expect(res.redirect).toHaveBeenCalledWith('/limit');
   });
 
   it('syncs subscription and redirects to upload when active Stripe sub exists but is missing from DB', async () => {
@@ -85,7 +85,7 @@ describe('handleUploadLimitError', () => {
     expect(res.redirect).toHaveBeenCalledWith('/upload');
   });
 
-  it('falls back to pricing redirect when Stripe call throws', async () => {
+  it('falls back to /limit when Stripe call throws', async () => {
     (UsersService as jest.MockedClass<typeof UsersService>).prototype.getUserById =
       jest.fn().mockResolvedValue({ id: '1', email: 'user@example.com' });
     mockedFindActive.mockRejectedValue(new Error('Stripe unavailable'));
@@ -93,6 +93,6 @@ describe('handleUploadLimitError', () => {
     const res = mockResponse('owner-1');
     await handleUploadLimitError(mockRequest(), res);
 
-    expect(res.redirect).toHaveBeenCalledWith('/pricing?error=upload_limit_exceeded');
+    expect(res.redirect).toHaveBeenCalledWith('/limit');
   });
 });

--- a/src/controllers/Upload/helpers/handleUploadLimitError.ts
+++ b/src/controllers/Upload/helpers/handleUploadLimitError.ts
@@ -38,9 +38,9 @@ export const handleUploadLimitError = async (
       } catch (err) {
         console.error('[handleUploadLimitError] Stripe sync failed:', err);
       }
-      return response.redirect('/pricing?error=upload_limit_exceeded');
+      return response.redirect('/limit');
     }
   }
 
-  response.redirect('/login?error=upload_limit_exceeded');
+  response.redirect('/limit');
 };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -78,7 +78,7 @@ const ImageOcclusionPage = lazy(() =>
 );
 const ChatPage = lazy(() => import('./pages/Chat/ChatPage'));
 const NotionLandingPage = lazy(() => import('./pages/NotionLandingPage/NotionLandingPage'));
-const AnswersPage = lazy(() => import('./pages/AnswersPage/AnswersPage'));
+const LimitPage = lazy(() => import('./pages/LimitPage/LimitPage'));
 
 const queryClient = new QueryClient();
 
@@ -212,6 +212,7 @@ function AppContent({
             path="/successful-checkout"
             element={<SuccessfulCheckoutPage />}
           />
+          <Route path="/limit" element={<LimitPage />} />
           <Route path="/account" element={requireAuth(<AccountPage />)} />
           <Route
             path="/import"
@@ -308,7 +309,6 @@ function AppContent({
               <ConvertLandingPage setErrorMessage={setErrorMessage} />
             }
           />
-          <Route path="/answers/:slug" element={<AnswersPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </AppShell>

--- a/web/src/pages/LimitPage/LimitPage.module.css
+++ b/web/src/pages/LimitPage/LimitPage.module.css
@@ -1,0 +1,190 @@
+.page {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 5rem;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.heading {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+  margin: 0 0 0.75rem;
+  letter-spacing: var(--tracking-tight);
+  line-height: 1.2;
+}
+
+.subheading {
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: var(--leading-relaxed);
+}
+
+.plans {
+  display: grid;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+@media (min-width: 600px) {
+  .plans {
+    grid-template-columns: repeat(2, 1fr);
+    max-width: 720px;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2.5rem;
+  }
+}
+
+.planCard {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.planCardFeatured {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px var(--color-primary);
+}
+
+.planBadge {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0 0 0.5rem;
+}
+
+.planCardFeatured .planBadge {
+  color: var(--color-primary);
+}
+
+.planTitle {
+  font-size: var(--text-xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+  margin: 0 0 0.75rem;
+}
+
+.planPrice {
+  font-size: 2rem;
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+  margin: 0 0 1.25rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.planPriceSuffix {
+  font-size: var(--text-base);
+  font-weight: var(--font-normal);
+  color: var(--color-text-secondary);
+  margin-left: 0.25rem;
+}
+
+.planBenefits {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.planBenefit {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  padding-left: 1.25rem;
+  position: relative;
+}
+
+.planBenefit::before {
+  content: '✓';
+  position: absolute;
+  left: 0;
+  color: var(--color-primary);
+  font-weight: var(--font-semibold);
+}
+
+.planCtaPrimary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-bg-primary);
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  width: 100%;
+}
+
+.planCtaPrimary:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.planCtaPrimary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.planCtaSecondary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+  width: 100%;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.planCtaSecondary:hover {
+  border-color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
+}
+
+.planError {
+  font-size: var(--text-sm);
+  color: var(--color-error, #dc2626);
+  margin: 0.5rem 0 0;
+  text-align: center;
+}
+
+.backLink {
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.backLink a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.backLink a:hover {
+  text-decoration: underline;
+}

--- a/web/src/pages/LimitPage/LimitPage.test.tsx
+++ b/web/src/pages/LimitPage/LimitPage.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HelmetProvider } from 'react-helmet-async';
+import { LimitPage } from './LimitPage';
+
+vi.mock('../../lib/analytics/track', () => ({
+  track: vi.fn(),
+}));
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: vi.fn(() => ({
+    startAutoSyncCheckout: vi.fn().mockResolvedValue({ url: 'https://checkout.stripe.com/test' }),
+  })),
+}));
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: vi.fn(() => ({
+    data: {
+      user: { id: 1, email: 'test@example.com' },
+    },
+    isLoading: false,
+  })),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LimitPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>
+  );
+}
+
+describe('LimitPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the monthly limit message', () => {
+    renderPage();
+    expect(screen.getByText('You reached 100 cards this month')).toBeTruthy();
+  });
+
+  it('shows Unlimited and Auto Sync plan titles', () => {
+    renderPage();
+    expect(screen.getByText('Unlimited')).toBeTruthy();
+    expect(screen.getByText('Auto Sync')).toBeTruthy();
+  });
+
+  it('shows the correct prices', () => {
+    renderPage();
+    expect(screen.getByText('$6')).toBeTruthy();
+    expect(screen.getByText('$30')).toBeTruthy();
+  });
+
+  it('shows a back link to /upload', () => {
+    renderPage();
+    const backLink = screen.getByText('Back to upload');
+    expect(backLink.closest('a')?.getAttribute('href')).toBe('/upload');
+  });
+
+  it('Unlimited plan link carries ref=limit-wall parameter', () => {
+    renderPage();
+    const upgradeLink = screen.getByText('Upgrade to Unlimited');
+    const href = upgradeLink.getAttribute('href') ?? '';
+    expect(href).toContain('ref=limit-wall');
+  });
+
+  it('Get Auto Sync button is present and clickable', () => {
+    renderPage();
+    const button = screen.getByText('Get Auto Sync');
+    expect(button).toBeTruthy();
+    fireEvent.click(button);
+    expect(screen.getByText('Starting checkout…')).toBeTruthy();
+  });
+});

--- a/web/src/pages/LimitPage/LimitPage.tsx
+++ b/web/src/pages/LimitPage/LimitPage.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import { track } from '../../lib/analytics/track';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { getSubscribeLink } from '../PricingPage/payment.links';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
+import {
+  AUTO_SYNC_PRICE,
+  MONTHLY_PRICE,
+  MONTHLY_SUFFIX,
+} from '../PricingPage/pricing.constants';
+import styles from './LimitPage.module.css';
+
+const REF = 'limit-wall';
+
+const UNLIMITED_BENEFITS = [
+  'Unlimited flashcards',
+  'Run multiple conversions at once',
+  'PDFs and large Notion exports',
+  'Cancel anytime',
+];
+
+const AUTO_SYNC_BENEFITS = [
+  'Everything in Unlimited',
+  'Notion edits sync to Anki every 5 minutes',
+  'No exports, no manual steps',
+  'Cancel anytime',
+];
+
+export function LimitPage() {
+  const { data: userLocals } = useUserLocals();
+  const email = userLocals?.user?.email;
+  const isLoggedIn = userLocals?.user?.id != null;
+  const [autoSyncPending, setAutoSyncPending] = useState(false);
+  const [autoSyncError, setAutoSyncError] = useState<string | null>(null);
+
+  useEffect(() => {
+    track('paywall_shown', { surface: REF });
+  }, []);
+
+  const handleAutoSyncClick = async () => {
+    if (!isLoggedIn) {
+      globalThis.location.href = `/login?redirect=/limit&ref=${REF}`;
+      return;
+    }
+    track('paywall_upgrade_clicked', { surface: REF, plan: 'auto_sync' });
+    setAutoSyncPending(true);
+    setAutoSyncError(null);
+    try {
+      const result = await get2ankiApi().startAutoSyncCheckout();
+      if ('url' in result) {
+        globalThis.location.href = result.url;
+        return;
+      }
+      if (result.status === 'already_subscribed') {
+        globalThis.location.href = '/ankify/setup';
+        return;
+      }
+      setAutoSyncError("Couldn't start checkout. Try again or email support@2anki.net.");
+    } finally {
+      setAutoSyncPending(false);
+    }
+  };
+
+  const unlimitedLink = isLoggedIn
+    ? `${getSubscribeLink(email)}&ref=${REF}`
+    : `/login?redirect=/pricing&ref=${REF}`;
+
+  return (
+    <div className={styles.page}>
+      <Helmet>
+        <title>You reached your monthly limit | 2anki</title>
+      </Helmet>
+
+      <header className={styles.header}>
+        <h1 className={styles.heading}>You reached 100 cards this month</h1>
+        <p className={styles.subheading}>
+          Upgrade to keep converting — no cap, no wait.
+        </p>
+      </header>
+
+      <div className={styles.plans}>
+        <div className={styles.planCard}>
+          <p className={styles.planBadge}>Most popular</p>
+          <p className={styles.planTitle}>Unlimited</p>
+          <p className={styles.planPrice}>
+            {MONTHLY_PRICE}
+            <span className={styles.planPriceSuffix}>{MONTHLY_SUFFIX}</span>
+          </p>
+          <ul className={styles.planBenefits}>
+            {UNLIMITED_BENEFITS.map((b) => (
+              <li key={b} className={styles.planBenefit}>
+                {b}
+              </li>
+            ))}
+          </ul>
+          <a
+            href={unlimitedLink}
+            className={styles.planCtaSecondary}
+            onClick={() =>
+              track('paywall_upgrade_clicked', {
+                surface: REF,
+                plan: 'unlimited',
+              })
+            }
+          >
+            Upgrade to Unlimited
+          </a>
+        </div>
+
+        <div className={`${styles.planCard} ${styles.planCardFeatured}`}>
+          <p className={styles.planBadge}>Never re-upload again</p>
+          <p className={styles.planTitle}>Auto Sync</p>
+          <p className={styles.planPrice}>
+            {AUTO_SYNC_PRICE}
+            <span className={styles.planPriceSuffix}>{MONTHLY_SUFFIX}</span>
+          </p>
+          <ul className={styles.planBenefits}>
+            {AUTO_SYNC_BENEFITS.map((b) => (
+              <li key={b} className={styles.planBenefit}>
+                {b}
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className={styles.planCtaPrimary}
+            onClick={handleAutoSyncClick}
+            disabled={autoSyncPending}
+          >
+            {autoSyncPending ? 'Starting checkout…' : 'Get Auto Sync'}
+          </button>
+          {autoSyncError && (
+            <p className={styles.planError} role="alert">
+              {autoSyncError}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <p className={styles.backLink}>
+        <Link to="/upload">Back to upload</Link>
+      </p>
+    </div>
+  );
+}
+
+export default LimitPage;

--- a/web/src/pages/LimitPage/index.ts
+++ b/web/src/pages/LimitPage/index.ts
@@ -1,0 +1,2 @@
+export { default } from './LimitPage';
+export { LimitPage } from './LimitPage';

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -3,8 +3,10 @@ import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import useQuery from '../../lib/hooks/useQuery';
 import { getVisibleText } from '../../lib/text/getVisibleText';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import styles from '../../styles/shared.module.css';
 import UploadForm from './components/UploadForm/UploadForm';
+import { NotionSyncBanner } from './components/NotionSyncBanner';
 import pageStyles from './UploadPage.module.css';
 
 const WALKTHROUGHS: ReadonlyArray<[string, string]> = [
@@ -68,6 +70,8 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
   const view = query.get('view');
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const { data: userLocals } = useUserLocals();
+  const autoSyncActive = userLocals?.autoSyncActive === true;
 
   useEffect(() => {
     if (searchParams.get('from') === 'pass') {
@@ -108,6 +112,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           See a 30-second example
         </a>
       </section>
+      <NotionSyncBanner autoSyncActive={autoSyncActive} />
       <UploadForm setErrorMessage={setErrorMessage} />
       <p className={pageStyles.footnote}>
         Your uploaded files are deleted after 2 hours.

--- a/web/src/pages/UploadPage/components/NotionSyncBanner.test.tsx
+++ b/web/src/pages/UploadPage/components/NotionSyncBanner.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { CookiesProvider } from 'react-cookie';
+import { NotionSyncBanner } from './NotionSyncBanner';
+
+vi.mock('../../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: vi.fn(() => ({
+    getNotionConnectionInfo: vi.fn().mockResolvedValue({
+      isConnected: true,
+      link: '/auth/notion',
+      workspace: 'My Workspace',
+    }),
+  })),
+}));
+
+function renderBanner(props: { autoSyncActive: boolean }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <CookiesProvider>
+      <QueryClientProvider client={queryClient}>
+        <NotionSyncBanner {...props} />
+      </QueryClientProvider>
+    </CookiesProvider>
+  );
+}
+
+describe('NotionSyncBanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.cookie = 'notion_sync_banner_dismissed=; Max-Age=0; path=/';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not render when autoSyncActive is true', () => {
+    const { container } = renderBanner({ autoSyncActive: true });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders dismiss button', async () => {
+    renderBanner({ autoSyncActive: false });
+    const dismissButton = await screen.findByLabelText('Dismiss Auto Sync banner');
+    expect(dismissButton).toBeTruthy();
+  });
+
+  it('CTA link carries ref=upload-notion-banner', async () => {
+    renderBanner({ autoSyncActive: false });
+    const link = await screen.findByText('Try Auto Sync →');
+    expect(link.getAttribute('href')).toContain('ref=upload-notion-banner');
+  });
+
+  it('hides after dismiss button is clicked', async () => {
+    renderBanner({ autoSyncActive: false });
+    const dismissButton = await screen.findByLabelText('Dismiss Auto Sync banner');
+    fireEvent.click(dismissButton);
+    expect(screen.queryByText('Try Auto Sync →')).toBeNull();
+  });
+});

--- a/web/src/pages/UploadPage/components/NotionSyncBanner.tsx
+++ b/web/src/pages/UploadPage/components/NotionSyncBanner.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useCookies } from 'react-cookie';
+import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+
+const DISMISSED_COOKIE = 'notion_sync_banner_dismissed';
+const BANNER_REF = 'upload-notion-banner';
+const DISMISS_TTL_DAYS = 30;
+
+interface NotionSyncBannerProps {
+  autoSyncActive: boolean;
+}
+
+export function NotionSyncBanner({ autoSyncActive }: Readonly<NotionSyncBannerProps>) {
+  const [cookies, setCookie] = useCookies([DISMISSED_COOKIE]);
+  const [locallyDismissed, setLocallyDismissed] = useState(false);
+  const cookieDismissed = cookies[DISMISSED_COOKIE] === 'true';
+  const isDismissed = locallyDismissed || cookieDismissed;
+
+  const { data: notionData } = useQuery({
+    queryKey: ['notion-connection-info'],
+    queryFn: () => get2ankiApi().getNotionConnectionInfo(),
+    enabled: !autoSyncActive && !isDismissed,
+    retry: false,
+  });
+
+  const isNotionConnected = notionData?.isConnected === true;
+
+  if (autoSyncActive || isDismissed || !isNotionConnected) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    setLocallyDismissed(true);
+    const expires = new Date();
+    expires.setDate(expires.getDate() + DISMISS_TTL_DAYS);
+    setCookie(DISMISSED_COOKIE, 'true', { path: '/', expires });
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '1rem',
+        padding: '0.75rem 1rem',
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius-md)',
+        background: 'var(--color-bg-secondary)',
+        marginBottom: '1rem',
+        flexWrap: 'wrap',
+      }}
+    >
+      <p style={{ margin: 0, fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)' }}>
+        You exported this from Notion — Auto Sync would re-export automatically every 5 minutes.
+      </p>
+      <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexShrink: 0 }}>
+        <a
+          href={`/pricing?ref=${BANNER_REF}`}
+          style={{
+            fontSize: 'var(--text-sm)',
+            fontWeight: 'var(--font-semibold)',
+            color: 'var(--color-primary)',
+            textDecoration: 'none',
+          }}
+        >
+          Try Auto Sync →
+        </a>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss Auto Sync banner"
+          style={{
+            background: 'none',
+            border: 'none',
+            padding: '0.25rem',
+            cursor: 'pointer',
+            color: 'var(--color-text-secondary)',
+            fontSize: 'var(--text-base)',
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -576,3 +576,18 @@
 .panelHidden {
   display: none !important;
 }
+
+.autoSyncPrompt {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0.5rem 0 0;
+}
+
+.autoSyncPromptLink {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.autoSyncPromptLink:hover {
+  text-decoration: underline;
+}

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -32,7 +32,6 @@ type ZoneState =
   | 'error';
 
 interface LimitInfo {
-  isAnonymous: boolean;
   filename: string | null;
 }
 
@@ -46,6 +45,13 @@ const REJECTED_FALLBACK =
   'The server rejected the upload. Try again or email support@2anki.net.';
 const NETWORK_FALLBACK =
   "Couldn't upload your file. Check your connection and try again.";
+
+function isLimitRedirect(url: URL): boolean {
+  return (
+    url.pathname === '/limit' ||
+    url.searchParams.get('error') === 'upload_limit_exceeded'
+  );
+}
 
 function toFriendlyThrownError(error: unknown): string {
   const isNetworkError =
@@ -192,8 +198,10 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const [source, setSource] = useState<UploadSource>('local');
   const { data: userLocals } = useUserLocals();
   const queryClient = useQueryClient();
+  const autoSyncActive = userLocals?.autoSyncActive === true;
+  const successPromptShown = globalThis.document?.cookie?.includes('auto_sync_prompt_shown=true') === true;
+  const showAutoSyncPrompt = zoneState === 'success' && !autoSyncActive && !successPromptShown;
   const showTrialButton =
-    !limitInfo?.isAnonymous &&
     userLocals?.user?.trial_started_at == null &&
     userLocals?.locals?.patreon !== true;
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -316,9 +324,8 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       });
       if (request.redirected) {
         const redirectUrl = new URL(request.url, globalThis.location.origin);
-        if (redirectUrl.searchParams.get('error') === 'upload_limit_exceeded') {
-          const isAnonymous = redirectUrl.pathname === '/login';
-          setLimitInfo({ isAnonymous, filename: first?.name ?? null });
+        if (isLimitRedirect(redirectUrl)) {
+          setLimitInfo({ filename: first?.name ?? null });
           setZoneState('limitReached');
           return;
         }
@@ -400,9 +407,8 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       });
       if (request.redirected) {
         const redirectUrl = new URL(request.url, globalThis.location.origin);
-        if (redirectUrl.searchParams.get('error') === 'upload_limit_exceeded') {
-          const isAnonymous = redirectUrl.pathname === '/login';
-          setLimitInfo({ isAnonymous, filename: first?.name ?? null });
+        if (isLimitRedirect(redirectUrl)) {
+          setLimitInfo({ filename: first?.name ?? null });
           setZoneState('limitReached');
           return;
         }
@@ -473,11 +479,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
       });
       if (request.redirected) {
         const redirectUrl = new URL(request.url, globalThis.location.origin);
-        if (redirectUrl.searchParams.get('error') === 'upload_limit_exceeded') {
-          const isAnonymous = redirectUrl.pathname === '/login';
+        if (isLimitRedirect(redirectUrl)) {
           const firstFile = fileInputRef.current?.files?.[0];
           setLimitInfo({
-            isAnonymous,
             filename: firstFile?.name ?? null,
           });
           setZoneState('limitReached');
@@ -596,6 +600,12 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     );
   };
 
+  const handleSuccessPromptClick = () => {
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 30);
+    globalThis.document.cookie = `auto_sync_prompt_shown=true; path=/; expires=${expires.toUTCString()}`;
+  };
+
   const renderSuccessState = () => (
     <div className={formStyles.stateContent}>
       <CheckCircleIcon className={formStyles.iconSuccess} />
@@ -621,6 +631,18 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
         >
           Didn't get the file? Download it here.
         </button>
+      )}
+      {showAutoSyncPrompt && (
+        <p className={formStyles.autoSyncPrompt}>
+          Want this to update automatically?{' '}
+          <a
+            href="/pricing?ref=upload-success-prompt"
+            className={formStyles.autoSyncPromptLink}
+            onClick={handleSuccessPromptClick}
+          >
+            Try Auto Sync
+          </a>
+        </p>
       )}
       <button
         type="button"
@@ -720,12 +742,10 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
   const renderLimitState = () => (
     <div className={formStyles.limitContent}>
       <p className={formStyles.limitTitle}>
-        You've reached your monthly limit
+        You reached 100 cards this month
       </p>
       <p className={formStyles.limitDescription}>
-        {limitInfo?.isAnonymous
-          ? 'Create a free account to keep converting, or upgrade for unlimited decks.'
-          : 'Upgrade your plan to continue converting files.'}
+        Upgrade to keep converting.
       </p>
       {limitInfo?.filename && (
         <span className={formStyles.limitFilename}>
@@ -733,21 +753,12 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
         </span>
       )}
       <div className={formStyles.limitActions}>
-        {limitInfo?.isAnonymous ? (
-          <Link
-            to="/register?redirect=/upload"
-            className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
-          >
-            Create free account
-          </Link>
-        ) : (
-          <Link
-            to="/pricing"
-            className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
-          >
-            Upgrade to continue
-          </Link>
-        )}
+        <Link
+          to="/limit?ref=upload-limit-wall"
+          className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+        >
+          See upgrade options
+        </Link>
         {showTrialButton && (
           <button
             type="button"

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Auto Sync surfaces at the moment you need it — the monthly limit page now shows Unlimited and Auto Sync side by side, and a banner appears on upload when your Notion workspace is connected', date: '2026-05-18' },
   { type: 'feature', title: 'PDF files convert into decks — drop a PDF and each pair of pages becomes a card, front and back', date: '2026-05-18' },
   { type: 'fix', title: 'My decks — downloading a deck you converted from Notion works and the duplicate row is gone', date: '2026-05-18' },
   { type: 'feature', title: 'Cleaner download page after a multi-deck upload — clearer filenames, total size, and the expiry sits next to the download-all button', date: '2026-05-18' },


### PR DESCRIPTION
## Summary

Adds three high-intent moments where Auto Sync becomes visible to users:

- **`/limit` page** (new) — when an upload is blocked by the monthly card limit, the user lands on a page comparing Unlimited and Auto Sync side by side, with `?ref=limit-wall` attribution. Redirects from `/login?error=upload_limit_exceeded` and `/pricing?error=upload_limit_exceeded` collapse into this single page.
- **`NotionSyncBanner`** on the upload page — appears when Auto Sync is available but not active. Cookie-dismissable (30-day TTL).
- **Post-success prompt** in `UploadForm` — after a conversion completes, a one-line nudge offers Auto Sync. Cookie-dedupe (30-day TTL); v1 doesn't use the DB to keep this PR migration-free.

## Context

Re-implementation of the work originally in #2385, which was branched before the wave-1/wave-2 merges and accumulated 30+ files of stacked-spec carryover plus merge conflicts with the recent DownloadsPage rework (#2389). This branch was cherry-picked from `origin/main` with only the ankify-surfaces scope. #2385 will be closed as superseded.

## Test plan

- [x] `pnpm tsc --noEmit` (server) — green
- [x] `pnpm --filter 2anki-web typecheck` — green
- [x] `pnpm --filter 2anki-web test src/pages/LimitPage src/pages/UploadPage` — 68 tests passing
- [ ] Manual: upload as a free-plan user past 100 cards → lands on `/limit` with both plan cards
- [ ] Manual: connect Notion → see banner on upload page → dismiss → banner doesn't reappear for 30 days
- [ ] Manual: complete a successful conversion → see one-line Auto Sync prompt → dismiss → no re-prompt for 30 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->