### PR TITLE
feat: add AdSense for anonymous visitors

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="Content-Security-Policy"
-    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';">
+    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com; img-src 'self' data: https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com;">
   <link rel="apple-touch-icon" href="/logo192.png" />
   <!--
       Notice the use of  in the tags above.
@@ -165,6 +165,7 @@
       document.head.appendChild(script);
     });
   </script>
+  <script id="adsense-script" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9593032741719801" crossorigin="anonymous"></script>
 </head>
 
 <body>

--- a/web/src/components/AdSense/AdSenseScript.test.ts
+++ b/web/src/components/AdSense/AdSenseScript.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { removeAdSenseScript, ADSENSE_SCRIPT_ID } from './AdSenseScript';
+
+function makeDoc(): Document {
+  return document.implementation.createHTMLDocument();
+}
+
+function makeDocWithScript(): Document {
+  const doc = makeDoc();
+  const script = doc.createElement('script');
+  script.id = ADSENSE_SCRIPT_ID;
+  doc.head.appendChild(script);
+  return doc;
+}
+
+describe('removeAdSenseScript', () => {
+  it('removes the script tag when present', () => {
+    const doc = makeDocWithScript();
+    expect(doc.getElementById(ADSENSE_SCRIPT_ID)).not.toBeNull();
+    removeAdSenseScript(doc);
+    expect(doc.getElementById(ADSENSE_SCRIPT_ID)).toBeNull();
+  });
+
+  it('does not throw when the script tag is absent', () => {
+    const doc = makeDoc();
+    expect(() => removeAdSenseScript(doc)).not.toThrow();
+  });
+
+  it('is idempotent — calling twice does not throw', () => {
+    const doc = makeDocWithScript();
+    removeAdSenseScript(doc);
+    expect(() => removeAdSenseScript(doc)).not.toThrow();
+    expect(doc.getElementById(ADSENSE_SCRIPT_ID)).toBeNull();
+  });
+});

--- a/web/src/components/AdSense/AdSenseScript.ts
+++ b/web/src/components/AdSense/AdSenseScript.ts
@@ -1,0 +1,5 @@
+export const ADSENSE_SCRIPT_ID = 'adsense-script';
+
+export function removeAdSenseScript(doc: Document = document): void {
+  doc.getElementById(ADSENSE_SCRIPT_ID)?.remove();
+}

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -334,6 +334,7 @@
   flex-direction: column;
   min-width: 0;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 .mobileTopBar {

--- a/web/src/components/AppShell/AppShell.tsx
+++ b/web/src/components/AppShell/AppShell.tsx
@@ -1,9 +1,10 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { PageLayout } from '../Layout/PageLayout';
 import { SidebarLayout } from './SidebarLayout';
 import { SidebarFeatures, SidebarLocals } from './Sidebar';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { removeAdSenseScript } from '../AdSense/AdSenseScript';
 
 const TOP_BAR_PATHS = new Set(['/login', '/register', '/forgot']);
 const TOP_BAR_PREFIXES = ['/users/r/'];
@@ -31,6 +32,14 @@ export function AppShell({
   children,
 }: Readonly<AppShellProps>) {
   const { pathname } = useLocation();
+
+  useEffect(() => {
+    if (isLoggedIn == null) return;
+    const isPricingRoute = pathname === '/pricing';
+    if (isLoggedIn || isPricingRoute) {
+      removeAdSenseScript();
+    }
+  }, [isLoggedIn, pathname]);
 
   const onLogOut = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>

--- a/web/src/components/Layout/Layout.module.css
+++ b/web/src/components/Layout/Layout.module.css
@@ -4,4 +4,5 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  overflow-x: hidden;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-adsense-anon.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-adsense-anon.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-adsense-anon",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "2anki stays ad-free once you sign in — ads show only to visitors who haven't logged in"
+}


### PR DESCRIPTION
## Summary
- Adds Google AdSense `<script>` site-wide in `web/index.html` so prerendered SEO pages and anonymous landing visitors load ads from first paint.
- Removes the script from the DOM in `AppShell` once auth resolves and the user is logged in, or when the route is `/pricing`.
- Extends the CSP to allow AdSense + DoubleClick domains.
- Adds `overflow-x: hidden` to the main content wrapper to prevent ad-induced horizontal scroll on mobile.

## Gate
- Logged-out → ads.
- Logged-in (any account, paying or free) → no ads.
- `/pricing` → never ads, even for anon (cannibalizes the Auto Sync upgrade CTA).

## Implementation notes
The `useEffect` lives in `AppShell` (not `AppContent` as originally planned) because `AppShell` is already inside the `BrowserRouter` context and already uses `useLocation`. `AppContent` wraps `BrowserRouter`, so `useLocation` cannot be called there. The behaviour is identical.

`isLoggedIn == null` guards the loading state (`undefined`) — no flicker, no premature removal.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes:

## Test plan
- [ ] Anon hits `/` → AdSense script present in `<head>`.
- [ ] Anon hits `/pricing` → script removed by mount.
- [ ] Log in → script removed.
- [ ] No CSP violations in console (open DevTools → Console).
- [ ] Mobile (375px): no horizontal scroll.

## Operational follow-ups
- Enable Auto Ads in the AdSense console: keep In-article + Multiplex; disable Anchor, Vignette, and any push-notification format.
- Capture 7-day baseline of paid-conversion rate, signup→paid, /upload p95, bounce, AdSense net RPM before relying on the data.
- Kill criteria (per PM): paid conversion -15 % WoW, AdSense net <$30/mo at day 14, /upload p95 +500 ms, or ≥2 support emails citing ads.

## Sonar
sonar-scanner was not run locally — the worktree environment does not have `SONAR_TOKEN` configured and the scanner is not installed. The diff is small: one new pure-function module (`AdSenseScript.ts`, 4 lines), one `useEffect` in `AppShell.tsx`, CSP string changes in `index.html`, and CSS additions. No user input handling, no HTTP calls, no new data flows. No known Sonar risk patterns apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782065859&installation_id=132681956&pr_number=2645&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2645&signature=8df8bcb11c9cfe33bdf0377ea06b6bcaaad5c088d9a49cf83c5a6b00dac7b81c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->