### PR TITLE
chore: allow post-merge cleanup commands without permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,11 @@
   "permissions": {
     "allow": [
       "Bash(git commit *)",
+      "Bash(git branch -D *)",
+      "Bash(git branch -d *)",
+      "Bash(git fetch --prune *)",
+      "Bash(git worktree remove *)",
+      "Bash(git worktree prune)",
 
       "Write(src/**/*.test.ts)",
       "Write(web/src/**/*.test.ts)",


### PR DESCRIPTION
## Summary

- Add `git branch -D`, `git branch -d`, `git fetch --prune`, `git worktree remove`, and `git worktree prune` to the project-level permission allow list
- These are the post-merge cleanup commands documented in `CLAUDE.md` under Git — they should run automatically without prompting on any machine

No changelog entry — internal tooling, no user-visible behavior change.

## Test plan

- [ ] Clone fresh, run Claude Code, merge a PR — cleanup commands should not prompt for permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->