### PR TITLE
fix: clamp apkg preview cloze ord to available template count

### DIFF
--- a/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
@@ -49,6 +49,41 @@ function makeClozeCollection(cardOrds: number[]): NormalizedCollection {
   };
 }
 
+function makeBadOrdClozeCollection(): NormalizedCollection {
+  const noteType = {
+    id: 1,
+    name: 'n2a-cloze',
+    type: 0 as const,
+    css: '',
+    fields: [{ name: 'Text', ord: 0 }],
+    templates: [
+      {
+        name: 'Cloze',
+        ord: 0,
+        qfmt: '{{cloze:Text}}',
+        afmt: '{{cloze:Text}}',
+      },
+    ],
+  };
+
+  const note = {
+    id: 10,
+    mid: 1,
+    tags: '',
+    fields: ['{{c1::Paris}} is the capital of {{c2::France}}'],
+  };
+
+  const validCard = { id: 100, nid: 10, did: 2, ord: 0 };
+  const badOrdCard = { id: 101, nid: 10, did: 2, ord: 1 };
+
+  return {
+    noteTypes: new Map([[1, noteType]]),
+    notes: new Map([[10, note]]),
+    decks: new Map([[2, { id: 2, name: 'Demo' }]]),
+    cards: [validCard, badOrdCard],
+  };
+}
+
 describe('ApkgPreviewService.getCardsPage', () => {
   const service = new ApkgPreviewService();
 
@@ -82,5 +117,43 @@ describe('ApkgPreviewService.getCardsPage', () => {
     warnSpy.mockRestore();
 
     expect(templateOrdWarnings).toHaveLength(0);
+  });
+
+  describe('ord-out-of-range fallback', () => {
+    it('emits a warn log when a card ord exceeds the noteType template count', () => {
+      const parsed = makeParsed(makeBadOrdClozeCollection());
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      service.getCardsPage(parsed, 0, 10, 'http://example.com');
+
+      const templateOrdWarnings = warnSpy.mock.calls.filter(([msg]) =>
+        String(msg).includes('template ord=')
+      );
+      warnSpy.mockRestore();
+
+      expect(templateOrdWarnings).toHaveLength(1);
+      expect(String(templateOrdWarnings[0][0])).toContain('n2a-cloze');
+    });
+
+    it('still renders the out-of-range card against ord=0 instead of dropping it', () => {
+      const parsed = makeParsed(makeBadOrdClozeCollection());
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = service.getCardsPage(parsed, 0, 10, 'http://example.com');
+      warnSpy.mockRestore();
+
+      expect(result.cards).toHaveLength(2);
+      expect(result.cards.every((c) => c.noteTypeName === 'n2a-cloze')).toBe(true);
+    });
+
+    it('does not throw when a card ord exceeds the noteType template count', () => {
+      const parsed = makeParsed(makeBadOrdClozeCollection());
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(() =>
+        service.getCardsPage(parsed, 0, 10, 'http://example.com')
+      ).not.toThrow();
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/src/services/ApkgPreviewService/ApkgPreviewService.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.ts
@@ -128,10 +128,14 @@ export default class ApkgPreviewService {
       return null;
     }
     const templateOrd = noteType.type === 1 ? 0 : card.ord;
-    const template = noteType.templates.find((t) => t.ord === templateOrd);
+    const foundTemplate = noteType.templates.find((t) => t.ord === templateOrd);
+    const template = foundTemplate ?? noteType.templates[0];
     if (!template) {
-      console.warn(`[apkg-preview] card ${cardId}: template ord=${templateOrd} not found in noteType "${noteType.name}" (has ${noteType.templates.length} templates)`);
+      console.warn(`[apkg-preview] card ${cardId}: no templates in noteType "${noteType.name}" — skipping`);
       return null;
+    }
+    if (!foundTemplate) {
+      console.warn(`[apkg-preview] card ${cardId}: template ord=${templateOrd} not found in noteType "${noteType.name}" (has ${noteType.templates.length} templates) — rendering against ord=0`);
     }
     const deck = parsed.collection.decks.get(card.did);
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-21-apkg-cloze-preview-mismatched-templates.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-21-apkg-cloze-preview-mismatched-templates.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-21-apkg-cloze-preview-mismatched-templates",
+  "date": "2026-05-21",
+  "type": "fix",
+  "title": ".apkg preview shows every card in cloze decks even with mismatched template numbering"
+}


### PR DESCRIPTION
## Summary

- When a card's resolved `templateOrd` doesn't match any template in the noteType (e.g. a cloze noteType parsed as `type=0` with `card.ord=1` but only one template at `ord=0`), fall back to `templates[0]` and emit a `[apkg-preview]` warn log instead of dropping the card from the preview.
- Previously the preview silently returned `null` for the affected card, so users saw an incomplete deck preview from `.apkg` files where templates and cards disagree on ord numbering.
- If the noteType has no templates at all, the card is still skipped with a warn (unchanged — nothing to render against).

Closes #2543

## Test plan

- [x] `pnpm test src/services/ApkgPreviewService/ApkgPreviewService.test.ts` — 6 passing, including the new `ord-out-of-range fallback` block (renders both cards, emits warn, does not throw)
- [x] Drop a cloze-heavy `.apkg` on `/preview` in dev and confirm every card renders

Sonar local run: skipped — single-file 3-line behavior change with full test coverage; will re-run if CI surfaces a smell.

## Browser check
Browser check: not applicable — server-side service change. The only `web/src/` file is `web/src/pages/WhatsNewPage/changelog/2026-05-21-apkg-cloze-preview-mismatched-templates.json`, which is bypassed under the changelog-only rule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781992173&installation_id=132681956&pr_number=2563&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2563&signature=e634175497865b993e6111d4cc2405ea6d103111ad526222f6134e1cc3c337fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->