### PR TITLE
fix: upload page lets you switch source without refresh

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -697,6 +697,21 @@
   margin: 0.75rem auto 0;
 }
 
+.changeSourceLink {
+  align-self: flex-start;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.changeSourceLink:hover {
+  color: var(--color-text-primary);
+}
+
 .panelHidden {
   display: none !important;
 }

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -327,6 +327,38 @@ describe('UploadForm analytics events', () => {
     process.env.REACT_APP_DROPBOX_APP_KEY = previousKey;
   });
 
+  it('shows a "Change source" button inside the Dropbox panel after selecting Dropbox', async () => {
+    const previousKey = process.env.REACT_APP_DROPBOX_APP_KEY;
+    process.env.REACT_APP_DROPBOX_APP_KEY = 'test-key';
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const dropboxChip = container.querySelector('button[aria-label="Dropbox"]') as HTMLButtonElement;
+    await act(async () => {
+      dropboxChip.click();
+    });
+    const changeBtn = container.querySelector('button[aria-label="Change upload source"]');
+    expect(changeBtn).not.toBeNull();
+    process.env.REACT_APP_DROPBOX_APP_KEY = previousKey;
+  });
+
+  it('clicking "Change source" in the Dropbox panel returns to the local panel', async () => {
+    const previousKey = process.env.REACT_APP_DROPBOX_APP_KEY;
+    process.env.REACT_APP_DROPBOX_APP_KEY = 'test-key';
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const dropboxChip = container.querySelector('button[aria-label="Dropbox"]') as HTMLButtonElement;
+    await act(async () => {
+      dropboxChip.click();
+    });
+    const changeBtn = container.querySelector('button[aria-label="Change upload source"]') as HTMLButtonElement;
+    await act(async () => {
+      changeBtn.click();
+    });
+    const localPanel = container.querySelector('#upload-panel-local')!;
+    const dropboxPanel = container.querySelector('#upload-panel-dropbox')!;
+    expect(localPanel.getAttribute('aria-hidden')).toBe('false');
+    expect(dropboxPanel.getAttribute('aria-hidden')).toBe('true');
+    process.env.REACT_APP_DROPBOX_APP_KEY = previousKey;
+  });
+
   it('does not fire conversion_success when the deck is empty', async () => {
     const gtag = (globalThis as AnalyticsGlobals).gtag!;
 

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1308,6 +1308,14 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
           aria-hidden={!showDropboxPanel}
         >
           <div className={formStyles.stateContent}>
+            <button
+              type="button"
+              className={formStyles.changeSourceLink}
+              aria-label="Change upload source"
+              onClick={() => setSource('local')}
+            >
+              ← Change source
+            </button>
             <DropboxIcon className={formStyles.dropboxIconLarge} />
             <span className={formStyles.dropText}>
               Pick a file from your Dropbox to convert it into a deck
@@ -1343,6 +1351,14 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
           aria-hidden={!showGoogleDrivePanel}
         >
           <div className={formStyles.stateContent}>
+            <button
+              type="button"
+              className={formStyles.changeSourceLink}
+              aria-label="Change upload source"
+              onClick={() => setSource('local')}
+            >
+              ← Change source
+            </button>
             <GoogleDriveIcon className={formStyles.dropboxIconLarge} />
             <span className={formStyles.dropText}>
               Pick a Doc, Sheet, Slide, or file from your Google Drive.

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-picker-back.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-picker-back.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-upload-picker-back",
+  "date": "2026-05-22",
+  "type": "fix",
+  "title": "Switch upload source without refreshing the page"
+}


### PR DESCRIPTION
## What
Adds a 'Change source' back button inside the Dropbox and Google Drive upload panels so users can return to the file/Notion source picker without refreshing the page.

## Why
A user reported that after clicking Dropbox or Google Drive in the upload source picker, there was no way to go back to the original source selection (local file, Notion, etc.) without a full page reload.

## How
Added a `changeSourceLink` button at the top of each remote-source panel (Dropbox and Google Drive) that calls `setSource('local')` when clicked. Styled to match the existing `resetLink` pattern — text-only underlined link, unobtrusive but discoverable. No structural changes to `UploadSourceChips.tsx` or the chip toggle logic (which already supported clicking the active chip to deselect it, but was not obviously discoverable).

## Measuring success
After deploy: zero support reports of needing to refresh after clicking Dropbox or Google Drive. The button renders at `button[aria-label="Change upload source"]` so it can be targeted in analytics if needed.

## Testing
- Unit tests added: 2 new tests in `UploadForm.test.tsx`
  - 'shows a "Change source" button inside the Dropbox panel after selecting Dropbox'
  - 'clicking "Change source" in the Dropbox panel returns to the local panel'
- All 29 `UploadForm.test.tsx` tests pass
- All 64 UploadForm-suite tests pass (5 test files)
- Server tsc: clean
- Web typecheck: clean
- Web lint (Biome): clean

## Browser check
Browser check: not applicable — dev server is not running in this environment; change is a straightforward button render in an existing panel with no conditional logic or new state

## Changelog
"Switch upload source without refreshing the page" — added to `web/src/pages/WhatsNewPage/changelog/2026-05-22-upload-picker-back.json`

## Risks
Minimal. The button only renders inside the Dropbox and Google Drive panels (already gated by `showChips && source === 'dropbox/google_drive'`). Clicking it calls `setSource('local')` which is already exercised by the existing chip toggle tests.

## Goal alignment
Reduces friction in the upload flow — users can switch sources without abandoning the page. Directly improves the convert-experience for users who accidentally select the wrong source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782021586&installation_id=132681956&pr_number=2570&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2570&signature=0ed947bdee6d3a2b99a993f5fb2d2bbfbc44ffbb440a271e13a532c4dc47db28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->