### PR TITLE
fix: stop throwing on expired/invalid JWTs in isValidToken

### DIFF
--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -36,11 +36,41 @@ test('newJWTToken includes an expiration claim', async () => {
   expect(decoded.exp! - decoded.iat!).toBe(86400);
 });
 
-test('isValidToken rejects an expired token', async () => {
-  const service = createService();
-  const token = jwt.sign({ userId: 1 }, SECRET, { expiresIn: '0s' });
+describe('isValidToken', () => {
+  it('resolves true for a freshly signed token', async () => {
+    const service = createService();
+    const token = jwt.sign({ userId: 1 }, SECRET, { expiresIn: '1h' });
 
-  await expect(service.isValidToken(token)).rejects.toThrow();
+    await expect(service.isValidToken(token)).resolves.toBe(true);
+  });
+
+  it('resolves false for an expired token (no throw)', async () => {
+    const service = createService();
+    const token = jwt.sign({ userId: 1 }, SECRET, { expiresIn: '0s' });
+
+    await expect(service.isValidToken(token)).resolves.toBe(false);
+  });
+
+  it('resolves false for a token signed with a different secret', async () => {
+    const service = createService();
+    const token = jwt.sign({ userId: 1 }, 'a-different-secret', {
+      expiresIn: '1h',
+    });
+
+    await expect(service.isValidToken(token)).resolves.toBe(false);
+  });
+
+  it('resolves false for a malformed token string', async () => {
+    const service = createService();
+
+    await expect(service.isValidToken('not-a-jwt')).resolves.toBe(false);
+  });
+
+  it('resolves false for an empty token', async () => {
+    const service = createService();
+
+    await expect(service.isValidToken('')).resolves.toBe(false);
+  });
 });
 
 describe('loginWithNotion', () => {

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -22,18 +22,18 @@ class AuthenticationService {
   ) {}
 
   isValidToken(token: string): Promise<boolean> {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       if (!token) {
         resolve(false);
         return;
       }
-      jwt.verify(token, process.env.SECRET!, (error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve(true);
-        }
-      });
+      try {
+        jwt.verify(token, process.env.SECRET!, (error) => {
+          resolve(!error);
+        });
+      } catch {
+        resolve(false);
+      }
     });
   }
 

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Sign-in page comes back to a clean form even if your last session expired', date: '2026-05-20' },
   { type: 'fix', title: 'Template chat — clearer message when the AI is briefly unavailable, and a "no changes" note when nothing actually changed', date: '2026-05-20' },
   { type: 'fix', title: 'Template chat — Try again button next to chat errors, so a quick upstream blip doesn\'t cost you the prompt you just typed', date: '2026-05-20' },
   { type: 'fix', title: 'Long quiz questions and headings now convert to a deck instead of failing', date: '2026-05-20' },


### PR DESCRIPTION
## What

Fixes the live bug Al hit at https://2anki.net/login: a stale token cookie produced `{ "code": "unknown", "message": "jwt expired" }` instead of just letting the user log in.

## Why

`AuthenticationService.isValidToken` is named like a boolean check and typed `Promise<boolean>`, but it **rejected** with the underlying `TokenExpiredError` whenever the JWT was expired. The rejection propagated through `configureUserLocal` → `RequireAuthentication`/`OptionalAuthentication` → Express's error chain → `ErrorHandler.tsx`, which serialised it as `{ code: 'unknown', message: err.message }` with status 400. The login page (and any page mounting `useUserLocals`) then either rendered the JSON or got an opaque error.

## How

One semantic fix in `src/services/AuthenticationService.ts`:

```ts
isValidToken(token: string): Promise<boolean> {
  return new Promise((resolve) => {
    if (!token) { resolve(false); return; }
    try {
      jwt.verify(token, process.env.SECRET!, (error) => resolve(!error));
    } catch {
      resolve(false);
    }
  });
}
```

- Async errors (expired, signature mismatch) come through the callback → `resolve(!error)` → `false`.
- `jwt.verify` throws synchronously for some malformed inputs (`jwt malformed`) — the try/catch swallows those into `false` as well.
- The method now answers its own question instead of throwing.

After this:
- Expired JWT on a protected endpoint → `RequireAuthentication` returns `401 { message: 'Authentication required' }` (the clean path that already exists).
- Expired JWT on the sign-in page → `useUserLocals` flips `isError`, the existing `useEffect` in `LoginPage.tsx` clears the `token` cookie, and the login form renders.
- `resetPassword` controller (the other caller, at `UsersControllers.ts:222`) redirects to `/login` cleanly — its try/catch around the call is now dead, but harmless.

## Testing

Replaced the single "isValidToken rejects an expired token" test (which documented the bug as correct) with a proper `describe` block covering:

- Fresh token → resolves `true`.
- Expired token → resolves `false` (no throw — explicit regression guard).
- Wrong signature → resolves `false`.
- Malformed token string → resolves `false`.
- Empty string → resolves `false`.

Full server suite green: **1601 passed, 0 failed** (7 skipped, 8 todo).

## Changelog

Added to `web/src/pages/WhatsNewPage/changelog.ts`:

\`Sign-in page comes back to a clean form even if your last session expired\`

## Risks

Touches auth — but the change is strictly a relaxation of an error path that was producing a 400 instead of either a clean 401 or a no-op. The only callers of `isValidToken` are `getUserFrom` (already guards with `if (!isValid) return null`) and `resetPassword` (already has try/catch). Nothing depended on the throw as control flow.

Will run `/security-review` before merge per CLAUDE.md (auth-touching PR).

## Goal alignment

A user staring at \`{code:"unknown", message:"jwt expired"}\` on the login page is one who won't sign back in. Trust + retention.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781887529&installation_id=132681956&pr_number=2494&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2494&signature=544adfed263549ae6fecb0cdbc1c2820f3b51918e4bfc125a28fa0cb22f5aec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->