### PR TITLE
fix: mind map edit-shrink and missing image media in apkg

### DIFF
--- a/src/usecases/mindmaps/ExportMindmapUseCase.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.ts
@@ -42,11 +42,13 @@ export class ExportMindmapUseCase {
     data: MindmapData,
     deckName: string,
     cardType: MindmapCardType,
-    filenameMap: Record<string, string>
+    filenameMap: Record<string, string>,
+    allMediaFilenames: string[]
   ): Note[] {
     if (cardType === 'markmap') {
       const html = mindmapToMarkmapHtml(data, deckName, filenameMap);
       const note = new Note(deckName, html);
+      if (allMediaFilenames.length > 0) note.media = allMediaFilenames;
       return [note];
     }
     if (cardType === 'basic') {
@@ -68,11 +70,19 @@ export class ExportMindmapUseCase {
     const collectedImages = collectMindmapImages(mapData, uploadBase);
 
     const filenameMap: Record<string, string> = {};
+    const allMediaFilenames: string[] = [];
     for (const img of collectedImages) {
       filenameMap[img.filename] = img.filename;
+      allMediaFilenames.push(img.filename);
     }
 
-    const notes = this.buildNotes(mapData, resolvedDeckName, cardType, filenameMap);
+    const notes = this.buildNotes(
+      mapData,
+      resolvedDeckName,
+      cardType,
+      filenameMap,
+      allMediaFilenames
+    );
 
     const workspaceDir = path.join(os.tmpdir(), `mindmap-export-${randomUUID()}`);
     fs.mkdirSync(workspaceDir, { recursive: true });

--- a/src/usecases/mindmaps/mindmapToClozeNotes.ts
+++ b/src/usecases/mindmaps/mindmapToClozeNotes.ts
@@ -74,6 +74,11 @@ export function mindmapToClozeNotes(
     });
     const note = new Note(parts.join(' → '), '');
     note.cloze = true;
+    const media = path
+      .map((id) => imageUrlMap.get(id))
+      .map((url) => (url == null ? null : filenameMap[url.split('/').pop() ?? '']))
+      .filter((m): m is string => m != null);
+    if (media.length > 0) note.media = media;
     return note;
   });
 }

--- a/src/usecases/mindmaps/mindmapToNotes.test.ts
+++ b/src/usecases/mindmaps/mindmapToNotes.test.ts
@@ -97,6 +97,7 @@ describe('mindmapToNotes', () => {
 
     expect(result[0].back).toContain('<img src="abc.png"');
     expect(result[0].back).toContain('Child with image');
+    expect(result[0].media).toEqual(['abc.png']);
   });
 
   it('node with image and no filename map falls back to label only', () => {

--- a/src/usecases/mindmaps/mindmapToNotes.ts
+++ b/src/usecases/mindmaps/mindmapToNotes.ts
@@ -5,13 +5,16 @@ function buildNodeBack(
   label: string,
   imageUrl: string | undefined,
   filenameMap: Record<string, string>
-): string {
-  if (imageUrl == null) return label;
+): { html: string; media: string | null } {
+  if (imageUrl == null) return { html: label, media: null };
   const filename = imageUrl.split('/').pop() ?? '';
   const mapped = filenameMap[filename];
-  if (mapped == null) return label;
+  if (mapped == null) return { html: label, media: null };
   const imgTag = `<img src="${mapped}" alt="${label}" style="max-width:100%;height:auto;">`;
-  return label.length > 0 ? `${imgTag}<br>${label}` : imgTag;
+  return {
+    html: label.length > 0 ? `${imgTag}<br>${label}` : imgTag,
+    media: mapped,
+  };
 }
 
 export function mindmapToNotes(
@@ -29,7 +32,10 @@ export function mindmapToNotes(
     const front = buildNodeBack(parentNode.label, parentNode.image?.url, filenameMap);
     const back = buildNodeBack(childNode.label, childNode.image?.url, filenameMap);
 
-    notes.push(new Note(front, back));
+    const note = new Note(front.html, back.html);
+    const media = [front.media, back.media].filter((m): m is string => m != null);
+    if (media.length > 0) note.media = media;
+    notes.push(note);
   }
   return notes;
 }

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -581,9 +581,16 @@ export function MindmapEditor() {
 
   function startRename(nodeId: string) {
     setNodes((ns) =>
-      ns.map((n) =>
-        n.id === nodeId ? { ...n, data: { ...n.data, editing: true } } : n
-      )
+      ns.map((n) => {
+        if (n.id !== nodeId) return n;
+        const measured = (n as Node & { measured?: { width?: number; height?: number } }).measured;
+        return {
+          ...n,
+          data: { ...n.data, editing: true },
+          width: n.width ?? measured?.width,
+          height: n.height ?? measured?.height,
+        };
+      })
     );
   }
 


### PR DESCRIPTION
## What

Two regressions from #2603 that surfaced after merge:

1. **Double-clicking a node to edit shrank it.** Content-sized nodes (no explicit width yet) collapsed to the textarea's intrinsic width when entering edit.
2. **Images appeared in card HTML but didn't render in Anki.** The card back contained `<img src="681ad808-...png">` but the apkg shipped without the image bytes attached.

## Why

1. With `cols={1}` + `width: 100%`, the textarea and parent kept asking each other for a size; for nodes that hadn't been resized, the parent was content-sized and the textarea won.
2. The Python deck packager only bundles files each card lists in its `media` array. `CustomExporter.addMedia` wrote the bytes to the workspace, but `note.media` was never populated, so the build step ignored them.

## How

1. `startRename` copies React Flow's `node.measured.{width,height}` onto the node before flipping `editing: true` if width/height aren't already explicit. The edit-mode textarea then has dimensions to fill.
2. `mindmapToNotes`, `mindmapToClozeNotes`, and the markmap branch in `ExportMindmapUseCase` populate `note.media` with the filenames of any images they reference. Existing image-tag emission stays unchanged.

## Testing

- `mindmapToNotes.test.ts` extended to assert `note.media` is `['abc.png']` when a node has an image.
- All mindmap unit tests pass (server + web).
- `pnpm --filter 2anki-web typecheck` clean; `npx tsc --noEmit` clean.

## Browser check
Browser check: not applicable — fixes need verification in the browser + Anki; the harness has no browser.

## Risks

- The Python packager is shared with every other deck path. Populating `note.media` here uses the same pattern existing paths (`DeckParser`, `handleNestedBulletPointsInMarkdown`) already use, so the risk is contained to the mindmap export.

## Goal alignment

Simpler/faster/more beautiful: a card with an image showing nothing is worse than no image. Restoring "what you see in the editor is what lands in Anki" closes the loop the spec promised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782041309&installation_id=132681956&pr_number=2609&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2609&signature=af57bfd627ed91accef7f3915e81782beef9257b626ffed7856aede46bbf6596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->