### PR TITLE
fix: show apkg preview on Notion-converted deck rows

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -250,6 +250,52 @@ describe('DownloadsPage source labels', () => {
   });
 });
 
+describe('DownloadsPage preview button on done job rows', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:00:00Z'));
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    mockUploads = [];
+    mockDropboxUploads = [];
+    mockGoogleDriveUploads = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as AnalyticsGlobals).hj;
+    delete (globalThis as AnalyticsGlobals).gtag;
+  });
+
+  it('renders the preview link when a done job has a .apkg download_key', () => {
+    mockJobs = [
+      buildJob({
+        status: 'done',
+        type: 'page',
+        title: 'Pharmacology Ch. 4',
+        download_key: 'deck-abc123.apkg',
+      }),
+    ];
+    renderAt('/downloads');
+    const previewLink = screen.getByLabelText('Preview Pharmacology Ch. 4');
+    expect(previewLink).toBeInTheDocument();
+    expect(previewLink.getAttribute('href')).toBe('/preview/apkg/deck-abc123.apkg');
+  });
+
+  it('does not render the preview link when download_key does not end with .apkg', () => {
+    mockJobs = [
+      buildJob({
+        status: 'done',
+        type: 'page',
+        title: 'Some deck',
+        download_key: 'deck-abc123.zip',
+      }),
+    ];
+    renderAt('/downloads');
+    expect(screen.queryByLabelText('Preview Some deck')).not.toBeInTheDocument();
+  });
+});
+
 describe('renderJobStatusCell — URL construction', () => {
   it('uses /api/download/u/<download_key> when download_key is present', () => {
     const job = buildJob({

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -359,6 +359,16 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                 </td>
                                 <td>
                                   <div className={styles.actions}>
+                                    {isDoneJob(row.job.status) && row.job.download_key != null && APKG_PATTERN.test(row.job.download_key) && (
+                                      <Link
+                                        to={`/preview/apkg/${encodeURIComponent(row.job.download_key)}`}
+                                        className={styles.iconButton}
+                                        aria-label={`Preview ${row.job.title ?? 'deck'}`}
+                                        title="Preview"
+                                      >
+                                        <EyeIcon width={18} height={18} />
+                                      </Link>
+                                    )}
                                     {isFailed ? (
                                       renderJobStatusWithToggle({
                                         job: row.job,

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Preview your deck from My Decks before opening Anki — works for Notion conversions, not just direct uploads', date: '2026-05-20' },
   { type: 'feature', title: 'Share a converted deck with a link — recipient can preview the cards and download the .apkg without an account', date: '2026-05-20' },
   { type: 'fix', title: 'Print page handles bigger decks — free covers up to 1000 cards, and the error tells you the exact count and cap if you go over', date: '2026-05-20' },
   { type: 'fix', title: 'Dropped an .apkg on the upload page by mistake? The error now points you to Print Decks instead of a dead end', date: '2026-05-20' },


### PR DESCRIPTION
## Summary

- On /downloads the eye-icon preview link only rendered on raw upload rows (`row.kind === 'file'`). Notion conversions come in as `'job'` rows, and `toDeckRows` dedupes away the matching file row when the job is done with a matching `download_key` — so the preview affordance disappeared for the dominant path.
- Render the same eye-icon `<Link>` in the job-row Actions cell when `isDoneJob(j.status) && j.download_key` matches `/\.apkg$/i`. Order matches file rows: `[Preview] [Download] [SendToAnkify?] [Delete] [Restart?]`. `aria-label` falls back to "Preview deck" when `j.title` is null.
- Two new vitest cases in `DownloadsPage.test.tsx` covering the apkg and non-apkg `download_key` branches. Changelog entry stacked at the top of `changelog.ts`.

Out of scope: `toDeckRows` dedupe, file-row ordering, analytics on preview clicks, `renderJobStatusCell` internals.

## Test plan

- [x] `pnpm --filter 2anki-web test DownloadsPage.test.tsx --run` — 22/22 green (2 new)
- [x] `pnpm --filter 2anki-web typecheck`
- [x] `pnpm --filter 2anki-web lint`
- [ ] Visual check on /downloads: done Notion-converted deck row shows an eye-icon to the left of the download icon and routes to `/preview/apkg/<download_key>`
- [ ] Visual check: in-progress and failed job rows do NOT show the preview icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->