### PR TITLE
style: refresh login page (mascot, headline, magic-link helper)

### DIFF
--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.module.css
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.module.css
@@ -1,0 +1,12 @@
+.mascot {
+  display: block;
+  width: 48px;
+  height: auto;
+  margin: 0 auto 1.5rem;
+}
+
+.subtitle {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: -1.25rem 0 1.75rem;
+}

--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
@@ -32,10 +32,28 @@ describe('LoginForm', () => {
 
   it('renders email step with email input and primary CTA', () => {
     renderLoginForm();
-    expect(screen.getByText('Log in')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Log in to 2anki' })
+    ).toBeInTheDocument();
     expect(screen.getByRole('textbox', { name: 'Email' })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Email me a sign-in link' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows the product subtitle on the email step', () => {
+    renderLoginForm();
+    expect(
+      screen.getByText('Turn your notes into Anki cards.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows the magic-link helper text under the email input', () => {
+    renderLoginForm();
+    expect(
+      screen.getByText(
+        "We'll email you a sign-in link — no password needed."
+      )
     ).toBeInTheDocument();
   });
 

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -10,6 +10,7 @@ import { WithNotionLink } from '../../../../components/forms/WithNotionLink';
 import { WithMicrosoftLink } from '../../../../components/forms/WithMicrosoftLink';
 import { get2ankiApi } from '../../../../lib/backend/get2ankiApi';
 import styles from '../../../../styles/auth.module.css';
+import loginStyles from './LoginForm.module.css';
 
 type LoginStep = 'email' | 'password' | 'check-email';
 
@@ -60,9 +61,17 @@ function LoginForm() {
 
   return (
     <div className={styles.formPage}>
+      <img
+        src="/mascot/navbar-logo.png"
+        alt=""
+        className={loginStyles.mascot}
+      />
       <div className={styles.formCard}>
         <TopMessage />
-        <h1 className={styles.formTitle}>Log in</h1>
+        <h1 className={styles.formTitle}>Log in to 2anki</h1>
+        <p className={loginStyles.subtitle}>
+          Turn your notes into Anki cards.
+        </p>
         {isEmailStep ? (
           <>
             <div className={styles.field}>
@@ -86,6 +95,9 @@ function LoginForm() {
                   required
                 />
               </label>
+              <p className={styles.helpMuted}>
+                We&apos;ll email you a sign-in link — no password needed.
+              </p>
             </div>
             <div className={styles.field}>
               <button

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-login-page-refresh.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-login-page-refresh.json
@@ -1,0 +1,1 @@
+{"id":"2026-05-24-login-page-refresh","date":"2026-05-24","type":"style","title":"Refreshed login page — clearer headline and a one-line note explaining the magic-link sign-in"}


### PR DESCRIPTION
## Summary
- Adds the 2anki cat mascot above the form card (48px), a two-line headline ("Log in to 2anki" + "Turn your notes into Anki cards."), and one line of helper text under the email input explaining the magic-link sign-in.
- Inspired by Notion's login screen — borrowing the two-line headline pattern and the helper-under-input pattern, but explicitly **not** the icon-card OAuth grid (we have 3 providers; grid implies more parity than we have) or Apple/Passkey/SSO buttons (no enterprise use case).
- The primary CTA label ("Email me a sign-in link") and the stacked Google/Notion/Microsoft OAuth buttons are unchanged. Renaming the CTA to "Continue" would have surprised users expecting a password prompt.

All new styles live in a new login-scoped CSS module (`LoginForm.module.css`). `auth.module.css` is untouched, so the register, forgot-password, reset, check-your-email, and magic-link pages render identically to before.

## Test plan
- [x] `pnpm --filter 2anki-web test src/pages/LoginPage` is green
- [x] `pnpm --filter 2anki-web typecheck` and `pnpm --filter 2anki-web lint` are green
- [x] Visit /login — mascot, headline, subtitle, and helper text all render
- [x] Click "Use password instead" — password step still works as before
- [x] Visit /register and /forgot — visually unchanged (no auth.module.css ripple)

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Alexander authorized merge after reviewing the deploy preview (https://deploy-preview-2710--notion2anki.netlify.app).

## Sonar
`sonar-scanner` not installed in this env; the diff is a single login-scoped CSS module + small TSX edits (no new control flow, no taint sinks, no auth/payment changes). Expect a clean Sonar run, but flagging in case it bounces.

Trio synthesis driving the design choice is in the conversation log: PM said "borrow the headline + helper text; do not borrow the grid or rename the CTA"; designer specified the exact mascot/copy/layout; engineer flagged the auth.module.css ripple and the state-machine risk of renaming the CTA. All three converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)