### PR TITLE
feat: selected-node toolbar (rename, center, color, delete)

### DIFF
--- a/src/usecases/mindmaps/MindmapData.ts
+++ b/src/usecases/mindmaps/MindmapData.ts
@@ -1,4 +1,9 @@
 export interface MindmapData {
-  nodes: Array<{ id: string; label: string; position?: { x: number; y: number } }>;
+  nodes: Array<{
+    id: string;
+    label: string;
+    position?: { x: number; y: number };
+    color?: string | null;
+  }>;
   edges: Array<{ source: string; target: string }>;
 }

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -241,9 +241,9 @@ export function MindmapEditor() {
     const rfNodes: Node[] = map.data.nodes.map((n) => ({
       id: n.id,
       type: 'mindmap',
-      data: { label: n.label },
+      data: { label: n.label, color: n.color ?? null },
       position: n.position ?? { x: 0, y: 0 },
-      style: NODE_STYLE,
+      style: n.color == null ? NODE_STYLE : { ...NODE_STYLE, borderColor: n.color, boxShadow: `0 0 0 1px ${n.color}` },
     }));
     const rfEdges: Edge[] = map.data.edges.map((e) => ({
       id: `${e.source}-${e.target}`,
@@ -269,6 +269,7 @@ export function MindmapEditor() {
             id: n.id,
             label: String(n.data.label ?? ''),
             position: { x: n.position.x, y: n.position.y },
+            color: (n.data as { color?: string | null }).color ?? null,
           })),
           edges: es.map((e) => ({ source: e.source, target: e.target })),
         };
@@ -298,6 +299,28 @@ export function MindmapEditor() {
     );
   }, [setNodes]);
 
+  const centerOnNode = useCallback((nodeId: string) => {
+    rfInstance?.fitView({ nodes: [{ id: nodeId }], duration: 300, maxZoom: 1.2 });
+  }, [rfInstance]);
+
+  const setNodeColor = useCallback((nodeId: string, color: string | null) => {
+    setNodes((ns) => {
+      const updated = ns.map((n) =>
+        n.id === nodeId
+          ? {
+              ...n,
+              data: { ...n.data, color },
+              style: color == null
+                ? NODE_STYLE
+                : { ...NODE_STYLE, borderColor: color, boxShadow: `0 0 0 1px ${color}` },
+            }
+          : n
+      );
+      persistData(updated, edges);
+      return updated;
+    });
+  }, [setNodes, persistData, edges]);
+
   const nodeTypes = useMemo(
     () => ({
       mindmap: (props: Parameters<typeof MindmapNode>[0]) => (
@@ -307,11 +330,15 @@ export function MindmapEditor() {
             ...props.data,
             onCommit: (label: string) => commitLabel(props.id, label),
             onCancel: () => cancelEdit(props.id),
+            onStartRename: () => startRename(props.id),
+            onCenter: () => centerOnNode(props.id),
+            onSetColor: (color: string | null) => setNodeColor(props.id, color),
+            onDelete: () => deleteNode(props.id),
           }}
         />
       ),
     }),
-    [commitLabel, cancelEdit]
+    [commitLabel, cancelEdit, centerOnNode, setNodeColor, startRename, deleteNode]
   );
 
   const onConnect = useCallback(

--- a/web/src/pages/MindmapsPage/MindmapNode.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.test.tsx
@@ -4,7 +4,9 @@ import { MindmapNode } from './MindmapNode';
 
 vi.mock('@xyflow/react', () => ({
   Handle: () => null,
-  Position: { Left: 'left', Right: 'right' },
+  NodeToolbar: ({ children, isVisible }: { children: React.ReactNode; isVisible?: boolean }) =>
+    isVisible ? children : null,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
 }));
 
 function makeProps(overrides: Partial<{

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -1,17 +1,67 @@
-import { useEffect, useRef } from 'react';
-import { Handle, Position, type NodeProps } from '@xyflow/react';
+import { useEffect, useRef, useState } from 'react';
+import { Handle, NodeToolbar, Position, type NodeProps } from '@xyflow/react';
+import PencilIcon from '../../components/icons/PencilIcon';
+import TrashIcon from '../../components/icons/TrashIcon';
+import SwatchIcon from '../../components/icons/SwatchIcon';
 
 export interface MindmapNodeData {
   label: string;
   editing?: boolean;
+  color?: string | null;
   onCommit?: (label: string) => void;
   onCancel?: () => void;
+  onStartRename?: () => void;
+  onCenter?: () => void;
+  onSetColor?: (color: string | null) => void;
+  onDelete?: () => void;
   [key: string]: unknown;
 }
 
-export function MindmapNode({ data }: NodeProps) {
+const COLOR_PRESETS: Array<{ name: string; value: string | null }> = [
+  { name: 'Default', value: null },
+  { name: 'Blue', value: '#3b82f6' },
+  { name: 'Green', value: '#10b981' },
+  { name: 'Amber', value: '#f59e0b' },
+  { name: 'Red', value: '#ef4444' },
+  { name: 'Purple', value: '#8b5cf6' },
+];
+
+const toolbarButtonStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: 'transparent',
+  border: 'none',
+  borderRadius: 'var(--radius-sm)',
+  padding: '0.25rem',
+  cursor: 'pointer',
+  color: 'var(--color-text-primary)',
+  width: '28px',
+  height: '28px',
+};
+
+function CenterIcon({ width = 16, height = 16 }: Readonly<{ width?: number; height?: number }>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v3M12 18v3M3 12h3M18 12h3" />
+    </svg>
+  );
+}
+
+export function MindmapNode({ data, selected }: NodeProps) {
   const nodeData = data as MindmapNodeData;
   const inputRef = useRef<HTMLInputElement>(null);
+  const [colorPickerOpen, setColorPickerOpen] = useState(false);
 
   useEffect(() => {
     if (nodeData.editing && inputRef.current != null) {
@@ -19,6 +69,10 @@ export function MindmapNode({ data }: NodeProps) {
       inputRef.current.select();
     }
   }, [nodeData.editing]);
+
+  useEffect(() => {
+    if (!selected) setColorPickerOpen(false);
+  }, [selected]);
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     e.stopPropagation();
@@ -37,6 +91,87 @@ export function MindmapNode({ data }: NodeProps) {
 
   return (
     <>
+      <NodeToolbar
+        isVisible={selected === true && nodeData.editing !== true}
+        position={Position.Top}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: '0.25rem',
+            background: 'var(--color-bg-primary)',
+            border: '1px solid var(--color-border)',
+            borderRadius: 'var(--radius-md)',
+            boxShadow: 'var(--shadow-md)',
+            padding: '0.25rem',
+          }}
+        >
+          <div style={{ display: 'flex', gap: '0.125rem' }}>
+            <button
+              type="button"
+              title="Rename"
+              aria-label="Rename"
+              onClick={() => nodeData.onStartRename?.()}
+              style={toolbarButtonStyle}
+            >
+              <PencilIcon width={16} height={16} />
+            </button>
+            <button
+              type="button"
+              title="Center on this node"
+              aria-label="Center on this node"
+              onClick={() => nodeData.onCenter?.()}
+              style={toolbarButtonStyle}
+            >
+              <CenterIcon />
+            </button>
+            <button
+              type="button"
+              title="Color"
+              aria-label="Color"
+              onClick={() => setColorPickerOpen((o) => !o)}
+              style={toolbarButtonStyle}
+            >
+              <SwatchIcon width={16} height={16} />
+            </button>
+            <button
+              type="button"
+              title="Delete"
+              aria-label="Delete"
+              onClick={() => nodeData.onDelete?.()}
+              style={{ ...toolbarButtonStyle, color: '#ef4444' }}
+            >
+              <TrashIcon width={16} height={16} />
+            </button>
+          </div>
+          {colorPickerOpen && (
+            <div style={{ display: 'flex', gap: '0.25rem', padding: '0.25rem' }}>
+              {COLOR_PRESETS.map((c) => (
+                <button
+                  key={c.name}
+                  type="button"
+                  title={c.name}
+                  aria-label={c.name}
+                  onClick={() => {
+                    nodeData.onSetColor?.(c.value);
+                    setColorPickerOpen(false);
+                  }}
+                  style={{
+                    width: '20px',
+                    height: '20px',
+                    borderRadius: '50%',
+                    border: '1px solid var(--color-border)',
+                    background: c.value ?? 'var(--color-bg-secondary)',
+                    cursor: 'pointer',
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </NodeToolbar>
       <Handle type="source" position={Position.Left} id="left" />
       <Handle type="source" position={Position.Top} id="top" />
       <Handle type="source" position={Position.Bottom} id="bottom" />

--- a/web/src/pages/MindmapsPage/useMindmap.ts
+++ b/web/src/pages/MindmapsPage/useMindmap.ts
@@ -5,6 +5,7 @@ export interface MindmapNode {
   id: string;
   label: string;
   position?: { x: number; y: number };
+  color?: string | null;
 }
 
 export interface MindmapEdge {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-node-toolbar.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-node-toolbar.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-node-toolbar",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind maps — selected nodes show a toolbar with rename, center, color, and delete"
+}


### PR DESCRIPTION
## What

A floating toolbar appears above the selected mind map node with four actions:

- **Rename** (pencil) — flips the node into inline edit mode.
- **Center** (crosshair) — `fitView` focuses on this node with `maxZoom: 1.2`.
- **Color** (swatch) — opens a 6-swatch picker: Default, Blue, Green, Amber, Red, Purple. Sets the node's border color + matching shadow ring. Default clears.
- **Delete** (trash) — removes the node and cascades its edges.

## Why

Mouse-first users currently need to know the keyboard shortcuts (F2, Backspace) or the right-click menu (which only some users discover). A persistent toolbar surfaces the actions without requiring discovery. Matches the Figma/Whimsical/Obsidian pattern.

## Trio caveat — colors

The trio recommended skipping color. PM: "doesn't map to an Anki card." Designer: same. Shipping anyway per your explicit ask. Implementation is purely visual: `color: string | null` is stored on the node and renders as the border, but `mindmapToNotes` / `mindmapToClozeNotes` / `mindmapToMarkmapTree` all use only `id` and `label` — the apkg output is unchanged regardless of color choice.

## How

- `MindmapData.nodes` gains optional `color?: string | null` (server + client types in sync).
- `MindmapNode.tsx` renders `<NodeToolbar>` (React Flow primitive) when `selected === true && editing !== true`. Toolbar buttons call new optional callbacks on `data`: `onStartRename`, `onCenter`, `onSetColor`, `onDelete`.
- `MindmapEditor.tsx` injects the callbacks via the `nodeTypes` wrapper. Two new helpers:
  - `centerOnNode(id)` — `rfInstance.fitView({ nodes: [{ id }], duration: 300, maxZoom: 1.2 })`.
  - `setNodeColor(id, color)` — updates the node's data + style, persists.
- Loader applies the saved color as `borderColor` + `boxShadow` ring.
- `persistData` includes `color` per node.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass (test mock for `@xyflow/react` extended with `NodeToolbar` + `Position.Top/Bottom`)

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Click a node — toolbar appears above. Click each button: rename (input opens inline), center (canvas zooms to the node), color → pick a swatch (node border tints), delete (node and edges gone). Click off — toolbar hides.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-node-toolbar.json`

## Risks

- The toolbar may overlap nodes positioned near the top of the canvas. React Flow's `NodeToolbar` defaults to top placement — if the user pans so a node sits at the very top, the toolbar would clip out of view. Acceptable for v1; React Flow auto-flips placement on collision in some versions, behavior to verify in browser.
- Adding `color` to MindmapData is a schema growth, not a migration — existing maps' nodes get `color: null` on first re-save. No backfill needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782037762&installation_id=132681956&pr_number=2599&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2599&signature=bca39b73a8b661e9be87de33397dfc85db99a399aa6026dc3b50d4a07656dd6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->