### PR TITLE
fix: accept sidebar auto-minimize and card-size events

### DIFF
--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -120,4 +120,15 @@ describe('EventsController', () => {
     controller.track(req, res);
     expect(res.status).toHaveBeenCalledWith(202);
   });
+
+  it.each([
+    'sidebar_auto_minimize_fired',
+    'sidebar_auto_minimize_reverted',
+    'card_size_selected',
+  ])('returns 202 for sidebar/card-size event: %s', (eventName) => {
+    const { controller, req, res } = buildMocks({ userId: 1 });
+    req.body = { name: eventName };
+    controller.track(req, res);
+    expect(res.status).toHaveBeenCalledWith(202);
+  });
 });

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -20,6 +20,9 @@ export const KNOWN_EVENTS = new Set([
   'photo_entry_point_clicked',
   'photo_upload_started',
   'photo_quota_reached',
+  'sidebar_auto_minimize_fired',
+  'sidebar_auto_minimize_reverted',
+  'card_size_selected',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;


### PR DESCRIPTION
## What
Adds three missing event names to the server-side analytics allowlist in `src/types/AnalyticsEvents.ts`.

## Why
Real prod traffic was receiving 400 responses for valid events emitted by the web client:
- `sidebar_auto_minimize_fired`
- `sidebar_auto_minimize_reverted`
- `card_size_selected`

The web side `KNOWN_EVENTS` listed 23 names; the server listed 22. These three were on the web side only, so every POST to `/api/events/track` for them returned `{"error":"Unknown event name"}`.

## How
Added the three strings to the `as const` Set in `src/types/AnalyticsEvents.ts`. No DB change needed — the `events` table accepts any string; the allowlist is the only guard.

`vision_photo_converted` (server-only, not emitted by web) left untouched — separate issue.

## Measuring success
After deploy: zero 400s on `POST /api/events/track` for the three event names. Observable via server logs filtering `Unknown event name` and `sidebar_auto_minimize` or `card_size_selected`.

## Testing
- Extended `src/controllers/EventsController.test.ts` with an `it.each` covering all three new names asserting 202.
- All 39 tests pass.

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files touched.

## Changelog
No entry — internal plumbing fix, users don't see the analytics event names.

## Risks
None. Adding to an allowlist cannot break existing accepted events. Rollback: revert the two-line addition to `AnalyticsEvents.ts`.

## Goal alignment
Accurate analytics data is load-bearing for measuring which features drive retention toward the 300K-user goal. Dropped events are invisible blind spots.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782157085&installation_id=132681956&pr_number=2682&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2682&signature=7ba0ae12d3513af3dd5d95cc76483409206f09024c8e0f7670224c13e7b3dd7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->