### PR TITLE
fix: drop redundant inner focus ring on chat composer textarea

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -484,6 +484,10 @@
   field-sizing: content;
 }
 
+.textarea:focus {
+  box-shadow: none;
+}
+
 .textarea:disabled {
   opacity: 0.5;
   cursor: not-allowed;


### PR DESCRIPTION
## What
Adds `.textarea:focus { box-shadow: none; }` to ChatPanel.module.css to suppress the inner focus ring that leaked through from the global `textarea:focus` rule in base.css.

## Why
The global rule in `web/src/styles/base.css:333-338` applies `box-shadow: 0 0 0 3px var(--color-focus-ring)` to every textarea. The chat composer already strips `border` and `outline` on its inner textarea, but not `box-shadow`, so users saw two stacked rings when focusing the composer.

## How
One CSS rule. `.ChatPanel_textarea__hash:focus` has specificity (0,2,0) vs global `textarea:focus` at (0,1,1) — no `!important` needed.

## Measuring success
On /chat, focusing the composer textarea shows exactly one focus ring (around the pill), not two.

## Testing
- Unit tests: ChatPanel.test.tsx 25/25 passed (no test change needed — this is a pure visual fix)

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Al to verify — open /chat, focus the composer textarea, confirm only one focus ring is visible (around the pill, not also inside the textarea).

## Changelog
No entry — pure visual polish, no user-visible behavior change.

## Risks
Minimal. The rule is scoped tightly to .textarea inside ChatPanel. No other textarea inherits it.

## Goal alignment
Polishes the /chat surface, removes a visual glitch that undermines confidence in the product.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782161378&installation_id=132681956&pr_number=2689&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2689&signature=b827e59df3ff5b3bd45992cc11df78f6b4d8c0a52a7f23a31496117f32a37c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
