### PR TITLE
docs: fill feature gaps in /documentation

### DIFF
--- a/web/src/pages/DocsPage/content/cards/ai-flashcards.md
+++ b/web/src/pages/DocsPage/content/cards/ai-flashcards.md
@@ -1,0 +1,73 @@
+---
+title: AI flashcard generation
+description: When 2anki should write the cards for you — Claude for any PDF, Vertex AI for question generation.
+---
+
+Two card options send your source to an AI model instead of running the normal toggle/bullet parser. Use them when your source isn't already shaped like flashcards — long-form PDFs, lecture transcripts, dense study material — and you want the model to pull the question-answer pairs out for you.
+
+**Plan:** Subscription or Lifetime. Free accounts see the toggles but the conversion falls back to the standard parser.
+
+## When to use this
+
+- Your source is a PDF that's all prose — a textbook chapter, an article, lecture notes — and there are no toggles or bullets to convert.
+- You've tried the standard parser and it produced too few cards, or none.
+- You have a specific angle you want the cards to take ("focus on dates and names", "use clinical vignettes", "skip the introduction").
+
+If your source is already structured — Notion toggles, Obsidian bullets, a spreadsheet with question and answer columns — the standard parser will be faster and more accurate. Skip AI for those.
+
+## Generate Flashcards with Claude AI
+
+The general-purpose option. Sends your content to Anthropic's Claude and uses the response as your deck.
+
+1. On the upload screen, open the settings panel.
+2. Switch **Generate Flashcards with Claude AI** on.
+3. (Optional) Open **User instructions** and write a sentence or two about the kind of cards you want.
+4. Upload your file. The job runs in the background — you can leave the page and come back to **My uploads** to download.
+
+The result is a normal `.apkg`. You can re-download it from **My uploads** for as long as your plan keeps it (see [Limits and quotas](/documentation/help/limits) for storage windows).
+
+### Writing good user instructions
+
+The model does better with a clear angle than with a long brief. One or two sentences is plenty.
+
+Useful instructions:
+
+- "Focus on USMLE Step 1 high-yield. Skip background paragraphs."
+- "Make every card a clinical vignette ending in a question."
+- "Use the exact wording from the source on the back."
+
+Skip instructions like "make great flashcards" or "explain everything" — the model already tries to do that.
+
+## Generate Questions from Single PDF File Uploads (Vertex AI)
+
+A narrower option, scoped to single PDFs. Sends the PDF to Google Vertex AI to generate question-and-answer pairs page by page.
+
+1. Open the settings panel before uploading.
+2. Switch **Generate Questions from Single PDF File Uploads** on.
+3. Upload a single PDF. ZIPs and Markdown don't use this path.
+
+Use this when you want question generation tuned to a specific page-by-page rhythm, or when Claude's output for a particular textbook looks off. The output runs through the same packaging step, so the resulting `.apkg` opens in Anki just like any other.
+
+## Storage and privacy
+
+AI conversions take longer than the standard parser — the deck builds in the background and is stored in your account so you can re-download it. Plan windows:
+
+| Plan | How long the AI deck is kept |
+|---|---|
+| Free | Falls back to standard parser (no AI) |
+| Subscription | Kept while your subscription is active |
+| Lifetime | Kept indefinitely |
+
+We send the content to the model only to build your deck. We don't train on it. Full details on the [privacy policy](/documentation/reference/privacy).
+
+## Common mistakes
+
+- **Empty PDF.** If the model can't find anything to turn into a card, the conversion fails with *Claude couldn't find any content to turn into flashcards in this Notion page* (the same message fires for PDFs). Check that the PDF has selectable text — scanned images won't work without OCR first.
+- **Conflicting options.** Turning on both **Generate Flashcards with Claude AI** and the standard toggle options doesn't double the cards. Claude takes over for the whole document.
+- **Cost expectation.** Each AI conversion uses model credits on our end. We don't pass per-card pricing through, but very large PDFs may take several minutes to finish.
+
+## Related
+
+- [Card options](/documentation/cards/card-options) — the rest of the toggles
+- [File formats](/documentation/reference/file-formats) — what PDFs we accept
+- [Limits and quotas](/documentation/help/limits) — Claude AI is a paid option

--- a/web/src/pages/DocsPage/content/cards/parser-rules.md
+++ b/web/src/pages/DocsPage/content/cards/parser-rules.md
@@ -1,0 +1,84 @@
+---
+title: Parser rules
+description: Override the default toggle-to-card mapping for a specific Notion page.
+---
+
+By default, 2anki turns every top-level toggle on a Notion page into a flashcard. Rules let you change that for a specific page — turn callouts into cards, treat tables as cards, nest sub-decks under headings, or change how tags get detected.
+
+**Plan:** Free
+
+## When to use this
+
+- You write your notes as paragraphs or callouts, not toggles, and the default parser produces an empty deck.
+- You want every row of a Notion table to become a card (column 1 → front, column 2 → back).
+- You want H2 or H3 headings inside a page to become sub-decks instead of card content.
+- You want strikethrough text to mark tags, or the opposite.
+
+Rules apply to **one Notion page**. Each page has its own rule. Account-level [card options](/documentation/cards/card-options) handle defaults that span every page.
+
+## Open the rules editor
+
+1. Connect Notion if you haven't yet — see [Connect Notion](/documentation/start-here/connect-notion).
+2. Go to [2anki.net/notion](https://2anki.net/notion) and find the page you want to customize.
+3. Click the **Settings** (gear) icon next to the page.
+4. The page opens at `/rules/<page-id>` with the four rule groups described below.
+
+## The four rule groups
+
+### Decks and sub-decks
+
+Notion pages and databases always become decks. Pick which blocks **inside** the page nest as sub-decks. Available choices:
+
+- `child_page` — Notion sub-pages become sub-decks (default).
+- `child_database` — inline databases become sub-decks.
+- `toggle` — a top-level toggle becomes a sub-deck instead of a flashcard. Its children become the cards in that sub-deck.
+- `heading_1` / `heading_2` / `heading_3` — headings split the page into sub-decks. Content under each heading goes into that sub-deck.
+
+Pick zero or more. If you pick none, the whole page is one deck.
+
+### Flashcards
+
+Which Notion block types become individual cards. Default is just `toggle`. Available choices:
+
+- `toggle` — the default. Heading is the front, contents are the back.
+- `bulleted_list_item` / `numbered_list_item` — top-level bullets become cards. The bullet text is the front; nested bullets are the back.
+- `to_do` — to-do blocks become cards. Useful for [MCQ](/documentation/cards/mcq) detection.
+- `paragraph` / `callout` / `quote` / `code` — turn these into cards when your notes don't use toggles. The block content is the front; the back stays blank unless you also enable something else.
+- `column_list` — Notion's two-column layout becomes a card. Column 1 is the front, column 2 is the back.
+- `table` — table rows become cards. Column 1 is the front, column 2 is the back. Columns 3 and beyond render as a small inline table on the back. **(New.)**
+- `heading_1` / `heading_2` / `heading_3` — make headings the card front. The content under each heading becomes the back.
+
+You can combine these. If you turn on both `toggle` and `bulleted_list_item`, both become cards.
+
+### Tags and notifications
+
+**Tag format** — how 2anki finds tags inside your content:
+
+- **strikethrough** (default) — strikethrough text becomes a tag. Strikethrough inside a toggle is a tag local to that card; strikethrough at the page level is a global tag.
+- **heading** — H1/H2/H3 headings become tags. Useful when your notes already have a heading hierarchy you want to keep as tags.
+
+**Email the deck when it's ready** — when on, the finished `.apkg` is emailed to your account address. Decks under 24 MB go as an attachment; larger decks include a download link instead.
+
+### Card options
+
+The same panel as [Card options](/documentation/cards/card-options), but scoped to this one Notion page. Changes here override your account defaults for this page only. Use it to tweak font size, card templates, or per-page MCQ behaviour without changing every other page.
+
+## Save and reset
+
+The save bar at the bottom of the page has three actions:
+
+- **Save changes** — applies the rule to this page only. The next [sync](/documentation/sync/how-it-works) uses it.
+- **Cancel** — discards anything you've changed in this session. Existing saved rules stay.
+- **Reset to defaults** — clears the rule and card options for this page so it falls back to your account defaults.
+
+## Common mistakes
+
+- **Empty deck after editing the rule.** If you turn off `toggle` without turning anything else on, 2anki has nothing to make cards from. Pick at least one block type under **Flashcards**.
+- **Sub-deck explosion.** Turning on `heading_1` *and* `heading_2` *and* `heading_3` for sub-decks produces deeply nested decks. Pick the heading level that matches the structure you actually have.
+- **Rule on the wrong page.** Rules attach to the page ID you opened. Editing the rule on the parent page doesn't change sub-pages — they need their own rule if you want different behaviour.
+
+## Related
+
+- [Card options](/documentation/cards/card-options) — account-level defaults
+- [Notion blocks we support](/documentation/cards/notion-blocks) — what each block does on the card
+- [How sync works](/documentation/sync/how-it-works) — when rule changes take effect on a synced page

--- a/web/src/pages/DocsPage/content/help/common-problems.md
+++ b/web/src/pages/DocsPage/content/help/common-problems.md
@@ -45,6 +45,16 @@ If you saw an error and want the fix, find the heading below that matches what y
 
 **How to fix it.** Split the PDF into smaller files (every PDF reader has a "split" option), or [subscribe](/pricing) to remove the cap. See [Limits and quotas](/documentation/help/limits) for the full list.
 
+## "This PDF is password-protected."
+
+**What you saw.** You uploaded a PDF and the upload area switched to a password input with the file name shown above it.
+
+**Why it happened.** The PDF was created with an open password — Anki can't read it, and neither can 2anki, until you unlock it.
+
+**How to fix it.** Type the password into the input and click **Unlock**. The file is decrypted in memory, converted, and the password is discarded — we don't store it. If you don't know the password, ask whoever shared the PDF, or remove the password in your PDF reader (most readers have a **File → Save as → Properties → Security → No Security** option) and re-upload.
+
+If you click anywhere else and the input goes away, drop the file in again — the password prompt comes back.
+
 ## "Could not create a deck using your file and rules."
 
 **What you saw.** The upload finishes but produces no deck.

--- a/web/src/pages/DocsPage/content/help/limits.md
+++ b/web/src/pages/DocsPage/content/help/limits.md
@@ -12,7 +12,7 @@ description: What's allowed on each plan, and how long your decks stick around.
 | Free | 100 MB per request |
 | Subscription / Lifetime | ~10 GB per request |
 
-Free covers anonymous and signed-in users without a paid plan. The file-size limit lives in `src/lib/misc/getUploadLimits.ts`.
+Free covers anonymous and signed-in users without a paid plan.
 
 ## PDF pages
 

--- a/web/src/pages/DocsPage/content/reference/glossary.md
+++ b/web/src/pages/DocsPage/content/reference/glossary.md
@@ -10,7 +10,10 @@ description: Words 2anki and Anki use, in plain language.
 - **Deck** — a named collection of cards in Anki. One upload usually makes one deck.
 - **Document** — what we call the source file you upload (HTML, Markdown, ZIP, PDF, etc.).
 - **Data source** — a third-party integration we read from. The main one is Notion.
+- **Favorites** — pages you've starred in the Notion picker. Quick-access list at [2anki.net/favorites](https://2anki.net/favorites).
+- **Feedback widget** — the in-app form for sending us short reactions (great/okay/bad) plus a note. Lives at [2anki.net/feedback](https://2anki.net/feedback).
 - **Flashcard** — a single front/back pair. 2anki makes basic, reversed, cloze, and input cards.
+- **Image Quiz HTML** — an experimental card option that uses OCR to pull image-and-answer pairs out of HTML quiz exports.
 - **Input card** — a card where you type the answer. Triggered by bold text in HTML when **Treat Bold Text as Input** is on.
 - **Job** — the background task that turns your upload into a deck. It moves through pending → running → done (or failed).
 - **MCQ card** — a multiple-choice card with 2–7 options and one correct answer. Triggered by a Notion toggle whose children are to-do blocks with one checked, or bullets with one fully bolded.
@@ -18,6 +21,8 @@ description: Words 2anki and Anki use, in plain language.
 - **Rules** — user-defined transformations that override the default toggle-to-card mapping. Advanced, optional.
 - **Settings** — your account-level defaults. Per-upload options override settings.
 - **Sync** — keeps a Notion page and an Anki deck in step. See [How sync works](/documentation/sync/how-it-works).
+- **Theme** — the visual style of the app. Pick from light, dark, gold, or purple in the top navigation. The choice is remembered per browser.
 - **Toggle** — a Notion (or HTML `<details>`) block that expands and collapses. By default 2anki turns each top-level toggle into one flashcard.
+- **Tour** — the four-step walkthrough that runs the first time you visit the upload page. Skippable. Doesn't run again.
 - **Upload** — a document you've sent to 2anki. The job that runs against the upload produces the deck.
 - **User** — your account. Owns uploads, decks, and settings.

--- a/web/src/pages/DocsPage/content/reference/plans.md
+++ b/web/src/pages/DocsPage/content/reference/plans.md
@@ -1,0 +1,68 @@
+---
+title: Short plans and trial
+description: Day Pass, Week Pass, and the 1-hour Unlimited trial — when one-time access makes sense.
+---
+
+Most people use Free or a monthly Subscription. But three short options exist for when neither fits — a deck for the weekend, a one-off cram session, or trying the paid features before paying.
+
+For the full plan list and prices, see the [pricing page](/pricing).
+
+## 1-hour Unlimited trial
+
+Free for any signed-in account that hasn't used it yet. One hour of Unlimited — no payment, no card on file.
+
+- **Length:** 1 hour from the moment you start it.
+- **Cost:** Free.
+- **Where:** the **Try Unlimited free for 1 hour** button on the [pricing page](/pricing). Visible only if you're signed in, on Free, and haven't used the trial before.
+- **What you get:** the full Unlimited feature set — unlimited cards, larger uploads, PDF support, [AI flashcards](/documentation/cards/ai-flashcards), the works.
+- **What happens after:** your account goes back to Free at the end of the hour. Decks built during the trial follow the [Free storage window](/documentation/help/limits#storage) — 24 hours.
+
+Use this when you have one big upload to do and want to confirm the paid path works for your source before subscribing.
+
+## Day Pass — $4
+
+24 hours of Unlimited access, paid once.
+
+- **Length:** 24 hours from purchase.
+- **Cost:** $4, one-time.
+- **What you get:** Unlimited conversions, every upload format (`.zip`, `.html`, `.md`, `.csv`, `.apkg`), image occlusion, custom card templates.
+- **Where:** **Day Pass** on the [pricing page](/pricing).
+
+Use this when you have a weekend of cards to build and don't want a recurring charge.
+
+## Week Pass — $9
+
+7 days of Unlimited access, paid once.
+
+- **Length:** 7 days from purchase.
+- **Cost:** $9, one-time.
+- **What you get:** same feature set as the Day Pass.
+- **Where:** **Week Pass** on the [pricing page](/pricing).
+
+Use this when you have a week to prep for an exam or a sprint to digitize a stack of notes.
+
+## How the short plans differ from Subscription
+
+| | Free | Day Pass | Week Pass | Unlimited (sub) | Lifetime |
+|---|---|---|---|---|---|
+| Cost | $0 | $4 | $9 | $6 / mo | from $345 once |
+| Length | forever | 24 h | 7 days | until cancelled | forever |
+| Cards per month | 100 | unlimited | unlimited | unlimited | unlimited |
+| PDF support | — | ✓ | ✓ | ✓ | ✓ |
+| [AI flashcards](/documentation/cards/ai-flashcards) | — | ✓ | ✓ | ✓ | ✓ |
+| [Auto Sync](/documentation/sync/how-it-works) | — | — | — | $30/mo add-on | ✓ |
+| Recurring charge | — | — | — | monthly | — |
+
+Day Pass and Week Pass do not include Auto Sync. If you need ongoing Notion → Anki sync, you need a Subscription with Auto Sync or a Lifetime plan.
+
+## Common mistakes
+
+- **Buying a pass while the trial is running.** The 1-hour trial runs its course — passes are added on top. If you've already started the trial, finish it before paying.
+- **Expecting the pass to renew.** Day and Week passes are one-time. When the window closes, you go back to Free. Buy another pass or move to a Subscription if you want continuous access.
+- **Mixing payment paths.** Lifetime is a separate, application-based plan paid through Patreon (see [pricing](/pricing)). Day and Week passes are Stripe checkouts.
+
+## Related
+
+- [Pricing](/pricing) — current plan list and purchase links
+- [Limits and quotas](/documentation/help/limits) — what's in each plan
+- [Privacy policy](/documentation/reference/privacy) — payment processing and data

--- a/web/src/pages/DocsPage/content/start-here/import-from-anki.md
+++ b/web/src/pages/DocsPage/content/start-here/import-from-anki.md
@@ -1,0 +1,42 @@
+---
+title: Import an Anki deck into Notion
+description: Turn an .apkg into Notion toggle pages — free up to 1,000 cards per import.
+---
+
+The reverse of everything else 2anki does. You upload an existing `.apkg` and we recreate the cards as toggles inside a Notion page. Useful for moving an old deck back into notes you can edit, or for giving a study deck to someone who works in Notion instead of Anki.
+
+**Plan:** Free up to 1,000 cards per import. Subscription and Lifetime get unlimited imports.
+
+## When to use this
+
+- You have an Anki deck and want the cards as Notion content you can rewrite.
+- You're handing a study set to a teammate or classmate who already lives in Notion.
+- You want to re-do a deck — fix typos, rewrite questions, change templates — and then push it back out through the normal 2anki flow.
+
+This is a one-time copy, not a live sync. Edits in Notion after the import don't flow back into the original `.apkg`. For ongoing sync, see [How sync works](/documentation/sync/how-it-works).
+
+## Run the import
+
+1. Open [2anki.net/import](https://2anki.net/import). If you haven't connected Notion yet, you'll be sent to do that first — see [Connect Notion](/documentation/start-here/connect-notion).
+2. Drop your `.apkg` onto the upload area, or click to pick one. Only `.apkg` files work here.
+3. Pick a destination:
+   - **Quick import** creates a new "2anki Imports" page in your workspace.
+   - **Choose a page** lets you nest the import under an existing top-level page. Only pages you've shared with the 2anki integration show up.
+4. Click **Import to selected page** (or **Quick import**). The progress bar shows cards as they land.
+5. When it finishes, click **Open in Notion** to jump straight to the new page.
+
+:::tip
+Cards become toggles — the front is the toggle summary, the back is what's inside. Cloze cards keep their `{{c1::...}}` syntax so you can re-import them later.
+:::
+
+## Common mistakes
+
+- **Wrong file type.** The page only accepts `.apkg`. If you have a `.colpkg` (full collection backup), open it in Anki first and export the deck you want as `.apkg`.
+- **Deck over the free limit.** Free hits a hard stop at 1,000 cards per import. Split the deck in Anki (right-click → **Export** with a filtered subset) or [upgrade](/pricing) for unlimited.
+- **Page not in the picker.** The destination picker only shows pages where the 2anki integration has access. Open the page in Notion → **Share** → **Add connections** → pick **2anki**.
+
+## Related
+
+- [Connect Notion](/documentation/start-here/connect-notion) — the workspace connection this flow uses
+- [Limits and quotas](/documentation/help/limits) — what each plan includes
+- [Pricing](/pricing) — upgrade for unlimited imports

--- a/web/src/pages/DocsPage/content/start-here/upload-a-file.md
+++ b/web/src/pages/DocsPage/content/start-here/upload-a-file.md
@@ -36,6 +36,15 @@ Use [Connect Notion](/documentation/start-here/connect-notion) when the source i
 4. Click **Convert**. When it finishes, click **Download** to grab the `.apkg`.
 5. Open the file in Anki — see [Open your deck in Anki](/documentation/start-here/open-in-anki).
 
+## Upload from Dropbox or Google Drive
+
+If your file lives in cloud storage, you don't have to download it first.
+
+- **Dropbox** — click **Choose from Dropbox** on the upload screen, sign in once, and pick the file. The chooser supports the same formats as the regular upload.
+- **Google Drive** — click **Choose from Google Drive**. You can pick any file 2anki accepts, plus native Google Docs, Sheets, and Slides. Native Google files are converted to a bulleted outline first — see [Common problems](/documentation/help/common-problems#my-google-doc-converted-to-0-cards) for the shape that produces cards.
+
+Both buttons are visible only when the integration is configured for the page you're on. If you don't see them, drag the file in from your computer instead.
+
 :::tip
 Toggle lists make the cleanest cards. If your source is plain prose, the conversion will still work, but you'll get better results from a structure where each card is one toggle, one bullet pair, or one row.
 :::

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -20,6 +20,10 @@ export const sidebar: SidebarGroup[] = [
       },
       { label: 'Upload a file instead', slug: 'start-here/upload-a-file' },
       { label: 'Open your deck in Anki', slug: 'start-here/open-in-anki' },
+      {
+        label: 'Import an Anki deck into Notion',
+        slug: 'start-here/import-from-anki',
+      },
     ],
   },
   {
@@ -29,6 +33,8 @@ export const sidebar: SidebarGroup[] = [
       { label: 'Card types', slug: 'cards/card-types' },
       { label: 'Multiple choice questions', slug: 'cards/mcq' },
       { label: 'Notion blocks we support', slug: 'cards/notion-blocks' },
+      { label: 'Parser rules', slug: 'cards/parser-rules' },
+      { label: 'AI flashcard generation', slug: 'cards/ai-flashcards' },
       { label: 'Markdown and Obsidian', slug: 'cards/markdown' },
       { label: 'HTML', slug: 'cards/html' },
     ],
@@ -58,6 +64,7 @@ export const sidebar: SidebarGroup[] = [
     items: [
       { label: 'Glossary', slug: 'reference/glossary' },
       { label: 'File formats', slug: 'reference/file-formats' },
+      { label: 'Short plans and trial', slug: 'reference/plans' },
       { label: 'Self-hosting', slug: 'reference/self-hosting' },
       { label: 'API access', slug: 'reference/api' },
       { label: 'Privacy policy', slug: 'reference/privacy' },


### PR DESCRIPTION
## Summary

A trio audit (pm/designer/engineer) compared the live docs at 2anki.net/documentation against the codebase and surfaced a list of features that ship in product but aren't documented. This is **Wave 1**: copy-only, no UI changes, no logic. Wave 2 (Image Occlusion, Templates browser, Chat assistant, Print/PDF export) needs screenshots and ships separately.

### What changed

**4 new pages**
- `start-here/import-from-anki` — Anki → Notion reverse import (free up to 1,000 cards/import).
- `cards/ai-flashcards` — Claude AI and Vertex AI options on one page; when each fires; how to write good user instructions; storage/privacy notes.
- `cards/parser-rules` — the `/rules/:id` editor: deck/sub-deck rules, flashcard block types, tag format, per-page card-options overrides.
- `reference/plans` — Day Pass ($4/24h), Week Pass ($9/7d), 1-hour Unlimited trial, comparison table.

**4 expansions**
- `start-here/upload-a-file` — Dropbox + Google Drive upload paths.
- `help/common-problems` — password-protected PDF entry (closes the "locked PDF → vague error → no docs hit" journey PM flagged).
- `reference/glossary` — Favorites, Feedback widget, Image Quiz HTML, Theme, Tour (5 short lines).
- `help/limits` — removes a `src/lib/misc/getUploadLimits.ts` reference per VOICE.md (no internal file paths in user-facing copy).

**Sidebar**
- "Start here" gains the import page.
- "Make better cards" gains parser-rules and ai-flashcards.
- "Reference" gains plans.

### Trio resolutions baked into the plan

- **No "Beyond Notion" top-level section** — designer's IA wins; the existing 6 sections are already goal-shaped.
- **Theme switcher / per-page overrides / per-page MCQ TTS → glossary or existing pages**, not new pages.
- **PDF password unlock → entry in `common-problems.md`**, not a standalone page.
- **Image Occlusion / Templates / Chat → Wave 2** (need screenshots).

### Not in this PR

- No changelog entry. These are documentation additions, not product-behavior changes — per `CLAUDE.md` the changelog table covers `feat:`/`fix:`/etc., not `docs:`.
- No sonar-scanner run. Doc-only changes with one sidebar.ts array update; per `.claude/rules/sonar.md` sonar is skipped for "pure doc/dep/test/typo changes".

## Test plan

- [ ] `/check` is green (server tsc + web typecheck + 774 vitest + biome lint all clean locally).
- [ ] Visit `/documentation/start-here/import-from-anki` and confirm the page renders.
- [ ] Visit `/documentation/cards/ai-flashcards` and confirm the page renders.
- [ ] Visit `/documentation/cards/parser-rules` and confirm the page renders.
- [ ] Visit `/documentation/reference/plans` and confirm the page renders.
- [ ] Click through the sidebar — three new entries appear under their groups.
- [ ] Spot-check the four expanded pages for the new sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->