### PR TITLE
feat: show Send to Anki to free users with Auto Sync upsell

### DIFF
--- a/web/src/pages/DownloadsPage/components/SendToAnkifyButton.test.tsx
+++ b/web/src/pages/DownloadsPage/components/SendToAnkifyButton.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import SendToAnkifyButton from './SendToAnkifyButton';
+
+const navigateMock = vi.fn();
+const dispatchMock = vi.fn();
+const listClientsMock = vi.fn();
+const trackMock = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('../../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+vi.mock('../../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    dispatchUploadToAnkify: (...args: unknown[]) => dispatchMock(...args),
+    listAnkifyClients: () => listClientsMock(),
+  }),
+}));
+
+let mockLocalsData: { locals: { patreon: boolean }; autoSyncActive: boolean } | undefined;
+
+vi.mock('../../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => ({ data: mockLocalsData }),
+}));
+
+const renderButton = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <SendToAnkifyButton uploadId={42} filename="Pharmacology.apkg" />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('SendToAnkifyButton', () => {
+  beforeEach(() => {
+    navigateMock.mockReset();
+    dispatchMock.mockReset();
+    listClientsMock.mockReset();
+    trackMock.mockReset();
+    listClientsMock.mockResolvedValue([{ status: 'active' }]);
+    dispatchMock.mockResolvedValue({ created: 1, updated: 0, anki_web_sync: 'synced' });
+  });
+
+  afterEach(() => {
+    mockLocalsData = undefined;
+  });
+
+  it('routes free users to the Auto Sync upsell on click and never calls the API', async () => {
+    mockLocalsData = { locals: { patreon: false }, autoSyncActive: false };
+    renderButton();
+    const button = screen.getByRole('button', { name: /send to my anki/i });
+    fireEvent.click(button);
+    expect(navigateMock).toHaveBeenCalledWith('/pricing?upsell=auto-sync');
+    expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+      surface: 'ankify_button',
+      plan: 'auto_sync',
+    });
+    expect(dispatchMock).not.toHaveBeenCalled();
+    expect(listClientsMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatches the upload for lifetime (patreon) users', async () => {
+    mockLocalsData = { locals: { patreon: true }, autoSyncActive: false };
+    renderButton();
+    const button = await screen.findByRole('button', { name: /send this to my anki/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(42));
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatches the upload for Auto Sync subscribers', async () => {
+    mockLocalsData = { locals: { patreon: false }, autoSyncActive: true };
+    renderButton();
+    const button = await screen.findByRole('button', { name: /send this to my anki/i });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(42));
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/DownloadsPage/components/SendToAnkifyButton.tsx
+++ b/web/src/pages/DownloadsPage/components/SendToAnkifyButton.tsx
@@ -1,5 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
+import { track } from '../../../lib/analytics/track';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import { useUserLocals } from '../../../lib/hooks/useUserLocals';
 
@@ -10,27 +12,35 @@ interface Props {
 
 export default function SendToAnkifyButton({ uploadId, filename }: Props) {
   const { data } = useUserLocals();
-  const isEnabled = data?.locals?.patreon === true;
+  const hasAccess =
+    data?.locals?.patreon === true || data?.autoSyncActive === true;
   const api = get2ankiApi();
+  const navigate = useNavigate();
 
   const { data: clients } = useQuery({
     queryKey: ['ankify-clients'],
     queryFn: () => api.listAnkifyClients(),
-    enabled: isEnabled,
+    enabled: hasAccess,
   });
 
   const dispatch = useMutation({
     mutationFn: () => api.dispatchUploadToAnkify(Number(uploadId)),
   });
 
-  if (!isEnabled) {
-    return null;
-  }
+  const handleClick = () => {
+    if (!hasAccess) {
+      track('paywall_upgrade_clicked', { surface: 'ankify_button', plan: 'auto_sync' });
+      navigate('/pricing?upsell=auto-sync');
+      return;
+    }
+    dispatch.mutate();
+  };
 
   const hasActive = (clients ?? []).some((c) => c.status === 'active');
-  const disabled = dispatch.isPending || !hasActive;
+  const disabled = hasAccess && (dispatch.isPending || !hasActive);
 
   const label = (() => {
+    if (!hasAccess) return 'Send to my Anki';
     if (dispatch.isPending) return 'Sending to your Anki…';
     if (dispatch.isSuccess) {
       const data = dispatch.data;
@@ -51,6 +61,7 @@ export default function SendToAnkifyButton({ uploadId, filename }: Props) {
   })();
 
   const title = (() => {
+    if (!hasAccess) return 'Auto Sync sends decks straight to your Anki — see plans';
     if (!hasActive) return 'Set up your Anki on the Ankify page first';
     if (dispatch.isError) return (dispatch.error as Error).message;
     if (dispatch.isSuccess && dispatch.data.anki_web_sync === 'failed') {
@@ -62,7 +73,7 @@ export default function SendToAnkifyButton({ uploadId, filename }: Props) {
   return (
     <button
       type="button"
-      onClick={() => dispatch.mutate()}
+      onClick={handleClick}
       disabled={disabled}
       title={title}
       style={{

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -322,6 +322,11 @@
     0 18px 44px -18px var(--color-focus-ring);
 }
 
+.cardAutoSyncUpsell {
+  box-shadow: 0 0 0 3px var(--color-primary),
+    0 18px 44px -18px var(--color-focus-ring);
+}
+
 .cardAutoSync::before {
   content: '';
   position: absolute;

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -77,11 +77,19 @@ export default function PricingPage({
   const [subscribeError, setSubscribeError] = useState<string | null>(null);
   const [dayPassState, setDayPassState] = useState<PassState>('idle');
   const [weekPassState, setWeekPassState] = useState<PassState>('idle');
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const fromPaywall = searchParams.get('source') === 'paywall-cancel';
   const fromContext = searchParams.get('from');
   const showContextBanner =
     fromContext != null && !isLoggedIn ? false : fromContext != null;
+  const isAutoSyncUpsell = searchParams.get('upsell') === 'auto-sync';
+
+  useEffect(() => {
+    if (!isAutoSyncUpsell) return;
+    const next = new URLSearchParams(searchParams);
+    next.delete('upsell');
+    setSearchParams(next, { replace: true });
+  }, [isAutoSyncUpsell, searchParams, setSearchParams]);
 
   const isLifetime = patreon === true;
   const showAutoSyncNew = isAutoSyncNewChipVisible();
@@ -263,6 +271,11 @@ export default function PricingPage({
             You're on the free plan — 100 cards per month.
           </div>
         )}
+        {isAutoSyncUpsell && (
+          <div className={styles.contextBanner} role="status">
+            Auto Sync sends any deck straight to your Anki — no downloading, no importing.
+          </div>
+        )}
         <p className={styles.intro}>
           {isUS
             ? 'Built for spaced repetition — MCAT, USMLE, bar exam, and language prep. 100 cards a month free, plus Anki → Notion imports up to 1,000 notes each.'
@@ -335,6 +348,7 @@ export default function PricingPage({
           isLifetime={isLifetime}
           isActive={autoSyncActive}
           capReached={showCapReached}
+          highlighted={isAutoSyncUpsell}
           caption={autoSyncCaptionText}
           waitlistLabel={waitlistLabel}
           waitlistDisabled={

--- a/web/src/pages/PricingPage/components/AutoSyncCard.tsx
+++ b/web/src/pages/PricingPage/components/AutoSyncCard.tsx
@@ -16,6 +16,7 @@ interface AutoSyncCardProps {
   isLifetime: boolean;
   isActive: boolean;
   capReached: boolean;
+  highlighted?: boolean;
   caption?: string;
   waitlistLabel: string;
   waitlistDisabled: boolean;
@@ -28,6 +29,7 @@ export function AutoSyncCard({
   isLifetime,
   isActive,
   capReached,
+  highlighted = false,
   caption,
   waitlistLabel,
   waitlistDisabled,
@@ -35,11 +37,14 @@ export function AutoSyncCard({
   onWaitlist,
 }: Readonly<AutoSyncCardProps>) {
   const newBadge = showNewBadge ? 'New — built for Notion' : undefined;
+  const cardClass = highlighted
+    ? `${styles.cardAutoSync} ${styles.cardAutoSyncUpsell}`
+    : styles.cardAutoSync;
 
   if (isLifetime) {
     return (
       <PricingCard
-        className={styles.cardAutoSync}
+        className={cardClass}
         title="Auto Sync"
         price={AUTO_SYNC_PRICE}
         priceSuffix={MONTHLY_SUFFIX}
@@ -54,7 +59,7 @@ export function AutoSyncCard({
   if (isActive) {
     return (
       <PricingCard
-        className={styles.cardAutoSync}
+        className={cardClass}
         title="Auto Sync"
         price={AUTO_SYNC_PRICE}
         priceSuffix={MONTHLY_SUFFIX}
@@ -72,7 +77,7 @@ export function AutoSyncCard({
   if (capReached) {
     return (
       <PricingCard
-        className={styles.cardAutoSync}
+        className={cardClass}
         title="Auto Sync"
         price={AUTO_SYNC_PRICE}
         priceSuffix={MONTHLY_SUFFIX}
@@ -90,7 +95,7 @@ export function AutoSyncCard({
 
   return (
     <PricingCard
-      className={styles.cardAutoSync}
+      className={cardClass}
       title="Auto Sync"
       price={AUTO_SYNC_PRICE}
       priceSuffix={MONTHLY_SUFFIX}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Send to my Anki on every finished deck — Auto Sync subscribers send instantly, everyone else lands on the upgrade page', date: '2026-05-20' },
   { type: 'fix', title: 'Preview your deck from My Decks before opening Anki — works for Notion conversions, not just direct uploads', date: '2026-05-20' },
   { type: 'feature', title: 'Share a converted deck with a link — recipient can preview the cards and download the .apkg without an account', date: '2026-05-20' },
   { type: 'fix', title: 'Print page handles bigger decks — free covers up to 1000 cards, and the error tells you the exact count and cap if you go over', date: '2026-05-20' },


### PR DESCRIPTION
## Summary

- `SendToAnkifyButton` was hidden from free users *and* from Auto Sync subscribers (the gate read `patreon === true` only, not `hasAnkifyAccess`). Both broken: subscribers couldn't use the feature they pay for, and free users had no idea it existed.
- Gate switched to `patreon === true || autoSyncActive === true`, matching `Sidebar.tsx:187` and `src/lib/ankify/access.ts`.
- Free users now see the button on every done deck row. Click navigates to `/pricing?upsell=auto-sync` (no API calls, no dispatch) and fires `paywall_upgrade_clicked` for analytics.
- `PricingPage` consumes the param: banner above the plan cards (`Auto Sync sends any deck straight to your Anki — no downloading, no importing.`), Auto Sync card gets a 3px primary-color ring, param stripped from the URL after mount so back/forward stays clean.
- Three new unit tests in `SendToAnkifyButton.test.tsx`: free user → navigate + track, never dispatch; patreon user → dispatch; Auto Sync subscriber → dispatch.

Trio synthesis: PM/Designer/Engineer all agreed on the routing target, the bundled gate fix, the in-row placement, and no GrowthBook gate. Conflict on the free-user label (PM: identical to paid; Designer: explicit gate signal) — resolved in favor of PM because the user's ask was explicitly "same label, upgrade prompt on click."

Out of scope: changing the Notion-source gate on job rows (claude/AI jobs still don't show this button — separate decision), a modal-based upsell, GrowthBook experimentation.

## Test plan

- [x] `pnpm --filter 2anki-web test --run` — 829/829 tests pass (3 new)
- [x] `pnpm --filter 2anki-web typecheck`
- [x] `pnpm --filter 2anki-web lint`
- [ ] Visual check on /downloads as a free user: button reads "Send to my Anki", clicking navigates to /pricing with banner + ring on Auto Sync card
- [ ] Visual check on /downloads as a lifetime/Auto-Sync user: button dispatches, no navigation
- [ ] After landing on /pricing?upsell=auto-sync, the param is stripped from the URL bar
- [ ] `sonar-scanner` before flipping ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->