### PR TITLE
fix(storage): normalize SPACES_ENDPOINT scheme

### DIFF
--- a/src/lib/storage/StorageHandler.ts
+++ b/src/lib/storage/StorageHandler.ts
@@ -8,6 +8,8 @@ import {
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
+import { normalizeS3Endpoint } from './normalizeS3Endpoint';
+
 export interface StoredObject {
   Body: Buffer | undefined;
 }
@@ -16,12 +18,8 @@ class StorageHandler {
   s3: S3Client;
 
   constructor() {
-    // DigitalOcean Spaces endpoint. SPACES_ENDPOINT is a required
-    // production env var; the non-null assertion matches how
-    // SPACES_DEFAULT_BUCKET_NAME is treated below.
-    // NOSONAR — non-null assertion is intentional
     this.s3 = new S3Client({
-      endpoint: process.env.SPACES_ENDPOINT!,
+      endpoint: normalizeS3Endpoint(process.env.SPACES_ENDPOINT),
       region: process.env.SPACES_REGION ?? 'us-east-1',
     });
   }

--- a/src/lib/storage/normalizeS3Endpoint.test.ts
+++ b/src/lib/storage/normalizeS3Endpoint.test.ts
@@ -1,0 +1,22 @@
+import { normalizeS3Endpoint } from './normalizeS3Endpoint';
+
+describe('normalizeS3Endpoint', () => {
+  it.each([
+    ['fra1.digitaloceanspaces.com', 'https://fra1.digitaloceanspaces.com'],
+    [
+      'https://fra1.digitaloceanspaces.com',
+      'https://fra1.digitaloceanspaces.com',
+    ],
+    ['http://localhost:9000', 'http://localhost:9000'],
+    ['nyc3.digitaloceanspaces.com', 'https://nyc3.digitaloceanspaces.com'],
+  ])('normalizes %s → %s', (input, expected) => {
+    expect(normalizeS3Endpoint(input)).toBe(expected);
+  });
+
+  it.each([
+    [undefined, 'SPACES_ENDPOINT is required'],
+    ['', 'SPACES_ENDPOINT is required'],
+  ])('throws when env is %p', (input, message) => {
+    expect(() => normalizeS3Endpoint(input)).toThrow(message);
+  });
+});

--- a/src/lib/storage/normalizeS3Endpoint.ts
+++ b/src/lib/storage/normalizeS3Endpoint.ts
@@ -1,0 +1,6 @@
+export function normalizeS3Endpoint(raw: string | undefined): string {
+  if (raw == null || raw === '') {
+    throw new Error('SPACES_ENDPOINT is required');
+  }
+  return /^https?:\/\//.test(raw) ? raw : `https://${raw}`;
+}


### PR DESCRIPTION
## Summary

- Prod is logging recurring `TypeError: Invalid URL` from `@smithy/core` since the AWS SDK v3 migration in #2293 (47 min ago). Input: bare hostname `fra1.digitaloceanspaces.com`.
- The v2 client tolerated scheme-less hostnames; Smithy's URL parser doesn't.
- Every S3 write to DigitalOcean Spaces throws — image uploads and persisted decks currently broken in prod.
- Fix: normalize `SPACES_ENDPOINT` at `S3Client` construction. Prepend `https://` if no scheme present. Throw early if env is missing instead of lying with `!`.
- Companion operational fix: prod `.env` is being updated to add the scheme directly so the bleed stops in <30s, without waiting on a deploy.

## Why this PR even if the env is fixed

The next env drift (new region, dev override, local override) re-introduces the same break. The normalization defends against recurrence and matches the AWS SDK v3 migration's stricter URL contract.

## Test plan

- [x] `pnpm test src/lib/storage/normalizeS3Endpoint.test.ts` — 6/6 passing (it.each covers bare host, full URL, http://localhost, undefined, empty string)
- [x] `npx tsc --noEmit` clean
- [ ] Post-deploy: tail `pm2 logs server` for absence of `ERR_INVALID_URL` on Spaces operations
- [ ] Post-deploy: upload an image deck end-to-end via `/upload`

No changelog entry — internal regression fix, no user-visible behavior change beyond "uploads stop being broken".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781896517&installation_id=132681956&pr_number=2516&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2516&signature=b5ec21f678cfe2e35ef86f13518c2aea017f0e6c858e862b2ad05af0a5053edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->