### PR TITLE
fix: align feedback widget ratings with /ops chart buckets

### DIFF
--- a/migrations/20260614000000_emoji_feedback_created_at_index.js
+++ b/migrations/20260614000000_emoji_feedback_created_at_index.js
@@ -1,0 +1,9 @@
+exports.up = (knex) =>
+  knex.schema.alterTable('emoji_feedback', (table) => {
+    table.index(['created_at'], 'emoji_feedback_created_at_idx');
+  });
+
+exports.down = (knex) =>
+  knex.schema.alterTable('emoji_feedback', (table) => {
+    table.dropIndex(['created_at'], 'emoji_feedback_created_at_idx');
+  });

--- a/web/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -7,9 +7,9 @@ import styles from './FeedbackWidget.module.css';
 type WidgetStatus = 'idle' | 'sending' | 'sent' | 'error';
 
 const EMOJIS = [
-  { label: 'Enraged', emoji: '\u{1F621}' },
-  { label: 'Skeptical', emoji: '\u{1F928}' },
-  { label: 'Love it', emoji: '\u{1F60D}' },
+  { label: 'Enraged', emoji: '\u{1F621}', value: 1 },
+  { label: 'Skeptical', emoji: '\u{1F928}', value: 2 },
+  { label: 'Love it', emoji: '\u{1F60D}', value: 5 },
 ] as const;
 
 interface FeedbackWidgetProps {
@@ -55,20 +55,17 @@ export function FeedbackWidget({
     <div className={compact ? styles.widgetCompact : styles.widget}>
       {!compact && <p className={styles.prompt}>How's your experience?</p>}
       <div className={styles.emojiRow}>
-        {EMOJIS.map((item, index) => {
-          const rating = index + 1;
-          return (
-            <button
-              key={rating}
-              type="button"
-              aria-label={item.label}
-              className={`${styles.emojiButton} ${selectedRating === rating ? styles.emojiSelected : ''}`}
-              onClick={() => setSelectedRating(rating)}
-            >
-              {item.emoji}
-            </button>
-          );
-        })}
+        {EMOJIS.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            aria-label={item.label}
+            className={`${styles.emojiButton} ${selectedRating === item.value ? styles.emojiSelected : ''}`}
+            onClick={() => setSelectedRating(item.value)}
+          >
+            {item.emoji}
+          </button>
+        ))}
       </div>
       {selectedRating != null && selectedRating <= 2 && (
         <p className={styles.nudge}>

--- a/web/src/pages/OpsPage/BusinessTab.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.tsx
@@ -125,6 +125,44 @@ export default function BusinessTab() {
 
       <section
         className={styles.section}
+        aria-labelledby="biz-section-emoji"
+      >
+        <header className={styles.sectionHeader}>
+          <h2 id="biz-section-emoji" className={styles.sectionTitle}>
+            Emoji feedback
+          </h2>
+          <p className={styles.sectionHint}>
+            Ratings and comments from the in-app emoji widget
+          </p>
+        </header>
+        <div className={styles.grid}>
+          <ChartPanel
+            title="Emoji feedback, last 30 days"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.emoji_feedback_ratings?.length ?? 0) === 0}
+            emptyText="No emoji feedback yet."
+          >
+            <EmojiFeedbackChart
+              points={visible?.emoji_feedback_ratings ?? []}
+            />
+          </ChartPanel>
+
+          <ChartPanel
+            title="Recent feedback comments"
+            subtitle="Latest text feedback from the emoji widget"
+            isLoading={showInitialSkeleton}
+            isEmpty={(visible?.emoji_feedback_comments?.length ?? 0) === 0}
+            emptyText="No feedback comments yet."
+          >
+            <EmojiFeedbackCommentsList
+              points={visible?.emoji_feedback_comments ?? []}
+            />
+          </ChartPanel>
+        </div>
+      </section>
+
+      <section
+        className={styles.section}
         aria-labelledby="biz-section-revenue"
       >
         <header className={styles.sectionHeader}>
@@ -251,44 +289,6 @@ export default function BusinessTab() {
           >
             <ReEngagementCommentsList
               points={visible?.reengagement_comments_recent ?? []}
-            />
-          </ChartPanel>
-        </div>
-      </section>
-
-      <section
-        className={styles.section}
-        aria-labelledby="biz-section-emoji"
-      >
-        <header className={styles.sectionHeader}>
-          <h2 id="biz-section-emoji" className={styles.sectionTitle}>
-            Emoji feedback
-          </h2>
-          <p className={styles.sectionHint}>
-            Ratings and comments from the in-app emoji widget
-          </p>
-        </header>
-        <div className={styles.grid}>
-          <ChartPanel
-            title="Emoji feedback, last 30 days"
-            isLoading={showInitialSkeleton}
-            isEmpty={(visible?.emoji_feedback_ratings?.length ?? 0) === 0}
-            emptyText="No emoji feedback yet."
-          >
-            <EmojiFeedbackChart
-              points={visible?.emoji_feedback_ratings ?? []}
-            />
-          </ChartPanel>
-
-          <ChartPanel
-            title="Recent feedback comments"
-            subtitle="Latest text feedback from the emoji widget"
-            isLoading={showInitialSkeleton}
-            isEmpty={(visible?.emoji_feedback_comments?.length ?? 0) === 0}
-            emptyText="No feedback comments yet."
-          >
-            <EmojiFeedbackCommentsList
-              points={visible?.emoji_feedback_comments ?? []}
             />
           </ChartPanel>
         </div>


### PR DESCRIPTION
## Summary
Follow-up to #2565. Fixes three issues with the simplified feedback widget and the `/ops/business` view of it.

- **Correctness.** Widget now submits ratings **1 / 2 / 5** (was 1 / 2 / 3). The `/ops/business` emoji chart and comments list hardcode rating 3 as 😐 neutral and rating 5 as 😍 love-it; under the old mapping every love-it press would have been displayed as a neutral face. Aligning to 5 also lines the widget up with `DeckFeedbackPrompt`, which already uses 5 for positive.
- **Placement.** `Emoji feedback` section moved above `Revenue & subscriptions` on the business tab so the customer-voice signal lands above the fold instead of after four full sections.
- **Speed.** Added an index on `emoji_feedback.created_at` — both DB queries on the page (`countByRating` with a 30-day filter, `recentComments` with `ORDER BY created_at DESC LIMIT 20`) currently full-scan + sort. The table is small today but will not stay small.

No changelog entry — internal correctness fix plus admin-only `/ops` change, no user-visible behavior change in the widget itself.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: maintainer-authorized merge — diff reviewed, /ops change is admin-only and emoji widget mapping change is invisible to users at the call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)