### PR TITLE
fix: branch limit-state description on trial availability

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -775,4 +775,45 @@ describe('limit state — start trial button', () => {
       expect(title?.textContent).toMatch(/50 MB/i);
     });
   });
+
+  it('shows trial-used description and no trial button when trial_started_at is set (file_size)', async () => {
+    mockUseUserLocals.mockReturnValue({
+      data: {
+        user: { id: 1, trial_started_at: '2025-01-01T00:00:00.000Z' },
+        locals: { owner: 1, patreon: false, subscriber: false, subscriptionInfo: { active: false, email: '', linked_email: '' } },
+        linked_email: '',
+      } as unknown as ReturnType<typeof useUserLocals>['data'],
+      isLoading: false,
+      error: null,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: true,
+      url: 'http://localhost/limit?kind=file_size',
+      status: 200,
+      headers: new Headers({}),
+      blob: () => Promise.resolve(new Blob([])),
+    }));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('[class*="limitContent"]')).not.toBeNull();
+    });
+
+    const trialBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.match(/Start 1-hour trial/i)
+    );
+    expect(trialBtn).toBeUndefined();
+
+    const description = container.querySelector('[class*="limitDescription"]');
+    expect(description?.textContent).not.toMatch(/Start a 1-hour trial/i);
+    expect(description?.textContent).toMatch(/Your trial is used/i);
+  });
 });

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -68,6 +68,20 @@ function getLimitKind(url: URL): 'file_size' | 'card_count' {
   return url.searchParams.get('kind') === 'card_count' ? 'card_count' : 'file_size';
 }
 
+function getLimitDescription(
+  kind: 'file_size' | 'card_count',
+  trialAvailable: boolean
+): string {
+  if (kind === 'file_size') {
+    return trialAvailable
+      ? 'Start a 1-hour trial to convert files of any size, or split the file and try again.'
+      : 'Your trial is used. Split the file, or upgrade to convert files of any size.';
+  }
+  return trialAvailable
+    ? 'Start a 1-hour trial to keep converting, or upgrade for no monthly cap.'
+    : 'Your trial is used. Upgrade for no monthly cap, or wait until next month.';
+}
+
 function formatFileSize(bytes: number): string {
   if (bytes < 1024 * 1024) {
     return `${Math.round(bytes / 1024)} KB`;
@@ -832,9 +846,10 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     const title = isFileSize
       ? 'This file is over the 50 MB limit'
       : 'You reached your monthly limit of 100 cards';
-    const description = isFileSize
-      ? 'Start a 1-hour trial to convert files of any size, or split the file and try again.'
-      : 'Start a 1-hour trial to keep converting, or upgrade for no monthly cap.';
+    const description = getLimitDescription(
+      isFileSize ? 'file_size' : 'card_count',
+      showTrialButton
+    );
 
     return (
       <div className={formStyles.limitContent}>


### PR DESCRIPTION
## Summary

Follow-up to #2432. That PR fixed the silent "Start 1-hour trial" button, but the limit-state description string was left unconditional — so a user who had already consumed their trial would see *"Start a 1-hour trial to convert files of any size..."* with no corresponding button. The page promised something it wasn't offering.

This PR adds the missing branch on trial availability.

## What changed

- Extracted `getLimitDescription(kind, trialAvailable)` as a module-level pure helper.
- Wired `renderLimitState` to pass `showTrialButton` as the trial-availability flag.
- Four-variant matrix now fully covered:
  | kind | trial available | trial used |
  | --- | --- | --- |
  | file_size | Start a 1-hour trial to convert files of any size, or split the file and try again. | Your trial is used. Split the file, or upgrade to convert files of any size. |
  | card_count | Start a 1-hour trial to keep converting, or upgrade for no monthly cap. | Your trial is used. Upgrade for no monthly cap, or wait until next month. |

## Test plan

- [x] New Vitest case in `UploadForm.test.tsx` covering trial-used + file-size — asserts the button is hidden and the description switches to "Your trial is used".
- [x] `pnpm --filter 2anki-web typecheck` clean
- [x] `pnpm --filter 2anki-web lint` clean
- [x] 25/25 tests in `UploadForm.test.tsx` pass
- [ ] Manual: log in, exhaust 1-hour trial (or set `trial_started_at` to a past date in DB), upload a 60 MB file, confirm the inline limit state shows "Your trial is used. Split the file, or upgrade to convert files of any size." with only the *See upgrade options* and *Try a different file* actions.

No changelog entry — the user-visible-capability line in #2432 ("Start 1-hour trial on the upload limit screen now actually starts the trial and resumes your upload") covers this correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->