### PR TITLE
feat: upsell card on Downloads and upload success

### DIFF
--- a/web/src/components/UpsellCard/UpsellCard.module.css
+++ b/web/src/components/UpsellCard/UpsellCard.module.css
@@ -1,0 +1,99 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+}
+
+.headline {
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.body {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-bg-primary);
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--transition-fast);
+}
+
+.primary:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.primary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.secondary {
+  font-size: var(--text-sm);
+  color: var(--color-primary);
+  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-family: inherit;
+}
+
+.secondary:hover:not(:disabled) {
+  text-decoration: underline;
+}
+
+.secondary:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.dot {
+  color: var(--color-text-tertiary);
+  user-select: none;
+}
+
+@media (max-width: 600px) {
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .dot {
+    display: none;
+  }
+
+  .secondary {
+    text-align: center;
+    padding: 0.25rem 0;
+  }
+}

--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { UpsellCard } from './UpsellCard';
+
+const mockStartPassCheckout = vi.fn();
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    startPassCheckout: mockStartPassCheckout,
+  }),
+}));
+
+const mockUseUserLocals = vi.fn();
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => mockUseUserLocals(),
+}));
+
+const mockTrack = vi.fn();
+
+vi.mock('../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+const freeUser = {
+  data: {
+    locals: { patreon: false, subscriber: false },
+    user: { email: 'free@example.com' },
+  },
+};
+
+const payingUser = {
+  data: {
+    locals: { patreon: false, subscriber: true },
+    user: { email: 'paying@example.com' },
+  },
+};
+
+const anonymousUser = { data: undefined };
+
+describe('UpsellCard', () => {
+  beforeEach(() => {
+    mockTrack.mockClear();
+    mockStartPassCheckout.mockReset();
+  });
+
+  it('renders three CTAs for free users', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    render(<UpsellCard surface="downloads_upsell" />);
+    expect(screen.getByRole('button', { name: 'Day Pass $4' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Week Pass $9' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Unlimited $6/mo' })).toBeInTheDocument();
+  });
+
+  it('renders nothing for paying users', () => {
+    mockUseUserLocals.mockReturnValue(payingUser);
+    const { container } = render(<UpsellCard surface="downloads_upsell" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders for anonymous users', () => {
+    mockUseUserLocals.mockReturnValue(anonymousUser);
+    render(<UpsellCard surface="downloads_upsell" />);
+    expect(screen.getByRole('button', { name: 'Day Pass $4' })).toBeInTheDocument();
+  });
+
+  it('uses the downloads surface headline on /downloads', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    render(<UpsellCard surface="downloads_upsell" />);
+    expect(screen.getByText('Converting more this month?')).toBeInTheDocument();
+  });
+
+  it('uses the upload-success surface headline on upload success', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    render(<UpsellCard surface="upload_success_upsell" />);
+    expect(screen.getByText('More decks coming?')).toBeInTheDocument();
+  });
+
+  it('fires paywall_shown with the surface on mount for free users', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    render(<UpsellCard surface="downloads_upsell" />);
+    expect(mockTrack).toHaveBeenCalledWith('paywall_shown', { surface: 'downloads_upsell' });
+  });
+
+  it('does not fire paywall_shown for paying users', () => {
+    mockUseUserLocals.mockReturnValue(payingUser);
+    render(<UpsellCard surface="downloads_upsell" />);
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('fires paywall_upgrade_clicked with plan=day_pass when Day Pass is clicked', async () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    mockStartPassCheckout.mockResolvedValue({ url: 'https://checkout.stripe.com/day' });
+    Object.defineProperty(globalThis, 'location', { writable: true, value: { href: '' } });
+
+    render(<UpsellCard surface="downloads_upsell" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Day Pass $4' }));
+
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+        surface: 'downloads_upsell',
+        plan: 'day_pass',
+      });
+      expect(mockStartPassCheckout).toHaveBeenCalledWith('24h');
+    });
+  });
+
+  it('fires paywall_upgrade_clicked with plan=week_pass when Week Pass is clicked', async () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    mockStartPassCheckout.mockResolvedValue({ url: 'https://checkout.stripe.com/week' });
+    Object.defineProperty(globalThis, 'location', { writable: true, value: { href: '' } });
+
+    render(<UpsellCard surface="upload_success_upsell" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Week Pass $9' }));
+
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+        surface: 'upload_success_upsell',
+        plan: 'week_pass',
+      });
+      expect(mockStartPassCheckout).toHaveBeenCalledWith('7d');
+    });
+  });
+
+  it('fires paywall_upgrade_clicked with plan=unlimited when Unlimited is clicked', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    render(<UpsellCard surface="downloads_upsell" />);
+    fireEvent.click(screen.getByRole('link', { name: 'Unlimited $6/mo' }));
+    expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+      surface: 'downloads_upsell',
+      plan: 'unlimited',
+    });
+  });
+
+  it('shows Redirecting label and disables buttons while pass checkout is pending', async () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    let resolveCheckout: (value: { status: 'error' }) => void = () => {};
+    mockStartPassCheckout.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheckout = resolve;
+      })
+    );
+
+    render(<UpsellCard surface="downloads_upsell" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Day Pass $4' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
+    });
+
+    resolveCheckout({ status: 'error' });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Day Pass $4' })).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+
+import { track } from '../../lib/analytics/track';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
+import { isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
+import { getSubscribeLink } from '../../pages/PricingPage/payment.links';
+import styles from './UpsellCard.module.css';
+
+type Surface = 'downloads_upsell' | 'upload_success_upsell';
+
+interface UpsellCardProps {
+  readonly surface: Surface;
+}
+
+const HEADLINE: Record<Surface, string> = {
+  downloads_upsell: 'Converting more this month?',
+  upload_success_upsell: 'More decks coming?',
+};
+
+const BODY: Record<Surface, string> = {
+  downloads_upsell:
+    'Free plan is 100 cards a month and one conversion at a time. A pass removes both limits without a subscription.',
+  upload_success_upsell:
+    'Free plan caps at 100 cards a month and one job at a time. A pass removes both for the next day or week.',
+};
+
+export function UpsellCard({ surface }: UpsellCardProps) {
+  const { data } = useUserLocals();
+  const [pendingKind, setPendingKind] = useState<'24h' | '7d' | null>(null);
+
+  const paying = isPayingUser(data?.locals);
+
+  useEffect(() => {
+    if (paying) return;
+    track('paywall_shown', { surface });
+  }, [paying, surface]);
+
+  if (paying) return null;
+
+  const email = data?.user?.email;
+
+  const handlePassClick = async (kind: '24h' | '7d') => {
+    track('paywall_upgrade_clicked', {
+      surface,
+      plan: kind === '24h' ? 'day_pass' : 'week_pass',
+    });
+    setPendingKind(kind);
+    const result = await get2ankiApi().startPassCheckout(kind);
+    if ('url' in result) {
+      globalThis.location.href = result.url;
+      return;
+    }
+    setPendingKind(null);
+  };
+
+  const handleUnlimitedClick = () => {
+    track('paywall_upgrade_clicked', { surface, plan: 'unlimited' });
+  };
+
+  return (
+    <section className={styles.card} aria-label="Keep going without the monthly cap">
+      <p className={styles.headline}>{HEADLINE[surface]}</p>
+      <p className={styles.body}>{BODY[surface]}</p>
+      <div className={styles.actions}>
+        <button
+          type="button"
+          className={styles.primary}
+          onClick={() => handlePassClick('24h')}
+          disabled={pendingKind != null}
+        >
+          {pendingKind === '24h' ? 'Redirecting…' : 'Day Pass $4'}
+        </button>
+        <button
+          type="button"
+          className={styles.secondary}
+          onClick={() => handlePassClick('7d')}
+          disabled={pendingKind != null}
+        >
+          {pendingKind === '7d' ? 'Redirecting…' : 'Week Pass $9'}
+        </button>
+        <span className={styles.dot} aria-hidden="true">·</span>
+        <a
+          className={styles.secondary}
+          href={getSubscribeLink(email)}
+          onClick={handleUnlimitedClick}
+        >
+          Unlimited $6/mo
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/UpsellCard/index.ts
+++ b/web/src/components/UpsellCard/index.ts
@@ -1,0 +1,1 @@
+export { UpsellCard } from './UpsellCard';

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -24,10 +24,7 @@ import { fireAnalyticsEvent } from '../../lib/analytics/fireAnalyticsEvent';
 import { track } from '../../lib/analytics/track';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabel';
-import {
-  MONTHLY_PRICE,
-  MONTHLY_SUFFIX,
-} from '../PricingPage/pricing.constants';
+import { UpsellCard } from '../../components/UpsellCard';
 import JobResponse from '../../schemas/public/JobResponse';
 import styles from './DownloadsPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
@@ -549,10 +546,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                 </div>
                 {showUpgradeFooter && !isGloballyEmpty && (
                   <div className={styles.upgradeFooter}>
-                    Hitting the 100-card limit?{' '}
-                    <Link to="/pricing">
-                      Upgrade to Unlimited — {MONTHLY_PRICE} {MONTHLY_SUFFIX}, cancel anytime →
-                    </Link>
+                    <UpsellCard surface="downloads_upsell" />
                   </div>
                 )}
               </div>

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -23,6 +23,7 @@ import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
 import { fireAnalyticsEvent } from '../../../../lib/analytics/fireAnalyticsEvent';
 import { track } from '../../../../lib/analytics/track';
 import ChatPanel from '../../../../components/ChatPanel/ChatPanel';
+import { UpsellCard } from '../../../../components/UpsellCard';
 import formStyles from './UploadForm.module.css';
 import sharedStyles from '../../../../styles/shared.module.css';
 
@@ -826,6 +827,9 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
             Try Auto Sync
           </a>
         </p>
+      )}
+      {!showAutoSyncPrompt && (
+        <UpsellCard surface="upload_success_upsell" />
       )}
       <button
         type="button"

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Just finished a conversion? Day Pass and Week Pass appear on Downloads and upload success, with the free-plan limits explained up front', date: '2026-05-19' },
   { type: 'style', title: 'Pricing page — Lifetime now sits in its own One-time payment section and the three pricing rows share the same spacing', date: '2026-05-19' },
   { type: 'style', title: 'Chat replies — tighter line spacing, lists, and paragraphs so a full answer fits on one screen', date: '2026-05-19' },
   { type: 'style', title: 'Pricing page — Day Pass and Week Pass sit at the top as full cards, no more accordion to click open', date: '2026-05-19' },


### PR DESCRIPTION
## Summary

Catches free users at the moment of peak satisfaction (just downloaded a deck, or just finished an upload) with pay-once options. Targets the conversion leak surfaced by 30 days of analytics + cancellation data:

- 81% of all traffic is US, and US users hit `/pricing` at **0.15%** (vs UK 9.3% / DE 5.9%)
- `/limit` page has 3 views in 30 days — almost nobody hits the cap
- `/downloads` gets 1,428 monthly views, currently showed only a single one-line link to /pricing
- The upload-success state had no pay-once option (only an Auto Sync prompt for users with Notion connected)
- 49% of recent cancellations are "I finished what I needed" — the exact cohort a Day Pass serves better than a monthly sub

## Copy decision

The card explains the free-plan limits up front — **100 cards a month AND one conversion at a time** — so users understand what they're trading before the limit bites. Surfaces them at the moment of success, not at the moment of frustration.

Two surface variants:

- `downloads_upsell`: "Converting more this month? / Free plan is 100 cards a month and one conversion at a time. A pass removes both limits without a subscription."
- `upload_success_upsell`: "More decks coming? / Free plan caps at 100 cards a month and one job at a time. A pass removes both for the next day or week."

CTAs: **Day Pass \$4 (primary button)**, then Week Pass \$9 and Unlimited \$6/mo as text-link secondaries. Pay-once leads because the audience is students and the cancellation data says they don't want subscriptions.

## Files

- New shared `UpsellCard` component under `web/src/components/UpsellCard/`
- `/downloads`: replaces the old `upgradeFooter` one-line link with the new card
- `/upload` success: gates the new card against the existing `showAutoSyncPrompt` so only one upsell fires at a time
- Suppressed for paying users via `isPayingUser`
- Existing `PaywallBanner` on `/downloads` (contextual notice when a concurrent free-plan job is cancelled) is untouched

## Test plan

- [x] \`pnpm --filter 2anki-web test UpsellCard\` — 11/11 pass
- [x] \`pnpm --filter 2anki-web test DownloadsPage UploadForm\` — 109/109 pass
- [x] \`pnpm --filter 2anki-web typecheck\` — clean
- [x] \`pnpm --filter 2anki-web lint\` — clean
- [ ] Visual check on /downloads as a free user — card replaces the old footer link, sits below the deck table
- [ ] Visual check on upload success as a free user without Notion connected — card appears below the success message
- [ ] Visual check on upload success as a free user WITH Notion connected — AutoSync prompt shows instead (no double upsell)
- [ ] Click Day Pass \$4 → Stripe checkout opens
- [ ] Telemetry — \`paywall_shown\` and \`paywall_upgrade_clicked\` fire with new surface values

## Notes

- Did not promote `PaywallBanner.tsx` to a shared abstraction yet — we're at two occurrences of "upsell-ish component," one short of the rule-of-three threshold.
- Sonar-scanner not run locally — one new isolated component + small JSX swaps; expect clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->