### PR TITLE
fix: onboarding tour renders in dark mode

### DIFF
--- a/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.module.css
+++ b/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.module.css
@@ -1,6 +1,6 @@
 .tour {
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #e5e7eb);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 20px 24px;
   margin-bottom: 20px;
@@ -17,26 +17,26 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--color-border, #e5e7eb);
+  background: var(--color-border);
 }
 
 .dotActive {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--color-primary, #3b82f6);
+  background: var(--color-primary);
 }
 
 .title {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-text, #111827);
+  color: var(--color-text-primary);
   margin: 0 0 6px;
 }
 
 .hint {
   font-size: 0.875rem;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--color-text-tertiary);
   margin: 0 0 18px;
 }
 
@@ -48,8 +48,8 @@
 
 .btnPrimary {
   padding: 6px 16px;
-  background: var(--color-primary, #3b82f6);
-  color: #fff;
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
   border: none;
   border-radius: 6px;
   font-size: 0.875rem;
@@ -57,27 +57,27 @@
 }
 
 .btnPrimary:hover {
-  background: #2563eb;
+  background: var(--color-primary-hover);
 }
 
 .btnSecondary {
   padding: 6px 16px;
   background: transparent;
-  color: var(--color-text, #374151);
-  border: 1px solid var(--color-border, #e5e7eb);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
   border-radius: 6px;
   font-size: 0.875rem;
   cursor: pointer;
 }
 
 .btnSecondary:hover {
-  background: var(--color-surface-hover, #f9fafb);
+  background: var(--color-bg-secondary);
 }
 
 .btnSkip {
   padding: 6px 12px;
   background: transparent;
-  color: var(--color-text-muted, #6b7280);
+  color: var(--color-text-tertiary);
   border: none;
   font-size: 0.875rem;
   cursor: pointer;
@@ -85,5 +85,5 @@
 }
 
 .btnSkip:hover {
-  color: var(--color-text, #374151);
+  color: var(--color-text-primary);
 }

--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -5,6 +5,7 @@ export interface ChangelogEntry {
 }
 
 export const changelog: ChangelogEntry[] = [
+  { type: 'fix', title: 'Onboarding tour now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — dropped the duplicated "Make flashcards" heading; the navbar identifies the page and the form is the focus', date: '2026-05-21' },
   { type: 'fix', title: 'Photo-to-flashcards page now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — explainer card moved below the upload form so the form is the unambiguous primary action', date: '2026-05-21' },


### PR DESCRIPTION
## Summary
Swaps `OnboardingTour.module.css` from undefined design tokens (`--color-surface`, `--color-text-muted`, `--color-surface-hover`, `--color-text`) to the real themed tokens (`--color-bg-primary`, `--color-text-tertiary`, `--color-bg-secondary`, `--color-text-primary`, `--color-primary-hover`). Same fix as #2550 applied to the tour component.

## Why
Every `var(--color-surface, #fff)` was falling through to its hardcoded light-mode fallback because those token names don't exist in `styles/base.css`. The tour stayed white-on-light regardless of theme.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

## Test plan
- [x] OnboardingTour.test.tsx — 10/10 pass (no color assertions)
- [x] typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781985452&installation_id=132681956&pr_number=2556&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2556&signature=cb7d92bd606e889bc48a3fb056c8abe790d58a392c1107527ed29dff89ccff95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->