### PR TITLE
feat: left-click an edge opens the same menu as right-click

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -700,6 +700,9 @@ export function MindmapEditor() {
             e.preventDefault();
             setContextMenu({ x: e.clientX, y: e.clientY, nodeId: null, edgeId: edge.id });
           }}
+          onEdgeClick={(e, edge) => {
+            setContextMenu({ x: e.clientX, y: e.clientY, nodeId: null, edgeId: edge.id });
+          }}
           onConnectEnd={(e, connectionState) => {
             if (connectionState.toNode != null) return;
             if (rfInstance == null) return;
@@ -856,6 +859,7 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Double-click / F2 — rename node</p>
           <p style={{ margin: '0 0 0.25rem' }}>Double-click canvas — add node here</p>
           <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu (node, edge, or canvas)</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Click an edge — open its menu</p>
           <p style={{ margin: '0 0 0.25rem' }}>Drag from a node — new connected node</p>
           <p style={{ margin: '0 0 0.25rem' }}>Ctrl/Cmd+A — select all</p>
           <p style={{ margin: '0 0 0.25rem' }}>Esc — clear selection</p>


### PR DESCRIPTION
## What

Left-clicking an edge now opens the context menu (currently just "Remove connection"). Right-click still does the same thing.

## Why

Right-click was the only way to surface edge actions. Most users will reach for left-click first; nothing happened visibly, so the action was unreachable for them.

## How

One new prop on `<ReactFlow>`:

```tsx
onEdgeClick={(e, edge) => {
  setContextMenu({ x: e.clientX, y: e.clientY, nodeId: null, edgeId: edge.id });
}}
```

Side-panel hint added: `Click an edge — open its menu`.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Click an edge between two nodes — menu appears with "Remove connection".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782038628&installation_id=132681956&pr_number=2602&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2602&signature=2559e11176534b2f6f62960d394c7fec532bc67329ba1f475f4fcca4e427b487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->