### PR TITLE
feat(web): wire PhotoToFlashcards into ImageOcclusionPage

### DIFF
--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
@@ -745,3 +745,83 @@
 .drawerCancelBtn:hover {
   color: var(--color-text-primary);
 }
+
+.photoToDeck {
+  margin: 0 auto var(--space-lg, 1.5rem);
+  max-width: 720px;
+  padding: var(--space-md, 1.25rem);
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: var(--radius-md, 0.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 0.75rem);
+}
+
+.photoToDeckHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.photoToDeckTitle {
+  margin: 0;
+  font-size: var(--text-lg, 1.125rem);
+  font-weight: var(--font-medium, 500);
+  color: var(--color-text-primary, #111827);
+}
+
+.photoToDeckSubtitle {
+  margin: 0;
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--color-text-secondary, #6b7280);
+}
+
+.photoToDeckRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 0.75rem);
+}
+
+.photoDropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  min-height: 160px;
+  padding: var(--space-md, 1.25rem);
+  border: 2px dashed var(--color-border, #d1d5db);
+  border-radius: var(--radius-md, 0.5rem);
+  background: var(--color-surface-muted, #f9fafb);
+  text-align: center;
+  cursor: pointer;
+  transition: border-color var(--transition-fast, 150ms);
+}
+
+.photoDropzone:hover {
+  border-color: var(--color-primary, #3b82f6);
+}
+
+.photoDropzoneTitle {
+  font-size: var(--text-base, 1rem);
+  color: var(--color-text-primary, #374151);
+}
+
+.photoDropzoneHint {
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--color-text-muted, #9ca3af);
+}
+
+.photoPreview {
+  max-width: 100%;
+  max-height: 240px;
+  object-fit: contain;
+  border-radius: var(--radius-sm, 0.25rem);
+}
+
+.photoToDeckFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm, 0.75rem);
+}

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
@@ -7,6 +7,7 @@ import { ImageEntry, OcclusionRect } from './types';
 import { OcclusionCanvas } from './components/OcclusionCanvas';
 import { ImageQueue } from './components/ImageQueue';
 import { NotionImportDrawer } from './components/NotionImportDrawer';
+import { PhotoToFlashcards } from './components/PhotoToFlashcards';
 import styles from '../../styles/shared.module.css';
 import pageStyles from './ImageOcclusionPage.module.css';
 
@@ -385,6 +386,7 @@ export function ImageOcclusionPage() {
           </button>
         </div>
       )}
+      <PhotoToFlashcards isPaying={isPaying} />
       <div className={`${pageStyles.pageLayout} ${drawerOpen ? pageStyles.pageLayoutDrawerOpen : ''}`}>
         <NotionImportDrawer
           isOpen={drawerOpen}

--- a/web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.test.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PhotoToFlashcards } from './PhotoToFlashcards';
+
+const FAKE_DATA_URL = 'data:image/jpeg;base64,YWJjMTIz';
+
+function makePhoto(name = 'note.jpg', type = 'image/jpeg', sizeBytes = 1024): File {
+  const blob = new Blob(['x'.repeat(sizeBytes)], { type });
+  return new File([blob], name, { type });
+}
+
+function mockFileReader() {
+  class FakeFileReader {
+    result: string | null = null;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    readAsDataURL() {
+      this.result = FAKE_DATA_URL;
+      setTimeout(() => this.onload?.(), 0);
+    }
+  }
+  vi.stubGlobal('FileReader', FakeFileReader);
+}
+
+function mockImageDimensions(width = 800, height = 600) {
+  class FakeImage {
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    naturalWidth = width;
+    naturalHeight = height;
+    set src(_v: string) {
+      setTimeout(() => this.onload?.(), 0);
+    }
+  }
+  vi.stubGlobal('Image', FakeImage);
+}
+
+function mockObjectUrl() {
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:fake'),
+    revokeObjectURL: vi.fn(),
+  });
+}
+
+describe('PhotoToFlashcards', () => {
+  beforeEach(() => {
+    mockFileReader();
+    mockImageDimensions();
+    mockObjectUrl();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the title and audience hint', () => {
+    render(<PhotoToFlashcards isPaying={false} />);
+    expect(screen.getByText('Snap a photo, get cards')).toBeTruthy();
+    expect(screen.getByText(/textbook pages, lecture slides, and handwritten notes/)).toBeTruthy();
+    expect(screen.getByText(/Ankify access required/)).toBeTruthy();
+  });
+
+  it('omits the access notice for paying users', () => {
+    render(<PhotoToFlashcards isPaying={true} />);
+    expect(screen.queryByText(/Ankify access required/)).toBeNull();
+  });
+
+  it('rejects unsupported file types', () => {
+    render(<PhotoToFlashcards isPaying={true} />);
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(input, { target: { files: [pdf] } });
+    expect(screen.getByText('Use JPEG, PNG, WebP, or GIF.')).toBeTruthy();
+  });
+
+  it('rejects photos over 10 MB', () => {
+    render(<PhotoToFlashcards isPaying={true} />);
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    const oversized = makePhoto('big.jpg', 'image/jpeg', 11 * 1024 * 1024);
+    fireEvent.change(input, { target: { files: [oversized] } });
+    expect(screen.getByText('Photo is over the 10 MB limit. Try a smaller image.')).toBeTruthy();
+  });
+
+  it('shows the specific 404 message when the route is disabled', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<PhotoToFlashcards isPaying={true} />);
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto()] } });
+    fireEvent.click(screen.getByText('Get flashcards'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Photo to deck isn’t available yet/)).toBeTruthy();
+    });
+  });
+
+  it('shows the access-required message on 403', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 403 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<PhotoToFlashcards isPaying={true} />);
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto()] } });
+    fireEvent.click(screen.getByText('Get flashcards'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ankify access is required for photo to deck/)).toBeTruthy();
+    });
+  });
+
+  it('shows the too-large message on 413', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 413 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<PhotoToFlashcards isPaying={true} />);
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto()] } });
+    fireEvent.click(screen.getByText('Get flashcards'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Photo is too large/)).toBeTruthy();
+    });
+  });
+
+  it('shows the card-count success state when the deck arrives', async () => {
+    const apkgBlob = new Blob(['fake-apkg-bytes'], { type: 'application/octet-stream' });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(apkgBlob, {
+        status: 200,
+        headers: { 'X-Card-Count': '12', 'Content-Type': 'application/octet-stream' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const clickSpy = vi.fn();
+    HTMLAnchorElement.prototype.click = clickSpy;
+
+    render(<PhotoToFlashcards isPaying={true} />);
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto('biology.jpg')] } });
+    fireEvent.click(screen.getByText('Get flashcards'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/12 cards from your photo\. Deck downloaded\./)).toBeTruthy();
+    });
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.test.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.test.tsx
@@ -126,9 +126,8 @@ describe('PhotoToFlashcards', () => {
   });
 
   it('shows the card-count success state when the deck arrives', async () => {
-    const apkgBlob = new Blob(['fake-apkg-bytes'], { type: 'application/octet-stream' });
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(apkgBlob, {
+      new Response('fake-apkg-bytes', {
         status: 200,
         headers: { 'X-Card-Count': '12', 'Content-Type': 'application/octet-stream' },
       })

--- a/web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.tsx
@@ -1,0 +1,239 @@
+import { useRef, useState } from 'react';
+
+import styles from '../../../styles/shared.module.css';
+import pageStyles from '../ImageOcclusionPage.module.css';
+
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const MAX_SIZE_BYTES = 10 * 1024 * 1024;
+
+type Status = 'idle' | 'reading' | 'done';
+
+interface PhotoToFlashcardsProps {
+  isPaying: boolean;
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      resolve(result.split(',')[1] ?? '');
+    };
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function getImageDimensions(file: File): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve({ width: img.naturalWidth, height: img.naturalHeight });
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Could not read image dimensions'));
+    };
+    img.src = url;
+  });
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function PhotoToFlashcards({ isPaying }: PhotoToFlashcardsProps) {
+  const [deckName, setDeckName] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>('idle');
+  const [cardCount, setCardCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const reset = () => {
+    setFile(null);
+    setPreviewUrl(null);
+    setStatus('idle');
+    setCardCount(0);
+    setError(null);
+  };
+
+  const handleFile = (next: File) => {
+    setError(null);
+    if (!ALLOWED_TYPES.includes(next.type)) {
+      setError('Use JPEG, PNG, WebP, or GIF.');
+      return;
+    }
+    if (next.size > MAX_SIZE_BYTES) {
+      setError('Photo is over the 10 MB limit. Try a smaller image.');
+      return;
+    }
+    setFile(next);
+    setPreviewUrl(URL.createObjectURL(next));
+    setStatus('idle');
+    setCardCount(0);
+  };
+
+  const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.files?.[0];
+    if (next != null) handleFile(next);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLLabelElement>) => {
+    e.preventDefault();
+    const next = e.dataTransfer.files[0];
+    if (next != null) handleFile(next);
+  };
+
+  const handleConvert = async () => {
+    if (file == null) {
+      setError('Select a photo first.');
+      return;
+    }
+    setError(null);
+    setStatus('reading');
+
+    try {
+      const [imageBase64, dimensions] = await Promise.all([
+        fileToBase64(file),
+        getImageDimensions(file),
+      ]);
+
+      const baseName = file.name.replace(/\.[^.]+$/, '') || 'Photo deck';
+      const name = deckName.trim() || baseName;
+
+      const res = await fetch('/api/image-occlusion/photo-to-deck', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          imageBase64,
+          mediaType: file.type,
+          deckName: name,
+          width: dimensions.width,
+          height: dimensions.height,
+        }),
+      });
+
+      if (res.status === 404) {
+        setError('Photo to deck isn’t available yet.');
+        setStatus('idle');
+        return;
+      }
+      if (res.status === 403) {
+        setError('Ankify access is required for photo to deck.');
+        setStatus('idle');
+        return;
+      }
+      if (res.status === 413) {
+        setError('Photo is too large. Try a smaller or lower-resolution image.');
+        setStatus('idle');
+        return;
+      }
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({ message: res.statusText }))) as {
+          message?: string;
+        };
+        setError(body.message ?? 'Couldn’t read this photo. Try again.');
+        setStatus('idle');
+        return;
+      }
+
+      const count = Number(res.headers.get('X-Card-Count') ?? '0');
+      const blob = await res.blob();
+      downloadBlob(blob, `${name}.apkg`);
+      setCardCount(count);
+      setStatus('done');
+    } catch {
+      setError('Something broke on our end. Try again in a moment.');
+      setStatus('idle');
+    }
+  };
+
+  return (
+    <section className={pageStyles.photoToDeck} aria-label="Photo to deck">
+      <div className={pageStyles.photoToDeckHeader}>
+        <h2 className={pageStyles.photoToDeckTitle}>Snap a photo, get cards</h2>
+        <p className={pageStyles.photoToDeckSubtitle}>
+          Works on textbook pages, lecture slides, and handwritten notes.
+          {!isPaying && ' Ankify access required.'}
+        </p>
+      </div>
+
+      <div className={pageStyles.photoToDeckRow}>
+        <label className={pageStyles.deckNameLabel} htmlFor="photo-deck-name">
+          Deck name
+        </label>
+        <input
+          id="photo-deck-name"
+          type="text"
+          value={deckName}
+          onChange={(e) => setDeckName(e.target.value)}
+          className={pageStyles.deckNameInput}
+          placeholder={file?.name.replace(/\.[^.]+$/, '') || 'Photo deck'}
+        />
+      </div>
+
+      <label
+        className={pageStyles.photoDropzone}
+        htmlFor="photo-file-input"
+        onDrop={handleDrop}
+        onDragOver={(e) => e.preventDefault()}
+      >
+        {previewUrl == null ? (
+          <>
+            <span className={pageStyles.photoDropzoneTitle}>Drop a photo or click to select</span>
+            <span className={pageStyles.photoDropzoneHint}>JPEG, PNG, WebP, GIF — up to 10 MB</span>
+          </>
+        ) : (
+          <img src={previewUrl} alt="Selected photo" className={pageStyles.photoPreview} />
+        )}
+        <input
+          ref={fileInputRef}
+          id="photo-file-input"
+          type="file"
+          accept={ALLOWED_TYPES.join(',')}
+          onChange={handleFileInput}
+          hidden
+        />
+      </label>
+
+      {error != null && <div className={styles.notificationDanger}>{error}</div>}
+
+      {status === 'done' && (
+        <div className={styles.notificationSuccess}>
+          {cardCount} {cardCount === 1 ? 'card' : 'cards'} from your photo. Deck downloaded.
+        </div>
+      )}
+
+      <div className={pageStyles.photoToDeckFooter}>
+        <button
+          type="button"
+          className={styles.btnSecondary}
+          onClick={reset}
+          disabled={file == null && status === 'idle'}
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          className={styles.btnPrimary}
+          onClick={handleConvert}
+          disabled={file == null || status === 'reading'}
+        >
+          {status === 'reading' ? 'Reading your photo' : 'Get flashcards'}
+        </button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Frontend follow-up to #2507 (Vision backend, merged). Adds the `PhotoToFlashcards` upload component as a focused card at the top of `/image-occlusion`, above the existing two-panel occlusion editor.

The user picks a photo (drag-drop or click) → component reads dimensions + base64 → POSTs to `/api/image-occlusion/photo-to-deck` → on 200, downloads the returned `.apkg` blob and shows `N cards from your photo. Deck downloaded.`

## Why this is draft

The server route stays env-gated (`VISION_ENABLED=false` default). Until you flip it on for the shadow test, no user can complete a photo→deck conversion. The UI is harmless in that state — a 404 from the route maps to the specific copy `Photo to deck isn't available yet`. Mark ready once you're comfortable enabling the route in prod or staging.

## Surface area

- New: `web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.tsx` (~210 LOC)
- New: `web/src/pages/ImageOcclusionPage/components/PhotoToFlashcards.test.tsx` (8 vitest cases)
- Modified: `web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx` — one import + one component render above the existing layout
- Modified: `web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css` — appended `photoToDeck*`, `photoDropzone*`, `photoPreview` class blocks using existing CSS vars

## Error surfaces

| Status | Copy |
|---|---|
| 404 (route disabled) | `Photo to deck isn't available yet.` |
| 403 (no Ankify access) | `Ankify access is required for photo to deck.` |
| 413 (over token ceiling) | `Photo is too large. Try a smaller or lower-resolution image.` |
| Other non-OK | message from response body, else `Couldn't read this photo. Try again.` |
| Network/JS throw | `Something broke on our end. Try again in a moment.` |

All sentence case, no exclamation marks, no emoji, per VOICE.md.

## Test plan

- [x] `pnpm --filter 2anki-web test -- --run PhotoToFlashcards` — 8/8 passing
- [x] `pnpm --filter 2anki-web typecheck` clean
- [x] `pnpm --filter 2anki-web lint` clean
- [ ] **Visual check (you do this):** load `/image-occlusion`, confirm the photo card renders above the occlusion editor and doesn't break the existing flow on desktop + mobile
- [ ] **Live test (post-VISION_ENABLED flip):** drop a real textbook photo, confirm card count + download

## No changelog entry

Because the server route is `VISION_ENABLED=false` in prod, no real user can complete this flow yet. The changelog entry should land in the PR that flips the env flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781899412&installation_id=132681956&pr_number=2517&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2517&signature=65e9e51bc97d3c952214871d0211677b2d207ce637855c31447db68c981e979b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->