### PR TITLE
fix: theme What's new board so dark mode stops looking broken

### DIFF
--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -36,7 +36,7 @@
 /* ── Column ── */
 
 .column {
-  background: #f7f7f5;
+  background: var(--color-bg-secondary);
   border-radius: 8px;
   padding: 12px;
   min-height: 400px;
@@ -61,7 +61,7 @@
 }
 
 .columnCount {
-  color: #787774;
+  color: var(--color-text-secondary);
   font-variant-numeric: tabular-nums;
 }
 
@@ -78,7 +78,7 @@
 
 .card {
   background: var(--color-bg-primary);
-  border: 1px solid #e9e9e7;
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   padding: 12px;
   display: flex;
@@ -88,14 +88,14 @@
 }
 
 .card:hover {
-  background: #fbfbfa;
+  background: var(--color-bg-tertiary);
 }
 
 .typeTag {
   font-size: 10px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: #787774;
+  color: var(--color-text-secondary);
   margin-bottom: 2px;
 }
 
@@ -112,13 +112,13 @@
 
 .cardSecondary {
   font-size: 12px;
-  color: #787774;
+  color: var(--color-text-secondary);
   margin-top: 2px;
 }
 
 .trackedLink {
   font-size: 12px;
-  color: #787774;
+  color: var(--color-text-secondary);
   text-decoration: none;
   margin-top: 6px;
   align-self: flex-start;
@@ -133,7 +133,7 @@
 
 .emptyState {
   font-size: 13px;
-  color: #787774;
+  color: var(--color-text-secondary);
   margin: 0 0 8px;
 }
 
@@ -141,7 +141,7 @@
 
 .reportLink {
   font-size: 13px;
-  color: #787774;
+  color: var(--color-text-secondary);
   text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary

The kanban redesign on `/whats-new` shipped with hardcoded hex colors that only worked on the light theme. In dark mode the columns stayed pale gray on a dark page and the card borders disappeared; gold and purple themes were off too.

## What changed

`web/src/pages/WhatsNewPage/WhatsNewPage.module.css`

Replaced nine hex literals with the existing theme tokens:

| Before | After | Where |
|---|---|---|
| `#f7f7f5` | `var(--color-bg-secondary)` | Column background |
| `#e9e9e7` | `var(--color-border)` | Card border |
| `#fbfbfa` | `var(--color-bg-tertiary)` | Card hover |
| `#787774` | `var(--color-text-secondary)` | Column count, type tag, card secondary, tracked link, empty state, report link (6 sites) |

All four themes (light, dark, gold, purple) already define these tokens — confirmed in `web/src/styles/base.css`.

## Test plan

- [x] `pnpm --filter 2anki-web vitest run src/pages/WhatsNewPage` — 5 tests pass
- [ ] After deploy: open https://2anki.net/whats-new in each theme and confirm column backgrounds + card borders look right

## Changelog

No entry — visual fix on a page that should already have worked; users wouldn't write "the page is themed now" in a release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->