### PR TITLE
style: tighten type scale — --text-sm to 14px

### DIFF
--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-tighter-type-scale.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-tighter-type-scale.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-tighter-type-scale",
+  "date": "2026-05-23",
+  "type": "style",
+  "title": "Sidebar, table cells, and labels now sit visually smaller than body copy for clearer hierarchy"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -40,8 +40,8 @@
     sans-serif;
 
   /* Type scale */
-  --text-xs: 0.9375rem;
-  --text-sm: 1.125rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
   --text-base: 1.125rem;
   --text-lg: 1.25rem;
   --text-xl: 1.375rem;
@@ -319,7 +319,7 @@ textarea,
 select {
   width: 100%;
   padding: 0.625rem 0.875rem;
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   font-family: var(--font-sans);
   color: var(--color-text-primary);
   background: var(--color-bg-primary);


### PR DESCRIPTION
## What
Drop `--text-xs` from 15px to 12px and `--text-sm` from 18px to 14px in `web/src/styles/base.css`. Override the global form input rule from `--text-sm` to `--text-base` (18px) to keep inputs at the readability floor.

## Why
Closes #2361. Right now `--text-sm` and `--text-base` are both 18px, so sidebar identity, table cells, button labels, and form labels collide at the same size as body copy. Visual hierarchy is built on color and weight alone. Bringing `--text-sm` to 14px gives the hierarchy its third dimension (size). Designer's call from the trio review, deferred from #2350 as a deliberate system-wide decision. `--text-xs` drops to 12px to keep the monotonic ordering `xs < sm < base` intact.

## How
Three edits in `web/src/styles/base.css`:
1. `--text-xs: 0.9375rem` → `0.75rem` (15px → 12px)
2. `--text-sm: 1.125rem` → `0.875rem` (18px → 14px)
3. Global input/textarea/select rule: `font-size: var(--text-sm)` → `font-size: var(--text-base)` (prevents iOS Safari viewport zoom on focus, which fires when computed font-size is below ~16px)

No other files touched. `--text-base` and all other tokens are unchanged.

## Measuring success
Visual hierarchy is restored — sidebar, tables, button labels, and form labels now de-emphasize against body copy. Stripe-class polish.

## Testing
- Unit tests added: none (CSS token change; no logic to test)
- Server tsc: green
- Web typecheck: green
- Web vitest: 1040 tests passing
- Web lint: green

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Al walked the hot spots from #2361 (sidebar identity, downloads table, form labels vs inputs, button labels, account subscription card, empty states, modal headers). Reads small but ships — hierarchy is restored, `--text-base` (18px) remains the readability floor for body copy and form inputs.

## Changelog
Sidebar, table cells, and labels now sit visually smaller than body copy for clearer hierarchy

## Risks
Every page that uses `--text-sm` changes visually. Single revert (`git revert`) rolls it back cleanly. Specific risk: a surface where 14px is too small — mitigation is to override that surface to `var(--text-base)` in its own module CSS rather than reverting the token.

## Goal alignment
Cleaner visual hierarchy → more Stripe-class look → better first impression → lower bounce rate → 300K growth lever.

No user docs needed — pure visual polish, no functional change.
