### PR TITLE
feat: photo to deck for everyone, free plan capped at 5 / month

### DIFF
--- a/src/controllers/PhotoToFlashcardsController.ts
+++ b/src/controllers/PhotoToFlashcardsController.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import { PhotoToFlashcardsUseCase } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 import type { VisionMediaType } from '../lib/claude/countVisionTokens';
 import { buildContentDisposition } from '../lib/buildContentDisposition';
+import { isPaying } from '../lib/isPaying';
 
 const ALLOWED_MEDIA_TYPES: VisionMediaType[] = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
@@ -48,7 +49,8 @@ export class PhotoToFlashcardsController {
     const width = typeof body.width === 'number' ? body.width : 512;
     const height = typeof body.height === 'number' ? body.height : 512;
 
-    const hasAccess = res.locals['email'] != null;
+    const owner = (res.locals['owner'] ?? '') as string;
+    const paying = isPaying(res.locals);
 
     let result: Awaited<ReturnType<PhotoToFlashcardsUseCase['execute']>>;
     try {
@@ -56,17 +58,30 @@ export class PhotoToFlashcardsController {
         imageBase64,
         mediaType,
         deckName,
-        hasAccess,
+        owner,
+        isPaying: paying,
         imageDimensions: { width, height },
       });
     } catch (err) {
-      const e = err as Error & { status?: number };
+      const e = err as Error & {
+        status?: number;
+        used?: number;
+        limit?: number;
+      };
       if (e.status === 403) {
         res.status(403).json({ message: e.message });
         return;
       }
       if (e.status === 413) {
         res.status(413).json({ message: e.message });
+        return;
+      }
+      if (e.status === 429) {
+        res.status(429).json({
+          message: e.message,
+          used: e.used,
+          limit: e.limit,
+        });
         return;
       }
       throw err;

--- a/src/routes/ImageOcclusionRouter.ts
+++ b/src/routes/ImageOcclusionRouter.ts
@@ -1,7 +1,6 @@
 import express from "express";
 import multer from "multer";
 import RequireAuthentication from "./middleware/RequireAuthentication";
-import RequireAnkifyAccess from "./middleware/RequireAnkifyAccess";
 import ImageOcclusionController from "../controllers/ImageOcclusionController";
 import { IoDraftController } from "../controllers/IoDraftController";
 import { PhotoToFlashcardsController } from "../controllers/PhotoToFlashcardsController";
@@ -9,10 +8,9 @@ import { CreateImageOcclusionDeckUseCase } from "../usecases/imageOcclusion/Crea
 import { PhotoToFlashcardsUseCase } from "../usecases/imageOcclusion/PhotoToFlashcardsUseCase";
 import { IoDraftRepository } from "../data_layer/IoDraftRepository";
 import NotionRepository from "../data_layer/NotionRespository";
+import { EventsRepository } from "../data_layer/EventsRepository";
 import { getDatabase } from "../data_layer";
 import StorageHandler from "../lib/storage/StorageHandler";
-
-const VISION_ENABLED = process.env.VISION_PHOTO_ENABLED === 'true';
 
 const ImageOcclusionRouter = () => {
   const router = express.Router();
@@ -20,7 +18,7 @@ const ImageOcclusionRouter = () => {
   const upload = multer({ dest:"/tmp", fileFilter:(_req,file,cb)=>{ cb(null,ALLOWED.includes(file.mimetype)); }, limits:{fileSize:10*1024*1024} });
   const oc = new ImageOcclusionController(new CreateImageOcclusionDeckUseCase());
   const dc = new IoDraftController(new IoDraftRepository(getDatabase()), new StorageHandler(), new NotionRepository(getDatabase()));
-  const ptf = new PhotoToFlashcardsController(new PhotoToFlashcardsUseCase());
+  const ptf = new PhotoToFlashcardsController(new PhotoToFlashcardsUseCase(new EventsRepository(getDatabase())));
 
   /**
    * @swagger
@@ -178,47 +176,45 @@ const ImageOcclusionRouter = () => {
    */
   router.delete("/api/image-occlusion/draft/:id", RequireAuthentication, (req,res)=>dc.remove(req,res));
 
-  if (VISION_ENABLED) {
-    /**
-     * @swagger
-     * /api/image-occlusion/photo-to-deck:
-     *   post:
-     *     summary: Generate an Anki deck from a photo via Claude Vision
-     *     tags: [ImageOcclusion]
-     *     security:
-     *       - bearerAuth: []
-     *       - cookieAuth: []
-     *     requestBody:
-     *       required: true
-     *       content:
-     *         application/json:
-     *           schema:
-     *             type: object
-     *             properties:
-     *               imageBase64:
-     *                 type: string
-     *               mediaType:
-     *                 type: string
-     *               deckName:
-     *                 type: string
-     *               width:
-     *                 type: number
-     *               height:
-     *                 type: number
-     *     responses:
-     *       200:
-     *         description: Anki deck generated
-     *       400:
-     *         description: Invalid input
-     *       401:
-     *         description: Authentication required
-     *       403:
-     *         description: Ankify access required
-     *       413:
-     *         description: Image too large
-     */
-    router.post("/api/image-occlusion/photo-to-deck", RequireAnkifyAccess, express.json({ limit: "20mb" }), (req,res)=>ptf.create(req,res));
-  }
+  /**
+   * @swagger
+   * /api/image-occlusion/photo-to-deck:
+   *   post:
+   *     summary: Generate an Anki deck from a photo via Claude Vision
+   *     tags: [ImageOcclusion]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               imageBase64:
+   *                 type: string
+   *               mediaType:
+   *                 type: string
+   *               deckName:
+   *                 type: string
+   *               width:
+   *                 type: number
+   *               height:
+   *                 type: number
+   *     responses:
+   *       200:
+   *         description: Anki deck generated
+   *       400:
+   *         description: Invalid input
+   *       401:
+   *         description: Authentication required
+   *       403:
+   *         description: Ankify access required
+   *       413:
+   *         description: Image too large
+   */
+  router.post("/api/image-occlusion/photo-to-deck", RequireAuthentication, express.json({ limit: "20mb" }), (req,res)=>ptf.create(req,res));
 
   /**
    * @swagger

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -15,6 +15,7 @@ export const KNOWN_EVENTS = new Set([
   'purchase',
   'email_clicked',
   'email_batch_sent',
+  'vision_photo_converted',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -1,15 +1,25 @@
-import { PhotoToFlashcardsUseCase } from './PhotoToFlashcardsUseCase';
+import {
+  PhotoToFlashcardsUseCase,
+  FREE_PHOTO_QUOTA_PER_MONTH,
+} from './PhotoToFlashcardsUseCase';
+import type { IEventsRepository } from '../../data_layer/EventsRepository';
 
 jest.mock('node:fs');
 jest.mock('node:child_process');
 
 const mockFs = jest.requireMock('node:fs') as typeof import('node:fs');
-const mockChild = jest.requireMock('node:child_process') as typeof import('node:child_process');
+const mockChild = jest.requireMock(
+  'node:child_process'
+) as typeof import('node:child_process');
 
 const STUB_CLAUDE_RESPONSE = `[{"deck":"My Photo","cards":[{"q":"What is photosynthesis?","a":"The process by which plants convert light into energy"},{"q":"What do plants need?","a":"Water, sunlight, and CO2"}]}]`;
 
 jest.mock('../../lib/claude/ClaudeService', () => ({
   getAnthropicClient: jest.fn(),
+}));
+
+jest.mock('../../services/events/track', () => ({
+  track: jest.fn(),
 }));
 
 function setupFsMocks() {
@@ -28,27 +38,46 @@ function setupPythonMock(apkgPath = '/tmp/result.apkg') {
   (mockChild.spawn as jest.Mock).mockReturnValue(mockProcess);
 
   setTimeout(() => {
-    const stdoutHandler = mockProcess.stdout.on.mock.calls.find(([e]) => e === 'data')?.[1];
+    const stdoutHandler = mockProcess.stdout.on.mock.calls.find(
+      ([e]) => e === 'data'
+    )?.[1];
     stdoutHandler?.(apkgPath);
-    const closeHandler = mockProcess.on.mock.calls.find(([e]) => e === 'close')?.[1];
+    const closeHandler = mockProcess.on.mock.calls.find(
+      ([e]) => e === 'close'
+    )?.[1];
     closeHandler?.(0);
   }, 0);
 
   return mockProcess;
 }
 
+function makeEventsStub(usedThisMonth = 0): IEventsRepository {
+  return {
+    insertEvents: jest.fn().mockResolvedValue(undefined),
+    countByName: jest.fn().mockResolvedValue(0),
+    countDistinctUsers: jest.fn().mockResolvedValue(0),
+    countByNameForUser: jest.fn().mockResolvedValue(usedThisMonth),
+  };
+}
+
+const BASE_INPUT = {
+  imageBase64: 'abc123',
+  mediaType: 'image/jpeg' as const,
+  deckName: 'Test',
+  owner: 'user@example.com',
+  imageDimensions: { width: 100, height: 100 },
+};
+
 describe('PhotoToFlashcardsUseCase', () => {
   const mockMessageCreate = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    const { getAnthropicClient } = jest.requireMock('../../lib/claude/ClaudeService') as {
-      getAnthropicClient: jest.Mock;
-    };
+    const { getAnthropicClient } = jest.requireMock(
+      '../../lib/claude/ClaudeService'
+    ) as { getAnthropicClient: jest.Mock };
     getAnthropicClient.mockReturnValue({
-      messages: {
-        create: mockMessageCreate,
-      },
+      messages: { create: mockMessageCreate },
     });
     mockMessageCreate.mockResolvedValue({
       content: [{ type: 'text', text: STUB_CLAUDE_RESPONSE }],
@@ -58,99 +87,81 @@ describe('PhotoToFlashcardsUseCase', () => {
     setupPythonMock();
   });
 
-  describe('access gate', () => {
-    it('throws 403 when hasAccess is false', async () => {
-      const useCase = new PhotoToFlashcardsUseCase();
+  describe('free quota', () => {
+    it('blocks a free user at the monthly limit with status 429', async () => {
+      const events = makeEventsStub(FREE_PHOTO_QUOTA_PER_MONTH);
+      const useCase = new PhotoToFlashcardsUseCase(events);
       await expect(
-        useCase.execute({
-          imageBase64: 'abc123',
-          mediaType: 'image/jpeg',
-          deckName: 'Test',
-          hasAccess: false,
-          imageDimensions: { width: 100, height: 100 },
-        })
-      ).rejects.toMatchObject({ status: 403 });
+        useCase.execute({ ...BASE_INPUT, isPaying: false })
+      ).rejects.toMatchObject({
+        status: 429,
+        used: FREE_PHOTO_QUOTA_PER_MONTH,
+        limit: FREE_PHOTO_QUOTA_PER_MONTH,
+      });
+      expect(mockMessageCreate).not.toHaveBeenCalled();
     });
 
-    it('does not call Claude when access is denied', async () => {
-      const useCase = new PhotoToFlashcardsUseCase();
-      await expect(
-        useCase.execute({
-          imageBase64: 'abc123',
-          mediaType: 'image/jpeg',
-          deckName: 'Test',
-          hasAccess: false,
-          imageDimensions: { width: 100, height: 100 },
+    it('lets a free user through when under the limit', async () => {
+      const events = makeEventsStub(FREE_PHOTO_QUOTA_PER_MONTH - 1);
+      const useCase = new PhotoToFlashcardsUseCase(events);
+      const result = await useCase.execute({ ...BASE_INPUT, isPaying: false });
+      expect(result.cardCount).toBe(2);
+    });
+
+    it('skips the count check entirely for paying users', async () => {
+      const events = makeEventsStub(FREE_PHOTO_QUOTA_PER_MONTH * 10);
+      const useCase = new PhotoToFlashcardsUseCase(events);
+      const result = await useCase.execute({ ...BASE_INPUT, isPaying: true });
+      expect(result.cardCount).toBe(2);
+      expect(events.countByNameForUser).not.toHaveBeenCalled();
+    });
+
+    it('tracks a vision_photo_converted event on success', async () => {
+      const events = makeEventsStub(0);
+      const useCase = new PhotoToFlashcardsUseCase(events);
+      await useCase.execute({ ...BASE_INPUT, isPaying: false });
+      const { track } = jest.requireMock(
+        '../../services/events/track'
+      ) as { track: jest.Mock };
+      expect(track).toHaveBeenCalledWith(
+        'vision_photo_converted',
+        expect.objectContaining({
+          props: expect.objectContaining({ card_count: 2 }),
         })
-      ).rejects.toMatchObject({ status: 403 });
-      expect(mockMessageCreate).not.toHaveBeenCalled();
+      );
     });
   });
 
   describe('token ceiling', () => {
-    it('throws 413 when estimated tokens exceed the ceiling (large image)', async () => {
-      const useCase = new PhotoToFlashcardsUseCase();
+    it('throws 413 when estimated tokens exceed the ceiling', async () => {
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
       await expect(
         useCase.execute({
-          imageBase64: 'abc123',
-          mediaType: 'image/jpeg',
-          deckName: 'Test',
-          hasAccess: true,
-          imageDimensions: { width: 100, height: 100 },
+          ...BASE_INPUT,
+          isPaying: true,
           tokenCeilingOverride: 1,
         })
       ).rejects.toMatchObject({ status: 413 });
       expect(mockMessageCreate).not.toHaveBeenCalled();
     });
-
-    it('proceeds when estimated tokens are within ceiling', async () => {
-      const useCase = new PhotoToFlashcardsUseCase();
-      const result = await useCase.execute({
-        imageBase64: 'abc123',
-        mediaType: 'image/jpeg',
-        deckName: 'Test',
-        hasAccess: true,
-        imageDimensions: { width: 100, height: 100 },
-        tokenCeilingOverride: 999999,
-      });
-      expect(result.cardCount).toBeGreaterThan(0);
-    });
   });
 
   describe('card extraction', () => {
     it('returns the correct card count from Claude response', async () => {
-      const useCase = new PhotoToFlashcardsUseCase();
-      const result = await useCase.execute({
-        imageBase64: 'abc123',
-        mediaType: 'image/jpeg',
-        deckName: 'My Photo',
-        hasAccess: true,
-        imageDimensions: { width: 100, height: 100 },
-      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      const result = await useCase.execute({ ...BASE_INPUT, isPaying: true });
       expect(result.cardCount).toBe(2);
     });
 
     it('returns an apkg file path ending in .apkg', async () => {
-      const useCase = new PhotoToFlashcardsUseCase();
-      const result = await useCase.execute({
-        imageBase64: 'abc123',
-        mediaType: 'image/jpeg',
-        deckName: 'My Photo',
-        hasAccess: true,
-        imageDimensions: { width: 100, height: 100 },
-      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      const result = await useCase.execute({ ...BASE_INPUT, isPaying: true });
       expect(result.apkgPath).toMatch(/\.apkg$/);
     });
 
     it('calls Claude Vision API with base64 image block', async () => {
-      const useCase = new PhotoToFlashcardsUseCase();
-      await useCase.execute({
-        imageBase64: 'abc123',
-        mediaType: 'image/jpeg',
-        deckName: 'My Photo',
-        hasAccess: true,
-        imageDimensions: { width: 100, height: 100 },
-      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await useCase.execute({ ...BASE_INPUT, isPaying: true });
       expect(mockMessageCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           messages: expect.arrayContaining([
@@ -158,7 +169,10 @@ describe('PhotoToFlashcardsUseCase', () => {
               content: expect.arrayContaining([
                 expect.objectContaining({
                   type: 'image',
-                  source: expect.objectContaining({ type: 'base64', data: 'abc123' }),
+                  source: expect.objectContaining({
+                    type: 'base64',
+                    data: 'abc123',
+                  }),
                 }),
               ]),
             }),

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -7,12 +7,18 @@ import { spawn, execFileSync } from 'node:child_process';
 import { getAnthropicClient } from '../../lib/claude/ClaudeService';
 import { countVisionTokens, VISION_TOKEN_CEILING, VisionMediaType } from '../../lib/claude/countVisionTokens';
 import { CREATE_DECK_DIR } from '../../lib/constants';
+import { track } from '../../services/events/track';
+import type { IEventsRepository } from '../../data_layer/EventsRepository';
+
+export const FREE_PHOTO_QUOTA_PER_MONTH = 5;
+const VISION_PHOTO_EVENT = 'vision_photo_converted';
 
 export interface PhotoToFlashcardsInput {
   imageBase64: string;
   mediaType: VisionMediaType;
   deckName: string;
-  hasAccess: boolean;
+  owner: string;
+  isPaying: boolean;
   imageDimensions: { width: number; height: number };
   tokenCeilingOverride?: number;
 }
@@ -22,6 +28,15 @@ export interface PhotoToFlashcardsResult {
   cardCount: number;
   estimatedCostUsd: number;
   tileCount: number;
+}
+
+function ownerToUserId(owner: string): number | null {
+  const n = Number(owner);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function startOfMonth(now: Date = new Date()): Date {
+  return new Date(now.getFullYear(), now.getMonth(), 1);
 }
 
 const VISION_PROMPT = `Extract atomic question-and-answer flashcard pairs from this image.
@@ -115,6 +130,20 @@ function makePayloadTooLargeError(): Error & { status: number } {
   return err;
 }
 
+function makeFreeQuotaReachedError(used: number, limit: number): Error & {
+  status: number;
+  used: number;
+  limit: number;
+} {
+  const err = new Error(
+    `Free plan is ${limit} photos per month. You've used ${used}. Upgrade for unlimited.`
+  ) as Error & { status: number; used: number; limit: number };
+  err.status = 429;
+  err.used = used;
+  err.limit = limit;
+  return err;
+}
+
 interface CompactCard {
   q: string;
   a: string;
@@ -174,9 +203,21 @@ function buildDeckInfo(
 }
 
 export class PhotoToFlashcardsUseCase {
+  constructor(private readonly events?: IEventsRepository) {}
+
   async execute(input: PhotoToFlashcardsInput): Promise<PhotoToFlashcardsResult> {
-    if (!input.hasAccess) {
-      throw makeForbiddenError();
+    const userId = ownerToUserId(input.owner);
+
+    if (!input.isPaying && this.events != null) {
+      const used = await this.events.countByNameForUser(
+        VISION_PHOTO_EVENT,
+        startOfMonth(),
+        userId,
+        userId == null ? input.owner : null
+      );
+      if (used >= FREE_PHOTO_QUOTA_PER_MONTH) {
+        throw makeFreeQuotaReachedError(used, FREE_PHOTO_QUOTA_PER_MONTH);
+      }
     }
 
     const { tokens, tiles } = countVisionTokens({
@@ -259,6 +300,12 @@ export class PhotoToFlashcardsUseCase {
       input_tokens: inputTokens,
       output_tokens: outputTokens,
     }));
+
+    track(VISION_PHOTO_EVENT, {
+      userId: ownerToUserId(input.owner),
+      anonymousId: ownerToUserId(input.owner) == null ? input.owner : null,
+      props: { card_count: cardCount, tile_count: tiles },
+    });
 
     return { apkgPath, cardCount, estimatedCostUsd, tileCount: tiles };
   }

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
@@ -77,13 +77,13 @@ describe('PhotoToFlashcardsPage', () => {
     render(<PhotoToFlashcardsPage />);
     expect(screen.getByText('Snap a photo, get cards')).toBeTruthy();
     expect(screen.getByText(/textbook pages, lecture slides, and handwritten notes/)).toBeTruthy();
-    expect(screen.getByText(/Ankify access required/)).toBeTruthy();
+    expect(screen.getByText(/Free plan: 5 photos per month/)).toBeTruthy();
   });
 
-  it('omits the access notice for paying users', () => {
+  it('omits the free-plan notice for paying users', () => {
     setLocals({ paying: true });
     render(<PhotoToFlashcardsPage />);
-    expect(screen.queryByText(/Ankify access required/)).toBeNull();
+    expect(screen.queryByText(/Free plan: 5 photos per month/)).toBeNull();
   });
 
   it('rejects unsupported file types', () => {
@@ -119,9 +119,9 @@ describe('PhotoToFlashcardsPage', () => {
     });
   });
 
-  it('shows the access-required message on 403', async () => {
+  it('shows the sign-in message on 401/403', async () => {
     setLocals({ paying: true });
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 403 }));
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
     vi.stubGlobal('fetch', fetchMock);
 
     render(<PhotoToFlashcardsPage />);
@@ -130,7 +130,31 @@ describe('PhotoToFlashcardsPage', () => {
     fireEvent.click(screen.getByText('Get flashcards'));
 
     await waitFor(() => {
-      expect(screen.getByText(/Ankify access is required for photo to deck/)).toBeTruthy();
+      expect(screen.getByText(/Sign in to use photo to deck/)).toBeTruthy();
+    });
+  });
+
+  it('shows the free-plan limit message on 429', async () => {
+    setLocals({ paying: false });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ used: 5, limit: 5 }), {
+          status: 429,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<PhotoToFlashcardsPage />);
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto()] } });
+    fireEvent.click(screen.getByText('Get flashcards'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Free plan is 5 photos per month\. Upgrade for unlimited\./)
+      ).toBeTruthy();
     });
   });
 

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -131,13 +131,23 @@ export function PhotoToFlashcardsPage() {
         setStatus('idle');
         return;
       }
-      if (res.status === 403) {
-        setError('Ankify access is required for photo to deck.');
+      if (res.status === 401 || res.status === 403) {
+        setError('Sign in to use photo to deck.');
         setStatus('idle');
         return;
       }
       if (res.status === 413) {
         setError('Photo is too large. Try a smaller or lower-resolution image.');
+        setStatus('idle');
+        return;
+      }
+      if (res.status === 429) {
+        const body = (await res.json().catch(() => ({}))) as {
+          used?: number;
+          limit?: number;
+        };
+        const limit = body.limit ?? 5;
+        setError(`Free plan is ${limit} photos per month. Upgrade for unlimited.`);
         setStatus('idle');
         return;
       }
@@ -167,7 +177,7 @@ export function PhotoToFlashcardsPage() {
         <h1 className={pageStyles.pageTitle}>Snap a photo, get cards</h1>
         <p className={pageStyles.pageSubtitle}>
           Works on textbook pages, lecture slides, and handwritten notes.
-          {!isPaying && ' Ankify access required.'}
+          {!isPaying && ' Free plan: 5 photos per month.'}
         </p>
       </header>
 

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Photo to deck — drop a photo of your textbook page, lecture slide, or handwritten notes, get an Anki deck back. Free plan: 5 photos per month', date: '2026-05-20' },
   { type: 'fix', title: 'LaTeX cloze cards with multiple code blocks render with the right boundaries', date: '2026-05-20' },
   { type: 'feature', title: 'Unlimited now offers yearly billing — $60 / yr, 2 months free', date: '2026-05-20' },
   { type: 'fix', title: 'Re-importing the same Notion page updates your existing Anki notes instead of adding duplicates', date: '2026-05-20' },


### PR DESCRIPTION
## Summary

Replaces the \`VISION_PHOTO_ENABLED\` env gate with a per-user monthly quota tracked via the existing \`events\` table. Photo to deck is now:

- **Always registered** — no more 404 from an unset env var
- **Open to any signed-in user** — \`RequireAuthentication\` replaces \`RequireAnkifyAccess\`
- **Capped at 5 photos / month on the free plan** — Lifetime / Unlimited / Auto Sync users skip the check entirely

Cost is bounded by the cap; no infrastructure feature-flag system needed for one feature.

## What changed

| Layer | Change |
|---|---|
| Route | Drop \`if (VISION_ENABLED)\`; \`RequireAuthentication\` instead of \`RequireAnkifyAccess\` |
| Use case | Takes \`EventsRepository\` via constructor. For non-paying callers, counts \`vision_photo_converted\` events since start of month; throws \`{ status: 429, used, limit }\` at the cap. Tracks the event on success. |
| Controller | Passes \`owner\` + \`isPaying\` instead of the old \`hasAccess\` bool. Maps 429 → HTTP 429 \`{ message, used, limit }\`. |
| Types | New event name \`vision_photo_converted\` in \`KNOWN_EVENTS\` |
| Frontend | Subtitle: "Free plan: 5 photos per month" for free users. 401/403 → sign-in prompt. 429 → "Free plan is N photos per month. Upgrade for unlimited." |
| Changelog | New entry — feature is now reachable for real users |

## Test plan

- [x] \`pnpm test src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts\` — 8/8 (quota at limit / under limit, paying bypass, event tracked, token ceiling, card extraction)
- [x] \`pnpm --filter 2anki-web test PhotoToFlashcardsPage\` — 9/9 (subtitle copy, paying-user copy elision, 401, 413, 429, 404, success)
- [x] \`npx tsc --noEmit\` (server) — clean
- [x] \`pnpm --filter 2anki-web typecheck\` — clean
- [x] \`pnpm --filter 2anki-web lint\` — clean
- [ ] After merge: smoke test on prod \`/photo-to-deck\` — confirm a successful conversion as a paying user; then test the quota path as a free user

## Spec deviation

The original spec (#2506) gated this behind \`hasAnkifyAccess\`. Per your push back on env-var feature flags and the broader "open it up to everyone" direction, the access model is now the free-plan cap. This matches the existing model elsewhere in the product (free users have monthly card limits; paying users don't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781901600&installation_id=132681956&pr_number=2520&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2520&signature=f7b6b792d77bf375eafe79f4648f02da8d642c76466fd4c638799917b9c9ca10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->