### PR TITLE
fix: halve template gallery iframe scale so thumbnails are readable

### DIFF
--- a/web/src/pages/TemplatesPage/TemplatesPage.module.css
+++ b/web/src/pages/TemplatesPage/TemplatesPage.module.css
@@ -48,11 +48,11 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 800px;
-  height: 450px;
+  width: 400px;
+  height: 225px;
   border: 0;
   transform-origin: top left;
-  transform: scale(calc(100cqw / 800px));
+  transform: scale(calc(100cqw / 400px));
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

Template gallery thumbnails at \`/templates\` were rendering into an 800×450 internal iframe and CSS-scaling down to fit ~280px gallery cards — scale factor ~0.35. Text designed for full-screen Anki review ended up at ~5–6px effective, so most thumbnails looked empty even though their CSS and content were correct.

This was a pre-existing weakness of the thumbnail design (since 2026-05-15) that the conditional-blocks fix from #2482 just exposed — before that, the literal \`{{#Field}}\` / \`{{/Field}}\` tokens filled space and gave the cards a sense of populated content; with proper section handling, the actual minimal designs are now visible.

## What changed

\`web/src/pages/TemplatesPage/TemplatesPage.module.css\` — \`.previewFrame\`:

| | Before | After |
|---|---|---|
| Internal width | 800px | 400px |
| Internal height | 450px | 225px |
| Scale | calc(100cqw / 800px) ≈ 0.35 | calc(100cqw / 400px) ≈ 0.7 |
| Effective text @ 16px | ~5.6px | ~11.2px |

Aspect ratio stays 16:9, no layout shift, no other CSS changes. The \`.modalFrame\` (click-to-zoom preview) is left at 800×600 — that surface exists for the full-fidelity preview.

## Test plan

- [x] \`pnpm --filter 2anki-web vitest run src/pages/TemplatesPage\` — 44 tests pass
- [x] \`pnpm --filter 2anki-web typecheck\` clean
- [x] \`pnpm --filter 2anki-web lint\` clean
- [ ] After deploy: open https://2anki.net/templates, confirm text is readable on Vocabulary Card, Medical Term, Quote, Math & Science, Modern Cloze, Clean Basic, Minimal, Code Card without zooming
- [ ] Click into any card to open the modal preview, confirm full-fidelity 800×600 rendering still works

## Not building (deferred)

- A static screenshot-per-template fallback (would fix Image Occlusion too, since its canvas needs JS that the sandbox blocks). Separate spec — multi-day work.
- Resizing the modal preview. Reachable from any card; full fidelity is the right call there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->