### PR TITLE
style: notion-style heading-2 toggle for How it works on /upload

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.module.css
+++ b/web/src/pages/UploadPage/UploadPage.module.css
@@ -155,20 +155,16 @@
 
 .howItWorks {
   max-width: 800px;
-  margin: 1.5rem auto 0;
+  margin: 1.5rem 0 0;
 }
 
 .howItWorksSummary {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: 0.5rem;
   cursor: pointer;
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--color-text-tertiary);
   list-style: none;
   padding: 0;
-  transition: color var(--transition-fast);
 }
 
 .howItWorksSummary::-webkit-details-marker {
@@ -176,22 +172,31 @@
 }
 
 .howItWorksSummary::before {
-  content: '▾';
-  font-size: 0.875em;
+  content: '▶';
+  font-size: 0.75em;
+  color: var(--color-text-tertiary);
   display: inline-block;
   transition: transform var(--transition-fast);
 }
 
 .howItWorks[open] .howItWorksSummary::before {
-  transform: rotate(180deg);
+  transform: rotate(90deg);
 }
 
 .howItWorks[open] .howItWorksSummary {
   margin-bottom: 0.75rem;
 }
 
-.howItWorksSummary:hover {
+.howItWorksHeading {
+  margin: 0;
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
   color: var(--color-text-primary);
+  transition: color var(--transition-fast);
+}
+
+.howItWorksSummary:hover .howItWorksHeading {
+  color: var(--color-text-link);
 }
 
 .howItWorksSummary:focus-visible {

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -131,7 +131,9 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
         <UpsellCard surface="upload_idle_upsell" hideForAnonymous />
       </div>
       <details className={pageStyles.howItWorks}>
-        <summary className={pageStyles.howItWorksSummary}>How it works</summary>
+        <summary className={pageStyles.howItWorksSummary}>
+          <h2 className={pageStyles.howItWorksHeading}>How it works</h2>
+        </summary>
         <p className={pageStyles.footnote}>
           Your uploaded files are deleted after 2 hours.
         </p>


### PR DESCRIPTION
## Summary
Restyles the "How it works" disclosure on /upload as a Notion-style heading-2 toggle:

- Left-aligned (was centered)
- Summary text is now an `<h2>` (semibold, `--text-xl`) so it lands in the document outline
- Triangle indicator moved to the left of the heading, rotating from `▶` (collapsed) to `▼` (open)
- Hover state turns the heading link-colored for affordance

## Why
Al wanted the toggle to read like a Notion h2 toggle — small triangle, big heading, left-aligned. Previous version was a quiet text-link style that read like a utility control; the new style says "this is a section heading" instead.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

## Test plan
- [x] UploadPage.test.tsx — 6/6 pass
- [x] typecheck green
- [x] Keyboard nav still works (Tab → Space/Enter to toggle)
- [x] `<h2>` nested in `<summary>` is valid HTML and proper a11y semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781984594&installation_id=132681956&pr_number=2551&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2551&signature=84be7282d3c1be808fd8aad0c2edd07040c007978bd632827c63844387e3e4bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->