### PR TITLE
docs: add assumption-surfacing and trace-to-request process rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ Every PR is checked against both — does it make the experience simpler/faster/
 
 ## Process
 
+- Surface assumptions before coding. If a request has multiple valid interpretations, present them — don't pick silently. If something is unclear, stop and ask. If a simpler approach exists, say so.
+- Every changed line should trace directly to the user's request. If a diff includes lines that don't connect back to what was asked, remove them before committing.
 - TDD by default: failing test → verify it fails for the right reason → simplest pass → refactor. If asked to skip tests, confirm first.
 - Outside-in testing. Mock only external dependencies (HTTP, third-party APIs, email) — never internal services.
 - A passing suite is not proof of correctness — review affected user flows for regressions before committing.


### PR DESCRIPTION
## Summary

- Add explicit rule to surface assumptions before coding — present multiple interpretations instead of picking silently, stop and ask when unclear
- Add "every changed line traces to the request" heuristic — a single self-check that replaces scanning 15 individual prohibitions in the code-quality rules

Inspired by [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills), which distills Karpathy's LLM coding critique into four principles. Our CLAUDE.md already covered ~80% of the same ground; these two lines close the remaining gaps.

No changelog entry — internal docs, no user-visible behavior change.

## Test plan

- [ ] Verify the two new bullets render correctly in the Process section
- [ ] Confirm no existing rules were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->