### PR TITLE
style: move upload-page primer below the upload form

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -100,6 +100,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           <span> to convert</span>
         </div>
       )}
+      <UploadForm setErrorMessage={setErrorMessage} />
       {primerVisible && (
         <section className={pageStyles.primer} aria-label="How 2anki works">
           <button
@@ -126,7 +127,6 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           </a>
         </section>
       )}
-      <UploadForm setErrorMessage={setErrorMessage} />
       <div className={pageStyles.upsellWrapper}>
         <UpsellCard surface="upload_idle_upsell" hideForAnonymous />
       </div>

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'style', title: 'Upload page — explainer card moved below the upload form so the form is the unambiguous primary action', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — "How it works" steps and file-retention note collapsed behind a single disclosure', date: '2026-05-21' },
   { type: 'style', title: 'Upgrade prompt — shorter, more honest copy about what a pass actually unlocks', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — primer rewritten to cover PDF, Word, Markdown, HTML, and Notion; Notion-only walkthrough videos removed', date: '2026-05-21' },


### PR DESCRIPTION
## Summary
Moves the "How cards are made" primer card from above the upload form to between the form and the UpsellCard. Same content, dismiss behavior, and visibility gate — only the position changes.

## Why
The primer above the form competed with the form for attention. The form is the primary action on /upload; nothing user-facing should sit above it. Anyone who needs the explanation finds it one screen down.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

## Test plan
- [x] UploadPage.test.tsx — 6/6 pass (no test asserts on primer position)
- [x] typecheck green
- [x] Primer dismiss still works; visibility gate unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781984135&installation_id=132681956&pr_number=2549&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2549&signature=ba7d2d85cc12cb15b401770f95106f7bd1ddd89a9ce3e2e961dfef762100dad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->