### PR TITLE
fix: trailing-slashed template dir and deck.name for Python builder

### DIFF
--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -183,7 +183,7 @@ describe('PhotoToFlashcardsUseCase', () => {
   });
 
   describe('deck builder invocation', () => {
-    it('spawns create_deck.py with deck_info.json and the template dir', async () => {
+    it('spawns create_deck.py with deck_info.json and a trailing-slashed template dir', async () => {
       const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
       await useCase.execute({ ...BASE_INPUT, isPaying: true });
       expect(mockChild.spawn).toHaveBeenCalledTimes(1);
@@ -191,7 +191,22 @@ describe('PhotoToFlashcardsUseCase', () => {
       expect(argv).toHaveLength(3);
       expect(argv[0]).toMatch(/create_deck\.py$/);
       expect(argv[1]).toMatch(/deck_info\.json$/);
-      expect(argv[2]).toMatch(/templates$/);
+      expect(argv[2]).toMatch(/templates[\\/]$/);
+    });
+
+    it('writes a deck_info.json with deck.name (not deck.deck) so the Python script can read it', async () => {
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await useCase.execute({ ...BASE_INPUT, isPaying: true });
+      const writeCall = (mockFs.writeFileSync as jest.Mock).mock.calls.find(
+        ([p]) => typeof p === 'string' && p.endsWith('deck_info.json')
+      );
+      expect(writeCall).toBeDefined();
+      const payload = JSON.parse(writeCall![1] as string) as Array<{
+        name?: string;
+        deck?: string;
+      }>;
+      expect(payload[0]).toHaveProperty('name');
+      expect(payload[0]).not.toHaveProperty('deck');
     });
   });
 });

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -94,7 +94,7 @@ function runDeckBridge(workspaceDir: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const proc = spawn(
       python,
-      [CREATE_DECK_SCRIPT_PATH, deckInfoPath, TEMPLATE_DIR],
+      [CREATE_DECK_SCRIPT_PATH, deckInfoPath, TEMPLATE_DIR + path.sep],
       { cwd: workspaceDir }
     );
     const stdoutChunks: string[] = [];
@@ -186,7 +186,7 @@ function buildDeckInfo(
   );
 
   return {
-    deck: deckName,
+    name: deckName,
     id: Math.abs(
       Array.from(deckName).reduce(
         (h, ch) => Math.trunc(Math.imul(31, h) + (ch.codePointAt(0) ?? 0)),


### PR DESCRIPTION
## Summary
Follow-up to #2521 after **actually running** create_deck.py end-to-end against a real workspace. Two more bugs surfaced:

1. **Missing trailing slash on template dir.** `create_deck/helpers/read_template.py:16` does naive string concat (`template_dir + path`), so the template argv must end with a separator. `TEMPLATE_DIR` from `src/lib/constants.ts` has no trailing slash, which is why prod produced `src/templatescloze_style.css` (FileNotFoundError). The Notion → Anki pipeline works because `CardGenerator.ts:73` explicitly passes `'../../templates/'` with a trailing slash. Append `path.sep` at the spawn site instead of mutating the shared constant.

2. **Wrong field name on the deck object.** Python reads `deck["name"]` at lines 197 and 209 of `create_deck.py`. `buildDeckInfo` in the photo use case was writing `{ deck: deckName, ... }`. Rename `deck:` → `name:` to match the contract every other path already uses.

**Verified end-to-end** before pushing: stub payload through the real Python script in `/tmp/photo-repro/` produces a 53KB `Repro-123.apkg`. The "skip real-app verification" failure mode I outlined in the retro on #2521 was exactly the failure that let these two bugs ship in the first patch — fixing process and code in the same PR.

## Test plan
- [x] `pnpm test src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts` — 10/10 (8 existing + new argv argv-shape test + new deck.name payload test)
- [x] `npx tsc --noEmit -p .` — clean
- [x] Manual repro: `python3 create_deck/create_deck.py /tmp/photo-repro/deck_info.json src/templates/` produces a real .apkg
- [ ] Upload a photo on /photo-to-deck after deploy, confirm the .apkg downloads
- [ ] `/deploy-status` after merge

## Follow-up
As called out in the #2521 retro, `runDeckBridge` in `PhotoToFlashcardsUseCase.ts` is a hand-rolled spawn that duplicates `CardGenerator.ts`. Worth consolidating in a separate PR so this can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781902679&installation_id=132681956&pr_number=2522&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2522&signature=c8aab9d79b04ceb6654b593bdbde89e3881ec1e97e5b6db774b63bcdcedd5ec0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->