### PR TITLE
feat: editable mind map title + double-click canvas to add node

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -192,6 +192,7 @@ export function MindmapEditor() {
   const [toast, setToast] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string } | null>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -200,6 +201,18 @@ export function MindmapEditor() {
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  useEffect(() => {
+    if (titleRef.current != null && document.activeElement !== titleRef.current) {
+      titleRef.current.innerText = map?.title ?? 'Untitled';
+    }
+  }, [map?.title]);
+
+  function commitTitle(text: string) {
+    const trimmed = text.trim();
+    if (trimmed.length === 0 || trimmed === (map?.title ?? '')) return;
+    updateMindmap.mutate({ title: trimmed });
+  }
 
   useEffect(() => {
     if (map == null) return;
@@ -490,7 +503,18 @@ export function MindmapEditor() {
 
   return (
     <div style={{ display: 'flex', height: 'calc(100vh - 60px)' }}>
-      <div style={{ flex: 1, position: 'relative' }}>
+      <div
+        style={{ flex: 1, position: 'relative' }}
+        onDoubleClick={(e) => {
+          const target = e.target as HTMLElement;
+          if (target.closest('.react-flow__node') != null) return;
+          if (target.closest('.react-flow__handle') != null) return;
+          if (target.closest('.react-flow__controls') != null) return;
+          const parentId = selectedNodeId ?? nodes[0]?.id;
+          if (parentId == null) return;
+          addChildNode(parentId);
+        }}
+      >
         <ReactFlow
           nodes={nodes}
           edges={edges}
@@ -524,10 +548,38 @@ export function MindmapEditor() {
         }}
       >
         <h2
+          ref={titleRef}
+          contentEditable
+          suppressContentEditableWarning
+          spellCheck={false}
+          title="Click to rename"
+          onBlur={(e) => {
+            const text = e.currentTarget.innerText;
+            if (text.trim().length === 0) {
+              e.currentTarget.innerText = map?.title ?? 'Untitled';
+              return;
+            }
+            commitTitle(text);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.currentTarget.blur();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              e.currentTarget.innerText = map?.title ?? 'Untitled';
+              e.currentTarget.blur();
+            }
+            e.stopPropagation();
+          }}
           style={{
             fontSize: 'var(--text-lg)',
             fontWeight: 'var(--font-semibold)',
-            margin: 0,
+            margin: '-0.125rem -0.25rem',
+            padding: '0.125rem 0.25rem',
+            borderRadius: 'var(--radius-sm)',
+            outline: 'none',
+            cursor: 'text',
           }}
         >
           {map?.title ?? 'Untitled'}
@@ -545,7 +597,8 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Tab — add child</p>
           <p style={{ margin: '0 0 0.25rem' }}>Enter — add sibling</p>
           <p style={{ margin: '0 0 0.25rem' }}>Backspace — delete</p>
-          <p style={{ margin: '0 0 0.25rem' }}>Double-click / F2 — rename</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Double-click / F2 — rename node</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Double-click canvas — add node</p>
           <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu</p>
         </div>
         <div style={{ marginTop: 'auto' }}>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-editor-discoverability.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-editor-discoverability.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-editor-discoverability",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind maps — rename a map by clicking the title, add a node by double-clicking the canvas"
+}


### PR DESCRIPTION
## What

Two small editor-discoverability fixes prompted by browser testing of the mind maps feature.

1. **Editable map title.** The side-panel h2 is now `contentEditable`. Click it, type a new name, Enter (or click out) commits via `PATCH /api/mindmaps/:id`. Escape reverts. Empty value snaps back to the previous title.

2. **Double-click canvas to add a node.** Double-clicking anywhere on the canvas background (not on a node, handle, or controls) adds a child to the currently selected node — or to the root if no selection. The existing double-click-a-node-to-rename gesture is preserved.

## Why

Before this PR, every saved map showed as 'Untitled' because nothing in the UI ever wrote a new title. Backend supported it; UI just never wired it up. Caught immediately on real-browser testing.

Double-click-canvas closes the discoverability gap for mouse-first users: until now the only way to add a node was Tab on a selected node (keyboard) or the right-click context menu. The most intuitive gesture — double-click on empty canvas — did nothing.

## How

- New `titleRef`, `useEffect` to sync `map.title` into the h2 when the element is not focused (lets external updates flow in without interrupting typing), `commitTitle` helper that calls `updateMindmap.mutate({ title })`.
- h2 gets `contentEditable`, `suppressContentEditableWarning`, an `onBlur` that commits (or restores on empty), and an `onKeyDown` that handles Enter (commit) and Escape (revert).
- Canvas wrapper div gets `onDoubleClick`. Handler skips when the target is inside `.react-flow__node`, `.react-flow__handle`, or `.react-flow__controls`, then calls `addChildNode(selectedNodeId ?? rootId)`.
- Side-panel hints add two lines: `Double-click canvas — add node` and the existing `Double-click / F2 — rename node` is clarified to say "node".

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass
- Author note: no new tests for the editor gestures specifically — these are interaction wiring better verified by browser smoke.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Click the title in the right panel, rename, press Enter — confirm the title persists on refresh. Try Escape and click-out behavior. Double-click empty canvas with a node selected — confirm a child appears. Double-click a node — confirm rename still fires (no double-action).

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-editor-discoverability.json`

## Risks

- contentEditable + React is famously fiddly. The useEffect guards against re-rendering over the user's caret by checking `document.activeElement !== titleRef.current` before setting innerText. Edge cases like browser autocorrect or paste-with-newlines aren't specifically handled — falling back to "user can re-type" is acceptable.
- Double-click handler runs on the wrapper div, so any future custom React Flow panel (legend, minimap) inside that div would receive the double-click too. The `closest()` check on `.react-flow__*` catches the common cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782034585&installation_id=132681956&pr_number=2589&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2589&signature=ad8217998c44c69467f716b99568e777c10152863ef3d3f9a35ea6f08b45b5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->