### PR TITLE
style: slim home walkthrough wall to 10 videos, non-Notion first

### DIFF
--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -59,11 +59,11 @@ describe('HomePage (anonymous)', () => {
     expect(playButtons.length).toBe(3);
   });
 
-  it('renders all 16 walkthrough play buttons after clicking expand', () => {
+  it('renders all 10 walkthrough play buttons after clicking expand', () => {
     renderHome();
-    const expandButton = screen.getByRole('button', { name: /show all 16 videos/i });
+    const expandButton = screen.getByRole('button', { name: /show all 10 videos/i });
     fireEvent.click(expandButton);
     const playButtons = screen.getAllByRole('button', { name: /play:/i });
-    expect(playButtons.length).toBe(16);
+    expect(playButtons.length).toBe(10);
   });
 });

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -46,19 +46,13 @@ const WALKTHROUGHS: ReadonlyArray<[string, string]> = [
   ['jpR_grXWTTw', 'PDF to Anki in Seconds — No Plugins, No Manual Work'],
   ['roQ3awaVa2E', 'Image Occlusion Comes to 2anki.net — Anatomy Flashcards in Seconds'],
   ['UnTo_fN1jpc', 'How I use Notion to Anki as a medical student'],
+  ['NLUfAWA2LJI', 'Turn any website into Anki flashcards'],
+  ['r9pPNl8Mx_Q', 'How to use cloze deletions'],
+  ['lpC7C9wJoTA', 'Use Notion to Anki for learning languages'],
+  ['vINpYLMW9AE', 'Best Notion hack for medical students'],
   ['E51yLIIS3bk', 'Notion2Anki — Perfekter Workflow fürs Lernen'],
   ['57dW_buqtGM', 'Notion to Anki — Tutorial en Español'],
-  ['NLUfAWA2LJI', 'Turn any website into Anki flashcards'],
   ['RHReYOKywZc', 'Créer des flashcards Anki avec Notion'],
-  ['r9pPNl8Mx_Q', 'How to use cloze deletions'],
-  ['vINpYLMW9AE', 'Best Notion hack for medical students'],
-  ['JrYdp18Hbs8', 'Notion to Anki — complete guide'],
-  ['lpC7C9wJoTA', 'Use Notion to Anki for learning languages'],
-  ['Ah-_wm2fgIk', 'Instantly turn your Notion notes into Anki flashcards'],
-  ['9V0_N-Ex1U0', 'Notion to Anki walkthrough'],
-  ['6CyurZC4Bf0', 'Turn your Notion notes into Anki flashcards'],
-  ['A9aqXH2jVwQ', 'Notion to Anki tutorial'],
-  ['PDdEGonPCNk', 'Notion to Anki — quick start'],
 ];
 
 function VideoCard({ embedId, title }: Readonly<{ embedId: string; title: string }>) {
@@ -198,7 +192,7 @@ export function HomePage({
             onClick={() => setShowAll(!showAll)}
             aria-expanded={showAll}
           >
-            {showAll ? '▴ Show fewer' : '▾ Show all 16 videos'}
+            {showAll ? '▴ Show fewer' : '▾ Show all 10 videos'}
           </button>
         </div>
       </section>

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -7,6 +7,7 @@ export interface ChangelogEntry {
 export const changelog: ChangelogEntry[] = [
   { type: 'fix', title: 'Onboarding tour now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — dropped the duplicated "Make flashcards" heading; the navbar identifies the page and the form is the focus', date: '2026-05-21' },
+  { type: 'style', title: 'Home page walkthroughs slimmed to 10 videos, with non-Notion sources surfacing first', date: '2026-05-21' },
   { type: 'fix', title: 'Photo-to-flashcards page now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — explainer card moved below the upload form so the form is the unambiguous primary action', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — "How it works" steps and file-retention note collapsed behind a single disclosure', date: '2026-05-21' },


### PR DESCRIPTION
## Summary
Slims the home-page walkthrough wall from 16 to 10 videos, drops 6 redundant Notion-tutorial entries that taught the same thing, and reorders so non-Notion-titled videos surface first in the expanded grid.

## Why
After #2542 added PDF + image-occlusion as featured, the expanded list still leaned 12-of-16 Notion-titled. A non-Notion visitor clicking "Show all" saw a wall of Notion content. Slimming the redundant tutorials and surfacing the broader videos earlier keeps the home page honest about being a multi-format product.

## How
Replaced the 16-entry `WALKTHROUGHS` array with 10 entries in the specified order. Removed IDs: `JrYdp18Hbs8`, `Ah-_wm2fgIk`, `9V0_N-Ex1U0`, `6CyurZC4Bf0`, `A9aqXH2jVwQ`, `PDdEGonPCNk`. Updated button copy from "Show all 16 videos" → "Show all 10 videos".

## Measuring success
Visitors clicking "Show all" encounter a balanced mix rather than a wall of Notion titles. No metric infra needed — visual audit on the page confirms the order.

## Testing
- Unit tests updated: expanded-count assertion 16 → 10, button name matcher updated. All 7 tests pass.
- Typecheck green.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes:

## Changelog
`{ type: 'style', title: 'Home page walkthroughs slimmed to 10 videos, with non-Notion sources surfacing first', date: '2026-05-21' }`

## Risks
Low. Static data array edit with no logic change. Rollback is a one-line revert.

## Goal alignment
Reduces Notion-bias on the anonymous landing page, helping convert visitors who come from non-Notion workflows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781984997&installation_id=132681956&pr_number=2552&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2552&signature=8df6f0a5e06a6f86c788412324d9f9cf44a926b5fe68ab394ac17c1ade9559b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
