### PR TITLE
fix: card fills template preview iframe and starter section moves up

### DIFF
--- a/web/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -359,31 +359,6 @@ export function TemplatesPage() {
           </div>
         </section>
       )}
-      {officialStarters.length > 0 && (
-        <section
-          className={styles.section}
-          aria-labelledby="official-note-types-heading"
-        >
-          <h2
-            id="official-note-types-heading"
-            className={styles.sectionHeading}
-          >
-            Official 2anki templates
-          </h2>
-          <div className={styles.grid}>
-            {officialStarters.map((starter) => (
-              <NoteTypeCard
-                key={starter.id}
-                starter={starter}
-                ownedByUser={false}
-                busy={busyId === starter.id}
-                onDownload={handleDownload}
-                onPreview={setPreviewed}
-              />
-            ))}
-          </div>
-        </section>
-      )}
       {defaultStarters.length > 0 && (
         <section
           className={styles.section}
@@ -397,6 +372,31 @@ export function TemplatesPage() {
           </h2>
           <div className={styles.grid}>
             {defaultStarters.map((starter) => (
+              <NoteTypeCard
+                key={starter.id}
+                starter={starter}
+                ownedByUser={false}
+                busy={busyId === starter.id}
+                onDownload={handleDownload}
+                onPreview={setPreviewed}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+      {officialStarters.length > 0 && (
+        <section
+          className={styles.section}
+          aria-labelledby="official-note-types-heading"
+        >
+          <h2
+            id="official-note-types-heading"
+            className={styles.sectionHeading}
+          >
+            Official 2anki templates
+          </h2>
+          <div className={styles.grid}>
+            {officialStarters.map((starter) => (
               <NoteTypeCard
                 key={starter.id}
                 starter={starter}

--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
@@ -71,9 +71,11 @@ export function buildPreviewDocument(
 ): string {
   const body = renderCardSide(noteType, previewData, side);
   return `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>
-html, body { margin: 0; padding: 0; width: 100%; height: 100%; }
+html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #fff; color: #111; }
 body { overflow: hidden; display: flex; }
 body > .card { flex: 1; min-height: 100%; box-sizing: border-box; }
 ${noteType.css ?? ''}
+html, body { margin: 0 !important; padding: 0 !important; max-width: none !important; width: 100% !important; height: 100% !important; }
+body { display: flex !important; }
 </style></head><body><div class="card">${body}</div></body></html>`;
 }


### PR DESCRIPTION
## Summary

Two gallery fixes in the same surface, prompted by user feedback after #2482 + #2483 deployed.

### 1. Cards fill the iframe edge to edge

\`notion.css\` ships with \`body { margin: 2em auto; max-width: 900px }\` — that meant every Notion-flavoured starter (Default Basic/Cloze/Type-the-answer, Only Notion variants) rendered with a band of the gallery card background showing through the top and bottom of the iframe. Visible as a \"offset\" between the preview wrap and the card content.

Separately, \"Raw Note (no style)\" has \`cssFile: null\` so \`noteType.css\` is empty — the wrapper left both html and body transparent, so the thumbnail showed whatever was behind the iframe.

Fix in \`renderNoteTypePreview.ts > buildPreviewDocument\`:
- Wrapper sets a default \`background: #fff; color: #111\` on html and body.
- Wrapper re-asserts \`margin: 0 / padding: 0 / max-width: none / width: 100% / height: 100%\` on html and body *after* the template CSS, with \`!important\` so notion.css's \`body { margin: 2em auto; max-width: 900px }\` no longer wins.
- Templates that set their own \`.card\` background (Quote = #1c1917, Alex Deluxe = blue gradient, Abhiyan = night-mode dark) still win because that selector is more specific than the body reset.

### 2. Section reorder — Starter note types lead the page

Visible sections were ordered:
1. Your note types
2. Official 2anki templates
3. Starter note types

Reordered to:
1. Your note types
2. **Starter note types** (Clean Basic, Modern Cloze, Vocabulary, Medical, Code, Minimal, Quote, Math & Science — polished designs)
3. Official 2anki templates (Default / Only Notion / Raw / Abhiyan / Alex variants)

User's own work still leads. The polished gallery comes next so the first impression is the strong designs, not the historical defaults.

## Test plan

- [x] \`pnpm --filter 2anki-web vitest run src/pages/TemplatesPage\` — 44 tests pass
- [x] \`pnpm --filter 2anki-web typecheck\` clean
- [x] \`pnpm --filter 2anki-web lint\` clean
- [ ] After deploy: hard-refresh \`/templates\`, confirm Only Notion thumbnails fill the iframe (no dark band top/bottom), confirm Raw Note (no style) has a white background, confirm Starter section appears above Official

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->