### PR TITLE
feat: mind map — 4-way handles, drag-end auto-creates, snap-to-grid

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -10,6 +10,7 @@ import {
   type Connection,
   type ReactFlowInstance,
   Background,
+  ConnectionMode,
 } from '@xyflow/react';
 import dagre from 'dagre';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -208,7 +209,7 @@ export function MindmapEditor() {
   const [exporting, setExporting] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string | null; flowX?: number; flowY?: number; connectFrom?: string } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string | null; flowX?: number; flowY?: number } | null>(null);
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -503,6 +504,18 @@ export function MindmapEditor() {
         return;
       }
 
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+        e.preventDefault();
+        setNodes((ns) => ns.map((n) => ({ ...n, selected: true })));
+        return;
+      }
+
+      if (e.key === 'Escape') {
+        setNodes((ns) => ns.map((n) => ({ ...n, selected: false })));
+        setSelectedNodeId(null);
+        return;
+      }
+
       if (selectedNodeId == null) return;
 
       if (e.key === 'Tab') {
@@ -599,14 +612,7 @@ export function MindmapEditor() {
             if (fromNodeId == null) return;
             const mouse = 'changedTouches' in e ? e.changedTouches[0] : (e as MouseEvent);
             const flow = rfInstance.screenToFlowPosition({ x: mouse.clientX, y: mouse.clientY });
-            setContextMenu({
-              x: mouse.clientX,
-              y: mouse.clientY,
-              nodeId: null,
-              flowX: flow.x,
-              flowY: flow.y,
-              connectFrom: fromNodeId,
-            });
+            createNodeAt(flow, fromNodeId);
           }}
           onNodeClick={(_e, node) => setSelectedNodeId(node.id)}
           onNodeDoubleClick={(_e, node) => startRename(node.id)}
@@ -632,6 +638,9 @@ export function MindmapEditor() {
             });
           }}
           proOptions={{ hideAttribution: true }}
+          connectionMode={ConnectionMode.Loose}
+          snapToGrid
+          snapGrid={[20, 20]}
           fitView
         >
           <Controls />
@@ -752,7 +761,9 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Double-click / F2 — rename node</p>
           <p style={{ margin: '0 0 0.25rem' }}>Double-click canvas — add node here</p>
           <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu (node or canvas)</p>
-          <p style={{ margin: '0 0 0.25rem' }}>Drag from a node — connect or branch</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Drag from a node — new connected node</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Ctrl/Cmd+A — select all</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Esc — clear selection</p>
           <p style={{ margin: '0 0 0.25rem' }}>Ctrl/Cmd+L — tidy layout</p>
         </div>
         <div style={{ marginTop: 'auto' }}>
@@ -824,37 +835,13 @@ export function MindmapEditor() {
               onDelete={(id) => { deleteNode(id); setContextMenu(null); }}
             />
           )}
-          {contextMenu.nodeId == null && contextMenu.connectFrom != null && (
-            <>
-              <ContextMenuItem
-                label="Add connected node"
-                shortcut=""
-                onSelect={() => {
-                  if (contextMenu.flowX != null && contextMenu.flowY != null) {
-                    createNodeAt({ x: contextMenu.flowX, y: contextMenu.flowY }, contextMenu.connectFrom ?? null);
-                  }
-                  setContextMenu(null);
-                }}
-              />
-              <ContextMenuItem
-                label="Add disconnected node"
-                shortcut=""
-                onSelect={() => {
-                  if (contextMenu.flowX != null && contextMenu.flowY != null) {
-                    createNodeAt({ x: contextMenu.flowX, y: contextMenu.flowY }, null);
-                  }
-                  setContextMenu(null);
-                }}
-              />
-            </>
-          )}
-          {contextMenu.nodeId == null && contextMenu.connectFrom == null && (
+          {contextMenu.nodeId == null && (
             <ContextMenuItem
               label="Add node here"
               shortcut="Double-click"
               onSelect={() => {
                 if (contextMenu.flowX != null && contextMenu.flowY != null) {
-                  createNodeAt({ x: contextMenu.flowX, y: contextMenu.flowY }, selectedNodeId);
+                  createNodeAt({ x: contextMenu.flowX, y: contextMenu.flowY }, null);
                 }
                 setContextMenu(null);
               }}

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -37,7 +37,9 @@ export function MindmapNode({ data }: NodeProps) {
 
   return (
     <>
-      <Handle type="target" position={Position.Left} />
+      <Handle type="source" position={Position.Left} id="left" />
+      <Handle type="source" position={Position.Top} id="top" />
+      <Handle type="source" position={Position.Bottom} id="bottom" />
       {nodeData.editing ? (
         <input
           ref={inputRef}
@@ -61,7 +63,7 @@ export function MindmapNode({ data }: NodeProps) {
           {nodeData.label}
         </span>
       )}
-      <Handle type="source" position={Position.Right} />
+      <Handle type="source" position={Position.Right} id="right" />
     </>
   );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-canvas-polish.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-canvas-polish.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-canvas-polish",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind maps — drag from any side to connect, snap-to-grid alignment, drag-end auto-creates a connected node"
+}


### PR DESCRIPTION
## What

Five small Obsidian-inspired UX improvements to the mind map canvas.

1. **Drag from any side** — nodes have handles on top, right, bottom, and left. `connectionMode=Loose` lets any handle connect to any handle. Previously you could only drag right → left.
2. **Drag-end auto-creates a connected node** — drag from a handle, release on empty pane, new node spawns at the release point connected to the source. Lands in edit mode. The two-option menu we shipped in #2594 is gone; the gesture is unambiguous, so the menu was friction.
3. **Snap-to-grid (20px)** — `snapToGrid` + `snapGrid={[20, 20]}` props on `<ReactFlow>`. Free positions look aligned without dagre.
4. **Cmd/Ctrl+A select all.**
5. **Escape clears selection** (rename inside a node still handled by the node component itself).

## Why

Real-browser testing surfaced: only horizontal connections possible (top/bottom handles missing); drag-end menu was an extra click on an unambiguous gesture; free-positioned nodes looked messy without snap; no bulk select. All four were called out in the Obsidian Canvas research as table-stakes affordances we were missing.

## How

- `MindmapNode.tsx`: four handles, all `type="source"`, with explicit `id="left|top|right|bottom"`. Works as both source and target under loose connection mode.
- `MindmapEditor.tsx`:
  - Imports `ConnectionMode` from `@xyflow/react`, sets `connectionMode={ConnectionMode.Loose}`.
  - Adds `snapToGrid` + `snapGrid={[20, 20]}`.
  - `onConnectEnd` now calls `createNodeAt(flow, fromNodeId)` directly instead of opening the context menu.
  - Drops the `connectFrom` field from `contextMenu` state and removes the "Add connected / disconnected" menu branch.
  - Keyboard handler: Cmd/Ctrl+A marks all nodes `selected: true`; Escape clears selection.
- Side-panel hints updated.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Drag from any side of a node to any side of another — connects. Drag and release on empty pane — new connected node appears under cursor in edit mode. Drag a node — snaps to 20px grid. Ctrl/Cmd+A — all nodes outlined as selected. Esc — clears selection.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-canvas-polish.json`

## Risks

- `ConnectionMode.Loose` allows multi-edges between the same two nodes (just dragging in different directions). For our edge → card semantics this could produce duplicate cards. Out of scope for this PR; track as a follow-up if a user reports it.
- Existing maps had implicit Left/Right handles. New maps using top/bottom handles will save edges with `sourceHandle` / `targetHandle` populated. The export pipeline doesn't read those fields, so no impact on .apkg output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782037269&installation_id=132681956&pr_number=2597&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2597&signature=1e23ebc759b494bd13a85e985d3828fd3033fb8dfe257e479ee69da16bb033ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->