### PR TITLE
fix(ops): unbreak Conversions tab and speed up Business tab

### DIFF
--- a/src/data_layer/BusinessMetricsCacheRepository.ts
+++ b/src/data_layer/BusinessMetricsCacheRepository.ts
@@ -2,8 +2,11 @@ import type { Knex } from 'knex';
 
 import type { BusinessMetricKey } from '../services/ops/BusinessMetricsService';
 
+export type StripeSourceCacheKey = '_stripe_subs' | '_stripe_invoices';
+export type BusinessCacheKey = BusinessMetricKey | StripeSourceCacheKey;
+
 export interface BusinessMetricsCacheEntry {
-  key: BusinessMetricKey;
+  key: BusinessCacheKey;
   value: unknown;
   cachedAt: Date;
   expiresAt: Date;
@@ -36,7 +39,7 @@ export class BusinessMetricsCacheRepository
       'expires_at'
     );
     return rows.map((row) => ({
-      key: row.metric_key as BusinessMetricKey,
+      key: row.metric_key as BusinessCacheKey,
       value: row.value,
       cachedAt: new Date(row.cached_at),
       expiresAt: new Date(row.expires_at),
@@ -61,7 +64,7 @@ export class BusinessMetricsCacheRepository
 export class InMemoryBusinessMetricsCacheRepository
   implements IBusinessMetricsCacheRepository
 {
-  private readonly entries = new Map<BusinessMetricKey, BusinessMetricsCacheEntry>();
+  private readonly entries = new Map<BusinessCacheKey, BusinessMetricsCacheEntry>();
 
   async loadAll(): Promise<BusinessMetricsCacheEntry[]> {
     return Array.from(this.entries.values()).map((entry) => ({ ...entry }));

--- a/src/services/ops/BusinessMetricsService.test.ts
+++ b/src/services/ops/BusinessMetricsService.test.ts
@@ -490,6 +490,99 @@ describe('BusinessMetricsService', () => {
     });
   });
 
+  describe('source-data cache (stripe subs/invoices)', () => {
+    it('caches subs and invoices as source-data entries, not per-metric', async () => {
+      const stripe = buildFakeStripe({
+        allSubs: [sub('sub_1', [monthly(1000)], { created: daysAgoEpoch(60) })],
+        invoices: [
+          { id: 'inv_1', status: 'open', attempt_count: 1, created: daysAgoEpoch(1) },
+        ],
+      });
+      const cache = new InMemoryBusinessMetricsCacheRepository();
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+        cacheRepository: cache,
+      });
+
+      await service.getMetrics();
+
+      const cached = await cache.loadAll();
+      const keys = cached.map((e) => e.key).sort();
+      expect(keys).toEqual(
+        expect.arrayContaining(['_stripe_subs', '_stripe_invoices'])
+      );
+      // None of the Stripe-derived per-metric keys should be cached anymore
+      expect(keys).not.toContain('mrr_usd');
+      expect(keys).not.toContain('failed_payments_7d');
+    });
+
+    it('serves stale cache immediately and refreshes in the background', async () => {
+      const stripe = buildFakeStripe({
+        allSubs: [sub('sub_1', [monthly(1000)], { created: daysAgoEpoch(60) })],
+      });
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+      });
+
+      await service.getMetrics();
+      expect(stripe.subscriptions.list).toHaveBeenCalledTimes(1);
+
+      // Past TTL — second call should NOT block but should kick a background refresh
+      jest.advanceTimersByTime(16 * 60 * 1000);
+      const second = await service.getMetrics();
+      // Stale data returned immediately; cache_age_seconds reflects the staleness
+      expect(second.mrr_usd).toBeCloseTo(10, 5);
+      expect(second.cache_age_seconds).toBeGreaterThanOrEqual(16 * 60);
+
+      // The background refresh should have started (Stripe called a second time)
+      await service.waitForInflightRefresh();
+      expect(stripe.subscriptions.list).toHaveBeenCalledTimes(2);
+    });
+
+    it('single-flights concurrent refreshes (one Stripe pagination, not two)', async () => {
+      const stripe = buildFakeStripe({
+        allSubs: [sub('sub_1', [monthly(1000)], { created: daysAgoEpoch(60) })],
+      });
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+      });
+
+      const [a, b] = await Promise.all([
+        service.getMetrics(),
+        service.getMetrics(),
+      ]);
+
+      expect(stripe.subscriptions.list).toHaveBeenCalledTimes(1);
+      expect(stripe.invoices.list).toHaveBeenCalledTimes(1);
+      expect(a.mrr_usd).toBe(b.mrr_usd);
+    });
+
+    it('cold start with subs failing still returns invoice-derived metrics', async () => {
+      const stripe = buildFakeStripe({
+        invoices: [
+          { id: 'inv_1', status: 'open', attempt_count: 1, created: daysAgoEpoch(1) },
+        ],
+      });
+      (stripe.subscriptions.list as jest.Mock).mockRejectedValueOnce(
+        new Error('subs boom')
+      );
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+      });
+
+      const result = await service.getMetrics();
+
+      expect(result.mrr_usd).toBeNull();
+      expect(result.active_paying_subs).toBeNull();
+      expect(result.failed_payments_7d).toBe(1);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ metric: 'mrr_usd', message: 'subs boom' }),
+        ])
+      );
+    });
+  });
+
   describe('cancellation feedback', () => {
     it('returns top reasons (last 90 days) and recent comments from the repo', async () => {
       const stripe = buildFakeStripe({});

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -3,6 +3,7 @@ import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 
 import { getStripe } from '../../lib/integrations/stripe';
 import {
+  BusinessCacheKey,
   BusinessMetricsCacheEntry,
   IBusinessMetricsCacheRepository,
   InMemoryBusinessMetricsCacheRepository,
@@ -146,6 +147,41 @@ interface NormalizedInvoice {
   createdMs: number;
 }
 
+const STRIPE_SUBS_CACHE_KEY: BusinessCacheKey = '_stripe_subs';
+const STRIPE_INVOICES_CACHE_KEY: BusinessCacheKey = '_stripe_invoices';
+
+const SUBS_DERIVED_METRICS: BusinessMetricKey[] = [
+  'mrr_usd',
+  'active_paying_subs',
+  'net_new_mrr_mtd_usd',
+  'new_paid_conversions_7d',
+  'churn_30d_pct',
+  'mrr_timeseries',
+  'active_subs_timeseries',
+  'conversions_vs_churn_weekly',
+];
+
+const INVOICES_DERIVED_METRICS: BusinessMetricKey[] = [
+  'failed_payments_7d',
+  'failed_payments_weekly',
+];
+
+interface SourceRefreshResult {
+  subs: NormalizedSubscription[] | null;
+  invoices: NormalizedInvoice[] | null;
+  subsError: string | null;
+  invoicesError: string | null;
+}
+
+interface ResolvedSources {
+  subs: NormalizedSubscription[] | null;
+  invoices: NormalizedInvoice[] | null;
+  subsError: string | null;
+  invoicesError: string | null;
+  subsEntry: BusinessMetricsCacheEntry | null;
+  invoicesEntry: BusinessMetricsCacheEntry | null;
+}
+
 export class BusinessMetricsService {
   private readonly stripeFactory: () => Stripe;
 
@@ -161,9 +197,7 @@ export class BusinessMetricsService {
 
   private readonly signupCountryRepository: ISignupCountryRepository | null;
 
-  private allSubsPromise: Promise<NormalizedSubscription[]> | null = null;
-
-  private invoicesPromise: Promise<NormalizedInvoice[]> | null = null;
+  private inflightSourceRefresh: Promise<SourceRefreshResult> | null = null;
 
   constructor(deps: BusinessMetricsServiceDeps = {}) {
     this.stripeFactory = deps.stripeFactory ?? (() => getStripe());
@@ -186,55 +220,134 @@ export class BusinessMetricsService {
     const now = new Date();
     const errors: BusinessMetricError[] = [];
 
-    this.allSubsPromise = null;
-    this.invoicesPromise = null;
-
     const cachedByKey = await this.loadCacheMap();
 
-    const subDerived = (computer: (subs: NormalizedSubscription[]) => unknown) =>
-      async () => computer(await this.loadAllSubs());
-    const invoiceDerived = (
-      computer: (invoices: NormalizedInvoice[]) => unknown
-    ) => async () => computer(await this.loadInvoices(now));
+    const sources = await this.resolveSources(cachedByKey, now);
 
+    const dbTasks = this.buildDbMetricTasks(now);
+    const usedEntries: BusinessMetricsCacheEntry[] = [];
+    const freshEntries: BusinessMetricsCacheEntry[] = [];
+
+    if (sources.subsEntry != null) usedEntries.push(sources.subsEntry);
+    if (sources.invoicesEntry != null) usedEntries.push(sources.invoicesEntry);
+
+    const dbSettled = await Promise.all(
+      dbTasks.map(({ key, fetch }) =>
+        this.resolveMetric(
+          key,
+          fetch,
+          now,
+          cachedByKey,
+          usedEntries,
+          freshEntries
+        ).catch((error: unknown) => {
+          const message = error instanceof Error ? error.message : String(error);
+          errors.push({ metric: key, message });
+          return null;
+        })
+      )
+    );
+
+    if (freshEntries.length > 0) {
+      try {
+        await this.cacheRepository.upsertMany(freshEntries);
+      } catch (error) {
+        console.error('[ops] business metrics cache upsert failed', error);
+      }
+    }
+
+    const dbValueByKey = new Map<BusinessMetricKey, unknown>();
+    dbTasks.forEach(({ key }, idx) => {
+      dbValueByKey.set(key, dbSettled[idx]);
+    });
+
+    const cacheAgeSeconds = computeCacheAgeSeconds(usedEntries, now);
+
+    const subs = sources.subs;
+    const invoices = sources.invoices;
+    const fromSubs = <T>(fn: (s: NormalizedSubscription[]) => T): T | null =>
+      subs != null ? fn(subs) : null;
+    const fromInvoices = <T>(fn: (i: NormalizedInvoice[]) => T): T | null =>
+      invoices != null ? fn(invoices) : null;
+
+    const response: BusinessMetricsResponse = {
+      mrr_usd: fromSubs((s) => computeMrrUsd(s, now)),
+      net_new_mrr_mtd_usd: fromSubs((s) => computeNetNewMrrMtdUsd(s, now)),
+      active_paying_subs: fromSubs((s) => computeActiveCount(s, now)),
+      churn_30d_pct: fromSubs((s) => computeChurn30dPct(s, now)),
+      failed_payments_7d: fromInvoices((i) => computeFailedPayments7d(i, now)),
+      new_paid_conversions_7d: fromSubs((s) => computeNewPaidConversions7d(s, now)),
+      mrr_timeseries: fromSubs((s) => computeMrrTimeseries(s, now)),
+      active_subs_timeseries: fromSubs((s) => computeActiveSubsTimeseries(s, now)),
+      conversions_vs_churn_weekly: fromSubs((s) =>
+        computeConversionsChurnWeekly(s, now)
+      ),
+      failed_payments_weekly: fromInvoices((i) =>
+        computeFailedPaymentsWeekly(i, now)
+      ),
+      cancellation_reasons_top: dbValueByKey.get('cancellation_reasons_top') as
+        | CancellationReasonCount[]
+        | null,
+      cancellation_comments_recent: dbValueByKey.get(
+        'cancellation_comments_recent'
+      ) as CancellationCommentEntry[] | null,
+      emoji_feedback_ratings: dbValueByKey.get(
+        'emoji_feedback_ratings'
+      ) as EmojiFeedbackRatingCount[] | null,
+      emoji_feedback_comments: dbValueByKey.get(
+        'emoji_feedback_comments'
+      ) as EmojiFeedbackCommentEntry[] | null,
+      reengagement_reasons_top: dbValueByKey.get(
+        'reengagement_reasons_top'
+      ) as ReEngagementReasonCount[] | null,
+      reengagement_comments_recent: dbValueByKey.get(
+        'reengagement_comments_recent'
+      ) as ReEngagementCommentEntry[] | null,
+      signup_countries_90d: dbValueByKey.has('signup_countries_90d')
+        ? (dbValueByKey.get('signup_countries_90d') as SignupCountryCount[] | null)
+        : null,
+      as_of: now.toISOString(),
+      cache_age_seconds: cacheAgeSeconds,
+    };
+
+    if (sources.subsError != null) {
+      for (const key of SUBS_DERIVED_METRICS) {
+        errors.push({ metric: key, message: sources.subsError });
+      }
+    }
+    if (sources.invoicesError != null) {
+      for (const key of INVOICES_DERIVED_METRICS) {
+        errors.push({ metric: key, message: sources.invoicesError });
+      }
+    }
+
+    if (errors.length > 0) {
+      response.errors = errors;
+    }
+
+    return response;
+  }
+
+  // Test helper: lets a test await a background SWR refresh.
+  // Production callers never need this; SWR is fire-and-forget by design.
+  async waitForInflightRefresh(): Promise<void> {
+    const inflight = this.inflightSourceRefresh;
+    if (inflight != null) {
+      try {
+        await inflight;
+      } catch {
+        // background refresh errors are surfaced on the next request's error array
+      }
+    }
+  }
+
+  private buildDbMetricTasks(
+    now: Date
+  ): Array<{ key: BusinessMetricKey; fetch: () => Promise<unknown> }> {
     const tasks: Array<{
       key: BusinessMetricKey;
       fetch: () => Promise<unknown>;
     }> = [
-      { key: 'mrr_usd', fetch: subDerived((s) => computeMrrUsd(s, now)) },
-      {
-        key: 'active_paying_subs',
-        fetch: subDerived((s) => computeActiveCount(s, now)),
-      },
-      {
-        key: 'net_new_mrr_mtd_usd',
-        fetch: subDerived((s) => computeNetNewMrrMtdUsd(s, now)),
-      },
-      {
-        key: 'new_paid_conversions_7d',
-        fetch: subDerived((s) => computeNewPaidConversions7d(s, now)),
-      },
-      { key: 'churn_30d_pct', fetch: subDerived((s) => computeChurn30dPct(s, now)) },
-      {
-        key: 'failed_payments_7d',
-        fetch: invoiceDerived((i) => computeFailedPayments7d(i, now)),
-      },
-      {
-        key: 'mrr_timeseries',
-        fetch: subDerived((s) => computeMrrTimeseries(s, now)),
-      },
-      {
-        key: 'active_subs_timeseries',
-        fetch: subDerived((s) => computeActiveSubsTimeseries(s, now)),
-      },
-      {
-        key: 'conversions_vs_churn_weekly',
-        fetch: subDerived((s) => computeConversionsChurnWeekly(s, now)),
-      },
-      {
-        key: 'failed_payments_weekly',
-        fetch: invoiceDerived((i) => computeFailedPaymentsWeekly(i, now)),
-      },
       {
         key: 'cancellation_reasons_top',
         fetch: () =>
@@ -286,107 +399,169 @@ export class BusinessMetricsService {
             REENGAGEMENT_COMMENTS_LIMIT
           ),
       },
-      ...(this.signupCountryRepository != null
-        ? [
-            {
-              key: 'signup_countries_90d' as BusinessMetricKey,
-              fetch: () =>
-                this.signupCountryRepository!.countBySignupCountry(
-                  new Date(
-                    now.getTime() -
-                      SIGNUP_COUNTRIES_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
-                  ),
-                  SIGNUP_COUNTRIES_LIMIT
-                ),
-            },
-          ]
-        : []),
     ];
 
-    const usedEntries: BusinessMetricsCacheEntry[] = [];
-    const freshEntries: BusinessMetricsCacheEntry[] = [];
+    if (this.signupCountryRepository != null) {
+      tasks.push({
+        key: 'signup_countries_90d',
+        fetch: () =>
+          this.signupCountryRepository!.countBySignupCountry(
+            new Date(
+              now.getTime() -
+                SIGNUP_COUNTRIES_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
+            ),
+            SIGNUP_COUNTRIES_LIMIT
+          ),
+      });
+    }
 
-    const settled = await Promise.all(
-      tasks.map(({ key, fetch }) =>
-        this.resolveMetric(key, fetch, now, cachedByKey, usedEntries, freshEntries).catch(
-          (error: unknown) => {
-            const message =
-              error instanceof Error ? error.message : String(error);
-            errors.push({ metric: key, message });
-            return null;
-          }
-        )
-      )
-    );
+    return tasks;
+  }
 
-    if (freshEntries.length > 0) {
+  private async resolveSources(
+    cachedByKey: Map<BusinessCacheKey, BusinessMetricsCacheEntry>,
+    now: Date
+  ): Promise<ResolvedSources> {
+    const cachedSubs = cachedByKey.get(STRIPE_SUBS_CACHE_KEY);
+    const cachedInvoices = cachedByKey.get(STRIPE_INVOICES_CACHE_KEY);
+    const subsFresh =
+      cachedSubs != null && cachedSubs.expiresAt.getTime() > now.getTime();
+    const invoicesFresh =
+      cachedInvoices != null &&
+      cachedInvoices.expiresAt.getTime() > now.getTime();
+
+    if (subsFresh && invoicesFresh) {
+      return {
+        subs: cachedSubs!.value as NormalizedSubscription[],
+        invoices: cachedInvoices!.value as NormalizedInvoice[],
+        subsError: null,
+        invoicesError: null,
+        subsEntry: cachedSubs!,
+        invoicesEntry: cachedInvoices!,
+      };
+    }
+
+    const hasBothCached = cachedSubs != null && cachedInvoices != null;
+    if (!hasBothCached) {
+      const refresh = await this.startOrJoinSourceRefresh(now);
+      return this.buildSourcesFromRefresh(refresh, now);
+    }
+
+    this.startOrJoinSourceRefresh(now).catch(() => undefined);
+    return {
+      subs: cachedSubs!.value as NormalizedSubscription[],
+      invoices: cachedInvoices!.value as NormalizedInvoice[],
+      subsError: null,
+      invoicesError: null,
+      subsEntry: cachedSubs!,
+      invoicesEntry: cachedInvoices!,
+    };
+  }
+
+  private buildSourcesFromRefresh(
+    refresh: SourceRefreshResult,
+    now: Date
+  ): ResolvedSources {
+    const expiresAt = new Date(now.getTime() + this.cacheTtlMs);
+    return {
+      subs: refresh.subs,
+      invoices: refresh.invoices,
+      subsError: refresh.subsError,
+      invoicesError: refresh.invoicesError,
+      subsEntry:
+        refresh.subs != null
+          ? {
+              key: STRIPE_SUBS_CACHE_KEY,
+              value: refresh.subs,
+              cachedAt: now,
+              expiresAt,
+            }
+          : null,
+      invoicesEntry:
+        refresh.invoices != null
+          ? {
+              key: STRIPE_INVOICES_CACHE_KEY,
+              value: refresh.invoices,
+              cachedAt: now,
+              expiresAt,
+            }
+          : null,
+    };
+  }
+
+  private startOrJoinSourceRefresh(
+    now: Date
+  ): Promise<SourceRefreshResult> {
+    if (this.inflightSourceRefresh != null) {
+      return this.inflightSourceRefresh;
+    }
+    const promise = this.runSourceRefresh(now);
+    this.inflightSourceRefresh = promise;
+    promise
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.inflightSourceRefresh === promise) {
+          this.inflightSourceRefresh = null;
+        }
+      });
+    return promise;
+  }
+
+  private async runSourceRefresh(now: Date): Promise<SourceRefreshResult> {
+    const [subsResult, invoicesResult] = await Promise.allSettled([
+      this.fetchAllSubs(),
+      this.fetchInvoices(now),
+    ]);
+
+    const subs =
+      subsResult.status === 'fulfilled' ? subsResult.value : null;
+    const subsError =
+      subsResult.status === 'rejected'
+        ? messageOf(subsResult.reason)
+        : null;
+    const invoices =
+      invoicesResult.status === 'fulfilled' ? invoicesResult.value : null;
+    const invoicesError =
+      invoicesResult.status === 'rejected'
+        ? messageOf(invoicesResult.reason)
+        : null;
+
+    const expiresAt = new Date(now.getTime() + this.cacheTtlMs);
+    const toCache: BusinessMetricsCacheEntry[] = [];
+    if (subs != null) {
+      toCache.push({
+        key: STRIPE_SUBS_CACHE_KEY,
+        value: subs,
+        cachedAt: now,
+        expiresAt,
+      });
+    }
+    if (invoices != null) {
+      toCache.push({
+        key: STRIPE_INVOICES_CACHE_KEY,
+        value: invoices,
+        cachedAt: now,
+        expiresAt,
+      });
+    }
+    if (toCache.length > 0) {
       try {
-        await this.cacheRepository.upsertMany(freshEntries);
+        await this.cacheRepository.upsertMany(toCache);
       } catch (error) {
-        console.error('[ops] business metrics cache upsert failed', error);
+        console.error(
+          '[ops] business source cache upsert failed',
+          error
+        );
       }
     }
 
-    const valueByKey = new Map<BusinessMetricKey, unknown>();
-    tasks.forEach(({ key }, idx) => {
-      valueByKey.set(key, settled[idx]);
-    });
-
-    const cacheAgeSeconds = computeCacheAgeSeconds(usedEntries, now);
-
-    const response: BusinessMetricsResponse = {
-      mrr_usd: valueByKey.get('mrr_usd') as number | null,
-      net_new_mrr_mtd_usd: valueByKey.get('net_new_mrr_mtd_usd') as number | null,
-      active_paying_subs: valueByKey.get('active_paying_subs') as number | null,
-      churn_30d_pct: valueByKey.get('churn_30d_pct') as number | null,
-      failed_payments_7d: valueByKey.get('failed_payments_7d') as number | null,
-      new_paid_conversions_7d: valueByKey.get('new_paid_conversions_7d') as
-        | number
-        | null,
-      mrr_timeseries: valueByKey.get('mrr_timeseries') as
-        | MrrTimeseriesPoint[]
-        | null,
-      active_subs_timeseries: valueByKey.get('active_subs_timeseries') as
-        | ActiveSubsTimeseriesPoint[]
-        | null,
-      conversions_vs_churn_weekly: valueByKey.get('conversions_vs_churn_weekly') as
-        | ConversionsChurnWeekPoint[]
-        | null,
-      failed_payments_weekly: valueByKey.get('failed_payments_weekly') as
-        | FailedPaymentsWeekPoint[]
-        | null,
-      cancellation_reasons_top: valueByKey.get('cancellation_reasons_top') as
-        | CancellationReasonCount[]
-        | null,
-      cancellation_comments_recent: valueByKey.get(
-        'cancellation_comments_recent'
-      ) as CancellationCommentEntry[] | null,
-      emoji_feedback_ratings: valueByKey.get('emoji_feedback_ratings') as EmojiFeedbackRatingCount[] | null,
-      emoji_feedback_comments: valueByKey.get('emoji_feedback_comments') as EmojiFeedbackCommentEntry[] | null,
-      reengagement_reasons_top: valueByKey.get(
-        'reengagement_reasons_top'
-      ) as ReEngagementReasonCount[] | null,
-      reengagement_comments_recent: valueByKey.get(
-        'reengagement_comments_recent'
-      ) as ReEngagementCommentEntry[] | null,
-      signup_countries_90d: valueByKey.has('signup_countries_90d')
-        ? (valueByKey.get('signup_countries_90d') as SignupCountryCount[] | null)
-        : null,
-      as_of: now.toISOString(),
-      cache_age_seconds: cacheAgeSeconds,
-    };
-
-    if (errors.length > 0) {
-      response.errors = errors;
-    }
-
-    return response;
+    return { subs, invoices, subsError, invoicesError };
   }
 
   private async loadCacheMap(): Promise<
-    Map<BusinessMetricKey, BusinessMetricsCacheEntry>
+    Map<BusinessCacheKey, BusinessMetricsCacheEntry>
   > {
-    const map = new Map<BusinessMetricKey, BusinessMetricsCacheEntry>();
+    const map = new Map<BusinessCacheKey, BusinessMetricsCacheEntry>();
     try {
       const rows = await this.cacheRepository.loadAll();
       for (const row of rows) {
@@ -402,7 +577,7 @@ export class BusinessMetricsService {
     key: BusinessMetricKey,
     fetcher: () => Promise<unknown>,
     now: Date,
-    cachedByKey: Map<BusinessMetricKey, BusinessMetricsCacheEntry>,
+    cachedByKey: Map<BusinessCacheKey, BusinessMetricsCacheEntry>,
     usedEntries: BusinessMetricsCacheEntry[],
     freshEntries: BusinessMetricsCacheEntry[]
   ): Promise<unknown> {
@@ -421,13 +596,6 @@ export class BusinessMetricsService {
     usedEntries.push(entry);
     freshEntries.push(entry);
     return value;
-  }
-
-  private loadAllSubs(): Promise<NormalizedSubscription[]> {
-    if (this.allSubsPromise == null) {
-      this.allSubsPromise = this.fetchAllSubs();
-    }
-    return this.allSubsPromise;
   }
 
   private async fetchAllSubs(): Promise<NormalizedSubscription[]> {
@@ -449,13 +617,6 @@ export class BusinessMetricsService {
       startingAfter = hasMore ? page.data[page.data.length - 1].id : undefined;
     }
     return result;
-  }
-
-  private loadInvoices(now: Date): Promise<NormalizedInvoice[]> {
-    if (this.invoicesPromise == null) {
-      this.invoicesPromise = this.fetchInvoices(now);
-    }
-    return this.invoicesPromise;
   }
 
   private async fetchInvoices(now: Date): Promise<NormalizedInvoice[]> {
@@ -481,6 +642,9 @@ export class BusinessMetricsService {
     return result;
   }
 }
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
 const computeCacheAgeSeconds = (
   entries: BusinessMetricsCacheEntry[],

--- a/src/services/ops/ConversionMetricsService.test.ts
+++ b/src/services/ops/ConversionMetricsService.test.ts
@@ -1,36 +1,157 @@
-import { ConversionMetricsService } from './ConversionMetricsService';
-import knex from 'knex';
+import knex, { Knex } from 'knex';
 
-describe('ConversionMetricsService', () => {
-  let db: any;
+import { ConversionMetricsService } from './ConversionMetricsService';
+
+async function makeDb(): Promise<Knex> {
+  const db = knex({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+  await db.schema.createTable('jobs', (t) => {
+    t.increments('id');
+    t.string('owner').notNullable();
+    t.string('object_id').notNullable();
+    t.string('title');
+    t.string('type');
+    t.string('status');
+    t.timestamp('created_at').defaultTo(db.fn.now());
+    t.timestamp('last_edited_time');
+    t.string('job_reason_failure');
+    t.integer('card_count');
+  });
+  await db.schema.createTable('users', (t) => {
+    t.string('id').primary();
+    t.string('stripe_customer_id');
+  });
+  return db;
+}
+
+async function insertUser(db: Knex, id: string, stripeCustomerId: string | null) {
+  await db('users').insert({ id, stripe_customer_id: stripeCustomerId });
+}
+
+async function insertJob(
+  db: Knex,
+  attrs: {
+    owner: string;
+    object_id: string;
+    type: string;
+    status?: string;
+    created_at?: Date;
+    job_reason_failure?: string;
+  }
+) {
+  await db('jobs').insert({
+    owner: attrs.owner,
+    object_id: attrs.object_id,
+    type: attrs.type,
+    status: attrs.status ?? 'done',
+    created_at: attrs.created_at ?? new Date(),
+    last_edited_time: new Date(),
+    job_reason_failure: attrs.job_reason_failure ?? null,
+  });
+}
+
+describe('ConversionMetricsService — graceful failure', () => {
+  it('returns null for every metric when the db throws', async () => {
+    const failing = {
+      raw: jest.fn(),
+    } as unknown as Knex;
+    const service = new ConversionMetricsService(failing);
+    const metrics = await service.getMetrics();
+
+    expect(metrics.free_conversions_7d).toBeNull();
+    expect(metrics.paid_conversions_7d).toBeNull();
+    expect(metrics.free_conversion_success_rate_7d).toBeNull();
+    expect(metrics.paid_conversion_success_rate_7d).toBeNull();
+    expect(metrics.conversion_errors_7d_top_reasons).toBeNull();
+    expect(metrics.failed_conversions_weekly).toBeNull();
+  });
+});
+
+describe('ConversionMetricsService — counts cover the real Notion job types', () => {
+  let db: Knex;
   let service: ConversionMetricsService;
 
-  beforeEach(() => {
-    db = {
-      raw: jest.fn().mockReturnValue('raw_result'),
-    };
-    service = new ConversionMetricsService(db as any);
+  beforeEach(async () => {
+    db = await makeDb();
+    service = new ConversionMetricsService(db);
+    await insertUser(db, 'free-user', null);
+    await insertUser(db, 'paid-user', 'cus_paid');
   });
 
-  it('returns null for metrics when query fails gracefully', async () => {
-    const metrics = await service.getMetrics();
-
-    expect(metrics.free_conversions_7d).toBe(null);
-    expect(metrics.paid_conversions_7d).toBe(null);
-    expect(metrics.free_conversion_success_rate_7d).toBe(null);
-    expect(metrics.paid_conversion_success_rate_7d).toBe(null);
-    expect(metrics.conversion_errors_7d_top_reasons).toBe(null);
-    expect(metrics.failed_conversions_weekly).toBe(null);
+  afterEach(async () => {
+    await db.destroy();
   });
 
-  it('has expected response shape', async () => {
+  it('counts free conversions stored as type=page or type=database', async () => {
+    await insertJob(db, { owner: 'free-user', object_id: 'p-1', type: 'page' });
+    await insertJob(db, { owner: 'free-user', object_id: 'p-2', type: 'database' });
+    await insertJob(db, { owner: 'free-user', object_id: 'p-3', type: 'conversion' });
+
     const metrics = await service.getMetrics();
 
-    expect(metrics).toHaveProperty('free_conversions_7d');
-    expect(metrics).toHaveProperty('paid_conversions_7d');
-    expect(metrics).toHaveProperty('free_conversion_success_rate_7d');
-    expect(metrics).toHaveProperty('paid_conversion_success_rate_7d');
-    expect(metrics).toHaveProperty('conversion_errors_7d_top_reasons');
-    expect(metrics).toHaveProperty('failed_conversions_weekly');
+    expect(metrics.free_conversions_7d).toBe(3);
+  });
+
+  it('counts paid conversions stored as type=page or type=database', async () => {
+    await insertJob(db, { owner: 'paid-user', object_id: 'p-4', type: 'page' });
+    await insertJob(db, { owner: 'paid-user', object_id: 'p-5', type: 'database' });
+
+    const metrics = await service.getMetrics();
+
+    expect(metrics.paid_conversions_7d).toBe(2);
+  });
+
+  it('ignores apkg_import and claude (ankify) jobs — those are separate flows', async () => {
+    await insertJob(db, { owner: 'free-user', object_id: 'a-1', type: 'apkg_import' });
+    await insertJob(db, { owner: 'free-user', object_id: 'a-2', type: 'claude' });
+
+    const metrics = await service.getMetrics();
+
+    expect(metrics.free_conversions_7d).toBe(0);
+    expect(metrics.paid_conversions_7d).toBe(0);
+  });
+
+  it('computes free success rate over page+database+conversion jobs', async () => {
+    await insertJob(db, { owner: 'free-user', object_id: 's-1', type: 'page', status: 'done' });
+    await insertJob(db, { owner: 'free-user', object_id: 's-2', type: 'database', status: 'done' });
+    await insertJob(db, { owner: 'free-user', object_id: 's-3', type: 'page', status: 'failed' });
+
+    const metrics = await service.getMetrics();
+
+    expect(metrics.free_conversion_success_rate_7d).toBeCloseTo((2 / 3) * 100, 5);
+  });
+
+  it('groups top failure reasons across Notion job types', async () => {
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'f-1',
+      type: 'page',
+      status: 'failed',
+      job_reason_failure: 'rate limit',
+    });
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'f-2',
+      type: 'database',
+      status: 'failed',
+      job_reason_failure: 'rate limit',
+    });
+    await insertJob(db, {
+      owner: 'paid-user',
+      object_id: 'f-3',
+      type: 'page',
+      status: 'failed',
+      job_reason_failure: 'timeout',
+    });
+
+    const metrics = await service.getMetrics();
+
+    expect(metrics.conversion_errors_7d_top_reasons).toEqual([
+      { reason: 'rate limit', count: 2 },
+      { reason: 'timeout', count: 1 },
+    ]);
   });
 });

--- a/src/services/ops/ConversionMetricsService.ts
+++ b/src/services/ops/ConversionMetricsService.ts
@@ -30,6 +30,8 @@ export interface ConversionMetricsResponse {
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const WEEKLY_HISTORY_WEEKS = 12;
 
+const NOTION_CONVERSION_TYPES: string[] = ['page', 'database', 'conversion'];
+
 export class ConversionMetricsService {
   constructor(private readonly database: Knex) {}
 
@@ -77,7 +79,7 @@ export class ConversionMetricsService {
       .join('users', 'jobs.owner', '=', 'users.id')
       .where('jobs.status', 'done')
       .where('jobs.created_at', '>=', sevenDaysAgo)
-      .where('jobs.type', 'conversion')
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
       .whereRaw(
         "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
       )
@@ -92,7 +94,7 @@ export class ConversionMetricsService {
       .join('users', 'jobs.owner', '=', 'users.id')
       .where('jobs.status', 'done')
       .where('jobs.created_at', '>=', sevenDaysAgo)
-      .where('jobs.type', 'conversion')
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
       .whereRaw("users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''")
       .count('jobs.id as count')
       .first();
@@ -104,7 +106,7 @@ export class ConversionMetricsService {
     const result = await this.database('jobs')
       .join('users', 'jobs.owner', '=', 'users.id')
       .where('jobs.created_at', '>=', sevenDaysAgo)
-      .where('jobs.type', 'conversion')
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
       .whereRaw(
         "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
       )
@@ -125,7 +127,7 @@ export class ConversionMetricsService {
     const result = await this.database('jobs')
       .join('users', 'jobs.owner', '=', 'users.id')
       .where('jobs.created_at', '>=', sevenDaysAgo)
-      .where('jobs.type', 'conversion')
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
       .whereRaw("users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''")
       .whereIn('jobs.status', ['done', 'failed'])
       .select(
@@ -146,7 +148,7 @@ export class ConversionMetricsService {
     const results = await this.database('jobs')
       .where('jobs.status', 'failed')
       .where('jobs.created_at', '>=', sevenDaysAgo)
-      .where('jobs.type', 'conversion')
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
       .whereNotNull('jobs.job_reason_failure')
       .select('jobs.job_reason_failure as reason')
       .count('jobs.id as count')
@@ -181,7 +183,7 @@ export class ConversionMetricsService {
       .where('jobs.status', 'failed')
       .where('jobs.created_at', '>=', new Date(earliestStart))
       .where('jobs.created_at', '<', new Date(weekEnd))
-      .where('jobs.type', 'conversion')
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
       .select(
         this.database.raw(
           `DATE_TRUNC('week', jobs.created_at) AS week_start`

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -251,6 +251,54 @@ describe('BusinessTab', () => {
     expect(screen.getByText(/Last good data shown below/i)).toBeInTheDocument();
   });
 
+  test('shows a subtle refreshing hint during background refetch (not the red banner)', async () => {
+    let resolveSecondFetch!: () => void;
+    const secondFetchPromise = new Promise<void>((r) => {
+      resolveSecondFetch = r;
+    });
+    let callCount = 0;
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => {
+        const idx = callCount++;
+        if (idx === 1) {
+          await secondFetchPromise;
+        }
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => buildSampleMetrics({ cache_age_seconds: 600 }),
+        };
+      }
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <BusinessTab />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(screen.getByText('$4,820')).toBeInTheDocument());
+    expect(screen.queryByText(/refreshing/i)).toBeNull();
+
+    queryClient.invalidateQueries({ queryKey: ['ops-business-metrics'] });
+
+    await waitFor(() =>
+      expect(screen.getByText(/refreshing/i)).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText(/\/api\/ops\/business\/metrics failed/i)
+    ).toBeNull();
+
+    resolveSecondFetch();
+    await waitFor(() => expect(screen.queryByText(/refreshing/i)).toBeNull());
+  });
+
   test('renders no <pre> JSON dump anywhere', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -39,7 +39,7 @@ const buildMrrFootnote = (
 };
 
 export default function BusinessTab() {
-  const { data, error, isLoading } = useBusinessMetrics();
+  const { data, error, isLoading, isFetching } = useBusinessMetrics();
   const [lastSnapshot, setLastSnapshot] =
     useState<BusinessMetricsResponse | null>(null);
 
@@ -68,6 +68,16 @@ export default function BusinessTab() {
           /api/ops/business/metrics failed: {error.message}. Last good data
           shown below.
         </div>
+      )}
+
+      {isFetching && !isLoading && visible != null && error == null && (
+        <p className={styles.refreshHint}>
+          Last updated{' '}
+          {visible.cache_age_seconds == null
+            ? 'just now'
+            : `${formatCacheAge(visible.cache_age_seconds)} ago`}
+          {' — refreshing'}
+        </p>
       )}
 
       <div className={styles.cardGrid}>

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -307,6 +307,13 @@
   margin-bottom: 1rem;
 }
 
+.refreshHint {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0 0 1rem;
+  font-variant-numeric: tabular-nums;
+}
+
 .refreshButton {
   font-family: inherit;
 }


### PR DESCRIPTION
## Summary

- **Conversions tab**: was showing ~zero for every metric. `ConversionMetricsService` filtered on `jobs.type = 'conversion'`, but real Notion conversions land with `type='page'` or `type='database'` (the web client passes the Notion object type through `NotionController.convert`). `'conversion'` is only a rare fallback default. Broadened all six queries to `whereIn(['page','database','conversion'])` — the same canonical conversion set `JobRepository.markInterruptedNotionJobs` already uses. `apkg_import` and `claude` (Ankify) intentionally excluded; they're separate product flows.
- **Business tab**: was slow because (1) `Promise.all` blocked the HTTP response on the slowest task — DB-only sections (cancellation, emoji feedback, reengagement, signup countries) waited on Stripe pagination; (2) cache was keyed per derived metric, so a single expired entry retriggered the full subs/invoices pagination; (3) `allSubsPromise`/`invoicesPromise` were reset per request, defeating single-flight across concurrent ops viewers.
- Refactor: cache **source data** (`_stripe_subs`, `_stripe_invoices`) instead of derived metrics. Stripe-derived computations are pure functions and run in-memory from the cached source on every request. **Stale-while-revalidate**: cached source served immediately even when expired, with a background refresh kicked off (instance-level single-flight). Cold-start blocks only when there is no cache at all. DB-backed metrics keep their per-metric cache.
- Frontend: `BusinessTab` shows a subtle `Last updated Xm ago — refreshing` hint during background refetches (using `isFetching` from React Query). Red error banner stays error-only.

## Test plan

- [x] Server tsc + Jest (1741 tests pass; 245 suites)
- [x] Web typecheck + Biome lint clean
- [x] Web vitest (113 files, 883 tests pass)
- [x] Conversions: new sqlite-backed tests assert `whereIn` picks up `type='page'`/`'database'`, ignores `apkg_import`/`claude`, computes success rate over the broadened set
- [x] Business: new tests verify `_stripe_subs`/`_stripe_invoices` cached as source-data keys (not per-metric); SWR (stale served immediately, background refresh kicked); single-flight (two concurrent `getMetrics` calls = one Stripe pagination); partial failure (subs throw → mrr null with error, invoices succeed → failed_payments returned)
- [x] BusinessTab: new test asserts the refreshing hint appears during background refetch and NOT the red banner; disappears when refetch completes

## Notes for review

- **No changelog entry** — internal-only ops dashboard, no user-visible change.
- **Sonar not run locally** (no `SONAR_TOKEN` configured) — expect possible bounces; happy to address. Most of the new code is straight refactor with smaller per-function complexity than before; the biggest function (`getMetrics`) is shorter than the original.
- **Follow-up issues to file** (not in this PR):
  - Add `time_to_first_deck_p50_7d` and upload→download conversion rate to Conversions tab (PM ask during trio).
  - Extract `JobsMetricsRepository` so `ConversionMetricsService` stops importing `Knex` directly (`src/services/CLAUDE.md` discipline).

## Trio synthesis

- **PM**: scope Conversions to Notion only (`page`, `database`, `conversion`) — don't blur with apkg/Ankify. Single slow-but-cached response fine; if it ever exceeds ~8s split by data source (which is what we did).
- **Designer**: SWR is the right pattern — existing `lastSnapshot` infra already 90% there. Subtle muted "refreshing" line, not the red banner. Keep empty-state copy unchanged.
- **Engineer**: cache the source not the derived metrics; stale-while-revalidate; module-level/instance-level single-flight (delete the per-request reset); leave the Knex-direct-import refactor for a follow-up; sqlite-backed integration test for Conversions, fake-cache/clock unit tests for Business.

All three converged; no conflicts to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781963058&installation_id=132681956&pr_number=2534&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2534&signature=7d5bd3305fae79af2d125bebd35321068dd2092e39967093de138d458ed1397a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->