### PR TITLE
fix: bind react-flow controls to app theme tokens

### DIFF
--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-controls-dark.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-controls-dark.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-mindmap-controls-dark",
+  "date": "2026-05-23",
+  "type": "fix",
+  "title": "Mindmap zoom and fit-view buttons are visible in dark mode"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -360,3 +360,15 @@ button {
     transform: rotate(360deg);
   }
 }
+
+/* =====================================================================
+   REACT FLOW — bind library tokens to app design tokens so canvas
+   chrome (controls, etc.) follows the active theme.
+   ===================================================================== */
+.react-flow {
+  --xy-controls-button-background-color: var(--color-bg-secondary);
+  --xy-controls-button-background-color-hover: var(--color-bg-tertiary);
+  --xy-controls-button-color: var(--color-text-secondary);
+  --xy-controls-button-color-hover: var(--color-text-primary);
+  --xy-controls-button-border-color: var(--color-border);
+}


### PR DESCRIPTION
## Summary
- The default `@xyflow/react` controls (zoom in, zoom out, fit view, toggle interactivity) shipped with a white background and dark icon. In dark mode they effectively disappeared against the canvas; on gold/purple they clashed with the tinted page background.
- xyflow exposes `--xy-controls-button-*` custom properties. Bind them once on `.react-flow` to our `--color-bg-secondary` / `--color-text-secondary` / `--color-border` design tokens so the chrome adapts to whichever theme is active — no per-theme overrides needed.
- Follow-up audit issue for the rest of the react-flow chrome (minimap, edge labels, attribution, background pattern): #2652.

## Trio synthesis
- **PM**: ship single tiny PR; file a follow-up audit issue (done — #2652).
- **Designer**: use `[data-theme='dark'] .react-flow__controls-button` with design tokens; gold/purple have light backgrounds so default xyflow CSS clashes too.
- **Engineer**: no existing react-flow overrides anywhere; `base.css` is the right home.
- **Synthesized**: skipped the theme gate entirely and bound xyflow's CSS variables to our tokens once on `.react-flow`. Adapts to all four themes via the existing token cascade; no specificity or `!important` needed.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Al verified visually in dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782127390&installation_id=132681956&pr_number=2653&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2653&signature=016a58a0fb107ce46ab9dd9323848b385d1970accc126e8862e711e2813306aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->