### PR TITLE
fix: stop AI-rewrite banner from flickering between legal pages

### DIFF
--- a/web/src/pages/DocsPage/DocsPage.module.css
+++ b/web/src/pages/DocsPage/DocsPage.module.css
@@ -101,6 +101,10 @@
   line-height: var(--leading-normal);
 }
 
+.main[data-legal="true"] .wipBanner {
+  display: none;
+}
+
 .wipBanner a {
   color: var(--color-warning-text);
   font-weight: var(--font-medium);

--- a/web/src/pages/DocsPage/DocsPage.test.tsx
+++ b/web/src/pages/DocsPage/DocsPage.test.tsx
@@ -16,8 +16,6 @@ vi.mock('./DocsDrawer', () => ({
   DocsDrawer: () => null,
 }));
 
-const WIP_TEXT = /These docs are being rewritten with help from AI/;
-
 function renderAt(path: string) {
   return render(
     <MemoryRouter initialEntries={[path]}>
@@ -28,29 +26,33 @@ function renderAt(path: string) {
   );
 }
 
+function mainEl(): HTMLElement {
+  return screen.getByRole('main');
+}
+
 describe('DocsPage', () => {
-  it('shows the WIP banner on the docs home', () => {
+  it('does not mark the docs home as legal', () => {
     renderAt('/documentation');
-    expect(screen.getByText(WIP_TEXT)).toBeInTheDocument();
+    expect(mainEl()).not.toHaveAttribute('data-legal');
   });
 
-  it('shows the WIP banner on a regular doc page', () => {
+  it('does not mark a regular doc page as legal', () => {
     renderAt('/documentation/start-here/connect-notion');
-    expect(screen.getByText(WIP_TEXT)).toBeInTheDocument();
+    expect(mainEl()).not.toHaveAttribute('data-legal');
   });
 
-  it('hides the WIP banner on the privacy policy page', () => {
+  it('marks the privacy policy page as legal', () => {
     renderAt('/documentation/reference/privacy');
-    expect(screen.queryByText(WIP_TEXT)).not.toBeInTheDocument();
+    expect(mainEl()).toHaveAttribute('data-legal', 'true');
   });
 
-  it('hides the WIP banner on the terms of service page', () => {
+  it('marks the terms of service page as legal', () => {
     renderAt('/documentation/reference/terms');
-    expect(screen.queryByText(WIP_TEXT)).not.toBeInTheDocument();
+    expect(mainEl()).toHaveAttribute('data-legal', 'true');
   });
 
-  it('hides the WIP banner even with a trailing slash on the legal slug', () => {
+  it('marks the legal page even with a trailing slash', () => {
     renderAt('/documentation/reference/privacy/');
-    expect(screen.queryByText(WIP_TEXT)).not.toBeInTheDocument();
+    expect(mainEl()).toHaveAttribute('data-legal', 'true');
   });
 });

--- a/web/src/pages/DocsPage/DocsPage.tsx
+++ b/web/src/pages/DocsPage/DocsPage.tsx
@@ -43,8 +43,11 @@ export default function DocsPage() {
 
       <DocsDrawer isOpen={menuOpen} onClose={closeMenu} activeSlug={slug} />
 
-      <main className={styles.main}>
-        {!LEGAL_SLUGS.has(slug) && <WipBanner />}
+      <main
+        className={styles.main}
+        data-legal={LEGAL_SLUGS.has(slug) ? 'true' : undefined}
+      >
+        <WipBanner />
         {slug ? <DocContent slug={slug} /> : <DocsHome />}
       </main>
     </div>


### PR DESCRIPTION
## Summary

Follow-up to #2473. That PR added a conditional render to hide the WipBanner on \`reference/privacy\` and \`reference/terms\`. The user reported it still flickers when switching between Privacy and Terms via the sidebar — even though the deployed JS bundle does contain the LEGAL_SLUGS guard.

The root cause is that React conditional rendering (\`{guard && <WipBanner />}\`) toggles whether the element is in the DOM. Across an SPA navigation, any co-fired state update (e.g. the mobile-menu close handler that fires alongside NavLink's navigate) can cause a brief render where the slug observed by the component is in an unexpected intermediate state — which mounts the banner for one paint.

## Fix

Render \`<WipBanner />\` unconditionally inside \`<main>\`, and toggle its visibility via a CSS rule scoped to a \`data-legal\` attribute on the wrapper:

\`\`\`tsx
<main className={styles.main} data-legal={LEGAL_SLUGS.has(slug) ? 'true' : undefined}>
  <WipBanner />
  ...
</main>
\`\`\`

\`\`\`css
.main[data-legal="true"] .wipBanner {
  display: none;
}
\`\`\`

The banner element stays in the DOM across every navigation — only an attribute on the parent flips. \`display: none\` keeps it out of the accessibility tree on legal pages.

## Test changes

Tests now assert the \`data-legal\` attribute on \`<main>\` rather than the banner-text presence. JSDOM in vitest doesn't reliably apply CSS-module rules, so checking the attribute is more reliable than checking computed visibility.

## Test plan

- [x] \`pnpm --filter 2anki-web typecheck\` — clean
- [x] \`pnpm --filter 2anki-web test:run\` — 790/790
- [x] \`pnpm --filter 2anki-web lint\` — clean
- [ ] Hard-reload /documentation/reference/privacy then click Terms in the sidebar; confirm no banner flash either direction
- [ ] Navigate from a regular doc page to a legal page; confirm the banner cleanly disappears (no flicker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->