### PR TITLE
style: gap between OAuth buttons on /login

### DIFF
--- a/web/src/styles/auth.module.css
+++ b/web/src/styles/auth.module.css
@@ -109,6 +109,7 @@
   width: 100%;
   min-height: 2.75rem;
   padding: 0.625rem 1.25rem;
+  margin-top: 0.75rem;
   margin-bottom: 0.5rem;
   font-size: var(--text-sm);
   font-weight: var(--font-medium);


### PR DESCRIPTION
## What
Adds `margin-top: 0.75rem` to the `.notionButton` class in `auth.module.css`, creating visible spacing between the "Sign in with Google" and "Continue with Notion" buttons on /login.

## Why
Recent PRs (#2684, #2685) changed the OAuth button layout and left the two buttons flush against each other with no gap. Al flagged this.

## How
Single CSS property added to the existing `.notionButton` rule. No new tokens — 0.75rem matches the surrounding spacing rhythm in the form (divider margin is 1.5rem, field margin-bottom is 1.5rem; 0.75rem is the natural half-step). On /register the button order is reversed (Notion first), so this adds equivalent top spacing there too, keeping both pages consistent.

## Measuring success
Visual: open /login, confirm visible gap between the two OAuth buttons. Matches /register.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Al to verify — open /login, confirm the gap between 'Sign in with Google' and 'Continue with Notion' looks balanced and matches /register.

## Changelog
No entry — pure visual polish, spacing-only, no behavior change.

## Risks
None. Single CSS property on an existing rule. Rollback is a one-line revert.

## Goal alignment
Polish on the login/register critical path supports conversion. Minor but part of the quality bar that keeps users trusting the product.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782160748&installation_id=132681956&pr_number=2687&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2687&signature=71690c84b56af3c64b6a437d84698f5c2d40fa848b8514883196ed9a55a78282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
