### PR TITLE
fix: emit Anki-compatible MathJax delimiters in AI prompts

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -4,6 +4,7 @@ import {
   parseDeckResponse,
   rewriteAudioAnchors,
   normalizeTag,
+  SYSTEM_PROMPT,
 } from './ClaudeService';
 
 describe('looksLikeEmptyContentExplanation', () => {
@@ -199,5 +200,27 @@ describe('EMPTY_CONTENT_USER_MESSAGE', () => {
     expect(EMPTY_CONTENT_USER_MESSAGE.toLowerCase()).toMatch(
       /empty|layout element/
     );
+  });
+});
+
+describe('SYSTEM_PROMPT — Anki math conventions', () => {
+  it('specifies \\(...\\) for inline math', () => {
+    expect(SYSTEM_PROMPT).toContain('\\(...\\)');
+  });
+
+  it('specifies \\[...\\] for display math', () => {
+    expect(SYSTEM_PROMPT).toContain('\\[...\\]');
+  });
+
+  it('forbids $...$ inline delimiter', () => {
+    expect(SYSTEM_PROMPT).toMatch(/NEVER\s+\$\.\.\.\$/);
+  });
+
+  it('forbids $$...$$ display delimiter', () => {
+    expect(SYSTEM_PROMPT).toMatch(/NEVER\s+\$\$\.\.\.\$\$/);
+  });
+
+  it('includes a chemistry example using \\ce{}', () => {
+    expect(SYSTEM_PROMPT).toContain('\\ce{');
   });
 });

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -7,8 +7,9 @@ import { splitOversizedCards } from './splitOversizedCards';
 import { detect } from '../cardStyle/headingDriven/detect';
 import { splitByHeadings } from '../cardStyle/headingDriven/splitByHeadings';
 import { getCardStylePromptFragment } from './getCardStylePromptFragment';
+import { ANKI_MATH_FRAGMENT } from './ankiMathFragment';
 
-const SYSTEM_PROMPT = `
+export const SYSTEM_PROMPT = `
 You are an Anki flashcard generator. Output ONLY a compact JSON array.
 
 Format (nothing else — no markdown, no explanation):
@@ -34,6 +35,8 @@ Minimum-information rules (one fact per card):
 - One definition with its example may stay on a single card
 - Cloze cards are already single-fact — do not split them
 - If the user's additional instructions explicitly ask for detailed or longer cards, defer to those instructions over these rules
+
+${ANKI_MATH_FRAGMENT}
 `.trim();
 
 export const EMPTY_CONTENT_USER_MESSAGE =

--- a/src/lib/claude/FEATURE.md
+++ b/src/lib/claude/FEATURE.md
@@ -17,6 +17,8 @@ The claude lib converts HTML content into Anki flashcards using the Anthropic AP
 
 **Tag normalization:** `normalizeTag(raw: string): string` (exported) converts a raw tag string from Claude's response into a safe Anki tag: lowercase, spaces→`_`, non-`[a-z0-9_]` characters stripped, capped at 32 characters. Called in `expandCompactDeckInfo` (Claude-text path) and in `buildDeckInfo` inside `PhotoToFlashcardsUseCase` (Photo-to-Deck path). Empty tags (e.g. all-punctuation input) are filtered out before the card is written. The `SYSTEM_PROMPT` already declares `"tags": string[]` in the schema; `expandCompactDeckInfo` now normalizes every tag the model emits and drops empty results.
 
+**Math delimiter contract:** `ANKI_MATH_FRAGMENT` (exported from `ankiMathFragment.ts`) is a short instruction block injected into every Claude prompt that may produce math content. It instructs Claude to use `\(...\)` for inline math and `\[...\]` for display math, never `$...$` or `$$...$$`. Chemistry uses `\(\ce{...}\)` via mhchem. The fragment is shared across `SYSTEM_PROMPT` (exported from `ClaudeService.ts`), `buildVisionPrompt`, and `buildVerbatimPrompt` in `PhotoToFlashcardsUseCase.ts` to prevent the three copies from drifting.
+
 ---
 
 ## Heading-driven contract (`cardStyle: 'heading-driven'`)

--- a/src/lib/claude/ankiMathFragment.test.ts
+++ b/src/lib/claude/ankiMathFragment.test.ts
@@ -1,0 +1,23 @@
+import { ANKI_MATH_FRAGMENT } from './ankiMathFragment';
+
+describe('ANKI_MATH_FRAGMENT', () => {
+  it('specifies inline math delimiter as \\(...\\)', () => {
+    expect(ANKI_MATH_FRAGMENT).toContain('\\(...\\)');
+  });
+
+  it('specifies display math delimiter as \\[...\\]', () => {
+    expect(ANKI_MATH_FRAGMENT).toContain('\\[...\\]');
+  });
+
+  it('explicitly forbids $...$ inline delimiter', () => {
+    expect(ANKI_MATH_FRAGMENT).toMatch(/NEVER\s+\$\.\.\.\$/);
+  });
+
+  it('explicitly forbids $$...$$ display delimiter', () => {
+    expect(ANKI_MATH_FRAGMENT).toMatch(/NEVER\s+\$\$\.\.\.\$\$/);
+  });
+
+  it('includes a chemistry example using \\ce{}', () => {
+    expect(ANKI_MATH_FRAGMENT).toContain('\\ce{');
+  });
+});

--- a/src/lib/claude/ankiMathFragment.ts
+++ b/src/lib/claude/ankiMathFragment.ts
@@ -1,0 +1,5 @@
+export const ANKI_MATH_FRAGMENT = `Math formatting rules (Anki MathJax):
+- Inline math: \\(...\\) — NEVER $...$
+- Display math: \\[...\\] — NEVER $$...$$
+- Chemistry: \\(\\ce{H2O}\\) or \\[\\ce{2H2 + O2 -> 2H2O}\\]
+- Avoid nested }} inside cloze math — prefer flat expressions`;

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -344,6 +344,48 @@ describe('PhotoToFlashcardsUseCase', () => {
     });
   });
 
+  describe('Anki math conventions in prompts', () => {
+    it('buildVisionPrompt contains the inline math delimiter \\(...\\)', () => {
+      expect(buildVisionPrompt('balanced')).toContain('\\(...\\)');
+    });
+
+    it('buildVisionPrompt contains the display math delimiter \\[...\\]', () => {
+      expect(buildVisionPrompt('balanced')).toContain('\\[...\\]');
+    });
+
+    it('buildVisionPrompt forbids $...$ delimiter', () => {
+      expect(buildVisionPrompt('balanced')).toMatch(/NEVER\s+\$\.\.\.\$/);
+    });
+
+    it('buildVisionPrompt forbids $$...$$ delimiter', () => {
+      expect(buildVisionPrompt('balanced')).toMatch(/NEVER\s+\$\$\.\.\.\$\$/);
+    });
+
+    it('buildVisionPrompt includes a chemistry example using \\ce{}', () => {
+      expect(buildVisionPrompt('balanced')).toContain('\\ce{');
+    });
+
+    it('buildVerbatimPrompt contains the inline math delimiter \\(...\\)', () => {
+      expect(buildVerbatimPrompt()).toContain('\\(...\\)');
+    });
+
+    it('buildVerbatimPrompt contains the display math delimiter \\[...\\]', () => {
+      expect(buildVerbatimPrompt()).toContain('\\[...\\]');
+    });
+
+    it('buildVerbatimPrompt forbids $...$ delimiter', () => {
+      expect(buildVerbatimPrompt()).toMatch(/NEVER\s+\$\.\.\.\$/);
+    });
+
+    it('buildVerbatimPrompt forbids $$...$$ delimiter', () => {
+      expect(buildVerbatimPrompt()).toMatch(/NEVER\s+\$\$\.\.\.\$\$/);
+    });
+
+    it('buildVerbatimPrompt includes a chemistry example using \\ce{}', () => {
+      expect(buildVerbatimPrompt()).toContain('\\ce{');
+    });
+  });
+
   describe('density control', () => {
     it('uses the balanced rule line when no density is provided', async () => {
       const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'node:crypto';
 import { spawn, execFileSync } from 'node:child_process';
 
 import { getAnthropicClient, normalizeTag } from '../../lib/claude/ClaudeService';
+import { ANKI_MATH_FRAGMENT } from '../../lib/claude/ankiMathFragment';
 import { countVisionTokens, VISION_TOKEN_CEILING, VisionMediaType } from '../../lib/claude/countVisionTokens';
 import { CREATE_DECK_DIR, CREATE_DECK_SCRIPT_PATH, TEMPLATE_DIR } from '../../lib/constants';
 import { track } from '../../services/events/track';
@@ -66,7 +67,9 @@ Rules:
 - Preserve important formatting but keep cards concise
 - ${DENSITY_RULE[density]}
 - Use the image content as the deck name if no other name is obvious
-- Add 1–3 topic tags per card in the "tags" field: short, lowercase, snake_case, drawn from the actual content (e.g. "enzymes", "michaelis_menten") — not broad labels like "biology" or "chapter_4"`;
+- Add 1–3 topic tags per card in the "tags" field: short, lowercase, snake_case, drawn from the actual content (e.g. "enzymes", "michaelis_menten") — not broad labels like "biology" or "chapter_4"
+
+${ANKI_MATH_FRAGMENT}`;
 }
 
 export function buildVerbatimPrompt(): string {
@@ -81,7 +84,9 @@ Rules:
 - If no correct answer is visible for an MCQ, omit "correct_index"
 - If text is illegible, write [illegible] in its place
 - Use the page title or subject as the deck name if visible; otherwise use "Verbatim deck"
-- Do not add tags`;
+- Do not add tags
+
+${ANKI_MATH_FRAGMENT}`;
 }
 
 const INPUT_COST_PER_MILLION = 3;

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-anki-mathjax-delimiters.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-anki-mathjax-delimiters.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-anki-mathjax-delimiters",
+  "date": "2026-05-23",
+  "type": "fix",
+  "title": "Math formulas in AI-generated cards render in Anki instead of showing raw symbols"
+}


### PR DESCRIPTION
## What
Add a shared `ANKI_MATH_FRAGMENT` constant and inject it into all three Claude prompts (text conversion, generative photo, verbatim photo). Claude now uses `\(...\)` for inline math, `\[...\]` for display math, and `\(\ce{...}\)` for chemistry — never `$...$` or `$$...$$`.

## Why
Closes #2663. Anki's MathJax renderer expects `\(...\)`/`\[...\]` delimiters. Claude defaults to `$...$`/`$$...$$` (markdown convention), which Anki renders as literal dollar signs around text. Users uploading math-heavy notes got unusable cards.

## How
- New file `src/lib/claude/ankiMathFragment.ts` exports `ANKI_MATH_FRAGMENT` — a single source of truth so all three prompt sites stay in sync.
- `SYSTEM_PROMPT` in `ClaudeService.ts` is now exported (was `const`) so it can be tested without a live Claude call.
- Fragment appended to the end of each prompt after existing rules, so existing prompt logic is untouched.
- Coordination: only touches the math-instruction block; does not modify the verbatim hierarchy or card-size logic being added by other parallel PRs.

## Measuring success
After deploy: convert a Notion page or photo containing `$E = mc^2$` and verify the downloaded deck shows `\(...\)` delimiters in the card fields, not raw `$` characters. The structured log line `[Claude] chunk done` already fires per conversion; no new telemetry needed for this prompt-text change.

## Testing
- Unit tests added: `src/lib/claude/ankiMathFragment.test.ts` (5 tests on the fragment itself)
- `ClaudeService.test.ts` — 5 new assertions on `SYSTEM_PROMPT` math conventions
- `PhotoToFlashcardsUseCase.test.ts` — 10 new assertions on `buildVisionPrompt` and `buildVerbatimPrompt`
- All 77 tests in the three affected files pass; full suite (server tsc + web typecheck + 1042 web vitest + biome lint) green.

## Browser check
Browser check: not applicable — prompt-text change, no rendered UI output

## Changelog
Math formulas in AI-generated cards render in Anki instead of showing raw symbols

## Risks
Prompt additions are appended after existing rules — no structural changes. The fragment adds ~5 lines to each prompt (~100 tokens input overhead per call). Prompt caching on `SYSTEM_PROMPT` still applies after the first call per process. No latency impact beyond the first cache miss. Rollback: revert the `${ANKI_MATH_FRAGMENT}` interpolations in the three prompt functions.

## Goal alignment
Users converting math-heavy study notes (STEM students, medical students) currently get broken cards. This unblocks a meaningful cohort and removes friction on a core conversion path — directly supporting the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782144909&installation_id=132681956&pr_number=2672&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2672&signature=4b0e09889dfa8f5c73262c621dafd001488e379e002d953bf3b3699ad6ab9ca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->