### PR TITLE
style: collapse upload-page how-it-works behind a disclosure

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.module.css
+++ b/web/src/pages/UploadPage/UploadPage.module.css
@@ -153,4 +153,51 @@
   color: var(--color-text-secondary);
 }
 
+.howItWorks {
+  max-width: 800px;
+  margin: 1.5rem auto 0;
+}
+
+.howItWorksSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-tertiary);
+  list-style: none;
+  padding: 0;
+  transition: color var(--transition-fast);
+}
+
+.howItWorksSummary::-webkit-details-marker {
+  display: none;
+}
+
+.howItWorksSummary::before {
+  content: '▾';
+  font-size: 0.875em;
+  display: inline-block;
+  transition: transform var(--transition-fast);
+}
+
+.howItWorks[open] .howItWorksSummary::before {
+  transform: rotate(180deg);
+}
+
+.howItWorks[open] .howItWorksSummary {
+  margin-bottom: 0.75rem;
+}
+
+.howItWorksSummary:hover {
+  color: var(--color-text-primary);
+}
+
+.howItWorksSummary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
 

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -130,48 +130,51 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
       <div className={pageStyles.upsellWrapper}>
         <UpsellCard surface="upload_idle_upsell" hideForAnonymous />
       </div>
-      <p className={pageStyles.footnote}>
-        Your uploaded files are deleted after 2 hours.
-      </p>
-      <p className={pageStyles.settingsHint}>
-        Change deck names, templates, and conversion defaults in{' '}
-        <Link to="/card-options?returnTo=/upload">Settings</Link>.
-      </p>
-      <div className={pageStyles.steps}>
-        <div className={pageStyles.step}>
-          <span className={pageStyles.stepNumber}>1</span>
-          <div>
-            <p className={pageStyles.stepTitle}>Drop or choose a file</p>
-            <p className={pageStyles.stepBody}>
-              Notion export, PDF, HTML, Markdown, Word, Excel, PowerPoint, or
-              CSV.{' '}
-              <a href="/documentation/start-here/upload-a-file">
-                How to export from Notion
-              </a>
-            </p>
+      <details className={pageStyles.howItWorks}>
+        <summary className={pageStyles.howItWorksSummary}>How it works</summary>
+        <p className={pageStyles.footnote}>
+          Your uploaded files are deleted after 2 hours.
+        </p>
+        <p className={pageStyles.settingsHint}>
+          Change deck names, templates, and conversion defaults in{' '}
+          <Link to="/card-options?returnTo=/upload">Settings</Link>.
+        </p>
+        <div className={pageStyles.steps}>
+          <div className={pageStyles.step}>
+            <span className={pageStyles.stepNumber}>1</span>
+            <div>
+              <p className={pageStyles.stepTitle}>Drop or choose a file</p>
+              <p className={pageStyles.stepBody}>
+                Notion export, PDF, HTML, Markdown, Word, Excel, PowerPoint, or
+                CSV.{' '}
+                <a href="/documentation/start-here/upload-a-file">
+                  How to export from Notion
+                </a>
+              </p>
+            </div>
+          </div>
+          <div className={pageStyles.step}>
+            <span className={pageStyles.stepNumber}>2</span>
+            <div>
+              <p className={pageStyles.stepTitle}>We build your deck</p>
+              <p className={pageStyles.stepBody}>
+                Images, code blocks, cloze deletions, and formatting all transfer.
+                Usually takes a few seconds.
+              </p>
+            </div>
+          </div>
+          <div className={pageStyles.step}>
+            <span className={pageStyles.stepNumber}>3</span>
+            <div>
+              <p className={pageStyles.stepTitle}>Open in Anki</p>
+              <p className={pageStyles.stepBody}>
+                Your .apkg downloads automatically. Import it into Anki or
+                AnkiDroid and start studying.
+              </p>
+            </div>
           </div>
         </div>
-        <div className={pageStyles.step}>
-          <span className={pageStyles.stepNumber}>2</span>
-          <div>
-            <p className={pageStyles.stepTitle}>We build your deck</p>
-            <p className={pageStyles.stepBody}>
-              Images, code blocks, cloze deletions, and formatting all transfer.
-              Usually takes a few seconds.
-            </p>
-          </div>
-        </div>
-        <div className={pageStyles.step}>
-          <span className={pageStyles.stepNumber}>3</span>
-          <div>
-            <p className={pageStyles.stepTitle}>Open in Anki</p>
-            <p className={pageStyles.stepBody}>
-              Your .apkg downloads automatically. Import it into Anki or
-              AnkiDroid and start studying.
-            </p>
-          </div>
-        </div>
-      </div>
+      </details>
     </div>
   );
 }

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'style', title: 'Upload page — "How it works" steps and file-retention note collapsed behind a single disclosure', date: '2026-05-21' },
   { type: 'style', title: 'Upgrade prompt — shorter, more honest copy about what a pass actually unlocks', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — primer rewritten to cover PDF, Word, Markdown, HTML, and Notion; Notion-only walkthrough videos removed', date: '2026-05-21' },
   { type: 'style', title: 'Home page — community walkthroughs collapse to 3 by default; expand for all 14', date: '2026-05-21' },


### PR DESCRIPTION
## Summary
Wraps the file-retention note, the settings hint, and the 3-step explainer on /upload inside a single `<details>` element with a "How it works" summary. The page lands quieter — the upload zone is the headline; the secondary context is one click away.

Native HTML disclosure (no useState, no JS state) — keyboard focus + screen reader semantics come for free.

## Why
After PR #2546 broadened the primer and removed the walkthrough wall, the lower half of /upload still stacks five blocks (footnote, settings hint, 3 steps) for a returning user mid-task. Hiding them behind a disclosure preserves the content for anyone who wants it without competing with the upload form for attention.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

## Test plan
- [x] UploadPage.test.tsx — 6/6 pass (no test asserts on the affected strings)
- [x] typecheck green
- [x] Native `<details>` keyboard nav works out of the box (Tab to summary, Space/Enter to toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781983915&installation_id=132681956&pr_number=2548&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2548&signature=07f2074737733ec0e7de4544418b6046ab47e3322367ea2421064f9d1ab8495a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->