### PR TITLE
fix: viewport-relative base font-size in template preview

### DIFF
--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
@@ -71,6 +71,9 @@ export function buildPreviewDocument(
 ): string {
   const body = renderCardSide(noteType, previewData, side);
   return `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>
+html { font-size: clamp(8px, 2.5vw, 16px); }
+:where(h1) { font-size: 1.4em; }
+:where(h2) { font-size: 1.25em; }
 html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #fff; color: #111; }
 body { overflow: hidden; display: flex; }
 :where(body > .card) {


### PR DESCRIPTION
## Summary

Templates with em-based font sizing — Alex Deluxe Cloze (\`.container-front { font-size: 2.81em }\`), Notion-flavoured fonts, others — compounded through h1's default \`2em\` into ~80-90px text that overflowed the 400px gallery iframe. Bigger templates wrapped to 3+ lines and clipped at the bottom of the 225px iframe height. Alex Deluxe (Blue — Cloze) lost the leading "The" because it scrolled out.

## What changes

Two CSS lines in the wrapper of \`renderNoteTypePreview.ts\`:

\`\`\`css
html { font-size: clamp(8px, 2.5vw, 16px); }
:where(h1) { font-size: 1.4em; }
:where(h2) { font-size: 1.25em; }
\`\`\`

- \`clamp(8px, 2.5vw, 16px)\` on \`html\` — at the 400px gallery iframe internal width, base = 10px. At a wider editor preview iframe (~500-800px) base settles at 12-16px. At the 800px modal preview, capped at 16px. Templates that use \`rem\` or \`em\` inherit this base and shrink proportionally with iframe width.
- \`:where(h1) { font-size: 1.4em }\` and \`:where(h2) { font-size: 1.25em }\` — dampens browser-default \`h1: 2em / h2: 1.5em\` so multi-em compounding (\`.container-front 2.81em\` × \`h1 2em\` = ~5.6em) doesn't blow up at the gallery scale. Wrapped in \`:where()\` so templates with explicit h1/h2 sizing still win.

## Result

- Alex Deluxe (Blue) and (Blue — Cloze) — text now fits the gallery thumbnail on two readable lines instead of clipping.
- Other em/rem-based templates (Modern Cloze, Vocabulary, Quote) auto-scale gracefully with iframe width.
- Pixel-based fonts (Clean Basic at \`font-size: 32px\` and similar) are unaffected — those need separate per-template treatment.
- Editor preview at \`/templates/edit/*\` renders with a comfortable base because the iframe is wider; \`clamp()\` picks the right value for the context.

## Test plan

- [x] \`pnpm --filter 2anki-web vitest run src/pages/TemplatesPage\` — 44 tests pass
- [x] \`pnpm --filter 2anki-web typecheck\` clean
- [x] \`pnpm --filter 2anki-web lint\` clean
- [ ] After deploy: hard-refresh \`/templates\`, confirm Alex Deluxe Cloze shows "The capital of [...] is [...]" within its card without clipping
- [ ] After deploy: \`/templates/edit/vocab-language\` editor preview still looks right (clamp scales the base up as the iframe widens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->