### PR TITLE
fix: align onboarding-tour Playwright fixture with the real cutoff

### DIFF
--- a/web/tests/onboarding-tour.spec.ts
+++ b/web/tests/onboarding-tour.spec.ts
@@ -30,7 +30,7 @@ const OLD_USER_LOCALS = {
   ...NEW_USER_LOCALS,
   user: {
     ...NEW_USER_LOCALS.user,
-    created_at: '2026-06-07T10:00:00.000Z',
+    created_at: '2026-04-15T10:00:00.000Z',
     onboarded_at: null,
   },
 };


### PR DESCRIPTION
## Summary

The Playwright test [\`tests/onboarding-tour.spec.ts:123\`](https://github.com/2anki/server/blob/main/web/tests/onboarding-tour.spec.ts#L123) — *"user created before migration cutoff does not see the tour"* — has been **failing on every PR**, including main itself. The pre-existing failure has blocked the local merge-status hook on the recent docs PRs (#2463 already merged via admin bypass, #2464 still open and blocked).

## Diagnosis

| Field | Value |
|---|---|
| Production cutoff | \`MIGRATION_CUTOFF = '2026-05-19T00:00:00.000Z'\` ([OnboardingTour.tsx:29](https://github.com/2anki/server/blob/main/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.tsx#L29)) |
| OLD_USER fixture | \`created_at: '2026-06-07T10:00:00.000Z'\` |
| Comparison | \`2026-06-07 >= 2026-05-19\` → true → tour shown → test fails |

The fixture date was AFTER the cutoff but the test name claims it represents a user from BEFORE the cutoff. The two were never reconciled.

The unit test (\`OnboardingTour.test.tsx\`) doesn't trip on this because it injects \`migrationDate={MIGRATION_DATE}\` via prop, using \`'2026-06-08T00:00:00.000Z'\` so 06-07 is correctly "before". The Playwright test runs the real component and hits the production const directly.

## Fix

One line. Move OLD_USER's \`created_at\` to \`'2026-04-15T10:00:00.000Z'\` — clearly before the production cutoff.

No production code change. The component, the cutoff date, and every other test stay as they are.

## Not in this PR

- No changelog entry — test-only change, no user-visible behavior.
- No sonar-scanner — single test-fixture line per \`.claude/rules/sonar.md\` exception list.

## Test plan

- [ ] CI: Playwright workflow goes green for the first time in days.
- [ ] All other tests stay green (unit test for the same component was already passing via prop injection — no risk of regressing it).
- [ ] Once merged, #2464 (docs Wave 2) gets a clean check rollup and can merge normally without admin bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->