### PR TITLE
spec: magic-link-first login

### DIFF
--- a/Documentation/specs/magic-link-first-login.md
+++ b/Documentation/specs/magic-link-first-login.md
@@ -1,0 +1,59 @@
+# Magic-link-first /login
+
+## Problem
+
+The /login email step hides the magic-link option as a small text link under a "Continue with email" button, so users who expect a passwordless flow are dropped into a password form they never set. Support keeps seeing "I forgot my password but I never set one" — the password fork is the wrong default.
+
+## What changes
+
+Three changes in `web/src/pages/LoginPage/components/LoginForm/index.tsx`, email step only.
+
+1. **Primary CTA on the email step becomes `Email me a sign-in link`.** Click handler: `handleSendMagicLink` — calls `get2ankiApi().requestMagicLink(email, 'login')` and transitions to the existing `check-email` step. Disabled when `email.length === 0`. Loading label: `Sending`.
+2. **Password becomes a secondary text link below the CTA: `Use password instead`.** Click handler: `event.preventDefault()` then `setStep('password')` (the same body that lives in `handleContinueWithEmail` today). Always visible — does not depend on email length.
+3. **The old magic-link text link below the CTA is removed from the email step.** It was the secondary affordance for the same action the CTA now performs; keeping it duplicates the click target. The magic-link text link inside the password step stays as-is.
+
+## What stays the same
+
+- OAuth section (Notion above Google, copy and order untouched).
+- `/register` page — not touched.
+- Step 2 (password screen) — layout, fields, `Log in` button, `Forgot your password?` link, and the `Send a login link instead` text link all unchanged.
+- Magic-link backend endpoint (`requestMagicLink`) and the `check-email` step component.
+- `Forgot your password?` link on the email step.
+- `Sign up — it's free` footer link.
+- Email-restored-from-`localStorage` behaviour and the blur-to-persist handler.
+
+## Files the engineer will touch
+
+- `web/src/pages/LoginPage/components/LoginForm/index.tsx` — swap the primary CTA label and click handler; rename and demote the password affordance; remove the duplicate magic-link text link.
+- `web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx` — update the assertions below.
+- `web/src/lib/text/app.document.json` — no change. `Sign in with Google` stays where it is; `Continue with Notion` stays as a hard-coded literal in the component.
+
+### Test assertions to update
+
+| Current | Replace with |
+| --- | --- |
+| `getByRole('button', { name: 'Continue with email' })` (used in 6 places) | `getByRole('button', { name: 'Email me a sign-in link' })` |
+| `queryByText('Email me a sign-in link')` returning null until email is typed | Drop the negative assertion — the button is always rendered now. Keep the disabled-when-empty assertion: button is `disabled` until the email field has a value. |
+| Test `transitions to password step after clicking continue` | Rewrite: clicking `Use password instead` (link) transitions to the password step. |
+| Test `transitions to check-email step after clicking magic link` (currently goes via the password step) | Rewrite: type email, click `Email me a sign-in link`, assert `Check your email` appears — no detour through password step. |
+| Test `shows email-me-a-sign-in-link when email is filled in on email step` | Delete — the affordance no longer depends on email presence. |
+
+Add one new test: `Use password instead` link is visible on the email step and transitions to the password step on click.
+
+## Success metric
+
+- **Leading:** the `Email me a sign-in link` button is clicked on the email step on at least 60% of /login sessions that submit anything. (Today the magic-link text link is buried; password is the default.)
+- **Lagging:** zero new "I forgot my password but I never set one" reports in the support@2anki.net inbox over the four weeks after merge. Currently a recurring theme.
+- **Guardrail:** first-card-review rate for returning users (logged in within 7 days of last session) does not drop week-over-week after merge.
+
+## Rollback
+
+Single `git revert <sha>` on the merge commit. No data migration, no env vars, no DB change — the backend endpoint and the `check-email` step both already exist and are already in use.
+
+## Out of scope
+
+- "It's free" copy on the sign-up link.
+- /register page restructure.
+- Any layout change to the password step.
+- OAuth button order, labels, or styling.
+- Analytics instrumentation for the new CTA (track via existing route-level events; if the leading metric needs a dedicated event, file a follow-up).


### PR DESCRIPTION
## Summary
Draft spec for collapsing the hidden email-step fork on /login. PM trio surfaced this earlier; hygiene PR (#2685) already shipped. This PR holds the spec while /implement takes it over.

## What changes (per spec)
- Email-step primary CTA becomes **"Email me a sign-in link"** — calls `requestMagicLink(email, 'login')` and transitions to `check-email` step.
- Password becomes a secondary text link below: **"Use password instead"** — transitions to the existing password step (unchanged).
- Duplicate buried magic-link text link on the email step is removed (becomes redundant once the primary CTA does the same thing).

## What stays the same
- OAuth section (Notion + Google order from #2684 preserved).
- /register page (separate concern).
- Step 2 password screen (no layout change).
- Magic-link backend endpoint.

## Lifecycle
Per the spec workflow in CLAUDE.md, this spec file at `Documentation/specs/magic-link-first-login.md` will be removed by `/implement` in a `chore: remove implemented spec` commit before the implementation PR flips ready. Branch name is `feat/spec-magic-link-first-login` (not `docs/spec-…`) so it graduates to `feat:` cleanly.

## Browser check
Browser check: not applicable — docs-only PR, no rendered output.

## Test plan
- [ ] Spec format matches the existing `Documentation/specs/` convention
- [ ] Three baked decisions are unambiguous
- [ ] Test-assertion delta is enumerated so /implement knows what to update

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782161516&installation_id=132681956&pr_number=2690&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2690&signature=71fa11ab31d690468c85265fa5d4a680171fefcccbe321dc1a85ba845daec74f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->