### PR TITLE
fix(io): open Auto create to all signed-in users + free quota

### DIFF
--- a/src/controllers/AutoSuggestOcclusionsController.test.ts
+++ b/src/controllers/AutoSuggestOcclusionsController.test.ts
@@ -58,8 +58,8 @@ describe('AutoSuggestOcclusionsController', () => {
     expect(res.json).toHaveBeenCalledWith({ rects });
   });
 
-  it('returns 403 when use case throws a 403 error', async () => {
-    const err = Object.assign(new Error('forbidden'), { status: 403 });
+  it('returns 429 when use case throws a quota-reached error', async () => {
+    const err = Object.assign(new Error('quota reached'), { status: 429 });
     const useCase = {
       execute: jest.fn().mockRejectedValue(err),
     } as unknown as jest.Mocked<AutoSuggestOcclusionsUseCase>;
@@ -68,7 +68,7 @@ describe('AutoSuggestOcclusionsController', () => {
 
     await controller.suggest(makeReq(VALID_BODY), res);
 
-    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.status).toHaveBeenCalledWith(429);
   });
 
   it('returns 413 when use case throws a 413 error', async () => {

--- a/src/controllers/AutoSuggestOcclusionsController.ts
+++ b/src/controllers/AutoSuggestOcclusionsController.ts
@@ -41,7 +41,15 @@ export class AutoSuggestOcclusionsController {
 
     const width = typeof body.width === 'number' ? body.width : 512;
     const height = typeof body.height === 'number' ? body.height : 512;
-    const hasAccess = res.locals['patreon'] === true || res.locals['subscriber'] === true;
+    const isPaying =
+      res.locals['patreon'] === true || res.locals['subscriber'] === true;
+    const ownerRaw = res.locals['owner'];
+    const userId =
+      typeof ownerRaw === 'number'
+        ? ownerRaw
+        : typeof ownerRaw === 'string' && /^\d+$/.test(ownerRaw)
+          ? Number(ownerRaw)
+          : null;
 
     let result: Awaited<ReturnType<AutoSuggestOcclusionsUseCase['execute']>>;
     try {
@@ -50,12 +58,13 @@ export class AutoSuggestOcclusionsController {
         mediaType: body.mediaType,
         width,
         height,
-        hasAccess,
+        isPaying,
+        userId,
       });
     } catch (err) {
       const e = err as Error & { status?: number };
-      if (e.status === 403) {
-        res.status(403).json({ message: e.message });
+      if (e.status === 429) {
+        res.status(429).json({ message: e.message });
         return;
       }
       if (e.status === 413) {

--- a/src/routes/ImageOcclusionRouter.ts
+++ b/src/routes/ImageOcclusionRouter.ts
@@ -1,7 +1,6 @@
 import express from "express";
 import multer from "multer";
 import RequireAuthentication from "./middleware/RequireAuthentication";
-import RequireAnkifyAccess from "./middleware/RequireAnkifyAccess";
 import ImageOcclusionController from "../controllers/ImageOcclusionController";
 import { IoDraftController } from "../controllers/IoDraftController";
 import { PhotoToFlashcardsController } from "../controllers/PhotoToFlashcardsController";
@@ -24,7 +23,10 @@ const ImageOcclusionRouter = () => {
   const dc = new IoDraftController(new IoDraftRepository(getDatabase()), new StorageHandler(), new NotionRepository(getDatabase()));
   const ptf = new PhotoToFlashcardsController(new PhotoToFlashcardsUseCase(new EventsRepository(getDatabase())));
   const autoSuggest = new AutoSuggestOcclusionsController(
-    new AutoSuggestOcclusionsUseCase(new AutoOcclusionService())
+    new AutoSuggestOcclusionsUseCase(
+      new AutoOcclusionService(),
+      new EventsRepository(getDatabase())
+    )
   );
 
   /**
@@ -289,7 +291,7 @@ const ImageOcclusionRouter = () => {
    *       413:
    *         description: Image too large
    */
-  router.post("/api/image-occlusion/auto-suggest", RequireAnkifyAccess, express.json({ limit: "20mb" }), (req,res)=>autoSuggest.suggest(req,res));
+  router.post("/api/image-occlusion/auto-suggest", RequireAuthentication, express.json({ limit: "20mb" }), (req,res)=>autoSuggest.suggest(req,res));
 
   return router;
 };

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -20,6 +20,8 @@ export const KNOWN_EVENTS = new Set([
   'photo_entry_point_clicked',
   'photo_upload_started',
   'photo_quota_reached',
+  'auto_occlusion_suggested',
+  'auto_occlusion_quota_reached',
   'sidebar_auto_minimize_fired',
   'sidebar_auto_minimize_reverted',
   'card_size_selected',

--- a/src/usecases/imageOcclusion/AutoSuggestOcclusionsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/AutoSuggestOcclusionsUseCase.test.ts
@@ -1,5 +1,9 @@
-import { AutoSuggestOcclusionsUseCase } from './AutoSuggestOcclusionsUseCase';
+import {
+  AutoSuggestOcclusionsUseCase,
+  FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH,
+} from './AutoSuggestOcclusionsUseCase';
 import type { AutoOcclusionService } from '../../services/imageOcclusion/AutoOcclusionService';
+import type { IEventsRepository } from '../../data_layer/EventsRepository';
 
 function makeMockService(rects: unknown[] = []) {
   return {
@@ -11,24 +15,56 @@ function makeMockService(rects: unknown[] = []) {
   } as unknown as jest.Mocked<AutoOcclusionService>;
 }
 
+function makeMockEvents(usedCount = 0) {
+  return {
+    countByNameForUser: jest.fn().mockResolvedValue(usedCount),
+  } as unknown as jest.Mocked<IEventsRepository>;
+}
+
 const BASE_INPUT = {
   imageBase64: 'abc123',
   mediaType: 'image/jpeg' as const,
   width: 1080,
   height: 720,
-  hasAccess: true,
+  isPaying: true,
+  userId: 42,
 };
 
 describe('AutoSuggestOcclusionsUseCase', () => {
-  it('throws 403 when user does not have access', async () => {
+  it('throws 429 when a free user has hit the monthly quota', async () => {
     const service = makeMockService();
-    const useCase = new AutoSuggestOcclusionsUseCase(service);
+    const events = makeMockEvents(FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH);
+    const useCase = new AutoSuggestOcclusionsUseCase(service, events);
 
     await expect(
-      useCase.execute({ ...BASE_INPUT, hasAccess: false })
-    ).rejects.toMatchObject({ status: 403 });
+      useCase.execute({ ...BASE_INPUT, isPaying: false })
+    ).rejects.toMatchObject({ status: 429 });
 
     expect(service.suggest).not.toHaveBeenCalled();
+  });
+
+  it('allows a free user when under the monthly quota', async () => {
+    const service = makeMockService([
+      { id: 'r1', x: 0.1, y: 0.1, w: 0.2, h: 0.05, label: 'A', shape: 'rect', confidence: 0.9, source: 'auto' },
+    ]);
+    const events = makeMockEvents(FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH - 1);
+    const useCase = new AutoSuggestOcclusionsUseCase(service, events);
+
+    const result = await useCase.execute({ ...BASE_INPUT, isPaying: false });
+
+    expect(result.rects).toHaveLength(1);
+    expect(service.suggest).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the quota check for paying users', async () => {
+    const service = makeMockService();
+    const events = makeMockEvents(FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH * 10);
+    const useCase = new AutoSuggestOcclusionsUseCase(service, events);
+
+    await useCase.execute({ ...BASE_INPUT, isPaying: true });
+
+    expect(events.countByNameForUser).not.toHaveBeenCalled();
+    expect(service.suggest).toHaveBeenCalledTimes(1);
   });
 
   it('throws 413 when image exceeds the token ceiling', async () => {

--- a/src/usecases/imageOcclusion/AutoSuggestOcclusionsUseCase.ts
+++ b/src/usecases/imageOcclusion/AutoSuggestOcclusionsUseCase.ts
@@ -2,13 +2,19 @@ import { createHash } from 'node:crypto';
 import { countVisionTokens, VISION_TOKEN_CEILING } from '../../lib/claude/countVisionTokens';
 import type { VisionMediaType } from '../../lib/claude/countVisionTokens';
 import type { AutoOcclusionService, SuggestedRect } from '../../services/imageOcclusion/AutoOcclusionService';
+import type { IEventsRepository } from '../../data_layer/EventsRepository';
+import { track } from '../../services/events/track';
+
+export const FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH = 5;
+const AUTO_OCCLUSION_EVENT = 'auto_occlusion_suggested';
 
 export interface AutoSuggestInput {
   imageBase64: string;
   mediaType: VisionMediaType;
   width: number;
   height: number;
-  hasAccess: boolean;
+  isPaying: boolean;
+  userId: number | null;
 }
 
 export interface AutoSuggestResult {
@@ -25,18 +31,29 @@ interface CacheEntry {
 
 const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-function makeAccessError(): Error & { status: number } {
-  const err = new Error('Auto Sync access required') as Error & { status: number };
-  err.status = 403;
-  return err;
-}
-
 function makePayloadTooLargeError(): Error & { status: number } {
   const err = new Error('Photo is too large — try a smaller or lower-resolution image') as Error & {
     status: number;
   };
   err.status = 413;
   return err;
+}
+
+function makeFreeQuotaReachedError(used: number, quota: number): Error & {
+  status: number;
+} {
+  const err = new Error(
+    `Free auto-suggest limit reached this month (${used} / ${quota}). Upgrade for unlimited.`
+  ) as Error & { status: number };
+  err.status = 429;
+  return err;
+}
+
+function startOfMonth(now: Date = new Date()): Date {
+  const d = new Date(now);
+  d.setUTCDate(1);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
 }
 
 function hashImage(imageBase64: string): string {
@@ -46,11 +63,26 @@ function hashImage(imageBase64: string): string {
 export class AutoSuggestOcclusionsUseCase {
   private readonly cache = new Map<string, CacheEntry>();
 
-  constructor(private readonly service: AutoOcclusionService) {}
+  constructor(
+    private readonly service: AutoOcclusionService,
+    private readonly events?: IEventsRepository
+  ) {}
 
   async execute(input: AutoSuggestInput): Promise<AutoSuggestResult> {
-    if (!input.hasAccess) {
-      throw makeAccessError();
+    if (!input.isPaying && this.events != null && input.userId != null) {
+      const used = await this.events.countByNameForUser(
+        AUTO_OCCLUSION_EVENT,
+        startOfMonth(),
+        input.userId,
+        null
+      );
+      if (used >= FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH) {
+        track('auto_occlusion_quota_reached', {
+          userId: input.userId,
+          props: { used, quota: FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH },
+        });
+        throw makeFreeQuotaReachedError(used, FREE_AUTO_OCCLUSION_QUOTA_PER_MONTH);
+      }
     }
 
     const { tokens } = countVisionTokens({
@@ -85,6 +117,15 @@ export class AutoSuggestOcclusionsUseCase {
     };
 
     this.cache.set(cacheKey, { result, expiresAt: now + CACHE_TTL_MS });
+
+    track(AUTO_OCCLUSION_EVENT, {
+      userId: input.userId,
+      props: {
+        rect_count: result.rects.length,
+        input_tokens: result.inputTokens,
+        output_tokens: result.outputTokens,
+      },
+    });
 
     console.log(
       JSON.stringify({

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.tsx
@@ -284,7 +284,7 @@ export function ImageOcclusionPage() {
 
   const runAutoSuggest = useCallback(
     async (entry: ImageEntry, file: File) => {
-      if (!isPaying) return;
+      if (!isLoggedIn) return;
       setDetectingFor(entry.id);
       try {
         const reader = new FileReader();

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -288,9 +288,6 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
 
   const { data: userLocals } = useUserLocals();
   const queryClient = useQueryClient();
-  const autoSyncActive = userLocals?.autoSyncActive === true;
-  const successPromptShown = globalThis.document?.cookie?.includes('auto_sync_prompt_shown=true') === true;
-  const showAutoSyncPrompt = zoneState === 'success' && !autoSyncActive && !successPromptShown;
   const isAuthenticated = userLocals?.user?.id != null;
   const showTrialButton =
     isAuthenticated &&
@@ -718,12 +715,6 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
     );
   };
 
-  const handleSuccessPromptClick = () => {
-    const expires = new Date();
-    expires.setDate(expires.getDate() + 30);
-    globalThis.document.cookie = `auto_sync_prompt_shown=true; path=/; expires=${expires.toUTCString()}`;
-  };
-
   const renderMcqDrawer = () => (
     <div className={formStyles.mcqDrawer}>
       <p className={formStyles.mcqDrawerHeading}>Preview</p>
@@ -805,21 +796,7 @@ function UploadForm({ setErrorMessage }: Readonly<UploadFormProps>) {
           Didn't get the file? Download it here.
         </button>
       )}
-      {showAutoSyncPrompt && (
-        <p className={formStyles.autoSyncPrompt}>
-          Want this to update automatically?{' '}
-          <a
-            href="/pricing?ref=upload-success-prompt"
-            className={formStyles.autoSyncPromptLink}
-            onClick={handleSuccessPromptClick}
-          >
-            Try Auto Sync
-          </a>
-        </p>
-      )}
-      {!showAutoSyncPrompt && (
-        <UpsellCard surface="upload_success_upsell" />
-      )}
+      <UpsellCard surface="upload_success_upsell" />
       <button
         type="button"
         className={formStyles.actionButton}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-auto-occlusion-open-gate.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-auto-occlusion-open-gate.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-auto-occlusion-open-gate",
+  "date": "2026-05-24",
+  "type": "feature",
+  "title": "Image occlusion — anyone signed in can try Auto create; free accounts get 5 auto-suggestions per month"
+}


### PR DESCRIPTION
## Why

Live test of the freshly-shipped Auto create button (PR #2614) returned 403 from `/api/image-occlusion/auto-suggest` on prod, including for the user's lifetime account. Two real problems:

1. **Wrong gate.** Route used `RequireAnkifyAccess`, which only lets through `users.patreon === true` OR an active Auto Sync subscription. Subscribers, trial users, and anyone else got blocked at the middleware before the controller ran.
2. **No free quota.** The product intent is "any paying user can use it, even trial users can try it" — but free users would burn unbounded Anthropic vision tokens.

## What

- Swap `RequireAnkifyAccess` → `RequireAuthentication` on the auto-suggest route. Now anyone signed in can hit it.
- Free quota: **5 auto-suggestions per month**, tracked via the existing `EventsRepository` pattern that `PhotoToFlashcardsUseCase` already uses. New analytics events `auto_occlusion_suggested` and `auto_occlusion_quota_reached`.
- Controller maps quota-reached errors to 429 (not 403); paying users skip the check entirely.
- UI gate on `ImageOcclusionPage` switched from `isPaying` to `isLoggedIn` so the button renders for everyone signed in.
- Bundled per request: removed "Want this to update automatically? Try Auto Sync" prompt from the upload-form success state. `UpsellCard` still renders on the same surface.

## Test plan

- [x] Server tsc, server jest, web typecheck, web vitest, web lint, biome — green locally
- Use case tests cover: paying user skips quota check, free user under quota succeeds, free user at quota throws 429, oversized image still throws 413
- Controller test updated for 429 instead of 403

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified the new gate end-to-end locally with a free user and a paying user. Upload-form Auto Sync prompt removal is purely a cosmetic delete on the success view.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-05-24-auto-occlusion-open-gate.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782167988&installation_id=132681956&pr_number=2696&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2696&signature=46206a4ad7f5fc2c6ede6d4a7764a0f4b468dbbc65825a444437b2d6090131c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->