### PR TITLE
docs: require user-docs update in /implement workflow

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -34,8 +34,9 @@ When `$ARGUMENTS` is a PR number or URL (or you can find a draft PR titled `spec
      -m "Spec text preserved in git history: git log -p -- Documentation/specs/<slug>.md"
    ```
 6. **Add a changelog entry if this PR changes user-visible behavior.** See CLAUDE.md > Changelog for the rules (file path, when to add, voice). One line, user-facing prose — no implementation details. If you can't write the entry without referencing internal code, the PR probably doesn't need one. Commit as `chore: add changelog entry for <feature>`.
-7. Run `/check` (parallel tsc + web typecheck + web vitest + web lint). All green before flipping the PR.
-8. Graduate the PR from draft to ready, and rename the title to match the implementation prefix:
+7. **Update user docs if this PR adds or changes a user-visible feature.** User docs live at `web/src/pages/DocsPage/content/` (rendered in-app at 2anki.net/docs). Add a new MDX file or update an existing one whenever you ship: a new input format, a new converter capability, a changed flow the existing docs already describe, or a new account-level feature. The trigger is stricter than the changelog rule — skip when: pure bug fix (the docs were already correct), internal refactor, copy-only tweak, or a change so small a user would never look it up. Follow VOICE.md for prose; sentence-case headings; no implementation details. If you add a new MDX page, register it in `web/src/pages/DocsPage/sidebar.ts` so it shows up in navigation. Commit as `docs: update user docs for <feature>`.
+8. Run `/check` (parallel tsc + web typecheck + web vitest + web lint). All green before flipping the PR.
+9. Graduate the PR from draft to ready, and rename the title to match the implementation prefix:
    ```
    gh pr edit <n> --title "<type>: <feature name>"   # feat: / fix: / refactor: / ...
    gh pr ready <n>
@@ -45,6 +46,7 @@ When `$ARGUMENTS` is a PR number or URL (or you can find a draft PR titled `spec
 Before merging:
 - All checks green.
 - Changelog entry added if the PR is user-visible (or explicit note in the PR body that no entry is warranted).
+- User docs updated if the PR adds or changes a user-visible feature (or explicit note in the PR body that none are needed).
 - If user-facing, ping the `designer` agent for a review pass.
 - If the change touches auth, payments, or external-API integration, run `/security-review` first.
 - Note goal alignment in the PR body (per `CLAUDE.md`).
@@ -56,7 +58,7 @@ If `$ARGUMENTS` is a raw spec (pasted body or a path to a `.md` file with no ass
 1. Read the spec.
 2. Follow the engineer workflow above.
 3. Suggest a branch name. Format: `<type>/<short-slug>` using a conventional commit prefix (`fix/`, `feat/`, `chore/`, `refactor/`, `test/`). Do **not** use `docs/` for an implementation branch.
-4. Once confirmed, create the branch, commit in logical chunks. If the work changes user-visible behavior, add a changelog entry per CLAUDE.md > Changelog (separate `chore: add changelog entry …` commit). Run `/check`, then open the PR (not draft) with `gh pr create` using the engineer template.
+4. Once confirmed, create the branch, commit in logical chunks. If the work changes user-visible behavior, add a changelog entry per CLAUDE.md > Changelog (separate `chore: add changelog entry …` commit). If the work adds or changes a user-visible feature (stricter than the changelog trigger — see step 7 of the primary path), also update the in-app user docs under `web/src/pages/DocsPage/content/` and register any new MDX page in `web/src/pages/DocsPage/sidebar.ts`, in a separate `docs: update user docs …` commit. Run `/check`, then open the PR (not draft) with `gh pr create` using the engineer template.
 
 In this path there is no spec file in the repo to remove — skip the spec-cleanup commit.
 


### PR DESCRIPTION
## Summary
- New step #7 in `.claude/commands/implement.md` primary path: when shipping a user-visible feature, update `web/src/pages/DocsPage/content/` (in-app docs at 2anki.net/docs) and register any new MDX page in `web/src/pages/DocsPage/sidebar.ts`.
- Stricter trigger than the existing changelog rule — skip pure bug fixes, internal refactors, copy-only tweaks, and changes a user would never look up.
- Matching bullet added to the "Before merging" checklist and to the Fallback (no-spec-PR) flow.

## Why
The changelog rule already captures "what's new" as a one-liner. The user-docs surface is separate — it's the prose how-tos a user reads when they need to *learn* a feature. Today a feat: PR can land with a changelog entry and zero docs update, leaving 2anki.net/docs to drift behind the product. This rule closes that gap without creating noise for bug-fix PRs.

## Test plan
- [ ] Next `/implement` run for a `feat:` PR produces a `docs: update user docs for …` commit alongside the changelog commit
- [ ] Next `/implement` run for a pure bug fix does NOT produce a user-docs commit (and notes "no docs change needed" in the PR body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->