### PR TITLE
fix: sidebar collapse polish — top toggle, ThemeToggle, clean logout

### DIFF
--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -28,23 +28,31 @@
   min-width: 0;
 }
 
-.sidebarCollapseToggle {
+.sidebarHeader {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-md);
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem 1rem;
+}
+
+.sidebarHeader .sidebarLogo {
+  padding: 0;
+}
+
+.sidebarCollapseToggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--radius-sm);
   border: none;
   background: none;
   color: var(--color-text-tertiary);
-  text-align: left;
-  font-family: inherit;
-  font-size: var(--text-sm);
-  font-weight: var(--font-normal);
-  line-height: 1.25;
   cursor: pointer;
-  width: 100%;
-  margin-top: 0.5rem;
+  flex-shrink: 0;
+  padding: 0;
 }
 
 .sidebarCollapseToggle:hover {
@@ -66,16 +74,21 @@
     display: none;
   }
 
-  .sidebar.sidebarCollapsed .sidebarRow,
-  .sidebar.sidebarCollapsed .sidebarCollapseToggle {
+  .sidebar.sidebarCollapsed .sidebarRow {
     justify-content: center;
     padding: var(--space-2);
     gap: 0;
   }
 
-  .sidebar.sidebarCollapsed .sidebarLogo {
-    justify-content: center;
-    padding: 0.25rem 0 1rem;
+  .sidebar.sidebarCollapsed .sidebarHeader {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.25rem 0 0.75rem;
+  }
+
+  .sidebar.sidebarCollapsed .sidebarHeader .sidebarLogo img {
+    height: 24px;
   }
 
   .sidebar.sidebarCollapsed .sidebarTheme {

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -21,6 +21,7 @@ import UserCircleIcon from '../icons/UserCircleIcon';
 import SettingsIcon from '../icons/SettingsIcon';
 import WrenchIcon from '../icons/WrenchIcon';
 import { ThemeSwitcher } from '../ThemeSwitcher/ThemeSwitcher';
+import { ThemeToggle } from '../ThemeSwitcher/ThemeToggle';
 import styles from './AppShell.module.css';
 
 const TRIAL_DURATION_MS = 60 * 60 * 1000;
@@ -240,14 +241,26 @@ export function Sidebar({
       data-testid="app-sidebar"
       data-collapsed={collapsed ? 'true' : 'false'}
     >
-      <Link
-        className={styles.sidebarLogo}
-        to="/"
-        aria-label="2anki home"
-        onClick={handleNavClick()}
-      >
-        <img src={logoSrc} alt="" />
-      </Link>
+      <div className={styles.sidebarHeader}>
+        <Link
+          className={styles.sidebarLogo}
+          to="/"
+          aria-label="2anki home"
+          onClick={handleNavClick()}
+        >
+          <img src={logoSrc} alt="" />
+        </Link>
+        <button
+          type="button"
+          onClick={() => setCollapsed(!collapsed)}
+          className={styles.sidebarCollapseToggle}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-pressed={collapsed}
+          title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
+          {collapsed ? <ArrowRightIcon width={16} height={16} /> : <ArrowLeftIcon width={16} height={16} />}
+        </button>
+      </div>
       <nav className={styles.sidebarNav}>
         <div className={styles.sidebarGroup}>
           <SidebarRow
@@ -401,7 +414,7 @@ export function Sidebar({
         )}
       </nav>
       <div className={styles.sidebarTheme}>
-        <ThemeSwitcher />
+        {collapsed ? <ThemeToggle /> : <ThemeSwitcher />}
       </div>
       <div className={styles.sidebarSpacer} />
       <div className={styles.identity}>
@@ -427,24 +440,14 @@ export function Sidebar({
           className={styles.sidebarRow}
           href="/users/logout"
           onClick={handleNavClick(onLogOut)}
+          title={getVisibleText('navigation.logout')}
         >
           <ArrowRightOnRectangleIcon width={20} height={20} />
-          {getVisibleText('navigation.logout')}
+          <span className={styles.sidebarRowLabel}>
+            {getVisibleText('navigation.logout')}
+          </span>
         </a>
       </div>
-      <button
-        type="button"
-        onClick={() => setCollapsed(!collapsed)}
-        className={styles.sidebarCollapseToggle}
-        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        aria-pressed={collapsed}
-        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-      >
-        {collapsed ? <ArrowRightIcon width={16} height={16} /> : <ArrowLeftIcon width={16} height={16} />}
-        <span className={styles.sidebarRowLabel}>
-          {collapsed ? 'Expand' : 'Collapse'}
-        </span>
-      </button>
       <div className={styles.sidebarMore}>
         <div className={styles.sidebarMoreLinks}>
           <Link to="/whats-new" onClick={handleNavClick()}>


### PR DESCRIPTION
## What

Three quality issues with yesterday's sidebar-collapse landing:

1. **Collapse toggle moves to the top.** Yesterday's version had it at the bottom — far from the primary use case (collapsing to make room for content). Now sits next to the logo, one reach away from where you'd look first.
2. **ThemeSwitcher swaps to ThemeToggle when collapsed.** The full four-icon picker (☀ ☾ ✦ ◆) doesn't fit a 64px rail. Use the existing `ThemeToggle` (single cycling icon, the same pattern used in the anon navbar) while collapsed; restore the full picker when expanded.
3. **Log out row no longer overflows when collapsed.** The logout `<a>` wasn't using `sidebarRowLabel`, so "Log out" stayed visible and pushed the icon off-center. Wrap it like every other row and add a `title` attribute for hover-tooltip parity.

## Why

Al hit all three issues within minutes of yesterday's merge.

## Testing

- `pnpm --filter 2anki-web typecheck && pnpm --filter 2anki-web lint` — green.
- `pnpm --filter 2anki-web test src/components/AppShell` — 44/44 green.

## Visual check

- Collapsed sidebar: toggle next to logo, theme icon shows the current theme and cycles on click, logout row centered around the icon.
- Expanded sidebar: same as before, plus toggle now at the top of the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->