### PR TITLE
fix: mind map — Basic default export, dark-mode-safe whole-map card

### DIFF
--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -40,9 +40,9 @@ export class MindmapController {
   }
 
   private resolveCardType(raw: unknown): MindmapCardType {
-    if (raw === 'basic') return 'basic';
+    if (raw === 'cloze') return 'cloze';
     if (raw === 'markmap') return 'markmap';
-    return 'cloze';
+    return 'basic';
   }
 
   async list(_req: Request, res: Response) {

--- a/src/routes/MindmapRouter.test.ts
+++ b/src/routes/MindmapRouter.test.ts
@@ -169,7 +169,7 @@ describe('MindmapRouter', () => {
       expect(res.headers.get('content-type')).toContain('application/octet-stream');
     });
 
-    it('defaults to cloze card type when card_type is omitted', async () => {
+    it('defaults to basic card type when card_type is omitted', async () => {
       mockGetById.mockResolvedValue(baseMap);
 
       const res = await fetch(`${url}/api/mindmaps/export-id/export`, {
@@ -207,7 +207,7 @@ describe('MindmapRouter', () => {
       expect(res.headers.get('content-type')).toContain('application/octet-stream');
     });
 
-    it('treats unknown card_type as cloze', async () => {
+    it('treats unknown card_type as basic', async () => {
       mockGetById.mockResolvedValue(baseMap);
 
       const res = await fetch(`${url}/api/mindmaps/export-id/export`, {

--- a/src/usecases/mindmaps/ExportMindmapUseCase.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.ts
@@ -54,7 +54,7 @@ export class ExportMindmapUseCase {
   }
 
   async execute(input: ExportInput): Promise<Buffer> {
-    const { id, userId, deckName, cardType = 'cloze' } = input;
+    const { id, userId, deckName, cardType = 'basic' } = input;
     const map = await this.repo.findById(id, userId);
     if (map == null) {
       throw new MindmapNotFoundError();

--- a/src/usecases/mindmaps/mindmapToMarkmapHtml.ts
+++ b/src/usecases/mindmaps/mindmapToMarkmapHtml.ts
@@ -38,8 +38,12 @@ export function mindmapToMarkmapHtml(data: MindmapData, title: string): string {
 <meta charset="utf-8">
 <title>${title}</title>
 <style>
-html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #fff; }
-svg#mindmap { width: 100%; height: 100%; display: block; }
+html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: transparent; color: inherit; }
+svg#mindmap { width: 100%; height: 100%; display: block; color: inherit; }
+svg#mindmap text { fill: currentColor; }
+svg#mindmap path.markmap-link { stroke: currentColor; opacity: 0.6; }
+.night_mode svg#mindmap text { fill: #e9e9eb; }
+.night_mode svg#mindmap path.markmap-link { stroke: #9ba3af; opacity: 0.8; }
 </style>
 </head>
 <body>
@@ -50,7 +54,7 @@ svg#mindmap { width: 100%; height: 100%; display: block; }
 (function () {
   var data = ${treeJson};
   if (!data) {
-    document.body.innerHTML = '<p style="font-family:sans-serif;padding:1rem;color:#888">Empty mind map</p>';
+    document.body.innerHTML = '<p style="font-family:sans-serif;padding:1rem;color:inherit;opacity:0.7">Empty mind map</p>';
     return;
   }
   var mm = markmap.Markmap.create(document.getElementById('mindmap'), {}, data);

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -66,7 +66,7 @@ interface ExportModalProps {
 
 function ExportModal({ defaultName, basicCardCount, clozeCardCount, onExport, onClose, exporting }: Readonly<ExportModalProps>) {
   const [deckName, setDeckName] = useState(defaultName);
-  const [cardType, setCardType] = useState<MindmapCardType>('cloze');
+  const [cardType, setCardType] = useState<MindmapCardType>('basic');
 
   function cardCountLabel(): string {
     if (cardType === 'markmap') return '1 card';
@@ -141,21 +141,21 @@ function ExportModal({ defaultName, basicCardCount, clozeCardCount, onExport, on
             <input
               type="radio"
               name="card-type"
-              value="cloze"
-              checked={cardType === 'cloze'}
-              onChange={() => setCardType('cloze')}
-            />
-            Cloze — one card per path, each node clozed in sequence
-          </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.25rem', fontSize: 'var(--text-sm)', cursor: 'pointer' }}>
-            <input
-              type="radio"
-              name="card-type"
               value="basic"
               checked={cardType === 'basic'}
               onChange={() => setCardType('basic')}
             />
             Basic — one card per edge (parent → child)
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.25rem', fontSize: 'var(--text-sm)', cursor: 'pointer' }}>
+            <input
+              type="radio"
+              name="card-type"
+              value="cloze"
+              checked={cardType === 'cloze'}
+              onChange={() => setCardType('cloze')}
+            />
+            Cloze — one card per path, each node clozed in sequence
           </label>
           <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: 'var(--text-sm)', cursor: 'pointer' }}>
             <input

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-basic-default-dark-mode.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-basic-default-dark-mode.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-mindmap-basic-default-dark-mode",
+  "date": "2026-05-22",
+  "type": "fix",
+  "title": "Mind maps — Basic is the default export type; whole-map cards render correctly in Anki dark mode"
+}


### PR DESCRIPTION
## What

Two production-testing complaints rolled into one PR.

1. **Basic is the export default again.** The modal listed Cloze first and defaulted to it. Reorder: Basic → Cloze → Whole map. Default state flips to `'basic'` across the modal, the use case, and the controller's `resolveCardType` fallback.

2. **The whole-map (markmap) card now respects Anki's dark mode.** Previously hard-coded `background: #fff` + relied on markmap's default `#000` text fill. In Anki night mode the card was a bright white rectangle in an otherwise dark UI. Now: transparent background, `currentColor` for text and edge stroke, plus a `.night_mode` override that picks readable colors when Anki's night-mode class is applied.

## Why

You reported "The generated cards look bad due to some dark mode thing" and "Make Basic first and default." Both fixed.

## How

**Default flip:**
- `MindmapEditor.tsx` — `useState<MindmapCardType>('basic')`. Radio order: Basic, Cloze, Whole map.
- `ExportMindmapUseCase.ts` — `cardType = 'basic'` default in the destructuring.
- `MindmapController.resolveCardType` — unknown values fall to `'basic'` instead of `'cloze'`.
- `MindmapRouter.test.ts` — test names updated; existing assertions still hold (they only checked status codes).

**Dark mode in markmap HTML:**

```css
html, body { background: transparent; color: inherit; }
svg#mindmap text { fill: currentColor; }
svg#mindmap path.markmap-link { stroke: currentColor; opacity: 0.6; }
.night_mode svg#mindmap text { fill: #e9e9eb; }
.night_mode svg#mindmap path.markmap-link { stroke: #9ba3af; opacity: 0.8; }
```

The `.night_mode` class is what Anki adds when night mode is active.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `npx tsc --noEmit -p .` — clean (excluding pre-existing onboarded_at issue)
- `pnpm test src/usecases/mindmaps/ --testPathIgnorePatterns=mindmapToMarkmapHtml` — 31 pass
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass
- The markmap-route test still fails locally with `Cannot find module 'markmap-view/dist/browser/index.js'` — pre-existing issue #2593, unrelated to this PR.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Open the export modal — Basic is preselected, listed first. Export a Whole-map deck, open in Anki, toggle dark mode — card text/edges remain readable; no white rectangle.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-22-mindmap-basic-default-dark-mode.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782039042&installation_id=132681956&pr_number=2604&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2604&signature=8e213be31e45233cf74142d1d50537ec9ed68410cffe1f42553150015aa8d63d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->