### PR TITLE
fix(test): scope Unlimited price assertion to unblock CI

### DIFF
--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -355,8 +355,9 @@ describe('PricingPage Unlimited billing toggle', () => {
 
   it('shows $6 / mo by default', () => {
     renderAt('/pricing', { unlimitedYearlyAvailable: true });
-    expect(screen.getByText('$6')).toBeInTheDocument();
-    expect(screen.getByText('/ mo')).toBeInTheDocument();
+    const price = screen.getByText('$6');
+    expect(price).toBeInTheDocument();
+    expect(price.parentElement?.textContent ?? '').toContain('/ mo');
   });
 
   it('shows $60 / yr and 2 months free after selecting Yearly', () => {


### PR DESCRIPTION
## Summary

CI is failing for every open PR on `PricingPage.test.tsx > shows \$6 / mo by default`:

\`\`\`
TestingLibraryElementError: Found multiple elements with the text: / mo
\`\`\`

The yearly billing toggle from #2388 introduced additional "/ mo" suffixes elsewhere on the pricing page (Auto Sync etc.), so the bare \`getByText('/ mo')\` is no longer unique.

Scope the suffix assertion to the price element's parent — the \`_cardPriceLine_\` wrapper that holds \`\$6\` and its suffix together. \`\$6\` is still a unique hit, so the test still specifically guards the Unlimited card.

## Test plan

- [x] \`pnpm --filter 2anki-web test --run src/pages/PricingPage/PricingPage.test.tsx\` — 38/38 passing
- [ ] CI green on this PR
- [ ] Once merged, the failing job on #2517 (Vision frontend) should clear on rebase

No changelog entry — test-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781900284&installation_id=132681956&pr_number=2518&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2518&signature=4633536ffd451a750e36e6369ca7694e60a4c411ac381ca544074171252a14f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->