### PR TITLE
feat: wire heading-driven card style into image-to-deck path

### DIFF
--- a/src/controllers/PhotoToFlashcardsController.ts
+++ b/src/controllers/PhotoToFlashcardsController.ts
@@ -6,8 +6,10 @@ import {
   PhotoToFlashcardsUseCase,
   DEFAULT_PHOTO_DENSITY,
   DEFAULT_PHOTO_MODE,
+  DEFAULT_PHOTO_CARD_STYLE,
   type PhotoDensity,
   type PhotoMode,
+  type PhotoCardStyle,
 } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 import type { VisionMediaType } from '../lib/claude/countVisionTokens';
 import { buildContentDisposition } from '../lib/buildContentDisposition';
@@ -16,6 +18,7 @@ import { isPaying } from '../lib/isPaying';
 const ALLOWED_MEDIA_TYPES: VisionMediaType[] = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 const ALLOWED_DENSITIES: PhotoDensity[] = ['sparse', 'balanced', 'dense'];
 const ALLOWED_MODES: PhotoMode[] = ['generative', 'verbatim'];
+const ALLOWED_CARD_STYLES: PhotoCardStyle[] = ['generative', 'heading-driven'];
 
 interface RawPhotoBody {
   imageBase64?: unknown;
@@ -26,6 +29,7 @@ interface RawPhotoBody {
   includeSourceImage?: unknown;
   density?: unknown;
   mode?: unknown;
+  cardStyle?: unknown;
 }
 
 function isAllowedMediaType(value: unknown): value is VisionMediaType {
@@ -42,6 +46,12 @@ function parseMode(value: unknown): PhotoMode {
   return typeof value === 'string' && (ALLOWED_MODES as string[]).includes(value)
     ? (value as PhotoMode)
     : DEFAULT_PHOTO_MODE;
+}
+
+function parseCardStyle(value: unknown): PhotoCardStyle {
+  return typeof value === 'string' && (ALLOWED_CARD_STYLES as string[]).includes(value)
+    ? (value as PhotoCardStyle)
+    : DEFAULT_PHOTO_CARD_STYLE;
 }
 
 export class PhotoToFlashcardsController {
@@ -78,6 +88,7 @@ export class PhotoToFlashcardsController {
       typeof body.includeSourceImage === 'boolean' ? body.includeSourceImage : true;
 
     const mode = parseMode(body.mode);
+    const cardStyle = parseCardStyle(body.cardStyle);
 
     let result: Awaited<ReturnType<PhotoToFlashcardsUseCase['execute']>>;
     try {
@@ -91,6 +102,7 @@ export class PhotoToFlashcardsController {
         includeSourceImage,
         density: parseDensity(body.density),
         mode,
+        cardStyle,
       });
     } catch (err) {
       const e = err as Error & {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -3,6 +3,7 @@ import {
   FREE_PHOTO_QUOTA_PER_MONTH,
   buildVisionPrompt,
   buildVerbatimPrompt,
+  buildHeadingDrivenVisionPrompt,
 } from './PhotoToFlashcardsUseCase';
 import type { IEventsRepository } from '../../data_layer/EventsRepository';
 
@@ -528,6 +529,73 @@ describe('PhotoToFlashcardsUseCase', () => {
         expect(text).toContain('<li>');
         expect(text).toContain('hierarchy');
       });
+    });
+  });
+
+  describe('heading-driven card style', () => {
+    it('buildHeadingDrivenVisionPrompt contains slide-title detection instruction', () => {
+      const prompt = buildHeadingDrivenVisionPrompt();
+      expect(prompt).toMatch(/slide|heading|title/i);
+    });
+
+    it('buildHeadingDrivenVisionPrompt is distinct from buildVisionPrompt', () => {
+      expect(buildHeadingDrivenVisionPrompt()).not.toEqual(buildVisionPrompt('balanced'));
+    });
+
+    it('buildHeadingDrivenVisionPrompt is distinct from buildVerbatimPrompt', () => {
+      expect(buildHeadingDrivenVisionPrompt()).not.toEqual(buildVerbatimPrompt());
+    });
+
+    it('sends the heading-driven prompt to Claude when cardStyle is heading-driven', async () => {
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await useCase.execute({ ...BASE_INPUT, isPaying: true, cardStyle: 'heading-driven' });
+      const [callArgs] = mockMessageCreate.mock.calls[0];
+      const text = (
+        callArgs.messages[0].content as Array<{ type: string; text?: string }>
+      ).find((b) => b.type === 'text')?.text;
+      expect(text).toMatch(/slide|heading|title/i);
+      expect(text).not.toContain('6 to 10 cards');
+      expect(text).not.toContain('exactly as written');
+    });
+
+    it('sends the generative prompt (not heading-driven) when cardStyle is absent', async () => {
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await useCase.execute({ ...BASE_INPUT, isPaying: true });
+      const [callArgs] = mockMessageCreate.mock.calls[0];
+      const text = (
+        callArgs.messages[0].content as Array<{ type: string; text?: string }>
+      ).find((b) => b.type === 'text')?.text;
+      expect(text).toContain('6 to 10 cards');
+    });
+
+    it('tracks card_style: heading-driven in the analytics event', async () => {
+      const events = makeEventsStub(0);
+      const useCase = new PhotoToFlashcardsUseCase(events);
+      await useCase.execute({ ...BASE_INPUT, isPaying: false, cardStyle: 'heading-driven' });
+      const { track } = jest.requireMock(
+        '../../services/events/track'
+      ) as { track: jest.Mock };
+      expect(track).toHaveBeenCalledWith(
+        'vision_photo_converted',
+        expect.objectContaining({
+          props: expect.objectContaining({ card_style: 'heading-driven' }),
+        })
+      );
+    });
+
+    it('tracks card_style: generative when cardStyle is absent', async () => {
+      const events = makeEventsStub(0);
+      const useCase = new PhotoToFlashcardsUseCase(events);
+      await useCase.execute({ ...BASE_INPUT, isPaying: false });
+      const { track } = jest.requireMock(
+        '../../services/events/track'
+      ) as { track: jest.Mock };
+      expect(track).toHaveBeenCalledWith(
+        'vision_photo_converted',
+        expect.objectContaining({
+          props: expect.objectContaining({ card_style: 'generative' }),
+        })
+      );
     });
   });
 

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -16,9 +16,11 @@ const VISION_PHOTO_EVENT = 'vision_photo_converted';
 
 export type PhotoDensity = 'sparse' | 'balanced' | 'dense';
 export type PhotoMode = 'generative' | 'verbatim';
+export type PhotoCardStyle = 'generative' | 'heading-driven';
 
 export const DEFAULT_PHOTO_DENSITY: PhotoDensity = 'balanced';
 export const DEFAULT_PHOTO_MODE: PhotoMode = 'generative';
+export const DEFAULT_PHOTO_CARD_STYLE: PhotoCardStyle = 'generative';
 
 export interface PhotoToFlashcardsInput {
   imageBase64: string;
@@ -31,6 +33,7 @@ export interface PhotoToFlashcardsInput {
   includeSourceImage?: boolean;
   density?: PhotoDensity;
   mode?: PhotoMode;
+  cardStyle?: PhotoCardStyle;
 }
 
 export interface PhotoToFlashcardsResult {
@@ -88,6 +91,29 @@ Rules:
 - Preserve hierarchy: if the source has nested bullets, indented items, or nesting markers (→, >, -, •, *), emit the answer as nested HTML lists using <ul><li>…<ul><li>…</li></ul></li></ul>. Sibling items at the same level are separate <li> elements. Do not flatten a multi-level structure into a single line with > separators. If the source has no visible hierarchy (a single line or a flat list with no nesting), emit plain text — do not introduce spurious structure.
 
 ${ANKI_MATH_FRAGMENT}`;
+}
+
+export function buildHeadingDrivenVisionPrompt(): string {
+  return `Extract flashcard pairs from this image, grouping by slide title or section heading.
+
+Output ONLY a compact JSON array. Format (nothing else — no markdown, no explanation):
+[{"deck":"Deck Name","cards":[{"q":"front text","a":"back text","tags":["topic_tag"]}]}]
+
+Rules:
+- Detect slide titles, section headings, or chapter titles visible on the image
+- For each heading, produce 2–6 cards covering the key facts under that heading
+- Each card tests one atomic fact
+- Q is the question or term, A is the answer or definition
+- Use the detected heading as a tag on each card so slides stay traceable (short, lowercase, snake_case)
+- Add 1–3 content tags per card in addition to the heading tag
+- Use the overall topic as the deck name
+- If no distinct headings are visible, treat the full image as one section`;
+}
+
+function resolvePrompt(mode: PhotoMode, cardStyle: PhotoCardStyle, density: PhotoDensity): string {
+  if (mode === 'verbatim') return buildVerbatimPrompt();
+  if (cardStyle === 'heading-driven') return buildHeadingDrivenVisionPrompt();
+  return buildVisionPrompt(density);
 }
 
 const INPUT_COST_PER_MILLION = 3;
@@ -311,10 +337,11 @@ export class PhotoToFlashcardsUseCase {
             },
             {
               type: 'text',
-              text:
-                (input.mode ?? DEFAULT_PHOTO_MODE) === 'verbatim'
-                  ? buildVerbatimPrompt()
-                  : buildVisionPrompt(input.density ?? DEFAULT_PHOTO_DENSITY),
+              text: resolvePrompt(
+                input.mode ?? DEFAULT_PHOTO_MODE,
+                input.cardStyle ?? DEFAULT_PHOTO_CARD_STYLE,
+                input.density ?? DEFAULT_PHOTO_DENSITY
+              ),
             },
           ],
         },
@@ -382,6 +409,7 @@ export class PhotoToFlashcardsUseCase {
         card_count: cardCount,
         tile_count: tiles,
         source_mode: input.mode ?? DEFAULT_PHOTO_MODE,
+        card_style: input.cardStyle ?? DEFAULT_PHOTO_CARD_STYLE,
       },
     });
 


### PR DESCRIPTION
## What

Adds `PhotoCardStyle` (`'generative' | 'heading-driven'`) to the image-to-deck path. When `cardStyle` is `'heading-driven'`, the use case sends a distinct Vision prompt that instructs Claude to detect slide titles / section headings in the image and produce 2–6 cards per heading, rather than the standard density-based generation.

Follow-up to #2617 (heading-driven text path). Closes #2660.

## Why

The heading-driven splitter shipped in #2617 covers markdown, HTML, and Notion exports via the text path. Photo-to-deck uploads (slide decks, textbook pages) were excluded because `PhotoToFlashcardsUseCase` doesn't route through `generateDeckInfo`. This PR wires the feature so it's ready when the card-style picker (#2616) lands.

## How

- Added `PhotoCardStyle = 'generative' | 'heading-driven'` type and `DEFAULT_PHOTO_CARD_STYLE` constant.
- Added `buildHeadingDrivenVisionPrompt()` — instructs Claude Vision to group cards by detected slide/section headings (2–6 cards per heading).
- Added `resolvePrompt(mode, cardStyle, density)` — single-sourced three-way dispatch: verbatim > heading-driven > generative. Density is silently ignored when `cardStyle` is `'heading-driven'` (the heading-driven prompt owns card count).
- Controller validates `cardStyle` against an allowlist, falls back to `'generative'`.
- `card_style` added to the `vision_photo_converted` analytics event.

**Open question resolved:** The Vision response doesn't contain structured slide titles — Claude returns raw Q/A pairs. For images, heading-driven works at the prompt level (asking the model to detect headings in the image), not via the text splitter that reads from the document structure. The existing `splitByHeadings` / `detect` pipeline is not used for the image path.

**Density relationship:** Heading-driven replaces density for slides. When `cardStyle === 'heading-driven'`, the prompt controls card count (2–6 per slide). Density is ignored. This is the correct behavior — once the picker lands, users choose one mode, not both.

## Measuring success

After #2616 ships, query the analytics events:
```sql
SELECT card_style, COUNT(*) FROM vision_photo_converted WHERE date > '2026-05-23' GROUP BY card_style;
```
Non-zero `heading-driven` rows confirm the wiring is reached.

## Testing

- Unit tests added: 6 new tests in `PhotoToFlashcardsUseCase.test.ts` — prompt selection (heading-driven vs generative vs verbatim), prompt content contracts, analytics tracking.
- All 57 tests in the affected suite pass: `PhotoToFlashcardsUseCase`, `splitByHeadings`, `detect`, and `headingDrivenWiring`.
- Server tsc: clean. Web tsc: clean. Web vitest: 1042/1042 pass.

## Browser check

Browser check: not applicable — server-side only, no web/src changes.

## Changelog

No changelog entry — wiring only, no user-visible behavior until the card-style picker ships (#2616).

## Risks

- Other agents (#2663, #2664) are editing `PhotoToFlashcardsUseCase.ts` in parallel. This PR touches only `PhotoToFlashcardsInput` (adding `cardStyle?`) and the prompt-selection code path. Expect a rebase against main when those PRs merge — the diff is narrow and the conflict surface is small.
- The heading-driven Vision prompt asks Claude to detect headings in the image. Quality degrades for images with no visible headings (plain notes, photos). Claude falls back to treating the full image as one section — acceptable.

## Goal alignment

Heading-driven card style is a fidelity improvement for slide-deck users, reducing card noise by grouping output around slide structure. This directly targets the "simplest, fastest way to turn what they're studying into beautiful flashcards" goal, and slide-deck uploads are a high-volume surface for student users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782144985&installation_id=132681956&pr_number=2674&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2674&signature=7468ac684876dbba11c7578876e2d3eb5f4b86423aa3ee3d4613bfdd76b2678c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->