### PR TITLE
fix: mind map editor usability

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMindmapById, useUpdateMindmap, exportMindmap } from './useMindmap';
 import type { MindmapData } from './useMindmap';
+import styles from '../../styles/shared.module.css';
 
 const NODE_WIDTH = 172;
 const NODE_HEIGHT = 36;
@@ -110,34 +111,14 @@ function ExportModal({ defaultName, cardCount, onExport, onClose, exporting }: R
           {cardCount} {cardCount === 1 ? 'card' : 'cards'}
         </p>
         <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
-          <button
-            type="button"
-            onClick={onClose}
-            style={{
-              padding: '0.5rem 1rem',
-              background: 'transparent',
-              border: '1px solid var(--color-border)',
-              borderRadius: 'var(--radius-sm)',
-              cursor: 'pointer',
-              color: 'var(--color-text-secondary)',
-            }}
-          >
+          <button type="button" onClick={onClose} className={styles.btnSecondary}>
             Cancel
           </button>
           <button
             type="button"
             disabled={exporting || deckName.trim().length === 0}
             onClick={() => onExport(deckName.trim())}
-            style={{
-              padding: '0.5rem 1rem',
-              background: 'var(--color-primary)',
-              color: '#fff',
-              border: 'none',
-              borderRadius: 'var(--radius-sm)',
-              cursor: 'pointer',
-              fontWeight: 'var(--font-medium)',
-              opacity: exporting ? 0.7 : 1,
-            }}
+            className={`${styles.btnPrimary} ${styles.btnInline}`}
           >
             Download deck
           </button>
@@ -171,18 +152,25 @@ export function MindmapEditor() {
 
   useEffect(() => {
     if (map == null) return;
-    const rfNodes: Node[] = map.data.nodes.map((n) => ({
+    const nodeStyle = {
+      borderRadius: 'var(--radius-md)',
+      border: '1px solid var(--color-border)',
+      background: 'var(--color-bg-primary)',
+      boxShadow: 'var(--shadow-sm)',
+      padding: '0.5rem 1rem',
+      fontSize: 'var(--text-sm)',
+    };
+
+    const sourceNodes =
+      map.data.nodes.length > 0
+        ? map.data.nodes
+        : [{ id: crypto.randomUUID(), label: map.title || 'Untitled' }];
+
+    const rfNodes: Node[] = sourceNodes.map((n) => ({
       id: n.id,
       data: { label: n.label },
       position: { x: 0, y: 0 },
-      style: {
-        borderRadius: 'var(--radius-md)',
-        border: '1px solid var(--color-border)',
-        background: 'var(--color-bg-primary)',
-        boxShadow: 'var(--shadow-sm)',
-        padding: '0.5rem 1rem',
-        fontSize: 'var(--text-sm)',
-      },
+      style: nodeStyle,
     }));
     const rfEdges: Edge[] = map.data.edges.map((e) => ({
       id: `${e.source}-${e.target}`,
@@ -194,6 +182,9 @@ export function MindmapEditor() {
     const laidOut = layoutGraph(rfNodes, rfEdges);
     setNodes(laidOut);
     setEdges(rfEdges);
+    if (laidOut.length === 1) {
+      setSelectedNodeId(laidOut[0].id);
+    }
   }, [map, setNodes, setEdges]);
 
   const persistData = useCallback(
@@ -330,9 +321,20 @@ export function MindmapEditor() {
   }
 
   useEffect(() => {
+    function isEditableTarget(target: EventTarget | null): boolean {
+      if (!(target instanceof HTMLElement)) return false;
+      const tag = target.tagName;
+      return (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT' ||
+        target.isContentEditable
+      );
+    }
+
     function handleKeyDown(e: KeyboardEvent) {
       if (selectedNodeId == null) return;
-      if (e.target !== document.body) return;
+      if (isEditableTarget(e.target)) return;
 
       if (e.key === 'Tab') {
         e.preventDefault();
@@ -341,6 +343,7 @@ export function MindmapEditor() {
         e.preventDefault();
         addSiblingNode(selectedNodeId);
       } else if (e.key === 'Backspace') {
+        e.preventDefault();
         deleteNode(selectedNodeId);
       }
     }
@@ -381,14 +384,8 @@ export function MindmapEditor() {
         <button
           type="button"
           onClick={() => navigate('/mindmaps')}
-          style={{
-            marginTop: '1rem',
-            padding: '0.5rem 1rem',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-sm)',
-            cursor: 'pointer',
-            background: 'transparent',
-          }}
+          className={styles.btnSecondary}
+          style={{ marginTop: '1rem' }}
         >
           Back to Mind maps
         </button>
@@ -406,6 +403,7 @@ export function MindmapEditor() {
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           onNodeClick={(_e, node) => setSelectedNodeId(node.id)}
+          proOptions={{ hideAttribution: true }}
           fitView
         >
           <Controls />
@@ -451,16 +449,7 @@ export function MindmapEditor() {
           <button
             type="button"
             onClick={() => setShowExport(true)}
-            style={{
-              width: '100%',
-              padding: '0.75rem',
-              background: 'var(--color-primary)',
-              color: '#fff',
-              border: 'none',
-              borderRadius: 'var(--radius-md)',
-              cursor: 'pointer',
-              fontWeight: 'var(--font-medium)',
-            }}
+            className={styles.btnPrimary}
           >
             Download deck
           </button>

--- a/web/src/pages/MindmapsPage/MindmapLimitModal.tsx
+++ b/web/src/pages/MindmapsPage/MindmapLimitModal.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import styles from '../LimitPage/LimitPage.module.css';
+import sharedStyles from '../../styles/shared.module.css';
 
 interface MindmapLimitModalProps {
   onClose: () => void;
@@ -30,18 +31,7 @@ export function MindmapLimitModal({ onClose }: Readonly<MindmapLimitModalProps>)
         >
           Upgrade
         </Link>
-        <button
-          type="button"
-          onClick={onClose}
-          style={{
-            padding: '0.75rem 1.5rem',
-            background: 'transparent',
-            border: '1px solid var(--color-border)',
-            borderRadius: 'var(--radius-md)',
-            cursor: 'pointer',
-            color: 'var(--color-text-secondary)',
-          }}
-        >
+        <button type="button" onClick={onClose} className={sharedStyles.btnSecondary}>
           Not now
         </button>
       </div>

--- a/web/src/pages/MindmapsPage/MindmapList.tsx
+++ b/web/src/pages/MindmapsPage/MindmapList.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { MindmapLimitModal } from './MindmapLimitModal';
-import { useMindmapList, useDeleteMindmap } from './useMindmap';
+import { useMindmapList, useCreateMindmap, useDeleteMindmap } from './useMindmap';
 import styles from '../../styles/shared.module.css';
 
 export function MindmapList() {
+  const navigate = useNavigate();
   const { data, isLoading } = useMindmapList();
+  const createMindmap = useCreateMindmap();
   const deleteMindmap = useDeleteMindmap();
   const [showLimitModal, setShowLimitModal] = useState(false);
 
@@ -19,12 +21,15 @@ export function MindmapList() {
     !data.access.hasUnlimited &&
     data.access.currentCount >= data.access.freeMapLimit - 1;
 
-  function handleNewMap() {
+  async function handleNewMap() {
     if (atCap) {
       setShowLimitModal(true);
       return;
     }
-    window.location.href = '/mindmaps/new';
+    const created = await createMindmap.mutateAsync('Untitled');
+    if (created?.id != null) {
+      navigate(`/mindmaps/${created.id}`);
+    }
   }
 
   if (showLimitModal) {
@@ -142,15 +147,8 @@ export function MindmapList() {
           <button
             type="button"
             onClick={() => deleteMindmap.mutate(map.id)}
-            style={{
-              padding: '0.375rem 0.75rem',
-              background: 'transparent',
-              border: '1px solid var(--color-border)',
-              borderRadius: 'var(--radius-sm)',
-              cursor: 'pointer',
-              color: 'var(--color-text-secondary)',
-              fontSize: 'var(--text-sm)',
-            }}
+            className={styles.btnSecondary}
+            style={{ minHeight: 'auto', padding: '0.375rem 0.75rem', fontSize: 'var(--text-sm)' }}
           >
             Delete
           </button>


### PR DESCRIPTION
## What

Fixes four real-browser bugs in the mind map editor that prevented the feature from working as shipped in #2575.

## Why

After #2575 merged, opening `/mindmaps` and clicking **New map** produced an empty editor with no node to select, Tab moved focus instead of adding a child, and Cancel/Delete buttons were unreadable against the dark theme. The feature was unusable end-to-end.

## How

1. **New map button created nothing.** `handleNewMap` navigated to `/mindmaps/new` (a literal `new` as the id), so the editor then fetched a nonexistent map. Use `useCreateMindmap` to POST first, then navigate to the returned uuid.
2. **Empty maps had no root.** A brand-new map loaded with 0 nodes, so the user had nothing to Tab from. Seed a client-side root labelled with the map title when `data.nodes` is empty, and auto-select it so Tab works immediately.
3. **Tab / Enter / Backspace didn't fire.** The keydown handler bailed when `e.target !== document.body`, but after clicking the canvas the React Flow viewport div is the target. Replace the body check with an `isEditableTarget` guard so the handler runs on the canvas but stays out of inputs.
4. **Dark mode contrast.** The transparent + `--color-text-secondary` pattern on Cancel / Delete / Not now buttons was washed out on dark backgrounds. Switch to the existing `shared.module.css` `btnPrimary` and `btnSecondary` classes which carry the correct tokens for both modes.

Also hide the React Flow attribution via `proOptions.hideAttribution`.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test` — 927/927 pass
- No new tests written: these are visual/integration fixes that the existing browser smoke test would catch. The honor-system Browser check below is what verifies them.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify on localhost before merge — these fixes only matter if they work in a real browser. Flip the boxes after a smoke test (create a map, Tab to add children, Download deck, confirm dark mode looks right).

## Goal alignment

Simpler/faster/more beautiful: the editor now does what the UI says it does. Without these fixes the launched feature is broken on first contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782031400&installation_id=132681956&pr_number=2576&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2576&signature=ed1155920e764a30cc3c80612ed388435423f3d1c608135043ea59936a95eb11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->