### PR TITLE
style: hide AI-rewrite notice on privacy and terms pages

### DIFF
--- a/web/src/pages/DocsPage/DocsPage.test.tsx
+++ b/web/src/pages/DocsPage/DocsPage.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import DocsPage from './DocsPage';
+
+vi.mock('./DocContent', () => ({
+  DocContent: ({ slug }: { slug: string }) => <div>doc-content:{slug}</div>,
+}));
+vi.mock('./DocsHome', () => ({
+  DocsHome: () => <div>docs-home</div>,
+}));
+vi.mock('./DocsSidebar', () => ({
+  DocsSidebar: () => <nav>sidebar</nav>,
+}));
+vi.mock('./DocsDrawer', () => ({
+  DocsDrawer: () => null,
+}));
+
+const WIP_TEXT = /These docs are being rewritten with help from AI/;
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/documentation/*" element={<DocsPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('DocsPage', () => {
+  it('shows the WIP banner on the docs home', () => {
+    renderAt('/documentation');
+    expect(screen.getByText(WIP_TEXT)).toBeInTheDocument();
+  });
+
+  it('shows the WIP banner on a regular doc page', () => {
+    renderAt('/documentation/start-here/connect-notion');
+    expect(screen.getByText(WIP_TEXT)).toBeInTheDocument();
+  });
+
+  it('hides the WIP banner on the privacy policy page', () => {
+    renderAt('/documentation/reference/privacy');
+    expect(screen.queryByText(WIP_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('hides the WIP banner on the terms of service page', () => {
+    renderAt('/documentation/reference/terms');
+    expect(screen.queryByText(WIP_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('hides the WIP banner even with a trailing slash on the legal slug', () => {
+    renderAt('/documentation/reference/privacy/');
+    expect(screen.queryByText(WIP_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DocsPage/DocsPage.tsx
+++ b/web/src/pages/DocsPage/DocsPage.tsx
@@ -13,6 +13,8 @@ function stripTrailingSlashes(value: string): string {
   return end === value.length ? value : value.slice(0, end);
 }
 
+const LEGAL_SLUGS = new Set(['reference/privacy', 'reference/terms']);
+
 export default function DocsPage() {
   const params = useParams();
   const slug = stripTrailingSlashes(params['*'] ?? '');
@@ -42,7 +44,7 @@ export default function DocsPage() {
       <DocsDrawer isOpen={menuOpen} onClose={closeMenu} activeSlug={slug} />
 
       <main className={styles.main}>
-        <WipBanner />
+        {!LEGAL_SLUGS.has(slug) && <WipBanner />}
         {slug ? <DocContent slug={slug} /> : <DocsHome />}
       </main>
     </div>


### PR DESCRIPTION
## Summary

The WipBanner ("These docs are being rewritten with help from AI…") is appropriate on product docs but wrong on legal copy. Privacy policy and Terms of service are reviewed legal content per \`.claude/rules/security.md\`, not AI-rewritten, and the disclaimer suggests otherwise.

Guards the banner against the two legal slugs (\`reference/privacy\`, \`reference/terms\`) in \`DocsPage.tsx\`. Adds \`DocsPage.test.tsx\` with five cases: banner shows on home, shows on a regular doc page, hidden on privacy, hidden on terms, and hidden on the trailing-slash variant.

No changelog entry — removing a banner that shouldn't have been there on those pages reads as a cleanup, not a user-facing improvement worth announcing on the What's New page.

## Test plan

- [x] \`pnpm --filter 2anki-web typecheck\` — clean
- [x] \`pnpm --filter 2anki-web test:run\` — 779/779 (5 new)
- [x] \`pnpm --filter 2anki-web lint\` — clean
- [ ] Load \`/documentation/reference/privacy\` and \`/documentation/reference/terms\` — banner absent
- [ ] Load \`/documentation/start-here/connect-notion\` — banner still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->