### PR TITLE
fix: prerender all sitemap URLs with unique title and meta

### DIFF
--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { emitLandingPages, emitAnswersPages } from './prerenderLandingPages';
+import {
+  emitAnswersPages,
+  emitLandingPages,
+  emitMetaOnlyPages,
+  emitNotionMarketplacePage,
+} from './prerenderLandingPages';
 import notionCopy from '../src/pages/LandingPage/copy/notion';
 import { ANSWERS_PAGES } from '../src/pages/AnswersPage/answersConfig';
 
@@ -45,7 +50,7 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(10);
+    expect(files).toHaveLength(11);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );
@@ -56,6 +61,9 @@ describe('emitLandingPages', () => {
       true
     );
     expect(files.some((p) => p.endsWith('pdf-to-anki/index.html'))).toBe(true);
+    expect(files.some((p) => p.endsWith('anki-to-notion/index.html'))).toBe(
+      true
+    );
     expect(
       files.some((p) => p.endsWith('convert/notion-to-anki/index.html'))
     ).toBe(true);
@@ -150,6 +158,58 @@ describe('emitLandingPages', () => {
     );
     expect(html).toContain('<meta property="og:image"');
     expect(html).toContain('<meta name="twitter:card"');
+  });
+});
+
+describe('emitMetaOnlyPages', () => {
+  it('writes one HTML file per meta-only route', () => {
+    const files = emitMetaOnlyPages(buildDir);
+    expect(files.some((p) => p.endsWith('upload/index.html'))).toBe(true);
+    expect(files.some((p) => p.endsWith('pricing/index.html'))).toBe(true);
+    expect(files.some((p) => p.endsWith('about/index.html'))).toBe(true);
+  });
+
+  it('sets a unique title per route', () => {
+    emitMetaOnlyPages(buildDir);
+    const upload = readFileSync(join(buildDir, 'upload', 'index.html'), 'utf8');
+    const pricing = readFileSync(join(buildDir, 'pricing', 'index.html'), 'utf8');
+    const about = readFileSync(join(buildDir, 'about', 'index.html'), 'utf8');
+    expect(upload).toContain('<title>Upload notes and get an Anki deck — 2anki</title>');
+    expect(pricing).toContain('<title>Pricing — Free, Day Pass, Unlimited, Auto Sync | 2anki</title>');
+    expect(about).toContain('<title>About 2anki — open-source Notion to Anki converter</title>');
+  });
+
+  it('points the canonical link at the route URL', () => {
+    emitMetaOnlyPages(buildDir);
+    const html = readFileSync(join(buildDir, 'pricing', 'index.html'), 'utf8');
+    expect(html).toContain('<link rel="canonical" href="https://2anki.net/pricing">');
+  });
+
+  it('leaves the root div empty so React mounts without a flash', () => {
+    emitMetaOnlyPages(buildDir);
+    const html = readFileSync(join(buildDir, 'upload', 'index.html'), 'utf8');
+    expect(html).toContain('<div id="root"></div>');
+  });
+
+  it('does not duplicate og:* tags from the source index', () => {
+    emitMetaOnlyPages(buildDir);
+    const html = readFileSync(join(buildDir, 'upload', 'index.html'), 'utf8');
+    expect(countMatches(html, /<meta\s+property="og:title"/g)).toBe(1);
+    expect(countMatches(html, /<meta\s+property="og:url"/g)).toBe(1);
+    expect(countMatches(html, /<meta\s+name="twitter:title"/g)).toBe(1);
+  });
+});
+
+describe('emitNotionMarketplacePage', () => {
+  it('writes a unique title and canonical', () => {
+    emitNotionMarketplacePage(buildDir);
+    const html = readFileSync(
+      join(buildDir, 'notion-marketplace', 'index.html'),
+      'utf8'
+    );
+    expect(html).toContain('<title>Notion to Anki — automatic sync | 2anki</title>');
+    expect(html).toContain('<link rel="canonical" href="https://2anki.net/notion-marketplace">');
+    expect(html).toContain('Your Notion notes become Anki cards');
   });
 });
 

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -4,6 +4,7 @@ import notionCopy from '../src/pages/LandingPage/copy/notion';
 import quizletCopy from '../src/pages/LandingPage/copy/quizlet';
 import markdownCopy from '../src/pages/LandingPage/copy/markdown';
 import pdfCopy from '../src/pages/LandingPage/copy/pdf';
+import ankiToNotionCopy from '../src/pages/LandingPage/copy/ankiToNotion';
 import { CONVERT_LANDING_PAGES } from '../src/pages/ConvertLandingPage/convertLandingConfig';
 import { ANSWERS_PAGES } from '../src/pages/AnswersPage/answersConfig';
 import type { LandingCopy } from '../src/pages/LandingPage/types';
@@ -13,6 +14,7 @@ const LANDING_COPIES: LandingCopy[] = [
   quizletCopy,
   markdownCopy,
   pdfCopy,
+  ankiToNotionCopy,
   ...Array.from(CONVERT_LANDING_PAGES.values()),
 ];
 
@@ -170,6 +172,68 @@ export function emitLandingPages(buildDir: string): string[] {
   return emitted;
 }
 
+export interface MetaOnlyPageMeta {
+  pathname: string;
+  title: string;
+  description: string;
+}
+
+const META_ONLY_PAGES: MetaOnlyPageMeta[] = [
+  {
+    pathname: '/upload',
+    title: 'Upload notes and get an Anki deck — 2anki',
+    description:
+      'Drop a Notion export, PDF, Markdown, CSV, HTML, or .apkg file. Get an Anki deck back. Free for the first 100 cards a month, no add-on required.',
+  },
+  {
+    pathname: '/pricing',
+    title: 'Pricing — Free, Day Pass, Unlimited, Auto Sync | 2anki',
+    description:
+      'Compare 2anki plans. Free converts 100 cards a month. Unlimited at $6/mo. Auto Sync at $30/mo polls your Notion workspace and keeps your decks current.',
+  },
+  {
+    pathname: '/about',
+    title: 'About 2anki — open-source Notion to Anki converter',
+    description:
+      'Why 2anki exists, who builds it, and how the project stays free and open source. Independent, no venture funding, supported by lifetime and subscription users.',
+  },
+];
+
+export function emitMetaOnlyPages(buildDir: string): string[] {
+  const indexPath = join(buildDir, 'index.html');
+  const source = readFileSync(indexPath, 'utf8');
+  const emitted: string[] = [];
+
+  for (const meta of META_ONLY_PAGES) {
+    const canonical = `https://2anki.net${meta.pathname}`;
+    const slug = meta.pathname.replace(/^\//, '');
+    const outDir = join(buildDir, slug);
+    const outPath = join(outDir, 'index.html');
+    mkdirSync(dirname(outPath), { recursive: true });
+
+    const titleTag = `<title>${escapeHtml(meta.title)}</title>`;
+    const descriptionTag = `<meta name="description" content="${escapeHtml(meta.description)}">`;
+    const ogTags = [
+      `<meta property="og:title" content="${escapeHtml(meta.title)}">`,
+      `<meta property="og:description" content="${escapeHtml(meta.description)}">`,
+      `<meta property="og:url" content="${canonical}">`,
+      '<meta property="og:type" content="website">',
+      `<meta name="twitter:title" content="${escapeHtml(meta.title)}">`,
+      `<meta name="twitter:description" content="${escapeHtml(meta.description)}">`,
+    ].join('\n  ');
+
+    let html = source.replace(/<title>[\s\S]*?<\/title>/, titleTag);
+    html = html.replace(/<meta\s+name="description"[^>]*>/, descriptionTag);
+    html = html.replace(/<link\s+rel="canonical"[^>]*>/, `<link rel="canonical" href="${canonical}">`);
+    html = stripExistingMeta(html);
+    html = html.replace(/<\/head>/, `  ${ogTags}\n</head>`);
+
+    writeFileSync(outPath, html, 'utf8');
+    emitted.push(outPath);
+  }
+  return emitted;
+}
+
 export function emitAnswersPages(buildDir: string): string[] {
   const indexPath = join(buildDir, 'index.html');
   const source = readFileSync(indexPath, 'utf8');
@@ -206,6 +270,10 @@ if (process.argv[1] && process.argv[1].endsWith('prerenderLandingPages.ts')) {
   process.stdout.write(`prerendered ${marketplacePage}\n`);
   const answerFiles = emitAnswersPages(buildDir);
   for (const file of answerFiles) {
+    process.stdout.write(`prerendered ${file}\n`);
+  }
+  const metaOnlyFiles = emitMetaOnlyPages(buildDir);
+  for (const file of metaOnlyFiles) {
     process.stdout.write(`prerendered ${file}\n`);
   }
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,7 +2,12 @@ import { defineConfig, loadEnv, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import path from 'node:path';
-import { emitLandingPages } from './scripts/prerenderLandingPages';
+import {
+  emitAnswersPages,
+  emitLandingPages,
+  emitMetaOnlyPages,
+  emitNotionMarketplacePage,
+} from './scripts/prerenderLandingPages';
 
 function landingPrerender(): Plugin {
   return {
@@ -11,6 +16,9 @@ function landingPrerender(): Plugin {
     closeBundle() {
       const buildDir = path.resolve(__dirname, 'build');
       emitLandingPages(buildDir);
+      emitNotionMarketplacePage(buildDir);
+      emitAnswersPages(buildDir);
+      emitMetaOnlyPages(buildDir);
     },
   };
 }


### PR DESCRIPTION
## What

Fixes Search Console's *Soft 404* flag by giving every sitemap URL unique HTML.

- Wires `emitNotionMarketplacePage` + `emitAnswersPages` into the Vite build plugin (they existed in the script but were never called during `vite build`).
- Adds `ankiToNotionCopy` to `LANDING_COPIES` so `/anki-to-notion` gets the same landing-page prerender treatment as `/notion-to-anki` etc.
- New `emitMetaOnlyPages` function — writes per-route HTML with unique title, description, canonical, OpenGraph, and Twitter tags but leaves `<div id="root"></div>` empty so React mounts without a visible flash. Used for `/upload`, `/pricing`, `/about` (real interactive pages that don't want a hero fragment).

## Why

Google Search Console emailed: "Search Console has identified that some pages on your site are not indexed due to the following new reason: Soft 404." Curling the live site confirmed six URLs in `sitemap.xml` were serving byte-identical 8301-byte HTML (md5 `feca811…`):

- `/`
- `/upload`
- `/pricing`
- `/about`
- `/anki-to-notion`
- `/notion-marketplace`

To Google that's six copies of one page → soft 404 on the duplicates. The other 10 sitemap URLs (`/notion-to-anki`, `/quizlet-to-anki`, `/markdown-to-anki`, `/pdf-to-anki`, and the six `/convert/*` pages) were serving the prerendered landing-page HTML and were fine.

## How

1. `web/vite.config.ts` — `landingPrerender` plugin's `closeBundle` now calls `emitLandingPages`, `emitNotionMarketplacePage`, `emitAnswersPages`, and `emitMetaOnlyPages` instead of just the first.
2. `web/scripts/prerenderLandingPages.ts` — adds `ankiToNotion` to `LANDING_COPIES`, adds `emitMetaOnlyPages` with three entries, wires the new function into the CLI block.
3. `web/scripts/prerenderLandingPages.test.ts` — six new test cases covering the new function and the wired-up `emitNotionMarketplacePage`.

## Measuring success

- Watch Search Console's "Soft 404" count over the next 7–14 days — it should drop to zero on the six URLs as Google recrawls.
- Watch indexed-page count on the same URLs — soft-404'd pages currently don't show up in the index; they should reappear after recrawl.
- Direct verification: `curl -L https://2anki.net/{upload,pricing,about,anki-to-notion,notion-marketplace}` should return HTML with a unique `<title>` and `<link rel="canonical">` per page.

## Testing

- `pnpm --filter 2anki-web typecheck` — green.
- `pnpm --filter 2anki-web lint` — green (Biome).
- `pnpm --filter 2anki-web test -- scripts/prerenderLandingPages.test.ts` — 18/18 green (12 existing + 6 new).
- `pnpm --filter 2anki-web build` — green; verified each new prerender writes a `build/<slug>/index.html` with unique title/canonical.
- Server `pnpm exec tsc --noEmit` — clean.

## Risks

- **Build-output footprint:** four new HTML files (`/upload`, `/pricing`, `/about`, `/anki-to-notion`) plus the previously-missing `/notion-marketplace` and `/answers/*`. ~few KB each. Negligible.
- **React-mount flash:** `emitMetaOnlyPages` leaves the root div empty, so the SPA shell still hydrates exactly as before — no visible difference for users. `/anki-to-notion` now gets the landing-page hero fragment briefly before React mounts, matching the existing `/notion-to-anki` behavior.
- **No sitemap change in this PR:** the existing `sitemap.xml` already lists all the affected URLs. They were correct; the build pipeline was the problem.

## Goal alignment

- **Simplest, fastest path from notes to cards** — search-engine visibility is the cheapest unit of user acquisition. If Google de-indexes `/upload`, organic traffic to the primary conversion entry point drops.
- **Scale to 300K** — direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->