### PR TITLE
feat: mention Auto Sync in Notion one-at-a-time paywall message

### DIFF
--- a/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
@@ -131,6 +131,22 @@ describe('SearchObjectEntry convert button', () => {
     expect(screen.getByRole('link', { name: 'Upgrade' })).toHaveAttribute('href', '/pricing');
   });
 
+  it('on 402: shows Auto Sync link to /ankify', async () => {
+    mockConvert.mockResolvedValue({
+      status: 402,
+      json: async () => ({ reason: 'free_plan_one_at_a_time' }),
+    });
+
+    renderEntry();
+    fireEvent.click(screen.getByRole('link', { name: 'Convert to Anki' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Auto Sync' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('link', { name: 'Auto Sync' })).toHaveAttribute('href', '/ankify');
+  });
+
   it('on 409: shows already-converting copy', async () => {
     mockConvert.mockResolvedValue({
       status: 409,

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -101,7 +101,8 @@ function SearchObjectEntry(props: Readonly<Props>) {
         {status === 'paywall' && (
           <span className={styles.convertStatus}>
             Free plan — one conversion at a time.{' '}
-            <Link to="/pricing">Upgrade</Link> or wait.
+            <Link to="/pricing">Upgrade</Link> or try{' '}
+            <Link to="/ankify">Auto Sync</Link>.
           </span>
         )}
         {status === 'conflict' && (

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,8 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'feature', title: 'Notion search — hitting the one-at-a-time cap now shows a link to Auto Sync alongside the upgrade option', date: '2026-05-21' },
+  { type: 'style', title: 'Home page walkthroughs slimmed to 10 videos, with non-Notion sources surfacing first', date: '2026-05-21' },
   { type: 'fix', title: 'Onboarding tour now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — dropped the duplicated "Make flashcards" heading; the navbar identifies the page and the form is the focus', date: '2026-05-21' },
   { type: 'fix', title: 'Photo-to-flashcards page now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },


### PR DESCRIPTION
## What

When a free user hits the per-conversion cap on the Notion search page, the inline status message now includes a direct link to Auto Sync alongside the existing upgrade link.

Before: `Free plan — one conversion at a time. Upgrade or wait.`
After:  `Free plan — one conversion at a time. Upgrade or try Auto Sync.`

## Why

A user reported the exact friction: "I'm too lazy to download each of my Notion pages individually and upload them." That's precisely the problem Auto Sync (0/mo) solves — it keeps Notion pages synced to Anki automatically, no manual uploads. The product existed; it just wasn't mentioned where the friction surfaces.

## Research findings

**1. Where is the cap gated?**
`src/controllers/NotionController.ts:216` — confirmed: `const maxJobs = paying ? Infinity : 1`. When exceeded, `CancelJobUseCase` runs and a `JobLimitError` is thrown. The controller catches it and returns `402 { reason: 'free_plan_one_at_a_time' }`.

**2. What does a free user see?**
The 402 response is handled in `web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx`. When status becomes `'paywall'`, it renders: "Free plan — one conversion at a time. Upgrade or wait." with a link to `/pricing`. No Ankify mention.

**3. Where is Ankify positioned?**
- `/ankify` — authenticated setup flow (requires Notion OAuth)
- Auto Sync = 0/mo (confirmed in `FEATURE.md`, `LimitPage.tsx`, `NotionLandingPage.tsx`)
- `LimitPage` (monthly card cap wall) already shows Auto Sync prominently. But `LimitPage` is for the *card count* cap, not the *per-conversion* cap — different surface, different flow.

**4. Existing Notion-specific paywall surface?**
No dedicated component. The paywall message lives inline in `SearchObjectEntry`. This confirmed Option A is the right call.

## How

Single inline change to the paywall status in `SearchObjectEntry/index.tsx`: appended `or try <Link to="/ankify">Auto Sync</Link>.` after the existing Upgrade link.

One new test in `SearchObjectEntry.test.tsx` asserts the Auto Sync link appears with `href=/ankify` on a 402 response.

The copy is honest: it names the product, does not claim it is free, and does not promise features. The `/ankify` page shows 0/mo and requires signup before checkout begins.

## Measuring success

`[event] paywall_shown` already fires on every 402. The existing `paywall_upgrade_clicked` analytics event with `{ plan: 'auto_sync' }` will fire if the user clicks through `/ankify` and starts checkout — query that in the analytics dashboard to measure conversion lift from this surface.

## Testing

- Unit test added: `SearchObjectEntry.test.tsx` — "on 402: shows Auto Sync link to /ankify"
- Existing tests unchanged and passing (7 pre-existing pass)
- TypeScript: `pnpm --filter 2anki-web typecheck` — clean

## Browser check

Browser check: not applicable — the change is copy only (one additional `<Link>` component alongside an existing one); the component renders correctly given the existing test structure verifies the DOM output

## Changelog

`{ type: 'feature', title: 'Notion search — hitting the one-at-a-time cap now shows a link to Auto Sync alongside the upgrade option', date: '2026-05-21' }`

## Risks

- Low. One additional `<Link>` in an inline status span. No new state, no new API call, no new component.
- Rollback: revert the 3-line JSX change in `index.tsx`.

## Goal alignment

Surfaces the highest-value upsell (Auto Sync, 0/mo) at the exact moment the manual-conversion friction hits. Users who would pay for Auto Sync currently bounce from this screen not knowing it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781985353&installation_id=132681956&pr_number=2555&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2555&signature=936b6e93530983e9152ea03906f4a8755d355ba05d7c2401ace1d6ade9199a2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
