### PR TITLE
fix(io): detect diagram labels with leader lines / arrows

### DIFF
--- a/src/services/imageOcclusion/AutoOcclusionService.ts
+++ b/src/services/imageOcclusion/AutoOcclusionService.ts
@@ -27,26 +27,40 @@ export interface AutoOcclusionSuggestResult {
   outputTokens: number;
 }
 
-const CONFIDENCE_THRESHOLD = 0.6;
+const CONFIDENCE_THRESHOLD = 0.5;
 
-const AUTO_OCCLUSION_PROMPT = `Analyze this image for visually emphasized terms that should become Anki flashcard occlusions.
+const AUTO_OCCLUSION_PROMPT = `Find text labels in this image that should become Anki flashcard occlusions. The reader will study by trying to recall each label after it is hidden.
 
-Look for:
-1. Terms with a highlighted background (yellow, green, blue, pink marker overlay)
-2. Bold or heavy-weight text that stands out from surrounding body text
+Detect ALL of these label types:
 
-For each emphasized term or phrase, return its bounding box as a fraction of image dimensions (0.0 to 1.0).
+1. **Diagram labels with leader lines or arrows.** A line connects the label text to a specific feature (anatomy diagrams, parts diagrams, scientific figures, maps, exploded views). Each label should become its own occlusion. Example: "Aorta" connected by a line to a blood vessel in a heart diagram.
+
+2. **Callouts and annotations.** Text that names or points to a region of the image — typically near the edges, in a different style from the underlying art.
+
+3. **Highlighted terms.** Text with a yellow / green / blue / pink marker overlay.
+
+4. **Bold or emphasized terms.** Text that stands out by weight, color, or size from surrounding body text.
+
+5. **Table headers, axis labels, and named regions** in charts or maps.
+
+Do NOT occlude:
+- Image titles or captions describing the whole image
+- Body paragraphs of running text
+- Watermarks, copyright lines, or logos
+- The features themselves (anatomy parts, map regions) — occlude only the text labels that name them
+
+For each label, return its bounding box around the TEXT itself (not the feature it points to). Use normalized coordinates 0.0–1.0 of the full image.
 
 Output ONLY a compact JSON object. Format (nothing else):
-{"rects":[{"x":0.1,"y":0.05,"w":0.3,"h":0.08,"label":"term text","confidence":0.9}]}
+{"rects":[{"x":0.1,"y":0.05,"w":0.3,"h":0.08,"label":"Aorta","confidence":0.95}]}
 
 Rules:
 - x, y are the top-left corner (normalized 0–1)
-- w, h are width and height (normalized 0–1)
-- label is the exact text inside the emphasized region
-- confidence is 0.0–1.0 (how certain you are this is an emphasized term)
-- Only include terms with confidence >= 0.6
-- If no emphasized terms are found, return: {"rects":[]}`;
+- w, h are width and height (normalized 0–1) — keep the box tight around the label text
+- label is the exact text the user would need to recall (one term per rect)
+- confidence is 0.0–1.0
+- Only include rects with confidence >= 0.5
+- If no labels are found, return: {"rects":[]}`;
 
 interface RawRect {
   x?: unknown;
@@ -95,8 +109,8 @@ export class AutoOcclusionService {
     const client = getAnthropicClient();
 
     const response = await client.messages.create({
-      model: 'claude-sonnet-4-5',
-      max_tokens: 2048,
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4096,
       messages: [
         {
           role: 'user',


### PR DESCRIPTION
## Why

Live test on a Cleveland Clinic heart anatomy diagram (typeset labels connected to features by leader lines — no highlights, no bold) returned zero suggestions. The previous prompt only looked for highlighted-background or bold-text terms, so labelled-diagram images — one of the most common study materials — were a dead zone.

## What

- Broaden the auto-occlusion prompt to detect diagram labels with leader lines or arrows, callouts/annotations, table headers, axis labels, and named regions on charts/maps — in addition to the existing highlighted and bold paths.
- Explicit instruction to occlude the **label text**, not the feature the label points to. Review flow: image stays visible with the leader line, label is hidden, user recalls the term.
- Confidence threshold 0.6 → 0.5. Well-formed diagram labels are unambiguous and the higher cut was rejecting them.
- `max_tokens` 2048 → 4096 for dense diagrams (15+ labels).
- Model: `claude-sonnet-4-5` → `claude-sonnet-4-6` (current Sonnet).

## Test plan

- [x] Server tsc + jest green locally (5 existing AutoOcclusionService tests still pass — the prompt is the only diff)
- Iter 2 backlog: dogfood on 10 representative images per spec's smallest-test criterion (≥60% accept-rate on 7 of 10)

## Browser check
Browser check: not applicable — server-only prompt + model swap, no UI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782168228&installation_id=132681956&pr_number=2697&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2697&signature=7ab034e8c675f9ee14426144acf01316be25d306528bcfc5344a0868685198ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->