### PR TITLE
fix: chat cloze cards build correctly + unblock CI (p-limit pin)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "morgan": "^1.10.0",
     "multer": "^2.0.1",
     "nodemailer": "^8.0.1",
-    "p-limit": "^7.3.0",
+    "p-limit": "^3.1.0",
     "pdf-parse": "1.1.1",
     "pg": "^8.11.3",
     "piscina": "^5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: ^8.0.1
         version: 8.0.7
       p-limit:
-        specifier: ^7.3.0
-        version: 7.3.0
+        specifier: ^3.1.0
+        version: 3.1.0
       pdf-parse:
         specifier: 1.1.1
         version: 1.1.1
@@ -6112,10 +6112,6 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
-  p-limit@7.3.0:
-    resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
-    engines: {node: '>=20'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
@@ -7799,10 +7795,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   yummies@7.19.4:
     resolution: {integrity: sha512-OO7jPtnYW+D8DX/1P1vQsWGZZjpQljuW2oEHc3RJ1a8e6SiWOtIUCL8sTwkLO6kaf7NfocRr/ld48vXZnO2hOg==}
@@ -14403,10 +14395,6 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
-  p-limit@7.3.0:
-    dependencies:
-      yocto-queue: 1.2.2
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
@@ -16200,8 +16188,6 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.2.2: {}
 
   yummies@7.19.4(react@19.2.6):
     dependencies:

--- a/src/usecases/chat/ChatDeckUseCase.test.ts
+++ b/src/usecases/chat/ChatDeckUseCase.test.ts
@@ -1,4 +1,4 @@
-import { looksLikeCloze } from './ChatDeckUseCase';
+import { looksLikeCloze, transformBlankToCloze } from './ChatDeckUseCase';
 
 describe('looksLikeCloze', () => {
   it('returns true for a single cloze marker', () => {
@@ -33,5 +33,73 @@ describe('looksLikeCloze', () => {
 
   it('returns false on an empty string', () => {
     expect(looksLikeCloze('')).toBe(false);
+  });
+});
+
+describe('transformBlankToCloze', () => {
+  it('rewrites a single ___ blank with the back content as {{c1::...}}', () => {
+    expect(
+      transformBlankToCloze({
+        front: 'The Norwegian word for hunting is ___.',
+        back: 'jakt',
+      })
+    ).toEqual({
+      front: 'The Norwegian word for hunting is {{c1::jakt}}.',
+      back: '',
+    });
+  });
+
+  it('only rewrites the first blank when the front has multiple', () => {
+    expect(
+      transformBlankToCloze({
+        front: 'A ___ eats ___ for breakfast.',
+        back: 'cat',
+      })
+    ).toEqual({
+      front: 'A {{c1::cat}} eats ___ for breakfast.',
+      back: '',
+    });
+  });
+
+  it('leaves the card unchanged when front already uses canonical cloze syntax', () => {
+    const card = {
+      front: 'The capital of {{c1::France}} is Paris.',
+      back: '',
+    };
+    expect(transformBlankToCloze(card)).toEqual(card);
+  });
+
+  it('leaves the card unchanged when there is no blank pattern in the front', () => {
+    const card = { front: 'What is the capital of France?', back: 'Paris' };
+    expect(transformBlankToCloze(card)).toEqual(card);
+  });
+
+  it('leaves the card unchanged when back is empty or whitespace-only', () => {
+    const card = { front: 'A ___ is a furry pet.', back: '   ' };
+    expect(transformBlankToCloze(card)).toEqual(card);
+  });
+
+  it('trims surrounding whitespace from the back content before substitution', () => {
+    expect(
+      transformBlankToCloze({
+        front: 'Hjort means ___ in English.',
+        back: '  deer  ',
+      })
+    ).toEqual({
+      front: 'Hjort means {{c1::deer}} in English.',
+      back: '',
+    });
+  });
+
+  it('accepts 2-or-more underscores as a blank marker', () => {
+    expect(
+      transformBlankToCloze({
+        front: 'Two underscores too: __',
+        back: 'still works',
+      })
+    ).toEqual({
+      front: 'Two underscores too: {{c1::still works}}',
+      back: '',
+    });
   });
 });

--- a/src/usecases/chat/ChatDeckUseCase.ts
+++ b/src/usecases/chat/ChatDeckUseCase.ts
@@ -20,9 +20,21 @@ function randomDeckId(): number {
 }
 
 const CLOZE_PATTERN = /\{\{c\d+::/;
+const BLANK_PATTERN = /_{2,}/;
 
 export function looksLikeCloze(front: string): boolean {
   return CLOZE_PATTERN.test(front);
+}
+
+export function transformBlankToCloze(card: ChatDeckCard): ChatDeckCard {
+  if (CLOZE_PATTERN.test(card.front)) return card;
+  if (!BLANK_PATTERN.test(card.front)) return card;
+  const trimmedBack = card.back.trim();
+  if (trimmedBack.length === 0) return card;
+  return {
+    front: card.front.replace(BLANK_PATTERN, `{{c1::${trimmedBack}}}`),
+    back: '',
+  };
 }
 
 export class ChatDeckUseCase {
@@ -32,6 +44,7 @@ export class ChatDeckUseCase {
     fs.mkdirSync(workspaceDir, { recursive: true });
 
     try {
+      const normalizedCards = cards.map(transformBlankToCloze);
       const deckInfo = [
         {
           name: deckName,
@@ -45,7 +58,7 @@ export class ChatDeckUseCase {
             inputModelName: 'n2a-input',
             useNotionId: false,
           },
-          cards: cards.map((c, index) => ({
+          cards: normalizedCards.map((c, index) => ({
             name: c.front,
             back: c.back,
             tags: [],

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -18,6 +18,14 @@ Help users understand material, answer study questions, and generate flashcards.
 [{"front": "question or term", "back": "answer or definition"}]
 \`\`\`
 
+For fill-in-the-blank or cloze cards, put the answer inline using Anki cloze syntax on the front and leave back empty:
+
+\`\`\`json
+[{"front": "The capital of France is {{c1::Paris}}.", "back": ""}]
+\`\`\`
+
+Use {{c1::...}}, {{c2::...}}, {{c3::...}} for separate blanks within the same card. Do not use bare ___ placeholders — the deck builder expects Anki cloze syntax for cloze cards.
+
 Never output raw JSON without the code fence. Always include the opening \`\`\`json and closing \`\`\` markers.
 
 Supported input on 2anki:

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-chat-cloze-cards.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-chat-cloze-cards.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-chat-cloze-cards",
+  "date": "2026-05-22",
+  "type": "fix",
+  "title": "Chat — fill-in-the-blank cards from chat now build as real Anki cloze cards"
+}


### PR DESCRIPTION
## What

Two fixes bundled because the second was blocking the first from merging:

1. **Cloze cards from `/chat` now build as real Anki Cloze**. Cards with `___` fill-in-the-blank placeholders were importing as Basic Front/Back instead of Cloze.
2. **Pin `p-limit` to `^3.1.0`**. Dependabot PR #2626 bumped to `7.3.0` which is ESM-only, breaking `src/usecases/uploads/getPackagesFromZip.test.ts` under ts-jest CommonJS. Server CI on main is currently red; this revert restores it.

## Why

**Cloze**: Real user signal — Al generated a Norwegian-vocab quiz on `/chat` and got cards like `front: "The Norwegian word for hunting is ___", back: "jakt"`. These imported into Anki as plain Front/Back rather than Cloze, defeating the format. Root cause: PR #2255 (15 May) added correct `{{c1::}}` detection but the prompt never tells the model to use that syntax — it only documents the generic `{"front": "...", "back": "..."}` shape. So the model picks whatever blank-fill markup it wants (commonly `___`) and the deck builder doesn't see cloze syntax.

**p-limit**: Required to unblock this PR's CI; the regression is on `main`, not introduced here. Pinning a working version is the fastest path. Moving the project to ESM is a separate, larger effort.

## How

Cloze fix:
- Prompt update (`ChatUseCase.ts`) documents the cloze JSON format with an explicit example and instructs the model to use `{{c1::answer}}` inline (back empty) for fill-in-the-blank, never bare `___`.
- New `transformBlankToCloze()` helper in `ChatDeckUseCase.ts` rewrites cards that still arrive with `___` + non-empty back into canonical `{{c1::back}}` before the `looksLikeCloze` check. Handles old models, edge cases, and the cards Al already has.

p-limit pin:
- One-character change in `package.json` (`^7.3.0` → `^3.1.0`) plus the resulting lockfile delta.

## Measuring success

Generate a fill-in-the-blank deck on `/chat` (e.g. "make me 10 cloze cards on Norwegian wildlife"). Download. Open in Anki. Confirm cards are the **Cloze** note type, not Basic.

## Testing

- 7 new unit tests for `transformBlankToCloze` (single blank rewrite, multi-blank first-only, already-cloze passthrough, no-blank passthrough, empty-back passthrough, whitespace trim, 2-underscore minimum).
- 8 existing `looksLikeCloze` tests still pass.
- `getPackagesFromZip.test.ts` (the one that was broken by p-limit 7.x) passes locally.
- 69 chat use-case tests pass. Server `tsc --noEmit` clean.

## Risks

- `_{2,}` regex could match underscores inside identifiers (`foo__bar`). Cards with code in the front are rare and the user would notice immediately. If it surfaces, tighten to `_{3,}` or space-bound the match.
- Pinning p-limit defers the ESM migration; Dependabot will re-propose the 7.x bump and should be dismissed with a comment until the project moves to ESM.
- Prompt change adds ~80 tokens to the cached system prompt — negligible.

## Goal alignment

Cards from `/chat` are the simplest path from a user's question to a usable deck. When the cards arrive in Anki as the wrong type, the round-trip is broken. This fix gets the chat path back to its actual contract.

## Browser check

Browser check: not applicable — server-side prompt + deck-builder change. The only `web/src/` file is the changelog JSON (bypasses the gate per `.claude/rules/browser-attestation.md`).

## Changelog

Added: `Chat — fill-in-the-blank cards from chat now build as real Anki cloze cards`.