### PR TITLE
feat: mind map — persist positions, Tidy layout opt-in

### DIFF
--- a/src/usecases/mindmaps/MindmapData.ts
+++ b/src/usecases/mindmaps/MindmapData.ts
@@ -1,4 +1,4 @@
 export interface MindmapData {
-  nodes: Array<{ id: string; label: string }>;
+  nodes: Array<{ id: string; label: string; position?: { x: number; y: number } }>;
   edges: Array<{ source: string; target: string }>;
 }

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -235,11 +235,13 @@ export function MindmapEditor() {
   useEffect(() => {
     if (map == null) return;
 
+    const someHasPosition = map.data.nodes.some((n) => n.position != null);
+
     const rfNodes: Node[] = map.data.nodes.map((n) => ({
       id: n.id,
       type: 'mindmap',
       data: { label: n.label },
-      position: { x: 0, y: 0 },
+      position: n.position ?? { x: 0, y: 0 },
       style: NODE_STYLE,
     }));
     const rfEdges: Edge[] = map.data.edges.map((e) => ({
@@ -249,11 +251,11 @@ export function MindmapEditor() {
       style: { stroke: 'var(--color-border)' },
     }));
 
-    const laidOut = layoutGraph(rfNodes, rfEdges);
-    setNodes(laidOut);
+    const initialNodes = someHasPosition ? rfNodes : layoutGraph(rfNodes, rfEdges);
+    setNodes(initialNodes);
     setEdges(rfEdges);
-    if (laidOut.length === 1) {
-      setSelectedNodeId(laidOut[0].id);
+    if (initialNodes.length === 1) {
+      setSelectedNodeId(initialNodes[0].id);
     }
   }, [map, setNodes, setEdges]);
 
@@ -262,7 +264,11 @@ export function MindmapEditor() {
       if (saveTimer.current != null) clearTimeout(saveTimer.current);
       saveTimer.current = setTimeout(() => {
         const data: MindmapData = {
-          nodes: ns.map((n) => ({ id: n.id, label: String(n.data.label ?? '') })),
+          nodes: ns.map((n) => ({
+            id: n.id,
+            label: String(n.data.label ?? ''),
+            position: { x: n.position.x, y: n.position.y },
+          })),
           edges: es.map((e) => ({ source: e.source, target: e.target })),
         };
         updateMindmap.mutate({ data });
@@ -346,7 +352,7 @@ export function MindmapEditor() {
       target: newId,
       style: { stroke: 'var(--color-border)' },
     };
-    const updatedNodes = layoutGraph([...nodes, newNode], [...edges, newEdge]);
+    const updatedNodes = [...nodes, newNode];
     const updatedEdges = [...edges, newEdge];
     setNodes(updatedNodes);
     setEdges(updatedEdges);
@@ -388,11 +394,10 @@ export function MindmapEditor() {
             },
           ];
 
-    const laidOut = layoutGraph(updatedNodes, updatedEdges);
-    setNodes(laidOut);
+    setNodes(updatedNodes);
     setEdges(updatedEdges);
     setSelectedNodeId(newId);
-    persistData(laidOut, updatedEdges);
+    persistData(updatedNodes, updatedEdges);
   }
 
   function deleteNode(nodeId: string) {
@@ -407,11 +412,10 @@ export function MindmapEditor() {
     const updatedEdges = edges.filter(
       (e) => e.source !== nodeId && e.target !== nodeId
     );
-    const laidOut = layoutGraph(updatedNodes, updatedEdges);
-    setNodes(laidOut);
+    setNodes(updatedNodes);
     setEdges(updatedEdges);
     setSelectedNodeId(null);
-    persistData(laidOut, updatedEdges);
+    persistData(updatedNodes, updatedEdges);
   }
 
   function startRename(nodeId: string) {
@@ -420,6 +424,15 @@ export function MindmapEditor() {
         n.id === nodeId ? { ...n, data: { ...n.data, editing: true } } : n
       )
     );
+  }
+
+  function handleTidy() {
+    if (nodes.length === 0) return;
+    const laidOut = layoutGraph(nodes, edges);
+    setNodes(laidOut);
+    persistData(laidOut, edges);
+    rfInstance?.fitView({ duration: 300 });
+    showToast('Layout updated');
   }
 
   function createNodeAt(position: { x: number; y: number }, parentId?: string | null) {
@@ -482,8 +495,15 @@ export function MindmapEditor() {
     }
 
     function handleKeyDown(e: KeyboardEvent) {
-      if (selectedNodeId == null) return;
       if (isEditableTarget(e.target)) return;
+
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'l') {
+        e.preventDefault();
+        handleTidy();
+        return;
+      }
+
+      if (selectedNodeId == null) return;
 
       if (e.key === 'Tab') {
         e.preventDefault();
@@ -590,6 +610,7 @@ export function MindmapEditor() {
           }}
           onNodeClick={(_e, node) => setSelectedNodeId(node.id)}
           onNodeDoubleClick={(_e, node) => startRename(node.id)}
+          onNodeDragStop={() => persistData(nodes, edges)}
           onNodeContextMenu={(e, node) => {
             e.preventDefault();
             setSelectedNodeId(node.id);
@@ -616,6 +637,28 @@ export function MindmapEditor() {
           <Controls />
           <Background />
         </ReactFlow>
+        <button
+          type="button"
+          onClick={handleTidy}
+          title="Tidy layout (Ctrl/Cmd+L)"
+          style={{
+            position: 'absolute',
+            right: '1rem',
+            bottom: '1rem',
+            zIndex: 4,
+            padding: '0.5rem 0.875rem',
+            background: 'var(--color-bg-primary)',
+            color: 'var(--color-text-primary)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-md)',
+            boxShadow: 'var(--shadow-sm)',
+            cursor: 'pointer',
+            fontSize: 'var(--text-sm)',
+            fontWeight: 'var(--font-medium)',
+          }}
+        >
+          Tidy layout
+        </button>
       </div>
       <div
         style={{
@@ -710,6 +753,7 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Double-click canvas — add node here</p>
           <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu (node or canvas)</p>
           <p style={{ margin: '0 0 0.25rem' }}>Drag from a node — connect or branch</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Ctrl/Cmd+L — tidy layout</p>
         </div>
         <div style={{ marginTop: 'auto' }}>
           <button

--- a/web/src/pages/MindmapsPage/useMindmap.ts
+++ b/web/src/pages/MindmapsPage/useMindmap.ts
@@ -4,6 +4,7 @@ import { get, post, patch, del } from '../../lib/backend/api';
 export interface MindmapNode {
   id: string;
   label: string;
+  position?: { x: number; y: number };
 }
 
 export interface MindmapEdge {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-tidy-layout.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-tidy-layout.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-tidy-layout",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind maps — drag nodes anywhere and they stay there; Tidy layout button (Ctrl/Cmd+L) re-arranges on demand"
+}


### PR DESCRIPTION
## What

Dagre auto-layout no longer runs on every state change. Positions are stored per node and survive reload. A floating **Tidy layout** button (Ctrl/Cmd+L) re-runs dagre on demand and fits the view.

## Why

Real-browser testing surfaced that nodes "moved on their own" — every Tab, Enter, or delete kicked off a fresh dagre pass and overrode positions the user had placed. Worse, dragged positions were never persisted at all; they died on reload. Obsidian Canvas does 100% user-placed positioning with no auto-layout; this PR brings us closer to that model while keeping dagre as an opt-in recovery tool.

## How

- `MindmapData.nodes` gains an optional `position: { x, y }` field (server + client type files in sync).
- `MindmapEditor` loader uses stored positions when any node has one. Falls back to a single dagre pass when ALL nodes are positionless (legacy maps).
- `addChildNode`, `addSiblingNode`, `deleteNode` no longer call `layoutGraph`. New nodes spawn at parent ± offset; deletion just filters.
- `onNodeDragStop` calls `persistData(nodes, edges)` so dragged positions are saved.
- `persistData` now includes `position` in each node it saves.
- New `handleTidy` runs `layoutGraph` once, persists, and calls `rfInstance.fitView({ duration: 300 })`. Bound to a floating button (bottom-right of canvas) and Ctrl/Cmd+L.
- Side panel hint added: `Ctrl/Cmd+L — tidy layout`.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass
- `pnpm test src/usecases/mindmaps/ --testPathIgnorePatterns=mindmapToMarkmapHtml` — 31 pass
- Markmap export tests fail with `Cannot find module 'markmap-view/dist/browser/index.js'` — pre-existing on main, tracked in #2593, unrelated to this PR.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Open a map, drag nodes around, refresh — positions stick. Press Ctrl/Cmd+L — dagre re-layouts and view fits. Click the Tidy button — same. Add a child via Tab — appears at parent+offset (no global reshuffle).

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-tidy-layout.json`

## Risks

- Legacy maps (created before this PR) have no stored positions. The first load runs dagre once; the user's first drag then persists the positions. No data migration needed.
- The Tidy button overlaps the `<Controls />` cluster (bottom-left vs bottom-right). No collision at default canvas sizes, but a narrow viewport could put them close. Acceptable for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782036962&installation_id=132681956&pr_number=2596&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2596&signature=7eba4d72baab75c376ec406a982b2c61a7522c673251c49b83d502d07f2b5788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->