### PR TITLE
feat: mind map node context menu

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -141,6 +141,7 @@ export function MindmapEditor() {
   const [exporting, setExporting] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string } | null>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -320,6 +321,37 @@ export function MindmapEditor() {
     persistData(laidOut, updatedEdges);
   }
 
+  function renameNode(nodeId: string) {
+    const node = nodes.find((n) => n.id === nodeId);
+    if (node == null) return;
+    const current = String(node.data.label ?? '');
+    const next = window.prompt('Rename node', current);
+    if (next == null) return;
+    const trimmed = next.trim();
+    if (trimmed.length === 0 || trimmed === current) return;
+    const updatedNodes = nodes.map((n) =>
+      n.id === nodeId ? { ...n, data: { ...n.data, label: trimmed } } : n
+    );
+    setNodes(updatedNodes);
+    persistData(updatedNodes, edges);
+  }
+
+  useEffect(() => {
+    if (contextMenu == null) return;
+    function close() {
+      setContextMenu(null);
+    }
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') close();
+    }
+    document.addEventListener('click', close);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('click', close);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [contextMenu]);
+
   useEffect(() => {
     function isEditableTarget(target: EventTarget | null): boolean {
       if (!(target instanceof HTMLElement)) return false;
@@ -403,6 +435,12 @@ export function MindmapEditor() {
           onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           onNodeClick={(_e, node) => setSelectedNodeId(node.id)}
+          onNodeDoubleClick={(_e, node) => renameNode(node.id)}
+          onNodeContextMenu={(e, node) => {
+            e.preventDefault();
+            setSelectedNodeId(node.id);
+            setContextMenu({ x: e.clientX, y: e.clientY, nodeId: node.id });
+          }}
           proOptions={{ hideAttribution: true }}
           fitView
         >
@@ -443,7 +481,8 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Tab — add child</p>
           <p style={{ margin: '0 0 0.25rem' }}>Enter — add sibling</p>
           <p style={{ margin: '0 0 0.25rem' }}>Backspace — delete</p>
-          <p style={{ margin: '0 0 0.25rem' }}>Double-click — edit label</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Double-click — rename</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu</p>
         </div>
         <div style={{ marginTop: 'auto' }}>
           <button
@@ -486,6 +525,100 @@ export function MindmapEditor() {
           {toast}
         </div>
       )}
+
+      {contextMenu != null && (
+        <div
+          role="menu"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: 'fixed',
+            top: contextMenu.y,
+            left: contextMenu.x,
+            background: 'var(--color-bg-primary)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-md)',
+            boxShadow: 'var(--shadow-md)',
+            padding: '0.25rem',
+            minWidth: '180px',
+            zIndex: 3000,
+          }}
+        >
+          <ContextMenuItem
+            label="Add child"
+            shortcut="Tab"
+            onSelect={() => {
+              addChildNode(contextMenu.nodeId);
+              setContextMenu(null);
+            }}
+          />
+          <ContextMenuItem
+            label="Add sibling"
+            shortcut="Enter"
+            onSelect={() => {
+              addSiblingNode(contextMenu.nodeId);
+              setContextMenu(null);
+            }}
+          />
+          <ContextMenuItem
+            label="Rename"
+            shortcut="Double-click"
+            onSelect={() => {
+              const nodeId = contextMenu.nodeId;
+              setContextMenu(null);
+              renameNode(nodeId);
+            }}
+          />
+          <ContextMenuItem
+            label="Delete"
+            shortcut="Backspace"
+            onSelect={() => {
+              deleteNode(contextMenu.nodeId);
+              setContextMenu(null);
+            }}
+          />
+        </div>
+      )}
     </div>
+  );
+}
+
+interface ContextMenuItemProps {
+  label: string;
+  shortcut: string;
+  onSelect: () => void;
+}
+
+function ContextMenuItem({ label, shortcut, onSelect }: Readonly<ContextMenuItemProps>) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onSelect}
+      style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        width: '100%',
+        padding: '0.5rem 0.75rem',
+        background: 'transparent',
+        border: 'none',
+        borderRadius: 'var(--radius-sm)',
+        color: 'var(--color-text-primary)',
+        fontSize: 'var(--text-sm)',
+        textAlign: 'left',
+        cursor: 'pointer',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = 'var(--color-bg-secondary)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'transparent';
+      }}
+    >
+      <span>{label}</span>
+      <span style={{ color: 'var(--color-text-secondary)', fontSize: 'var(--text-xs)', marginLeft: '1rem' }}>
+        {shortcut}
+      </span>
+    </button>
   );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mind-map-context-menu.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mind-map-context-menu.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mind-map-context-menu",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind map nodes — right-click for a menu, double-click to rename"
+}


### PR DESCRIPTION
## What

Right-click a mind map node to open a four-item context menu — Add child / Add sibling / Rename / Delete. Double-click a node to rename it.

## Why

The keyboard model (Tab/Enter/Backspace) is fast for power users but invisible to anyone who hasn't read the side-panel hints. Mouse-first users had no way to discover or trigger the actions. The side panel also advertised "Double-click — edit label" but the handler was never wired, so the docs lied.

## How

- `onNodeContextMenu` handler on `<ReactFlow>` — calls `preventDefault()` to suppress the browser's menu, selects the node, opens a positioned `<div role="menu">` at the click coords.
- Each menu item shows the action and its keyboard shortcut.
- Menu closes on click outside (document-level click listener) or Escape (document-level keydown listener), with cleanup on unmount.
- `onNodeDoubleClick` wired to a `renameNode` helper using `window.prompt` for v1. A future PR can replace this with an inline contentEditable; the prompt is good enough to honour the existing docs.
- Side panel hints updated: "Right-click — menu" added, "Double-click — rename" replaces the misleading "edit label" line.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test` — 927/927 pass
- No new tests written; this is interaction wiring better verified by browser smoke than by jsdom-mocked event simulation.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Open a map, right-click a node, exercise all four menu items. Double-click a node and rename it. Confirm Escape and click-outside close the menu. Try the canvas at 375px — context menu is irrelevant there (mobile fallback banner renders instead).

## Changelog

`Mind map nodes — right-click for a menu, double-click to rename` in `web/src/pages/WhatsNewPage/changelog/2026-05-22-mind-map-context-menu.json`.

## Risks

1. **`window.prompt` is browser-native and ugly** — it works, but a future iteration should swap to an inline editor. Logged as known follow-up.
2. **Context menu coordinates are `clientX/Y`** — fixed-positioned, ignores scroll. Editor is fixed-height (calc(100vh - 60px)) so scroll inside the canvas isn't a concern. If we add a scrollable wrapper in the future, switch to viewport-relative coords.

## Goal alignment

Simpler/faster: users who don't read the keyboard hints can still drive the editor. The discoverability gap was the most common path to "this doesn't work" in browser testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782031682&installation_id=132681956&pr_number=2577&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2577&signature=846a72583ba6071ee18358048dcfd48219aff262d3b674b686d1bf3be3225278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->