### PR TITLE
fix: recover Claude JSON responses with unescaped quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "google-auth-library": "^10.6.2",
     "html-to-text": "^10.0.0",
     "http-proxy-middleware": "^4.0.0",
+    "jsonrepair": "^3.14.0",
     "jsonwebtoken": "^9.0.0",
     "knex": "^3.1.0",
     "mammoth": "^1.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       http-proxy-middleware:
         specifier: ^4.0.0
         version: 4.0.0
+      jsonrepair:
+        specifier: ^3.14.0
+        version: 3.14.0
       jsonwebtoken:
         specifier: ^9.0.0
         version: 9.0.3
@@ -5439,6 +5442,10 @@ packages:
 
   jsonrepair@3.13.3:
     resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==}
+    hasBin: true
+
+  jsonrepair@3.14.0:
+    resolution: {integrity: sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg==}
     hasBin: true
 
   jsonwebtoken@9.0.3:
@@ -14024,6 +14031,8 @@ snapshots:
   json5@2.2.3: {}
 
   jsonrepair@3.13.3: {}
+
+  jsonrepair@3.14.0: {}
 
   jsonwebtoken@9.0.3:
     dependencies:

--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -61,6 +61,27 @@ describe('parseDeckResponse', () => {
   it('throws generic error when there is no ] at all', () => {
     expect(() => parseDeckResponse('not json', 'not json', 0)).toThrow('Claude returned invalid JSON');
   });
+
+  it('recovers a card whose value contains an unescaped ASCII " (the German-quote prod failure)', () => {
+    // Claude emits raw ASCII " when source HTML has „kaputt macht" (German low/high quotes).
+    // The premature " closes the string and JSON.parse dies on the following character.
+    const broken =
+      '[{"deck":"Corporate Finance","cards":[{"q":"Erkläre","a":"Linie „kaputt macht".</p> mehr text"}]}]';
+    expect(() => JSON.parse(broken)).toThrow();
+    const parsed = parseDeckResponse(broken, broken, 0);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].deck).toBe('Corporate Finance');
+    expect(parsed[0].cards).toHaveLength(1);
+    expect(parsed[0].cards[0].q).toBe('Erkläre');
+    expect(parsed[0].cards[0].a).toContain('kaputt macht');
+  });
+
+  it('still throws when jsonrepair cannot recover the response', () => {
+    const unrepairable = '[{"deck":"X","cards":[{"q":"a","a"';
+    expect(() => parseDeckResponse(unrepairable, unrepairable, 0)).toThrow(
+      'Claude returned invalid JSON'
+    );
+  });
 });
 
 describe('rewriteAudioAnchors', () => {

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -2,6 +2,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { Message } from '@anthropic-ai/sdk/resources/messages';
 import * as cheerio from 'cheerio';
 import { createHash } from 'node:crypto';
+import { jsonrepair } from 'jsonrepair';
 
 const SYSTEM_PROMPT = `
 You are an Anki flashcard generator. Output ONLY a compact JSON array.
@@ -288,6 +289,28 @@ function buildUserMessage(
   return `Convert this HTML content into the compact deck JSON:\n\n${strippedContent}${mediaFilesList}${instructionsSection}`;
 }
 
+function tryRepairDeckArray(toParse: string): unknown[] | null {
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(jsonrepair(toParse));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(candidate) || candidate.length === 0) return null;
+  const hasUsableCard = candidate.some((deck) => {
+    if (!deck || typeof deck !== 'object') return false;
+    const cards = (deck as { cards?: unknown }).cards;
+    if (!Array.isArray(cards)) return false;
+    return cards.some((card) => {
+      if (!card || typeof card !== 'object') return false;
+      const q = (card as { q?: unknown }).q;
+      const a = (card as { a?: unknown }).a;
+      return typeof q === 'string' && q.length > 0 && typeof a === 'string' && a.length > 0;
+    });
+  });
+  return hasUsableCard ? candidate : null;
+}
+
 export function parseDeckResponse(
   cleaned: string,
   raw: string,
@@ -302,16 +325,23 @@ export function parseDeckResponse(
   try {
     parsed = JSON.parse(toParse);
   } catch {
-    console.error('[Claude] Failed to parse response as JSON', {
-      raw,
-      cleaned,
-      toParse,
-      chunkIndex,
-    });
-    if (looksLikeEmptyContentExplanation(cleaned)) {
-      throw new Error(EMPTY_CONTENT_USER_MESSAGE);
+    // Repairs Claude's occasional unescaped " in string values (common with German „…" and other non-English quoting); plausibility check guards against over-eager repair on truncated content.
+    const repaired = tryRepairDeckArray(toParse);
+    if (repaired) {
+      parsed = repaired;
+      console.warn('[Claude] Recovered malformed JSON via jsonrepair', { chunkIndex });
+    } else {
+      console.error('[Claude] Failed to parse response as JSON', {
+        raw,
+        cleaned,
+        toParse,
+        chunkIndex,
+      });
+      if (looksLikeEmptyContentExplanation(cleaned)) {
+        throw new Error(EMPTY_CONTENT_USER_MESSAGE);
+      }
+      throw new Error(`Claude returned invalid JSON:\n${raw}`);
     }
-    throw new Error(`Claude returned invalid JSON:\n${raw}`);
   }
 
   if (!Array.isArray(parsed)) {

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'AI-generated decks from uploads with German, Swedish, or other non-English text convert into a finished deck', date: '2026-05-18' },
   { type: 'feature', title: 'Multi-page Notion exports convert several times faster — large uploads finish in seconds instead of waiting through each page', date: '2026-05-18' },
   { type: 'feature', title: 'Password-protected PDFs — type the password during upload and the file converts without third-party tools', date: '2026-05-18' },
   { type: 'fix', title: 'Upload errors — too large, wrong file type, password-protected PDF, and broken Notion formatting each show what to fix', date: '2026-05-18' },


### PR DESCRIPTION
## Summary

- Wraps `JSON.parse` in `parseDeckResponse` with a `jsonrepair` fallback, behind a plausibility check (at least one card with non-empty `q` and `a`) so we don't ship junk on truly truncated responses.
- Adds two tests in `ClaudeService.test.ts`: the German-quote recovery case and the repair-also-fails case.
- Adds a changelog entry — paying users on non-English content stop seeing silent "Failed" rows.

## Why

Spotted via Hotjar (German user, Safari, 1h ago). Job `169477` (`cofi Jost.zip`, Corporate Finance) failed with `Claude returned invalid JSON` because the model emitted a raw ASCII `"` to close a German `„…"` quote, prematurely ending the JSON string. Reproduced the parse failure locally on the user's payload and confirmed the fix recovers the full 56-card deck.

This is not isolated — **12 of the 13 most recent failed `claude` jobs in prod (~92%)** hit this same error class. Skew is heavy toward German/Swedish/medical-jargon decks.

## Trio

PM / designer / engineer all weighed in before code was written. PM said same-day hotfix and silent repair; designer said deliver-with-warning row; engineer recommended `jsonrepair` over tool_use to avoid an SDK migration under incident pressure. Compromise: ship the parser fix today (this PR), follow up with the UX surface (failure-row copy + repair-warning row) in a separate PR.

## Risk

`jsonrepair` is permissive — it'll happily close brackets on a truncated response and produce a deck with a card missing `a`. The plausibility check in `tryRepairDeckArray` guards against that: if no card with both `q` and `a` exists after repair, we fall through to the original error.

## Test plan

- [x] `pnpm test src/lib/claude/ClaudeService.test.ts` — 19/19 pass, including the two new cases
- [x] `pnpm test` (full server suite) — 1487 pass, 7 skipped, 8 todo
- [x] `pnpm --filter notion2anki-server build`
- [x] `pnpm --filter 2anki-web typecheck`, `lint`, `test:run` — all green
- [ ] Sonar local run skipped — `sonar-scanner` not installed in this environment. Expect Sonar CI feedback after push; small surface (one new helper + one new dep) should be low-risk.
- [ ] After merge + deploy: monitor `/api/upload/jobs` failure rate for `type='claude'` over next 24h; tail server logs for `[Claude] Recovered malformed JSON via jsonrepair` to confirm the path is firing for real users.

## Follow-ups (separate PRs)

- Web: failure-row copy + suppress restart for "invalid JSON" failures + email-support CTA.
- API: surface a `repaired` flag on the job response so the deck-ready row can show an amber "open them in Anki to check" note.
- Long-term: migrate to Anthropic structured output / tool_use, which eliminates this class entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->