### PR TITLE
fix: pass deck_info.json and template dir when building photo deck

### DIFF
--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -181,4 +181,17 @@ describe('PhotoToFlashcardsUseCase', () => {
       );
     });
   });
+
+  describe('deck builder invocation', () => {
+    it('spawns create_deck.py with deck_info.json and the template dir', async () => {
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await useCase.execute({ ...BASE_INPUT, isPaying: true });
+      expect(mockChild.spawn).toHaveBeenCalledTimes(1);
+      const [, argv] = (mockChild.spawn as jest.Mock).mock.calls[0];
+      expect(argv).toHaveLength(3);
+      expect(argv[0]).toMatch(/create_deck\.py$/);
+      expect(argv[1]).toMatch(/deck_info\.json$/);
+      expect(argv[2]).toMatch(/templates$/);
+    });
+  });
 });

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -6,7 +6,7 @@ import { spawn, execFileSync } from 'node:child_process';
 
 import { getAnthropicClient } from '../../lib/claude/ClaudeService';
 import { countVisionTokens, VISION_TOKEN_CEILING, VisionMediaType } from '../../lib/claude/countVisionTokens';
-import { CREATE_DECK_DIR } from '../../lib/constants';
+import { CREATE_DECK_DIR, CREATE_DECK_SCRIPT_PATH, TEMPLATE_DIR } from '../../lib/constants';
 import { track } from '../../services/events/track';
 import type { IEventsRepository } from '../../data_layer/EventsRepository';
 
@@ -88,12 +88,15 @@ function findPython(): string {
   return 'python3';
 }
 
-const DECK_SCRIPT_PATH = path.join(CREATE_DECK_DIR, 'create_deck.py');
-
 function runDeckBridge(workspaceDir: string): Promise<string> {
   const python = findPython();
+  const deckInfoPath = path.join(workspaceDir, 'deck_info.json');
   return new Promise((resolve, reject) => {
-    const proc = spawn(python, [DECK_SCRIPT_PATH, workspaceDir], { cwd: workspaceDir });
+    const proc = spawn(
+      python,
+      [CREATE_DECK_SCRIPT_PATH, deckInfoPath, TEMPLATE_DIR],
+      { cwd: workspaceDir }
+    );
     const stdoutChunks: string[] = [];
     const stderrChunks: string[] = [];
     proc.stdout.on('data', (chunk) => stdoutChunks.push(chunk.toString()));


### PR DESCRIPTION
## Summary
- Photo to Deck has been broken on prod since the backend shipped — every upload returned 400 with `IndexError: list index out of range` because `create_deck.py` was spawned with one argv (the workspace dir) instead of `[DATA_FILE, TEMPLATE_DIR]`.
- Fix: pass `workspaceDir/deck_info.json` and `src/templates` to match the contract `CardGenerator` already uses.
- Add a regression test that asserts the spawn argv shape. The previous test mocked `spawn` but never inspected the arguments, which is exactly how this bug slipped through CI.

No changelog entry — Photo to Deck only graduated to "for everyone" in efff3b8 (a few minutes ago), users haven't seen the working version yet. The existing feature entry from that commit already represents the rollout.

No sonar-scanner run locally — the diff is ~10 lines (argv shape + one test); no new functions, branches, or assertions. Happy to run it if anything bounces.

## Test plan
- [x] `pnpm test src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts` — 9/9 green (8 existing + 1 new argv assertion)
- [x] `npx tsc --noEmit -p .` — clean
- [ ] On 2anki.net after deploy: upload a photo on /photo-to-deck, confirm an .apkg downloads instead of the IndexError
- [ ] `/deploy-status` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781902266&installation_id=132681956&pr_number=2521&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2521&signature=4fad77d87a72da33612601f0e6ebd1dd51a57ff06df7972eb1dc26703c08f64c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->