### PR TITLE
fix: silence anon console noise — gate prefs sync, strip iframe scripts

### DIFF
--- a/web/src/lib/data_layer/userPreferencesSync.test.ts
+++ b/web/src/lib/data_layer/userPreferencesSync.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  acknowledgeAnkiWeb,
+  cancelPendingSync,
+  dismissUploadPrimer,
+  fetchUserPreferences,
+  hydrateFromServer,
+  migrateToServer,
+  scheduleSync,
+} from './userPreferencesSync';
+
+const setCookie = (value: string) => {
+  Object.defineProperty(document, 'cookie', {
+    configurable: true,
+    get: () => value,
+  });
+};
+
+const flushDebounce = async () => {
+  vi.advanceTimersByTime(600);
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('userPreferencesSync — anonymous user (no token cookie)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setCookie('');
+    localStorage.clear();
+    localStorage.setItem('2anki-theme', 'dark');
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 200 })
+    );
+  });
+
+  afterEach(() => {
+    cancelPendingSync();
+    fetchSpy.mockRestore();
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('scheduleSync does not call the preferences endpoint', async () => {
+    scheduleSync();
+    await flushDebounce();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetchUserPreferences returns null without calling fetch', async () => {
+    const result = await fetchUserPreferences();
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('hydrateFromServer is a no-op', async () => {
+    await hydrateFromServer();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('dismissUploadPrimer is a no-op', async () => {
+    await dismissUploadPrimer();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('migrateToServer is a no-op', async () => {
+    await migrateToServer();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('acknowledgeAnkiWeb still writes localStorage but does not call fetch', async () => {
+    await acknowledgeAnkiWeb();
+    expect(localStorage.getItem('ankify_anki_web_acknowledged')).toBe('true');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('userPreferencesSync — authenticated user (token cookie present)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setCookie('token=abc123; other=value');
+    localStorage.clear();
+    localStorage.setItem('2anki-theme', 'dark');
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 200 })
+    );
+  });
+
+  afterEach(() => {
+    cancelPendingSync();
+    fetchSpy.mockRestore();
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  it('scheduleSync PATCHes the preferences endpoint after the debounce window', async () => {
+    scheduleSync();
+    await flushDebounce();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/users/me/preferences',
+      expect.objectContaining({ method: 'PATCH' })
+    );
+  });
+});

--- a/web/src/lib/data_layer/userPreferencesSync.ts
+++ b/web/src/lib/data_layer/userPreferencesSync.ts
@@ -21,6 +21,11 @@ const PREFERENCES_URL = '/api/users/me/preferences';
 const MIGRATE_URL = '/api/users/me/preferences/migrate';
 export const ANKI_WEB_ACK_KEY = 'ankify_anki_web_acknowledged';
 
+function isAuthed(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.cookie.split(';').some((c) => c.trim().startsWith('token='));
+}
+
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 export function cancelPendingSync(): void {
@@ -45,6 +50,7 @@ export function scheduleSync(): void {
   cancelPendingSync();
   debounceTimer = setTimeout(async () => {
     debounceTimer = null;
+    if (!isAuthed()) return;
     const cardOptions = collectCardOptions();
     const theme = localStorage.getItem('2anki-theme');
     const body: Record<string, unknown> = {};
@@ -72,6 +78,7 @@ export async function acknowledgeAnkiWeb(): Promise<void> {
   try {
     localStorage.setItem(ANKI_WEB_ACK_KEY, 'true');
   } catch {}
+  if (!isAuthed()) return;
   try {
     await fetch(PREFERENCES_URL, {
       method: 'PATCH',
@@ -92,6 +99,7 @@ export interface ServerUserPreferences {
 }
 
 export async function fetchUserPreferences(): Promise<ServerUserPreferences | null> {
+  if (!isAuthed()) return null;
   try {
     const res = await fetch(PREFERENCES_URL, { credentials: 'include' });
     if (!res.ok) return null;
@@ -102,6 +110,7 @@ export async function fetchUserPreferences(): Promise<ServerUserPreferences | nu
 }
 
 export async function dismissUploadPrimer(): Promise<void> {
+  if (!isAuthed()) return;
   try {
     await fetch(PREFERENCES_URL, {
       method: 'PATCH',
@@ -115,6 +124,7 @@ export async function dismissUploadPrimer(): Promise<void> {
 }
 
 export async function hydrateFromServer(): Promise<void> {
+  if (!isAuthed()) return;
   try {
     const res = await fetch(PREFERENCES_URL, { credentials: 'include' });
     if (!res.ok) return;
@@ -138,6 +148,7 @@ export async function hydrateFromServer(): Promise<void> {
 }
 
 export async function migrateToServer(): Promise<void> {
+  if (!isAuthed()) return;
   const cardOptions = collectCardOptions();
   const theme = localStorage.getItem('2anki-theme');
   const body: Record<string, unknown> = {};

--- a/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+
+import { CardFrame } from './CardFrame';
+import type { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
+
+const buildCard = (overrides: Partial<ApkgPreviewCard> = {}): ApkgPreviewCard => ({
+  id: 1,
+  ord: 0,
+  deckName: 'Sample Deck',
+  deckPath: ['Sample Deck'],
+  templateName: 'Basic',
+  noteTypeName: 'Basic',
+  front: 'Front content',
+  back: 'Back content',
+  css: 'body { color: #111; }',
+  ...overrides,
+});
+
+const getSrcDoc = (container: HTMLElement): string => {
+  const iframe = container.querySelector('iframe');
+  if (iframe == null) throw new Error('iframe not rendered');
+  return iframe.getAttribute('srcdoc') ?? '';
+};
+
+describe('CardFrame srcDoc sanitization', () => {
+  it('strips <script> tags from card.front', () => {
+    const card = buildCard({
+      front: 'Hello<script>alert(1)</script> world',
+    });
+    const { container } = render(<CardFrame card={card} />);
+    const srcDoc = getSrcDoc(container);
+    expect(srcDoc).toContain('Hello');
+    expect(srcDoc).toContain(' world');
+    expect(srcDoc).not.toMatch(/<script/i);
+    expect(srcDoc).not.toContain('alert(1)');
+  });
+
+  it('strips on* event handler attributes', () => {
+    const card = buildCard({
+      front: '<img src="x" onerror="alert(1)" /> <button onclick="boom()">go</button>',
+    });
+    const { container } = render(<CardFrame card={card} />);
+    const srcDoc = getSrcDoc(container);
+    expect(srcDoc).not.toMatch(/onerror/i);
+    expect(srcDoc).not.toMatch(/onclick/i);
+    expect(srcDoc).not.toContain('alert(1)');
+    expect(srcDoc).not.toContain('boom()');
+  });
+
+  it('strips <script> hidden inside card.css', () => {
+    const card = buildCard({
+      css: 'body{color:red}</style><script>alert(2)</script><style>',
+    });
+    const { container } = render(<CardFrame card={card} />);
+    const srcDoc = getSrcDoc(container);
+    expect(srcDoc).not.toMatch(/<script/i);
+    expect(srcDoc).not.toContain('alert(2)');
+  });
+
+  it('leaves benign markup intact', () => {
+    const card = buildCard({
+      front: '<p class="q"><strong>Q:</strong> What is spaced repetition?</p>',
+    });
+    const { container } = render(<CardFrame card={card} />);
+    const srcDoc = getSrcDoc(container);
+    expect(srcDoc).toContain('<p class="q">');
+    expect(srcDoc).toContain('<strong>Q:</strong>');
+  });
+});

--- a/web/src/pages/PreviewApkgPage/CardFrame.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.tsx
@@ -6,8 +6,15 @@ interface CardFrameProps {
   card: ApkgPreviewCard;
 }
 
+function stripScripts(input: string): string {
+  return input
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\s+on\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+}
+
 function buildSrcDoc(card: ApkgPreviewCard, side: 'front' | 'back'): string {
-  const html = side === 'front' ? card.front : card.back;
+  const html = stripScripts(side === 'front' ? card.front : card.back);
+  const css = stripScripts(card.css);
   return `<!doctype html>
 <html>
 <head>
@@ -16,7 +23,7 @@ function buildSrcDoc(card: ApkgPreviewCard, side: 'front' | 'back'): string {
 <style>
   html, body { margin: 0; padding: 1rem; background: #fff; color: #111; font-family: system-ui, sans-serif; }
   img, video { max-width: 100%; height: auto; }
-${card.css}
+${css}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

Two small fixes for noise spotted in prod browser consoles.

### 1. `/api/users/me/preferences` 401s on anonymous users

`scheduleSync` / `acknowledgeAnkiWeb` / `dismissUploadPrimer` / `fetchUserPreferences` / `hydrateFromServer` / `migrateToServer` fired PATCH/GET requests for every theme change or card-option save, regardless of auth state. Server replied 401 and the catch block swallowed it — purely cosmetic console noise plus a wasted roundtrip per change. A tiny `isAuthed()` helper peeks at the (non-HttpOnly) `token` cookie and short-circuits each function for true-anon users. LocalStorage still writes, so anon UX is unchanged.

### 2. "Blocked script execution in 'about:srcdoc'" on the preview page

`CardFrame` renders Anki card HTML in a sandboxed iframe with `allow-same-origin` only (no `allow-scripts` — by design). When a template contains `<script>` or `on*=` attributes, Chrome logs the warning. Strips them from `card.front` / `card.back` / `card.css` before passing into `srcDoc`. No security change — scripts couldn't run anyway, this just stops the warning from firing.

## Test plan

- [x] `pnpm --filter 2anki-web typecheck` clean
- [x] `pnpm --filter 2anki-web test` — 774 tests pass (+11 new covering both fixes)
- [ ] After deploy, open https://2anki.net/ in incognito and confirm no `/api/users/me/preferences` 401 in console after theme toggle
- [ ] Open an apkg preview and confirm no `about:srcdoc` script-block warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->