### PR TITLE
fix: Connect to Notion button stays usable when logged out

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -280,4 +280,79 @@ describe('NotionController', () => {
       expect(res.status).toHaveBeenCalledWith(400);
     });
   });
+
+  describe('getNotionLink', () => {
+    it('returns the OAuth link with isConnected=false when the caller is anonymous', async () => {
+      service = {
+        getClientId: jest.fn().mockReturnValue('client-abc'),
+        getNotionLinkInfo: jest.fn().mockResolvedValue({
+          link: 'https://api.notion.com/v1/oauth/authorize?client_id=client-abc',
+          isConnected: false,
+          workspace: null,
+        }),
+      } as any;
+      controller = new NotionController(service);
+      res = {
+        status: jest.fn().mockReturnThis(),
+        send: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+        locals: {},
+      } as any;
+
+      await controller.getNotionLink(
+        req as express.Request,
+        res as express.Response
+      );
+
+      expect(service.getNotionLinkInfo).toHaveBeenCalledWith(undefined);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          link: 'https://api.notion.com/v1/oauth/authorize?client_id=client-abc',
+          isConnected: false,
+        })
+      );
+    });
+
+    it('returns isConnected=true with workspace when the caller has a Notion token', async () => {
+      service = {
+        getClientId: jest.fn().mockReturnValue('client-abc'),
+        getNotionLinkInfo: jest.fn().mockResolvedValue({
+          link: 'https://api.notion.com/v1/oauth/authorize?client_id=client-abc',
+          isConnected: true,
+          workspace: 'Pristine Shrestha’s Notion',
+        }),
+      } as any;
+      controller = new NotionController(service);
+
+      await controller.getNotionLink(
+        req as express.Request,
+        res as express.Response
+      );
+
+      expect(service.getNotionLinkInfo).toHaveBeenCalledWith('owner1');
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isConnected: true,
+          workspace: 'Pristine Shrestha’s Notion',
+        })
+      );
+    });
+
+    it('returns 400 when the client ID is not configured', async () => {
+      service = {
+        getClientId: jest.fn().mockReturnValue(undefined),
+        getNotionLinkInfo: jest.fn(),
+      } as any;
+      controller = new NotionController(service);
+
+      await controller.getNotionLink(
+        req as express.Request,
+        res as express.Response
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(service.getNotionLinkInfo).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/routes/NotionRouter.ts
+++ b/src/routes/NotionRouter.ts
@@ -113,11 +113,13 @@ const NotionRouter = () => {
    * /api/notion/get-notion-link:
    *   get:
    *     summary: Get Notion connection link
-   *     description: Get the OAuth link to connect to Notion
+   *     description: |
+   *       Returns the OAuth link to connect to Notion. The link itself is
+   *       public — anonymous and expired-session users still get back a
+   *       working URL so the "Connect to Notion" button never goes inert.
+   *       `isConnected` and `workspace` are only populated when the caller
+   *       has a valid session.
    *     tags: [Notion]
-   *     security:
-   *       - bearerAuth: []
-   *       - cookieAuth: []
    *     responses:
    *       200:
    *         description: Notion link retrieved successfully
@@ -137,15 +139,11 @@ const NotionRouter = () => {
    *                   type: string
    *                   nullable: true
    *                   description: Connected workspace name
-   *       401:
-   *         description: Authentication required
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/Error'
    */
-  router.get('/api/notion/get-notion-link', RequireAuthentication, (req, res) =>
-    controller.getNotionLink(req, res)
+  router.get(
+    '/api/notion/get-notion-link',
+    OptionalAuthentication,
+    (req, res) => controller.getNotionLink(req, res)
   );
 
   /**

--- a/web/src/pages/SearchPage/helpers/useNotionData.test.tsx
+++ b/web/src/pages/SearchPage/helpers/useNotionData.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import useNotionData from './useNotionData';
+import Backend from '../../../lib/backend';
+
+const buildBackend = (
+  info: { isConnected?: boolean; link?: string; workspace?: string | null }
+) =>
+  ({
+    getNotionConnectionInfo: vi.fn().mockResolvedValue(info),
+  }) as unknown as Backend;
+
+describe('useNotionData', () => {
+  it('treats a logged-in user with a token as connected', async () => {
+    const backend = buildBackend({
+      isConnected: true,
+      link: 'https://api.notion.com/v1/oauth/authorize?client_id=abc',
+      workspace: 'Pristine’s Notion',
+    });
+
+    const { result } = renderHook(() => useNotionData(backend));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.connected).toBe(true);
+    expect(result.current.workSpace).toBe('Pristine’s Notion');
+    expect(result.current.connectionLink).toContain('notion.com');
+  });
+
+  it('treats a logged-in user without a token as not connected, with a working OAuth link', async () => {
+    const backend = buildBackend({
+      isConnected: false,
+      link: 'https://api.notion.com/v1/oauth/authorize?client_id=abc',
+      workspace: null,
+    });
+
+    const { result } = renderHook(() => useNotionData(backend));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connectionLink).toContain('notion.com');
+  });
+
+  it('does not default to "connected" when isConnected is missing — the connect button must stay visible', async () => {
+    const backend = buildBackend({
+      link: 'https://api.notion.com/v1/oauth/authorize?client_id=abc',
+      workspace: null,
+    });
+
+    const { result } = renderHook(() => useNotionData(backend));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connectionLink).toContain('notion.com');
+  });
+
+  it('falls back to an empty link when the request fails entirely', async () => {
+    const backend = {
+      getNotionConnectionInfo: vi
+        .fn()
+        .mockRejectedValue(new Error('network')),
+    } as unknown as Backend;
+
+    const { result } = renderHook(() => useNotionData(backend));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.connected).toBe(false);
+    expect(result.current.connectionLink).toBe('');
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/web/src/pages/SearchPage/helpers/useNotionData.tsx
+++ b/web/src/pages/SearchPage/helpers/useNotionData.tsx
@@ -25,8 +25,8 @@ export default function useNotionData(
         const data = await backend.getNotionConnectionInfo();
         const newState = {
           loading: false,
-          connected: data.isConnected ?? true,
-          connectionLink: data.link,
+          connected: data.isConnected === true,
+          connectionLink: data.link ?? '',
           workSpace: data.workspace,
         };
         setState(newState);


### PR DESCRIPTION
## Summary

Two real users this week hit the same dead end and both had valid Notion tokens sitting in the DB:

- **User 21770** — returned to 2anki after 5 days, found their session expired, hunted for a Connect button. When they found one it had no working href.
- **User 10781** — reconnected May 20 at 20:20, then their conversion failed at 20:21 (separate issue). They'd clearly hit the same disconnect moments before reconnecting.

The dead end was purely UI. `/api/notion/get-notion-link` required authentication, so a session-expired browser got 401, the frontend hook silently caught the error, and `connectionLink` became `''`. The button still rendered, but clicking it did nothing.

The OAuth link itself is public — it's just the Notion authorize URL keyed on our client ID. There's nothing in the response that needs to be gated on the caller.

## Changes

- `src/routes/NotionRouter.ts` — `/api/notion/get-notion-link` now uses `OptionalAuthentication`. Anonymous and expired-session callers get back the link, `isConnected: false`, `workspace: null`, and the button works.
- `web/src/pages/SearchPage/helpers/useNotionData.tsx` — `isConnected ?? true` becomes `=== true`. A malformed/empty response can no longer mask a disconnected state with a cheerful default. Also defends against `link` coming back null/undefined.
- Tests:
  - 3 new controller tests in `NotionController.test.ts` — anonymous caller, connected caller, missing client ID.
  - 4 new hook tests in `useNotionData.test.tsx` — connected, disconnected with link, missing flag, fetch failure.

## Test plan

- [x] In a clean browser (no `token` cookie) visit `/notion` — the Connect to Notion button is present and clicking it routes to Notion OAuth.
- [x] As a logged-in user with a valid Notion token, `/notion` shows the workspace name and search UI, not the connect button.
- [x] As a logged-in user *without* a Notion token, `/notion` shows the connect button and clicking it routes to Notion OAuth.
- [x] DevTools network: `GET /api/notion/get-notion-link` returns `200` with `{ link, isConnected, workspace }` whether or not the caller is logged in.

## Goal alignment

A working "Connect to Notion" button is the front door for the entire Notion path. We had users emailing support instead of converting more pages — that's a friction we shouldn't have shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)