### PR TITLE
chore: dedupe walkthrough changelog entry

### DIFF
--- a/web/src/pages/WhatsNewPage/changelog.ts
+++ b/web/src/pages/WhatsNewPage/changelog.ts
@@ -9,7 +9,6 @@ export const changelog: ChangelogEntry[] = [
   { type: 'style', title: 'Home page walkthroughs slimmed to 10 videos, with non-Notion sources surfacing first', date: '2026-05-21' },
   { type: 'fix', title: 'Onboarding tour now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — dropped the duplicated "Make flashcards" heading; the navbar identifies the page and the form is the focus', date: '2026-05-21' },
-  { type: 'style', title: 'Home page walkthroughs slimmed to 10 videos, with non-Notion sources surfacing first', date: '2026-05-21' },
   { type: 'fix', title: 'Photo-to-flashcards page now renders correctly in dark mode (and the gold and purple themes)', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — explainer card moved below the upload form so the form is the unambiguous primary action', date: '2026-05-21' },
   { type: 'style', title: 'Upload page — "How it works" steps and file-retention note collapsed behind a single disclosure', date: '2026-05-21' },


### PR DESCRIPTION
Removes a duplicate "Home page walkthroughs slimmed to 10 videos" line that landed twice during a parallel-PR rebase conflict resolution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781985727&installation_id=132681956&pr_number=2557&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2557&signature=bf77ee2e623fafc55d19c9cfe7142f8664e5aa0394af3db66c6f3a5f38e90290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->