### PR TITLE
fix: resolve cloze card preview dropping cards with ord >= 1

### DIFF
--- a/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
@@ -1,0 +1,86 @@
+import ApkgPreviewService from './ApkgPreviewService';
+import { NormalizedCollection } from './types';
+
+function makeParsed(collection: NormalizedCollection) {
+  return {
+    collection,
+    mediaMap: new Map<string, string>(),
+    mediaEntries: new Map<string, Buffer>(),
+    parsedAt: Date.now(),
+  };
+}
+
+function makeClozeCollection(cardOrds: number[]): NormalizedCollection {
+  const noteType = {
+    id: 1,
+    name: 'n2a-cloze',
+    type: 1 as const,
+    css: '',
+    fields: [{ name: 'Text', ord: 0 }],
+    templates: [
+      {
+        name: 'Cloze',
+        ord: 0,
+        qfmt: '{{cloze:Text}}',
+        afmt: '{{cloze:Text}}',
+      },
+    ],
+  };
+
+  const note = {
+    id: 10,
+    mid: 1,
+    tags: '',
+    fields: ['{{c1::Paris}} is the capital of {{c2::France}}'],
+  };
+
+  const cards = cardOrds.map((ord, i) => ({
+    id: 100 + i,
+    nid: 10,
+    did: 2,
+    ord,
+  }));
+
+  return {
+    noteTypes: new Map([[1, noteType]]),
+    notes: new Map([[10, note]]),
+    decks: new Map([[2, { id: 2, name: 'Demo' }]]),
+    cards,
+  };
+}
+
+describe('ApkgPreviewService.getCardsPage', () => {
+  const service = new ApkgPreviewService();
+
+  it('renders a cloze card at ord=0', () => {
+    const parsed = makeParsed(makeClozeCollection([0]));
+    const result = service.getCardsPage(parsed, 0, 10, 'http://example.com');
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].ord).toBe(0);
+    expect(result.cards[0].noteTypeName).toBe('n2a-cloze');
+  });
+
+  it('renders cloze cards at ord=1 and higher without the template-ord warning', () => {
+    const parsed = makeParsed(makeClozeCollection([0, 1]));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = service.getCardsPage(parsed, 0, 10, 'http://example.com');
+    warnSpy.mockRestore();
+
+    expect(result.cards).toHaveLength(2);
+    expect(result.cards[1].ord).toBe(1);
+  });
+
+  it('does not emit the template-ord warning for cloze cards with ord >= 1', () => {
+    const parsed = makeParsed(makeClozeCollection([0, 1, 2]));
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    service.getCardsPage(parsed, 0, 10, 'http://example.com');
+
+    const templateOrdWarnings = warnSpy.mock.calls.filter(([msg]) =>
+      String(msg).includes('template ord=')
+    );
+    warnSpy.mockRestore();
+
+    expect(templateOrdWarnings).toHaveLength(0);
+  });
+});

--- a/src/services/ApkgPreviewService/ApkgPreviewService.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.ts
@@ -127,9 +127,10 @@ export default class ApkgPreviewService {
       console.warn(`[apkg-preview] card ${cardId}: noteType ${note.mid} not found`);
       return null;
     }
-    const template = noteType.templates.find((t) => t.ord === card.ord);
+    const templateOrd = noteType.type === 1 ? 0 : card.ord;
+    const template = noteType.templates.find((t) => t.ord === templateOrd);
     if (!template) {
-      console.warn(`[apkg-preview] card ${cardId}: template ord=${card.ord} not found in noteType "${noteType.name}" (has ${noteType.templates.length} templates)`);
+      console.warn(`[apkg-preview] card ${cardId}: template ord=${templateOrd} not found in noteType "${noteType.name}" (has ${noteType.templates.length} templates)`);
       return null;
     }
     const deck = parsed.collection.decks.get(card.did);


### PR DESCRIPTION
## What
Cloze cards with 2 or more deletions were silently dropped from the deck preview. Any card from a `{{c2::...}}` or higher deletion showed the warning:

```
[apkg-preview] card <id>: template ord=1 not found in noteType "n2a-cloze" (has 1 templates)
```

and returned `null` from `renderCard`, making those cards invisible in the preview UI.

## Why
Anki's cloze note type always has exactly one template at `ord=0`. Cloze **cards** use `card.ord` as the 0-based cloze-deletion index (`{{c1::...}}` → ord=0, `{{c2::...}}` → ord=1, etc.). The template lookup was using `card.ord` directly as the template index, which only works for the first deletion on each note.

## How
In `renderCard` in `ApkgPreviewService.ts`: when the note type is cloze (`type === 1`), always use `templateOrd = 0` for the template lookup. `card.ord` still drives `activeClozeNumber` (unchanged) to render the correct active cloze highlight.

Change is 3 lines in one file. The `activeClozeNumber = noteType.type === 1 ? card.ord + 1 : null` line already present is left intact — it was correct, only the template lookup was wrong.

## Measuring success
The `[apkg-preview] card <id>: template ord=1 not found` warning stops appearing in prod pm2 logs after deploy. Deck previews for cloze notes with multiple deletions show all cards instead of only the first.

## Testing
- Unit tests added: `src/services/ApkgPreviewService/ApkgPreviewService.test.ts`
  - renders cloze card at ord=0 (baseline)
  - renders cloze cards at ord=1 and higher without dropping them
  - asserts no template-ord warning fires for ord >= 1 cards

## Browser check
Browser check: not applicable — server-side fix, no rendered output change

## Changelog
No changelog entry — the preview silently dropped cloze cards with multiple deletions. This is a correctness fix. Users with multi-deletion cloze decks will now see all their cards in preview, but no new feature is visible.

## Risks
None. Fix is local to the read-path preview rendering. Deck generation (Python bridge) is unaffected. Single-deletion cloze path (ord=0) is unchanged and covered by the existing renderCloze tests.

## Goal alignment
Preview correctness affects the conversion experience. Users with cloze-heavy decks were seeing fewer cards than expected, which undermines trust in the tool.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781981596&installation_id=132681956&pr_number=2540&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2540&signature=b1c26f722e91c09123b3c65ecfae396c51844101be8f90fc12bdb33bf0442bb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->