### PR TITLE
feat: single CTA on anonymous limit screen — create account and start trial atomically

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -23,6 +23,19 @@ jest.mock('../lib/misc/hashToken', () => ({
   default: jest.fn().mockReturnValue('hashed-token'),
 }));
 
+const mockMarkTrialStarted = jest.fn().mockResolvedValue(undefined);
+const mockGetById = jest.fn().mockResolvedValue({ patreon: false, trial_started_at: null });
+
+jest.mock('../data_layer/UsersRepository', () => {
+  return jest.fn().mockImplementation(() => ({
+    setSignupCountryIfMissing: jest.fn().mockResolvedValue(undefined),
+    getSignupCountry: jest.fn().mockResolvedValue(null),
+    markTrialStarted: mockMarkTrialStarted,
+    getById: mockGetById,
+    getCardUsage: jest.fn().mockResolvedValue({ cards_used: 0 }),
+  }));
+});
+
 import UsersController from './UsersControllers';
 import UsersService, { MagicLinkRateLimitError } from '../services/UsersService';
 import AuthenticationService from '../services/AuthenticationService';
@@ -195,6 +208,66 @@ describe('UsersController.register', () => {
       'al@example.com',
       null
     );
+  });
+
+  it('starts the trial after registration when start_trial flag is set', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const newJWTToken = jest.fn().mockResolvedValue('jwt-trial-tok');
+    const persistToken = jest.fn().mockResolvedValue(undefined);
+    const updateLastLoginAt = jest.fn().mockResolvedValue(undefined);
+    mockMarkTrialStarted.mockClear();
+    mockGetById.mockResolvedValue({ patreon: false, trial_started_at: null });
+
+    const { controller } = buildController({ register, newJWTToken, persistToken, updateLastLoginAt });
+    const req = {
+      body: { email: 'trial@example.com', password: SAMPLE_PW, start_trial: '1' },
+      query: {},
+    } as unknown as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(res.cookie).toHaveBeenCalledWith('token', 'jwt-trial-tok');
+    expect(mockMarkTrialStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fail registration when start_trial is set but trial already used', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const newJWTToken = jest.fn().mockResolvedValue('jwt-tok2');
+    mockMarkTrialStarted.mockClear();
+    mockGetById.mockResolvedValue({ patreon: false, trial_started_at: new Date() });
+
+    const { controller } = buildController({ register, newJWTToken });
+    const req = {
+      body: { email: 'existing@example.com', password: SAMPLE_PW, start_trial: '1' },
+      query: {},
+    } as unknown as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockMarkTrialStarted).not.toHaveBeenCalled();
+  });
+
+  it('does not start trial when start_trial flag is absent', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 1 }]);
+    mockMarkTrialStarted.mockClear();
+
+    const { controller } = buildController({ register });
+    const req = {
+      body: { email: 'notrial@example.com', password: SAMPLE_PW },
+      query: {},
+    } as unknown as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockMarkTrialStarted).not.toHaveBeenCalled();
   });
 
   it('returns 400 when the email is already registered', async () => {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -187,6 +187,15 @@ class UsersController {
         } catch {
           // country capture is best-effort
         }
+        if (req.body.start_trial === '1' || req.body.start_trial === true) {
+          try {
+            const trialRepo = new UsersRepository(this.db);
+            const trialUseCase = new StartTrialUseCase(trialRepo);
+            await trialUseCase.execute(newUser.id);
+          } catch (trialError) {
+            console.info('Trial start failed after registration', trialError);
+          }
+        }
         const token = await this.authService.newJWTToken(newUser.id);
         if (token) {
           await this.authService.persistToken(token, newUser.id.toString());

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -11,11 +11,18 @@ import styles from '../../styles/auth.module.css';
 interface Props {
   readonly setErrorMessage: ErrorHandlerType;
   readonly redirect?: string | null;
+  readonly startTrial?: boolean;
 }
 
 const MIN_PASSWORD_LENGTH = 8;
 
-function RegisterForm({ setErrorMessage, redirect }: Props) {
+function submitLabel(loading: boolean, startTrial: boolean | undefined): string {
+  if (loading) return 'Creating account…';
+  if (startTrial) return 'Create account and start trial';
+  return 'Create account';
+}
+
+function RegisterForm({ setErrorMessage, redirect, startTrial }: Props) {
   const [email, setEmail] = useState(localStorage.getItem('email') || '');
   const [tos, setTos] = useState(false);
   const [password, setPassword] = useState('');
@@ -44,7 +51,7 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
     setLoading(true);
 
     try {
-      const res = await get2ankiApi().register('', email, password, signupOrigin);
+      const res = await get2ankiApi().register('', email, password, signupOrigin, startTrial);
       if (res.status === 200) {
         globalThis.sessionStorage?.setItem('email_verification_pending', 'true');
         globalThis.location.href = redirect ? `/${redirect.replace(/^\//, '')}` : '/';
@@ -174,7 +181,7 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
               className={styles.submitButton}
               disabled={!isValid() || loading}
             >
-              {loading ? 'Creating account…' : 'Create account'}
+              {submitLabel(loading, startTrial)}
             </button>
           </div>
         </form>

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -380,12 +380,16 @@ export class Backend {
     name: string,
     email: string,
     password: string,
-    source?: string | null
+    source?: string | null,
+    startTrial?: boolean
   ): Promise<Response> {
     const endpoint = `${this.baseURL}users/register`;
     const payload: Record<string, string> = { name, email, password };
     if (source != null && source.length > 0) {
       payload.source = source;
+    }
+    if (startTrial === true) {
+      payload.start_trial = '1';
     }
     return post(endpoint, payload);
   }

--- a/web/src/pages/RegisterPage/RegisterPage.tsx
+++ b/web/src/pages/RegisterPage/RegisterPage.tsx
@@ -10,10 +10,11 @@ interface Props {
 export function RegisterPage({ setErrorMessage }: Readonly<Props>) {
   const [searchParams] = useSearchParams();
   const redirect = searchParams.get('redirect');
+  const startTrial = searchParams.get('start_trial') === '1';
 
   return (
     <AuthPageBackground>
-      <RegisterForm setErrorMessage={setErrorMessage} redirect={redirect} />
+      <RegisterForm setErrorMessage={setErrorMessage} redirect={redirect} startTrial={startTrial} />
     </AuthPageBackground>
   );
 }

--- a/web/src/pages/UploadPage/UploadPage.module.css
+++ b/web/src/pages/UploadPage/UploadPage.module.css
@@ -1,3 +1,21 @@
+/* ── Re-attach banner (shown after trial-on-register redirect) ── */
+
+.reattachBanner {
+  max-width: 800px;
+  margin: 0 0 1rem;
+  padding: 0.625rem 1rem;
+  background: var(--color-bg-secondary);
+  border-left: 3px solid var(--color-text-link);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.reattachBanner strong {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
 /* ── Toggle-model primer ── */
 
 .primer {

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -36,6 +36,55 @@ const renderPage = () => {
   );
 };
 
+const renderPageWithSession = (sessionKey: string, sessionValue: string | null) => {
+  if (sessionValue != null) {
+    globalThis.sessionStorage.setItem(sessionKey, sessionValue);
+  } else {
+    globalThis.sessionStorage.removeItem(sessionKey);
+  }
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/upload']}>
+        <Routes>
+          <Route
+            path="/upload"
+            element={<UploadPage setErrorMessage={() => {}} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('UploadPage reattach banner', () => {
+  beforeEach(() => {
+    fetchUserPreferences.mockResolvedValue({
+      cardOptions: null,
+      theme: null,
+      ankiWebAcknowledgedAt: null,
+      uploadPrimerDismissedAt: '2026-01-01',
+    });
+  });
+
+  it('shows the reattach banner when upload_pending_filename is set in sessionStorage', async () => {
+    renderPageWithSession('upload_pending_filename', 'biochemistry.zip');
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    expect(screen.getByRole('status').textContent).toContain('Re-attach');
+    expect(screen.getByRole('status').textContent).toContain('biochemistry.zip');
+    expect(screen.getByRole('status').textContent).toContain('to convert');
+    globalThis.sessionStorage.removeItem('upload_pending_filename');
+  });
+
+  it('does not show the reattach banner when upload_pending_filename is absent', async () => {
+    renderPageWithSession('upload_pending_filename', null);
+    await waitFor(() => expect(fetchUserPreferences).toHaveBeenCalled());
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});
+
 describe('UploadPage primer', () => {
   beforeEach(() => {
     dismissUploadPrimer.mockClear();

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -37,10 +37,10 @@ const renderPage = () => {
 };
 
 const renderPageWithSession = (sessionKey: string, sessionValue: string | null) => {
-  if (sessionValue != null) {
-    globalThis.sessionStorage.setItem(sessionKey, sessionValue);
-  } else {
+  if (sessionValue == null) {
     globalThis.sessionStorage.removeItem(sessionKey);
+  } else {
+    globalThis.sessionStorage.setItem(sessionKey, sessionValue);
   }
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -16,6 +16,8 @@ import styles from '../../styles/shared.module.css';
 import UploadForm from './components/UploadForm/UploadForm';
 import pageStyles from './UploadPage.module.css';
 
+const REATTACH_KEY = 'upload_pending_filename';
+
 const WALKTHROUGHS: ReadonlyArray<[string, string]> = [
   ['UnTo_fN1jpc', 'How I use Notion to Anki as a medical student'],
   ['JrYdp18Hbs8', 'Notion to Anki — complete guide'],
@@ -78,6 +80,10 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const [reattachFilename, setReattachFilename] = useState<string | null>(() => {
+    const stored = globalThis.sessionStorage?.getItem(REATTACH_KEY) ?? null;
+    return stored != null && stored.length > 0 ? stored : null;
+  });
 
   const prefsQuery = useReactQuery({
     queryKey: ['user-preferences'],
@@ -127,6 +133,13 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           Turn your notes into flashcards in seconds
         </p>
       </header>
+      {reattachFilename != null && (
+        <div className={pageStyles.reattachBanner} role="status">
+          <span>Re-attach </span>
+          <strong>{reattachFilename}</strong>
+          <span> to convert</span>
+        </div>
+      )}
       {primerVisible && (
         <section className={pageStyles.primer} aria-label="How 2anki works">
           <button

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -674,7 +674,7 @@ describe('limit state — start trial button', () => {
     return container;
   }
 
-  it('shows "Sign in to start trial" and hides "Start 1-hour trial" for anonymous users', async () => {
+  it('shows a single "Create account and start trial" CTA for anonymous users and no "Start 1-hour trial" button', async () => {
     const container = renderWithLimitReached({
       user: null,
       locals: { owner: 0, patreon: false, subscriber: false, subscriptionInfo: { active: false, email: '', linked_email: '' } },
@@ -695,9 +695,13 @@ describe('limit state — start trial button', () => {
     );
     expect(trialBtn).toBeUndefined();
 
-    const signInLink = container.querySelector('a[href*="login"]');
-    expect(signInLink).not.toBeNull();
-    expect(signInLink?.textContent).toContain('Sign in to start trial');
+    const registerLink = container.querySelector('a[href*="register"]');
+    expect(registerLink).not.toBeNull();
+    expect(registerLink?.textContent).toContain('Create account and start trial');
+    expect(registerLink?.getAttribute('href')).toContain('start_trial=1');
+
+    const loginLink = container.querySelector('a[href*="login"]');
+    expect(loginLink).toBeNull();
   });
 
   it('renders error message and preserves form when startTrial returns already_used', async () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -70,16 +70,16 @@ function getLimitKind(url: URL): 'file_size' | 'card_count' {
 
 function getLimitDescription(
   kind: 'file_size' | 'card_count',
-  trialAvailable: boolean
+  context: 'anonymous' | 'trial_available' | 'trial_used'
 ): string {
   if (kind === 'file_size') {
-    return trialAvailable
-      ? 'Start a 1-hour trial to convert files of any size, or split the file and try again.'
-      : 'Your trial is used. Split the file, or upgrade to convert files of any size.';
+    if (context === 'anonymous') return 'Create a free account to convert files of any size, or split the file and try again.';
+    if (context === 'trial_available') return 'Start a 1-hour trial to convert files of any size, or split the file and try again.';
+    return 'Your trial is used. Split the file, or upgrade to convert files of any size.';
   }
-  return trialAvailable
-    ? 'Start a 1-hour trial to keep converting, or upgrade for no monthly cap.'
-    : 'Your trial is used. Upgrade for no monthly cap, or wait until next month.';
+  if (context === 'anonymous') return 'Create a free account to start converting, or upgrade for no monthly cap.';
+  if (context === 'trial_available') return 'Start a 1-hour trial to keep converting, or upgrade for no monthly cap.';
+  return 'Your trial is used. Upgrade for no monthly cap, or wait until next month.';
 }
 
 function formatFileSize(bytes: number): string {
@@ -354,6 +354,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
 
   useEffect(() => {
     if (zoneState === 'success' && downloadLink && !showFallback) {
+      globalThis.sessionStorage?.removeItem('upload_pending_filename');
       if (cardCount !== 0) {
         fireAnalyticsEvent('deck_downloaded');
         track('deck_downloaded');
@@ -915,14 +916,28 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     );
   };
 
+  const saveFilenameForReattach = (filename: string | null) => {
+    if (filename != null && filename.length > 0) {
+      globalThis.sessionStorage?.setItem('upload_pending_filename', filename);
+    }
+  };
+
   const renderLimitState = () => {
     const isFileSize = limitInfo?.kind === 'file_size';
     const title = isFileSize
       ? 'This file is over the 50 MB limit'
       : 'You reached your monthly limit of 100 cards';
+    let limitContext: 'anonymous' | 'trial_available' | 'trial_used';
+    if (showSignInPrompt) {
+      limitContext = 'anonymous';
+    } else if (showTrialButton) {
+      limitContext = 'trial_available';
+    } else {
+      limitContext = 'trial_used';
+    }
     const description = getLimitDescription(
       isFileSize ? 'file_size' : 'card_count',
-      showTrialButton
+      limitContext
     );
 
     return (
@@ -943,29 +958,33 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
           </p>
         )}
         <div className={formStyles.limitActions}>
-          <Link
-            to="/limit?ref=upload-limit-wall"
-            className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
-          >
-            See upgrade options
-          </Link>
-          {showTrialButton && (
-            <button
-              type="button"
-              className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}
-              onClick={handleStartTrial}
-              disabled={trialPending}
-            >
-              {trialPending ? 'Starting trial' : 'Start 1-hour trial'}
-            </button>
-          )}
-          {showSignInPrompt && (
+          {showSignInPrompt ? (
             <Link
-              to="/login?redirect=/upload&ref=limit-wall"
-              className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}
+              to="/register?redirect=/upload&start_trial=1"
+              className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+              onClick={() => saveFilenameForReattach(limitInfo?.filename ?? null)}
             >
-              Sign in to start trial
+              Create account and start trial
             </Link>
+          ) : (
+            <>
+              <Link
+                to="/limit?ref=upload-limit-wall"
+                className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+              >
+                See upgrade options
+              </Link>
+              {showTrialButton && (
+                <button
+                  type="button"
+                  className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}
+                  onClick={handleStartTrial}
+                  disabled={trialPending}
+                >
+                  {trialPending ? 'Starting trial' : 'Start 1-hour trial'}
+                </button>
+              )}
+            </>
           )}
           <button
             type="button"


### PR DESCRIPTION
## What

Anonymous users who hit the upload limit (card count or file size) now see a single primary CTA — "Create account and start trial" — instead of the previous two-button layout ("See upgrade options" + hidden "Start 1-hour trial"). The CTA links to \`/register?redirect=/upload&start_trial=1\`. The registration endpoint atomically creates the account and starts the 1-hour trial in a single request. The originally-uploaded filename is preserved across the redirect via \`sessionStorage\`, and a one-line banner on the post-register upload page reads "Re-attach <filename> to convert."

## Why

Fixes #2362. Part of umbrella PR #2446 (first-deck-success activation wave). Wave 3 of 4. Merge order: after PR #2352, before PR #252 (onboarding tour).

Today the trial CTA for anonymous users was the "Sign in to start trial" link on the limit screen. The user had to: (1) sign in or register, (2) come back to upload, (3) separately start the trial. This PR collapses those steps into one: click the CTA → register → trial is already started.

## How

**Server** (`src/controllers/UsersControllers.ts`): The existing `/api/users/register` endpoint now reads `start_trial` from the request body. If set to `'1'`, it calls `StartTrialUseCase` after the user row is created and the JWT cookie is set. If the trial start fails (already used, already paid, or any error), the failure is logged but the signup succeeds — account creation is the more valuable side effect.

**Client** (`Backend.ts` / `RegisterForm` / `RegisterPage`): `RegisterPage` reads `start_trial=1` from the query string and passes it as a prop to `RegisterForm`. `RegisterForm` forwards it to the backend `register` call. The submit button label changes to "Create account and start trial" when the flag is present.

**Upload limit screen** (`UploadForm.tsx`): For anonymous users, replaced the two-button layout with a single `<Link>` to `/register?redirect=/upload&start_trial=1`. The filename is stored in `sessionStorage` (`upload_pending_filename`) when clicking the CTA. Added `saveFilenameForReattach` helper.

**Post-register banner** (`UploadPage.tsx` + CSS): Reads `upload_pending_filename` from `sessionStorage` on mount. If present, shows a one-line status banner: "Re-attach <filename> to convert." The sessionStorage entry is cleared on the next successful upload.

The `getLimitDescription` function was refactored to take a `'anonymous' | 'trial_available' | 'trial_used'` context instead of a boolean, giving each case its own copy.

## Measuring success

- Log line `Trial start failed after registration` appearing in prod logs at <1% rate confirms the happy path works and the fallback is catching edge cases
- A new `trial_started_at` row set on the same DB write as `created_at` (query: `SELECT count(*) FROM users WHERE trial_started_at::date = created_at::date AND created_at > now() - interval '24 hours'`) confirms atomic registration + trial is happening in production

## Testing

- Unit tests added: 3 new server-side tests in `UsersControllers.test.ts` covering the trial-on-register happy path, fallback when trial already used, and absence of trial when flag is not set
- 2 new UploadPage tests for the reattach banner (shown / not shown based on sessionStorage)
- Existing UploadForm limit-screen test updated to assert the new single-CTA design for anonymous users
- All 742 web tests pass; all 34 server controller tests pass; tsc clean on both server and web; Biome lint clean

## Changelog

Deferred to wave's final PR per spec (#2446 umbrella). No entry in this PR.

## Risks

- `start_trial` can only be triggered from within the same atomic `/users/register` request — there is no path for an attacker to trigger a trial on a third-party user's account. The flag is body-only (not a query param on the endpoint itself) and gated behind a new account creation. An existing user attempting to re-register gets a 400 before the trial code is reached.
- If `StartTrialUseCase` throws unexpectedly, the error is caught and logged; the signup response is still 200 with the JWT cookie set. The user can start the trial manually via the existing "Start 1-hour trial" button if needed.
- Filename stored in `sessionStorage` is rendered via React's normal text path (no `dangerouslySetInnerHTML`). CWE-79 safe.
- JWT secret is unchanged — no hardcoded fallback introduced. CWE-321 safe.
- `/security-review` is recommended before merge: this PR touches the signup flow (CWE-862 check above) and the trial-start path.

## Goal alignment

Directly addresses the first-deck-success activation gap: anonymous users who hit the limit can now convert in a single click-through instead of a multi-step detour. Reduces drop-off at the most critical conversion funnel step.

## Sonar

`sonar-scanner` was not run locally (no `SONAR_TOKEN` configured in this environment). New code paths are covered by unit tests. The only new security-adjacent path is the `start_trial` body flag handling, which does not touch user input beyond a string equality check against a fixed value.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->