### PR TITLE
docs: add user guide for Photo to deck

### DIFF
--- a/web/src/pages/DocsPage/content/cards/photo-to-deck.md
+++ b/web/src/pages/DocsPage/content/cards/photo-to-deck.md
@@ -1,0 +1,72 @@
+---
+title: Photo to deck
+description: Snap or upload a photo of your notes — textbook page, lecture slide, handwritten notes — and get an Anki deck back.
+---
+
+Photo to deck takes a single image and sends it to Claude's vision model, which reads the content and returns question-and-answer cards. The page is at [2anki.net/photo-to-deck](https://2anki.net/photo-to-deck).
+
+**Plan:** Free plan gets 5 photos per month. Paid plans are unlimited.
+
+## When to use this
+
+- A textbook page, lecture slide, or photographed page of notes you want as flashcards.
+- Handwritten notes — Claude reads cursive and printed handwriting reasonably well.
+- A whiteboard photo from class or a study session.
+
+If your source is already a file — PDF, markdown, a Notion page — use the standard upload flow on the home page instead. Photo to deck is for the moments where the easiest input is a photo.
+
+## Build a deck
+
+1. Open [2anki.net/photo-to-deck](https://2anki.net/photo-to-deck). You'll need to be signed in.
+2. (Optional) Name the deck. The default uses the photo's filename.
+3. Pick a card density (more on this below).
+4. Add a photo. Two ways:
+   - **Take a photo** — on a phone, this opens the rear camera directly.
+   - **Drop or pick** — drag an image into the dropzone, or click to open a file picker.
+5. (Optional) Toggle **Show source image on the back of each card** off if you only want text on the back. Default is on.
+6. Click **Get flashcards**. The deck downloads as a `.apkg` when ready.
+
+The page shows the number of cards extracted once the deck arrives. Open the file in Anki to import.
+
+## Supported formats and size
+
+- **Image types:** JPEG, PNG, WebP, GIF.
+- **Size cap:** 10 MB per photo. If you hit the cap, take the photo at a lower resolution or compress it before upload.
+- **Very large images** are also bounded by a token ceiling on the model side — if you see a "photo is too large" message even under 10 MB, the resolution is the issue, not the file size.
+
+## Card density
+
+The three chips under the deck name decide how many cards per image:
+
+- **Sparse — 3 to 5 cards.** Diagrams, single-concept slides, vocabulary lists where you want headline facts only.
+- **Balanced — 6 to 10 cards.** The default. Matches the typical output of the prior fixed prompt — start here.
+- **Dense — 12 to 20 cards.** Textbook pages, dense lecture slides, photographed notes where you want every distinct fact fanned out.
+
+The model targets the range; it doesn't always hit the exact count. Your choice is remembered between sessions on the same browser.
+
+## What ends up on the card
+
+- **Front:** the question or term Claude extracted from the image.
+- **Back:** the answer or definition. If **Show source image on the back of each card** is on (default), the original photo is embedded under the answer text so you can verify against the source while reviewing.
+- **Tags:** every card arrives with 1 to 3 topic tags drawn from the actual content — short, lowercase, snake_case (`enzymes`, `michaelis_menten`). Filter by tag in Anki's tag browser to study a subset.
+
+## Free plan and quota
+
+The free plan is capped at 5 photos per calendar month — vision calls cost real money on our side. When you hit the limit, the page shows how many you've used and a path to upgrade. The counter resets on the 1st of each month.
+
+Paid plans (Subscription or Lifetime) have no cap.
+
+## Tips for better results
+
+- **Crop tight.** If only a quarter of the photo is the content you care about, crop it before upload. Claude wastes tokens (and your quota) reading the rest.
+- **Daylight beats fluorescents.** Sharp, high-contrast photos extract more cleanly than dim or shadowed ones.
+- **One slide per photo.** A photo of two textbook pages at once forces the model to choose what to prioritize. Two single-page photos usually beat one double-page photo.
+- **Handwriting works — neat handwriting works better.** If yours is illegible to a friend, it'll be illegible to Claude too.
+- **Tried Balanced and got too few cards?** Switch to Dense and re-upload. Re-running costs another quota point on the free plan, so pick the density before the first run when you can.
+
+## When something doesn't work
+
+- **"Photo is too large"** — the image's resolution exceeds the vision model's token ceiling. Reduce resolution or take a tighter crop.
+- **"Free plan is 5 photos per month"** — you've hit the cap. Wait until the 1st, or upgrade.
+- **The cards came back wrong or sparse** — try the same photo at a higher density. If Dense still produces too few cards, the image is probably too low-contrast for the model to read confidently. Retake with better light.
+- **You'd rather draw your own card boundaries** on a diagram — use [Image occlusion](/documentation/cards/image-occlusion) instead. Photo to deck is for question-and-answer extraction; image occlusion is for spatial "what's behind the cover" cards.

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -37,6 +37,7 @@ export const sidebar: SidebarGroup[] = [
       { label: 'Parser rules', slug: 'cards/parser-rules' },
       { label: 'AI flashcard generation', slug: 'cards/ai-flashcards' },
       { label: 'Image occlusion', slug: 'cards/image-occlusion' },
+      { label: 'Photo to deck', slug: 'cards/photo-to-deck' },
       { label: 'Mind maps', slug: 'cards/mind-maps' },
       { label: 'Note types and templates', slug: 'cards/templates' },
       { label: 'Markdown and Obsidian', slug: 'cards/markdown' },


### PR DESCRIPTION
## What

Adds a dedicated user-facing doc page for Photo to deck, registered in the docs sidebar under **Make better cards** next to Image occlusion.

- `web/src/pages/DocsPage/content/cards/photo-to-deck.md` — the new page.
- `web/src/pages/DocsPage/sidebar.ts` — registers the new slug between Image occlusion and Mind maps.

Page covers: where to find the feature, the supported image types, the 10 MB cap, the free-plan quota of 5 photos per month, the Sparse / Balanced / Dense density chip (shipped in #2632), the **Show source image on the back of each card** toggle, the topic tags that arrive on every card, tips for better extraction, and a short troubleshooting list keyed to the actual error strings the page shows.

## Why

The `/photo-to-deck` route has been live and auth-gated for some time, but until now there was nothing in `/docs` to explain how to use it. A user landing on the page has had to discover the supported formats, the size cap, the quota behavior, and the density chip by trial and error.

This is the follow-up I called out in the engineering notes after #2632 merged. Closing the loop.

## How

Pattern-matched the existing `cards/image-occlusion.md` for structure and tone — same frontmatter shape, same Plan line, same section ordering. The MDX loader picks up the new file automatically via `import.meta.glob`; no loader change needed.

Internal link to `/documentation/cards/image-occlusion` cross-references the sibling feature so users who really want spatial cards land on the right tool.

## Measuring success

- Support inbox volume on "how do I upload a photo" / "why did I only get 2 cards" should drop once the page is live and crawlable.
- Organic landings on `/documentation/cards/photo-to-deck` from search 30+ days in.

## Testing

- `/check` all green: server build, web typecheck, web vitest (1011 passing — incl. `content-links.test.ts` and `loader.test.ts` which validate sidebar ↔ content consistency), web lint.
- Verified the loader test continues to pass with the new file present.

## Risks

- Pure content addition behind an existing renderer. The only behavior change is one more entry in the sidebar.
- If the loader test ever changes shape, new content files might need updating — but the glob-based loader makes the wiring automatic today.

## Browser check
Browser check: not applicable — new markdown content file rendered by the existing DocsPage loader; no rendered logic change, no new component, no new state.

## Goal alignment

**Simpler / faster / more beautiful**: yes — users discover what Photo to deck can do without writing to support or trial-and-erroring through the upload flow.

**Scale**: small positive — organic search hits on a documented feature page typically beat hits on an undocumented one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782133379&installation_id=132681956&pr_number=2659&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2659&signature=80a5d15c1240fa52039a2e6dc49cca42fde6338ce05915e9b9510270a0e099d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->