### PR TITLE
fix: starter prompt chips on /chat fill the textarea

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -66,6 +66,23 @@ describe('ChatPanel', () => {
     expect(screen.getByRole('textbox', { name: 'Message input' })).toBeInTheDocument();
   });
 
+  it('syncs the textarea when initialPrompt changes after mount', () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <ChatPanel initialPrompt="" />
+      </MemoryRouter>
+    );
+    const textarea = screen.getByRole('textbox', { name: 'Message input' }) as HTMLTextAreaElement;
+    expect(textarea.value).toBe('');
+
+    rerender(
+      <MemoryRouter>
+        <ChatPanel initialPrompt="Turn this into cloze cards: [paste]" />
+      </MemoryRouter>
+    );
+    expect(textarea.value).toBe('Turn this into cloze cards: [paste]');
+  });
+
   it('calls /api/chat/message when message is sent', async () => {
     mockPost.mockResolvedValueOnce(
       makeSseResponse([

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -143,6 +143,13 @@ export default function ChatPanel({
   const [expandedUserMessages, setExpandedUserMessages] = useState<Set<number>>(new Set());
   const [streamingText, setStreamingText] = useState('');
   const [inputValue, setInputValue] = useState(initialPrompt ?? '');
+
+  useEffect(() => {
+    if (initialPrompt != null && initialPrompt !== '') {
+      setInputValue(initialPrompt);
+    }
+  }, [initialPrompt]);
+
   const [isLoading, setIsLoading] = useState(false);
   const [networkError, setNetworkError] = useState<string | null>(null);
   const [limitReached, setLimitReached] = useState(false);


### PR DESCRIPTION
## What

Clicking a starter prompt chip on `/chat` ("Make 10 cards from notes I'll paste" / "Explain a concept, then make cards" / "Turn this into cloze cards: [paste]") didn't fill the textarea. The chip click updated `ChatPage`'s `panelSeed.draft` correctly, but `ChatPanel` read `initialPrompt` only as a one-shot `useState` initializer — subsequent prop changes never made it into `inputValue`.

## Fix

`ChatPanel` now syncs `inputValue` from `initialPrompt` via `useEffect` when the prop changes to a non-empty value. Empty values don't clobber typed input, so the user's in-progress draft is safe.

## Testing

- New Vitest case in `ChatPanel.test.tsx`: rerender with a new `initialPrompt` after mount; the textarea picks it up.
- All 6 ChatPanel tests + 710 web tests stay green.
- `pnpm --filter 2anki-web typecheck && pnpm --filter 2anki-web lint` — green.

## Risks

- A re-mounted `ChatPanel` with a non-empty `initialPrompt` will now overwrite the textarea if the prop ever changes. That's the intended behavior; the only callers that change `initialPrompt` are the upload-form inline panels (where the file context is fresh and overwriting is correct) and the starter chips on `/chat` (which now works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->