### PR TITLE
docs(rules): support reporter names and account detail stay private

### DIFF
--- a/.claude/rules/support-confidentiality.md
+++ b/.claude/rules/support-confidentiality.md
@@ -1,0 +1,35 @@
+# Support confidentiality
+
+Bug reports, support emails, and feedback frequently arrive with the reporter's name, email, Notion workspace name, deck titles, and other identifying detail. None of that goes into anything public.
+
+| Requirement | Do instead | Why |
+| --- | --- | --- |
+| Do not put a reporter's first or last name in a commit message, PR title, PR body, GitHub issue, code comment, FEATURE.md, spec, or changelog entry. | Use the numeric user ID (`user 21770`), the role ("a returning Notion user"), or "a real user this week." | The commit goes into `main`'s history forever; the PR is world-readable. People sharing a bug with support do not consent to becoming a public artifact. |
+| Do not put the reporter's email address, Notion workspace name, deck title, or any other content from their account in a commit, PR, issue, or doc. | Strip it. If a specific example is load-bearing, use a fabricated stand-in (`"Week 18: Polarised Lenses"` becomes `"a recent Notion page"`). | Workspace names and deck titles routinely contain the user's name, employer, school, or coursework. |
+| Do not paste a reporter's screenshot, email, or message body into a commit/PR/issue. | Reference the support inbox ("matches the toggle-with-table report in the inbox") without quoting. | Screenshots leak the same identifiers plus more (study material, handwriting, faces). |
+| Do not reference an internal Linear/issue tracker ID, support ticket ID, or message thread ID that ties back to a named user in a public artifact. | If you need a reference, paraphrase the symptom. | Same exposure pattern as the name itself. |
+| Do not write reporter names into `Documentation/specs/*.md` even if the spec is "draft-only." | Anonymize before the file lands in a branch. Specs end up in PRs and git history just like code does. | The lifecycle policy lets specs sit in `Documentation/specs/` for several days, fully public, before `/implement` removes them. |
+
+## Where reporter detail is okay
+
+- Local files outside the repo: `~/Downloads/reply-<name>.txt`, `~/Downloads/*.eml`, anything the user keeps offline.
+- Memory under `~/.claude/projects/.../memory/` — local to your machine, not committed.
+- The conversation with Al inside Claude Code — explaining what you found is the point of the conversation.
+- The drafted support reply itself — that obviously goes to the reporter.
+- Private support tooling (the inbox, Stripe customer record, Postgres) — Al's eyes only, not public.
+
+## Why "user 21770" instead of "an anonymous user"
+
+A numeric ID lets Al and future-you reconcile the artifact back to the original report without exposing identity. "An anonymous user" is fine for a changelog entry but loses the trail for engineering work. Pick the level of detail to match the audience:
+
+- Commit body / PR body / inline code: numeric ID is plenty.
+- Changelog entry / blog post / public docs: "a user", no ID.
+- Spec / FEATURE.md / RULES.md / READMEs: role or symptom only ("returning Notion user with an expired session"), no ID and no name.
+
+## When you slip up
+
+You will sometimes draft something with a name in it. The fix sequence:
+
+1. Editable artifacts first (`gh pr edit <n> --body ...`, GitHub issue body, draft spec) — those are one command away.
+2. Merged commits on `main` are harder. Force-pushing `main` to scrub a name is destructive and visible to every contributor; flag the slip to Al and let him decide whether the rewrite is worth it. Default answer is usually "no, leave it, do better next time."
+3. Save the lesson to memory so the next session doesn't repeat the same shape of slip.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Every PR is checked against both — does it make the experience simpler/faster/
 @.claude/rules/dependencies.md
 @.claude/rules/sonar.md
 @.claude/rules/parallel-pr-coordination.md
+@.claude/rules/support-confidentiality.md
 
 ## Git
 


### PR DESCRIPTION
## Why

I shipped PR #2525 today with two reporter names in the merged commit message on main. Force-push to scrub would be visible to every contributor — not worth it for a slip of this size — but the lesson is worth a rule file so the next session doesn't repeat the same shape of slip.

## What's in the rule

- **Where reporter detail does NOT go:** commits, PR titles/bodies, GitHub issues, code comments, FEATURE.md, RULES.md, specs in `Documentation/specs/`, changelog entries. Numeric user ID (\`user 21770\`) or role description (\`a returning Notion user\`) only.
- **Workspace names, deck titles, course names, page titles** are also identifying — strip them or use fabricated stand-ins.
- **Where reporter detail IS okay:** local files in \`~/Downloads/\`, the memory dir under \`~/.claude/\`, the conversation with Al, the reply email itself.
- **Slip-fix sequence:** editable artifacts first (PR body edit via \`gh pr edit\`), merged commits flagged to Al for the call (force-push to main is destructive and usually not worth it), lesson saved to memory.

Imported alongside the other rules in CLAUDE.md so it loads on every session.

## Already done in the same cleanup

- PR #2525 body edited to swap names for user IDs (\`gh pr edit 2525 --body ...\`)
- PR #2527 body edited likewise
- Memory entry \`feedback_support_confidentiality.md\` saved
- This rule file

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781942176&installation_id=132681956&pr_number=2528&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2528&signature=c3807ae2e57fa42c06fa2d84fc5989057d4c06c4935c8becc950b7f0a71519af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->