### PR TITLE
style: drop duplicated heading on /upload

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../lib/data_layer/userPreferencesSync';
 import useQuery from '../../lib/hooks/useQuery';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
-import { getVisibleText } from '../../lib/text/getVisibleText';
 import styles from '../../styles/shared.module.css';
 import { OnboardingTour } from './components/OnboardingTour/OnboardingTour';
 import UploadForm from './components/UploadForm/UploadForm';
@@ -83,12 +82,6 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
 
   return (
     <div className={styles.page}>
-      <header className={styles.pageHeader}>
-        <h1 className={styles.title}>{getVisibleText('upload.page.title')}</h1>
-        <p className={styles.subtitle}>
-          Turn your notes into flashcards in seconds
-        </p>
-      </header>
       <OnboardingTour
         createdAt={userLocals?.user?.created_at ?? null}
         onboardedAt={userLocals?.user?.onboarded_at ?? null}

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'style', title: 'Upload page — dropped the duplicated "Make flashcards" heading; the navbar identifies the page and the form is the focus', date: '2026-05-21' },
   { type: 'fix', title: 'Photo-to-flashcards page now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — explainer card moved below the upload form so the form is the unambiguous primary action', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — "How it works" steps and file-retention note collapsed behind a single disclosure', date: '2026-05-21' },


### PR DESCRIPTION
## Summary
Removes the `<h1>Make flashcards</h1>` + subtitle "Turn your notes into flashcards in seconds" from the top of `/upload`. The navbar already says "Make flashcards" and the upload form makes the action obvious — the heading was a third "you're on the upload page" cue for users who already knew that.

## Why
Al noted anonymous users on /upload see "Make flashcards" twice — once in the nav, once as the page H1. The H1+subtitle was restating what the surrounding chrome already conveys. Dropping it makes the upload form the unambiguous focus of the page; the "How it works" `<h2>` disclosure below still anchors heading semantics for screen readers.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

## Test plan
- [x] UploadPage.test.tsx — 6/6 pass (no tests asserted on the dropped strings)
- [x] typecheck green
- [x] `getVisibleText` import removed (was its only consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781985076&installation_id=132681956&pr_number=2553&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2553&signature=adc9181a53387cc49e41599e0e884e78d9d0cb596181ae212ca109e25b9aaf07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->