### PR TITLE
style: tighten chat prose spacing inside assistant messages

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -87,6 +87,7 @@
   border: none;
   box-shadow: none;
   padding: 0;
+  white-space: normal;
 }
 
 @media (max-width: 600px) {

--- a/web/src/pages/Chat/AssistantMarkdown.module.css
+++ b/web/src/pages/Chat/AssistantMarkdown.module.css
@@ -1,7 +1,7 @@
 .prose {
   color: var(--color-text-primary);
   font-size: var(--text-sm);
-  line-height: var(--leading-relaxed);
+  line-height: var(--leading-normal);
   word-break: break-word;
 }
 
@@ -9,7 +9,7 @@
 .prose > :last-child  { margin-bottom: 0; }
 
 .prose p {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.25rem;
 }
 
 .prose strong { font-weight: var(--font-semibold); }
@@ -17,11 +17,12 @@
 
 .prose ul,
 .prose ol {
-  margin: 0.25rem 0 0.5rem;
-  padding-left: 1.25rem;
+  margin: 0.125rem 0 0.25rem;
+  padding-left: 1.125rem;
 }
-.prose li { margin: 0.125rem 0; }
+.prose li { margin: 0; }
 .prose li > p { margin: 0; }
+.prose li + li { margin-top: 0.0625rem; }
 
 .prose h1,
 .prose h2,
@@ -29,7 +30,7 @@
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   line-height: var(--leading-snug);
-  margin: 0.75rem 0 0.25rem;
+  margin: 0.5rem 0 0.125rem;
 }
 
 .prose code {
@@ -41,8 +42,8 @@
 }
 
 .prose pre {
-  margin: 0.5rem 0;
-  padding: 0.75rem 0.875rem;
+  margin: 0.375rem 0;
+  padding: 0.5rem 0.75rem;
   background: var(--color-bg-tertiary);
   border-radius: var(--radius-md);
   overflow-x: auto;
@@ -61,7 +62,7 @@
 .prose hr {
   border: 0;
   border-top: 1px solid var(--color-border-light);
-  margin: 0.75rem 0;
+  margin: 0.5rem 0;
 }
 
 .prose a {
@@ -86,8 +87,8 @@
 }
 
 .prose blockquote {
-  margin: 0.5rem 0;
-  padding-left: 0.75rem;
+  margin: 0.375rem 0;
+  padding-left: 0.625rem;
   border-left: 2px solid var(--color-border);
   color: var(--color-text-secondary);
 }
@@ -95,7 +96,7 @@
 .prose table {
   font-variant-numeric: tabular-nums;
   border-collapse: collapse;
-  margin: 0.5rem 0;
+  margin: 0.375rem 0;
 }
 
 .prose th,

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -6,7 +6,7 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   { type: 'style', title: 'Pricing page — Lifetime now sits in its own One-time payment section and the three pricing rows share the same spacing', date: '2026-05-19' },
-  { type: 'style', title: 'Chat replies sit closer together so conversations stay on one screen', date: '2026-05-19' },
+  { type: 'style', title: 'Chat replies — tighter line spacing, lists, and paragraphs so a full answer fits on one screen', date: '2026-05-19' },
   { type: 'style', title: 'Pricing page — Day Pass and Week Pass sit at the top as full cards, no more accordion to click open', date: '2026-05-19' },
   { type: 'fix', title: 'The landing page paints faster on phones over slow connections', date: '2026-05-19' },
   { type: 'style', title: 'What\'s new page redesigned as a board — backlog, in progress, and shipped', date: '2026-05-19' },


### PR DESCRIPTION
## Summary

Follow-up to #2470. That PR removed the bubble chrome but the markdown body was still sized for long-form reading — line-height 1.625, paragraph margin 0.5rem, generous list rhythm — so a one-screen reply with a couple of paragraphs and a bullet list still felt airy.

Two root causes:

1. **`white-space: pre-wrap` was inherited from `.messageBubble` onto assistant content.** That rule exists for *user* messages where it preserves raw newlines. On the assistant side, react-markdown already controls whitespace; pre-wrap was turning text-node whitespace between react nodes into visible blank lines. Overridden to `normal` on `.messageBubbleAssistant`.
2. **Prose rhythm.** Dropped line-height to `--leading-normal` (1.5); halved paragraph margin (0.5rem → 0.25rem); tightened list, heading, code-block, blockquote, and hr margins to match a transcript surface.

Existing 2026-05-19 changelog entry updated in place rather than adding a duplicate — same surface, same day, same product improvement; just describes the final state honestly.

## Test plan

- [x] server tsc, web typecheck, vitest (773/773), Biome — all green locally
- [ ] Same welcome reply that exposed the issue should sit on one screen now
- [ ] Code blocks, headings, blockquotes, and tables still read clearly with the tighter rhythm
- [ ] Streaming reply with bullets — confirm spacing matches the finished state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->