### PR TITLE
feat: collapsible sidebar — icons-only mode like Slack

### DIFF
--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -20,6 +20,78 @@
   overflow-y: auto;
   background: var(--color-bg-secondary);
   padding: 1.25rem 0.75rem;
+  transition: width var(--transition-fast);
+}
+
+.sidebarRowLabel {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.sidebarCollapseToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  border: none;
+  background: none;
+  color: var(--color-text-tertiary);
+  text-align: left;
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: var(--font-normal);
+  line-height: 1.25;
+  cursor: pointer;
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.sidebarCollapseToggle:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-tertiary);
+}
+
+@media (min-width: 1024px) {
+  .sidebar.sidebarCollapsed {
+    width: 64px;
+    padding: 1.25rem 0.5rem;
+  }
+
+  .sidebar.sidebarCollapsed .sidebarRowLabel,
+  .sidebar.sidebarCollapsed .sidebarRowLockedLabel,
+  .sidebar.sidebarCollapsed .sidebarRowPill,
+  .sidebar.sidebarCollapsed .identity,
+  .sidebar.sidebarCollapsed .sidebarMore {
+    display: none;
+  }
+
+  .sidebar.sidebarCollapsed .sidebarRow,
+  .sidebar.sidebarCollapsed .sidebarCollapseToggle {
+    justify-content: center;
+    padding: var(--space-2);
+    gap: 0;
+  }
+
+  .sidebar.sidebarCollapsed .sidebarLogo {
+    justify-content: center;
+    padding: 0.25rem 0 1rem;
+  }
+
+  .sidebar.sidebarCollapsed .sidebarTheme {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 1023px) {
+  .sidebar.sidebarCollapsed {
+    width: 240px;
+  }
+
+  .sidebarCollapseToggle {
+    display: none;
+  }
 }
 
 @media (max-width: 1023px) {

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -1,6 +1,12 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function beforeEachReset() {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+}
 import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 
@@ -302,6 +308,41 @@ describe('Sidebar cards-used counter', () => {
     expect(
       screen.queryByText('/ 100 cards this month')
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('Sidebar collapse toggle', () => {
+  beforeEachReset();
+
+  it('defaults to expanded when localStorage has no preference', () => {
+    renderSidebar();
+    const aside = screen.getByRole('complementary', { name: 'primary' });
+    expect(aside).toHaveAttribute('data-collapsed', 'false');
+    expect(screen.getByRole('button', { name: 'Collapse sidebar' })).toBeInTheDocument();
+  });
+
+  it('toggles the data-collapsed attribute on click', () => {
+    renderSidebar();
+    const toggle = screen.getByRole('button', { name: 'Collapse sidebar' });
+    fireEvent.click(toggle);
+    const aside = screen.getByRole('complementary', { name: 'primary' });
+    expect(aside).toHaveAttribute('data-collapsed', 'true');
+    expect(screen.getByRole('button', { name: 'Expand sidebar' })).toBeInTheDocument();
+  });
+
+  it('persists the collapsed state to localStorage', () => {
+    renderSidebar();
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));
+    expect(localStorage.getItem('sidebar.collapsed')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: 'Expand sidebar' }));
+    expect(localStorage.getItem('sidebar.collapsed')).toBe('false');
+  });
+
+  it('reads the collapsed state from localStorage on mount', () => {
+    localStorage.setItem('sidebar.collapsed', 'true');
+    renderSidebar();
+    const aside = screen.getByRole('complementary', { name: 'primary' });
+    expect(aside).toHaveAttribute('data-collapsed', 'true');
   });
 });
 

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTheme } from '../../lib/hooks/useTheme';
 import { useCardUsage } from '../../lib/hooks/useCardUsage';
@@ -24,6 +24,30 @@ import { ThemeSwitcher } from '../ThemeSwitcher/ThemeSwitcher';
 import styles from './AppShell.module.css';
 
 const TRIAL_DURATION_MS = 60 * 60 * 1000;
+const COLLAPSED_STORAGE_KEY = 'sidebar.collapsed';
+
+function readCollapsedFromStorage(): boolean {
+  try {
+    return globalThis.localStorage?.getItem(COLLAPSED_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function useSidebarCollapsed(): [boolean, (next: boolean) => void] {
+  const [collapsed, setCollapsedState] = useState<boolean>(readCollapsedFromStorage);
+
+  const setCollapsed = useCallback((next: boolean) => {
+    setCollapsedState(next);
+    try {
+      globalThis.localStorage?.setItem(COLLAPSED_STORAGE_KEY, next ? 'true' : 'false');
+    } catch {
+      // localStorage unavailable (private mode, blocked) — state still updates in memory
+    }
+  }, []);
+
+  return [collapsed, setCollapsed];
+}
 
 interface CardUsageCounterProps {
   used: number;
@@ -128,17 +152,19 @@ function SidebarRow({
   children,
 }: Readonly<SidebarRowProps>) {
   const active = isActiveRoute(pathname, href, matchPrefix);
+  const label = typeof children === 'string' ? children : undefined;
   return (
     <Link
       to={href}
       onClick={onClick}
       aria-current={active ? 'page' : undefined}
+      title={label}
       className={`${styles.sidebarRow} ${
         active ? styles.sidebarRowActive : ''
       }`}
     >
       {Icon && <Icon width={20} height={20} />}
-      {children}
+      <span className={styles.sidebarRowLabel}>{children}</span>
     </Link>
   );
 }
@@ -161,6 +187,7 @@ function LockedSidebarRow({
       type="button"
       onClick={onActivate}
       aria-label={`${label} — upgrade to unlock`}
+      title={`${label} — upgrade to unlock`}
       className={`${styles.sidebarRow} ${styles.sidebarRowLocked}`}
     >
       {Icon && <Icon width={20} height={20} />}
@@ -182,6 +209,7 @@ export function Sidebar({
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const theme = useTheme();
+  const [collapsed, setCollapsed] = useSidebarCollapsed();
   const logoSrc = theme === 'light' ? '/mascot/navbar-logo.png' : '/mascot/Notion 1.png';
   const showAnkify =
     locals?.patreon === true || locals?.autoSyncActive === true;
@@ -207,9 +235,10 @@ export function Sidebar({
   return (
     <aside
       id={drawerId}
-      className={`${styles.sidebar} ${isOpen ? styles.sidebarOpen : ''}`}
+      className={`${styles.sidebar} ${isOpen ? styles.sidebarOpen : ''} ${collapsed ? styles.sidebarCollapsed : ''}`}
       aria-label="primary"
       data-testid="app-sidebar"
+      data-collapsed={collapsed ? 'true' : 'false'}
     >
       <Link
         className={styles.sidebarLogo}
@@ -403,6 +432,19 @@ export function Sidebar({
           {getVisibleText('navigation.logout')}
         </a>
       </div>
+      <button
+        type="button"
+        onClick={() => setCollapsed(!collapsed)}
+        className={styles.sidebarCollapseToggle}
+        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        aria-pressed={collapsed}
+        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      >
+        {collapsed ? <ArrowRightIcon width={16} height={16} /> : <ArrowLeftIcon width={16} height={16} />}
+        <span className={styles.sidebarRowLabel}>
+          {collapsed ? 'Expand' : 'Collapse'}
+        </span>
+      </button>
       <div className={styles.sidebarMore}>
         <div className={styles.sidebarMoreLinks}>
           <Link to="/whats-new" onClick={handleNavClick()}>

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Sidebar collapses to icons only — toggle at the bottom, choice sticks across sessions', date: '2026-05-18' },
   { type: 'feature', title: 'Upload errors — talk to Claude inline instead of jumping to a separate page', date: '2026-05-18' },
   { type: 'fix', title: 'Recovery screen — reload first, only reset local data if that does not fix it', date: '2026-05-18' },
   { type: 'feature', title: 'Empty deck — ask Claude what to fix without leaving the upload page', date: '2026-05-18' },


### PR DESCRIPTION
## What

Toggle button at the bottom of the sidebar collapses the full-width nav (240px) to a 64px icons-only rail. Choice persists across sessions in `localStorage` (`sidebar.collapsed`). Nav rows expose their label as a `title` attribute so hovering an icon in collapsed mode shows the name as a native browser tooltip.

Desktop only — at `<1024px` the existing drawer pattern controls visibility and the toggle is hidden, so mobile users never lose access to labels.

## Why

Al asked for it: like Slack — choose between full sidebar or icons only. A common pattern for users who want more screen real estate for content (especially on `/chat` and `/templates/edit` which already use a lot of width).

## How

- `useSidebarCollapsed` hook in `Sidebar.tsx` — reads/writes `localStorage` with try/catch for private-mode safety.
- New `data-collapsed` attribute and `sidebarCollapsed` class on the `<aside>`.
- `SidebarRow` and `LockedSidebarRow` get `title={label}` for tooltips.
- CSS rules (desktop-only media query) hide `.sidebarRowLabel`, `.sidebarRowLockedLabel`, `.sidebarRowPill`, `.identity`, and `.sidebarMore` when collapsed; center-aligns icons.
- Toggle button uses `ArrowLeftIcon` (collapse) / `ArrowRightIcon` (expand) with `aria-pressed` for screen readers.

## Testing

- 4 new Vitest cases in `Sidebar.test.tsx`:
  - Defaults to expanded with empty localStorage
  - Click toggles `data-collapsed`
  - Persists to localStorage
  - Reads from localStorage on mount
- `pnpm --filter 2anki-web typecheck && pnpm --filter 2anki-web lint` — green.
- All 33 Sidebar tests pass.

## Visual check

- Click "Collapse" at the bottom of the sidebar — width snaps to 64px, only icons remain.
- Hover an icon — native tooltip shows the label.
- Reload — collapsed state persists.
- Click "Expand" — full-width returns.
- Window <1024px → drawer pattern still works, toggle is hidden.

## Goal alignment

- **Simplest, fastest path** — power users get more horizontal space for the conversion surfaces.
- **Scale** — zero infra cost; pure CSS/localStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->