### PR TITLE
perf: skip user lookup on SPA shell route

### DIFF
--- a/src/controllers/IndexController/IndexController.ts
+++ b/src/controllers/IndexController/IndexController.ts
@@ -1,22 +1,11 @@
 import express from 'express';
 import { getDatabase } from '../../data_layer';
-import AuthenticationService from '../../services/AuthenticationService';
-import TokenRepository from '../../data_layer/TokenRepository';
-import UsersRepository from '../../data_layer/UsersRepository';
-import { configureUserLocal } from '../../routes/middleware/configureUserLocal';
 import { sendIndex } from './sendIndex';
 import { getDefaultEmailService } from '../../services/EmailService/EmailService';
 
 class IndexController {
-  public getIndex(request: express.Request, response: express.Response) {
-    const database = getDatabase();
-    const authService = new AuthenticationService(
-      new TokenRepository(database),
-      new UsersRepository(database)
-    );
-    configureUserLocal(request, response, authService, database).then(() => {
-      sendIndex(response);
-    });
+  public getIndex(_request: express.Request, response: express.Response) {
+    sendIndex(response);
   }
 
   async contactUs(req: express.Request, res: express.Response) {


### PR DESCRIPTION
## Summary

`GET /` and every non-`/api` route serve a static React shell — `sendIndex` reads `index.html` from disk and writes it back unchanged. It never reads `res.locals`.

The previous handler ran `configureUserLocal` first, which does up to **4 sequential database queries** (user-by-token, `isSubscriber`, `findActive` pass, `subscriptionInfo`) on every page load. The SPA fetches user state via `/api/users/debug/locals` after hydration anyway, so the work was wasted.

This drops the call from the shell route only — `RequireAuthentication`, `RequirePaying`, and `RequireAllowedOrigin` middlewares still use `configureUserLocal` for API routes that genuinely need user identity.

## Why this is also a bug fix

The previous code was:

```ts
configureUserLocal(...).then(() => { sendIndex(response); });
```

No `.catch`. When `configureUserLocal` threw — e.g. `TokenExpiredError` on a stale cookie, visible in prod logs right now — the response was never sent. The request just hung until the client timed out.

## Test plan

- [x] `pnpm test src/controllers/IndexController` — 10 tests pass
- [x] `pnpm tsc --noEmit` clean
- [ ] After deploy, curl `https://2anki.net/` and confirm TTFB drops (was ~150ms server-side; expect <50ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->