### PR TITLE
fix: guard against undefined packages from worker result message

### DIFF
--- a/src/usecases/uploads/GeneratePackagesUseCase.test.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.test.ts
@@ -1,0 +1,133 @@
+import { EventEmitter } from 'events';
+
+jest.mock('worker_threads', () => ({
+  Worker: jest.fn(),
+  workerData: null,
+  parentPort: null,
+  isMainThread: true,
+}));
+
+jest.mock('node:fs', () => ({
+  existsSync: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../lib/parser/WorkSpace');
+
+import GeneratePackagesUseCase from './GeneratePackagesUseCase';
+import { Worker } from 'worker_threads';
+import CardOption from '../../lib/parser/Settings/CardOption';
+import Workspace from '../../lib/parser/WorkSpace';
+import { UploadedFile } from '../../lib/storage/types';
+
+const MockWorker = Worker as jest.MockedClass<typeof Worker>;
+
+function makeWorkerEmitter(): EventEmitter {
+  const emitter = new EventEmitter();
+  MockWorker.mockImplementation(() => emitter as never);
+  return emitter;
+}
+
+function makeSettings(): CardOption {
+  return new CardOption({});
+}
+
+function makeWorkspace(): Workspace {
+  return {} as Workspace;
+}
+
+function makeFile(name: string): UploadedFile {
+  return {
+    fieldname: 'file',
+    originalname: name,
+    encoding: '7bit',
+    mimetype: 'text/plain',
+    size: 0,
+    stream: null as never,
+    destination: '',
+    filename: name,
+    path: '',
+    buffer: undefined as never,
+    key: 'test-key',
+  };
+}
+
+describe('GeneratePackagesUseCase', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves with packages and warnings when the worker sends a result message', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('notes.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', {
+      type: 'result',
+      packages: [{ name: 'notes.apkg', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 }],
+      warnings: [],
+    });
+
+    const result = await promise;
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].name).toBe('notes.apkg');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('resolves with an empty packages array when the worker sends a result with undefined packages', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('empty.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', { type: 'result', packages: undefined, warnings: undefined });
+
+    const result = await promise;
+    expect(result.packages).toEqual([]);
+  });
+
+  it('rejects when the worker sends an error message', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('bad.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', {
+      type: 'error',
+      message: "Cannot read properties of undefined (reading 'name')",
+    });
+
+    await expect(promise).rejects.toThrow("Cannot read properties of undefined (reading 'name')");
+  });
+
+  it('rejects when the worker emits an error event', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('crash.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('error', new Error('Worker crashed'));
+
+    await expect(promise).rejects.toThrow('Worker crashed');
+  });
+});

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -42,7 +42,7 @@ class GeneratePackagesUseCase {
         } else if (msg.type === 'error') {
           reject(new Error(msg.message));
         } else {
-          resolve({ packages: msg.packages, warnings: msg.warnings });
+          resolve({ packages: msg.packages ?? [], warnings: msg.warnings });
         }
       });
       worker.on('error', (error) => reject(error));

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-worker-packages-guard.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-worker-packages-guard.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-worker-packages-guard",
+  "date": "2026-05-23",
+  "type": "fix",
+  "title": "Uploads that produce no cards no longer cause a runtime crash downstream"
+}


### PR DESCRIPTION
## What
Guards the `packages` field in `GeneratePackagesUseCase` against `undefined` when the upload worker sends a result message. When the worker's `DeckParser` produces no payload, `msg.packages` can be `undefined`. Callers doing `packages[0].name` then crashed with `Cannot read properties of undefined (reading 'name')`.

## Why
Sibling crash to the one fixed in #2656 (`fix: guard DeckParser.name against empty payload`). That PR guarded the getter inside `DeckParser`. This PR guards the resolution point in `GeneratePackagesUseCase` where the worker result is forwarded to callers. Both share the same crash shape at `GeneratePackagesUseCase.ts:43` in pm2 logs.

## How
One-character change: `packages: msg.packages` → `packages: msg.packages ?? []`. Ensures callers always receive an array, never `undefined`, regardless of what the worker sends.

## Measuring success
The `Cannot read properties of undefined (reading 'name')` error originating in the upload worker stops appearing in pm2 logs. Zero occurrences of that pattern after a deploy confirms the fix is live.

## Testing
- Unit tests added: `src/usecases/uploads/GeneratePackagesUseCase.test.ts` (4 tests)
  - Resolves correctly with packages and warnings on success
  - Resolves with empty array when worker sends undefined packages (regression test for this bug)
  - Rejects when worker sends error message
  - Rejects when worker emits error event
- Confirmed failing test for the regression case before the fix, passes after.

## Browser check
Browser check: not applicable — server-side logic change only; the only `web/src/` file touched is under `web/src/pages/WhatsNewPage/changelog/` (changelog-only bypass applies).

## Changelog
"Uploads that produce no cards no longer cause a runtime crash downstream"

## Risks
No behaviour change when the worker sends a non-null packages array (short-circuit: ?? only fires for null/undefined). Rollback: revert the one-line change.

## Goal alignment
Prevents upload failures that surface as 500 errors to users. Reduces friction on the core conversion path, directly supporting the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782146514&installation_id=132681956&pr_number=2676&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2676&signature=49e35a5d13bf30f914f51e895cb3d7d0ee9c157c4fee6113aca2c456bfba80ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->