### PR TITLE
fix: lower onboarding-tour cutoff to today's ship date

### DIFF
--- a/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.tsx
+++ b/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.tsx
@@ -26,7 +26,7 @@ const STEPS: ReadonlyArray<Step> = [
   },
 ];
 
-const MIGRATION_CUTOFF = '2026-06-08T00:00:00.000Z';
+const MIGRATION_CUTOFF = '2026-05-19T00:00:00.000Z';
 
 interface OnboardingTourProps {
   createdAt: string | null;


### PR DESCRIPTION
## What

Lowers the onboarding-tour `MIGRATION_CUTOFF` constant from `'2026-06-08T00:00:00.000Z'` to `'2026-05-19T00:00:00.000Z'` (today, the wave's ship date).

## Why

The just-merged tour from #2456 gates on `created_at >= MIGRATION_CUTOFF`. The engineer used the migration filename `20260608000000_add_onboarded_at_to_users.js` as the cutoff source, but migration filenames in this repo are sequential placeholders rather than calendar dates. Today is `2026-05-19`, so:
- Every existing user has `created_at < 2026-06-08` → no tour (correct).
- Every new account today through June 7 has `created_at < 2026-06-08` → no tour (**wrong** — the spec says new accounts see it).

Spec language: "The tour does not appear for users with `created_at` more than 24 hours before the feature ships." Feature ships today; cutoff should be today.

## How

One-line constant change. Vitest unit tests for `OnboardingTour.tsx` use their own local `MIGRATION_DATE` test constant and pass it as the `migrationDate` prop, so they continue to pass without modification.

## Testing

- `pnpm --filter 2anki-web typecheck` clean.
- `pnpm --filter 2anki-web test:run` — 758/758 pass.
- Manual: a new account created from now on will see the four-step tour on their first visit to `/upload`.

## Risks

None. Pre-merge no real user could see the tour; after merge new accounts see it. No data change, no migration, no shape change.

## Goal alignment

Activation. The wave's tour piece is wired but invisible without this fix; this is what makes the feature actually reach the audience it was specced for.

## Notes

- No changelog entry — the wave's combined entry (already in main) covers it. This is the gate fix, not a new feature.
- No `/security-review` needed — pure constant change.
- No sonar local — single-line edit, well under the trivial-change threshold.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->