### PR TITLE
fix: sanitize path separators in deck filename

### DIFF
--- a/src/lib/anki/getDeckFilename.test.ts
+++ b/src/lib/anki/getDeckFilename.test.ts
@@ -12,3 +12,17 @@ test("does not append .apkg extension if it's already there", () => {
 test("uses package name if it's available", () => {
   expect(getDeckFilename(new Package('foo'))).toEqual('foo.apkg');
 });
+
+test('replaces forward slashes in the name with dashes', () => {
+  expect(getDeckFilename('Red Flags / Urgent Referral Criteria')).toEqual(
+    'Red Flags - Urgent Referral Criteria.apkg'
+  );
+});
+
+test('replaces backslashes with dashes', () => {
+  expect(getDeckFilename('a\\b\\c')).toEqual('a-b-c.apkg');
+});
+
+test('replaces null bytes with dashes', () => {
+  expect(getDeckFilename('a\0b')).toEqual('a-b.apkg');
+});

--- a/src/lib/anki/getDeckFilename.ts
+++ b/src/lib/anki/getDeckFilename.ts
@@ -1,4 +1,5 @@
 import Package from '../parser/Package';
+import { getSafeFilename } from '../getSafeFilename';
 
 function isPackage(something: unknown): something is Package {
   return something instanceof Package;
@@ -15,5 +16,6 @@ export default function getDeckFilename(something: Package | string): string {
   } else if (isString(something)) {
     name = something;
   }
-  return name.endsWith('.apkg') ? name : `${name}.apkg`;
+  const safe = getSafeFilename(name);
+  return safe.endsWith('.apkg') ? safe : `${safe}.apkg`;
 }

--- a/src/lib/getSafeFilename.test.ts
+++ b/src/lib/getSafeFilename.test.ts
@@ -3,3 +3,11 @@ import { getSafeFilename } from './getSafeFilename';
 test('returns filename without slashes', () => {
   expect(getSafeFilename('x/y/z')).toBe('x-y-z');
 });
+
+test('replaces backslashes with dashes', () => {
+  expect(getSafeFilename('x\\y\\z')).toBe('x-y-z');
+});
+
+test('replaces null bytes with dashes', () => {
+  expect(getSafeFilename('x\0y')).toBe('x-y');
+});

--- a/src/lib/getSafeFilename.ts
+++ b/src/lib/getSafeFilename.ts
@@ -1,3 +1,3 @@
 export function getSafeFilename(name: string) {
-  return name.replace(/\//g, '-');
+  return name.replace(/[/\\\0]/g, '-');
 }

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Notion pages with a slash in the title convert into a deck instead of failing silently', date: '2026-05-19' },
   { type: 'style', title: 'Multiple choice cards — correct rows stand out with a deeper green tint and a green rule on the left', date: '2026-05-18' },
   { type: 'fix', title: 'Deleting a Notion conversion from Downloads removes it in one click instead of two', date: '2026-05-18' },
   { type: 'fix', title: 'Start 1-hour trial on the upload limit screen now actually starts the trial and resumes your upload', date: '2026-05-18' },


### PR DESCRIPTION
## Summary
- Notion page titles containing `/` (e.g. `Red Flags / Urgent Referral Criteria`) crashed the deck-builder worker at `create_deck.py:215` (`os.replace`), because `getDeckFilename` produced a basename with an embedded `/` and `path.join` preserved it. The destination resolved to a non-existent subdirectory and the conversion failed silently — four crash emails landed in <12 hours from one user retrying the same page.
- Fix is contained to the TS helper. `getDeckFilename` now routes the name through `getSafeFilename`, which is extended to handle both path separators (`/`, `\`) and the NUL byte. The in-Anki deck display name is untouched — only the filename component is rewritten.
- Changelog: `Notion pages with a slash in the title convert into a deck instead of failing silently`.

Triage notes for the underlying user signal: 3 themes, 2 high-urgency. This PR closes Theme 1. Theme 2 (worker crashes are silent in-app) is a separate UX change and not in scope here — a follow-up issue is queued.

## Test plan
- [x] `pnpm test src/lib/anki/getDeckFilename.test.ts src/lib/getSafeFilename.test.ts` — green (new cases cover `/`, `\`, `\0`)
- [x] `pnpm test src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts src/lib/anki/CardGenerator.batch.test.ts` — green
- [x] `pnpm typecheck`, `pnpm --filter 2anki-web typecheck`, `pnpm --filter 2anki-web test:run`, `pnpm --filter 2anki-web lint` — all green
- [ ] `sonar-scanner` — not run locally; will surface after push

Pre-existing failures on `main` in `DownloadController`/`DownloadPage`/`ErrorHandler` suites are unrelated to this change (confirmed by stashing the diff and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->