### PR TITLE
feat: cloze-per-path as default export for mind maps

### DIFF
--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -7,6 +7,7 @@ import { ListMindmapsUseCase } from '../usecases/mindmaps/ListMindmapsUseCase';
 import { GetMindmapUseCase } from '../usecases/mindmaps/GetMindmapUseCase';
 import {
   ExportMindmapUseCase,
+  MindmapCardType,
   MindmapNotFoundError,
 } from '../usecases/mindmaps/ExportMindmapUseCase';
 import { MindmapsId } from '../data_layer/public/Mindmaps';
@@ -134,9 +135,11 @@ export class MindmapController {
       req.body.deck_name.trim().length > 0
         ? req.body.deck_name.trim()
         : undefined;
+    const cardType: MindmapCardType =
+      req.body?.card_type === 'basic' ? 'basic' : 'cloze';
 
     try {
-      const buffer = await this.exportUseCase.execute({ id, userId, deckName });
+      const buffer = await this.exportUseCase.execute({ id, userId, deckName, cardType });
       const fileName = `${(deckName ?? id).replace(/[^a-zA-Z0-9._-]/g, '_')}.apkg`;
       res.setHeader('Content-Type', 'application/octet-stream');
       res.setHeader(

--- a/src/routes/MindmapRouter.test.ts
+++ b/src/routes/MindmapRouter.test.ts
@@ -141,22 +141,23 @@ describe('MindmapRouter', () => {
   });
 
   describe('POST /api/mindmaps/:id/export', () => {
+    const baseMap = {
+      id: 'export-id',
+      user_id: 42,
+      title: 'Test deck',
+      data: {
+        nodes: [
+          { id: '1', label: 'Parent' },
+          { id: '2', label: 'Child' },
+        ],
+        edges: [{ source: '1', target: '2' }],
+      },
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
     it('returns application/octet-stream', async () => {
-      const map = {
-        id: 'export-id',
-        user_id: 42,
-        title: 'Test deck',
-        data: {
-          nodes: [
-            { id: '1', label: 'Parent' },
-            { id: '2', label: 'Child' },
-          ],
-          edges: [{ source: '1', target: '2' }],
-        },
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      };
-      mockGetById.mockResolvedValue(map);
+      mockGetById.mockResolvedValue(baseMap);
 
       const res = await fetch(`${url}/api/mindmaps/export-id/export`, {
         method: 'POST',
@@ -166,6 +167,43 @@ describe('MindmapRouter', () => {
 
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toContain('application/octet-stream');
+    });
+
+    it('defaults to cloze card type when card_type is omitted', async () => {
+      mockGetById.mockResolvedValue(baseMap);
+
+      const res = await fetch(`${url}/api/mindmaps/export-id/export`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deck_name: 'Test deck' }),
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts card_type basic and returns a deck', async () => {
+      mockGetById.mockResolvedValue(baseMap);
+
+      const res = await fetch(`${url}/api/mindmaps/export-id/export`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deck_name: 'Test deck', card_type: 'basic' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/octet-stream');
+    });
+
+    it('treats unknown card_type as cloze', async () => {
+      mockGetById.mockResolvedValue(baseMap);
+
+      const res = await fetch(`${url}/api/mindmaps/export-id/export`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deck_name: 'Test deck', card_type: 'unknown' }),
+      });
+
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/src/usecases/mindmaps/ExportMindmapUseCase.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.ts
@@ -7,6 +7,7 @@ import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
 import { MindmapsId } from '../../data_layer/public/Mindmaps';
 import { UsersId } from '../../data_layer/public/Users';
 import { mindmapToNotes } from './mindmapToNotes';
+import { mindmapToClozeNotes } from './mindmapToClozeNotes';
 import { MindmapData } from './MindmapData';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
 
@@ -17,10 +18,13 @@ export class MindmapNotFoundError extends Error {
   }
 }
 
+export type MindmapCardType = 'basic' | 'cloze';
+
 interface ExportInput {
   id: MindmapsId;
   userId: UsersId;
   deckName?: string;
+  cardType?: MindmapCardType;
 }
 
 function randomDeckId(): number {
@@ -32,14 +36,17 @@ export class ExportMindmapUseCase {
   constructor(private readonly repo: MindmapRepositoryInterface) {}
 
   async execute(input: ExportInput): Promise<Buffer> {
-    const { id, userId, deckName } = input;
+    const { id, userId, deckName, cardType = 'cloze' } = input;
     const map = await this.repo.findById(id, userId);
     if (map == null) {
       throw new MindmapNotFoundError();
     }
 
     const resolvedDeckName = deckName ?? map.title;
-    const notes = mindmapToNotes(map.data as MindmapData);
+    const notes =
+      cardType === 'basic'
+        ? mindmapToNotes(map.data as MindmapData)
+        : mindmapToClozeNotes(map.data as MindmapData);
 
     const workspaceDir = path.join(os.tmpdir(), `mindmap-export-${randomUUID()}`);
     fs.mkdirSync(workspaceDir, { recursive: true });

--- a/src/usecases/mindmaps/mindmapToClozeNotes.test.ts
+++ b/src/usecases/mindmaps/mindmapToClozeNotes.test.ts
@@ -1,0 +1,114 @@
+import { mindmapToClozeNotes } from './mindmapToClozeNotes';
+
+describe('mindmapToClozeNotes', () => {
+  it('returns empty array for empty graph', () => {
+    const result = mindmapToClozeNotes({ nodes: [], edges: [] });
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array for disconnected nodes (no edges)', () => {
+    const result = mindmapToClozeNotes({
+      nodes: [
+        { id: '1', label: 'Root' },
+        { id: '2', label: 'Isolated' },
+      ],
+      edges: [],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('produces one cloze note for a single linear path root → A → B', () => {
+    const result = mindmapToClozeNotes({
+      nodes: [
+        { id: '1', label: 'Root' },
+        { id: '2', label: 'A' },
+        { id: '3', label: 'B' },
+      ],
+      edges: [
+        { source: '1', target: '2' },
+        { source: '2', target: '3' },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].cloze).toBe(true);
+    expect(result[0].name).toContain('{{c1::Root}}');
+    expect(result[0].name).toContain('{{c2::A}}');
+    expect(result[0].name).toContain('B');
+  });
+
+  it('produces one cloze note per leaf for a star graph (root → A, root → B)', () => {
+    const result = mindmapToClozeNotes({
+      nodes: [
+        { id: 'root', label: 'Anatomy' },
+        { id: 'a', label: 'Bone' },
+        { id: 'b', label: 'Muscle' },
+      ],
+      edges: [
+        { source: 'root', target: 'a' },
+        { source: 'root', target: 'b' },
+      ],
+    });
+    expect(result).toHaveLength(2);
+    for (const note of result) {
+      expect(note.cloze).toBe(true);
+      expect(note.name).toContain('{{c1::Anatomy}}');
+    }
+    const names = result.map((n) => n.name);
+    expect(names.some((n) => n.includes('Bone'))).toBe(true);
+    expect(names.some((n) => n.includes('Muscle'))).toBe(true);
+  });
+
+  it('clozifies every node except the leaf for a deep tree', () => {
+    const result = mindmapToClozeNotes({
+      nodes: [
+        { id: '1', label: 'Science' },
+        { id: '2', label: 'Biology' },
+        { id: '3', label: 'Genetics' },
+        { id: '4', label: 'DNA' },
+      ],
+      edges: [
+        { source: '1', target: '2' },
+        { source: '2', target: '3' },
+        { source: '3', target: '4' },
+      ],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].cloze).toBe(true);
+    expect(result[0].name).toContain('{{c1::Science}}');
+    expect(result[0].name).toContain('{{c2::Biology}}');
+    expect(result[0].name).toContain('{{c3::Genetics}}');
+    expect(result[0].name).toContain('DNA');
+    expect(result[0].name).not.toContain('{{c4::DNA}}');
+  });
+
+  it('produces valid cloze notes', () => {
+    const result = mindmapToClozeNotes({
+      nodes: [
+        { id: '1', label: 'Q' },
+        { id: '2', label: 'A' },
+      ],
+      edges: [{ source: '1', target: '2' }],
+    });
+    expect(result[0].isValidClozeNote()).toBeTruthy();
+  });
+
+  it('handles a branching tree: root → A → C, root → B', () => {
+    const result = mindmapToClozeNotes({
+      nodes: [
+        { id: 'r', label: 'Root' },
+        { id: 'a', label: 'A' },
+        { id: 'b', label: 'B' },
+        { id: 'c', label: 'C' },
+      ],
+      edges: [
+        { source: 'r', target: 'a' },
+        { source: 'r', target: 'b' },
+        { source: 'a', target: 'c' },
+      ],
+    });
+    expect(result).toHaveLength(2);
+    const names = result.map((n) => n.name);
+    expect(names.some((n) => n.includes('C'))).toBe(true);
+    expect(names.some((n) => n.includes('B'))).toBe(true);
+  });
+});

--- a/src/usecases/mindmaps/mindmapToClozeNotes.ts
+++ b/src/usecases/mindmaps/mindmapToClozeNotes.ts
@@ -1,0 +1,58 @@
+import Note from '../../lib/parser/Note';
+import { MindmapData } from './MindmapData';
+
+function buildChildMap(data: MindmapData): Map<string, string[]> {
+  const childMap = new Map<string, string[]>();
+  for (const node of data.nodes) {
+    childMap.set(node.id, []);
+  }
+  for (const edge of data.edges) {
+    const children = childMap.get(edge.source);
+    if (children != null) {
+      children.push(edge.target);
+    }
+  }
+  return childMap;
+}
+
+function findRoots(data: MindmapData): string[] {
+  const hasParent = new Set(data.edges.map((e) => e.target));
+  return data.nodes.map((n) => n.id).filter((id) => !hasParent.has(id));
+}
+
+function collectPaths(
+  nodeId: string,
+  childMap: Map<string, string[]>,
+  currentPath: string[]
+): string[][] {
+  const path = [...currentPath, nodeId];
+  const children = childMap.get(nodeId) ?? [];
+  if (children.length === 0) {
+    return [path];
+  }
+  return children.flatMap((childId) => collectPaths(childId, childMap, path));
+}
+
+export function mindmapToClozeNotes(data: MindmapData): Note[] {
+  if (data.nodes.length === 0 || data.edges.length === 0) {
+    return [];
+  }
+
+  const nodeMap = new Map<string, string>(data.nodes.map((n) => [n.id, n.label]));
+  const childMap = buildChildMap(data);
+  const roots = findRoots(data);
+
+  const allPaths = roots.flatMap((root) => collectPaths(root, childMap, []));
+  const leafPaths = allPaths.filter((path) => path.length >= 2);
+
+  return leafPaths.map((path) => {
+    const parts = path.map((id, index) => {
+      const label = nodeMap.get(id) ?? id;
+      const isLeaf = index === path.length - 1;
+      return isLeaf ? label : `{{c${index + 1}::${label}}}`;
+    });
+    const note = new Note(parts.join(' → '), '');
+    note.cloze = true;
+    return note;
+  });
+}

--- a/web/src/pages/DocsPage/content/cards/mind-maps.md
+++ b/web/src/pages/DocsPage/content/cards/mind-maps.md
@@ -3,7 +3,7 @@ title: Mind maps
 description: Build a tree in your browser and download it as an Anki deck.
 ---
 
-The mind map editor at [2anki.net/mindmaps](https://2anki.net/mindmaps) lets you sketch a hierarchy in your browser — topics, sub-topics, nested concepts — and export it as a `.apkg` deck. Each edge in the map becomes one flashcard: the parent node is the front, the child node is the back.
+The mind map editor at [2anki.net/mindmaps](https://2anki.net/mindmaps) lets you sketch a hierarchy in your browser — topics, sub-topics, nested concepts — and export it as a `.apkg` deck. The export modal lets you choose between two card types before downloading.
 
 **Plan:** Free accounts can have 3 saved maps and 50 nodes per map. Auto-Sync ($30/mo) and Patreon lifetime give unlimited maps and nodes.
 
@@ -27,6 +27,27 @@ The mind map editor at [2anki.net/mindmaps](https://2anki.net/mindmaps) lets you
 
 ## How cards are generated
 
+The export modal offers two card types. **Cloze** is the default.
+
+### Cloze (default)
+
+Each root-to-leaf path becomes one cloze card. Every node along the path — except the final leaf — is wrapped in a cloze deletion. The leaf is the context anchor that ties the path together.
+
+A map with root **Science → Biology → Genetics** produces one card:
+```
+{{c1::Science}} → {{c2::Biology}} → Genetics
+```
+
+A star map — **Anatomy → Bone** and **Anatomy → Muscle** — produces two cards:
+```
+{{c1::Anatomy}} → Bone
+{{c1::Anatomy}} → Muscle
+```
+
+The card count shown in the modal equals the number of leaf nodes (nodes with no children).
+
+### Basic
+
 Each **edge** (parent → child connection) becomes one Basic card: the parent label is the front, the child label is the back.
 
 A simple star map — one root with three children — produces three cards:
@@ -34,7 +55,9 @@ A simple star map — one root with three children — produces three cards:
 - Root → Child B
 - Root → Child C
 
-A deeper tree produces one card per connection. Nodes with no edges (isolated nodes) do not produce cards.
+A deeper tree produces one card per connection. The card count shown equals the number of edges.
+
+Nodes with no edges (isolated nodes) produce no cards in either mode.
 
 ## Free-tier limits
 

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -13,7 +13,7 @@ import {
 import dagre from 'dagre';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useMindmapById, useUpdateMindmap, exportMindmap } from './useMindmap';
+import { useMindmapById, useUpdateMindmap, exportMindmap, type MindmapCardType } from './useMindmap';
 import type { MindmapData } from './useMindmap';
 import styles from '../../styles/shared.module.css';
 
@@ -45,14 +45,17 @@ function layoutGraph(nodes: Node[], edges: Edge[]): Node[] {
 
 interface ExportModalProps {
   defaultName: string;
-  cardCount: number;
-  onExport: (deckName: string) => void;
+  basicCardCount: number;
+  clozeCardCount: number;
+  onExport: (deckName: string, cardType: MindmapCardType) => void;
   onClose: () => void;
   exporting: boolean;
 }
 
-function ExportModal({ defaultName, cardCount, onExport, onClose, exporting }: Readonly<ExportModalProps>) {
+function ExportModal({ defaultName, basicCardCount, clozeCardCount, onExport, onClose, exporting }: Readonly<ExportModalProps>) {
   const [deckName, setDeckName] = useState(defaultName);
+  const [cardType, setCardType] = useState<MindmapCardType>('cloze');
+  const cardCount = cardType === 'basic' ? basicCardCount : clozeCardCount;
 
   return (
     <div
@@ -100,6 +103,44 @@ function ExportModal({ defaultName, cardCount, onExport, onClose, exporting }: R
             boxSizing: 'border-box',
           }}
         />
+        <fieldset
+          style={{
+            border: 'none',
+            padding: 0,
+            margin: '0 0 0.75rem',
+          }}
+        >
+          <legend
+            style={{
+              fontSize: 'var(--text-sm)',
+              color: 'var(--color-text-secondary)',
+              marginBottom: '0.5rem',
+              padding: 0,
+            }}
+          >
+            Card type
+          </legend>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.25rem', fontSize: 'var(--text-sm)', cursor: 'pointer' }}>
+            <input
+              type="radio"
+              name="card-type"
+              value="cloze"
+              checked={cardType === 'cloze'}
+              onChange={() => setCardType('cloze')}
+            />
+            Cloze — one card per path, each node clozed in sequence
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: 'var(--text-sm)', cursor: 'pointer' }}>
+            <input
+              type="radio"
+              name="card-type"
+              value="basic"
+              checked={cardType === 'basic'}
+              onChange={() => setCardType('basic')}
+            />
+            Basic — one card per edge (parent → child)
+          </label>
+        </fieldset>
         <p
           style={{
             fontSize: 'var(--text-sm)',
@@ -117,7 +158,7 @@ function ExportModal({ defaultName, cardCount, onExport, onClose, exporting }: R
           <button
             type="button"
             disabled={exporting || deckName.trim().length === 0}
-            onClick={() => onExport(deckName.trim())}
+            onClick={() => onExport(deckName.trim(), cardType)}
             className={`${styles.btnPrimary} ${styles.btnInline}`}
           >
             Download deck
@@ -378,13 +419,18 @@ export function MindmapEditor() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   });
 
-  const cardCount = edges.length;
+  const basicCardCount = edges.length;
+  const leafNodeIds = new Set(nodes.map((n) => n.id));
+  for (const edge of edges) {
+    leafNodeIds.delete(edge.source);
+  }
+  const clozeCardCount = leafNodeIds.size;
 
-  async function handleExport(deckName: string) {
+  async function handleExport(deckName: string, cardType: MindmapCardType) {
     if (id == null) return;
     setExporting(true);
     try {
-      const blob = await exportMindmap(id, deckName);
+      const blob = await exportMindmap(id, deckName, cardType);
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -493,7 +539,8 @@ export function MindmapEditor() {
       {showExport && (
         <ExportModal
           defaultName={map?.title ?? 'My deck'}
-          cardCount={cardCount}
+          basicCardCount={basicCardCount}
+          clozeCardCount={clozeCardCount}
           onExport={handleExport}
           onClose={() => setShowExport(false)}
           exporting={exporting}

--- a/web/src/pages/MindmapsPage/useMindmap.ts
+++ b/web/src/pages/MindmapsPage/useMindmap.ts
@@ -87,12 +87,18 @@ export function useDeleteMindmap() {
   });
 }
 
-export async function exportMindmap(id: string, deckName: string): Promise<Blob> {
+export type MindmapCardType = 'basic' | 'cloze';
+
+export async function exportMindmap(
+  id: string,
+  deckName: string,
+  cardType: MindmapCardType = 'cloze'
+): Promise<Blob> {
   const response = await fetch(`/api/mindmaps/${id}/export`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ deck_name: deckName }),
+    body: JSON.stringify({ deck_name: deckName, card_type: cardType }),
   });
   if (!response.ok) {
     throw new Error(`Export failed: ${response.statusText}`);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-cloze-default.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-cloze-default.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-cloze-default",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind map exports default to cloze cards — one card per path, each node tested in sequence"
+}


### PR DESCRIPTION
Closes #2580.

## What

Adds a `mindmapToClozeNotes` generator that walks every root-to-leaf path and produces one cloze card per path with intermediate nodes wrapped in `{{c1::}}` / `{{c2::}}` markers. Pipes `cardType` (`'basic' | 'cloze'`) through the export controller and use case. Flips the export modal default from Basic to Cloze.

## Why

The v1 risk flagged at trio review: shallow stars produced N context-free Basic cards. Cloze-per-path gives the parent label as front context with each step in the chain clozed out, which matches how learners drill hierarchies.

## How

- New pure function `src/usecases/mindmaps/mindmapToClozeNotes.ts` + tests (star, deep tree, empty, disconnected).
- `ExportMindmapUseCase.execute` now takes `cardType: 'basic' | 'cloze'`, defaulting to `cloze`. Dispatches to the right generator.
- `MindmapController` reads `card_type` from the request body.
- Web export modal: new radio group (Cloze / Basic), default `cloze`. The card-count display switches between basic and cloze counts as the user changes the radio.
- Docs updated at `web/src/pages/DocsPage/content/cards/mind-maps.md` — describes both modes and calls cloze the default.

## Testing

- `npx tsc --noEmit -p .` — clean
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm test src/usecases/mindmaps/` — 120 tests pass (23 suites)

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Open a map, click Download deck, confirm Cloze is preselected, export a small tree, open the .apkg in Anki, confirm cloze cards render. Try Basic toggle, confirm it still produces the old shape.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-cloze-default.json`.

## Risks

- Touches `MindmapEditor.tsx`, conflicts likely with #2586 (inline rename). Inline rename merges first → cloze rebase should be straightforward (different parts of the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782033693&installation_id=132681956&pr_number=2587&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2587&signature=42aa5a54c2084a52d96ef30573eb2c27d61d8f54e8a447745be61af9521e210e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->