### PR TITLE
feat: surface Day Pass at moment of value, trim friction-time upsells

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -576,12 +576,10 @@ export default function ChatPanel({
                 You've used all {FREE_MONTHLY_LIMIT} messages this month. Resets {formatResetDate(resetDate)}.
               </span>
               <a
-                href="https://www.patreon.com/alemayhu"
-                target="_blank"
-                rel="noreferrer"
+                href="/pricing"
                 className={styles.limitPanelLink}
               >
-                See Patreon plans
+                See plans
               </a>
             </div>
           )}

--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -68,21 +68,21 @@ describe('UpsellCard', () => {
   it('hides for anonymous users when hideForAnonymous is true', () => {
     mockUseUserLocals.mockReturnValue(anonymousUser);
     const { container } = render(
-      <UpsellCard surface="upload_idle_upsell" hideForAnonymous />
+      <UpsellCard surface="upload_success_upsell" hideForAnonymous />
     );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('still shows for free logged-in users when hideForAnonymous is true', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
-    render(<UpsellCard surface="upload_idle_upsell" hideForAnonymous />);
+    render(<UpsellCard surface="upload_success_upsell" hideForAnonymous />);
     expect(screen.getByRole('button', { name: 'Day Pass' })).toBeInTheDocument();
   });
 
   it('uses the downloads surface headline on /downloads', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     render(<UpsellCard surface="downloads_upsell" />);
-    expect(screen.getByText('More decks to download?')).toBeInTheDocument();
+    expect(screen.getByText('Converting more this month?')).toBeInTheDocument();
   });
 
   it('uses the upload-success surface headline on upload success', () => {

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -7,10 +7,7 @@ import { isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
 import { getSubscribeLink } from '../../pages/PricingPage/payment.links';
 import styles from './UpsellCard.module.css';
 
-type Surface =
-  | 'downloads_upsell'
-  | 'upload_success_upsell'
-  | 'upload_idle_upsell';
+type Surface = 'downloads_upsell' | 'upload_success_upsell';
 
 interface UpsellCardProps {
   readonly surface: Surface;
@@ -18,18 +15,15 @@ interface UpsellCardProps {
 }
 
 const HEADLINE: Record<Surface, string> = {
-  downloads_upsell: 'More decks to download?',
+  downloads_upsell: 'Converting more this month?',
   upload_success_upsell: 'More pages to convert?',
-  upload_idle_upsell: 'Whole stack to convert?',
 };
 
 const BODY: Record<Surface, string> = {
   downloads_upsell:
-    'A pass lifts the 100-card monthly cap. Day or week, no subscription.',
+    'A Day Pass lifts the 100-card limit for 24 hours — no subscription.',
   upload_success_upsell:
     'A pass lifts the 100-card monthly cap — for a day or a week, no subscription.',
-  upload_idle_upsell:
-    'A pass lifts the 100-card monthly cap. Day or week, no subscription.',
 };
 
 export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProps) {

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.module.css
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.module.css
@@ -93,3 +93,21 @@
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
 }
+
+.offerBody {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.tertiary {
+  align-self: center;
+  padding: 0.5rem 0.5rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+}
+
+.tertiary:hover {
+  color: var(--color-text-primary);
+}

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
@@ -3,18 +3,48 @@ import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const submitEmojiFeedback = vi.fn();
+const startPassCheckout = vi.fn();
 
 vi.mock('../../../lib/backend/get2ankiApi', () => ({
-  get2ankiApi: () => ({ submitEmojiFeedback }),
+  get2ankiApi: () => ({ submitEmojiFeedback, startPassCheckout }),
+}));
+
+const mockUseUserLocals = vi.fn();
+
+vi.mock('../../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => mockUseUserLocals(),
+}));
+
+const mockTrack = vi.fn();
+
+vi.mock('../../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
 }));
 
 import { DeckFeedbackPrompt, isDeckFeedbackSuppressed } from './DeckFeedbackPrompt';
 
 const SUPPRESSED_UNTIL_KEY = '2anki_deck_feedback_suppressed_until';
 
+const freeUser = {
+  data: {
+    locals: { patreon: false, subscriber: false },
+    user: { email: 'free@example.com' },
+  },
+};
+
+const payingUser = {
+  data: {
+    locals: { patreon: false, subscriber: true },
+    user: { email: 'paying@example.com' },
+  },
+};
+
 beforeEach(() => {
   submitEmojiFeedback.mockReset();
   submitEmojiFeedback.mockResolvedValue(undefined);
+  startPassCheckout.mockReset();
+  mockTrack.mockClear();
+  mockUseUserLocals.mockReturnValue(freeUser);
   localStorage.clear();
 });
 
@@ -36,7 +66,6 @@ describe('DeckFeedbackPrompt', () => {
     await waitFor(() => {
       expect(submitEmojiFeedback).toHaveBeenCalledWith(5, 'downloads/deck_done', undefined);
     });
-    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
   });
 
   it('opens the follow-up textarea when the user reports a problem', () => {
@@ -57,6 +86,7 @@ describe('DeckFeedbackPrompt', () => {
     await waitFor(() => {
       expect(submitEmojiFeedback).toHaveBeenCalledWith(1, 'downloads/deck_done', 'images were missing');
     });
+    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
   });
 
   it('posts rating 1 with no comment when the user skips the follow-up', async () => {
@@ -66,6 +96,7 @@ describe('DeckFeedbackPrompt', () => {
     await waitFor(() => {
       expect(submitEmojiFeedback).toHaveBeenCalledWith(1, 'downloads/deck_done', undefined);
     });
+    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
   });
 
   it('writes a 14-day suppression timestamp on dismiss', () => {
@@ -102,5 +133,86 @@ describe('DeckFeedbackPrompt', () => {
   it('isDeckFeedbackSuppressed returns true when timestamp is in the future', () => {
     localStorage.setItem(SUPPRESSED_UNTIL_KEY, String(Date.now() + 1000));
     expect(isDeckFeedbackSuppressed()).toBe(true);
+  });
+});
+
+describe('DeckFeedbackPrompt — Day Pass offer after positive rating', () => {
+  it('shows the Day Pass offer to a free user after they confirm the deck worked', async () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    expect(await screen.findByText('Deck came out right.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Keep going without the monthly limit — Day Pass, $4.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Get Day Pass' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'See all plans' })).toHaveAttribute(
+      'href',
+      '/pricing?source=deck_feedback'
+    );
+  });
+
+  it('does not show the Day Pass offer to paying users', async () => {
+    mockUseUserLocals.mockReturnValue(payingUser);
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Get Day Pass' })).not.toBeInTheDocument();
+  });
+
+  it('does not show the offer after a negative rating', async () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Something was off' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Get Day Pass' })).not.toBeInTheDocument();
+  });
+
+  it('fires paywall_shown with surface=deck_feedback_sent when the offer renders', async () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith('paywall_shown', {
+        surface: 'deck_feedback_sent',
+      });
+    });
+  });
+
+  it('fires paywall_upgrade_clicked with plan=day_pass and redirects on Day Pass click', async () => {
+    startPassCheckout.mockResolvedValue({ url: 'https://checkout.stripe.com/day' });
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    const cta = await screen.findByRole('button', { name: 'Get Day Pass' });
+    fireEvent.click(cta);
+    await waitFor(() => {
+      expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+        surface: 'deck_feedback_sent',
+        plan: 'day_pass',
+      });
+      expect(startPassCheckout).toHaveBeenCalledWith('24h');
+    });
+  });
+
+  it('shows Redirecting label and disables the button while Day Pass checkout is pending', async () => {
+    let resolveCheckout: (value: { status: 'error' }) => void = () => {};
+    startPassCheckout.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheckout = resolve;
+      })
+    );
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    const cta = await screen.findByRole('button', { name: 'Get Day Pass' });
+    fireEvent.click(cta);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
+    });
+    resolveCheckout({ status: 'error' });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Get Day Pass' })).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
@@ -1,6 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { track } from '../../../lib/analytics/track';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+import { useUserLocals } from '../../../lib/hooks/useUserLocals';
+import { isPayingUser } from '../../../components/NavigationBar/helpers/getPlanLabel';
 import styles from './DeckFeedbackPrompt.module.css';
 
 const SUPPRESSED_UNTIL_KEY = '2anki_deck_feedback_suppressed_until';
@@ -9,12 +12,13 @@ const FEEDBACK_PAGE = 'downloads/deck_done';
 const POSITIVE_RATING = 5;
 const NEGATIVE_RATING = 1;
 const COMMENT_MAX = 2000;
+const UPSELL_SURFACE = 'deck_feedback_sent';
 
 type Stage =
   | { kind: 'prompt' }
   | { kind: 'follow-up' }
   | { kind: 'sending' }
-  | { kind: 'sent' }
+  | { kind: 'sent'; rating: number }
   | { kind: 'error'; retry: () => void };
 
 function suppressForWindow(): void {
@@ -42,6 +46,18 @@ export function DeckFeedbackPrompt() {
   const [stage, setStage] = useState<Stage>({ kind: 'prompt' });
   const [comment, setComment] = useState('');
   const [dismissed, setDismissed] = useState(false);
+  const [dayPassPending, setDayPassPending] = useState(false);
+  const { data: userLocals } = useUserLocals();
+
+  const paying = isPayingUser(userLocals?.locals);
+  const showOffer =
+    stage.kind === 'sent' && stage.rating === POSITIVE_RATING && !paying;
+
+  useEffect(() => {
+    if (showOffer) {
+      track('paywall_shown', { surface: UPSELL_SURFACE });
+    }
+  }, [showOffer]);
 
   if (dismissed) return null;
 
@@ -59,7 +75,7 @@ export function DeckFeedbackPrompt() {
         withComment != null && withComment.length > 0 ? withComment : undefined
       );
       suppressForWindow();
-      setStage({ kind: 'sent' });
+      setStage({ kind: 'sent', rating });
     } catch {
       setStage({
         kind: 'error',
@@ -82,6 +98,27 @@ export function DeckFeedbackPrompt() {
 
   const handleSkipNegative = () => {
     void sendRating(NEGATIVE_RATING);
+  };
+
+  const handleDayPassClick = async () => {
+    track('paywall_upgrade_clicked', {
+      surface: UPSELL_SURFACE,
+      plan: 'day_pass',
+    });
+    setDayPassPending(true);
+    const result = await get2ankiApi().startPassCheckout('24h');
+    if ('url' in result) {
+      globalThis.location.href = result.url;
+      return;
+    }
+    setDayPassPending(false);
+  };
+
+  const handleSeeAllPlans = () => {
+    track('paywall_upgrade_clicked', {
+      surface: UPSELL_SURFACE,
+      plan: 'pricing_page',
+    });
   };
 
   return (
@@ -154,7 +191,33 @@ export function DeckFeedbackPrompt() {
         <p className={styles.status}>Sending</p>
       )}
 
-      {stage.kind === 'sent' && (
+      {showOffer && (
+        <>
+          <p className={styles.prompt}>Deck came out right.</p>
+          <p className={styles.offerBody}>
+            Keep going without the monthly limit — Day Pass, $4.
+          </p>
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.primary}
+              onClick={handleDayPassClick}
+              disabled={dayPassPending}
+            >
+              {dayPassPending ? 'Redirecting…' : 'Get Day Pass'}
+            </button>
+            <a
+              className={styles.tertiary}
+              href="/pricing?source=deck_feedback"
+              onClick={handleSeeAllPlans}
+            >
+              See all plans
+            </a>
+          </div>
+        </>
+      )}
+
+      {stage.kind === 'sent' && !showOffer && (
         <p className={styles.status}>Feedback received.</p>
       )}
 

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
@@ -58,7 +58,7 @@ describe('PaywallBanner', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        'We cancelled this new one so the conversion you already started can finish. Upgrade to Unlimited to run several at once.'
+        'This conversion was paused so the one you already started can finish. Upgrade to Unlimited to run several at once.'
       )
     ).toBeInTheDocument();
     const cta = screen.getByRole('link', {

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
@@ -40,8 +40,8 @@ export function PaywallBanner({ inProgressJob }: PaywallBannerProps) {
         One conversion at a time on the free plan
       </h2>
       <p className={styles.body}>
-        We cancelled this new one so the conversion you already started can
-        finish. Upgrade to Unlimited to run several at once.
+        This conversion was paused so the one you already started can finish.
+        Upgrade to Unlimited to run several at once.
       </p>
       <div className={styles.actions}>
         <a

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -179,8 +179,17 @@
   }
 }
 
+.pricesNote {
+  margin: 2.5rem auto 0;
+  max-width: 540px;
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  line-height: var(--leading-relaxed);
+}
+
 .philosophy {
-  margin: 3rem auto 0;
+  margin: 0.75rem auto 0;
   max-width: 540px;
   text-align: center;
   font-size: var(--text-sm);

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -379,6 +379,10 @@ export default function PricingPage({
         />
       </div>
 
+      <p className={styles.pricesNote}>
+        Prices in USD. Your card is charged in your local currency at checkout.
+      </p>
+
       <p className={styles.philosophy}>
         Free works forever. Paid plans support 2anki.net.
       </p>

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/SearchObjectEntry.test.tsx
@@ -129,22 +129,7 @@ describe('SearchObjectEntry convert button', () => {
     });
 
     expect(screen.getByRole('link', { name: 'Upgrade' })).toHaveAttribute('href', '/pricing');
-  });
-
-  it('on 402: shows Auto Sync link to /ankify', async () => {
-    mockConvert.mockResolvedValue({
-      status: 402,
-      json: async () => ({ reason: 'free_plan_one_at_a_time' }),
-    });
-
-    renderEntry();
-    fireEvent.click(screen.getByRole('link', { name: 'Convert to Anki' }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('link', { name: 'Auto Sync' })).toBeInTheDocument();
-    });
-
-    expect(screen.getByRole('link', { name: 'Auto Sync' })).toHaveAttribute('href', '/ankify');
+    expect(screen.queryByRole('link', { name: 'Auto Sync' })).not.toBeInTheDocument();
   });
 
   it('on 409: shows already-converting copy', async () => {

--- a/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
+++ b/web/src/pages/SearchPage/components/SearchObjectEntry/index.tsx
@@ -101,8 +101,7 @@ function SearchObjectEntry(props: Readonly<Props>) {
         {status === 'paywall' && (
           <span className={styles.convertStatus}>
             Free plan — one conversion at a time.{' '}
-            <Link to="/pricing">Upgrade</Link> or try{' '}
-            <Link to="/ankify">Auto Sync</Link>.
+            <Link to="/pricing">Upgrade</Link> or wait.
           </span>
         )}
         {status === 'conflict' && (

--- a/web/src/pages/UploadPage/UploadPage.module.css
+++ b/web/src/pages/UploadPage/UploadPage.module.css
@@ -1,10 +1,3 @@
-/* ── Upsell wrapper for free logged-in users (below upload form) ── */
-
-.upsellWrapper {
-  max-width: 800px;
-  margin: 1.5rem 0 0;
-}
-
 /* ── Re-attach banner (shown after trial-on-register redirect) ── */
 
 .reattachBanner {

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
-import { UpsellCard } from '../../components/UpsellCard';
 import useQuery from '../../lib/hooks/useQuery';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import styles from '../../styles/shared.module.css';
@@ -67,9 +66,6 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
         </div>
       )}
       <UploadForm setErrorMessage={setErrorMessage} />
-      <div className={pageStyles.upsellWrapper}>
-        <UpsellCard surface="upload_idle_upsell" hideForAnonymous />
-      </div>
       <details className={pageStyles.howItWorks}>
         <summary className={pageStyles.howItWorksSummary}>
           <h2 className={pageStyles.howItWorksHeading}>How it works</h2>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-21-day-pass-after-deck.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-21-day-pass-after-deck.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-21-day-pass-after-deck",
+  "date": "2026-05-21",
+  "type": "feature",
+  "title": "Day Pass offer right after a deck downloads — skip the monthly limit without a subscription"
+}


### PR DESCRIPTION
## Why

Al watches Hotjar recordings: most visitors just use the upload form on `2anki.net` and stay below the free-tier limits. They rarely hit a wall, so the upgrade prompt arrives at the wrong moments — either before they have value (idle `/upload`) or at moments of friction (Auto Sync cross-sell on the Notion one-at-a-time paywall). The post-download feedback widget shipped in #2558 sits at the peak-intent moment but currently only collects sentiment.

Trio review (pm + designer + engineer) ran in parallel before any code. Editorial rule it produced:

> **One upsell per moment-of-value, zero per moment-of-friction.**

## What changes

Pricing page (kept prices visible — both pm and designer recommended against handing the price slot to Stripe adaptive rendering; SEO, FAQ JSON-LD, and comparison-shop UX all point the same way):
- Add a single muted line below the card grid: *"Prices in USD. Your card is charged in your local currency at checkout."*

Moment-of-value upsell (the headline change):
- `DeckFeedbackPrompt` sent-state for free users now shows a Day Pass offer instead of the cold "Feedback received." status. Paying users still see the status; negative ratings never see the offer.

Trimmed friction-time upsells:
- Removed idle `UpsellCard` from `/upload` — no value attached yet, the offer landed flat. Deletes the now-unused `upload_idle_upsell` surface.
- Retargeted `/downloads` `UpsellCard`: "More decks to download?" → "Converting more this month?" with Day-Pass-first body copy.
- Reverted the Auto Sync cross-sell in the Notion one-at-a-time paywall (the user-visible change from #2555). Cross-selling \$30/mo to a user hitting a free-plan wall reads tone-deaf.
- Softened `PaywallBanner` copy: "We cancelled this new one" → "This conversion was paused."
- Repointed `ChatPanel` limit-panel link from `patreon.com/alemayhu` → `/pricing` (single funnel destination).

## Tests

`pnpm --filter 2anki-web test:run` → 116 files, 910 tests passing.
- New: 6 tests in `DeckFeedbackPrompt.test.tsx` for the offer (free vs paying, negative-rating suppression, `paywall_shown` tracking, Day Pass redirect, pending-state).
- Updated: `SearchObjectEntry.test.tsx` (dropped Auto Sync assertion + added negative), `PaywallBanner.test.tsx` (new body), `UpsellCard.test.tsx` (headline + swapped removed surface).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Al greenlit the merge directly. Netlify deploy preview available at https://deploy-preview-2562--notion2anki.netlify.app for spot-check.

## Sonar

Local \`sonar-scanner\` not run for this PR — Sonar token setup not configured on this box. Expect a Sonar bounce on cognitive complexity / nesting if any, since the only new logic surface is the \`showOffer\` branch in \`DeckFeedbackPrompt\`.

## Goal alignment

Simpler/faster/more beautiful: fewer upsells overall, one good one at the right moment. Toward scale: surfacing the friction-light Day Pass (\$4, no subscription) to students who currently bounce without ever seeing a wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)