### PR TITLE
fix: photo-to-flashcards page now renders in dark mode

### DIFF
--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
@@ -2,8 +2,8 @@
   margin: var(--space-lg, 1.5rem) auto;
   max-width: 720px;
   padding: var(--space-md, 1.25rem);
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md, 0.5rem);
   display: flex;
   flex-direction: column;
@@ -20,13 +20,13 @@
   margin: 0;
   font-size: var(--text-xl, 1.25rem);
   font-weight: var(--font-medium, 500);
-  color: var(--color-text-primary, #111827);
+  color: var(--color-text-primary);
 }
 
 .pageSubtitle {
   margin: 0;
   font-size: var(--text-sm, 0.875rem);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--color-text-secondary);
 }
 
 .row {
@@ -37,24 +37,24 @@
 
 .deckNameLabel {
   font-size: var(--text-sm, 0.875rem);
-  color: var(--color-text-secondary, #6b7280);
+  color: var(--color-text-secondary);
   min-width: 6rem;
 }
 
 .deckNameInput {
   flex: 1;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 0.375rem);
   font-size: var(--text-base, 1rem);
-  background: var(--color-surface, #fff);
-  color: var(--color-text-primary, #111827);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
 }
 
 .deckNameInput:focus {
-  outline: 2px solid var(--color-primary, #3b82f6);
+  outline: 2px solid var(--color-primary);
   outline-offset: -1px;
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .dropzone {
@@ -65,26 +65,26 @@
   gap: 0.375rem;
   min-height: 160px;
   padding: var(--space-md, 1.25rem);
-  border: 2px dashed var(--color-border, #d1d5db);
+  border: 2px dashed var(--color-border);
   border-radius: var(--radius-md, 0.5rem);
-  background: var(--color-surface-muted, #f9fafb);
+  background: var(--color-bg-secondary);
   text-align: center;
   cursor: pointer;
   transition: border-color var(--transition-fast, 150ms);
 }
 
 .dropzone:hover {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--color-primary);
 }
 
 .dropzoneTitle {
   font-size: var(--text-base, 1rem);
-  color: var(--color-text-primary, #374151);
+  color: var(--color-text-primary);
 }
 
 .dropzoneHint {
   font-size: var(--text-sm, 0.875rem);
-  color: var(--color-text-muted, #9ca3af);
+  color: var(--color-text-tertiary);
 }
 
 .preview {

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Photo-to-flashcards page now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — explainer card moved below the upload form so the form is the unambiguous primary action', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — "How it works" steps and file-retention note collapsed behind a single disclosure', date: '2026-05-21' },
   { type: 'style', title: 'Upgrade prompt — shorter, more honest copy about what a pass actually unlocks', date: '2026-05-21' },


### PR DESCRIPTION
## Summary
Swaps the `/photo-to-flashcards` page CSS from undefined design tokens (`--color-surface`, `--color-surface-muted`, `--color-text-muted`) to the real themed tokens (`--color-bg-primary`, `--color-bg-secondary`, `--color-text-tertiary`, etc.). The page now picks up dark, gold, and purple themes correctly.

## Why
Al reported the page looked bad in dark mode. Audit revealed the CSS referenced token names that aren't declared anywhere in `styles/base.css`, so every `var(--color-surface, #fff)` fell through to its hardcoded light-mode fallback regardless of theme. The page card, drop zone, input, and hint text all stayed white-on-light-gray when the rest of the app was in dark mode.

## Browser check
- [x] Golden path on localhost:3000/photo-to-flashcards (light + dark mode)
- [x] No console errors at 375px

## Test plan
- [x] PhotoToFlashcardsPage.test.tsx — 9/9 pass (no test asserts on colors)
- [x] typecheck green

## Follow-up
`OnboardingTour.module.css` uses the same undefined token pattern — flagged for a separate small fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781984310&installation_id=132681956&pr_number=2550&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2550&signature=3630dd4d89a5f3c25b96f2d4a1bdd0ae6af213015eb4dac96bafecdebb3c7326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->