### PR TITLE
feat: medical landing page family

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -51,6 +51,24 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://2anki.net/usmle-anki</loc>
+    <lastmod>2026-05-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/nursing-flashcards</loc>
+    <lastmod>2026-05-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/anki-from-medical-lecture-slides</loc>
+    <lastmod>2026-05-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/notion-marketplace</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(12);
+    expect(files).toHaveLength(15);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );
@@ -64,6 +64,15 @@ describe('emitLandingPages', () => {
     expect(files.some((p) => p.endsWith('anki-to-notion/index.html'))).toBe(
       true
     );
+    expect(files.some((p) => p.endsWith('usmle-anki/index.html'))).toBe(true);
+    expect(
+      files.some((p) => p.endsWith('nursing-flashcards/index.html'))
+    ).toBe(true);
+    expect(
+      files.some((p) =>
+        p.endsWith('anki-from-medical-lecture-slides/index.html')
+      )
+    ).toBe(true);
     expect(
       files.some((p) => p.endsWith('convert/notion-to-anki/index.html'))
     ).toBe(true);

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -5,6 +5,9 @@ import quizletCopy from '../src/pages/LandingPage/copy/quizlet';
 import markdownCopy from '../src/pages/LandingPage/copy/markdown';
 import pdfCopy from '../src/pages/LandingPage/copy/pdf';
 import ankiToNotionCopy from '../src/pages/LandingPage/copy/ankiToNotion';
+import usmleCopy from '../src/pages/LandingPage/copy/usmle';
+import nursingCopy from '../src/pages/LandingPage/copy/nursing';
+import medicalLectureSlidesCopy from '../src/pages/LandingPage/copy/medical-lecture-slides';
 import { CONVERT_LANDING_PAGES } from '../src/pages/ConvertLandingPage/convertLandingConfig';
 import { ANSWERS_PAGES } from '../src/pages/AnswersPage/answersConfig';
 import type { LandingCopy } from '../src/pages/LandingPage/types';
@@ -15,6 +18,9 @@ const LANDING_COPIES: LandingCopy[] = [
   markdownCopy,
   pdfCopy,
   ankiToNotionCopy,
+  usmleCopy,
+  nursingCopy,
+  medicalLectureSlidesCopy,
   ...Array.from(CONVERT_LANDING_PAGES.values()),
 ];
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,13 @@ const MarkdownToAnki = lazy(
   () => import('./pages/LandingPage/MarkdownToAnki')
 );
 const PdfToAnki = lazy(() => import('./pages/LandingPage/PdfToAnki'));
+const UsmleAnki = lazy(() => import('./pages/LandingPage/UsmleAnki'));
+const NursingFlashcards = lazy(
+  () => import('./pages/LandingPage/NursingFlashcards')
+);
+const AnkiFromMedicalLectureSlides = lazy(
+  () => import('./pages/LandingPage/AnkiFromMedicalLectureSlides')
+);
 const ConvertLandingPage = lazy(
   () => import('./pages/ConvertLandingPage/ConvertLandingPage')
 );
@@ -312,6 +319,22 @@ function AppContent({
           <Route
             path="/pdf-to-anki"
             element={<PdfToAnki setErrorMessage={setErrorMessage} />}
+          />
+          <Route
+            path="/usmle-anki"
+            element={<UsmleAnki setErrorMessage={setErrorMessage} />}
+          />
+          <Route
+            path="/nursing-flashcards"
+            element={<NursingFlashcards setErrorMessage={setErrorMessage} />}
+          />
+          <Route
+            path="/anki-from-medical-lecture-slides"
+            element={
+              <AnkiFromMedicalLectureSlides
+                setErrorMessage={setErrorMessage}
+              />
+            }
           />
           <Route path="/notion-marketplace" element={<NotionLandingPage />} />
           <Route

--- a/web/src/lib/signupOrigin.test.ts
+++ b/web/src/lib/signupOrigin.test.ts
@@ -48,6 +48,24 @@ describe('readSignupOrigin', () => {
     });
     expect(readSignupOrigin('', storage)).toBeNull();
   });
+
+  it.each([
+    '/usmle-anki',
+    '/nursing-flashcards',
+    '/anki-from-medical-lecture-slides',
+  ])('resolves %s from the source query param', (pathname) => {
+    const storage = buildStorage();
+    expect(readSignupOrigin(`?source=${pathname}`, storage)).toBe(pathname);
+  });
+
+  it.each([
+    '/usmle-anki',
+    '/nursing-flashcards',
+    '/anki-from-medical-lecture-slides',
+  ])('resolves %s from sessionStorage when query param is absent', (pathname) => {
+    const storage = buildStorage({ [SIGNUP_ORIGIN_KEY]: pathname });
+    expect(readSignupOrigin('', storage)).toBe(pathname);
+  });
 });
 
 describe('persistSignupOrigin', () => {
@@ -65,5 +83,18 @@ describe('persistSignupOrigin', () => {
 
   it('is a no-op when storage is unavailable', () => {
     expect(() => persistSignupOrigin('/pdf-to-anki', null)).not.toThrow();
+  });
+
+  it('persists each of the three medical landing paths', () => {
+    const medicalPaths = [
+      '/usmle-anki',
+      '/nursing-flashcards',
+      '/anki-from-medical-lecture-slides',
+    ];
+    for (const pathname of medicalPaths) {
+      const storage = buildStorage();
+      persistSignupOrigin(pathname, storage);
+      expect(storage.store[SIGNUP_ORIGIN_KEY]).toBe(pathname);
+    }
   });
 });

--- a/web/src/pages/LandingPage/AnkiFromMedicalLectureSlides.tsx
+++ b/web/src/pages/LandingPage/AnkiFromMedicalLectureSlides.tsx
@@ -1,0 +1,11 @@
+import LandingPage from './LandingPage';
+import medicalLectureSlidesCopy from './copy/medical-lecture-slides';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+
+interface Props {
+  setErrorMessage: ErrorHandlerType;
+}
+
+export default function AnkiFromMedicalLectureSlides({ setErrorMessage }: Readonly<Props>) {
+  return <LandingPage copy={medicalLectureSlidesCopy} setErrorMessage={setErrorMessage} />;
+}

--- a/web/src/pages/LandingPage/LandingPage.test.tsx
+++ b/web/src/pages/LandingPage/LandingPage.test.tsx
@@ -7,6 +7,9 @@ import { MemoryRouter } from 'react-router-dom';
 
 import LandingPage from './LandingPage';
 import notionCopy from './copy/notion';
+import usmleCopy from './copy/usmle';
+import nursingCopy from './copy/nursing';
+import medicalLectureSlidesCopy from './copy/medical-lecture-slides';
 
 function renderLandingPage(children: React.ReactElement) {
   const queryClient = new QueryClient({
@@ -81,5 +84,47 @@ describe('LandingPage', () => {
     expect(screen.getByText('Notion')).toBeInTheDocument();
     expect(screen.getByText('PDF')).toBeInTheDocument();
     expect(screen.getByText('Markdown')).toBeInTheDocument();
+  });
+
+  it('renders the USMLE h1 and links CTA to the usmle-anki source', () => {
+    renderLandingPage(
+      <LandingPage copy={usmleCopy} setErrorMessage={vi.fn()} />
+    );
+    expect(
+      screen.getByRole('heading', { level: 1, name: usmleCopy.h1 })
+    ).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /sign up free/i });
+    expect(link).toHaveAttribute(
+      'href',
+      `/register?source=${encodeURIComponent(usmleCopy.pathname)}`
+    );
+  });
+
+  it('renders the nursing h1 and links CTA to the nursing-flashcards source', () => {
+    renderLandingPage(
+      <LandingPage copy={nursingCopy} setErrorMessage={vi.fn()} />
+    );
+    expect(
+      screen.getByRole('heading', { level: 1, name: nursingCopy.h1 })
+    ).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /sign up free/i });
+    expect(link).toHaveAttribute(
+      'href',
+      `/register?source=${encodeURIComponent(nursingCopy.pathname)}`
+    );
+  });
+
+  it('renders the medical lecture slides h1 and links CTA to the correct source', () => {
+    renderLandingPage(
+      <LandingPage copy={medicalLectureSlidesCopy} setErrorMessage={vi.fn()} />
+    );
+    expect(
+      screen.getByRole('heading', { level: 1, name: medicalLectureSlidesCopy.h1 })
+    ).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /sign up free/i });
+    expect(link).toHaveAttribute(
+      'href',
+      `/register?source=${encodeURIComponent(medicalLectureSlidesCopy.pathname)}`
+    );
   });
 });

--- a/web/src/pages/LandingPage/NursingFlashcards.tsx
+++ b/web/src/pages/LandingPage/NursingFlashcards.tsx
@@ -1,0 +1,11 @@
+import LandingPage from './LandingPage';
+import nursingCopy from './copy/nursing';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+
+interface Props {
+  setErrorMessage: ErrorHandlerType;
+}
+
+export default function NursingFlashcards({ setErrorMessage }: Readonly<Props>) {
+  return <LandingPage copy={nursingCopy} setErrorMessage={setErrorMessage} />;
+}

--- a/web/src/pages/LandingPage/UsmleAnki.tsx
+++ b/web/src/pages/LandingPage/UsmleAnki.tsx
@@ -1,0 +1,11 @@
+import LandingPage from './LandingPage';
+import usmleCopy from './copy/usmle';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+
+interface Props {
+  setErrorMessage: ErrorHandlerType;
+}
+
+export default function UsmleAnki({ setErrorMessage }: Readonly<Props>) {
+  return <LandingPage copy={usmleCopy} setErrorMessage={setErrorMessage} />;
+}

--- a/web/src/pages/LandingPage/copy/medical-lecture-slides.ts
+++ b/web/src/pages/LandingPage/copy/medical-lecture-slides.ts
@@ -1,0 +1,49 @@
+import type { LandingCopy } from '../types';
+
+const medicalLectureSlidesCopy: LandingCopy = {
+  pathname: '/anki-from-medical-lecture-slides',
+  title: 'Turn medical lecture slides into Anki cards — 2anki',
+  description:
+    'Upload a PDF of your slides — headings become deck names, bullets become cards. Spaced repetition-ready Anki decks from any medical lecture. | 2anki',
+  h1: 'Turn lecture slides into Anki cards',
+  subhead:
+    'Upload a PDF of your slides — headings become deck names, bullets become cards.',
+  whatComesAcross: [
+    {
+      title: 'Diagrams',
+      body: 'Diagrams embedded in your slides come across as images inside the card, so clinical illustrations stay attached to the relevant concept.',
+    },
+    {
+      title: 'Image occlusion cards',
+      body: 'Image occlusion is a native Anki feature — after import, use the Anki image occlusion editor to mask labels on any diagram that came across.',
+    },
+    {
+      title: 'Bold and italic text',
+      body: 'Bolded terms and italicised definitions carry through to the card so your lecturer\'s emphasis guides your review.',
+    },
+    {
+      title: 'Nested lists',
+      body: 'Nested bullet hierarchies become nested cards, preserving the structure of multi-step clinical processes and classification systems.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Do scanned PDFs work?',
+      a: 'Only if the scan has a text layer from OCR. PDFs exported from PowerPoint or Keynote always have a text layer. If you photographed paper handouts, run them through an OCR tool first — macOS Preview and Adobe Acrobat both do this.',
+    },
+    {
+      q: 'Can it produce image occlusion cards?',
+      a: "Image occlusion is a native Anki feature built into the card editor — 2anki doesn't build the masks during conversion. 2anki brings your diagrams across as images. Open the resulting deck in Anki and use Anki's image occlusion tool to add label masks to any diagram.",
+    },
+    {
+      q: 'Can it handle a full course of slides?',
+      a: "Yes. Upload one lecture or one topic block at a time rather than an entire course as a single file. Smaller decks are easier to schedule and review, and Anki performs better with focused 200–500 card decks than with one massive deck.",
+    },
+    {
+      q: 'How is this different from Quizlet?',
+      a: 'Anki uses a spaced repetition algorithm that schedules each card based on your recall, so cards you find harder come back sooner. Quizlet offers flash-card practice but uses a different scheduling model. If your program or study group uses Anki, 2anki keeps your lecture notes in the same ecosystem.',
+    },
+  ],
+};
+
+export default medicalLectureSlidesCopy;

--- a/web/src/pages/LandingPage/copy/nursing.ts
+++ b/web/src/pages/LandingPage/copy/nursing.ts
@@ -1,0 +1,49 @@
+import type { LandingCopy } from '../types';
+
+const nursingCopy: LandingCopy = {
+  pathname: '/nursing-flashcards',
+  title: 'Anki flashcards from nursing lecture slides and notes — 2anki',
+  description:
+    'Drop a PDF or Notion export of your nursing notes. 2anki pulls out the terms, medications, and procedures as spaced repetition-ready Anki cards. | 2anki',
+  h1: 'Anki flashcards from nursing lecture slides and notes',
+  subhead:
+    'Drop a PDF or Notion export. 2anki pulls out the terms, medications, and procedures.',
+  whatComesAcross: [
+    {
+      title: 'Diagrams',
+      body: 'Anatomy and clinical diagrams embedded in your slides come across as images inside the card.',
+    },
+    {
+      title: 'Image occlusion cards',
+      body: 'Image occlusion is a native Anki feature — after import, use the Anki image occlusion editor to mask labels on anatomy diagrams.',
+    },
+    {
+      title: 'Bold and italic text',
+      body: 'Bolded drug names, italicised terms, and clinical emphasis carry through so the formatting you made guides your review.',
+    },
+    {
+      title: 'Nested lists',
+      body: 'Nested bullet hierarchies become nested cards, preserving the structure of nursing procedures and care plan steps.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Do scanned PDFs work?',
+      a: 'Only if the scan has a text layer from OCR. PDFs exported directly from a slide application always have a text layer. If you scanned printed handouts, run them through an OCR tool first — macOS Preview and Adobe Acrobat both do this.',
+    },
+    {
+      q: 'Can it produce image occlusion cards?',
+      a: "Image occlusion is a native Anki feature built into the card editor. 2anki brings your diagrams across as images; you then open the resulting deck in Anki and use Anki's image occlusion tool to add label masks to anatomy illustrations.",
+    },
+    {
+      q: 'Can it handle a full semester of nursing slides?',
+      a: "Yes. Upload one module or one topic at a time rather than the whole semester in one file. Smaller decks are easier to schedule, easier to review, and Anki handles 500-card decks more smoothly than 5,000-card ones.",
+    },
+    {
+      q: 'How is this different from Quizlet?',
+      a: "Anki uses spaced repetition to schedule each card based on your recall — cards you find harder come back sooner. Quizlet offers flash-card practice but schedules differently. Many nursing programs and study groups coordinate around Anki decks, so 2anki keeps your cards in the same ecosystem.",
+    },
+  ],
+};
+
+export default nursingCopy;

--- a/web/src/pages/LandingPage/copy/usmle.ts
+++ b/web/src/pages/LandingPage/copy/usmle.ts
@@ -1,0 +1,49 @@
+import type { LandingCopy } from '../types';
+
+const usmleCopy: LandingCopy = {
+  pathname: '/usmle-anki',
+  title: 'USMLE Anki decks from your own notes — 2anki',
+  description:
+    'Upload lecture slides, First Aid exports, or any PDF. Get a spaced repetition-ready Anki deck for USMLE Step 1 and Step 2. | 2anki',
+  h1: 'USMLE Step 1 and Step 2 decks from your own notes',
+  subhead:
+    'Upload lecture slides, First Aid exports, or any PDF. High-yield cards, spaced repetition-ready.',
+  whatComesAcross: [
+    {
+      title: 'Diagrams',
+      body: 'Diagrams embedded in your slides come across as images inside the card, so you review them in context.',
+    },
+    {
+      title: 'Image occlusion cards',
+      body: 'Image occlusion is a native Anki feature — after import, use the Anki image occlusion editor to mask labels directly on your diagrams.',
+    },
+    {
+      title: 'Bold and italic text',
+      body: 'Bolded drug names, italicised organisms, and other emphasis carry through to the card so the formatting you made guides your review.',
+    },
+    {
+      title: 'Nested lists',
+      body: 'Nested bullet hierarchies become nested cards, preserving the structure of pathophysiology steps and differential diagnosis lists.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Do scanned PDFs work?',
+      a: 'Only if the scan has a text layer from OCR. Slide exports from PowerPoint or Keynote always have a text layer. If you scanned paper notes with a phone, run them through an OCR tool first — macOS Preview and Adobe Acrobat both do this.',
+    },
+    {
+      q: 'Can it produce image occlusion cards?',
+      a: "Image occlusion is a native Anki feature built into the card editor — it's not something 2anki builds during conversion. What 2anki does is bring your diagrams across as images. Open the resulting deck in Anki, select an image card, and use Anki's image occlusion tool to add the masks.",
+    },
+    {
+      q: 'Can it handle a full course of slides?',
+      a: "Yes. Upload one block at a time — one module, one week, one organ system — rather than an entire year's worth of slides in one file. Anki handles 500-card decks far better than 5,000-card ones, and smaller decks are easier to schedule and share.",
+    },
+    {
+      q: 'How is this different from Quizlet?',
+      a: 'Anki uses a spaced repetition algorithm that schedules each card based on how well you remembered it, so high-yield cards you struggle with come back sooner. Quizlet offers flash-card practice but does not schedule cards the same way. If your program or study group uses Anki, 2anki keeps your decks in the same ecosystem.',
+    },
+  ],
+};
+
+export default usmleCopy;

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-medical-landing-pages.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-medical-landing-pages.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-medical-landing-pages",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Dedicated pages for USMLE, nursing, and medical lecture slides"
+}


### PR DESCRIPTION
## What

Three SEO landing pages — `/usmle-anki`, `/nursing-flashcards`, and `/anki-from-medical-lecture-slides` — built on the existing `LandingPage` template. Each page has per-vertical copy (h1, subhead, whatComesAcross, 4 FAQs) and is registered as a lazy route, prerendered with title/description/canonical/OG/Twitter, and included in the sitemap.

## Why

Medical is the highest-LTV vertical on Fiverr (19/63 sellers, €14–37 floors, repeat buyers). The product already converts lecture-slide PDFs in seconds for free — the gap is purely positioning. These pages say "USMLE", "nursing", and "lecture slides" back to searchers who are currently finding Fiverr sellers instead of 2anki.net. Moves us toward 300K users by capturing zero-marginal-cost organic search traffic in a high-intent vertical.

## How

Exact same pattern as `PdfToAnki.tsx`: three `copy/*.ts` files implementing `LandingCopy`, three 3-line wrapper components, three lazy `<Route>` entries in `App.tsx`, three entries appended to `LANDING_COPIES` in `prerenderLandingPages.ts`, three `<url>` blocks in `sitemap.xml`. No template changes.

Copy register: sentence case, no emoji, no exclamation marks, no fake warmth per VOICE.md. Fiverr medical language ("high-yield", "image occlusion", "exam-focused", "spaced repetition") used where it adds precision — "high-yield" only once, on the USMLE page.

## Measuring success

Weekly signups where `signupOrigin` is one of `{/usmle-anki, /nursing-flashcards, /anki-from-medical-lecture-slides}`. Target: +200 monthly signups from the three paths combined within 8 weeks of indexing. Baseline: 4-week trailing average for `/notion-to-anki` and `/pdf-to-anki`.

## Testing

- Unit tests added: 3 new `it` blocks in `LandingPage.test.tsx` asserting h1 and CTA href per copy; 6 new cases in `signupOrigin.test.ts` (3 round-trips via query param, 3 via sessionStorage, 1 persist block for all three paths); updated count assertion in `prerenderLandingPages.test.ts` from 12 to 15 with assertions for the three new files.
- All 119 test files, 944 tests pass.
- Server tsc: clean. Web typecheck: clean. Biome lint: clean.

## Browser check

Browser check: not applicable — copy-only addition on existing LandingPage template, no new rendering paths or interactions

## Changelog

"Dedicated pages for USMLE, nursing, and medical lecture slides" — `web/src/pages/WhatsNewPage/changelog/2026-05-22-medical-landing-pages.json`

## Risks

Low. No template changes, no new components beyond 3-line wrappers, no server changes. Rollback: revert the 4 commits. The three routes simply 404 without the lazy imports in `App.tsx`.

Sonar scanner not run locally — no token configured. Noted here per `.claude/rules/sonar.md` so reviewers expect a Sonar pass in CI. The new code is copy data structures and 3-line wrapper components; no control flow, no user input handling, no HTTP calls.

## Goal alignment

Owned medical search queries at $0 marginal cost per buyer compound toward 300K users. Same template, same UX, no new surface for users to learn — simpler/faster/more beautiful per the mission.