### PR TITLE
fix: clear fallback for Image Occlusion preview cards

### DIFF
--- a/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
@@ -1,6 +1,45 @@
 import ApkgPreviewService from './ApkgPreviewService';
 import { NormalizedCollection } from './types';
 
+const IO_TEMPLATE_QFMT =
+  '<div id="image-occlusion-container">{{Image}}<canvas id="image-occlusion-canvas"></canvas></div><script>anki.imageOcclusion.setup();</script>';
+
+function makeIoCollection(): NormalizedCollection {
+  const noteType = {
+    id: 1,
+    name: 'Image Occlusion',
+    type: 0 as const,
+    css: '.card { font-family: arial; }',
+    fields: [
+      { name: 'Occlusion', ord: 0 },
+      { name: 'Image', ord: 1 },
+      { name: 'Header', ord: 2 },
+    ],
+    templates: [
+      {
+        name: 'Image Occlusion',
+        ord: 0,
+        qfmt: IO_TEMPLATE_QFMT,
+        afmt: IO_TEMPLATE_QFMT,
+      },
+    ],
+  };
+
+  const note = {
+    id: 10,
+    mid: 1,
+    tags: '',
+    fields: ['[[oc1::shape]]', '<img src="study.png">', 'Chapter 1'],
+  };
+
+  return {
+    noteTypes: new Map([[1, noteType]]),
+    notes: new Map([[10, note]]),
+    decks: new Map([[2, { id: 2, name: 'Biology' }]]),
+    cards: [{ id: 100, nid: 10, did: 2, ord: 0 }],
+  };
+}
+
 function makeParsed(collection: NormalizedCollection) {
   return {
     collection,
@@ -154,6 +193,41 @@ describe('ApkgPreviewService.getCardsPage', () => {
         service.getCardsPage(parsed, 0, 10, 'http://example.com')
       ).not.toThrow();
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('Image Occlusion fallback', () => {
+    it('renders a fallback block instead of raw canvas markup', () => {
+      const parsed = makeParsed(makeIoCollection());
+      const result = service.getCardsPage(parsed, 0, 10, 'http://example.com');
+
+      expect(result.cards).toHaveLength(1);
+      expect(result.cards[0].front).toContain('Image Occlusion cards open with masks in Anki');
+    });
+
+    it('does not include <canvas> in the rendered output', () => {
+      const parsed = makeParsed(makeIoCollection());
+      const result = service.getCardsPage(parsed, 0, 10, 'http://example.com');
+
+      expect(result.cards[0].front).not.toContain('<canvas');
+      expect(result.cards[0].back).not.toContain('<canvas');
+    });
+
+    it('does not include <script> in the rendered output', () => {
+      const parsed = makeParsed(makeIoCollection());
+      const result = service.getCardsPage(parsed, 0, 10, 'http://example.com');
+
+      expect(result.cards[0].front).not.toContain('<script');
+      expect(result.cards[0].back).not.toContain('<script');
+    });
+
+    it('still includes the IO card in the deck list — does not drop it', () => {
+      const parsed = makeParsed(makeIoCollection());
+      const result = service.getCardsPage(parsed, 0, 10, 'http://example.com');
+
+      expect(result.total).toBe(1);
+      expect(result.cards).toHaveLength(1);
+      expect(result.cards[0].noteTypeName).toBe('Image Occlusion');
     });
   });
 });

--- a/src/services/ApkgPreviewService/ApkgPreviewService.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.ts
@@ -107,6 +107,31 @@ export default class ApkgPreviewService {
     };
   }
 
+  private isImageOcclusionTemplate(qfmt: string): boolean {
+    return qfmt.includes('image-occlusion-canvas');
+  }
+
+  private buildIoFallback(
+    card: { id: number; ord: number },
+    noteType: { name: string; css: string; templates: { name: string }[] },
+    deck: { id: number; name: string } | undefined
+  ): RenderedCard {
+    const fallback =
+      '<div class="apkg-preview-fallback">Image Occlusion cards open with masks in Anki. Download the deck to study them.</div>';
+    const deckPath = deck?.name ? deck.name.split('::') : [];
+    return {
+      id: card.id,
+      ord: card.ord,
+      templateName: noteType.templates[0]?.name ?? '',
+      deckName: deck?.name ?? '',
+      deckPath,
+      noteTypeName: noteType.name,
+      css: sanitizeCss(noteType.css),
+      front: fallback,
+      back: fallback,
+    };
+  }
+
   private renderCard(
     parsed: ParsedApkg,
     cardId: number,
@@ -138,6 +163,10 @@ export default class ApkgPreviewService {
       console.warn(`[apkg-preview] card ${cardId}: template ord=${templateOrd} not found in noteType "${noteType.name}" (has ${noteType.templates.length} templates) — rendering against ord=0`);
     }
     const deck = parsed.collection.decks.get(card.did);
+
+    if (this.isImageOcclusionTemplate(template.qfmt)) {
+      return this.buildIoFallback(card, noteType, deck);
+    }
 
     const activeClozeNumber = noteType.type === 1 ? card.ord + 1 : null;
     const frontFields =

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-io-preview-fallback.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-io-preview-fallback.json
@@ -1,0 +1,1 @@
+{"id":"2026-05-22-io-preview-fallback","date":"2026-05-22","type":"fix","title":"Image Occlusion preview now explains that masks render in Anki"}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-io-preview-fallback.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-io-preview-fallback.json
@@ -1,1 +1,1 @@
-{"id":"2026-05-22-io-preview-fallback","date":"2026-05-22","type":"fix","title":"Image Occlusion preview now explains that masks render in Anki"}
+{"id":"2026-05-22-io-preview-fallback","date":"2026-05-22","type":"fix","title":"Image Occlusion preview — download the deck to study the masks in Anki"}


### PR DESCRIPTION
## What
Image Occlusion cards in the apkg deck preview were displaying only a raw base image with no overlay and no explanation, because the preview sanitizer (correctly) strips `<canvas>` and `<script>`. Without context, users could not tell whether the preview was broken or the card was simply incomplete.

## Why
IO templates require Anki's JavaScript runtime to draw SVG mask shapes over a base image at review time. There is no static equivalent. Rather than silently rendering a misleading partial image, the preview now returns a plain fallback block that names the card type and directs the user to download the deck.

## How
Added `isImageOcclusionTemplate(qfmt)` — checks for the `image-occlusion-canvas` substring in the template front HTML, which is the most reliable marker (present in all IO note types regardless of what the user names the note type). Added `buildIoFallback()` which returns a `RenderedCard` with the fallback message in both `front` and `back`. The IO check fires before any rendering, so the sanitizer is never involved with IO cards.

The card is still returned and appears in the preview deck list — it is never silently dropped.

`sanitize.ts` is unchanged. No allowlist changes, no security regressions.

## Measuring success
Confirmed by the new regression tests in `ApkgPreviewService.test.ts`. In production: visiting the gallery preview for a deck containing IO cards should show the fallback message instead of a bare image. Server logs would show no `[apkg-preview]` warnings for IO cards.

## Testing
- Unit tests added: 4 new tests in `ApkgPreviewService.getCardsPage > Image Occlusion fallback`
  - Fallback block contains expected copy
  - Output contains no `<canvas>`
  - Output contains no `<script>`
  - IO card still appears in deck list (not dropped)
- All 34 tests pass

## Browser check
Browser check: not applicable — server-side preview output covered by ApkgPreviewService test

## Changelog
"Image Occlusion preview now explains that masks render in Anki" — added to `web/src/pages/WhatsNewPage/changelog/2026-05-22-io-preview-fallback.json`

## Risks
Only IO templates (those whose front template HTML contains `image-occlusion-canvas`) are affected. All other note types render as before.

## Goal alignment
Reduces user confusion for IO deck owners previewing their decks — a segment that uses 2anki as a distribution channel for pre-made decks. Clearer previews reduce support noise and improve trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782021518&installation_id=132681956&pr_number=2569&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2569&signature=2a616e5dfdb4f9ef6658dc9e698cd0ede1b8c53c274a12326e37e373ac53b459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->