### PR TITLE
feat: opt-out toggle for Photo-to-Deck source image

### DIFF
--- a/src/controllers/PhotoToFlashcardsController.ts
+++ b/src/controllers/PhotoToFlashcardsController.ts
@@ -15,6 +15,7 @@ interface RawPhotoBody {
   deckName?: unknown;
   width?: unknown;
   height?: unknown;
+  includeSourceImage?: unknown;
 }
 
 function isAllowedMediaType(value: unknown): value is VisionMediaType {
@@ -51,6 +52,8 @@ export class PhotoToFlashcardsController {
 
     const owner = (res.locals['owner'] ?? '') as string;
     const paying = isPaying(res.locals);
+    const includeSourceImage =
+      typeof body.includeSourceImage === 'boolean' ? body.includeSourceImage : true;
 
     let result: Awaited<ReturnType<PhotoToFlashcardsUseCase['execute']>>;
     try {
@@ -61,6 +64,7 @@ export class PhotoToFlashcardsController {
         owner,
         isPaying: paying,
         imageDimensions: { width, height },
+        includeSourceImage,
       });
     } catch (err) {
       const e = err as Error & {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -306,6 +306,35 @@ describe('PhotoToFlashcardsUseCase', () => {
       }>;
       expect(payload[0].cards[0].media[0]).toMatch(/\.png$/);
     });
+
+    describe('includeSourceImage: false', () => {
+      it('does not write the source image file to disk', async () => {
+        const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+        await useCase.execute({ ...BASE_INPUT, isPaying: true, includeSourceImage: false });
+
+        const imageWriteCall = (mockFs.writeFileSync as jest.Mock).mock.calls.find(
+          ([p]: [string]) => typeof p === 'string' && !p.endsWith('deck_info.json')
+        );
+        expect(imageWriteCall).toBeUndefined();
+      });
+
+      it('sets media to empty array on every card in deck_info.json', async () => {
+        const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+        await useCase.execute({ ...BASE_INPUT, isPaying: true, includeSourceImage: false });
+
+        const writeCall = (mockFs.writeFileSync as jest.Mock).mock.calls.find(
+          ([p]: [string]) => typeof p === 'string' && p.endsWith('deck_info.json')
+        );
+        expect(writeCall).toBeDefined();
+        const payload = JSON.parse(writeCall![1] as string) as Array<{
+          cards: Array<{ media: string[]; back: string }>;
+        }>;
+        for (const card of payload[0].cards) {
+          expect(card.media).toEqual([]);
+          expect(card.back).not.toContain('<img src=');
+        }
+      });
+    });
   });
 
   describe('VISION_PROMPT', () => {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -21,6 +21,7 @@ export interface PhotoToFlashcardsInput {
   isPaying: boolean;
   imageDimensions: { width: number; height: number };
   tokenCeilingOverride?: number;
+  includeSourceImage?: boolean;
 }
 
 export interface PhotoToFlashcardsResult {
@@ -294,7 +295,10 @@ export class PhotoToFlashcardsUseCase {
       (outputTokens / 1_000_000) * OUTPUT_COST_PER_MILLION;
 
     const deckName = input.deckName || (decks[0]?.deck ?? 'Photo deck');
-    const sourceFilename = `source-${randomUUID()}.${mediaTypeToExt(input.mediaType)}`;
+    const embedSourceImage = input.includeSourceImage ?? true;
+    const sourceFilename = embedSourceImage
+      ? `source-${randomUUID()}.${mediaTypeToExt(input.mediaType)}`
+      : null;
 
     const workspaceDir = path.join(os.tmpdir(), `vision-${randomUUID()}`);
     fs.mkdirSync(workspaceDir, { recursive: true });
@@ -303,10 +307,12 @@ export class PhotoToFlashcardsUseCase {
 
     let apkgPath: string;
     try {
-      fs.writeFileSync(
-        path.join(workspaceDir, sourceFilename),
-        Buffer.from(input.imageBase64, 'base64')
-      );
+      if (sourceFilename != null) {
+        fs.writeFileSync(
+          path.join(workspaceDir, sourceFilename),
+          Buffer.from(input.imageBase64, 'base64')
+        );
+      }
       fs.writeFileSync(
         path.join(workspaceDir, 'deck_info.json'),
         JSON.stringify([deckInfo]),

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
@@ -134,6 +134,14 @@
   text-align: center;
 }
 
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--color-text-secondary);
+}
+
 @media (hover: hover) and (pointer: fine) {
   .cameraButtonContainer {
     display: none;

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
@@ -262,4 +262,53 @@ describe('PhotoToFlashcardsPage', () => {
     });
     expect(mockTrack).toHaveBeenCalledWith('photo_quota_reached', { used: 5, limit: 5 });
   });
+
+  describe('source image toggle', () => {
+    it('renders the source image checkbox checked by default', () => {
+      render(<PhotoToFlashcardsPage />);
+      const checkbox = screen.getByRole('checkbox', {
+        name: /Show source image on the back of each card/,
+      }) as HTMLInputElement;
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it('sends includeSourceImage: true when checkbox is checked', async () => {
+      setLocals({ paying: true });
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [makePhoto()] } });
+      fireEvent.click(screen.getByRole('button', { name: 'Get flashcards' }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0][1] as RequestInit).body as string
+      ) as { includeSourceImage: boolean };
+      expect(body.includeSourceImage).toBe(true);
+    });
+
+    it('sends includeSourceImage: false when checkbox is unchecked', async () => {
+      setLocals({ paying: true });
+      const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      render(<PhotoToFlashcardsPage />);
+      const checkbox = screen.getByRole('checkbox', {
+        name: /Show source image on the back of each card/,
+      });
+      fireEvent.click(checkbox);
+
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [makePhoto()] } });
+      fireEvent.click(screen.getByRole('button', { name: 'Get flashcards' }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0][1] as RequestInit).body as string
+      ) as { includeSourceImage: boolean };
+      expect(body.includeSourceImage).toBe(false);
+    });
+  });
 });

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -62,6 +62,7 @@ export function PhotoToFlashcardsPage() {
   const [cardCount, setCardCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [uploadSource, setUploadSource] = useState<UploadSource>('library');
+  const [includeSourceImage, setIncludeSourceImage] = useState(true);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
 
@@ -134,6 +135,7 @@ export function PhotoToFlashcardsPage() {
           deckName: name,
           width: dimensions.width,
           height: dimensions.height,
+          includeSourceImage,
         }),
       });
 
@@ -207,6 +209,15 @@ export function PhotoToFlashcardsPage() {
           placeholder={file?.name.replace(/\.[^.]+$/, '') || 'Photo deck'}
         />
       </div>
+
+      <label className={pageStyles.checkboxRow}>
+        <input
+          type="checkbox"
+          checked={includeSourceImage}
+          onChange={(e) => setIncludeSourceImage(e.target.checked)}
+        />
+        Show source image on the back of each card
+      </label>
 
       <div className={pageStyles.cameraButtonContainer}>
         <button

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-photo-deck-source-image-toggle.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-photo-deck-source-image-toggle.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-photo-deck-source-image-toggle",
+  "date": "2026-05-22",
+  "type": "feature",
+  "title": "Photo-to-Deck — uncheck to skip bundling the source image on the back of each card"
+}


### PR DESCRIPTION
## What
Adds a checkbox to the Photo-to-Deck page that lets users skip bundling the source image on the back of each card. The checkbox defaults to checked, preserving the behavior shipped in #2636. When unchecked, the backend skips writing the image bytes to disk and `buildDeckInfo` receives `null` for `sourceFilename`, resulting in `media: []` and no `<img>` tag on any card back.

## Why
Follow-up to #2636 explicitly requested by Al. PM and designer both recommended against shipping this toggle (Photo-to-Deck cards showing the source image is the feature working as intended), but Al chose to ship it. Default-on means existing behavior is unchanged for all users who don't interact with the toggle.

## How
- `PhotoToFlashcardsInput` gains an optional `includeSourceImage?: boolean` field (default `true`).
- Controller reads `req.body.includeSourceImage` with `?? true` fallback; passes it to the use case.
- Use case gates the `fs.writeFileSync` image-bytes call behind the flag and passes `null` to `buildDeckInfo` when false.
- `buildDeckInfo` already handled `null` correctly (from prior null-branch logic).
- Frontend adds a single `useState(true)` and a labeled checkbox; the value flows into the JSON payload.

## Measuring success
When `includeSourceImage: false` is sent, the server log line `vision_call_success` is emitted without the image write syscall. No new log line needed — the absence of the image file in the workspace dir is observable from the existing `deck_info.json` payload (`media: []`). A spot-check: download a deck with the toggle off and confirm the .apkg contains no source image file.

## Testing
- Unit tests added: 2 new backend cases in `PhotoToFlashcardsUseCase.test.ts` (no image file written, media empty + no img tag).
- Unit tests added: 3 new frontend cases in `PhotoToFlashcardsPage.test.tsx` (checkbox renders checked by default, sends `true` when checked, sends `false` when unchecked).
- All 89 backend tests and 16 frontend page tests pass.

## Browser check
Browser check: not applicable — I cannot open localhost:3000 in this session. The change is a single checkbox and a scalar JSON field; no visual layout risk. Al should verify the checkbox renders and the toggle behaves correctly before merge.

## Changelog
"Photo-to-Deck — uncheck to skip bundling the source image on the back of each card"

## Risks
- Default-on: zero behavior change for existing users who don't touch the toggle.
- Rollback: revert this PR; no migration needed.
- No user data is stored; this is purely a per-request flag.

## Goal alignment
Respects user preferences on card format, reducing friction for users who want clean text-only cards. Small scope, low risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782065975&installation_id=132681956&pr_number=2646&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2646&signature=254295217b5ac03f316615a80eded4fb9510045d6b081051f0d5862c900e269c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->