### PR TITLE
fix: stop overriding template .card layout in gallery + editor preview

### DIFF
--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
@@ -73,7 +73,7 @@ export function buildPreviewDocument(
   return `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>
 html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #fff; color: #111; }
 body { overflow: hidden; display: flex; }
-body > .card {
+:where(body > .card) {
   flex: 1;
   min-height: 100%;
   box-sizing: border-box;
@@ -81,8 +81,6 @@ body > .card {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 16px;
-  text-align: center;
 }
 input, button, select, textarea { pointer-events: none; }
 ${noteType.css ?? ''}


### PR DESCRIPTION
## Summary

The previous fix (#2486) added \`body > .card { display: flex; ... padding: 16px; text-align: center }\` to the iframe wrapper. That selector is specificity 0,1,1 — higher than templates' own \`.card { ... }\` (0,1,0) — so it stomped every template that had its own centering and padding.

### Visible breakage

- **Live editor preview broken**: \`/templates/edit/vocab-language\` no longer centers because Vocabulary's \`.card { display: flex; align-items: center; padding: 32px 24px }\` was overridden by my wrapper.
- **Clean Basic** gallery thumbnail clipped the \`?\` from "What is the capital of France?" on the right edge (16px padding ate into the content area while the template's font size still assumed 800px internal).
- **Alexander Deluxe (Blue)** wrapped onto a second line that clipped at the bottom; **(Blue — Cloze)** lost the leading "The".

## What changes

One line in \`renderNoteTypePreview.ts\`: wrap the default \`.card\` layout rule in \`:where(body > .card)\` (specificity drops to 0,0,0). Templates' own \`.card\` rules now always win. Templates without a \`.card\` display rule (Default, Only Notion, Raw Note, Minimal) still get flex-column centering as the fallback. Padding removed — that's the template's call.

## Test plan

- [x] \`pnpm --filter 2anki-web vitest run src/pages/TemplatesPage\` — 44 tests pass
- [x] \`pnpm --filter 2anki-web typecheck\` clean
- [x] \`pnpm --filter 2anki-web lint\` clean
- [ ] After deploy: \`/templates/edit/vocab-language\` shows Vocab centered again
- [ ] After deploy: Clean Basic + Alexander Deluxe text no longer clips at edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->