### PR TITLE
fix: collapse /ops emoji chart to three buckets

### DIFF
--- a/web/src/pages/OpsPage/charts/EmojiFeedbackChart.tsx
+++ b/web/src/pages/OpsPage/charts/EmojiFeedbackChart.tsx
@@ -22,12 +22,12 @@ import {
 } from './timeSeriesChartHelpers';
 
 const EMOJI_LABELS: Record<number, string> = {
-  1: '\u{1F620}',
-  2: '\u{1F615}',
-  3: '\u{1F610}',
-  4: '\u{1F642}',
+  1: '\u{1F621}',
+  2: '\u{1F928}',
   5: '\u{1F60D}',
 };
+
+const VISIBLE_RATINGS = [1, 2, 5] as const;
 
 interface ChartRow {
   label: string;
@@ -36,7 +36,7 @@ interface ChartRow {
 
 const buildRows = (points: EmojiFeedbackRatingPoint[]): ChartRow[] => {
   const map = new Map(points.map((p) => [p.rating, p.count]));
-  return [1, 2, 3, 4, 5].map((r) => ({
+  return VISIBLE_RATINGS.map((r) => ({
     label: EMOJI_LABELS[r] ?? String(r),
     count: map.get(r) ?? 0,
   }));

--- a/web/src/pages/OpsPage/charts/EmojiFeedbackCommentsList.tsx
+++ b/web/src/pages/OpsPage/charts/EmojiFeedbackCommentsList.tsx
@@ -2,10 +2,8 @@ import { EmojiFeedbackCommentPoint } from '../businessTypes';
 import styles from '../OpsPage.module.css';
 
 const EMOJI_LABELS: Record<number, string> = {
-  1: '\u{1F620}',
-  2: '\u{1F615}',
-  3: '\u{1F610}',
-  4: '\u{1F642}',
+  1: '\u{1F621}',
+  2: '\u{1F928}',
   5: '\u{1F60D}',
 };
 


### PR DESCRIPTION
## Summary
Follow-up to #2568. The `/ops/business` chart and comments list still showed five emojis (😠 😕 😐 🙂 😍) because I left the legend wide to preserve four days of legacy widget data. With the widget simplified to three reactions submitting ratings 1 / 2 / 5, buckets 3 and 4 are dead going forward.

- Chart now renders three bars: 😡 (1), 🤨 (2), 😍 (5). Pre-simplification rating-3 and rating-4 responses are dropped from the chart.
- Comments list emoji map updated to the same three; legacy rating-3 / rating-4 comments fall back to the numeric label via the existing `?? point.rating` branch.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: maintainer-authorized merge — /ops change is admin-only; diff reviewed and chart legend now matches the widget surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)