### PR TITLE
fix: center gallery preview cards and add Image Occlusion fallback

### DIFF
--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
@@ -73,9 +73,30 @@ export function buildPreviewDocument(
   return `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>
 html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #fff; color: #111; }
 body { overflow: hidden; display: flex; }
-body > .card { flex: 1; min-height: 100%; box-sizing: border-box; }
+body > .card {
+  flex: 1;
+  min-height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  text-align: center;
+}
+input, button, select, textarea { pointer-events: none; }
 ${noteType.css ?? ''}
 html, body { margin: 0 !important; padding: 0 !important; max-width: none !important; width: 100% !important; height: 100% !important; }
 body { display: flex !important; }
+#image-occlusion-canvas, #image-occlusion-container > script { display: none !important; }
+#image-occlusion-container::after {
+  content: 'Image occlusion preview — install in Anki to see masks';
+  display: block;
+  padding: 12px;
+  color: #6b7280;
+  font-style: italic;
+  font-size: 14px;
+  text-align: center;
+}
 </style></head><body><div class="card">${body}</div></body></html>`;
 }


### PR DESCRIPTION
## Summary

Four gallery polish issues from the latest review.

### 1. Default-center .card content

Templates without their own \`.card\` display rules (Default, Only Notion, Raw Note, Minimal, parts of user-saved defaults) rendered short text in the top-left, leaving 70%+ of the thumbnail blank.

Wrapper now adds \`display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 16px; text-align: center\` on \`body > .card\` as a default. Templates that set their own \`.card\` display (Quote, Vocabulary, Modern Cloze, Code Card, etc.) keep their own layout because their declarations are equally specific and come later in the cascade.

### 2. Inert form fields

Default (Type the answer) renders an \`<input>\` in the qfmt; in the preview it became a focusable text box that looked broken at thumbnail scale. \`input, button, select, textarea { pointer-events: none }\` in the wrapper — they still render as styled elements but can't be focused.

### 3. Image Occlusion fallback

The canvas + script Anki uses to draw masks can't run in \`sandbox=\"\"\`. The thumbnail was always blank except for the Header text. Hide \`#image-occlusion-canvas\` and inject \"Image occlusion preview — install in Anki to see masks\" via \`::after\` on the container.

### 4. Background defaults (still in place from #2484)

White card behind every template that doesn't set its own background — Raw Note included.

## Test plan

- [x] \`pnpm --filter 2anki-web vitest run src/pages/TemplatesPage\` — 44 tests pass
- [x] \`pnpm --filter 2anki-web typecheck\` clean
- [x] \`pnpm --filter 2anki-web lint\` clean
- [ ] After deploy: hard-refresh \`/templates\`, confirm Default Basic/Cloze/Type-the-answer + Only Notion + Raw Note + Minimal now center their content vertically, and Image Occlusion shows the fallback message instead of a blank canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->