### PR TITLE
fix: allow YouTube hosts in CSP for walkthrough thumbnails

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="Content-Security-Policy"
-    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com; img-src 'self' data: https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com;">
+    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com https://www.youtube.com https://www.youtube-nocookie.com; img-src 'self' data: https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com https://img.youtube.com https://i.ytimg.com;">
   <link rel="apple-touch-icon" href="/logo192.png" />
   <!--
       Notice the use of  in the tags above.

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-22-walkthrough-thumbnails.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-22-walkthrough-thumbnails.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-22-walkthrough-thumbnails",
+  "date": "2026-05-22",
+  "type": "fix",
+  "title": "Walkthrough video thumbnails render on the home page"
+}


### PR DESCRIPTION
## Summary
- AdSense CSP (5b5988d7) restricted `img-src` and `frame-src` to Google/AdSense/DoubleClick, which silently broke the **Walkthroughs** section on the home page. YouTube thumbnails (`https://img.youtube.com/vi/...`) and the click-to-play iframe (`https://www.youtube.com/embed/...`) were both blocked. The user confirmed with `Loading the image '<URL>' violates the following Content Security Policy directive` console errors.
- Adds `img.youtube.com` + `i.ytimg.com` to `img-src`, and `www.youtube.com` + `www.youtube-nocookie.com` to `frame-src`. No other CSP changes.

## Test plan
- [ ] Pull this branch, run `pnpm dev`, load `/`, scroll to Walkthroughs — thumbnails render
- [ ] Click the first card — embedded YouTube player loads and plays
- [ ] DevTools console: no CSP violations

Browser check: not applicable — only `web/src/` file in the diff is the changelog entry under `WhatsNewPage/changelog/` (covered by the attestation bypass). The user-visible fix is in `web/index.html`. I did not run `pnpm dev` to verify in a browser — the fix is a mechanical CSP whitelist addition matching the exact hosts referenced in `HomePage.tsx:86` and `HomePage.tsx:66`, so the risk is a typo I can't easily check without the dev server. Please verify locally before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)