### PR TITLE
fix: tighten What's new layout — sidebar, columns, report CTA

### DIFF
--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -271,8 +271,9 @@
 
 .sidebarTheme {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
   padding: 0.5rem 0.75rem;
 }
 

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -137,37 +137,17 @@
   margin: 0 0 8px;
 }
 
-/* ── Report an issue row ── */
+/* ── Report an issue link (sits next to FeedbackWidget) ── */
 
-.reportRow {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  width: 100%;
-  padding: 8px 12px;
-  border-radius: 6px;
-  text-decoration: none;
-  color: #787774;
+.reportLink {
   font-size: 13px;
-  font-weight: 400;
-  margin-top: 8px;
-  transition: background var(--transition-fast), color var(--transition-fast);
-}
-
-.reportRow:hover {
-  background: #fbfbfa;
-  color: var(--color-text-primary);
-}
-
-.reportPlus {
-  font-size: 14px;
-  line-height: 1;
-}
-
-.reportHint {
-  font-size: 12px;
   color: #787774;
-  margin: 2px 0 0 12px;
+  text-decoration: none;
+}
+
+.reportLink:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
 }
 
 /* ── Shipped column ── */

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.test.tsx
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.test.tsx
@@ -32,18 +32,18 @@ const renderPage = async () => {
 };
 
 describe('WhatsNewPage kanban columns', () => {
-  it('renders all three column headers in board order: Backlog then In progress then Shipped', async () => {
+  it('renders all three column headers in board order: Shipped then In progress then Backlog', async () => {
     await renderPage();
     const headings = screen.getAllByRole('heading', { level: 2 });
     const texts = headings.map((h) => h.textContent ?? '');
-    const backlogIdx = texts.findIndex((t) => t.startsWith('Backlog'));
-    const inProgressIdx = texts.findIndex((t) => t.startsWith('In progress'));
     const shippedIdx = texts.findIndex((t) => t.startsWith('Shipped'));
-    expect(backlogIdx).toBeGreaterThanOrEqual(0);
-    expect(inProgressIdx).toBeGreaterThanOrEqual(0);
+    const inProgressIdx = texts.findIndex((t) => t.startsWith('In progress'));
+    const backlogIdx = texts.findIndex((t) => t.startsWith('Backlog'));
     expect(shippedIdx).toBeGreaterThanOrEqual(0);
-    expect(backlogIdx).toBeLessThan(inProgressIdx);
-    expect(inProgressIdx).toBeLessThan(shippedIdx);
+    expect(inProgressIdx).toBeGreaterThanOrEqual(0);
+    expect(backlogIdx).toBeGreaterThanOrEqual(0);
+    expect(shippedIdx).toBeLessThan(inProgressIdx);
+    expect(inProgressIdx).toBeLessThan(backlogIdx);
   });
 });
 

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.tsx
@@ -75,10 +75,66 @@ export default function WhatsNewPage() {
         </p>
         <div className={styles.inlineRating}>
           <FeedbackWidget page="/whats-new" compact />
+          <a
+            href="https://github.com/2anki/server/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.reportLink}
+          >
+            Report an issue →
+          </a>
         </div>
       </header>
 
       <div className={styles.board}>
+        <div className={`${styles.column} ${styles.columnShipped}`}>
+          <h2 className={styles.columnHeader}>
+            Shipped <span className={styles.columnCount}>· {changelog.length}</span>
+          </h2>
+          {shipped.length === 0 ? (
+            <p className={styles.emptyState}>Nothing shipped yet.</p>
+          ) : (
+            <div className={styles.timeline}>
+              {shipped.map((group) => (
+                <div key={group.date} className={styles.dateGroup}>
+                  <h3 className={styles.dateHeading}>{group.label}</h3>
+                  <ul className={styles.commitList}>
+                    {group.entries.map((entry, idx) => (
+                      <li key={`${entry.date}-${idx}`} className={styles.commitItem}>
+                        <span className={`${styles.typeBadge} ${styles['badge_' + entry.type]}`}>
+                          {TYPE_LABELS[entry.type] ?? entry.type}
+                        </span>
+                        <span className={styles.commitText}>{entry.title}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className={styles.column}>
+          <h2 className={styles.columnHeader}>
+            In progress <span className={styles.columnCount}>· {inProgress.length}</span>
+          </h2>
+          {inProgress.length === 0 ? (
+            <p className={styles.emptyState}>Nothing in flight.</p>
+          ) : (
+            <ul className={styles.cardList}>
+              {inProgress.map((item, idx) => (
+                <li key={`${item.startedAt}-${idx}`} className={styles.card}>
+                  {item.type && (
+                    <span className={styles.typeTag}>{item.type}</span>
+                  )}
+                  <span className={styles.cardTitle}>{item.title}</span>
+                  <span className={styles.cardSecondary}>{startedAgoLabel(item.startedAt)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
         <div className={styles.column}>
           <h2 className={styles.columnHeader}>
             Backlog <span className={styles.columnCount}>· {backlog.length}</span>
@@ -107,64 +163,6 @@ export default function WhatsNewPage() {
                 </li>
               ))}
             </ul>
-          )}
-          <a
-            href="https://github.com/2anki/server/issues/new"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.reportRow}
-          >
-            <span className={styles.reportPlus}>+</span>
-            <span>Report an issue</span>
-          </a>
-          <p className={styles.reportHint}>Something broken? Tell us what happened.</p>
-        </div>
-
-        <div className={styles.column}>
-          <h2 className={styles.columnHeader}>
-            In progress <span className={styles.columnCount}>· {inProgress.length}</span>
-          </h2>
-          {inProgress.length === 0 ? (
-            <p className={styles.emptyState}>Nothing in flight.</p>
-          ) : (
-            <ul className={styles.cardList}>
-              {inProgress.map((item, idx) => (
-                <li key={`${item.startedAt}-${idx}`} className={styles.card}>
-                  {item.type && (
-                    <span className={styles.typeTag}>{item.type}</span>
-                  )}
-                  <span className={styles.cardTitle}>{item.title}</span>
-                  <span className={styles.cardSecondary}>{startedAgoLabel(item.startedAt)}</span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-
-        <div className={`${styles.column} ${styles.columnShipped}`}>
-          <h2 className={styles.columnHeader}>
-            Shipped <span className={styles.columnCount}>· {changelog.length}</span>
-          </h2>
-          {shipped.length === 0 ? (
-            <p className={styles.emptyState}>Nothing shipped yet.</p>
-          ) : (
-            <div className={styles.timeline}>
-              {shipped.map((group) => (
-                <div key={group.date} className={styles.dateGroup}>
-                  <h3 className={styles.dateHeading}>{group.label}</h3>
-                  <ul className={styles.commitList}>
-                    {group.entries.map((entry, idx) => (
-                      <li key={`${entry.date}-${idx}`} className={styles.commitItem}>
-                        <span className={`${styles.typeBadge} ${styles['badge_' + entry.type]}`}>
-                          {TYPE_LABELS[entry.type] ?? entry.type}
-                        </span>
-                        <span className={styles.commitText}>{entry.title}</span>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary

Three small adjustments to the What's new kanban that shipped earlier today:

- **Sidebar** — "What's new" now stacks beneath the theme picker instead of sitting next to it.
- **Board column order** — Shipped → In progress → Backlog. Past → present → future reads more naturally than queue → done.
- **Report an issue CTA** — moved from the bottom of the Backlog column up next to the FeedbackWidget in the page header. The hint line is dropped since the widget's prompt already invites feedback.

No changelog entry — same-day polish on the page that just shipped.

## Test plan

- [x] `pnpm --filter 2anki-web typecheck` clean
- [x] `pnpm --filter 2anki-web test` — 763 tests pass
- [ ] Visual check on desktop: sidebar now stacks vertically, columns read Shipped → In progress → Backlog, "Report an issue" sits next to the emoji feedback
- [ ] Mobile: columns stack in the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->