### PR TITLE
style: lead login with Google, align label to Google brand

### DIFF
--- a/web/src/lib/text/app.document.json
+++ b/web/src/lib/text/app.document.json
@@ -18,7 +18,7 @@
   "navigation.settings": "Settings",
   "card.options": "Card options",
   "favorites.empty": "No favorites yet.",
-  "navigation.login.google": "Log in with Google",
+  "navigation.login.google": "Sign in with Google",
   "navigation.register.google": "Sign up with Google",
   "navigation.contact": "Contact",
   "navigation.documentation": "Documentation",

--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
@@ -46,7 +46,7 @@ describe('LoginForm', () => {
 
   it('shows Google OAuth button on email step', () => {
     renderLoginForm();
-    expect(screen.getByText('Log in with Google')).toBeInTheDocument();
+    expect(screen.getByText('Sign in with Google')).toBeInTheDocument();
   });
 
   it('transitions to password step after clicking continue', () => {

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -126,10 +126,10 @@ function LoginForm() {
             <div className={styles.divider}>
               <span className={styles.dividerLabel}>or</span>
             </div>
-            <WithNotionLink text="Continue with Notion" />
             <WithGoogleLink
               text={getVisibleText('navigation.login.google')}
             />
+            <WithNotionLink text="Continue with Notion" />
             <div className={styles.divider} />
           </>
         ) : (


### PR DESCRIPTION
## Summary
- Reorder the login OAuth list so **Sign in with Google** sits above **Continue with Notion**. Google accounts dominate the user base; leading with Google shortens the returner path.
- Update the Google button label from "Log in with Google" → "Sign in with Google". `VOICE.md` lists "Sign in with Google" as a protected provider-brand string.

## Trio synthesis
- **PM** — ship as requested; login order isn't load-bearing for the convert flow (Notion OAuth grant is requested again at convert time).
- **Designer** — Google above Notion, and fix the label while we're in there.
- **Engineer** — minimal swap in `LoginForm/index.tsx` + one JSON key.

No changelog entry — a button reorder + brand-compliance copy fix doesn't pass the "user would notice" bar.

No local `sonar-scanner` run — two-line UI change, no new code paths, no new functions.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: tick before flipping ready — visual spot-check on `/login`.

## Test plan
- [ ] `pnpm dev` → visit `/login`
- [ ] Confirm Google button renders above Notion button
- [ ] Confirm Google label reads "Sign in with Google"
- [ ] Confirm 375px width: no overflow, divider/spacing intact
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782157645&installation_id=132681956&pr_number=2684&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2684&signature=469aebdcee4cf3d69a1a76878b3bfb8662ef15d8713ed4d095ff4b8cfb5f3849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
