### PR TITLE
fix: cap deck filename to OS byte limit (no more long-title crashes)

### DIFF
--- a/create_deck/create_deck.py
+++ b/create_deck/create_deck.py
@@ -12,6 +12,17 @@ import json
 import sys
 import os
 
+from genanki import Note
+from genanki.util import guid_for
+
+from helpers.cards import get_safe_value
+from helpers.get_model import get_model
+from helpers.get_model_id import get_model_id
+from helpers.read_template import read_template
+from helpers.sanitize_tags import sanitize_tags
+from helpers.write_apkg import _write_new_apkg
+from backend.utils.email_error_alert import send_error_email
+
 _MAX_BASENAME_BYTES = 200
 
 
@@ -35,17 +46,6 @@ def _clamp_output_path(path: str) -> str:
         stem_str = ""
     new_basename = stem_str + ".apkg"
     return os.path.join(directory, new_basename)
-
-from genanki import Note
-from genanki.util import guid_for
-
-from helpers.cards import get_safe_value
-from helpers.get_model import get_model
-from helpers.get_model_id import get_model_id
-from helpers.read_template import read_template
-from helpers.sanitize_tags import sanitize_tags
-from helpers.write_apkg import _write_new_apkg
-from backend.utils.email_error_alert import send_error_email
 
 
 def build_one_deck(data_file, template_dir):

--- a/create_deck/create_deck.py
+++ b/create_deck/create_deck.py
@@ -12,6 +12,30 @@ import json
 import sys
 import os
 
+_MAX_BASENAME_BYTES = 200
+
+
+def _clamp_output_path(path: str) -> str:
+    directory = os.path.dirname(path)
+    basename = os.path.basename(path)
+    encoded = basename.encode("utf-8")
+    if len(encoded) <= _MAX_BASENAME_BYTES:
+        return path
+    ext = b".apkg"
+    max_stem_bytes = _MAX_BASENAME_BYTES - len(ext)
+    stem_bytes = encoded[: -len(ext)] if basename.endswith(".apkg") else encoded
+    truncated = stem_bytes[:max_stem_bytes]
+    while truncated:
+        try:
+            stem_str = truncated.decode("utf-8")
+            break
+        except UnicodeDecodeError:
+            truncated = truncated[:-1]
+    else:
+        stem_str = ""
+    new_basename = stem_str + ".apkg"
+    return os.path.join(directory, new_basename)
+
 from genanki import Note
 from genanki.util import guid_for
 
@@ -198,7 +222,7 @@ def run_batch(manifest_path, template_dir):
 
     for entry in entries:
         input_path = entry["input"]
-        output_path = entry["output"]
+        output_path = _clamp_output_path(entry["output"])
         deck_dir = os.path.dirname(input_path)
 
         original_cwd = os.getcwd()

--- a/create_deck/tests/test_batch_mode.py
+++ b/create_deck/tests/test_batch_mode.py
@@ -6,6 +6,16 @@ import tempfile
 import zipfile
 from pathlib import Path
 
+import importlib.util as _ilu
+
+_spec = _ilu.spec_from_file_location(
+    "create_deck_script",
+    Path(__file__).parents[1] / "create_deck.py",
+)
+_mod = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+_clamp_output_path = _mod._clamp_output_path
+
 REPO_ROOT = Path(__file__).parents[2]
 SCRIPT = REPO_ROOT / "create_deck" / "create_deck.py"
 TEMPLATE_DIR = str(REPO_ROOT / "src" / "templates") + os.sep
@@ -183,3 +193,64 @@ class TestBatchMode:
                 cwd=subdir,
             )
             assert result.returncode == 0
+
+
+class TestClampOutputPath:
+    def test_short_path_is_unchanged(self):
+        path = "/tmp/short.apkg"
+        assert _clamp_output_path(path) == path
+
+    def test_long_ascii_basename_is_truncated(self):
+        long_stem = "a" * 300
+        path = f"/tmp/{long_stem}.apkg"
+        result = _clamp_output_path(path)
+        assert result.endswith(".apkg")
+        assert len(os.path.basename(result).encode("utf-8")) <= 200
+
+    def test_long_german_basename_does_not_split_codepoint(self):
+        long_stem = "ä" * 150
+        path = f"/tmp/{long_stem}.apkg"
+        result = _clamp_output_path(path)
+        assert result.endswith(".apkg")
+        basename = os.path.basename(result)
+        assert len(basename.encode("utf-8")) <= 200
+        assert "ä" in basename
+        assert "�" not in basename
+
+    def test_directory_is_preserved_after_truncation(self):
+        long_stem = "x" * 300
+        path = f"/some/deep/dir/{long_stem}.apkg"
+        result = _clamp_output_path(path)
+        assert os.path.dirname(result) == "/some/deep/dir"
+
+    def test_exact_200_byte_basename_is_unchanged(self):
+        stem = "a" * 195
+        path = f"/tmp/{stem}.apkg"
+        assert len(os.path.basename(path).encode("utf-8")) == 200
+        assert _clamp_output_path(path) == path
+
+
+class TestBatchLongFilename:
+    def test_batch_succeeds_with_over_255_byte_output_path(self):
+        long_name = "Engramm" + ("ä" * 130)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            entry = _write_deck_workspace(tmpdir, "Engramm", "card.jpg")
+            long_output = os.path.join(tmpdir, f"{long_name}.apkg")
+            assert len(os.path.basename(long_output).encode("utf-8")) > 255
+
+            manifest_path = os.path.join(tmpdir, "manifest.json")
+            with open(manifest_path, "w") as f:
+                json.dump([{"input": entry["input"], "output": long_output}], f)
+
+            result = subprocess.run(
+                [PYTHON, str(SCRIPT), "--batch", manifest_path, str(TEMPLATE_DIR)],
+                capture_output=True,
+                text=True,
+                cwd=entry["subdir"],
+            )
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            lines = [l for l in result.stdout.strip().splitlines() if l.strip()]
+            assert len(lines) == 1
+            actual_path = lines[0]
+            assert os.path.exists(actual_path), f"apkg not found at {actual_path}"
+            assert len(os.path.basename(actual_path).encode("utf-8")) <= 200

--- a/src/lib/anki/getDeckFilename.test.ts
+++ b/src/lib/anki/getDeckFilename.test.ts
@@ -26,3 +26,33 @@ test('replaces backslashes with dashes', () => {
 test('replaces null bytes with dashes', () => {
   expect(getDeckFilename('a\0b')).toEqual('a-b.apkg');
 });
+
+test('truncates long German quiz heading to a safe filename under 200 bytes', () => {
+  const longTitle =
+    'Engramm-Quiz: Welche der folgenden Aussagen über die synaptische Plastizität ist korrekt? ' +
+    'A) LTP erhöht die Anzahl der AMPA-Rezeptoren B) LTD verstärkt die synaptische Übertragung ' +
+    'C) Calcium spielt keine Rolle D) NMDA-Rezeptoren sind nicht beteiligt';
+  const result = getDeckFilename(longTitle);
+  expect(result.endsWith('.apkg')).toBe(true);
+  expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(200);
+  expect(result).not.toContain('�');
+});
+
+test('truncates long CJK heading to a safe filename under 200 bytes', () => {
+  const longTitle = '中文标题'.repeat(30);
+  const result = getDeckFilename(longTitle);
+  expect(result.endsWith('.apkg')).toBe(true);
+  expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(200);
+  expect(result).not.toContain('�');
+});
+
+test('truncated filename is shorter than the full original title plus extension', () => {
+  const longTitle =
+    'Engramm-Quiz: Welche der folgenden Aussagen über die synaptische Plastizität ist korrekt? ' +
+    'A) LTP erhöht die Anzahl der AMPA-Rezeptoren B) LTD verstärkt die synaptische Übertragung ' +
+    'C) Calcium spielt keine Rolle D) NMDA-Rezeptoren sind nicht beteiligt';
+  const filename = getDeckFilename(longTitle);
+  const fullLength = Buffer.byteLength(longTitle + '.apkg', 'utf8');
+  expect(fullLength).toBeGreaterThan(200);
+  expect(Buffer.byteLength(filename, 'utf8')).toBeLessThanOrEqual(200);
+});

--- a/src/lib/anki/getDeckFilename.ts
+++ b/src/lib/anki/getDeckFilename.ts
@@ -1,5 +1,9 @@
 import Package from '../parser/Package';
-import { getSafeFilename } from '../getSafeFilename';
+import { getSafeFilename, truncateToBytes } from '../getSafeFilename';
+
+const APKG_EXTENSION = '.apkg';
+const MAX_BASENAME_BYTES = 200;
+const MAX_TITLE_BYTES = MAX_BASENAME_BYTES - Buffer.byteLength(APKG_EXTENSION, 'utf8');
 
 function isPackage(something: unknown): something is Package {
   return something instanceof Package;
@@ -17,5 +21,9 @@ export default function getDeckFilename(something: Package | string): string {
     name = something;
   }
   const safe = getSafeFilename(name);
-  return safe.endsWith('.apkg') ? safe : `${safe}.apkg`;
+  const base = safe.endsWith(APKG_EXTENSION)
+    ? safe.slice(0, safe.length - APKG_EXTENSION.length)
+    : safe;
+  const truncated = truncateToBytes(base, MAX_TITLE_BYTES);
+  return `${truncated}${APKG_EXTENSION}`;
 }

--- a/src/lib/getSafeFilename.test.ts
+++ b/src/lib/getSafeFilename.test.ts
@@ -1,4 +1,4 @@
-import { getSafeFilename } from './getSafeFilename';
+import { getSafeFilename, truncateToBytes } from './getSafeFilename';
 
 test('returns filename without slashes', () => {
   expect(getSafeFilename('x/y/z')).toBe('x-y-z');
@@ -10,4 +10,48 @@ test('replaces backslashes with dashes', () => {
 
 test('replaces null bytes with dashes', () => {
   expect(getSafeFilename('x\0y')).toBe('x-y');
+});
+
+describe('truncateToBytes', () => {
+  test('returns name unchanged when within byte limit', () => {
+    expect(truncateToBytes('hello', 200)).toBe('hello');
+  });
+
+  test('truncates ASCII-only name at the byte limit', () => {
+    const long = 'a'.repeat(300);
+    const result = truncateToBytes(long, 200);
+    expect(result).toBe('a'.repeat(200));
+    expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(200);
+  });
+
+  test('does not split a multi-byte German codepoint (ä = 2 bytes)', () => {
+    const long = 'ä'.repeat(150);
+    const result = truncateToBytes(long, 200);
+    expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(200);
+    expect(result).not.toContain('�');
+    expect(result).toMatch(/^ä+$/);
+  });
+
+  test('does not split a 3-byte CJK codepoint', () => {
+    const long = '中'.repeat(100);
+    const result = truncateToBytes(long, 200);
+    expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(200);
+    expect(result).not.toContain('�');
+    expect(result).toMatch(/^中+$/);
+  });
+
+  test('real German quiz question over 255 bytes truncates cleanly', () => {
+    const heading =
+      'Engramm-Quiz: Welche der folgenden Aussagen über die synaptische Plastizität ist korrekt? ' +
+      'A) LTP erhöht die Anzahl der AMPA-Rezeptoren B) LTD verstärkt die synaptische Übertragung ' +
+      'C) Calcium spielt keine Rolle D) NMDA-Rezeptoren sind nicht beteiligt';
+    const result = truncateToBytes(heading, 200);
+    expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(200);
+    expect(result).not.toContain('�');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test('returns empty string for empty input', () => {
+    expect(truncateToBytes('', 200)).toBe('');
+  });
 });

--- a/src/lib/getSafeFilename.ts
+++ b/src/lib/getSafeFilename.ts
@@ -1,3 +1,15 @@
 export function getSafeFilename(name: string) {
   return name.replace(/[/\\\0]/g, '-');
 }
+
+export function truncateToBytes(name: string, maxBytes: number): string {
+  const encoded = Buffer.from(name, 'utf8');
+  if (encoded.length <= maxBytes) {
+    return name;
+  }
+  let end = maxBytes;
+  while (end > 0 && (encoded[end] & 0xc0) === 0x80) {
+    end -= 1;
+  }
+  return encoded.slice(0, end).toString('utf8');
+}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Long quiz questions and headings now convert to a deck instead of failing', date: '2026-05-20' },
   { type: 'feature', title: 'Send to my Anki on every finished deck — Auto Sync subscribers send instantly, everyone else lands on the upgrade page', date: '2026-05-20' },
   { type: 'fix', title: 'Preview your deck from My Decks before opening Anki — works for Notion conversions, not just direct uploads', date: '2026-05-20' },
   { type: 'feature', title: 'Share a converted deck with a link — recipient can preview the cards and download the .apkg without an account', date: '2026-05-20' },


### PR DESCRIPTION
## What

Deck titles derived from long document headings were being used verbatim as the on-disk `.apkg` filename. ext4 caps a single filename component at 255 bytes; multi-byte UTF-8 (German ä/ü, CJK) exhausts that budget even faster than ASCII. Result: `OSError: [Errno 36] File name too long`.

## Why

5 identical production crashes today (15:46–15:52), same user, same German quiz deck. The deck's first heading — the full question with A/B/C answer options — became the filename. At ~580 bytes it blew past the OS limit every retry.

## How

**Producer fix** (`src/lib/getSafeFilename.ts`, `src/lib/anki/getDeckFilename.ts`):
- Added `truncateToBytes(name, maxBytes)` — byte-aware, never splits a multi-byte codepoint (trims back until `bytes.toString('utf8')` decodes cleanly).
- `getDeckFilename` now clamps the title portion to 195 bytes before appending `.apkg`, keeping the full basename under 200 bytes.
- The Anki deck name inside the `.apkg` (the `name` field in `deck_info.json`) is unaffected — users still see the full original title when they open the deck in Anki.

**Consumer guard** (`create_deck/create_deck.py`, `run_batch`):
- Added `_clamp_output_path(path)` — applies the same 200-byte cap to any `output` path before `os.replace()`, so even if a manifest is written by an older code path it cannot crash here.
- Uses try/except over the slice to find the valid UTF-8 boundary (the while-loop approach can miss leading bytes of multi-byte sequences).

## Measuring success

The specific error `[Errno 36] File name too long` will stop appearing in production error monitoring. The log line to watch: absence of this error in Sentry/pm2 logs after the next deploy.

## Testing

- TS unit tests: `src/lib/getSafeFilename.test.ts` — 6 new tests for `truncateToBytes` (ASCII, German 2-byte, CJK 3-byte, real quiz heading fixture).
- TS unit tests: `src/lib/anki/getDeckFilename.test.ts` — 3 new tests (long German heading, CJK heading, byte length assertion).
- Python unit tests: `TestClampOutputPath` — 5 unit tests for `_clamp_output_path` (passthrough, ASCII truncation, German codepoint preservation, directory preservation, exact-200 passthrough).
- Python integration test: `TestBatchLongFilename.test_batch_succeeds_with_over_255_byte_output_path` — runs `create_deck.py --batch` with a manifest whose output path has a >255-byte basename; asserts exit 0 and resulting file ≤200 bytes.
- All existing tests pass: 11/11 Python, 27/27 TS (for modified files).

## Changelog

`{ type: 'fix', title: 'Long quiz questions and headings now convert to a deck instead of failing', date: '2026-05-20' }`

## Risks

- Decks with very long titles get a truncated filename; the title in Anki is unchanged. Users who look at the file in Finder/Explorer will see a shorter name — this is acceptable vs crashing.
- Rollback: revert the 3 changed source files; the Python guard is purely additive.

## Goal alignment

Removes a conversion crash that blocked a user 5 times in 6 minutes. Every blocked conversion is a churned user. Directly serves the 300K-user goal by eliminating a class of hard failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->