### PR TITLE
fix: restore verifyEmail error logging

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -398,6 +398,25 @@ describe('UsersController.verifyEmail', () => {
 
     expect(res.redirect).toHaveBeenCalledWith('/login?verify_error=expired');
   });
+
+  it('logs the error and forwards it to next() when verification throws', async () => {
+    const dbError = new Error('Database connection failed');
+    const verifyMagicToken = jest.fn().mockRejectedValue(dbError);
+    const { controller } = buildVerifyEmailController({ verifyMagicToken });
+    const req = { params: { token: 'valid-tok' }, cookies: {} } as unknown as express.Request;
+    const res = buildVerifyEmailRes();
+    const next = jest.fn();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      await controller.verifyEmail(req, res, next);
+
+      expect(consoleError).toHaveBeenCalledWith('Email verification failed:', dbError);
+      expect(next).toHaveBeenCalledWith(dbError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });
 
 describe('UsersController.requestMagicLink', () => {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -224,10 +224,10 @@ class UsersController {
         return sendIndex(res);
       }
       return res.redirect('/login');
-    } catch (err) {
+    } catch (error) {
       console.info('Reset password failed');
-      console.error(err);
-      next(err);
+      console.error(error);
+      next(error);
     }
   }
 
@@ -723,6 +723,7 @@ class UsersController {
       await this.userService.markEmailVerified(result.userId.toString());
       return res.redirect(`${base}?verified=1`);
     } catch (error) {
+      console.error('Email verification failed:', error);
       next(error);
     }
   }


### PR DESCRIPTION
## Summary

- restore the `verifyEmail` catch-block error log before forwarding to Express error handling
- add a regression test that asserts the underlying error is logged and passed to `next(error)`

Closes #2295

## Tests

- `src/controllers/UsersControllers.ts` and `src/controllers/UsersControllers.test.ts` parse successfully with the TypeScript parser
- source-level proof confirmed the controller contains `console.error('Email verification failed:', error)` and the regression test asserts that log + `next(error)` path
