### PR TITLE
feat: remove mind map connections via right-click or Backspace

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -209,7 +209,7 @@ export function MindmapEditor() {
   const [exporting, setExporting] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string | null; flowX?: number; flowY?: number } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string | null; edgeId?: string; flowX?: number; flowY?: number } | null>(null);
   const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -324,6 +324,20 @@ export function MindmapEditor() {
     },
     [nodes, setEdges, persistData]
   );
+
+  const onEdgesDelete = useCallback(
+    (deleted: Edge[]) => {
+      const remaining = edges.filter((e) => !deleted.some((d) => d.id === e.id));
+      persistData(nodes, remaining);
+    },
+    [nodes, edges, persistData]
+  );
+
+  function deleteEdge(edgeId: string) {
+    const updatedEdges = edges.filter((e) => e.id !== edgeId);
+    setEdges(updatedEdges);
+    persistData(nodes, updatedEdges);
+  }
 
   function showToast(msg: string) {
     setToast(msg);
@@ -604,7 +618,12 @@ export function MindmapEditor() {
           onInit={setRfInstance}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
+          onEdgesDelete={onEdgesDelete}
           onConnect={onConnect}
+          onEdgeContextMenu={(e, edge) => {
+            e.preventDefault();
+            setContextMenu({ x: e.clientX, y: e.clientY, nodeId: null, edgeId: edge.id });
+          }}
           onConnectEnd={(e, connectionState) => {
             if (connectionState.toNode != null) return;
             if (rfInstance == null) return;
@@ -760,7 +779,7 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Backspace — delete</p>
           <p style={{ margin: '0 0 0.25rem' }}>Double-click / F2 — rename node</p>
           <p style={{ margin: '0 0 0.25rem' }}>Double-click canvas — add node here</p>
-          <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu (node or canvas)</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu (node, edge, or canvas)</p>
           <p style={{ margin: '0 0 0.25rem' }}>Drag from a node — new connected node</p>
           <p style={{ margin: '0 0 0.25rem' }}>Ctrl/Cmd+A — select all</p>
           <p style={{ margin: '0 0 0.25rem' }}>Esc — clear selection</p>
@@ -826,7 +845,19 @@ export function MindmapEditor() {
             zIndex: 3000,
           }}
         >
-          {contextMenu.nodeId != null && (
+          {contextMenu.edgeId != null && (
+            <ContextMenuItem
+              label="Remove connection"
+              shortcut="Backspace"
+              onSelect={() => {
+                if (contextMenu.edgeId != null) {
+                  deleteEdge(contextMenu.edgeId);
+                }
+                setContextMenu(null);
+              }}
+            />
+          )}
+          {contextMenu.edgeId == null && contextMenu.nodeId != null && (
             <NodeContextMenu
               nodeId={contextMenu.nodeId}
               onAddChild={(id) => { addChildNode(id); setContextMenu(null); }}
@@ -835,7 +866,7 @@ export function MindmapEditor() {
               onDelete={(id) => { deleteNode(id); setContextMenu(null); }}
             />
           )}
-          {contextMenu.nodeId == null && (
+          {contextMenu.edgeId == null && contextMenu.nodeId == null && (
             <ContextMenuItem
               label="Add node here"
               shortcut="Double-click"

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-edge-deletion.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-edge-deletion.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-edge-deletion",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind maps — right-click an edge to remove the connection; Backspace on a selected edge also saves"
+}


### PR DESCRIPTION
## What

Edge deletion in the mind map editor, two ways:

1. **Right-click an edge → "Remove connection"** in the context menu.
2. **Click an edge to select it, press Backspace** — React Flow's default edge-delete fires, the change now persists.

## Why

You asked "how do I remove a connection?" — the honest answer was you couldn't, cleanly. The only previous path was to delete one of the connected nodes (which also removed the node). React Flow's built-in Backspace technically removed the edge from local state but `onEdgesChange` ran through the bare reducer so the change never reached the DB.

## How

- New `onEdgesDelete` callback on `<ReactFlow>` → filters local edges against the deleted list and calls `persistData`. Catches the Backspace path.
- New `onEdgeContextMenu` handler → opens the existing context menu with an `edgeId` payload.
- New `deleteEdge(edgeId)` helper → drops the edge and persists. Used by the right-click menu item.
- `contextMenu` state gains `edgeId?: string`. Render branches guard against `edgeId` so the right-click on an edge doesn't accidentally fire the pane/node branches.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Right-click an edge — menu appears with "Remove connection". Click an edge, press Backspace — edge disappears, persists on reload.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-edge-deletion.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782037428&installation_id=132681956&pr_number=2598&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2598&signature=843fe4d759a65d4ddd4af25e9c2138bdb694b9f7193516aca03b412887725a21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->