### PR TITLE
feat: mascot Building cards, compact /chat, sendMessage refactor

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -29,10 +29,10 @@
 .messageListInner {
   max-width: 800px;
   margin: 0 auto;
-  padding: 2rem 1.5rem 1rem;
+  padding: 1.25rem 1.5rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 
 .message {
@@ -76,6 +76,7 @@
   color: var(--color-text-primary);
   border: 1px solid var(--color-border-light);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+  padding: 0.625rem 0.875rem;
 }
 
 .messageSkeleton {

--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -357,10 +357,31 @@
 }
 
 .buildingCards {
-  display: block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   font-size: var(--text-xs);
   color: var(--color-text-secondary);
   margin-top: 0.25rem;
+}
+
+.buildingCardsMascot {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-block;
+  animation: buildingCardsBounce 0.9s ease-in-out infinite;
+  transform-origin: bottom center;
+}
+
+@keyframes buildingCardsBounce {
+  0%, 100% { transform: translateY(0) scaleY(1); }
+  40% { transform: translateY(-0.35rem) scaleY(1.04); }
+  60% { transform: translateY(-0.35rem) scaleY(1.04); }
+  85% { transform: translateY(0) scaleY(0.96); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .buildingCardsMascot { animation: none; }
 }
 
 .userBubbleCollapsible {

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -521,7 +521,15 @@ export default function ChatPanel({
                         </AssistantMarkdown>
                       </div>
                       {isCardStreaming && (
-                        <span className={styles.buildingCards}>Building cards</span>
+                        <span className={styles.buildingCards}>
+                          <img
+                            src="/mascot/navbar-logo.png"
+                            alt=""
+                            aria-hidden="true"
+                            className={styles.buildingCardsMascot}
+                          />
+                          Building cards
+                        </span>
                       )}
                     </>
                   ) : (

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -523,7 +523,7 @@ export default function ChatPanel({
                       {isCardStreaming && (
                         <span className={styles.buildingCards}>
                           <img
-                            src="/mascot/navbar-logo.png"
+                            src="/mascot/Notion%201.png"
                             alt=""
                             aria-hidden="true"
                             className={styles.buildingCardsMascot}

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -88,6 +88,21 @@ function visibleStreamingText(text: string): string {
   return rawArrayIndex === -1 ? text : text.slice(0, rawArrayIndex);
 }
 
+export function parseSseEvent(rawEvent: string): { eventType: string; data: string } | null {
+  if (!rawEvent.trim()) return null;
+  let eventType = '';
+  let data = '';
+  for (const line of rawEvent.split('\n')) {
+    if (line.startsWith('event: ')) {
+      eventType = line.slice(7).trim();
+    } else if (line.startsWith('data: ')) {
+      data = line.slice(6);
+    }
+  }
+  if (eventType === '') return null;
+  return { eventType, data };
+}
+
 async function downloadDeck(cards: ChatCard[], deckName: string): Promise<void> {
   const response = await post('/api/chat/deck', { cards, deckName });
   if (!response.ok) {
@@ -315,6 +330,59 @@ export default function ChatPanel({
       return;
     }
 
+    const handleSseToken = (data: string) => {
+      const text = JSON.parse(data) as string;
+      setStreamingText((prev) => prev + text);
+    };
+
+    const handleSseDone = (data: string) => {
+      const result = JSON.parse(data) as ApiDonePayload;
+      const assistantMessage: Message = {
+        role: 'assistant',
+        content: result.content,
+        contentBefore: result.contentBefore,
+        contentAfter: result.contentAfter,
+        cards: result.cards,
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
+      setStreamingText('');
+      setMessagesUsedThisMonth((n) => n + 1);
+      setActiveConversationId(result.conversationId);
+      lastSavedDraftRef.current = '';
+      const provisionalTitle =
+        content.length > 60 ? `${content.slice(0, 60).trimEnd()}…` : content;
+      onConversationCreated?.(result.conversationId, provisionalTitle);
+      if (result.cards != null && result.cards.length > 0) {
+        onCardsGenerated?.(result.cards);
+      }
+    };
+
+    const handleSseError = (data: string) => {
+      const err = JSON.parse(data) as ApiErrorPayload;
+      if (err.type === 'rate_limit') {
+        setLimitReached(true);
+        if (err.resetDate != null) setResetDate(err.resetDate);
+        return;
+      }
+      if (err.type === 'conversation_not_found') {
+        setNetworkError('This conversation is gone. Start a new one.');
+        setActiveConversationId(null);
+        onConversationNotFound?.();
+        return;
+      }
+      if (err.type === 'consent_required') {
+        setShowConsentModal(true);
+        return;
+      }
+      setNetworkError("Couldn't send this message. Try again.");
+    };
+
+    const dispatchSseEvent = (eventType: string, data: string) => {
+      if (eventType === 'token') return handleSseToken(data);
+      if (eventType === 'done') return handleSseDone(data);
+      if (eventType === 'error') return handleSseError(data);
+    };
+
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
@@ -329,58 +397,8 @@ export default function ChatPanel({
         buffer = events.pop() ?? '';
 
         for (const rawEvent of events) {
-          if (!rawEvent.trim()) continue;
-
-          const lines = rawEvent.split('\n');
-          let eventType = '';
-          let data = '';
-
-          for (const line of lines) {
-            if (line.startsWith('event: ')) {
-              eventType = line.slice(7).trim();
-            } else if (line.startsWith('data: ')) {
-              data = line.slice(6);
-            }
-          }
-
-          if (eventType === 'token') {
-            const text = JSON.parse(data) as string;
-            setStreamingText((prev) => prev + text);
-          } else if (eventType === 'done') {
-            const result = JSON.parse(data) as ApiDonePayload;
-            const assistantMessage: Message = {
-              role: 'assistant',
-              content: result.content,
-              contentBefore: result.contentBefore,
-              contentAfter: result.contentAfter,
-              cards: result.cards,
-            };
-            setMessages((prev) => [...prev, assistantMessage]);
-            setStreamingText('');
-            setMessagesUsedThisMonth((n) => n + 1);
-            setActiveConversationId(result.conversationId);
-            lastSavedDraftRef.current = '';
-            const provisionalTitle =
-              content.length > 60 ? `${content.slice(0, 60).trimEnd()}…` : content;
-            onConversationCreated?.(result.conversationId, provisionalTitle);
-            if (result.cards != null && result.cards.length > 0) {
-              onCardsGenerated?.(result.cards);
-            }
-          } else if (eventType === 'error') {
-            const err = JSON.parse(data) as ApiErrorPayload;
-            if (err.type === 'rate_limit') {
-              setLimitReached(true);
-              if (err.resetDate != null) setResetDate(err.resetDate);
-            } else if (err.type === 'conversation_not_found') {
-              setNetworkError('This conversation is gone. Start a new one.');
-              setActiveConversationId(null);
-              onConversationNotFound?.();
-            } else if (err.type === 'consent_required') {
-              setShowConsentModal(true);
-            } else {
-              setNetworkError("Couldn't send this message. Try again.");
-            }
-          }
+          const parsed = parseSseEvent(rawEvent);
+          if (parsed != null) dispatchSseEvent(parsed.eventType, parsed.data);
         }
       }
     } catch {


### PR DESCRIPTION
## What

Three bundled polish items on top of yesterday's chat-quality merge:

1. **Mascot next to "Building cards"** — replaces the silent text span with `/mascot/Notion%201.png` + label and a gentle CSS bounce. Honors `prefers-reduced-motion`.
2. **Compact `/chat` spacing** — `messageListInner` gap drops from 1rem to 0.5rem and the assistant bubble inherits the same 0.625rem/0.875rem padding as the user bubble, so replies sit closer to surrounding messages.
3. **`sendMessage` SSE refactor** — engineer trio on PR #2323 flagged it as ~133 LOC / ~18-20 branches, Sonar bait. Extracts `parseSseEvent` (module-level pure function) and three local handlers (`handleSseToken`, `handleSseDone`, `handleSseError`) plus a tiny `dispatchSseEvent` router. Reader pump becomes parse → dispatch.

## Why

- Al reported the "Building cards" indicator felt static for the longest part of a reply.
- Al reported `/chat` replies had too much spacing from surrounding messages.
- Engineer trio said the sendMessage complexity would bounce a future PR through Sonar; cleared the deck before next chat-area change.

## Testing

- `pnpm --filter 2anki-web typecheck` — green.
- `pnpm --filter 2anki-web lint` — green (Biome).
- `pnpm --filter 2anki-web test` — 710/710 green. ChatPanel's four SSE-stream tests survived the refactor unchanged.
- Server `pnpm exec tsc --noEmit` — clean.

## Risks

- Mascot src uses `/mascot/Notion%201.png` (URL-encoded space). Verified the asset exists on prod (HTTP 200) and locally at `web/public/mascot/Notion 1.png`.
- Refactor is behavior-preserving — no new event types, no new branches, just code organization.

## Visual check (over to Al)

- `/chat` → send a message that asks for cards → during streaming, the mascot should bounce next to "Building cards".
- `/chat` → general conversation → consecutive messages should sit closer together than yesterday.
- `prefers-reduced-motion: reduce` → mascot is static (no animation).

## Goal alignment

- **Simplest, fastest path from notes to cards** — chat feels alive during the longest wait, denser layout fits more context on screen.
- **Scale** — refactor opens the next chat-area changes (sidebar collapse follow-up, templates editor migration) without a Sonar bounce.

## Follow-ups

- Sidebar collapse (Slack-style icons-only mode) — separate PR.
- Templates editor's bespoke chat migration to `ChatPanel` — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->