### PR TITLE
style: One-time payment heading + consistent spacing on pricing page

### DIFF
--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -106,7 +106,7 @@
   gap: 1.5rem;
   align-items: stretch;
   position: relative;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2.5rem;
 }
 
 @media (max-width: 900px) {
@@ -149,41 +149,33 @@
 }
 
 .sectionLabel + .anchorGrid,
-.sectionLabel + .passGrid {
+.sectionLabel + .passGrid,
+.sectionLabel + .grid {
   margin-top: 0;
 }
 
-.passGrid + .sectionLabel {
+.passGrid + .sectionLabel,
+.anchorGrid + .sectionLabel {
   margin-top: 1rem;
 }
 
 /* =====================================================================
-   GRID — single-card Lifetime row
+   GRID — single centered Lifetime card row
    ===================================================================== */
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: minmax(0, 480px);
+  justify-content: center;
   gap: 1.5rem;
   align-items: stretch;
   position: relative;
+  margin-bottom: 2.5rem;
 }
 
 @media (max-width: 900px) {
   .grid {
     grid-template-columns: 1fr;
     gap: 1rem;
-  }
-
-  .cardPro {
-    order: 1;
-  }
-
-  .cardAutoSync {
-    order: 2;
-  }
-
-  .cardLifetime {
-    order: 3;
   }
 }
 

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -71,6 +71,11 @@ describe('PricingPage layout', () => {
     expect(screen.getByText('Monthly plans')).toBeInTheDocument();
   });
 
+  it('shows the One-time payment section label above Lifetime', () => {
+    renderAt('/pricing');
+    expect(screen.getByText('One-time payment')).toBeInTheDocument();
+  });
+
   it('shows Day Pass and Week Pass as full cards without an accordion', () => {
     const { container } = renderAt('/pricing');
     expect(screen.getByRole('button', { name: 'Get Day Pass' })).toBeInTheDocument();

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -345,6 +345,7 @@ export default function PricingPage({
         />
       </div>
 
+      <p className={styles.sectionLabel}>One-time payment</p>
       <div className={styles.grid}>
         <PricingCard
           className={styles.cardLifetime}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'style', title: 'Pricing page — Lifetime now sits in its own One-time payment section and the three pricing rows share the same spacing', date: '2026-05-19' },
   { type: 'style', title: 'Chat replies sit closer together so conversations stay on one screen', date: '2026-05-19' },
   { type: 'style', title: 'Pricing page — Day Pass and Week Pass sit at the top as full cards, no more accordion to click open', date: '2026-05-19' },
   { type: 'fix', title: 'The landing page paints faster on phones over slow connections', date: '2026-05-19' },


### PR DESCRIPTION
## Summary

Follow-up to #2469. Three changes on `/pricing`:

1. **Lifetime gets its own section heading** — `One-time payment` — mirroring the structure of `Pay once — no subscription` (passes) and `Monthly plans` (subscriptions). All three sections now share the same labeled layout.
2. **Consistent spacing** — every pricing row now uses `margin-bottom: 2.5rem`; the previous \`.anchorGrid\` was \`1.5rem\`. Adjacency rules cover all three label→row pairings.
3. **Lifetime card carries equal visual weight** — was previously rendered as the only child of a 3-column grid, which made it skinny and visually deprioritized. Switched the grid to a centered single column (\`minmax(0, 480px)\`) so it matches the width of one card in the rows above without being elevated.

## Why "One-time payment" and not "One-time purchase"

"Payment" describes the billing shape (parallel to "no subscription" and "monthly plans" — all describe cadence, not the act of buying). "Purchase" implies you receive something instantly, which contradicts Lifetime's current \`mailto:\` application flow (engineer flagged this in #2469).

## Test plan

- [x] \`pnpm --filter 2anki-web test PricingPage PassCards\` — 41/41 pass (added one test for the new section label)
- [x] \`pnpm --filter 2anki-web typecheck\` — clean
- [x] \`pnpm --filter 2anki-web lint\` — clean
- [ ] Visual check on desktop — three labeled sections with the same vertical spacing; Lifetime card centered at ~480px
- [ ] Visual check on mobile (≤900px) — labels and cards stack cleanly

## Notes

- Audience read: students. Lifetime label stays styled identically to the other two labels — no elevation. PM and designer were aligned on this in the trio.
- Did not reword the philosophy line (PM suggested "Free stays free. Paid plans keep 2anki.net running."). Out of scope for "add heading + consistent spacing" — easy follow-up if "Free works forever" starts feeling like it collides with "One-time payment".
- Did not adopt a unified \`.pricingRow\` wrapper class to replace the three sibling-selector rules. Two extra lines today vs a larger refactor — flagged in engineer's notes.
- Sonar-scanner not run locally — pure CSS layout + one new test, expect clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->