### PR TITLE
fix: docs reference My Decks instead of stale My uploads

### DIFF
--- a/web/src/pages/DocsPage/content/cards/ai-flashcards.md
+++ b/web/src/pages/DocsPage/content/cards/ai-flashcards.md
@@ -22,9 +22,9 @@ The general-purpose option. Sends your content to Anthropic's Claude and uses th
 1. On the upload screen, open the settings panel.
 2. Switch **Generate Flashcards with Claude AI** on.
 3. (Optional) Open **User instructions** and write a sentence or two about the kind of cards you want.
-4. Upload your file. The job runs in the background — you can leave the page and come back to **My uploads** to download.
+4. Upload your file. The job runs in the background — you can leave the page and come back to **My Decks** to download.
 
-The result is a normal `.apkg`. Cards arrive pre-tagged with 1–3 topic tags drawn from the content — you can filter or browse by tag in Anki's tag browser the moment the deck opens. You can re-download the deck from **My uploads** for as long as your plan keeps it (see [Limits and quotas](/documentation/help/limits) for storage windows).
+The result is a normal `.apkg`. Cards arrive pre-tagged with 1–3 topic tags drawn from the content — you can filter or browse by tag in Anki's tag browser the moment the deck opens. You can re-download the deck from **My Decks** for as long as your plan keeps it (see [Limits and quotas](/documentation/help/limits) for storage windows).
 
 ### Writing good user instructions
 

--- a/web/src/pages/DocsPage/content/help/limits.md
+++ b/web/src/pages/DocsPage/content/help/limits.md
@@ -51,7 +51,7 @@ Your file lives on disk only long enough to build the deck. The `.apkg` is sent 
 
 ### Notion convert and Claude AI uploads
 
-These paths build your deck in the background and store the `.apkg` in our bucket so you can re-download it from **My uploads** and so [sync](/documentation/sync/how-it-works) has something to update.
+These paths build your deck in the background and store the `.apkg` in our bucket so you can re-download it from **My Decks** and so [sync](/documentation/sync/how-it-works) has something to update.
 
 | Plan | How long your decks stay in the bucket |
 |---|---|
@@ -59,7 +59,7 @@ These paths build your deck in the background and store the `.apkg` in our bucke
 | Subscription | Kept for as long as your subscription is active. |
 | Lifetime (Patreon) | Kept indefinitely. |
 
-If your subscription lapses, your stored decks are removed in the next daily cleanup — re-convert and they come back. You can also delete a deck yourself from **My uploads** at any time.
+If your subscription lapses, your stored decks are removed in the next daily cleanup — re-convert and they come back. You can also delete a deck yourself from **My Decks** at any time.
 
 ## Free vs paid
 

--- a/web/src/pages/DocsPage/content/reference/self-hosting.md
+++ b/web/src/pages/DocsPage/content/reference/self-hosting.md
@@ -57,7 +57,7 @@ Each integration adds a feature. You can run 2anki without any of them — the f
 | Anthropic Claude | `ANTHROPIC_API_KEY` | AI flashcard generation from PDFs |
 | Stripe | `STRIPE_KEY`, `STRIPE_ENDPOINT_SECRET` | Paid plans (skip if you're running for yourself) |
 | SendGrid | `SENDGRID_API_KEY` | Transactional email (password reset, etc.) |
-| DigitalOcean Spaces (S3-compatible) | `SPACES_ENDPOINT`, `SPACES_DEFAULT_BUCKET_NAME`, plus standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Remote storage for converted decks (needed for "My uploads" history and sync) |
+| DigitalOcean Spaces (S3-compatible) | `SPACES_ENDPOINT`, `SPACES_DEFAULT_BUCKET_NAME`, plus standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Remote storage for converted decks (needed for "My Decks" history and sync) |
 
 ## Where to get help
 

--- a/web/src/pages/DocsPage/content/start-here/upload-a-file.md
+++ b/web/src/pages/DocsPage/content/start-here/upload-a-file.md
@@ -67,7 +67,7 @@ Drop the wrong format and 2anki tells you. The error message names the supported
 We need the file long enough to convert it. After that:
 
 - **Anonymous and Free account file uploads** — the temporary working files are wiped within two hours. The `.apkg` is sent straight back as the response, so we don't keep a copy.
-- **Claude AI uploads and Notion conversions** are stored in your account so you can re-download from **My uploads**. Free accounts: removed within 24 hours. Subscription: kept while your sub is active. Lifetime: kept indefinitely.
+- **Claude AI uploads and Notion conversions** are stored in your account so you can re-download from **My Decks**. Free accounts: removed within 24 hours. Subscription: kept while your sub is active. Lifetime: kept indefinitely.
 - We don't read your content for any reason other than building your deck. We don't train models on it.
 
 The full story is on the [privacy policy](/documentation/reference/privacy). The hard numbers are on [Limits and quotas](/documentation/help/limits).


### PR DESCRIPTION
## What

Updates six references in the in-app docs from **My uploads** → **My Decks** across four MDX files.

| File | Occurrences |
|---|---|
| `web/src/pages/DocsPage/content/cards/ai-flashcards.md` | 2 |
| `web/src/pages/DocsPage/content/help/limits.md` | 2 |
| `web/src/pages/DocsPage/content/reference/self-hosting.md` | 1 |
| `web/src/pages/DocsPage/content/start-here/upload-a-file.md` | 1 |

## Why

The sidebar and the page itself shipped as **My Decks** on 2026-05-12 (changelog `2026-05-12-downloads-page-renamed-to-my-decks.json`). The rendered docs at `/documentation/...` kept the old label, so anyone following the docs would look for a sidebar entry that no longer exists.

## How

Six find-and-replace edits. No logic, no layout, no styling — pure noun substitution, capital D to match the sidebar label and i18n key `navigation.myDecks`.

## Measuring success

Docs and product UI now use the same label. Reduces a small but real moment of confusion for users following the AI flashcards / limits / upload pages.

## Testing

- Verified the only remaining `My uploads` strings in the repo are: test fixtures (deck-name literals), the past changelog title for the original rename, and a `MyDeck.pdf` filename example in `print-export.md` — none of those are stale UI labels.
- Type-check, lint, vitest unaffected — content-only change in MDX files that go through the existing docs loader.

## Risks

None. Worst case: a typo I didn't spot. The diff is six lines.

## Goal alignment

Doc/UI consistency keeps the experience simpler — users following docs land where they expect.

## Changelog

No entry — internal consistency fix; the original rename already had its own changelog entry, and a "the docs caught up" line would be noise to readers.

Browser check: not applicable — markdown content rename across four MDX files, no logic, layout, or rendering-structure change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782059639&installation_id=132681956&pr_number=2640&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2640&signature=5b0750349e1f647713694bfdd1ac82ea3ce840e0e3f74346ca1a2d11af84ba75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->