### PR TITLE
feat: simplify feedback widget to three reactions

### DIFF
--- a/web/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -7,10 +7,8 @@ import styles from './FeedbackWidget.module.css';
 type WidgetStatus = 'idle' | 'sending' | 'sent' | 'error';
 
 const EMOJIS = [
-  { label: 'Angry', emoji: '\u{1F620}' },
-  { label: 'Confused', emoji: '\u{1F615}' },
-  { label: 'Neutral', emoji: '\u{1F610}' },
-  { label: 'Happy', emoji: '\u{1F642}' },
+  { label: 'Enraged', emoji: '\u{1F621}' },
+  { label: 'Skeptical', emoji: '\u{1F928}' },
   { label: 'Love it', emoji: '\u{1F60D}' },
 ] as const;
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-simpler-feedback-widget.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-simpler-feedback-widget.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-simpler-feedback-widget",
+  "date": "2026-05-22",
+  "type": "style",
+  "title": "Feedback widget — three reactions: love it, skeptical, enraged"
+}


### PR DESCRIPTION
## Summary
- Collapses the 5-emoji feedback widget to 3 reactions: enraged (1), skeptical (2), love it (3).
- Same backend, same nudge ("Want to tell us more?" still fires on ratings ≤ 2).
- OpsPage chart and `DeckFeedbackPrompt` are unchanged — they keep the 1–5 range so historical responses still render with the right emoji.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes:

## Test plan
- [ ] Open the floating feedback widget, confirm three buttons render in order (enraged / skeptical / heart-eyes).
- [ ] Pick "enraged" — confirm the nudge link and comment box appear; submit.
- [ ] Pick "skeptical" — confirm the nudge still appears.
- [ ] Pick "love it" — confirm no nudge, comment box still optional, submit succeeds.
- [ ] Check OpsPage business tab still renders the bar chart with the old 5-emoji legend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782020890&installation_id=132681956&pr_number=2565&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2565&signature=fd971e01682bc9c31fc14cea20c90977d3b83196363a4656e1332558c7df7868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->