### PR TITLE
fix: photo-to-flashcards deck builder uses defensive template-dir join

### DIFF
--- a/create_deck/create_deck.py
+++ b/create_deck/create_deck.py
@@ -260,6 +260,10 @@ if __name__ == "__main__":
             run_batch(sys.argv[2], sys.argv[3])
             sys.exit(0)
 
+        if len(sys.argv) < 3:
+            print("usage: create_deck.py <deck_info.json> <template_dir>", file=sys.stderr)
+            sys.exit(1)
+
         DATA_FILE = sys.argv[1]
         TEMPLATE_DIR = sys.argv[2]
 

--- a/create_deck/helpers/read_template.py
+++ b/create_deck/helpers/read_template.py
@@ -1,6 +1,8 @@
 """
 Load template file
 """
+import os
+
 from .get_path_start import _path_start
 
 
@@ -13,7 +15,7 @@ def read_template(template_dir, path, fmt, value):
     :param value: value to use for replacement
     :return:
     """
-    file_path = path if path.startswith(_path_start()) else template_dir + path
+    file_path = path if path.startswith(_path_start()) else os.path.join(template_dir, path)
     with open(file_path, "r", encoding="utf-8") as file:
         if fmt and value:
             return file.read().replace(fmt, value)

--- a/create_deck/helpers/test_read_template.py
+++ b/create_deck/helpers/test_read_template.py
@@ -1,0 +1,38 @@
+"""
+Test that read_template resolves the file path correctly whether or not
+template_dir has a trailing separator.
+
+Regression guard for the path-concatenation bug where a missing trailing
+separator produced paths like '/abs/pathtemplatesfile.html' instead of
+'/abs/path/templates/file.html'.
+"""
+import os
+import tempfile
+
+import pytest
+
+from .read_template import read_template
+
+
+@pytest.fixture()
+def template_dir_with_file():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sample_path = os.path.join(tmpdir, "card_front.html")
+        with open(sample_path, "w", encoding="utf-8") as f:
+            f.write("hello {{Front}}")
+        yield tmpdir
+
+
+def test_read_template_with_trailing_separator(template_dir_with_file):
+    result = read_template(template_dir_with_file + os.sep, "card_front.html", None, None)
+    assert result == "hello {{Front}}"
+
+
+def test_read_template_without_trailing_separator(template_dir_with_file):
+    result = read_template(template_dir_with_file, "card_front.html", None, None)
+    assert result == "hello {{Front}}"
+
+
+def test_read_template_replacement(template_dir_with_file):
+    result = read_template(template_dir_with_file, "card_front.html", "{{Front}}", "Question")
+    assert result == "hello Question"


### PR DESCRIPTION
## Summary

- `read_template.py`: replace `template_dir + path` with `os.path.join(template_dir, path)` so callers without a trailing separator can no longer produce paths like `/abs/pathtemplatesfile.html`.
- `create_deck.py`: guard `sys.argv[2]` — when fewer than 3 argv are present, print a usage line to stderr and `exit(1)` instead of raising an uncaught `IndexError`.
- Add `helpers/test_read_template.py` covering trailing-separator, no-trailing-separator, and replacement call sites.
- All TS spawn sites already pass `TEMPLATE_DIR + path.sep` (confirmed by audit — only `PhotoToFlashcardsUseCase.ts:97` spawns `create_deck.py` in production TypeScript). This is defensive hardening against future drift and against the rare `IndexError` path observed in prod logs.

No changelog entry — defensive hardening with no user-visible behavior change. Failed uploads still fail; they just exit with a usage line instead of a Python traceback. Existing TS spawn sites are unchanged.

Closes #2544

## Test plan

- [x] python3 -m pytest create_deck/helpers/test_read_template.py -v — 3 passing
- [ ] Manually run a photo-to-deck upload in dev and confirm a successful conversion is unchanged

Sonar local run: skipped — python diff is outside Sonar's TS/JS analysis scope; no TS files changed in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781992291&installation_id=132681956&pr_number=2564&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2564&signature=ca15d1b1b372ab39143046bb768973aeb2f653c2263686588559f0302c144900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->