### PR TITLE
style: rewrite UpsellCard copy to match what a pass actually unlocks

### DIFF
--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -82,13 +82,13 @@ describe('UpsellCard', () => {
   it('uses the downloads surface headline on /downloads', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     render(<UpsellCard surface="downloads_upsell" />);
-    expect(screen.getByText('Converting more this month?')).toBeInTheDocument();
+    expect(screen.getByText('More decks to download?')).toBeInTheDocument();
   });
 
   it('uses the upload-success surface headline on upload success', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     render(<UpsellCard surface="upload_success_upsell" />);
-    expect(screen.getByText('More decks coming?')).toBeInTheDocument();
+    expect(screen.getByText('More pages to convert?')).toBeInTheDocument();
   });
 
   it('fires paywall_shown with the surface on mount for free users', () => {

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -18,18 +18,18 @@ interface UpsellCardProps {
 }
 
 const HEADLINE: Record<Surface, string> = {
-  downloads_upsell: 'Converting more this month?',
-  upload_success_upsell: 'More decks coming?',
-  upload_idle_upsell: 'Converting more this month?',
+  downloads_upsell: 'More decks to download?',
+  upload_success_upsell: 'More pages to convert?',
+  upload_idle_upsell: 'Whole stack to convert?',
 };
 
 const BODY: Record<Surface, string> = {
   downloads_upsell:
-    'Free plan is 100 cards a month and one conversion at a time. A pass removes both limits without a subscription.',
+    'A pass lifts the 100-card monthly cap. Day or week, no subscription.',
   upload_success_upsell:
-    'Free plan caps at 100 cards a month and one job at a time. A pass removes both for the next day or week.',
+    'A pass lifts the 100-card monthly cap — for a day or a week, no subscription.',
   upload_idle_upsell:
-    'Free plan is 100 cards a month and one conversion at a time. A pass removes both limits without a subscription.',
+    'A pass lifts the 100-card monthly cap. Day or week, no subscription.',
 };
 
 export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProps) {

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'style', title: 'Upgrade prompt — shorter, more honest copy about what a pass actually unlocks', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — primer rewritten to cover PDF, Word, Markdown, HTML, and Notion; Notion-only walkthrough videos removed', date: '2026-05-21' },
   { type: 'style', title: 'Home page — community walkthroughs collapse to 3 by default; expand for all 14', date: '2026-05-21' },
   { type: 'fix', title: 'Notion callouts and nested toggle cards no longer show raw HTML tags in your cards', date: '2026-05-21' },


### PR DESCRIPTION
## Summary
Rewrites the upgrade prompt copy on all three surfaces (downloads, upload-success, upload-idle) so it matches what a pass actually does. The previous copy claimed "removes one conversion at a time" — true only for the async Notion job queue, not for local file uploads which already accept multiple files in one drop for everyone. The honest sell is the 100-card monthly cap removal.

Tightens headlines and drops marketing flourish ("walk away", "run together").

## Why
A real user quote ("I'm too lazy to download each of my Notion pages individually and upload them") prompted a rewrite. Trio fact-check revealed the original draft over-claimed concurrency unlock on file-upload surfaces. This version names the universal truth (the 100-card cap) without over-promising. The Notion-specific friction the quote actually names points at Ankify (auto-sync) — separate surface, separate sweep.

## Before / after
| Surface | Old headline | New headline |
|---|---|---|
| `downloads_upsell` | Converting more this month? | More decks to download? |
| `upload_success_upsell` | More decks coming? | More pages to convert? |
| `upload_idle_upsell` | Converting more this month? | Whole stack to convert? |

Body across all three: "A pass lifts the 100-card monthly cap. Day or week, no subscription." (success variant appends "for a day or a week" for scope clarity).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

## Test plan
- [x] UpsellCard.test.tsx — both headline assertions updated, 13/13 pass
- [x] Changelog entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781983738&installation_id=132681956&pr_number=2547&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2547&signature=37985af03f8100ccb19a5985022810dc8775dc9c0467b7f455f245ac77ed4080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->