### PR TITLE
Fix empty upload diagnostics for memory-backed files

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -165,6 +165,41 @@ describe('UploadService.handleUpload — error paths', () => {
     expect(body.message).not.toMatch(/<[a-z]/i);
   });
 
+  it('uses in-memory uploaded file contents for empty-deck diagnostics when no disk path exists', async () => {
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      MockGeneratePackagesUseCase.mockImplementation(() => ({
+        execute: jest.fn().mockResolvedValue({ packages: [] }),
+      }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
+
+      const service = new UploadService(buildRepository(), {} as JobRepository);
+      const req = buildRequest({
+        files: [
+          {
+            fieldname: 'files',
+            originalname: 'memory-upload.html',
+            encoding: '7bit',
+            mimetype: 'text/html',
+            size: 36,
+            buffer: Buffer.from('<details><summary>Q</summary>A</details>'),
+          } as Express.Multer.File,
+        ],
+      });
+      const { res, capturedStatus } = buildResponse();
+
+      await service.handleUpload(req, res);
+
+      expect(capturedStatus()).toBe(400);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('<details>'));
+    } finally {
+      infoSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
+
   it('returns 400 JSON when deck serialization overflows (DeckTooLargeError path)', async () => {
     MockGeneratePackagesUseCase.mockImplementation(() => ({
       execute: jest.fn().mockRejectedValue(new DeckTooLargeError()),

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -71,7 +71,12 @@ function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
   for (const file of uploadedFiles ?? []) {
     console.info(`  name=${file.originalname} mimetype=${file.mimetype} size=${file.size}`);
     try {
-      const head = fs.readFileSync(file.path).slice(0, 1000).toString('utf8');
+      const contents = file.path ? fs.readFileSync(file.path) : file.buffer;
+      if (!contents) {
+        console.info('  no file contents available for diagnostics');
+        continue;
+      }
+      const head = contents.slice(0, 1000).toString('utf8');
       const hasDisplayContents = head.includes('display:contents');
       const hasToggleClass = head.includes('class="toggle"');
       const hasDetails = head.includes('<details');


### PR DESCRIPTION
## Summary
- read empty-deck diagnostics from `file.buffer` when multer has no disk path
- guard missing upload contents instead of passing `undefined` to `fs.readFileSync`
- add a regression test for memory-backed uploads that produce no packages

Closes #2497

## Tests
- `pnpm test -- src/services/UploadService.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec jest --runInBand` attempted; fails locally because dependencies were installed with lifecycle scripts disabled, so `better-sqlite3` has no native binding, and parser/canary tests fail with `PythonExitError` in this environment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781929386&installation_id=132681956&pr_number=2524&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2524&signature=bdb5131422b4a3adde0dd0966a595587f535cc61cafa9a38bf297a44ca0fd6e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->