### PR TITLE
style: tighten chat transcript and flatten Claude bubbles

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -32,17 +32,13 @@
   padding: 1.25rem 1.5rem 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .message {
   display: flex;
   flex-direction: column;
   max-width: 80%;
-}
-
-.messageAssistantWithCards {
-  max-width: 100%;
 }
 
 .messageUser {
@@ -53,6 +49,20 @@
 .messageAssistant {
   align-self: flex-start;
   align-items: flex-start;
+  max-width: 72%;
+  gap: 0.5rem;
+}
+
+.messageAssistantWithCards {
+  max-width: 100%;
+}
+
+.messageSenderLabel {
+  font-size: 0.6875rem;
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  letter-spacing: 0.01em;
+  margin-bottom: -0.25rem;
 }
 
 .messageBubble {
@@ -67,16 +77,21 @@
 .messageBubbleUser {
   background: var(--color-bg-secondary);
   color: var(--color-text-primary);
-  border: 1px solid var(--color-border);
-  padding: 0.625rem 0.875rem;
+  border: none;
+  padding: 0.5rem 0.75rem;
 }
 
 .messageBubbleAssistant {
-  background: var(--color-bg-primary);
+  background: transparent;
   color: var(--color-text-primary);
-  border: 1px solid var(--color-border-light);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
-  padding: 0.625rem 0.875rem;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+@media (max-width: 600px) {
+  .messageAssistant { max-width: 90%; }
+  .messageUser { max-width: 88%; }
 }
 
 .messageSkeleton {
@@ -399,9 +414,9 @@
 .userBubbleClamped::after {
   content: '';
   position: absolute;
-  left: 1px;
-  right: 1px;
-  bottom: 1px;
+  left: 0;
+  right: 0;
+  bottom: 0;
   height: 3.5rem;
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
   background: linear-gradient(to bottom, transparent 0%, var(--color-bg-secondary) 100%);

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -511,6 +511,7 @@ export default function ChatPanel({
                   })()}
                   {m.role === 'assistant' && (
                     <>
+                      <span className={styles.messageSenderLabel}>Claude</span>
                       {m.contentBefore != null && (
                         <div className={`${styles.messageBubble} ${styles.messageBubbleAssistant}`}>
                           <AssistantMarkdown>{m.contentBefore}</AssistantMarkdown>
@@ -540,6 +541,7 @@ export default function ChatPanel({
                 <div className={`${styles.message} ${styles.messageAssistant}`}>
                   {streamingText.length > 0 ? (
                     <>
+                      <span className={styles.messageSenderLabel}>Claude</span>
                       <div className={`${styles.messageBubble} ${styles.messageBubbleAssistant}`}>
                         <AssistantMarkdown isStreaming={!isCardStreaming}>
                           {visibleStreamingText(streamingText)}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'style', title: 'Chat replies sit closer together so conversations stay on one screen', date: '2026-05-19' },
   { type: 'style', title: 'Pricing page — Day Pass and Week Pass sit at the top as full cards, no more accordion to click open', date: '2026-05-19' },
   { type: 'fix', title: 'The landing page paints faster on phones over slow connections', date: '2026-05-19' },
   { type: 'style', title: 'What\'s new page redesigned as a board — backlog, in progress, and shipped', date: '2026-05-19' },


### PR DESCRIPTION
## Summary

- Removes the bordered card around assistant messages and adds a small **Claude** sender label, so replies read as a tight transcript instead of stacked framed boxes (MSN-IM-inspired density, not nostalgia).
- User bubbles keep their right-aligned shape for attribution but lose the border and tighten padding to `0.5rem 0.75rem`.
- Inter-turn gap goes from `0.5rem` → `0.75rem`; assistant max-width drops from 80% to 72% (90% on mobile); user max-width caps at 88% on mobile.
- `CardPreview` is untouched. The `messageAssistantWithCards` class earns its keep — it overrides max-width to 100% on card turns.
- One-line changelog entry added — *Chat replies sit closer together so conversations stay on one screen*.

## Trio synthesis

- **pm**: "MSN inspired" reads as transcript density, not chrome — chat is a workspace, not a social feed. No avatars, timestamps, winks, or per-user name colors.
- **designer**: Flatten assistant (no border, bg, shadow, padding), keep user bubble, label above the first content block of each turn in `--color-primary`.
- **engineer**: CSS-only for density + ~2 JSX lines for the label; existing role-based tests don't touch CSS classes so nothing breaks. One real risk surfaced: `.userBubbleClamped::after` offsets were `1px` because of the user border — dropped to `0` in the same diff.

## Test plan

- [x] server tsc, web typecheck, vitest (774/774), Biome — all green locally
- [ ] Visual check on `/chat` in light + dark mode — confirm the **Claude** label reads as attribution, not noise
- [ ] Long user message triggers expand/collapse — confirm fade gradient meets the bottom edge after border removal
- [ ] Stream a reply — label appears once text begins (not on the skeleton)
- [ ] Stream a reply that produces cards — confirm CardPreview still goes full-width
- [ ] Resize to ≤600px and confirm both sides shrink to the new mobile caps

## Notes

\`sonar-scanner\` not run locally — diff is CSS + one JSX span. Open to a Sonar bounce if it flags anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->