### PR TITLE
fix: load active subscriptions per request in MindmapController

### DIFF
--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -19,6 +19,7 @@ import {
 import { MindmapsId } from '../data_layer/public/Mindmaps';
 import { UsersId } from '../data_layer/public/Users';
 import { AnkifyAccessUser, AnkifyAccessSubscription } from '../lib/ankify/access';
+import SubscriptionService from '../services/SubscriptionService';
 
 export class MindmapController {
   constructor(
@@ -30,17 +31,20 @@ export class MindmapController {
     private readonly exportUseCase: ExportMindmapUseCase
   ) {}
 
-  private resolveUserContext(res: Response): {
+  private async resolveUserContext(res: Response): Promise<{
     userId: UsersId;
     user: AnkifyAccessUser;
     subscriptions: AnkifyAccessSubscription[];
     autoSyncProductId: string;
-  } {
+  }> {
+    const email = res.locals.email as string | undefined;
+    const subscriptions = email
+      ? await SubscriptionService.getUserActiveSubscriptions(email)
+      : [];
     return {
       userId: res.locals.owner as UsersId,
       user: { patreon: (res.locals.patreon as boolean | null | undefined) ?? null },
-      subscriptions:
-        (res.locals.subscriptionInfo as AnkifyAccessSubscription[] | null) ?? [],
+      subscriptions,
       autoSyncProductId: process.env.AUTO_SYNC_PRODUCT_ID ?? '',
     };
   }
@@ -53,7 +57,7 @@ export class MindmapController {
 
   async list(_req: Request, res: Response) {
     const { userId, user, subscriptions, autoSyncProductId } =
-      this.resolveUserContext(res);
+      await this.resolveUserContext(res);
 
     const result = await this.listUseCase.execute({
       userId,
@@ -66,7 +70,7 @@ export class MindmapController {
 
   async create(req: Request, res: Response) {
     const { userId, user, subscriptions, autoSyncProductId } =
-      this.resolveUserContext(res);
+      await this.resolveUserContext(res);
     const rawTitle =
       typeof req.body?.title === 'string' ? req.body.title.trim() : '';
     const title = rawTitle.length > 0 ? rawTitle : 'Untitled';
@@ -102,7 +106,7 @@ export class MindmapController {
 
   async update(req: Request, res: Response) {
     const { userId, user, subscriptions, autoSyncProductId } =
-      this.resolveUserContext(res);
+      await this.resolveUserContext(res);
     const id = req.params.id as MindmapsId;
     const title =
       req.body?.title != null ? String(req.body.title).trim() : undefined;

--- a/src/routes/MindmapRouter.test.ts
+++ b/src/routes/MindmapRouter.test.ts
@@ -9,6 +9,7 @@ const mockExport = jest.fn();
 const mockGetById = jest.fn();
 const mockUpdate = jest.fn();
 const mockCount = jest.fn();
+const mockGetUserActiveSubscriptions = jest.fn();
 
 jest.mock('../data_layer', () => ({
   getDatabase: jest.fn().mockReturnValue({}),
@@ -25,6 +26,14 @@ jest.mock('../data_layer/MindmapRepository', () => ({
   })),
 }));
 
+jest.mock('../services/SubscriptionService', () => ({
+  __esModule: true,
+  default: {
+    getUserActiveSubscriptions: (...args: unknown[]) =>
+      mockGetUserActiveSubscriptions(...args),
+  },
+}));
+
 jest.mock('./middleware/RequireAuthentication', () => {
   const middleware = (
     _req: express.Request,
@@ -32,8 +41,8 @@ jest.mock('./middleware/RequireAuthentication', () => {
     next: express.NextFunction
   ) => {
     res.locals.owner = 42;
+    res.locals.email = 'tester@example.com';
     res.locals.patreon = null;
-    res.locals.subscriptionInfo = [];
     next();
   };
   return middleware;
@@ -64,6 +73,7 @@ describe('MindmapRouter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetUserActiveSubscriptions.mockResolvedValue([]);
   });
 
   describe('POST /api/mindmaps', () => {
@@ -127,6 +137,28 @@ describe('MindmapRouter', () => {
         maxNodesPerMap: 50,
         currentCount: 1,
       });
+    });
+
+    it('reports hasUnlimited when the user has an active Auto Sync subscription', async () => {
+      const previousProductId = process.env.AUTO_SYNC_PRODUCT_ID;
+      process.env.AUTO_SYNC_PRODUCT_ID = 'prod_auto_sync_test';
+      mockList.mockResolvedValue([]);
+      mockCount.mockResolvedValue(0);
+      mockGetUserActiveSubscriptions.mockResolvedValue([
+        { active: true, stripe_product_id: 'prod_auto_sync_test' },
+      ]);
+
+      try {
+        const res = await fetch(`${url}/api/mindmaps`);
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.access.hasUnlimited).toBe(true);
+        expect(mockGetUserActiveSubscriptions).toHaveBeenCalledWith(
+          'tester@example.com'
+        );
+      } finally {
+        process.env.AUTO_SYNC_PRODUCT_ID = previousProductId;
+      }
     });
   });
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmaps-load-again.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmaps-load-again.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-mindmaps-load-again",
+  "date": "2026-05-23",
+  "type": "fix",
+  "title": "Mindmap list and create work again for everyone"
+}


### PR DESCRIPTION
## Summary
- Replace the bad cast in `MindmapController.resolveUserContext` with an explicit `SubscriptionService.getUserActiveSubscriptions(email)` call.
- `res.locals.subscriptionInfo` is the single-object shape from `getSubscriptionInfo` (`{ active, email, linked_email }`), not the `Subscriptions[]` array `hasAnkifyAccess` expects. The bad cast crashed every `list` / `create` / `update` request with `TypeError: subscriptions.some is not a function` for users without `patreon = true`.
- Test middleware previously set `subscriptionInfo = []` (always an array), so the prod-only crash never surfaced in CI. Now mocks `SubscriptionService` and adds a regression assertion for an active Auto Sync subscription.

## Test plan
- [x] `pnpm test src/routes/MindmapRouter.test.ts` — 89 passing including the new Auto Sync regression case
- [x] `npx tsc --noEmit` — clean
- [ ] Mindmap routes load on prod for a non-patreon user post-deploy

## Browser check
Browser check: not applicable — server-only fix; only `web/src/` file is a new changelog JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782126576&installation_id=132681956&pr_number=2650&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2650&signature=87d01bcf2c54c06bcfb40beca573ddbdca19cc559c6610014dcacea4304993c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->