### PR TITLE
feat: mind map — markdown labels, resizable nodes, paste-to-add

### DIFF
--- a/src/usecases/mindmaps/MindmapData.ts
+++ b/src/usecases/mindmaps/MindmapData.ts
@@ -3,6 +3,8 @@ export interface MindmapData {
     id: string;
     label: string;
     position?: { x: number; y: number };
+    width?: number;
+    height?: number;
     color?: string | null;
   }>;
   edges: Array<{ source: string; target: string }>;

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -243,6 +243,8 @@ export function MindmapEditor() {
       type: 'mindmap',
       data: { label: n.label, color: n.color ?? null },
       position: n.position ?? { x: 0, y: 0 },
+      width: n.width,
+      height: n.height,
       style: n.color == null ? NODE_STYLE : { ...NODE_STYLE, borderColor: n.color, boxShadow: `0 0 0 1px ${n.color}` },
     }));
     const rfEdges: Edge[] = map.data.edges.map((e) => ({
@@ -269,6 +271,8 @@ export function MindmapEditor() {
             id: n.id,
             label: String(n.data.label ?? ''),
             position: { x: n.position.x, y: n.position.y },
+            width: n.width,
+            height: n.height,
             color: (n.data as { color?: string | null }).color ?? null,
           })),
           edges: es.map((e) => ({ source: e.source, target: e.target })),
@@ -321,6 +325,50 @@ export function MindmapEditor() {
     });
   }, [setNodes, persistData, edges]);
 
+  useEffect(() => {
+    function handlePaste(e: ClipboardEvent) {
+      const target = e.target as HTMLElement | null;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return;
+      }
+      const text = e.clipboardData?.getData('text/plain')?.trim();
+      if (text == null || text.length === 0) return;
+      if (rfInstance == null) return;
+      e.preventDefault();
+      const center = rfInstance.screenToFlowPosition({
+        x: window.innerWidth / 2,
+        y: window.innerHeight / 2,
+      });
+      const newId = crypto.randomUUID();
+      const newNode: Node = {
+        id: newId,
+        type: 'mindmap',
+        data: { label: text },
+        position: center,
+        style: NODE_STYLE,
+      };
+      setNodes((ns) => {
+        const updated = [...ns, newNode];
+        persistData(updated, edges);
+        return updated;
+      });
+      setSelectedNodeId(newId);
+    }
+    document.addEventListener('paste', handlePaste);
+    return () => document.removeEventListener('paste', handlePaste);
+  }, [rfInstance, setNodes, persistData, edges]);
+
+  const setNodeSize = useCallback((nodeId: string, width: number, height: number) => {
+    setNodes((ns) => {
+      const updated = ns.map((n) =>
+        n.id === nodeId ? { ...n, width, height } : n
+      );
+      persistData(updated, edges);
+      return updated;
+    });
+  }, [setNodes, persistData, edges]);
+
   const nodeTypes = useMemo(
     () => ({
       mindmap: (props: Parameters<typeof MindmapNode>[0]) => (
@@ -334,11 +382,12 @@ export function MindmapEditor() {
             onCenter: () => centerOnNode(props.id),
             onSetColor: (color: string | null) => setNodeColor(props.id, color),
             onDelete: () => deleteNode(props.id),
+            onResizeEnd: (width: number, height: number) => setNodeSize(props.id, width, height),
           }}
         />
       ),
     }),
-    [commitLabel, cancelEdit, centerOnNode, setNodeColor, startRename, deleteNode]
+    [commitLabel, cancelEdit, centerOnNode, setNodeColor, setNodeSize, startRename, deleteNode]
   );
 
   const onConnect = useCallback(
@@ -810,6 +859,8 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Drag from a node — new connected node</p>
           <p style={{ margin: '0 0 0.25rem' }}>Ctrl/Cmd+A — select all</p>
           <p style={{ margin: '0 0 0.25rem' }}>Esc — clear selection</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Paste text — drops a new node on canvas</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Markdown supported in node labels</p>
           <p style={{ margin: '0 0 0.25rem' }}>Ctrl/Cmd+L — tidy layout</p>
         </div>
         <div style={{ marginTop: 'auto' }}>

--- a/web/src/pages/MindmapsPage/MindmapNode.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.test.tsx
@@ -4,6 +4,7 @@ import { MindmapNode } from './MindmapNode';
 
 vi.mock('@xyflow/react', () => ({
   Handle: () => null,
+  NodeResizer: () => null,
   NodeToolbar: ({ children, isVisible }: { children: React.ReactNode; isVisible?: boolean }) =>
     isVisible ? children : null,
   Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
@@ -56,7 +57,7 @@ describe('MindmapNode', () => {
     render(<MindmapNode {...makeProps({ editing: true, onCommit })} />);
     const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: '  Chemistry  ' } });
-    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter', ctrlKey: true });
     expect(onCommit).toHaveBeenCalledWith('Chemistry');
   });
 
@@ -73,7 +74,7 @@ describe('MindmapNode', () => {
     render(<MindmapNode {...makeProps({ label: 'Physics', editing: true, onCommit })} />);
     const input = screen.getByRole('textbox');
     fireEvent.change(input, { target: { value: '   ' } });
-    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter', ctrlKey: true });
     expect(onCommit).toHaveBeenCalledWith('Physics');
   });
 

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { Handle, NodeToolbar, Position, type NodeProps } from '@xyflow/react';
+import { Handle, NodeResizer, NodeToolbar, Position, type NodeProps } from '@xyflow/react';
+import Markdown from 'react-markdown';
 import PencilIcon from '../../components/icons/PencilIcon';
 import TrashIcon from '../../components/icons/TrashIcon';
 import SwatchIcon from '../../components/icons/SwatchIcon';
@@ -14,6 +15,7 @@ export interface MindmapNodeData {
   onCenter?: () => void;
   onSetColor?: (color: string | null) => void;
   onDelete?: () => void;
+  onResizeEnd?: (width: number, height: number) => void;
   [key: string]: unknown;
 }
 
@@ -60,7 +62,7 @@ function CenterIcon({ width = 16, height = 16 }: Readonly<{ width?: number; heig
 
 export function MindmapNode({ data, selected }: NodeProps) {
   const nodeData = data as MindmapNodeData;
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
 
   useEffect(() => {
@@ -74,12 +76,14 @@ export function MindmapNode({ data, selected }: NodeProps) {
     if (!selected) setColorPickerOpen(false);
   }, [selected]);
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     e.stopPropagation();
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
       const trimmed = inputRef.current?.value.trim() ?? '';
       nodeData.onCommit?.(trimmed.length > 0 ? trimmed : nodeData.label);
     } else if (e.key === 'Escape') {
+      e.preventDefault();
       nodeData.onCancel?.();
     }
   }
@@ -172,31 +176,53 @@ export function MindmapNode({ data, selected }: NodeProps) {
           )}
         </div>
       </NodeToolbar>
+      <NodeResizer
+        isVisible={selected === true && nodeData.editing !== true}
+        minWidth={120}
+        minHeight={36}
+        onResizeEnd={(_e, params) => nodeData.onResizeEnd?.(params.width, params.height)}
+        lineStyle={{ border: '1px dashed var(--color-primary)' }}
+        handleStyle={{ width: 8, height: 8, borderRadius: 2, background: 'var(--color-primary)' }}
+      />
       <Handle type="source" position={Position.Left} id="left" />
       <Handle type="source" position={Position.Top} id="top" />
       <Handle type="source" position={Position.Bottom} id="bottom" />
       {nodeData.editing ? (
-        <input
+        <textarea
           ref={inputRef}
-          type="text"
           defaultValue={nodeData.label}
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}
+          rows={Math.max(1, nodeData.label.split('\n').length)}
           style={{
             border: 'none',
             outline: 'none',
             background: 'transparent',
             fontSize: 'var(--text-sm)',
             width: '100%',
+            height: '100%',
             minWidth: '80px',
             color: 'var(--color-text-primary)',
             fontFamily: 'inherit',
+            resize: 'none',
+            padding: 0,
+            margin: 0,
+            overflow: 'auto',
           }}
         />
       ) : (
-        <span style={{ fontSize: 'var(--text-sm)', userSelect: 'none' }}>
-          {nodeData.label}
-        </span>
+        <div
+          style={{
+            fontSize: 'var(--text-sm)',
+            userSelect: 'none',
+            width: '100%',
+            height: '100%',
+            overflow: 'auto',
+            lineHeight: 1.4,
+          }}
+        >
+          <Markdown>{nodeData.label}</Markdown>
+        </div>
       )}
       <Handle type="source" position={Position.Right} id="right" />
     </>

--- a/web/src/pages/MindmapsPage/useMindmap.ts
+++ b/web/src/pages/MindmapsPage/useMindmap.ts
@@ -5,6 +5,8 @@ export interface MindmapNode {
   id: string;
   label: string;
   position?: { x: number; y: number };
+  width?: number;
+  height?: number;
   color?: string | null;
 }
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-rich-nodes.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-rich-nodes.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-rich-nodes",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Mind maps — markdown in node labels, resize nodes by their corners, paste text to drop a new node"
+}


### PR DESCRIPTION
## What

Three more Obsidian-inspired additions to the mind map editor.

1. **Markdown in node labels.** Display renders through `react-markdown` (already a dep). `**bold**`, `_italic_`, lists, headings, inline code — all work. Editing now opens a textarea so multi-line markdown is natural. Plain Enter inserts a newline; **Ctrl/Cmd+Enter commits**; Esc cancels. Matches Obsidian Canvas keyboard model.

2. **Resizable nodes.** Selected nodes get a `<NodeResizer>` overlay (corner drag). Min size 120×36. New optional `width` and `height` fields on `MindmapData`; loader applies them, saver stores them.

3. **Paste-text drops a new node.** Document-level paste listener creates a node at the center of the visible canvas with the clipboard text as label. Skipped when paste target is an input/textarea/contentEditable (so pasting into the title h2 or a node's edit textarea works normally).

## Why

Pulled directly from your asks: "allow markdown ... in the nodes", "resize nodes like obsidian does", "pasting text or images should work."

## What's NOT in this PR

- **Image paste / upload.** Needs a backend upload endpoint + S3 storage + media embed in the .apkg. Big enough for its own PR.
- **Markdown → HTML in export.** Currently the .apkg contains raw markdown text on card faces. Anki users see `**bold**` literally. Small server-side change (markdown-it is already a dep) but separate concern.
- **Rich text editor.** Markdown source covers most needs without a 200KB TipTap/Slate bundle. Revisit if users actually ask for WYSIWYG.

## How

- `MindmapData.nodes[i]` gains optional `width: number`, `height: number`. Synced across server + client types.
- `MindmapNode.tsx`:
  - Imports `NodeResizer` from `@xyflow/react` + `Markdown` from `react-markdown`.
  - `<NodeResizer isVisible={selected && !editing}>` overlay with corner handles.
  - Display side: `<Markdown>{label}</Markdown>` inside an overflow-auto div.
  - Editing side: `<textarea>` instead of `<input>`. Ctrl/Cmd+Enter commits, Esc cancels.
  - New `onResizeEnd` callback fires on resize handle release.
- `MindmapEditor.tsx`:
  - Loader maps stored `width`/`height` onto the React Flow node.
  - `persistData` saves `width`/`height`.
  - New `setNodeSize` helper updates the node and persists.
  - New `useEffect` registers a document-level paste listener that creates a node from clipboard text.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass (test updates: vi.mock returns `NodeResizer`; `Enter` tests now send `Enter + ctrlKey`)

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Edit a node, type `**bold**` then Ctrl/Cmd+Enter — node renders bold. Drag a corner — resize sticks across reload. Copy some text outside the app, click on the canvas (not a node), paste — new node appears in the middle with the text.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-rich-nodes.json`

## Risks

- Markdown rendering enables limited HTML through react-markdown's defaults (most HTML is escaped). User-provided markdown is rendered to that user only — no XSS path to other users since maps aren't shared. Sanitized only by react-markdown's defaults; if we ever introduce sharing, revisit with `sanitize-html`.
- The textarea editor changes the keyboard model: previously plain Enter committed (matched the input). Now plain Enter is a newline. Documented in the side panel hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782038338&installation_id=132681956&pr_number=2600&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2600&signature=d9a92e0ffd90b30509c6c52f86ac7db70bc1d6cb5d9197386bf5b589959ea5d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->