### PR TITLE
fix: batched deck builds write .apkg to parent workspace

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -311,7 +311,8 @@ export interface DeckInfoOnlyResult {
 
 export async function prepareDeckInfoOnly(
   input: DeckParserInput,
-  deckSubWorkspace: Workspace
+  deckSubWorkspace: Workspace,
+  outputWorkspace: Workspace
 ): Promise<DeckInfoOnlyResult> {
   const results = await Promise.all(input.files.map((file) => convertFile(file, input)));
   const convertedFiles = results.flatMap((r) => (r ? [r] : []));
@@ -337,7 +338,7 @@ export async function prepareDeckInfoOnly(
     }
   }
 
-  const outputPath = path.join(deckSubWorkspace.location, `${getDeckFilename(parser.name)}`);
+  const outputPath = path.join(outputWorkspace.location, `${getDeckFilename(parser.name)}`);
   const deckInfoPath = parser.writeDeckInfo(deckSubWorkspace);
 
   return {

--- a/src/usecases/uploads/getPackagesFromZip.test.ts
+++ b/src/usecases/uploads/getPackagesFromZip.test.ts
@@ -83,6 +83,56 @@ describe('getPackagesFromZip — batch concurrency', () => {
     expect(result.packages).toHaveLength(fileCount);
   });
 
+  it('passes parent workspace as outputWorkspace so .apkg files land where the downloader looks', async () => {
+    const fileNames = ['deck0.html', 'deck1.html', 'deck2.html'];
+
+    mockZipHandlerClass.mockImplementation(() => ({
+      build: jest.fn().mockResolvedValue(undefined),
+      getFileNames: jest.fn().mockReturnValue(fileNames),
+      files: fileNames.map((name) => ({ name, contents: '<html></html>' })),
+    }));
+
+    mockPrepareDeckInfoOnly.mockImplementation(({ name }: { name: string }) =>
+      Promise.resolve({
+        deckInfoPath: `/fake/${name}/deck_info.json`,
+        outputPath: `${FAKE_WORKSPACE_LOCATION}/${name}.apkg`,
+        name,
+        inputFileName: name,
+        deck: [],
+        cardCount: 1,
+        needsIndividualBuild: false,
+      })
+    );
+
+    mockCardGeneratorClass.mockImplementation(() => ({
+      runBatch: jest.fn().mockImplementation((entries: Array<{ output: string }>) =>
+        Promise.resolve(entries.map((e) => e.output))
+      ),
+    }));
+
+    process.env.UPLOAD_BUILD_CONCURRENCY = '1';
+
+    const settings = new CardOption({});
+    const workspace = { location: FAKE_WORKSPACE_LOCATION } as Workspace;
+
+    await getPackagesFromZip(
+      Buffer.from('fake-zip') as unknown as Uint8Array,
+      false,
+      settings,
+      workspace
+    );
+
+    delete process.env.UPLOAD_BUILD_CONCURRENCY;
+
+    expect(mockPrepareDeckInfoOnly).toHaveBeenCalled();
+    for (const call of mockPrepareDeckInfoOnly.mock.calls) {
+      const [, deckSubWorkspace, outputWorkspace] = call;
+      expect(outputWorkspace).toBe(workspace);
+      expect(outputWorkspace.location).toBe(FAKE_WORKSPACE_LOCATION);
+      expect(deckSubWorkspace.location).not.toBe(FAKE_WORKSPACE_LOCATION);
+    }
+  });
+
   it('falls through to single-file path when only one file is in the zip', async () => {
     const fileNames = ['only.html'];
 

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -48,7 +48,8 @@ async function buildDeckBatch(
           noLimits: paying,
           workspace: deckSubWorkspace,
         },
-        deckSubWorkspace
+        deckSubWorkspace,
+        workspace
       );
     })
   );


### PR DESCRIPTION
## What

#2416 broke multi-HTML zip uploads in prod. The batched Python path put each deck's `.apkg` in a per-deck sub-workspace, but the downstream zip-and-serve flow only inspects the top-level job workspace. Result: every `.apkg` built successfully on disk, but the downloader returned "No decks found in your upload."

Confirmed on prod for job `ea74b55f-d1af-40f1-bd49-4ddbc80de2c8`: 18 `.apkg` files written under `/tmp/workspaces/<job>/<sub-uuid>/<name>.apkg`, none visible at `/tmp/workspaces/<job>/`.

## Why

P0 user-facing regression introduced minutes ago by #2416 (`perf: batched Python invocation for deck building`). Multi-HTML zips are a common upload shape — Notion exports with multiple toggle pages, manual zips, fixture sets — so any user uploading more than one HTML in a zip currently sees an error.

## How

Three lines:

1. `prepareDeckInfoOnly` gains a third parameter `outputWorkspace: Workspace`. The `deckInfoPath` continues to live in the per-deck sub-workspace (still required so the batch manifest's `input` paths don't collide). The `outputPath` is now joined against `outputWorkspace.location` so Python writes the `.apkg` where the downstream serializer looks.
2. `buildDeckBatch` in `getPackagesFromZip.ts` passes the parent `workspace` as the third argument when calling `prepareDeckInfoOnly`. Same workspace pre-#2416 used.
3. New regression test in `getPackagesFromZip.test.ts` (`passes parent workspace as outputWorkspace …`) — asserts that every `prepareDeckInfoOnly` call receives the original `workspace` as `outputWorkspace` and a *different* location for the deck-info sub-workspace. Inspects `mock.calls[i][2]` directly; covers exactly the misroute that broke prod.

No collision risk introduced. Deck filenames are derived from deck titles, and same-title collisions were already last-write-wins before the batched path existed.

## Measuring success

- Prod logs: next multi-HTML zip upload completes with non-zero packages, downloader returns a `.apkg` (not "No decks found").
- The 18 already-built decks in workspace `ea74b55f-d1af-40f1-bd49-4ddbc80de2c8` won't recover automatically — that job is dead. New uploads will work.

## Testing

- Server: 7/7 tests in `getPackagesFromZip.test.ts` pass (including the new regression).
- tsc clean.
- sonar-scanner not run locally (no scanner binary installed — `SONAR_TOKEN` is in env but the CLI isn't on PATH). CI will validate.

## Risks

- Low. The change preserves pre-#2416 behaviour for output paths. The only file-system-level change is *which directory* the `.apkg` lands in; nothing in the Python side changes (the batch manifest already carries explicit absolute `output` paths, so Python writes wherever the manifest says).
- Sub-workspaces still get the `deck_info.json` and intermediate media files. Cleanup of those empty sub-workspaces is a separate concern; they're under `/tmp` and reaped on cycle.

## Goal alignment

Restores multi-HTML zip conversion immediately. Preserves the batched-Python latency win for the common case once the fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->