### PR TITLE
fix: cascade Notion-conversion delete so one click clears job + apkg

### DIFF
--- a/src/controllers/JobController.test.ts
+++ b/src/controllers/JobController.test.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import JobController from './JobController';
 import JobService from '../services/JobService';
+import DeleteJobUseCase from '../usecases/jobs/DeleteJobUseCase';
 import * as getOwnerModule from '../lib/User/getOwner';
 
 describe('JobController', () => {
   let jobService: JobService;
+  let deleteJobUseCase: DeleteJobUseCase;
   let jobController: JobController;
   let req: Partial<express.Request>;
   let res: Partial<express.Response>;
@@ -15,7 +17,10 @@ describe('JobController', () => {
       deleteJobById: jest.fn(),
       findJobByObjectId: jest.fn(),
     } as unknown as JobService;
-    jobController = new JobController(jobService);
+    deleteJobUseCase = {
+      execute: jest.fn(),
+    } as unknown as DeleteJobUseCase;
+    jobController = new JobController(jobService, deleteJobUseCase);
     req = { params: { id: '123' } };
     res = {
       send: jest.fn(),
@@ -127,19 +132,19 @@ describe('JobController', () => {
     expect(sent[0].download_key).toBeNull();
   });
 
-  it('should delete job by owner and send 200', async () => {
-    (jobService.deleteJobById as jest.Mock).mockResolvedValue(undefined);
+  it('should delegate delete to the use case and send 200', async () => {
+    (deleteJobUseCase.execute as jest.Mock).mockResolvedValue(undefined);
     await jobController.deleteJobByOwner(
       req as express.Request,
       res as express.Response
     );
-    expect(jobService.deleteJobById).toHaveBeenCalledWith('123', 'owner1');
+    expect(deleteJobUseCase.execute).toHaveBeenCalledWith('123', 'owner1');
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalled();
   });
 
   it('should handle error in deleteJobByOwner', async () => {
-    (jobService.deleteJobById as jest.Mock).mockRejectedValue(
+    (deleteJobUseCase.execute as jest.Mock).mockRejectedValue(
       new Error('fail')
     );
     await jobController.deleteJobByOwner(
@@ -151,7 +156,7 @@ describe('JobController', () => {
   });
 
   it('should handle job in progress error with 409 status', async () => {
-    (jobService.deleteJobById as jest.Mock).mockRejectedValue(
+    (deleteJobUseCase.execute as jest.Mock).mockRejectedValue(
       new Error('Cannot delete job while it is in progress')
     );
     await jobController.deleteJobByOwner(
@@ -159,8 +164,8 @@ describe('JobController', () => {
       res as express.Response
     );
     expect(res.status).toHaveBeenCalledWith(409);
-    expect(res.json).toHaveBeenCalledWith({ 
-      error: 'Cannot delete job while it is in progress' 
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Cannot delete job while it is in progress',
     });
   });
 

--- a/src/controllers/JobController.ts
+++ b/src/controllers/JobController.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import JobService from '../services/JobService';
 import { JobWithDownloadKey } from '../data_layer/JobRepository';
 import { getOwner } from '../lib/User/getOwner';
+import DeleteJobUseCase from '../usecases/jobs/DeleteJobUseCase';
 
 interface JobListItem extends JobWithDownloadKey {
   restartable: boolean;
@@ -29,7 +30,10 @@ function toJobListItem(job: JobWithDownloadKey): JobListItem {
 }
 
 class JobController {
-  constructor(private readonly service: JobService) {}
+  constructor(
+    private readonly service: JobService,
+    private readonly deleteJobUseCase: DeleteJobUseCase
+  ) {}
 
   async getJobsByOwner(_req: express.Request, res: express.Response) {
     const owner = getOwner(res);
@@ -75,7 +79,7 @@ class JobController {
   async deleteJobByOwner(req: express.Request, res: express.Response) {
     try {
       const id = req.params.id;
-      await this.service.deleteJobById(id, getOwner(res));
+      await this.deleteJobUseCase.execute(id, getOwner(res));
 
       res.status(200).send();
     } catch (error) {

--- a/src/controllers/Upload/DropboxController.test.ts
+++ b/src/controllers/Upload/DropboxController.test.ts
@@ -31,6 +31,7 @@ function makeController(
     deleteUpload: jest.fn().mockResolvedValue(1),
     getUploadsByOwner: jest.fn().mockResolvedValue([]),
     findByIdAndOwner: jest.fn().mockResolvedValue(null),
+    findByKey: jest.fn().mockResolvedValue(null),
     update: jest.fn().mockResolvedValue([]),
     getLastUploadForUser: jest.fn().mockResolvedValue(null),
   };

--- a/src/controllers/Upload/GoogleDriveController.test.ts
+++ b/src/controllers/Upload/GoogleDriveController.test.ts
@@ -30,6 +30,7 @@ function makeController(
     deleteUpload: jest.fn().mockResolvedValue(1),
     getUploadsByOwner: jest.fn().mockResolvedValue([]),
     findByIdAndOwner: jest.fn().mockResolvedValue(null),
+    findByKey: jest.fn().mockResolvedValue(null),
     update: jest.fn().mockResolvedValue([]),
     getLastUploadForUser: jest.fn().mockResolvedValue(null),
   };

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -37,6 +37,12 @@ describe('Upload file', () => {
       ): Promise<Uploads | null> {
         return Promise.resolve(null);
       },
+      findByKey: function (
+        _owner: number,
+        _key: string
+      ): Promise<Uploads | null> {
+        return Promise.resolve(null);
+      },
       update: function (
         owner: number,
         filename: string,

--- a/src/data_layer/JobRepository.ts
+++ b/src/data_layer/JobRepository.ts
@@ -31,6 +31,13 @@ class JobRepository {
     });
   }
 
+  deleteJobByObjectId(objectId: string, owner: string): Promise<number> {
+    return this.database(this.tableName).delete().where({
+      object_id: objectId,
+      owner: owner,
+    });
+  }
+
   create(id: string, owner: string, title?: string | null, type?: string) {
     return this.database(this.tableName)
       .insert({

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -10,6 +10,7 @@ export interface IUploadRepository {
   deleteUpload(owner: number, key: string): Promise<number>;
   getUploadsByOwner(owner: number): Promise<Uploads[]>;
   findByIdAndOwner(id: number, owner: number): Promise<Uploads | null>;
+  findByKey(owner: number, key: string): Promise<Uploads | null>;
   update(
     owner: number,
     filename: string,
@@ -51,6 +52,17 @@ class UploadRepository implements IUploadRepository {
     const row = await this.database<Uploads>(this.table)
       .select('*')
       .where({ id, owner })
+      .first();
+    return row ?? null;
+  }
+
+  async findByKey(owner: number, key: string): Promise<Uploads | null> {
+    if (owner == null || key == null) {
+      return null;
+    }
+    const row = await this.database<Uploads>(this.table)
+      .select('*')
+      .where({ owner, key })
       .first();
     return row ?? null;
   }

--- a/src/routes/UploadRouter.ts
+++ b/src/routes/UploadRouter.ts
@@ -20,17 +20,25 @@ import { GetDropboxUploadsUseCase } from '../usecases/uploads/GetDropboxUploadsU
 import { DeleteDropboxUploadUseCase } from '../usecases/uploads/DeleteDropboxUploadUseCase';
 import { GetGoogleDriveUploadsUseCase } from '../usecases/uploads/GetGoogleDriveUploadsUseCase';
 import { DeleteGoogleDriveUploadUseCase } from '../usecases/uploads/DeleteGoogleDriveUploadUseCase';
+import DeleteJobUseCase from '../usecases/jobs/DeleteJobUseCase';
 
 const UploadRouter = () => {
   const router = express.Router();
   const database = getDatabase();
+  const jobRepository = new JobRepository(database);
+  const jobService = new JobService(jobRepository);
+  const uploadService = new UploadService(
+    new UploadRepository(database),
+    jobRepository
+  );
   const jobController = new JobController(
-    new JobService(new JobRepository(database))
+    jobService,
+    new DeleteJobUseCase(jobService, uploadService)
   );
   const dropboxRepository = new DropboxRepository(database);
   const googleDriveRepository = new GoogleDriveRepository(database);
   const uploadController = new UploadController(
-    new UploadService(new UploadRepository(database), new JobRepository(database)),
+    uploadService,
     new NotionService(
       new NotionRepository(database),
       undefined,

--- a/src/services/JobService.test.ts
+++ b/src/services/JobService.test.ts
@@ -1,0 +1,77 @@
+import JobService from './JobService';
+import JobRepository, {
+  JobWithDownloadKey,
+} from '../data_layer/JobRepository';
+
+function makeJob(overrides: Partial<JobWithDownloadKey> = {}): JobWithDownloadKey {
+  return {
+    id: 42,
+    owner: '1',
+    object_id: 'obj',
+    status: 'done',
+    created_at: new Date(),
+    last_edited_time: new Date(),
+    title: 'Deck',
+    type: 'page',
+    job_reason_failure: '',
+    card_count: 1,
+    download_key: null,
+    upload_id: null,
+    ...overrides,
+  } as unknown as JobWithDownloadKey;
+}
+
+
+describe('JobService.deleteJobById', () => {
+  let repository: jest.Mocked<JobRepository>;
+  let service: JobService;
+
+  beforeEach(() => {
+    repository = {
+      getJobsByOwner: jest.fn(),
+      deleteJob: jest.fn().mockResolvedValue(1),
+    } as unknown as jest.Mocked<JobRepository>;
+    service = new JobService(repository);
+  });
+
+  it('returns the job (with download_key) after deleting it', async () => {
+    const job = makeJob({ download_key: 'k.apkg' });
+    repository.getJobsByOwner.mockResolvedValue([job]);
+
+    const result = await service.deleteJobById('42', '1');
+
+    expect(repository.deleteJob).toHaveBeenCalledWith('42', '1');
+    expect(result).toBe(job);
+  });
+
+  it('returns null when no matching job is found', async () => {
+    repository.getJobsByOwner.mockResolvedValue([]);
+
+    const result = await service.deleteJobById('42', '1');
+
+    expect(repository.deleteJob).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('throws when the job is still in progress', async () => {
+    repository.getJobsByOwner.mockResolvedValue([
+      makeJob({ status: 'started' }),
+    ]);
+
+    await expect(service.deleteJobById('42', '1')).rejects.toThrow(
+      'Cannot delete job while it is in progress'
+    );
+    expect(repository.deleteJob).not.toHaveBeenCalled();
+  });
+
+  it('throws when the job is in a step status', async () => {
+    repository.getJobsByOwner.mockResolvedValue([
+      makeJob({ status: 'step2_extracting' }),
+    ]);
+
+    await expect(service.deleteJobById('42', '1')).rejects.toThrow(
+      'Cannot delete job while it is in progress'
+    );
+    expect(repository.deleteJob).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/JobService.ts
+++ b/src/services/JobService.ts
@@ -7,24 +7,23 @@ class JobService {
     return this.repository.getJobsByOwner(owner);
   }
 
-  async deleteJobById(id: string, owner: string) {
-    // The id parameter here is actually the database primary key (job.id)
-    // We need to find the job by its database ID first to check its status
+  async deleteJobById(
+    id: string,
+    owner: string
+  ): Promise<JobWithDownloadKey | null> {
     const jobs = await this.repository.getJobsByOwner(owner);
     const job = jobs.find((j) => j.id.toString() === id);
 
     if (!job) {
-      // Job doesn't exist, nothing to do
-      return;
+      return null;
     }
 
-    // Prevent deleting jobs that are in progress
     if (job.status === 'started' || job.status.startsWith('step')) {
       throw new Error('Cannot delete job while it is in progress');
     }
 
-    // Delete the job using the database ID
-    return this.repository.deleteJob(id, owner);
+    await this.repository.deleteJob(id, owner);
+    return job;
   }
 
   findJobByObjectId(objectId: string, owner: string) {

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -21,6 +21,16 @@ jest.mock('../services/SubscriptionService', () => ({
   default: { findActiveStripeSubscriptions: jest.fn().mockResolvedValue([]) },
 }));
 
+const mockStorageDelete = jest.fn().mockResolvedValue(true);
+jest.mock('../lib/storage/StorageHandler', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      delete: mockStorageDelete,
+    })),
+  };
+});
+
 import GeneratePackagesUseCase from '../usecases/uploads/GeneratePackagesUseCase';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { DeckTooLargeError } from '../lib/parser/exporters/DeckTooLargeError';
@@ -36,6 +46,7 @@ function buildRepository(): IUploadRepository {
     deleteUpload: (_owner: number, _key: string) => Promise.resolve(1),
     getUploadsByOwner: (_owner: number) => Promise.resolve([] as Uploads[]),
     findByIdAndOwner: (_id: number, _owner: number) => Promise.resolve(null),
+    findByKey: (_owner: number, _key: string) => Promise.resolve(null),
     update: (_owner: number, _filename: string, _key: string, _size_mb: number) =>
       Promise.resolve([] as Uploads[]),
     getLastUploadForUser: (_userId: number) => Promise.resolve(null),
@@ -176,5 +187,83 @@ describe('UploadService.handleUpload — error paths', () => {
     const body = capturedJson() as { message: string };
     expect(body.message).not.toMatch(/at .*\(/);
     expect(body.message).not.toMatch(/RangeError/);
+  });
+});
+
+describe('UploadService.deleteUpload — cascade', () => {
+  beforeEach(() => {
+    mockStorageDelete.mockClear();
+  });
+
+  it('removes the upload row, the S3 object, and the linked job', async () => {
+    const repo: IUploadRepository = {
+      ...buildRepository(),
+      findByKey: jest.fn().mockResolvedValue({
+        id: 1,
+        owner: 7,
+        key: 'k.apkg',
+        filename: 'k.apkg',
+        object_id: 'obj-123',
+        size_mb: 1,
+        created_at: new Date(),
+      } as Uploads),
+      deleteUpload: jest.fn().mockResolvedValue(1),
+    };
+    const jobRepository = {
+      deleteJobByObjectId: jest.fn().mockResolvedValue(1),
+    } as unknown as JobRepository;
+
+    const service = new UploadService(repo, jobRepository);
+    await service.deleteUpload(7, 'k.apkg');
+
+    expect(repo.findByKey).toHaveBeenCalledWith(7, 'k.apkg');
+    expect(repo.deleteUpload).toHaveBeenCalledWith(7, 'k.apkg');
+    expect(mockStorageDelete).toHaveBeenCalledWith('k.apkg');
+    expect(jobRepository.deleteJobByObjectId).toHaveBeenCalledWith(
+      'obj-123',
+      '7'
+    );
+  });
+
+  it('skips the job delete when the upload row has no object_id', async () => {
+    const repo: IUploadRepository = {
+      ...buildRepository(),
+      findByKey: jest.fn().mockResolvedValue({
+        id: 1,
+        owner: 7,
+        key: 'k.apkg',
+        filename: 'k.apkg',
+        object_id: null,
+        size_mb: 1,
+        created_at: new Date(),
+      } as Uploads),
+      deleteUpload: jest.fn().mockResolvedValue(1),
+    };
+    const jobRepository = {
+      deleteJobByObjectId: jest.fn(),
+    } as unknown as JobRepository;
+
+    const service = new UploadService(repo, jobRepository);
+    await service.deleteUpload(7, 'k.apkg');
+
+    expect(repo.deleteUpload).toHaveBeenCalledWith(7, 'k.apkg');
+    expect(mockStorageDelete).toHaveBeenCalledWith('k.apkg');
+    expect(jobRepository.deleteJobByObjectId).not.toHaveBeenCalled();
+  });
+
+  it('skips the job delete when no matching upload row exists', async () => {
+    const repo: IUploadRepository = {
+      ...buildRepository(),
+      findByKey: jest.fn().mockResolvedValue(null),
+      deleteUpload: jest.fn().mockResolvedValue(0),
+    };
+    const jobRepository = {
+      deleteJobByObjectId: jest.fn(),
+    } as unknown as JobRepository;
+
+    const service = new UploadService(repo, jobRepository);
+    await service.deleteUpload(7, 'k.apkg');
+
+    expect(jobRepository.deleteJobByObjectId).not.toHaveBeenCalled();
   });
 });

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -172,9 +172,16 @@ class UploadService {
   }
 
   async deleteUpload(owner: number, key: string) {
+    const upload = await this.uploadRepository.findByKey(owner, key);
     const s = new StorageHandler();
     await this.uploadRepository.deleteUpload(owner, key);
     await s.delete(key);
+    if (upload?.object_id) {
+      await this.jobRepository.deleteJobByObjectId(
+        upload.object_id,
+        String(owner)
+      );
+    }
   }
 
   async handleUpload(req: express.Request, res: express.Response) {

--- a/src/usecases/jobs/DeleteJobUseCase.test.ts
+++ b/src/usecases/jobs/DeleteJobUseCase.test.ts
@@ -1,0 +1,67 @@
+import DeleteJobUseCase from './DeleteJobUseCase';
+import JobService from '../../services/JobService';
+import UploadService from '../../services/UploadService';
+import { JobWithDownloadKey } from '../../data_layer/JobRepository';
+
+describe('DeleteJobUseCase', () => {
+  let jobService: jest.Mocked<JobService>;
+  let uploadService: jest.Mocked<UploadService>;
+  let useCase: DeleteJobUseCase;
+
+  beforeEach(() => {
+    jobService = {
+      deleteJobById: jest.fn(),
+    } as unknown as jest.Mocked<JobService>;
+    uploadService = {
+      deleteUpload: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<UploadService>;
+    useCase = new DeleteJobUseCase(jobService, uploadService);
+  });
+
+  it('deletes the job and its linked upload when download_key is present', async () => {
+    const job = {
+      id: 99,
+      owner: '1',
+      download_key: 'abc.apkg',
+    } as unknown as JobWithDownloadKey;
+    jobService.deleteJobById.mockResolvedValue(job);
+
+    await useCase.execute('99', '1');
+
+    expect(jobService.deleteJobById).toHaveBeenCalledWith('99', '1');
+    expect(uploadService.deleteUpload).toHaveBeenCalledWith(1, 'abc.apkg');
+  });
+
+  it('skips upload deletion when the job has no download_key', async () => {
+    const job = {
+      id: 99,
+      owner: '1',
+      download_key: null,
+    } as unknown as JobWithDownloadKey;
+    jobService.deleteJobById.mockResolvedValue(job);
+
+    await useCase.execute('99', '1');
+
+    expect(jobService.deleteJobById).toHaveBeenCalledWith('99', '1');
+    expect(uploadService.deleteUpload).not.toHaveBeenCalled();
+  });
+
+  it('does nothing extra when the job does not exist', async () => {
+    jobService.deleteJobById.mockResolvedValue(null);
+
+    await useCase.execute('99', '1');
+
+    expect(uploadService.deleteUpload).not.toHaveBeenCalled();
+  });
+
+  it('propagates the in-progress error and does not touch uploads', async () => {
+    jobService.deleteJobById.mockRejectedValue(
+      new Error('Cannot delete job while it is in progress')
+    );
+
+    await expect(useCase.execute('99', '1')).rejects.toThrow(
+      'Cannot delete job while it is in progress'
+    );
+    expect(uploadService.deleteUpload).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/jobs/DeleteJobUseCase.ts
+++ b/src/usecases/jobs/DeleteJobUseCase.ts
@@ -1,0 +1,21 @@
+import JobService from '../../services/JobService';
+import UploadService from '../../services/UploadService';
+
+class DeleteJobUseCase {
+  constructor(
+    private readonly jobService: JobService,
+    private readonly uploadService: UploadService
+  ) {}
+
+  async execute(jobId: string, owner: string): Promise<void> {
+    const deleted = await this.jobService.deleteJobById(jobId, owner);
+    if (deleted?.download_key) {
+      await this.uploadService.deleteUpload(
+        Number(owner),
+        deleted.download_key
+      );
+    }
+  }
+}
+
+export default DeleteJobUseCase;

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -28,6 +28,7 @@ function makeUploadRepo(lastUpload: LastUpload | null = null): jest.Mocked<IUplo
     deleteUpload: jest.fn(),
     getUploadsByOwner: jest.fn(),
     findByIdAndOwner: jest.fn(),
+    findByKey: jest.fn(),
     update: jest.fn(),
     getLastUploadForUser: jest.fn().mockResolvedValue(lastUpload),
   };

--- a/src/usecases/ops/SendInactivityWarningsUseCase.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.ts
@@ -12,6 +12,7 @@ class NoOpUploadRepository implements IUploadRepository {
   deleteUpload(): Promise<number> { return Promise.resolve(0); }
   getUploadsByOwner(): Promise<never[]> { return Promise.resolve([]); }
   findByIdAndOwner(): Promise<null> { return Promise.resolve(null); }
+  findByKey(): Promise<null> { return Promise.resolve(null); }
   update(): Promise<never[]> { return Promise.resolve([]); }
   getLastUploadForUser(): Promise<null> { return Promise.resolve(null); }
 }

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -193,6 +193,16 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
 
   const activeJobs = jobs.filter((j) => isActiveJob(j.status));
 
+  const handleDeleteJob = async (id: Parameters<typeof deleteJob>[0]) => {
+    await deleteJob(id);
+    await refreshUploads();
+  };
+
+  const handleDeleteUpload = async (key: string) => {
+    await deleteUpload(key);
+    await refreshJobs();
+  };
+
   if (error) {
     redirectOnError(error);
     return null;
@@ -292,7 +302,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                   )}
                                   <button
                                     type="button"
-                                    onClick={() => deleteJob(row.job.id)}
+                                    onClick={() => handleDeleteJob(row.job.id)}
                                     className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                                     aria-label={`Delete ${row.job.title}`}
                                     title={isFailedJob(row.job.status) ? 'Delete' : 'Cancel'}
@@ -361,7 +371,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                   )}
                                   <button
                                     type="button"
-                                    onClick={() => deleteUpload(u.key)}
+                                    onClick={() => handleDeleteUpload(u.key)}
                                     className={`${styles.iconButton} ${styles.iconButtonDanger}`}
                                     aria-label={`Delete ${u.filename}`}
                                     title="Delete"

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Deleting a Notion conversion from Downloads removes it in one click instead of two', date: '2026-05-18' },
   { type: 'fix', title: 'Start 1-hour trial on the upload limit screen now actually starts the trial and resumes your upload', date: '2026-05-18' },
   { type: 'style', title: 'Upload page tips dismiss with an ✕ once you know the workflow, and the page stays cleaner above the upload form', date: '2026-05-18' },
   { type: 'fix', title: 'AI-generated decks from uploads with German, Swedish, or other non-English text convert into a finished deck', date: '2026-05-18' },


### PR DESCRIPTION
## Summary
- A Notion conversion writes both a `jobs` row and an `uploads` row; the Downloads page renders them in two sections and each had its own independent delete. Removing a conversion took two clicks and left an orphan upload (DB row + S3 object) or an orphan job, depending on which side you started from.
- `DeleteJobUseCase` (new) orchestrates job deletion + cascading to the linked upload via `UploadService.deleteUpload`. The use case lives in `src/usecases/jobs/` because crossing the job → upload + S3 boundary is orchestration, not reusable domain logic.
- `UploadService.deleteUpload` is now symmetric: it looks up the upload by key, deletes the row + S3 object, then deletes any matching job by `object_id`. Underpinned by two new repository methods: `UploadRepository.findByKey` and `JobRepository.deleteJobByObjectId`.
- `JobService.deleteJobById` now returns the deleted job (so the use case can read `download_key` without a second DB lookup) instead of `void`. Existing in-progress-status validation is unchanged.
- `DownloadsPage.tsx` calls the opposite list's refresh function after each delete so the UI mirrors the new server cascade immediately, no waiting for the 10 s poll.
- Changelog entry added.

## Trio
- **PM** — cascade both directions; scope to all job-sourced types (Notion / Dropbox / Google Drive); no confirm dialog.
- **Designer** — wanted a window.confirm; logged as follow-up. Renamed sections also deferred (out of scope for a fix).
- **Engineer** — flagged that upload_id is a JOIN alias not a column; suggested DB-first ordering since StorageHandler.delete already swallows errors.

Confirm-dialog conflict resolved in favor of PM: today's delete is already silent and irreversible — the only thing changing is that one click finishes the job instead of two. Adding a dialog now would feel like punishing the user for the bug.

## What still needs decisions (follow-ups, not in this PR)
- Add a window.confirm on the delete affordance (designer's call) — separate PR.
- Rename Downloads sections to Decks / Direct uploads — separate PR.

## Sonar
SonarCloud has automatic analysis enabled on this project, so the manual `sonar-scanner` run is blocked locally. Auto-analysis will run on this PR.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm --filter 2anki-web typecheck`, `lint`, `test:run` clean
- [x] New tests: DeleteJobUseCase.test.ts, JobService.test.ts, cascade describe block in UploadService.test.ts
- [x] Updated tests: JobController.test.ts (new constructor + delegation)
- [x] All *UploadRepository implementers updated for the new findByKey method
- [ ] `/security-review` (touches user data deletion + S3) — running after this PR opens
- [ ] Manual: delete a Notion conversion from the Downloads page, confirm both rows disappear from a single click and the S3 object is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->