### PR TITLE
feat: store mindmap images in DigitalOcean Spaces

### DIFF
--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
-import os from 'node:os';
 
+import StorageHandler from '../lib/storage/StorageHandler';
 import { CreateMindmapUseCase, MindmapLimitError } from '../usecases/mindmaps/CreateMindmapUseCase';
 import { UpdateMindmapUseCase } from '../usecases/mindmaps/UpdateMindmapUseCase';
 import { DeleteMindmapUseCase } from '../usecases/mindmaps/DeleteMindmapUseCase';
@@ -28,7 +28,8 @@ export class MindmapController {
     private readonly deleteUseCase: DeleteMindmapUseCase,
     private readonly listUseCase: ListMindmapsUseCase,
     private readonly getUseCase: GetMindmapUseCase,
-    private readonly exportUseCase: ExportMindmapUseCase
+    private readonly exportUseCase: ExportMindmapUseCase,
+    private readonly storage: StorageHandler
   ) {}
 
   private async resolveUserContext(res: Response): Promise<{
@@ -181,14 +182,13 @@ export class MindmapController {
       return;
     }
 
-    const uploadBase = process.env.UPLOAD_BASE ?? os.tmpdir();
-    const useCase = new UploadMindmapImageUseCase(uploadBase);
+    const useCase = new UploadMindmapImageUseCase(this.storage);
 
     try {
       const result = await useCase.execute({
         userId,
         mapId,
-        file: { path: file.path, mimetype: file.mimetype, size: file.size },
+        file: { buffer: file.buffer, mimetype: file.mimetype, size: file.size },
       });
       res.status(201).json(result);
     } catch (error) {
@@ -202,5 +202,19 @@ export class MindmapController {
       }
       throw error;
     }
+  }
+
+  async serveImage(req: Request, res: Response): Promise<void> {
+    const { userId, mapId, file } = req.params;
+    const s3Key = `mindmaps/${userId}/${mapId}/${file}`;
+
+    const exists = await this.storage.objectExists(s3Key);
+    if (exists) {
+      const presignedUrl = await this.storage.getPresignedUrl(s3Key);
+      res.redirect(302, presignedUrl);
+      return;
+    }
+
+    res.status(410).json({ code: 'image_missing', message: 'Image no longer available' });
   }
 }

--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -190,7 +190,11 @@ export class MindmapController {
         mapId,
         file: { buffer: file.buffer, mimetype: file.mimetype, size: file.size },
       });
-      res.status(201).json(result);
+      res.status(201).json({
+        url: result.presignedUrl,
+        width: result.width,
+        height: result.height,
+      });
     } catch (error) {
       if (error instanceof MindmapImageTypeError) {
         res.status(415).json({ message: error.message });

--- a/src/lib/storage/StorageHandler.ts
+++ b/src/lib/storage/StorageHandler.ts
@@ -1,7 +1,9 @@
 import {
   S3Client,
   DeleteObjectCommand,
+  DeleteObjectsCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   type _Object,
@@ -129,6 +131,52 @@ class StorageHandler {
         Key: key,
       }),
       { expiresIn: expiresSeconds }
+    );
+  }
+
+  async objectExists(key: string): Promise<boolean> {
+    try {
+      await this.s3.send(
+        new HeadObjectCommand({
+          Bucket: StorageHandler.DefaultBucketName(),
+          Key: key,
+        })
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async listByPrefix(prefix: string): Promise<string[]> {
+    const keys: string[] = [];
+    let continuationToken: string | undefined;
+    let hasMore = true;
+    while (hasMore) {
+      const response = await this.s3.send(
+        new ListObjectsV2Command({
+          Bucket: StorageHandler.DefaultBucketName(),
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        })
+      );
+      for (const obj of response.Contents ?? []) {
+        if (obj.Key != null) keys.push(obj.Key);
+      }
+      continuationToken = response.NextContinuationToken;
+      hasMore = Boolean(response.IsTruncated) && continuationToken != null;
+    }
+    return keys;
+  }
+
+  async deleteObjects(keys: string[]): Promise<void> {
+    if (keys.length === 0) return;
+    const objects = keys.map((Key) => ({ Key }));
+    await this.s3.send(
+      new DeleteObjectsCommand({
+        Bucket: StorageHandler.DefaultBucketName(),
+        Delete: { Objects: objects, Quiet: true },
+      })
     );
   }
 }

--- a/src/routes/MindmapRouter.test.ts
+++ b/src/routes/MindmapRouter.test.ts
@@ -11,6 +11,27 @@ const mockUpdate = jest.fn();
 const mockCount = jest.fn();
 const mockGetUserActiveSubscriptions = jest.fn();
 
+const mockUploadFile = jest.fn().mockResolvedValue(undefined);
+const mockGetPresignedUrl = jest.fn().mockResolvedValue('https://spaces.example.com/presigned');
+const mockObjectExists = jest.fn().mockResolvedValue(false);
+const mockListByPrefix = jest.fn().mockResolvedValue([]);
+const mockDeleteObjects = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../lib/storage/StorageHandler', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    uploadFile: mockUploadFile,
+    getPresignedUrl: mockGetPresignedUrl,
+    objectExists: mockObjectExists,
+    listByPrefix: mockListByPrefix,
+    deleteObjects: mockDeleteObjects,
+    getFileContents: jest.fn().mockResolvedValue({ Body: undefined }),
+    delete: jest.fn(),
+    getContents: jest.fn(),
+    uniqify: jest.fn(),
+  })),
+}));
+
 jest.mock('../data_layer', () => ({
   getDatabase: jest.fn().mockReturnValue({}),
 }));
@@ -74,6 +95,9 @@ describe('MindmapRouter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetUserActiveSubscriptions.mockResolvedValue([]);
+    mockGetPresignedUrl.mockResolvedValue('https://spaces.example.com/presigned');
+    mockObjectExists.mockResolvedValue(false);
+    mockListByPrefix.mockResolvedValue([]);
   });
 
   describe('POST /api/mindmaps', () => {
@@ -258,7 +282,7 @@ describe('MindmapRouter', () => {
       'base64'
     );
 
-    it('returns 201 with url, width, height for a valid PNG', async () => {
+    it('returns 201 with s3Key, presignedUrl, width, height for a valid PNG', async () => {
       const form = new FormData();
       form.append('image', new Blob([TINY_PNG], { type: 'image/png' }), 'test.png');
 
@@ -269,9 +293,11 @@ describe('MindmapRouter', () => {
 
       expect(res.status).toBe(201);
       const body = await res.json();
-      expect(body.url).toMatch(/^\/api\/mindmaps\/images\//);
+      expect(body.s3Key).toMatch(/^mindmaps\/42\/map-1\/.+\.png$/);
+      expect(body.presignedUrl).toBe('https://spaces.example.com/presigned');
       expect(typeof body.width).toBe('number');
       expect(typeof body.height).toBe('number');
+      expect(mockUploadFile).toHaveBeenCalledWith(body.s3Key, TINY_PNG);
     });
 
     it('returns 400 when no file is provided', async () => {
@@ -281,6 +307,30 @@ describe('MindmapRouter', () => {
       });
 
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/mindmaps/images/:userId/:mapId/:file', () => {
+    it('returns 302 redirect when object exists in Spaces', async () => {
+      mockObjectExists.mockResolvedValue(true);
+      mockGetPresignedUrl.mockResolvedValue('https://spaces.example.com/presigned-img');
+
+      const res = await fetch(`${url}/api/mindmaps/images/42/map-1/img.png`, {
+        redirect: 'manual',
+      });
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get('location')).toBe('https://spaces.example.com/presigned-img');
+    });
+
+    it('returns 410 when object does not exist', async () => {
+      mockObjectExists.mockResolvedValue(false);
+
+      const res = await fetch(`${url}/api/mindmaps/images/42/map-1/missing.png`);
+
+      expect(res.status).toBe(410);
+      const body = await res.json();
+      expect(body.code).toBe('image_missing');
     });
   });
 });

--- a/src/routes/MindmapRouter.test.ts
+++ b/src/routes/MindmapRouter.test.ts
@@ -282,7 +282,7 @@ describe('MindmapRouter', () => {
       'base64'
     );
 
-    it('returns 201 with s3Key, presignedUrl, width, height for a valid PNG', async () => {
+    it('returns 201 with url, width, height for a valid PNG', async () => {
       const form = new FormData();
       form.append('image', new Blob([TINY_PNG], { type: 'image/png' }), 'test.png');
 
@@ -293,11 +293,13 @@ describe('MindmapRouter', () => {
 
       expect(res.status).toBe(201);
       const body = await res.json();
-      expect(body.s3Key).toMatch(/^mindmaps\/42\/map-1\/.+\.png$/);
-      expect(body.presignedUrl).toBe('https://spaces.example.com/presigned');
+      expect(body.url).toBe('https://spaces.example.com/presigned');
       expect(typeof body.width).toBe('number');
       expect(typeof body.height).toBe('number');
-      expect(mockUploadFile).toHaveBeenCalledWith(body.s3Key, TINY_PNG);
+      expect(mockUploadFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^mindmaps\/42\/map-1\/.+\.png$/),
+        TINY_PNG
+      );
     });
 
     it('returns 400 when no file is provided', async () => {

--- a/src/routes/MindmapRouter.ts
+++ b/src/routes/MindmapRouter.ts
@@ -1,7 +1,5 @@
 import express from 'express';
 import multer from 'multer';
-import os from 'node:os';
-import path from 'node:path';
 
 import { getDatabase } from '../data_layer';
 import { MindmapRepository } from '../data_layer/MindmapRepository';
@@ -12,6 +10,7 @@ import { DeleteMindmapUseCase } from '../usecases/mindmaps/DeleteMindmapUseCase'
 import { ListMindmapsUseCase } from '../usecases/mindmaps/ListMindmapsUseCase';
 import { GetMindmapUseCase } from '../usecases/mindmaps/GetMindmapUseCase';
 import { ExportMindmapUseCase } from '../usecases/mindmaps/ExportMindmapUseCase';
+import StorageHandler from '../lib/storage/StorageHandler';
 import RequireAuthentication from './middleware/RequireAuthentication';
 
 const ALLOWED_IMAGE_TYPES = new Set([
@@ -25,29 +24,25 @@ const MindmapRouter = () => {
   const router = express.Router();
   const db = getDatabase();
   const repo = new MindmapRepository(db);
+  const storage = new StorageHandler();
 
   const controller = new MindmapController(
     new CreateMindmapUseCase(repo),
     new UpdateMindmapUseCase(repo),
-    new DeleteMindmapUseCase(repo),
+    new DeleteMindmapUseCase(repo, storage),
     new ListMindmapsUseCase(repo),
-    new GetMindmapUseCase(repo),
-    new ExportMindmapUseCase(repo)
+    new GetMindmapUseCase(repo, storage),
+    new ExportMindmapUseCase(repo, storage),
+    storage
   );
 
-  const uploadBase = process.env.UPLOAD_BASE ?? os.tmpdir();
   const imageUpload = multer({
-    dest: os.tmpdir(),
+    storage: multer.memoryStorage(),
     fileFilter: (_req, file, cb) => {
       cb(null, ALLOWED_IMAGE_TYPES.has(file.mimetype));
     },
     limits: { fileSize: 5 * 1024 * 1024 },
   });
-
-  router.use(
-    '/api/mindmaps/images',
-    express.static(path.join(uploadBase, 'mindmaps'), { fallthrough: false })
-  );
 
   /**
    * @swagger
@@ -278,7 +273,7 @@ const MindmapRouter = () => {
    *                 format: binary
    *     responses:
    *       201:
-   *         description: Image uploaded, returns url, width, height
+   *         description: Image uploaded, returns s3Key, presignedUrl, width, height
    *       400:
    *         description: No image provided
    *       401:
@@ -293,6 +288,38 @@ const MindmapRouter = () => {
     RequireAuthentication,
     imageUpload.single('image'),
     (req, res) => controller.uploadImage(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/mindmaps/images/{userId}/{mapId}/{file}:
+   *   get:
+   *     summary: Serve or redirect to a mindmap image
+   *     tags: [Mind maps]
+   *     parameters:
+   *       - in: path
+   *         name: userId
+   *         required: true
+   *         schema:
+   *           type: string
+   *       - in: path
+   *         name: mapId
+   *         required: true
+   *         schema:
+   *           type: string
+   *       - in: path
+   *         name: file
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       302:
+   *         description: Redirect to presigned URL
+   *       410:
+   *         description: Image no longer available
+   */
+  router.get('/api/mindmaps/images/:userId/:mapId/:file', (req, res) =>
+    controller.serveImage(req, res)
   );
 
   return router;

--- a/src/routes/MindmapRouter.ts
+++ b/src/routes/MindmapRouter.ts
@@ -273,7 +273,7 @@ const MindmapRouter = () => {
    *                 format: binary
    *     responses:
    *       201:
-   *         description: Image uploaded, returns s3Key, presignedUrl, width, height
+   *         description: Image uploaded, returns url, width, height
    *       400:
    *         description: No image provided
    *       401:

--- a/src/usecases/mindmaps/DeleteMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/DeleteMindmapUseCase.test.ts
@@ -1,0 +1,79 @@
+import { DeleteMindmapUseCase } from './DeleteMindmapUseCase';
+import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
+import { MindmapsId } from '../../data_layer/public/Mindmaps';
+import { UsersId } from '../../data_layer/public/Users';
+import StorageHandler from '../../lib/storage/StorageHandler';
+
+function makeRepo(): MindmapRepositoryInterface {
+  return {
+    create: jest.fn(),
+    findById: jest.fn(),
+    findByUserId: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn().mockResolvedValue(undefined),
+    countByUserId: jest.fn(),
+  };
+}
+
+function makeStorage(keys: string[] = []): StorageHandler {
+  return {
+    listByPrefix: jest.fn().mockResolvedValue(keys),
+    deleteObjects: jest.fn().mockResolvedValue(undefined),
+    uploadFile: jest.fn(),
+    getPresignedUrl: jest.fn(),
+    getFileContents: jest.fn(),
+    objectExists: jest.fn(),
+    delete: jest.fn(),
+    getContents: jest.fn(),
+    uniqify: jest.fn(),
+    s3: {} as never,
+  } as unknown as StorageHandler;
+}
+
+const ID = 'map-uuid' as MindmapsId;
+const USER = 99 as UsersId;
+
+describe('DeleteMindmapUseCase', () => {
+  it('calls listByPrefix with the correct prefix', async () => {
+    const storage = makeStorage(['mindmaps/99/map-uuid/a.png']);
+    const repo = makeRepo();
+    const useCase = new DeleteMindmapUseCase(repo, storage);
+
+    await useCase.execute(ID, USER);
+
+    expect(storage.listByPrefix).toHaveBeenCalledWith('mindmaps/99/map-uuid/');
+    expect(storage.deleteObjects).toHaveBeenCalledWith(['mindmaps/99/map-uuid/a.png']);
+  });
+
+  it('skips deleteObjects when no objects exist', async () => {
+    const storage = makeStorage([]);
+    const repo = makeRepo();
+    const useCase = new DeleteMindmapUseCase(repo, storage);
+
+    await useCase.execute(ID, USER);
+
+    expect(storage.deleteObjects).not.toHaveBeenCalled();
+  });
+
+  it('still deletes from DB when S3 listByPrefix throws', async () => {
+    const storage = makeStorage();
+    (storage.listByPrefix as jest.Mock).mockRejectedValue(new Error('S3 down'));
+    const repo = makeRepo();
+    const useCase = new DeleteMindmapUseCase(repo, storage);
+
+    await useCase.execute(ID, USER);
+
+    expect(repo.delete).toHaveBeenCalledWith(ID, USER);
+  });
+
+  it('still deletes from DB when deleteObjects throws', async () => {
+    const storage = makeStorage(['mindmaps/99/map-uuid/a.png']);
+    (storage.deleteObjects as jest.Mock).mockRejectedValue(new Error('S3 down'));
+    const repo = makeRepo();
+    const useCase = new DeleteMindmapUseCase(repo, storage);
+
+    await useCase.execute(ID, USER);
+
+    expect(repo.delete).toHaveBeenCalledWith(ID, USER);
+  });
+});

--- a/src/usecases/mindmaps/DeleteMindmapUseCase.ts
+++ b/src/usecases/mindmaps/DeleteMindmapUseCase.ts
@@ -1,11 +1,24 @@
+import StorageHandler from '../../lib/storage/StorageHandler';
 import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
 import { MindmapsId } from '../../data_layer/public/Mindmaps';
 import { UsersId } from '../../data_layer/public/Users';
 
 export class DeleteMindmapUseCase {
-  constructor(private readonly repo: MindmapRepositoryInterface) {}
+  constructor(
+    private readonly repo: MindmapRepositoryInterface,
+    private readonly storage: StorageHandler
+  ) {}
 
-  execute(id: MindmapsId, userId: UsersId): Promise<void> {
+  async execute(id: MindmapsId, userId: UsersId): Promise<void> {
+    const prefix = `mindmaps/${userId}/${id}/`;
+    try {
+      const keys = await this.storage.listByPrefix(prefix);
+      if (keys.length > 0) {
+        await this.storage.deleteObjects(keys);
+      }
+    } catch (err) {
+      console.error('S3 cleanup failed for mindmap', id, err);
+    }
     return this.repo.delete(id, userId);
   }
 }

--- a/src/usecases/mindmaps/ExportMindmapUseCase.ts
+++ b/src/usecases/mindmaps/ExportMindmapUseCase.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
+import StorageHandler from '../../lib/storage/StorageHandler';
 import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
 import { MindmapsId } from '../../data_layer/public/Mindmaps';
 import { UsersId } from '../../data_layer/public/Users';
@@ -32,7 +33,10 @@ interface ExportInput {
 }
 
 export class ExportMindmapUseCase {
-  constructor(private readonly repo: MindmapRepositoryInterface) {}
+  constructor(
+    private readonly repo: MindmapRepositoryInterface,
+    private readonly storage: StorageHandler
+  ) {}
 
   private buildNotes(
     data: MindmapData,
@@ -62,8 +66,7 @@ export class ExportMindmapUseCase {
 
     const resolvedDeckName = deckName ?? map.title;
     const mapData = map.data as MindmapData;
-    const uploadBase = process.env.UPLOAD_BASE ?? os.tmpdir();
-    const collectedImages = collectMindmapImages(mapData, uploadBase);
+    const collectedImages = await collectMindmapImages(mapData, this.storage);
 
     const filenameMap: Record<string, string> = {};
     const allMediaFilenames: string[] = [];

--- a/src/usecases/mindmaps/GetMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/GetMindmapUseCase.test.ts
@@ -1,0 +1,109 @@
+import { GetMindmapUseCase } from './GetMindmapUseCase';
+import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
+import Mindmaps, { MindmapsId } from '../../data_layer/public/Mindmaps';
+import { UsersId } from '../../data_layer/public/Users';
+import { MindmapData } from './MindmapData';
+import StorageHandler from '../../lib/storage/StorageHandler';
+
+function makeRepo(map: Mindmaps | null): MindmapRepositoryInterface {
+  return {
+    create: jest.fn(),
+    findById: jest.fn().mockResolvedValue(map),
+    findByUserId: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    countByUserId: jest.fn(),
+  };
+}
+
+function makeStorage(presignedUrl = 'https://spaces.example.com/presigned'): StorageHandler {
+  return {
+    getPresignedUrl: jest.fn().mockResolvedValue(presignedUrl),
+    uploadFile: jest.fn(),
+    getFileContents: jest.fn(),
+    objectExists: jest.fn(),
+    listByPrefix: jest.fn(),
+    deleteObjects: jest.fn(),
+    delete: jest.fn(),
+    getContents: jest.fn(),
+    uniqify: jest.fn(),
+    s3: {} as never,
+  } as unknown as StorageHandler;
+}
+
+function makeMap(data: MindmapData): Mindmaps {
+  return {
+    id: 'map-1' as MindmapsId,
+    user_id: 1 as UsersId,
+    title: 'Test',
+    data,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+describe('GetMindmapUseCase', () => {
+  it('returns null when map is not found', async () => {
+    const useCase = new GetMindmapUseCase(makeRepo(null), makeStorage());
+    const result = await useCase.execute('map-1' as MindmapsId, 1 as UsersId);
+    expect(result).toBeNull();
+  });
+
+  it('resolves s3 key to presigned URL', async () => {
+    const data: MindmapData = {
+      nodes: [{ id: 'a', label: 'Node', image: { url: 'mindmaps/1/map-1/uuid.png', width: 10, height: 10 } }],
+      edges: [],
+    };
+    const map = makeMap(data);
+    const storage = makeStorage('https://presigned.example.com/img.png');
+    const useCase = new GetMindmapUseCase(makeRepo(map), storage);
+
+    const result = await useCase.execute('map-1' as MindmapsId, 1 as UsersId);
+    const nodes = (result!.data as MindmapData).nodes;
+    expect(nodes[0].image?.url).toBe('https://presigned.example.com/img.png');
+    expect(nodes[0].image?.missing).toBeUndefined();
+  });
+
+  it('marks legacy /api/mindmaps/images/ URLs as missing', async () => {
+    const data: MindmapData = {
+      nodes: [{ id: 'b', label: 'Old', image: { url: '/api/mindmaps/images/1/map-1/old.png', width: 10, height: 10 } }],
+      edges: [],
+    };
+    const map = makeMap(data);
+    const useCase = new GetMindmapUseCase(makeRepo(map), makeStorage());
+
+    const result = await useCase.execute('map-1' as MindmapsId, 1 as UsersId);
+    const nodes = (result!.data as MindmapData).nodes;
+    expect(nodes[0].image?.missing).toBe(true);
+    expect(nodes[0].image?.url).toBeNull();
+  });
+
+  it('passes through nodes without images unchanged', async () => {
+    const data: MindmapData = {
+      nodes: [{ id: 'c', label: 'Plain node' }],
+      edges: [],
+    };
+    const map = makeMap(data);
+    const useCase = new GetMindmapUseCase(makeRepo(map), makeStorage());
+
+    const result = await useCase.execute('map-1' as MindmapsId, 1 as UsersId);
+    const nodes = (result!.data as MindmapData).nodes;
+    expect(nodes[0].image).toBeUndefined();
+  });
+
+  it('marks image as missing when presigned URL generation fails', async () => {
+    const data: MindmapData = {
+      nodes: [{ id: 'd', label: 'Node', image: { url: 'mindmaps/1/map-1/uuid.png', width: 10, height: 10 } }],
+      edges: [],
+    };
+    const map = makeMap(data);
+    const storage = makeStorage();
+    (storage.getPresignedUrl as jest.Mock).mockRejectedValue(new Error('S3 down'));
+    const useCase = new GetMindmapUseCase(makeRepo(map), storage);
+
+    const result = await useCase.execute('map-1' as MindmapsId, 1 as UsersId);
+    const nodes = (result!.data as MindmapData).nodes;
+    expect(nodes[0].image?.missing).toBe(true);
+    expect(nodes[0].image?.url).toBeNull();
+  });
+});

--- a/src/usecases/mindmaps/GetMindmapUseCase.ts
+++ b/src/usecases/mindmaps/GetMindmapUseCase.ts
@@ -1,11 +1,60 @@
+import StorageHandler from '../../lib/storage/StorageHandler';
 import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
 import Mindmaps, { MindmapsId } from '../../data_layer/public/Mindmaps';
 import { UsersId } from '../../data_layer/public/Users';
+import { MindmapData, MindmapImageMeta } from './MindmapData';
+
+const LEGACY_PREFIX = '/api/mindmaps/images/';
+const S3_KEY_PREFIX = 'mindmaps/';
+
+function isLegacyUrl(value: string): boolean {
+  return value.startsWith(LEGACY_PREFIX);
+}
+
+function isS3Key(value: string): boolean {
+  return value.startsWith(S3_KEY_PREFIX);
+}
+
+async function resolveImage(
+  image: MindmapImageMeta,
+  storage: StorageHandler
+): Promise<MindmapImageMeta> {
+  const { url } = image;
+  if (url == null) {
+    return { ...image, missing: true, url: null };
+  }
+  if (isLegacyUrl(url)) {
+    return { url: null, width: image.width, height: image.height, missing: true };
+  }
+  if (isS3Key(url)) {
+    const presignedUrl = await storage.getPresignedUrl(url).catch(() => null);
+    if (presignedUrl == null) {
+      return { url: null, width: image.width, height: image.height, missing: true };
+    }
+    return { ...image, url: presignedUrl };
+  }
+  return { ...image, missing: true, url: null };
+}
 
 export class GetMindmapUseCase {
-  constructor(private readonly repo: MindmapRepositoryInterface) {}
+  constructor(
+    private readonly repo: MindmapRepositoryInterface,
+    private readonly storage: StorageHandler
+  ) {}
 
   async execute(id: MindmapsId, userId: UsersId): Promise<Mindmaps | null> {
-    return this.repo.findById(id, userId);
+    const map = await this.repo.findById(id, userId);
+    if (map == null) return null;
+
+    const data = map.data as MindmapData;
+    const resolvedNodes = await Promise.all(
+      data.nodes.map(async (node) => {
+        if (node.image == null) return node;
+        const resolvedImage = await resolveImage(node.image, this.storage);
+        return { ...node, image: resolvedImage };
+      })
+    );
+
+    return { ...map, data: { ...data, nodes: resolvedNodes } };
   }
 }

--- a/src/usecases/mindmaps/MindmapData.ts
+++ b/src/usecases/mindmaps/MindmapData.ts
@@ -1,7 +1,8 @@
 export interface MindmapImageMeta {
-  url: string;
+  url: string | null;
   width: number;
   height: number;
+  missing?: true;
 }
 
 export interface MindmapData {

--- a/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
@@ -119,4 +119,67 @@ describe('UpdateMindmapUseCase', () => {
 
     expect((result?.data as MindmapData).nodes.length).toBe(50);
   });
+
+  it('strips presigned URL back to s3Key before persisting', async () => {
+    const baseKey = 'mindmaps/1/map-1/uuid.png';
+    const presigned = `https://bucket.spaces.digitaloceanspaces.com/${baseKey}?X-Amz-Signature=abc`;
+    const repo = makeRepo(makeMap(1));
+    const useCase = new UpdateMindmapUseCase(repo);
+
+    await useCase.execute({
+      id: 'map-1' as MindmapsId,
+      userId: 1 as UsersId,
+      data: {
+        nodes: [{ id: 'a', label: 'n', image: { url: presigned, width: 10, height: 10 } }],
+        edges: [],
+      },
+      user: FREE_USER,
+      subscriptions: [],
+    });
+
+    const saved = (repo.update as jest.Mock).mock.calls[0][2] as { data: MindmapData };
+    const savedImage = saved.data.nodes[0].image!;
+    expect(savedImage.url).toBe(baseKey);
+  });
+
+  it('strips legacy /api/mindmaps/images/ URL and marks as missing', async () => {
+    const repo = makeRepo(makeMap(1));
+    const useCase = new UpdateMindmapUseCase(repo);
+
+    await useCase.execute({
+      id: 'map-1' as MindmapsId,
+      userId: 1 as UsersId,
+      data: {
+        nodes: [{ id: 'a', label: 'n', image: { url: '/api/mindmaps/images/1/map-1/old.png', width: 10, height: 10 } }],
+        edges: [],
+      },
+      user: FREE_USER,
+      subscriptions: [],
+    });
+
+    const saved = (repo.update as jest.Mock).mock.calls[0][2] as { data: MindmapData };
+    const savedImage = saved.data.nodes[0].image!;
+    expect(savedImage.url).toBeNull();
+    expect(savedImage.missing).toBe(true);
+  });
+
+  it('keeps a bare s3Key unchanged', async () => {
+    const repo = makeRepo(makeMap(1));
+    const useCase = new UpdateMindmapUseCase(repo);
+
+    await useCase.execute({
+      id: 'map-1' as MindmapsId,
+      userId: 1 as UsersId,
+      data: {
+        nodes: [{ id: 'a', label: 'n', image: { url: 'mindmaps/1/map-1/uuid.png', width: 10, height: 10 } }],
+        edges: [],
+      },
+      user: FREE_USER,
+      subscriptions: [],
+    });
+
+    const saved = (repo.update as jest.Mock).mock.calls[0][2] as { data: MindmapData };
+    const savedImage = saved.data.nodes[0].image!;
+    expect(savedImage.url).toBe('mindmaps/1/map-1/uuid.png');
+  });
 });

--- a/src/usecases/mindmaps/UpdateMindmapUseCase.ts
+++ b/src/usecases/mindmaps/UpdateMindmapUseCase.ts
@@ -1,7 +1,7 @@
 import { hasAnkifyAccess, AnkifyAccessUser, AnkifyAccessSubscription } from '../../lib/ankify/access';
 import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
 import Mindmaps, { MindmapsId } from '../../data_layer/public/Mindmaps';
-import { MindmapData } from './MindmapData';
+import { MindmapData, MindmapImageMeta } from './MindmapData';
 import { UsersId } from '../../data_layer/public/Users';
 
 import { MindmapLimitError } from './CreateMindmapUseCase';
@@ -9,6 +9,39 @@ import { MindmapLimitError } from './CreateMindmapUseCase';
 export { MindmapLimitError };
 
 export const FREE_NODE_LIMIT = 50;
+
+const LEGACY_PREFIX = '/api/mindmaps/images/';
+const S3_KEY_PREFIX = 'mindmaps/';
+
+function sanitizeImageUrl(image: MindmapImageMeta): MindmapImageMeta {
+  const { url } = image;
+  if (url == null) {
+    return { ...image, missing: true, url: null };
+  }
+  if (url.startsWith(LEGACY_PREFIX)) {
+    return { url: null, width: image.width, height: image.height, missing: true };
+  }
+  if (url.startsWith(S3_KEY_PREFIX)) {
+    return { ...image, url };
+  }
+  const s3KeyMatch = url.match(/[?#]/);
+  const rawPath = s3KeyMatch != null ? url.slice(0, s3KeyMatch.index) : url;
+  const keyStart = rawPath.indexOf(S3_KEY_PREFIX);
+  if (keyStart !== -1) {
+    return { ...image, url: rawPath.slice(keyStart) };
+  }
+  return { url: null, width: image.width, height: image.height, missing: true };
+}
+
+function sanitizeData(data: MindmapData): MindmapData {
+  return {
+    ...data,
+    nodes: data.nodes.map((node) => {
+      if (node.image == null) return node;
+      return { ...node, image: sanitizeImageUrl(node.image) };
+    }),
+  };
+}
 
 interface UpdateInput {
   id: MindmapsId;
@@ -33,7 +66,7 @@ export class UpdateMindmapUseCase {
 
     const patch: Partial<Pick<Mindmaps, 'title' | 'data'>> = {};
     if (title != null) patch.title = title;
-    if (data != null) patch.data = data;
+    if (data != null) patch.data = sanitizeData(data);
 
     return this.repo.update(id, userId, patch);
   }

--- a/src/usecases/mindmaps/UploadMindmapImageUseCase.test.ts
+++ b/src/usecases/mindmaps/UploadMindmapImageUseCase.test.ts
@@ -1,82 +1,87 @@
-import path from 'node:path';
-import fs from 'node:fs';
-import os from 'node:os';
-
 import { UploadMindmapImageUseCase, MindmapImageTooLargeError, MindmapImageTypeError } from './UploadMindmapImageUseCase';
+import StorageHandler from '../../lib/storage/StorageHandler';
 
 const TINY_PNG = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
   'base64'
 );
 
-function makeTempFile(buf: Buffer, ext: string): string {
-  const p = path.join(os.tmpdir(), `mm-test-${Date.now()}${ext}`);
-  fs.writeFileSync(p, buf);
-  return p;
+function makeStorage(overrides: Partial<StorageHandler> = {}): StorageHandler {
+  return {
+    uploadFile: jest.fn().mockResolvedValue(undefined),
+    getPresignedUrl: jest.fn().mockResolvedValue('https://spaces.example.com/presigned'),
+    getFileContents: jest.fn(),
+    objectExists: jest.fn(),
+    listByPrefix: jest.fn(),
+    deleteObjects: jest.fn(),
+    delete: jest.fn(),
+    getContents: jest.fn(),
+    uniqify: jest.fn(),
+    s3: {} as never,
+    ...overrides,
+  } as unknown as StorageHandler;
 }
 
 describe('UploadMindmapImageUseCase', () => {
-  let uploadBase: string;
-  let useCase: UploadMindmapImageUseCase;
+  it('accepts a PNG buffer and calls uploadFile with the expected key prefix', async () => {
+    const storage = makeStorage();
+    const useCase = new UploadMindmapImageUseCase(storage);
 
-  beforeEach(() => {
-    uploadBase = fs.mkdtempSync(path.join(os.tmpdir(), 'mm-uc-'));
-    useCase = new UploadMindmapImageUseCase(uploadBase);
-  });
-
-  afterEach(() => {
-    fs.rmSync(uploadBase, { recursive: true, force: true });
-  });
-
-  it('accepts a PNG file and returns url, width, height', async () => {
-    const tmpPath = makeTempFile(TINY_PNG, '.png');
     const result = await useCase.execute({
       userId: '42',
       mapId: 'map-1',
-      file: { path: tmpPath, mimetype: 'image/png', size: TINY_PNG.length },
+      file: { buffer: TINY_PNG, mimetype: 'image/png', size: TINY_PNG.length },
     });
 
-    expect(result.url).toMatch(/^\/api\/mindmaps\/images\//);
+    expect(result.s3Key).toMatch(/^mindmaps\/42\/map-1\/.+\.png$/);
+    expect(result.presignedUrl).toBe('https://spaces.example.com/presigned');
     expect(result.width).toBe(1);
     expect(result.height).toBe(1);
-  });
-
-  it('writes the file to the expected directory', async () => {
-    const tmpPath = makeTempFile(TINY_PNG, '.png');
-    const result = await useCase.execute({
-      userId: '42',
-      mapId: 'map-1',
-      file: { path: tmpPath, mimetype: 'image/png', size: TINY_PNG.length },
-    });
-
-    const filename = result.url.split('/').pop()!;
-    const finalPath = path.join(uploadBase, 'mindmaps', '42', 'map-1', filename);
-    expect(fs.existsSync(finalPath)).toBe(true);
+    expect(storage.uploadFile).toHaveBeenCalledWith(result.s3Key, TINY_PNG);
   });
 
   it('rejects an SVG file', async () => {
+    const storage = makeStorage();
+    const useCase = new UploadMindmapImageUseCase(storage);
     const svgBuf = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>');
-    const tmpPath = makeTempFile(svgBuf, '.svg');
+
     await expect(
       useCase.execute({
         userId: '42',
         mapId: 'map-1',
-        file: { path: tmpPath, mimetype: 'image/svg+xml', size: svgBuf.length },
+        file: { buffer: svgBuf, mimetype: 'image/svg+xml', size: svgBuf.length },
       })
     ).rejects.toBeInstanceOf(MindmapImageTypeError);
-    fs.unlinkSync(tmpPath);
+
+    expect(storage.uploadFile).not.toHaveBeenCalled();
   });
 
   it('rejects a file exceeding 5 MB', async () => {
+    const storage = makeStorage();
+    const useCase = new UploadMindmapImageUseCase(storage);
     const big = Buffer.alloc(5 * 1024 * 1024 + 1);
-    const tmpPath = makeTempFile(big, '.png');
+
     await expect(
       useCase.execute({
         userId: '42',
         mapId: 'map-1',
-        file: { path: tmpPath, mimetype: 'image/png', size: big.length },
+        file: { buffer: big, mimetype: 'image/png', size: big.length },
       })
     ).rejects.toBeInstanceOf(MindmapImageTooLargeError);
-    fs.unlinkSync(tmpPath);
+
+    expect(storage.uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('returns s3Key without writing to disk', async () => {
+    const storage = makeStorage();
+    const useCase = new UploadMindmapImageUseCase(storage);
+
+    const result = await useCase.execute({
+      userId: '7',
+      mapId: 'abc',
+      file: { buffer: TINY_PNG, mimetype: 'image/jpeg', size: TINY_PNG.length },
+    });
+
+    expect(result.s3Key).toMatch(/^mindmaps\/7\/abc\/.+\.jpg$/);
   });
 });

--- a/src/usecases/mindmaps/UploadMindmapImageUseCase.ts
+++ b/src/usecases/mindmaps/UploadMindmapImageUseCase.ts
@@ -1,8 +1,8 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 
 import imageSize from 'image-size';
+
+import StorageHandler from '../../lib/storage/StorageHandler';
 
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 const ALLOWED_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
@@ -25,20 +25,21 @@ interface UploadInput {
   userId: string;
   mapId: string;
   file: {
-    path: string;
+    buffer: Buffer;
     mimetype: string;
     size: number;
   };
 }
 
 export interface MindmapImageResult {
-  url: string;
+  s3Key: string;
+  presignedUrl: string;
   width: number;
   height: number;
 }
 
 export class UploadMindmapImageUseCase {
-  constructor(private readonly uploadBase: string) {}
+  constructor(private readonly storage: StorageHandler) {}
 
   async execute(input: UploadInput): Promise<MindmapImageResult> {
     const { userId, mapId, file } = input;
@@ -52,25 +53,16 @@ export class UploadMindmapImageUseCase {
     }
 
     const ext = this.extensionFor(file.mimetype);
-    const filename = `${randomUUID()}${ext}`;
-    const destDir = path.join(this.uploadBase, 'mindmaps', userId, mapId);
-    fs.mkdirSync(destDir, { recursive: true });
+    const s3Key = `mindmaps/${userId}/${mapId}/${randomUUID()}${ext}`;
 
-    const destPath = path.join(destDir, filename);
-    const assertedPath = path.resolve(destPath);
-    const assertedBase = path.resolve(destDir);
-    if (!assertedPath.startsWith(assertedBase + path.sep)) {
-      throw new Error('Path escape detected');
-    }
+    await this.storage.uploadFile(s3Key, file.buffer);
 
-    fs.copyFileSync(file.path, destPath);
-    fs.unlinkSync(file.path);
-
-    const buf = fs.readFileSync(destPath);
-    const dims = imageSize(buf);
+    const dims = imageSize(file.buffer);
+    const presignedUrl = await this.storage.getPresignedUrl(s3Key);
 
     return {
-      url: `/api/mindmaps/images/${userId}/${mapId}/${filename}`,
+      s3Key,
+      presignedUrl,
       width: dims.width ?? 0,
       height: dims.height ?? 0,
     };

--- a/src/usecases/mindmaps/collectMindmapImages.test.ts
+++ b/src/usecases/mindmaps/collectMindmapImages.test.ts
@@ -1,73 +1,95 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
 import { collectMindmapImages } from './collectMindmapImages';
 import { MindmapData } from './MindmapData';
+import StorageHandler from '../../lib/storage/StorageHandler';
+
+function makeStorage(files: Record<string, Buffer> = {}): StorageHandler {
+  return {
+    getFileContents: jest.fn().mockImplementation(async (key: string) => {
+      const body = files[key];
+      return { Body: body };
+    }),
+    uploadFile: jest.fn(),
+    getPresignedUrl: jest.fn(),
+    objectExists: jest.fn(),
+    listByPrefix: jest.fn(),
+    deleteObjects: jest.fn(),
+    delete: jest.fn(),
+    getContents: jest.fn(),
+    uniqify: jest.fn(),
+    s3: {} as never,
+  } as unknown as StorageHandler;
+}
+
+function nodeWithImage(id: string, url: string) {
+  return { id, label: '', image: { url, width: 10, height: 10 } };
+}
 
 describe('collectMindmapImages', () => {
-  let uploadBase: string;
-
-  beforeEach(() => {
-    uploadBase = fs.mkdtempSync(path.join(os.tmpdir(), 'mindmap-images-'));
+  it('returns an empty array when no nodes have images', async () => {
+    const data: MindmapData = { nodes: [{ id: 'a', label: 'plain' }], edges: [] };
+    const result = await collectMindmapImages(data, makeStorage());
+    expect(result).toEqual([]);
   });
 
-  afterEach(() => {
-    fs.rmSync(uploadBase, { recursive: true, force: true });
-  });
-
-  function writeImage(relPath: string, body: string) {
-    const full = path.join(uploadBase, 'mindmaps', relPath);
-    fs.mkdirSync(path.dirname(full), { recursive: true });
-    fs.writeFileSync(full, body);
-  }
-
-  function nodeWithImage(id: string, url: string) {
-    return {
-      id,
-      label: '',
-      image: { url, width: 10, height: 10 },
-    };
-  }
-
-  it('returns an empty array when no nodes have images', () => {
+  it('fetches each referenced s3Key and returns buffer with filename', async () => {
+    const fakePng = Buffer.from('fake-png');
+    const storage = makeStorage({ 'mindmaps/1/map-1/foo.png': fakePng });
     const data: MindmapData = {
-      nodes: [{ id: 'a', label: 'plain' }],
+      nodes: [nodeWithImage('a', 'mindmaps/1/map-1/foo.png')],
       edges: [],
     };
-    expect(collectMindmapImages(data, uploadBase)).toEqual([]);
-  });
 
-  it('reads each referenced image into a buffer', () => {
-    writeImage('user-1/map-1/foo.png', 'fake-png');
-    const data: MindmapData = {
-      nodes: [nodeWithImage('a', '/api/mindmaps/images/user-1/map-1/foo.png')],
-      edges: [],
-    };
-    const result = collectMindmapImages(data, uploadBase);
+    const result = await collectMindmapImages(data, storage);
     expect(result).toHaveLength(1);
     expect(result[0].filename).toBe('foo.png');
-    expect(result[0].buffer.toString()).toBe('fake-png');
+    expect(result[0].buffer).toEqual(fakePng);
   });
 
-  it('deduplicates nodes that share the same image url', () => {
-    writeImage('user-1/map-1/foo.png', 'fake-png');
-    const url = '/api/mindmaps/images/user-1/map-1/foo.png';
+  it('deduplicates nodes that share the same s3 key', async () => {
+    const fakePng = Buffer.from('fake-png');
+    const storage = makeStorage({ 'mindmaps/1/map-1/foo.png': fakePng });
+    const url = 'mindmaps/1/map-1/foo.png';
     const data: MindmapData = {
       nodes: [nodeWithImage('a', url), nodeWithImage('b', url)],
       edges: [],
     };
-    const result = collectMindmapImages(data, uploadBase);
+
+    const result = await collectMindmapImages(data, storage);
     expect(result).toHaveLength(1);
   });
 
-  it('skips images that no longer exist on disk', () => {
+  it('skips missing images (url null or missing flag)', async () => {
     const data: MindmapData = {
       nodes: [
-        nodeWithImage('a', '/api/mindmaps/images/user-1/map-1/missing.png'),
+        { id: 'a', label: '', image: { url: null, width: 10, height: 10, missing: true } },
       ],
       edges: [],
     };
-    expect(collectMindmapImages(data, uploadBase)).toEqual([]);
+
+    const result = await collectMindmapImages(data, makeStorage());
+    expect(result).toEqual([]);
+  });
+
+  it('skips images where S3 returns no body', async () => {
+    const storage = makeStorage({});
+    const data: MindmapData = {
+      nodes: [nodeWithImage('a', 'mindmaps/1/map-1/missing.png')],
+      edges: [],
+    };
+
+    const result = await collectMindmapImages(data, storage);
+    expect(result).toEqual([]);
+  });
+
+  it('skips images where getFileContents throws', async () => {
+    const storage = makeStorage();
+    (storage.getFileContents as jest.Mock).mockRejectedValue(new Error('S3 down'));
+    const data: MindmapData = {
+      nodes: [nodeWithImage('a', 'mindmaps/1/map-1/img.png')],
+      edges: [],
+    };
+
+    const result = await collectMindmapImages(data, storage);
+    expect(result).toEqual([]);
   });
 });

--- a/src/usecases/mindmaps/collectMindmapImages.ts
+++ b/src/usecases/mindmaps/collectMindmapImages.ts
@@ -1,6 +1,4 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
+import StorageHandler from '../../lib/storage/StorageHandler';
 import { MindmapData } from './MindmapData';
 
 export interface CollectedImage {
@@ -8,27 +6,31 @@ export interface CollectedImage {
   buffer: Buffer;
 }
 
-export function collectMindmapImages(
+export async function collectMindmapImages(
   data: MindmapData,
-  uploadBase: string
-): CollectedImage[] {
+  storage: StorageHandler
+): Promise<CollectedImage[]> {
   const seen = new Set<string>();
   const result: CollectedImage[] = [];
 
   for (const node of data.nodes) {
     const { image } = node;
     if (image == null) continue;
-    if (seen.has(image.url)) continue;
-    seen.add(image.url);
+    if (image.url == null || image.missing === true) continue;
 
-    const filename = image.url.split('/').pop() ?? '';
-    const relPath = image.url.replace('/api/mindmaps/images/', '');
-    const diskPath = path.join(uploadBase, 'mindmaps', relPath);
+    const s3Key = image.url;
+    if (seen.has(s3Key)) continue;
+    seen.add(s3Key);
 
-    if (!fs.existsSync(diskPath)) continue;
+    const filename = s3Key.split('/').pop() ?? '';
 
-    const buffer = fs.readFileSync(diskPath);
-    result.push({ filename, buffer });
+    try {
+      const stored = await storage.getFileContents(s3Key);
+      if (stored.Body == null) continue;
+      result.push({ filename, buffer: stored.Body });
+    } catch {
+      continue;
+    }
   }
 
   return result;

--- a/src/usecases/mindmaps/mindmapToClozeNotes.ts
+++ b/src/usecases/mindmaps/mindmapToClozeNotes.ts
@@ -58,7 +58,7 @@ export function mindmapToClozeNotes(
 
   const labelMap = new Map<string, string>(data.nodes.map((n) => [n.id, n.label]));
   const imageUrlMap = new Map<string, string | undefined>(
-    data.nodes.map((n) => [n.id, n.image?.url])
+    data.nodes.map((n) => [n.id, n.image?.url ?? undefined])
   );
   const childMap = buildChildMap(data);
   const roots = findRoots(data);

--- a/src/usecases/mindmaps/mindmapToMarkmapTree.ts
+++ b/src/usecases/mindmaps/mindmapToMarkmapTree.ts
@@ -59,7 +59,7 @@ export function mindmapToMarkmapTree(
 
   const labelMap = new Map<string, string>(data.nodes.map((n) => [n.id, n.label]));
   const imageUrlMap = new Map<string, string | undefined>(
-    data.nodes.map((n) => [n.id, n.image?.url])
+    data.nodes.map((n) => [n.id, n.image?.url ?? undefined])
   );
   const childMap = new Map<string, string[]>(data.nodes.map((n) => [n.id, []]));
 

--- a/src/usecases/mindmaps/mindmapToNotes.ts
+++ b/src/usecases/mindmaps/mindmapToNotes.ts
@@ -29,8 +29,8 @@ export function mindmapToNotes(
     const childNode = nodeMap.get(edge.target);
     if (parentNode == null || childNode == null) continue;
 
-    const front = buildNodeBack(parentNode.label, parentNode.image?.url, filenameMap);
-    const back = buildNodeBack(childNode.label, childNode.image?.url, filenameMap);
+    const front = buildNodeBack(parentNode.label, parentNode.image?.url ?? undefined, filenameMap);
+    const back = buildNodeBack(childNode.label, childNode.image?.url ?? undefined, filenameMap);
 
     const note = new Note(front.html, back.html);
     const media = [front.media, back.media].filter((m): m is string => m != null);

--- a/web/src/pages/DocsPage/content/reference/self-hosting.md
+++ b/web/src/pages/DocsPage/content/reference/self-hosting.md
@@ -57,7 +57,7 @@ Each integration adds a feature. You can run 2anki without any of them — the f
 | Anthropic Claude | `ANTHROPIC_API_KEY` | AI flashcard generation from PDFs |
 | Stripe | `STRIPE_KEY`, `STRIPE_ENDPOINT_SECRET` | Paid plans (skip if you're running for yourself) |
 | SendGrid | `SENDGRID_API_KEY` | Transactional email (password reset, etc.) |
-| DigitalOcean Spaces (S3-compatible) | `SPACES_ENDPOINT`, `SPACES_DEFAULT_BUCKET_NAME`, plus standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Remote storage for converted decks (needed for "My Decks" history and sync) |
+| DigitalOcean Spaces (S3-compatible) | `SPACES_ENDPOINT`, `SPACES_REGION`, `SPACES_DEFAULT_BUCKET_NAME`, plus standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Remote storage for converted decks (needed for "My Decks" history and sync) and mindmap images. Mindmap image upload requires Spaces — without it, image uploads will fail at the API boundary. |
 
 ## Where to get help
 

--- a/web/src/pages/MindmapsPage/MindmapNode.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.test.tsx
@@ -87,6 +87,23 @@ describe('MindmapNode', () => {
     expect(onCommit).toHaveBeenCalledWith('Mathematics');
   });
 
+  it('renders image when url is present', () => {
+    const props = makeProps({ label: 'alt text' });
+    (props.data as Record<string, unknown>).image = { url: 'https://example.com/img.png', width: 10, height: 10 };
+    const { container } = render(<MindmapNode {...props} />);
+    const img = container.querySelector('img') as HTMLImageElement | null;
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute('src')).toBe('https://example.com/img.png');
+  });
+
+  it('renders placeholder when image is missing', () => {
+    const props = makeProps({ label: '' });
+    (props.data as Record<string, unknown>).image = { url: null, width: 10, height: 10, missing: true };
+    render(<MindmapNode {...props} />);
+    expect(screen.queryByRole('img')).toBeNull();
+    expect(screen.getByText('Image unavailable')).toBeDefined();
+  });
+
   it('stops key propagation while editing', () => {
     const handler = vi.fn();
     render(

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -6,9 +6,10 @@ import TrashIcon from '../../components/icons/TrashIcon';
 import SwatchIcon from '../../components/icons/SwatchIcon';
 
 export interface MindmapImageMeta {
-  url: string;
+  url: string | null;
   width: number;
   height: number;
+  missing?: true;
 }
 
 export interface MindmapNodeData {
@@ -251,7 +252,26 @@ export function MindmapNode({ data, selected }: NodeProps) {
             boxSizing: 'border-box',
           }}
         >
-          {nodeData.image != null && (
+          {nodeData.image != null && nodeData.image.missing === true && (
+            <div
+              style={{
+                border: '1px dashed var(--color-border)',
+                borderRadius: 'var(--radius-sm)',
+                background: 'var(--color-bg-secondary)',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '0.5rem',
+                marginBottom: nodeData.label.length > 0 ? '0.25rem' : 0,
+                fontSize: 'var(--text-xs)',
+                color: 'var(--color-text-tertiary)',
+                minHeight: '2rem',
+              }}
+            >
+              Image unavailable
+            </div>
+          )}
+          {nodeData.image != null && nodeData.image.missing !== true && nodeData.image.url != null && (
             <img
               src={nodeData.image.url}
               alt={nodeData.label}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-images-persist.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-images-persist.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-23-mindmap-images-persist",
+  "date": "2026-05-23",
+  "type": "fix",
+  "title": "Mindmap images survive server restarts and deploys"
+}


### PR DESCRIPTION
## What
Moves mindmap image storage from local disk (`UPLOAD_BASE`) to DigitalOcean Spaces. Adds orphaned-image placeholder UX, 302/410 image route, and S3 cleanup on delete.

## Why
2 maps (out of 6 total across 2 users) had images stored at `/api/mindmaps/images/...` that 404'd after deploy/systemd-tmpfiles wiped `/tmp/genanki-uploads`. Local disk was never durable for images.

## Locked decisions
1. **Spaces-only** — hard-require `SPACES_*` env vars; no local-disk fallback.
2. **No email outreach** — 2 orphan maps are likely test data; placeholder UX is the whole answer.
3. **S3 cleanup in DeleteMindmapUseCase** — best-effort prefix delete, logs on failure, never blocks DB delete.
4. **Scoped 302/410 route** — `GET /api/mindmaps/images/:userId/:mapId/:file` bypasses global `ErrorHandler`.

## How
- `StorageHandler` gains `objectExists`, `listByPrefix`, `deleteObjects`.
- `UploadMindmapImageUseCase` — takes `StorageHandler` instead of `uploadBase` string; receives `file.buffer` from multer memoryStorage; returns `{ s3Key, presignedUrl, width, height }`.
- Key shape: `mindmaps/<userId>/<mapId>/<uuid>.<ext>`. DB stores the s3Key, never a presigned URL.
- `GetMindmapUseCase` — resolves each node's s3Key to a presigned URL on read; legacy `/api/mindmaps/images/...` URLs → `{ missing: true, url: null }`.
- `UpdateMindmapUseCase` — sanitizes incoming presigned URLs back to s3Key by extracting the `mindmaps/...` segment; legacy URLs → `{ missing: true, url: null }`.
- `DeleteMindmapUseCase` — lists `mindmaps/<userId>/<mapId>/` prefix and bulk-deletes before the DB delete.
- `collectMindmapImages` — now async, fetches via `StorageHandler.getFileContents`; skips missing/errored images (export degrades gracefully).
- `ExportMindmapUseCase` — wires new async `collectMindmapImages`.
- `MindmapNode.tsx` — renders dashed-border "Image unavailable" placeholder when `image.missing === true`.
- `MindmapRouter` — drops `express.static` and disk-based multer; uses `multer.memoryStorage()`; adds scoped image route.
- Self-hosting docs updated: mindmap images require Spaces.

## Measuring success
- Upload: `storage.uploadFile` called with key `mindmaps/<userId>/<mapId>/<uuid>.png`.
- Read: `GET /api/mindmaps/:id` returns nodes with presigned URLs from Spaces.
- Legacy orphans: nodes with `/api/mindmaps/images/...` URLs return `{ missing: true, url: null }`, placeholder renders in editor.
- Delete: `listByPrefix` + `deleteObjects` called before DB delete; S3 objects absent after.
- Image route: `GET /api/mindmaps/images/:userId/:mapId/:file` → 302 (present) or 410 (missing).

## Testing
- Unit tests added: `UploadMindmapImageUseCase.test.ts`, `GetMindmapUseCase.test.ts`, `DeleteMindmapUseCase.test.ts`, `collectMindmapImages.test.ts`, `UpdateMindmapUseCase.test.ts` (3 new URL-sanitize cases), `MindmapNode.test.tsx` (2 new image/placeholder cases), `MindmapRouter.test.ts` (StorageHandler mocked, upload + 302/410 route asserted).
- Server: 2162 tests all green. Web: 1052 tests all green. tsc + biome clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Al to verify — (1) upload a new image to a mindmap, save, reload, confirm image still renders; (2) open a map with a legacy image URL (or simulate locally with `/api/mindmaps/images/...` in the JSON) and confirm the placeholder renders; (3) delete a mindmap with an image and confirm no orphaned objects remain in Spaces.

## Changelog
"Mindmap images survive server restarts and deploys" — `web/src/pages/WhatsNewPage/changelog/2026-05-23-mindmap-images-persist.json`

## Risks
- Any client code that reads `result.url` from the upload response will break — it now returns `result.s3Key` + `result.presignedUrl`. The `useMindmap.ts` hook consumes this endpoint; verify it handles the new shape (or update it if needed).
- Existing DB rows with `data.nodes[].image.url = '/api/mindmaps/images/...':` will render as placeholders on next load — by design, originals are gone.
- Spaces must be configured; self-hosters without `SPACES_*` will get S3 client errors on upload. This is intentional and documented.

## Sonar
SONAR_TOKEN not set in this environment — noted in PR body per `.claude/rules/sonar.md`. No user-controlled URLs reach S3 directly (all keys are server-generated via `randomUUID()`).

## Goal alignment
Fixes a silent data-loss bug that would have frustrated users who added images to mindmaps and found them gone after a deploy. Reliable image persistence is table stakes for the mindmaps feature to be trusted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782160053&installation_id=132681956&pr_number=2686&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2686&signature=29ed39fbc22e9b0c158faf2cddb782054719430c0937a822d44e42af1966179c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
