### PR TITLE
chore: allow GitHub issues for cross-cutting follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Every PR is checked against both — does it make the experience simpler/faster/
 - **Before flipping a PR ready (or before pushing a non-trivial code change), run `sonar-scanner` locally.** `/check` does not run SonarCloud's rule engine; cognitive complexity, nesting depth, redundant type assertions, and a11y smells only surface after the push. See `.claude/rules/sonar.md` for setup and the exact command. Skip only for pure doc/dep/test/typo changes.
 - Before `gh pr merge`: every `statusCheckRollup` entry must be non-FAILURE (not just required ones). The `check-merge-status.py` hook enforces this.
 - Touching auth, payments, or external-API integration? Run `/security-review` before merge.
-- Document scope/follow-ups in commit bodies, not new GitHub issues.
+- GitHub issues for follow-ups that need cross-cutting visibility, labels, or contributor pickup. Commit bodies for inline scope notes that travel with the change.
 
 ## Working speed
 


### PR DESCRIPTION
## Summary
- The previous CLAUDE.md rule said "follow-ups in commit bodies, not new GitHub issues" — well-intended (avoid issue-tracker sprawl) but it pushes cross-cutting, multi-PR work into squash-merge commit bodies where it becomes invisible.
- New wording keeps both tools with a clear split: inline scope notes that travel with a single change stay in commit bodies; follow-ups that need labels, contributor pickup, or visibility across multiple PRs move to GitHub issues.

## Test plan
- [ ] No code change — CLAUDE.md only. /check is unnecessary; reviewer just needs to skim the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->