### PR TITLE
fix: mind map — stable size during edit, double-click border to auto-size

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -31,6 +31,9 @@ const NODE_STYLE = {
   boxShadow: 'var(--shadow-sm)',
   padding: '0.5rem 1rem',
   fontSize: 'var(--text-sm)',
+  minWidth: '160px',
+  minHeight: '40px',
+  boxSizing: 'border-box' as const,
 };
 
 function layoutGraph(nodes: Node[], edges: Edge[]): Node[] {

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -31,8 +31,6 @@ const NODE_STYLE = {
   boxShadow: 'var(--shadow-sm)',
   padding: '0.5rem 1rem',
   fontSize: 'var(--text-sm)',
-  minWidth: '160px',
-  minHeight: '40px',
   boxSizing: 'border-box' as const,
 };
 
@@ -367,6 +365,20 @@ export function MindmapEditor() {
       const updated = ns.map((n) =>
         n.id === nodeId ? { ...n, width, height } : n
       );
+      persistData(updated, edges);
+      return updated;
+    });
+  }, [setNodes, persistData, edges]);
+
+  const autoSizeNode = useCallback((nodeId: string) => {
+    setNodes((ns) => {
+      const updated = ns.map((n) => {
+        if (n.id !== nodeId) return n;
+        const next = { ...n };
+        delete (next as { width?: number }).width;
+        delete (next as { height?: number }).height;
+        return next;
+      });
       persistData(updated, edges);
       return updated;
     });
@@ -716,7 +728,23 @@ export function MindmapEditor() {
             createNodeAt(flow, fromNodeId);
           }}
           onNodeClick={(_e, node) => setSelectedNodeId(node.id)}
-          onNodeDoubleClick={(_e, node) => startRename(node.id)}
+          onNodeDoubleClick={(e, node) => {
+            const wrapper = (e.target as HTMLElement).closest('.react-flow__node') as HTMLElement | null;
+            if (wrapper != null) {
+              const rect = wrapper.getBoundingClientRect();
+              const borderZone = 6;
+              const nearBorder =
+                e.clientX - rect.left < borderZone ||
+                rect.right - e.clientX < borderZone ||
+                e.clientY - rect.top < borderZone ||
+                rect.bottom - e.clientY < borderZone;
+              if (nearBorder) {
+                autoSizeNode(node.id);
+                return;
+              }
+            }
+            startRename(node.id);
+          }}
           onNodeDragStop={() => persistData(nodes, edges)}
           onNodeContextMenu={(e, node) => {
             e.preventDefault();
@@ -860,6 +888,7 @@ export function MindmapEditor() {
           <p style={{ margin: '0 0 0.25rem' }}>Enter — add sibling</p>
           <p style={{ margin: '0 0 0.25rem' }}>Backspace — delete</p>
           <p style={{ margin: '0 0 0.25rem' }}>Double-click / F2 — rename node</p>
+          <p style={{ margin: '0 0 0.25rem' }}>Double-click node border — auto-size to content</p>
           <p style={{ margin: '0 0 0.25rem' }}>Double-click canvas — add node here</p>
           <p style={{ margin: '0 0 0.25rem' }}>Right-click — menu (node, edge, or canvas)</p>
           <p style={{ margin: '0 0 0.25rem' }}>Click an edge — open its menu</p>

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -201,13 +201,14 @@ export function MindmapNode({ data, selected }: NodeProps) {
             fontSize: 'var(--text-sm)',
             width: '100%',
             height: '100%',
-            minWidth: '80px',
             color: 'var(--color-text-primary)',
             fontFamily: 'inherit',
+            lineHeight: 1.4,
             resize: 'none',
             padding: 0,
             margin: 0,
             overflow: 'auto',
+            boxSizing: 'border-box',
           }}
         />
       ) : (
@@ -219,6 +220,7 @@ export function MindmapNode({ data, selected }: NodeProps) {
             height: '100%',
             overflow: 'auto',
             lineHeight: 1.4,
+            boxSizing: 'border-box',
           }}
         >
           <Markdown>{nodeData.label}</Markdown>

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -193,7 +193,8 @@ export function MindmapNode({ data, selected }: NodeProps) {
           defaultValue={nodeData.label}
           onKeyDown={handleKeyDown}
           onBlur={handleBlur}
-          rows={Math.max(1, nodeData.label.split('\n').length)}
+          cols={1}
+          rows={1}
           style={{
             border: 'none',
             outline: 'none',
@@ -201,6 +202,7 @@ export function MindmapNode({ data, selected }: NodeProps) {
             fontSize: 'var(--text-sm)',
             width: '100%',
             height: '100%',
+            minWidth: 0,
             color: 'var(--color-text-primary)',
             fontFamily: 'inherit',
             lineHeight: 1.4,


### PR DESCRIPTION
## What

Editing a node no longer resizes its box. Double-click the node's border (within 6 px of any edge) to auto-size the node to its content.

## Why

First report: "the width changes when I start editing, why can't we edit inline." First commit on this branch tried to fix that with a `minWidth: 160px` floor, but you correctly pointed out that took away free resize. Reverted that and approached it from the other direction — stop the textarea from demanding intrinsic width.

You also asked: "double click on the border we should auto size the node based on its content." Wired.

## How

**No-jump:**
- `NODE_STYLE.minWidth/minHeight` removed. Users resize to any size again.
- Textarea: `cols={1}`, `rows={1}`, `minWidth: 0`. With `width: 100%` it takes the parent's interior exactly, no extra width demand.
- Display div and textarea share `line-height: 1.4` and `box-sizing: border-box` so the two states render at identical sizes.

**Auto-size on border-click:**
- `onNodeDoubleClick` (in `MindmapEditor.tsx`) measures the node's bounding rect against `e.clientX/Y`. If the click is within 6 px of any edge → `autoSizeNode(node.id)` which deletes `width`/`height` from the node so React Flow sizes to content. Otherwise it falls through to `startRename` as before.
- New `autoSizeNode` helper persists the cleared dimensions so the change survives reload.

## Testing

- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage` — 9 pass

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify. Click a node with a short label → edit happens in place, no width jump. Resize a node via corner drag → any size works. Double-click the node's border (the 1 px line itself) → snaps back to content size.

## Risks

- 6 px border zone is a heuristic. Users with chunky borders or zoomed canvases might find the zone too narrow or too wide. Adjust to feel right post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)