### PR TITLE
style: mindmap canvas reclaims width when sidebar collapses

### DIFF
--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -4,6 +4,12 @@
   min-height: 100vh;
 }
 
+@media (min-width: 1024px) {
+  .shell:has(.sidebarCollapsed) {
+    grid-template-columns: 64px 1fr;
+  }
+}
+
 @media (max-width: 1023px) {
   .shell {
     grid-template-columns: 1fr;

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-wider-when-sidebar-collapses.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-wider-when-sidebar-collapses.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-mindmap-wider-when-sidebar-collapses",
+  "date": "2026-05-23",
+  "type": "style",
+  "title": "Mindmap canvas uses the full width when the sidebar is collapsed"
+}


### PR DESCRIPTION
## What
When the sidebar is collapsed on desktop, the `.shell` grid now switches from `240px 1fr` to `64px 1fr` via a CSS `:has(.sidebarCollapsed)` selector. The main content column fills the freed space and React Flow picks up the change through its built-in ResizeObserver — no JS changes needed.

## Why
The mindmap editor canvas stayed pinned to the original column width even when the sidebar shrank to icon-only mode (64px), wasting ~176px of horizontal canvas space.

## How
One CSS rule added to `AppShell.module.css`, scoped to `@media (min-width: 1024px)` to match the existing collapsed-sidebar breakpoint.

## Measuring success
Toggle the sidebar on any mindmap — the canvas visibly expands immediately. ReactFlow's ResizeObserver handles the layout recomputation without a manual `fitView` call.

## Testing
- Unit tests: no behavior change, CSS-only. All 1050 Vitest tests pass.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified — sidebar toggle reclaims the canvas width as expected.

## Changelog
"Mindmap canvas uses the full width when the sidebar is collapsed" — added to `web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-wider-when-sidebar-collapses.json`

## Risks
`:has()` is supported in all modern browsers (Chrome 105+, Firefox 121+, Safari 15.4+). No IE11 requirement in this codebase.

## Goal alignment
Polishes the mindmap editing experience — more canvas space = less friction for users building decks from complex maps.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782157158&installation_id=132681956&pr_number=2683&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2683&signature=a341de1155638894c0e1f961c3d255f71f1771d5b8dc4e8bc76336bfccc66d7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
