### PR TITLE
chore: drop Snyk from dependabot batch playbook

### DIFF
--- a/.claude/commands/batch-tasks/dependabot.md
+++ b/.claude/commands/batch-tasks/dependabot.md
@@ -25,7 +25,7 @@ From the JSON:
   - `X != A` → `major`
   - If you cannot parse, treat as `unknown` and proceed as non-patch.
 - **Files** — list of changed paths.
-- **Labels** — surface any `snyk`-flagged or `security` labels.
+- **Labels** — surface any `security` label.
 
 ## Step 2 — belt-and-suspenders hard-block check
 
@@ -58,11 +58,11 @@ Invoke the `/check` skill — the existing parallel server tsc + web typecheck +
 
 Decision matrix:
 
-| bump | /check | snyk/security label | action |
+| bump | /check | security label | action |
 | --- | --- | --- | --- |
 | patch | green | none | `gh pr merge <n> --squash --delete-branch` → status `merged` |
 | patch | red | any | comment with the failure summary → status `needs-review` |
-| patch | green | snyk or security | comment "Snyk-flagged — needs eyes" → status `needs-review` |
+| patch | green | security | comment "Security-flagged — needs eyes" → status `needs-review` |
 | minor | any | any | comment with the bump level → status `needs-review` |
 | major | any | any | comment with the bump level → status `needs-review` |
 | unknown | any | any | comment "Could not parse bump level from title" → status `needs-review` |
@@ -73,7 +73,7 @@ Decision matrix:
 gh pr merge <n> --squash --delete-branch
 ```
 
-Only ever from the `patch + green + no snyk/security` row. Never from any other row.
+Only ever from the `patch + green + no security` row. Never from any other row.
 
 **Comment call (any `needs-review` exit):**
 


### PR DESCRIPTION
## Summary
- Removes `snyk`-label handling from `.claude/commands/batch-tasks/dependabot.md` ahead of uninstalling the Snyk GitHub App
- Collapses the auto-merge decision matrix to a single `security` column so the heuristic stays vendor-neutral

## Why
The Snyk GitHub App has been posting a persistent `security/snyk (aalemayhu)` ERROR status on every dependency PR (#2620, #2622, #2625, #2627, #2639), even on PRs that are fully green otherwise. Uninstalling the App from the org settings drops the noise; this PR keeps the playbook honest after that happens.

## Test plan
- [x] No code changes — pure playbook edit
- [x] Local diff reviewed; `security` label signal preserved

Browser check: not applicable — playbook-only change, no rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782062550&installation_id=132681956&pr_number=2643&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2643&signature=2a04308db6ec0a173226071d01af60c9610b0b9aaa8be84d47871af976360d05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->