### PR TITLE
perf: faster mobile LCP on the landing page

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -112,6 +112,14 @@ const serve = async () => {
   attachAnkifySessionProxy(app, server, ankifySessionValidate);
 
   app.use('/templates', express.static(templateDir));
+  // Hashed Vite output under /assets/* is content-addressed and immutable.
+  app.use(
+    '/assets',
+    express.static(`${BUILD_DIR}/assets`, {
+      immutable: true,
+      maxAge: '1y',
+    })
+  );
   app.use(express.static(BUILD_DIR));
 
   // API Documentation

--- a/web/index.html
+++ b/web/index.html
@@ -103,20 +103,22 @@
     }
   }
   </script>
-  <!-- Hotjar Tracking Code for https://2anki.net -->
+  <!-- Hotjar Tracking Code for https://2anki.net (deferred until after load) -->
   <script>
-    (function(h,o,t,j,a,r) {
-      h.hj=h.hj||function() {
-        const hjQueue=h.hj.q=h.hj.q||[];
-        hjQueue.push(arguments);
-      };
-      h._hjSettings={hjid: 2603407,hjsv: 6};
-      var headElement=o.getElementsByTagName('head')[0];
-      var scriptElement=o.createElement('script');
-      scriptElement.async=1;
-      scriptElement.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-      headElement.appendChild(scriptElement);
-    })(globalThis,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    globalThis.addEventListener('load', function () {
+      (function (h, o, t, j) {
+        h.hj = h.hj || function () {
+          const hjQueue = h.hj.q = h.hj.q || [];
+          hjQueue.push(arguments);
+        };
+        h._hjSettings = { hjid: 2603407, hjsv: 6 };
+        var headElement = o.getElementsByTagName('head')[0];
+        var scriptElement = o.createElement('script');
+        scriptElement.async = 1;
+        scriptElement.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+        headElement.appendChild(scriptElement);
+      })(globalThis, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
+    });
   </script>
 
   <!-- Legacy redirect (early + preserve URL) -->
@@ -135,30 +137,33 @@
   </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/bulma-switch.css">
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+    onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+  </noscript>
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <!-- Note: SRI not used for gtag.js as Google frequently updates this script, 
+  <!-- Global site tag (gtag.js) - Google Analytics (deferred until after load) -->
+  <!-- Note: SRI not used for gtag.js as Google frequently updates this script,
        which would break the integrity hash. Using secure loading with error handling instead. -->
   <script>
-    (function() {
-      globalThis.dataLayer=globalThis.dataLayer||[];
+    globalThis.addEventListener('load', function () {
+      globalThis.dataLayer = globalThis.dataLayer || [];
       function gtag() {
         dataLayer.push(arguments);
       }
-      const script=document.createElement('script');
-      script.async=true;
-      script.src='https://www.googletagmanager.com/gtag/js?id=G-X6K69TY3EX';
-      script.onerror=function() {
+      const script = document.createElement('script');
+      script.async = true;
+      script.src = 'https://www.googletagmanager.com/gtag/js?id=G-X6K69TY3EX';
+      script.onerror = function () {
         console.warn('Failed to load Google Analytics');
       };
-      script.onload=function() {
-        gtag('js',new Date());
-        gtag('config','G-X6K69TY3EX',{anonymize_ip: true});
+      script.onload = function () {
+        gtag('js', new Date());
+        gtag('config', 'G-X6K69TY3EX', { anonymize_ip: true });
       };
       document.head.appendChild(script);
-    })();
+    });
   </script>
 </head>
 

--- a/web/src/components/NavigationBar/NavigationBar.tsx
+++ b/web/src/components/NavigationBar/NavigationBar.tsx
@@ -12,7 +12,9 @@ function NavigationBar({ isLoggedIn }: Readonly<NavigationBarProps>) {
   const [active, setActive] = useState(false);
   const path = globalThis.location.pathname;
   const theme = useTheme();
-  const logoSrc = theme === 'light' ? '/mascot/navbar-logo.png' : '/mascot/Notion 1.png';
+  const isLight = theme === 'light';
+  const logoSrc = isLight ? '/mascot/navbar-logo.png' : '/mascot/Notion 1.png';
+  const logoWidth = isLight ? 103 : 33;
 
   const isResolved = isLoggedIn !== undefined;
 
@@ -20,7 +22,13 @@ function NavigationBar({ isLoggedIn }: Readonly<NavigationBarProps>) {
     <nav className={styles.navbar} aria-label="main navigation">
       <div className={styles.brand}>
         <a className={styles.logoLink} href="/">
-          <img src={logoSrc} alt="2anki Logo" />
+          <img
+            src={logoSrc}
+            alt="2anki Logo"
+            width={logoWidth}
+            height={28}
+            fetchPriority="high"
+          />
         </a>
         <button
           type="button"

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'The landing page paints faster on phones over slow connections', date: '2026-05-19' },
   { type: 'style', title: 'What\'s new page redesigned as a board — backlog, in progress, and shipped', date: '2026-05-19' },
   { type: 'feature', title: 'First upload — clearer no-cards message, one button to create an account and start a trial, and a quick first-visit tour', date: '2026-05-19' },
   { type: 'feature', title: 'Notion tables convert to flashcards — one row per card, column 1 on the front, column 2 on the back', date: '2026-05-19' },


### PR DESCRIPTION
## Summary

Targets the PageSpeed Insights mobile failure (LCP 3.2 s field / 6.9 s lab, CWV not passing). Four small, independently-shippable fixes:

- **Drop the orphaned `/bulma-switch.css` `<link>`.** The file does not exist in `web/public/` and is not imported anywhere in source — yet the browser still blocked paint waiting for the 404 response. Sneaky win.
- **Make Google Fonts non-blocking** via the standard `rel="preload"` + `onload` swap, with a `<noscript>` fallback. `font-display: swap` is already set, so the fallback font shows immediately and Inter swaps in when it lands.
- **Defer Hotjar + GA** until the `load` event. Both inline IIFEs attached an `async` script during head parse — small in bytes, but they contributed to the four long main-thread tasks Lighthouse flagged. Session-replay completeness drops by ~1 s on first paint; we keep all the data, just later.
- **Navbar logo (the actual LCP element on `/`)** gets explicit `width`/`height` and `fetchpriority=\"high\"`. The dark-theme logo is a separate problem — it's currently a 780×661 mascot PNG scaled to ~33×28, which is wasteful and probably ugly. Flagging for the designer; this PR just reserves the layout space.

Server side: serve `/assets/*` (hashed Vite output, content-addressed) with `Cache-Control: max-age=1y, immutable` so repeat visits stop re-validating every chunk.

## Why this set, why this order

Mobile field LCP is the actual user-felt problem — students on Android landing here from search rank pressure. Per CrUX, the metric is failing. The four fixes above hit the top three Lighthouse opportunities (render-blocking 600 ms, cache lifetime 98 KiB, image delivery / LCP candidate). Unused-JS (204 KiB) and the deeper bundle splitting are deliberately out of scope — that's a separate, larger PR.

## Test plan
- [x] `pnpm tsc --noEmit` (server)
- [x] `pnpm --filter 2anki-web typecheck`
- [x] `pnpm --filter 2anki-web build` (5.7s)
- [x] `pnpm --filter 2anki-web lint` (Biome clean)
- [x] `pnpm --filter 2anki-web test --run` (101 files / 774 tests pass)
- [ ] Manual smoke on mobile and desktop: landing page paints; theme switcher still works; Hotjar + GA still fire after load
- [ ] After merge: re-run PageSpeed Insights against `https://2anki.net/` and confirm mobile LCP drops
- [ ] Confirm Hotjar dashboard still receives sessions (deferred init means events fire post-load, but should still capture interaction)

## Follow-ups (separate PRs)

1. **Dark-theme navbar logo.** The current dark logo is a 780×661 PNG of the full mascot, displayed at ~33×28 in the navbar. Designer should produce a proper navbar-sized variant matching `navbar-logo.png`'s 140×38 aspect.
2. **Unused JS (204 KiB).** Lazy-load `HomePage`/`UploadPage` in `App.tsx`, defer Bugsnag init via `requestIdleCallback`, lazy-load Google Picker / Dropbox Chooser SDKs on first interaction. Needs a bundle analyzer pass first.
3. **Extend `landingPrerender` plugin to `/`.** The plugin in `web/vite.config.ts` already statically prerenders SEO routes (Notion, marketplace, answers). Extending the same pattern to `/` would put the LCP element in HTML at first byte — much bigger LCP move than full Express SSR, much smaller engineering lift. (See SSR notes in the chat — full SSR is not recommended here.)

## Changelog

`The landing page paints faster on phones over slow connections` — sentence case, no period, no fake warmth, per VOICE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->