### PR TITLE
fix: warn on stripped trailing prose in Claude JSON parser

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -84,6 +84,53 @@ describe('parseDeckResponse', () => {
       'Claude returned invalid JSON'
     );
   });
+
+  it('tolerates leading, interior, and trailing whitespace inside the JSON portion', () => {
+    const padded = `  \n\t${deckJson}   \n  `;
+    expect(parseDeckResponse(padded, padded, 0)).toEqual(deck);
+  });
+
+  it('preserves literal backticks inside card content (nested-fence robustness)', () => {
+    const withBackticks =
+      '[{"deck":"Shell","cards":[{"q":"List files","a":"Run `ls -la` to see hidden files"}]}]';
+    const parsed = parseDeckResponse(withBackticks, withBackticks, 0);
+    expect(parsed[0].cards[0].a).toBe('Run `ls -la` to see hidden files');
+  });
+
+  it('emits a structured warning when trailing prose is stripped (model-drift signal)', () => {
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    try {
+      const cleaned = `${deckJson}\n\nI've created flashcards for all key concepts.`;
+      parseDeckResponse(cleaned, cleaned, 7);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Claude] Trailing prose stripped',
+        expect.objectContaining({ chunkIndex: 7, strippedBytes: expect.any(Number) })
+      );
+      const callArg = warnSpy.mock.calls.find(
+        ([msg]) => msg === '[Claude] Trailing prose stripped'
+      )![1] as { strippedBytes: number };
+      expect(callArg.strippedBytes).toBeGreaterThan(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn about trailing prose when JSON parses cleanly with no trailing content', () => {
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    try {
+      parseDeckResponse(deckJson, deckJson, 0);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        '[Claude] Trailing prose stripped',
+        expect.anything()
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe('rewriteAudioAnchors', () => {

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -345,10 +345,19 @@ export function parseDeckResponse(
   raw: string,
   chunkIndex: number
 ): CompactDeck[] {
-  // Claude sometimes appends explanation prose after the closing fence/bracket.
-  // Truncate at the last ']' so trailing text doesn't break JSON.parse.
   const jsonEnd = cleaned.lastIndexOf(']');
   const toParse = jsonEnd >= 0 ? cleaned.slice(0, jsonEnd + 1) : cleaned;
+
+  if (jsonEnd >= 0) {
+    const trailing = cleaned.slice(jsonEnd + 1).trim();
+    if (trailing.length > 0) {
+      console.warn('[Claude] Trailing prose stripped', {
+        chunkIndex,
+        strippedBytes: trailing.length,
+        sample: trailing.slice(0, 80),
+      });
+    }
+  }
 
   let parsed: unknown;
   try {

--- a/src/lib/claude/FEATURE.md
+++ b/src/lib/claude/FEATURE.md
@@ -11,7 +11,7 @@ The claude lib converts HTML content into Anki flashcards using the Anthropic AP
 - Cards already under 600 plain-text chars — no change
 - Single-sentence answers over 600 chars — degenerate case, kept as-is
 
-**Observability:** After each chunk, a structured log line records `inputCardCount`, `outputCardCount`, `avgAnswerLenBefore`, `avgAnswerLenAfter`, and `chunkIndex` under the `[Claude] splitOversizedCards` key.
+**Observability:** After each chunk, a structured log line records `inputCardCount`, `outputCardCount`, `avgAnswerLenBefore`, `avgAnswerLenAfter`, and `chunkIndex` under the `[Claude] splitOversizedCards` key. `parseDeckResponse` truncates anything after the last `]` so trailing prose doesn't break `JSON.parse`; when non-whitespace bytes are stripped, it emits a `[Claude] Trailing prose stripped` warning with `chunkIndex`, `strippedBytes`, and an 80-char sample — grep this to track model drift.
 
 **Override path:** `userInstructions` passed to `generateDeckInfo` flow into the prompt as an "Additional instructions" block. A user asking for "keep cards detailed" or similar will get the prompt's min-info rules deprioritised in Claude's output — the splitter ceiling still applies as a hard guard.
 


### PR DESCRIPTION
## What

`parseDeckResponse` already truncates anything after the last `]` to survive trailing model prose. That recovery used to be silent — now it emits one structured `[Claude] Trailing prose stripped` warn with `chunkIndex`, `strippedBytes`, and an 80-char sample whenever the truncation actually drops content.

Also pins two robustness behaviors with tests: extra whitespace tolerance, and literal backticks inside card content (the "nested fences" case from the issue).

## Why

Closes #2227 — the unchecked silent strip was the model-drift blind spot called out in the issue. The warning gives us a grep target on prod when Claude's output shape shifts. Tests for `trailing prose` and `missing closing brace` were already present; the new tests cover the two remaining bullets from the issue (whitespace + nested fences). The third bullet (retry with "return only JSON" prompt) was intentionally dropped — `jsonrepair` already recovers the common drift patterns and a Claude retry doubles cost on the unhappy path.

## How

In `parseDeckResponse`, after locating `jsonEnd = cleaned.lastIndexOf(']')`, peek at `cleaned.slice(jsonEnd + 1).trim()`. If non-empty, emit `console.warn('[Claude] Trailing prose stripped', { chunkIndex, strippedBytes, sample })`. Whitespace-only trailing content stays silent. No behavior change to the happy path or to the existing `jsonrepair` fallback.

`FEATURE.md` updated alongside.

## Measuring success

Grep prod logs for `[Claude] Trailing prose stripped`. Frequency = model-drift signal. If the rate climbs against a stable user volume, that's a prompt to investigate model output drift before it turns into a parse-failure spike.

## Testing

`src/lib/claude/ClaudeService.test.ts` — 4 new cases:
- Tolerates leading/interior/trailing whitespace inside the JSON portion
- Preserves literal backticks inside card content (nested-fence robustness)
- Emits the structured `[Claude] Trailing prose stripped` warn when prose follows the last `]`
- Does **not** warn when the JSON parses cleanly with no trailing content

Server jest passes 35/35 on this file. `/check` (server tsc, web typecheck, web vitest, web lint) all green.

## Browser check

Not applicable — server-only change, no `web/src/` files touched.

## Changelog

No entry — internal observability change, no user-visible behavior shift. Users see the same recovered cards either way.

## Risks

One extra `console.warn` per Claude response that contains trailing prose. No new throw paths, no new branches on the happy path, no schema/migration impact. Rollback is a clean revert.

## Goal alignment

Better observability on the AI generation surface = faster reaction time when model output shifts. Caught drift early keeps the conversion experience reliable as we scale toward 300K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782153427&installation_id=132681956&pr_number=2678&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2678&signature=b38f7da2c70d62383834230d1e3a30ac13278c7737e0e7c6f818eab8855d8811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->