### PR TITLE
refactor: extract useUploadFormState hook from UploadForm

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1,4 +1,4 @@
-import { type SyntheticEvent, useEffect, useRef, useState } from 'react';
+import { type SyntheticEvent, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { ErrorHandlerType, classifyUploadError } from '../../../../components/errors/helpers/getErrorMessage';
@@ -10,6 +10,7 @@ import getHeadersFilename from '../../helpers/getHeadersFilename';
 import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadFileName';
 import { getEmptyDeckChatPrompt } from '../../helpers/getEmptyDeckChatPrompt';
 import { useDrag } from './hooks/useDrag';
+import { useUploadFormState } from './hooks/useUploadFormState';
 import { useFileValidation } from './hooks/useFileValidation';
 import { useDropboxChooser, type DropboxFile } from './hooks/useDropboxChooser';
 import {
@@ -27,25 +28,7 @@ import { UpsellCard } from '../../../../components/UpsellCard';
 import formStyles from './UploadForm.module.css';
 import sharedStyles from '../../../../styles/shared.module.css';
 
-type ZoneState =
-  | 'idle'
-  | 'converting'
-  | 'success'
-  | 'emptyDeck'
-  | 'limitReached'
-  | 'error'
-  | 'lockedPdf';
-
-interface LockedPdfInfo {
-  filename: string;
-  file: File;
-}
-
-interface LimitInfo {
-  filename: string | null;
-  fileSizeBytes: number | null;
-  kind: 'file_size' | 'card_count';
-}
+import type { ZoneState, LockedPdfInfo, LimitInfo } from './hooks/useUploadFormState';
 
 interface UploadFormProps {
   setErrorMessage: ErrorHandlerType;
@@ -225,36 +208,84 @@ function WarningIcon({ className }: Readonly<{ className?: string }>) {
 }
 
 function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
-  const [zoneState, setZoneState] = useState<ZoneState>('idle');
-  const [downloadLink, setDownloadLink] = useState<string | null>(null);
-  const [deckName, setDeckName] = useState('');
-  const [cardCount, setCardCount] = useState<number | null>(null);
-  const [mcqCount, setMcqCount] = useState<number>(0);
-  const [mcqSkippedCount, setMcqSkippedCount] = useState<number>(0);
-  const [mcqDrawerOpen, setMcqDrawerOpen] = useState(false);
-  const [mcqShowAnswer, setMcqShowAnswer] = useState(false);
-  const [warningMessage, setWarningMessage] = useState<string | null>(null);
-  const [limitInfo, setLimitInfo] = useState<LimitInfo | null>(null);
-  const [localError, setLocalError] = useState<UploadErrorBody | null>(null);
-  const [progressWidth, setProgressWidth] = useState(10);
-  const [progressSlow, setProgressSlow] = useState(false);
-  const [showFallback, setShowFallback] = useState(false);
-  const [trialPending, setTrialPending] = useState(false);
-  const [trialError, setTrialError] = useState<string | null>(null);
-  const [dropboxFilename, setDropboxFilename] = useState<string | null>(null);
-  const [dropboxPending, setDropboxPending] = useState(false);
-  const [dropboxError, setDropboxError] = useState<string | null>(null);
-  const [driveFilename, setDriveFilename] = useState<string | null>(null);
-  const [driveMimeType, setDriveMimeType] = useState<string | null>(null);
-  const [drivePending, setDrivePending] = useState(false);
-  const [driveError, setDriveError] = useState<string | null>(null);
-  const [source, setSource] = useState<UploadSource>('local');
-  const [showInlineChat, setShowInlineChat] = useState(false);
-  const [showErrorInlineChat, setShowErrorInlineChat] = useState(false);
-  const [lockedPdfInfo, setLockedPdfInfo] = useState<LockedPdfInfo | null>(null);
-  const [pdfCredential, setPdfCredential] = useState('');
-  const [pdfUnlockError, setPdfUnlockError] = useState<string | null>(null);
-  const [pdfAttemptCount, setPdfAttemptCount] = useState(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const convertRef = useRef<HTMLButtonElement>(null);
+  const downloadRef = useRef<HTMLAnchorElement>(null);
+  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const { validation, validate, reset: resetValidation } = useFileValidation();
+
+  const {
+    zoneState,
+    setZoneState,
+    downloadLink,
+    setDownloadLink,
+    deckName,
+    setDeckName,
+    cardCount,
+    setCardCount,
+    mcqCount,
+    setMcqCount,
+    mcqSkippedCount,
+    setMcqSkippedCount,
+    mcqDrawerOpen,
+    setMcqDrawerOpen,
+    mcqShowAnswer,
+    setMcqShowAnswer,
+    warningMessage,
+    setWarningMessage,
+    limitInfo,
+    setLimitInfo,
+    localError,
+    setLocalError,
+    progressWidth,
+    setProgressWidth,
+    progressSlow,
+    setProgressSlow,
+    showFallback,
+    setShowFallback,
+    trialPending,
+    setTrialPending,
+    trialError,
+    setTrialError,
+    dropboxFilename,
+    setDropboxFilename,
+    dropboxPending,
+    setDropboxPending,
+    dropboxError,
+    setDropboxError,
+    driveFilename,
+    setDriveFilename,
+    driveMimeType,
+    setDriveMimeType,
+    drivePending,
+    setDrivePending,
+    driveError,
+    setDriveError,
+    source,
+    setSource,
+    showInlineChat,
+    setShowInlineChat,
+    showErrorInlineChat,
+    setShowErrorInlineChat,
+    lockedPdfInfo,
+    setLockedPdfInfo,
+    pdfCredential,
+    setPdfCredential,
+    pdfUnlockError,
+    setPdfUnlockError,
+    pdfAttemptCount,
+    setPdfAttemptCount,
+    resetForm,
+  } = useUploadFormState(() => {
+    resetValidation();
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+    if (fallbackTimerRef.current) {
+      clearTimeout(fallbackTimerRef.current);
+    }
+  });
+
   const { data: userLocals } = useUserLocals();
   const queryClient = useQueryClient();
   const autoSyncActive = userLocals?.autoSyncActive === true;
@@ -266,11 +297,6 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     userLocals?.user?.trial_started_at == null &&
     userLocals?.locals?.patreon !== true;
   const showSignInPrompt = userLocals != null && !isAuthenticated;
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const convertRef = useRef<HTMLButtonElement>(null);
-  const downloadRef = useRef<HTMLAnchorElement>(null);
-  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
-  const { validation, validate, reset: resetValidation } = useFileValidation();
   const { openChooser, isConfigured: isDropboxConfigured } = useDropboxChooser(FORMATS);
   const { openPicker, isConfigured: isGoogleDriveConfigured } = useGooglePicker();
 
@@ -301,43 +327,6 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
 
   const submitFiles = () => {
     convertRef.current?.click();
-  };
-
-  const resetForm = () => {
-    setZoneState('idle');
-    setDownloadLink(null);
-    setDeckName('');
-    setCardCount(null);
-    setMcqCount(0);
-    setMcqSkippedCount(0);
-    setMcqDrawerOpen(false);
-    setMcqShowAnswer(false);
-    setWarningMessage(null);
-    setLimitInfo(null);
-    setTrialError(null);
-    setLocalError(null);
-    setProgressWidth(10);
-    setProgressSlow(false);
-    setShowFallback(false);
-    setDropboxFilename(null);
-    setDropboxError(null);
-    setDriveFilename(null);
-    setDriveMimeType(null);
-    setDriveError(null);
-    setSource('local');
-    setShowInlineChat(false);
-    setShowErrorInlineChat(false);
-    setLockedPdfInfo(null);
-    setPdfCredential('');
-    setPdfUnlockError(null);
-    setPdfAttemptCount(0);
-    resetValidation();
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-    if (fallbackTimerRef.current) {
-      clearTimeout(fallbackTimerRef.current);
-    }
   };
 
   const { dropHover } = useDrag({

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
@@ -1,0 +1,151 @@
+import { useState } from 'react';
+import type { UploadErrorBody } from '../../../../../types/UploadErrorBody';
+import type { UploadSource } from '../UploadSourceChips';
+
+export type ZoneState =
+  | 'idle'
+  | 'converting'
+  | 'success'
+  | 'emptyDeck'
+  | 'limitReached'
+  | 'error'
+  | 'lockedPdf';
+
+export interface LockedPdfInfo {
+  filename: string;
+  file: File;
+}
+
+export interface LimitInfo {
+  filename: string | null;
+  fileSizeBytes: number | null;
+  kind: 'file_size' | 'card_count';
+}
+
+export function useUploadFormState(onReset: () => void) {
+  const [zoneState, setZoneState] = useState<ZoneState>('idle');
+  const [downloadLink, setDownloadLink] = useState<string | null>(null);
+  const [deckName, setDeckName] = useState('');
+  const [cardCount, setCardCount] = useState<number | null>(null);
+  const [mcqCount, setMcqCount] = useState<number>(0);
+  const [mcqSkippedCount, setMcqSkippedCount] = useState<number>(0);
+  const [mcqDrawerOpen, setMcqDrawerOpen] = useState(false);
+  const [mcqShowAnswer, setMcqShowAnswer] = useState(false);
+  const [warningMessage, setWarningMessage] = useState<string | null>(null);
+  const [limitInfo, setLimitInfo] = useState<LimitInfo | null>(null);
+  const [localError, setLocalError] = useState<UploadErrorBody | null>(null);
+  const [progressWidth, setProgressWidth] = useState(10);
+  const [progressSlow, setProgressSlow] = useState(false);
+  const [showFallback, setShowFallback] = useState(false);
+  const [trialPending, setTrialPending] = useState(false);
+  const [trialError, setTrialError] = useState<string | null>(null);
+  const [dropboxFilename, setDropboxFilename] = useState<string | null>(null);
+  const [dropboxPending, setDropboxPending] = useState(false);
+  const [dropboxError, setDropboxError] = useState<string | null>(null);
+  const [driveFilename, setDriveFilename] = useState<string | null>(null);
+  const [driveMimeType, setDriveMimeType] = useState<string | null>(null);
+  const [drivePending, setDrivePending] = useState(false);
+  const [driveError, setDriveError] = useState<string | null>(null);
+  const [source, setSource] = useState<UploadSource>('local');
+  const [showInlineChat, setShowInlineChat] = useState(false);
+  const [showErrorInlineChat, setShowErrorInlineChat] = useState(false);
+  const [lockedPdfInfo, setLockedPdfInfo] = useState<LockedPdfInfo | null>(null);
+  const [pdfCredential, setPdfCredential] = useState('');
+  const [pdfUnlockError, setPdfUnlockError] = useState<string | null>(null);
+  const [pdfAttemptCount, setPdfAttemptCount] = useState(0);
+
+  const resetForm = () => {
+    setZoneState('idle');
+    setDownloadLink(null);
+    setDeckName('');
+    setCardCount(null);
+    setMcqCount(0);
+    setMcqSkippedCount(0);
+    setMcqDrawerOpen(false);
+    setMcqShowAnswer(false);
+    setWarningMessage(null);
+    setLimitInfo(null);
+    setTrialError(null);
+    setLocalError(null);
+    setProgressWidth(10);
+    setProgressSlow(false);
+    setShowFallback(false);
+    setDropboxFilename(null);
+    setDropboxError(null);
+    setDriveFilename(null);
+    setDriveMimeType(null);
+    setDriveError(null);
+    setSource('local');
+    setShowInlineChat(false);
+    setShowErrorInlineChat(false);
+    setLockedPdfInfo(null);
+    setPdfCredential('');
+    setPdfUnlockError(null);
+    setPdfAttemptCount(0);
+    onReset();
+  };
+
+  return {
+    zoneState,
+    setZoneState,
+    downloadLink,
+    setDownloadLink,
+    deckName,
+    setDeckName,
+    cardCount,
+    setCardCount,
+    mcqCount,
+    setMcqCount,
+    mcqSkippedCount,
+    setMcqSkippedCount,
+    mcqDrawerOpen,
+    setMcqDrawerOpen,
+    mcqShowAnswer,
+    setMcqShowAnswer,
+    warningMessage,
+    setWarningMessage,
+    limitInfo,
+    setLimitInfo,
+    localError,
+    setLocalError,
+    progressWidth,
+    setProgressWidth,
+    progressSlow,
+    setProgressSlow,
+    showFallback,
+    setShowFallback,
+    trialPending,
+    setTrialPending,
+    trialError,
+    setTrialError,
+    dropboxFilename,
+    setDropboxFilename,
+    dropboxPending,
+    setDropboxPending,
+    dropboxError,
+    setDropboxError,
+    driveFilename,
+    setDriveFilename,
+    driveMimeType,
+    setDriveMimeType,
+    drivePending,
+    setDrivePending,
+    driveError,
+    setDriveError,
+    source,
+    setSource,
+    showInlineChat,
+    setShowInlineChat,
+    showErrorInlineChat,
+    setShowErrorInlineChat,
+    lockedPdfInfo,
+    setLockedPdfInfo,
+    pdfCredential,
+    setPdfCredential,
+    pdfUnlockError,
+    setPdfUnlockError,
+    pdfAttemptCount,
+    setPdfAttemptCount,
+    resetForm,
+  };
+}


### PR DESCRIPTION
## Summary
Moves the 24 `useState` declarations and the `resetForm` function out of `UploadForm.tsx` and into a colocated `useUploadFormState` hook at `web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts`. Behavior is identical — verified by the existing 27 UploadForm tests passing untouched.

## Why
The engineer audit of /upload (earlier this session) flagged `UploadForm.tsx` (1421 LOC) as a complexity hotspot: 24 useState calls at the top of the component and a `resetForm` function that has to be manually kept in sync. The hook owns both, so adding new state in one place auto-handles the reset.

## Browser check
Browser check: not applicable — pure refactor with zero behavior change, verified by the existing 27 UploadForm tests passing untouched.

## Test plan
- [x] UploadForm.test.tsx — 27/27 pass without modification
- [x] typecheck green
- [x] No new tests added (refactor is covered by the existing suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781985327&installation_id=132681956&pr_number=2554&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2554&signature=e40a4ffcde9c41be6e7d26c47aa446a9c2c55e7b0e5049258e0a536206d82716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->