### PR TITLE
fix: preserve hierarchy in verbatim photo transcription

### DIFF
--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -498,6 +498,37 @@ describe('PhotoToFlashcardsUseCase', () => {
         })
       );
     });
+
+    describe('hierarchy preservation', () => {
+      it('buildVerbatimPrompt instructs Claude to use nested ul/li HTML for hierarchical content', () => {
+        const prompt = buildVerbatimPrompt();
+        expect(prompt).toContain('<ul>');
+        expect(prompt).toContain('<li>');
+      });
+
+      it('buildVerbatimPrompt instructs Claude not to flatten nested items with > separators', () => {
+        const prompt = buildVerbatimPrompt();
+        expect(prompt).toContain('Do not flatten');
+        expect(prompt).toContain('hierarchy');
+      });
+
+      it('buildVerbatimPrompt instructs Claude to keep single-line sources as plain text', () => {
+        const prompt = buildVerbatimPrompt();
+        expect(prompt).toContain('no visible hierarchy');
+      });
+
+      it('sends verbatim prompt with hierarchy instructions to Claude when mode is verbatim', async () => {
+        const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+        await useCase.execute({ ...BASE_INPUT, isPaying: true, mode: 'verbatim' });
+        const [callArgs] = mockMessageCreate.mock.calls[0];
+        const text = (
+          callArgs.messages[0].content as Array<{ type: string; text?: string }>
+        ).find((b) => b.type === 'text')?.text;
+        expect(text).toContain('<ul>');
+        expect(text).toContain('<li>');
+        expect(text).toContain('hierarchy');
+      });
+    });
   });
 
   describe('deck builder invocation', () => {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -85,6 +85,7 @@ Rules:
 - If text is illegible, write [illegible] in its place
 - Use the page title or subject as the deck name if visible; otherwise use "Verbatim deck"
 - Do not add tags
+- Preserve hierarchy: if the source has nested bullets, indented items, or nesting markers (→, >, -, •, *), emit the answer as nested HTML lists using <ul><li>…<ul><li>…</li></ul></li></ul>. Sibling items at the same level are separate <li> elements. Do not flatten a multi-level structure into a single line with > separators. If the source has no visible hierarchy (a single line or a flat list with no nesting), emit plain text — do not introduce spurious structure.
 
 ${ANKI_MATH_FRAGMENT}`;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-verbatim-hierarchy.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-verbatim-hierarchy.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-verbatim-hierarchy",
+  "date": "2026-05-23",
+  "type": "fix",
+  "title": "Verbatim photo cards preserve nested outlines as indented lists, not flattened text"
+}


### PR DESCRIPTION
## What
Updates `buildVerbatimPrompt()` to instruct Claude to emit nested `<ul><li>` HTML structure when transcribing hierarchical content, rather than flattening nested items into `>`-joined strings on a single line.

## Why
Closes #2664. When a user uploaded a photo of structured handwritten notes with multi-level bullets, Claude's verbatim transcription collapsed the entire tree into one line with `>` separators. Anki renders HTML fields correctly, so emitting `<ul><li>` structure preserves the parent/child relationships that make the card useful as a study aid.

## How
Added a single rule to the verbatim prompt instructing Claude to:
- Use `<ul><li>…<ul><li>…</li></ul></li></ul>` for nested content
- Keep sibling items as separate `<li>` elements, not chained with separators
- Leave single-line or flat-list sources as plain text (no spurious nesting)

The change is a prompt-only modification. No schema changes, no new deps, no changes to the response parser or deck builder — the HTML is written verbatim into the card's answer field, which Anki renders correctly.

## Measuring success
Cards from verbatim photo uploads with nested outlines will show indented list structure in Anki rather than a single flattened line. Observable via manual testing with a structured-notes photo.

## Testing
- Unit tests added: 4 new tests in the `hierarchy preservation` describe block within `PhotoToFlashcardsUseCase.test.ts`
  - Verifies `buildVerbatimPrompt()` contains `<ul>`, `<li>`, `hierarchy`, `no visible hierarchy`, and `Do not flatten`
  - Verifies the hierarchy instructions are sent to Claude when mode is verbatim
- All 221 existing tests continue to pass

## Browser check
Browser check: not applicable — prompt-only change; no frontend code modified (changelog-only web/src/ diff)

## Changelog
`Verbatim photo cards preserve nested outlines as indented lists, not flattened text`

## Risks
Prompt change carries the standard LLM unpredictability risk: Claude may occasionally produce malformed HTML for complex multi-level structures. The response parser (`parseClaudeVisionResponse`) is forgiving — it parses JSON regardless of what HTML is inside the string values. Rollback is a one-line revert of the prompt rule.

Latency/cost impact: zero — the added rule is ~60 tokens in the prompt, which is negligible against the image token cost (typically 1000–6000 tokens). No prompt caching is configured for this path.

## Goal alignment
Verbatim mode is most useful for users with highly structured study material (outlines, lecture notes, problem sets). Preserving hierarchy makes the mode actually usable for that audience, reducing friction in the core conversion flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782144764&installation_id=132681956&pr_number=2671&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2671&signature=d3fc5180e06f5fe1d26b06fd54f20d07d5a8e512f249eca9ee17d2dd9e7906ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->