### PR TITLE
style: explain doc/docx heading rule on /upload

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -96,3 +96,12 @@ describe('UploadPage photo-to-deck entry', () => {
     expect(screen.getByTestId('photo-to-deck-entry-stub')).toBeInTheDocument();
   });
 });
+
+describe('UploadPage doc/docx hint', () => {
+  it('renders the doc and docx heading rule hint', () => {
+    renderPage();
+    expect(
+      screen.getByText(/Doc and docx: use headings for the front of each card, body text for the back\./i)
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -101,7 +101,7 @@ describe('UploadPage doc/docx hint', () => {
   it('renders the doc and docx heading rule hint', () => {
     renderPage();
     expect(
-      screen.getByText(/Doc and docx: use headings for the front of each card, body text for the back\./i)
+      screen.getByText(/Doc and docx: use headings for the front of each card, body text for the back\. Plain paragraphs become separate cards\./i)
     ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -91,6 +91,9 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
                   How to export from Notion
                 </a>
               </p>
+              <p className={pageStyles.stepBody}>
+                Doc and docx: use headings for the front of each card, body text for the back.
+              </p>
             </div>
           </div>
           <div className={pageStyles.step}>

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -92,7 +92,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
                 </a>
               </p>
               <p className={pageStyles.stepBody}>
-                Doc and docx: use headings for the front of each card, body text for the back.
+                Doc and docx: use headings for the front of each card, body text for the back. Plain paragraphs become separate cards.
               </p>
             </div>
           </div>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-doc-hint.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-doc-hint.json
@@ -1,0 +1,1 @@
+{"id":"2026-05-22-upload-doc-hint","date":"2026-05-22","type":"style","title":"Upload page now explains how doc and docx files become cards"}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-doc-hint.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-doc-hint.json
@@ -1,1 +1,1 @@
-{"id":"2026-05-22-upload-doc-hint","date":"2026-05-22","type":"style","title":"Upload page now explains how doc and docx files become cards"}
+{"id":"2026-05-22-upload-doc-hint","date":"2026-05-22","type":"style","title":"Doc and docx imports — headings become card fronts, body becomes the back"}


### PR DESCRIPTION
## What
Adds a one-line hint inside the "How it works" step 1 body on /upload explaining that in .doc/.docx files, headings become card fronts and body text becomes card backs.

## Why
A user asked for this rule to be documented after discovering it through trial and error. The hint prevents the same confusion for the next person uploading a Word file.

## How
Single extra `<p className={pageStyles.stepBody}>` appended after the format list in step 1 of the existing How it works disclosure. No new CSS, no new components — reuses the existing `stepBody` style.

## Measuring success
Zero support questions about doc/docx card splitting after the next deploy. Secondary: no regression in the 923-test vitest suite.

## Testing
- Unit tests added: one new `it` in `UploadPage.test.tsx` asserting the hint text is in the document.

## Browser check
Browser check: not applicable — pure copy addition with vitest coverage

## Changelog
"Upload page now explains how doc and docx files become cards" added to `web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-doc-hint.json`.

## Risks
None. No logic change — static copy inside an existing paragraph element.

## Goal alignment
Reduces friction for Word users converting notes. Fewer confused first-time users → better activation rate → moves toward 300K users.

## Notes
Sonar: skipped — single-line copy change, no logic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782021050&installation_id=132681956&pr_number=2566&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2566&signature=dec59889e16e5e92c1626215c3b675576f4c7101b4dc3fc16693b7cd6ad6dde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->