### PR TITLE
fix: deploy detects failed pm2 restarts and pins process policy

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -30,11 +30,10 @@ jobs:
             nvm use $(cat ${SERVER_DIR}/.nvmrc)
 
             node --version
-            npm install -g pnpm
+            corepack enable
 
-            git -C ${SERVER_DIR} clean -fd
-            git -C ${SERVER_DIR} stash
-            git -C ${SERVER_DIR} pull origin
+            git -C ${SERVER_DIR} fetch origin main
+            git -C ${SERVER_DIR} reset --hard origin/main
             git -C ${SERVER_DIR} clean -fd
 
             pnpm --dir ${SERVER_DIR} install --frozen-lockfile
@@ -44,5 +43,22 @@ jobs:
             pnpm --dir ${SERVER_DIR} run build
             pnpm --filter 2anki-web -C ${SERVER_DIR} build
 
-            cd ${SERVER_DIR}/..
-            pm2 restart server --update-env
+            cd ${SERVER_DIR}
+            pm2 startOrRestart ecosystem.config.js --update-env
+            pm2 save
+
+            echo "Waiting for /api/version to respond..."
+            HEALTHY=0
+            for i in $(seq 1 15); do
+              if curl -fsS http://localhost:2020/api/version >/dev/null 2>&1; then
+                echo "Health check passed after ${i} attempts"
+                HEALTHY=1
+                break
+              fi
+              sleep 2
+            done
+            if [ "$HEALTHY" != "1" ]; then
+              echo "Health check failed — recent server logs:"
+              pm2 logs server --lines 80 --nostream
+              exit 1
+            fi

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+    {
+      name: 'server',
+      script: 'src/server.js',
+      exec_mode: 'fork',
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_restarts: 10,
+      min_uptime: '60s',
+      node_args: '--max-old-space-size=16384',
+      env: {
+        NODE_ENV: 'production',
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- Deploy workflow now fails when the post-restart server isn't healthy. Today's `t.char(64)` migration crash showed the gap: `pm2 restart` exits 0 the moment the *intent* is queued, so the workflow went green while prod was in a crash loop. New 30s health-check loop hits `/api/version` and dumps the last 80 pm2 lines if the new process doesn't respond.
- `ecosystem.config.js` at repo root captures the server process policy (`max_restarts: 10`, `min_uptime: 60s`, `node_args: --max-old-space-size=16384`, fork mode) in version control. Real crash loops will surface as a stopped process instead of churning the lifetime ↺ counter past 475.
- The old stash-and-pull dance is replaced with `fetch origin main` + hard-reset + `clean -fd` (stops the stash list from growing one entry per deploy and pins the branch). `npm install -g pnpm` becomes `corepack enable` so pnpm resolves to the `packageManager` pin in `package.json` (`pnpm@10.18.2`) instead of floating.

## Goal alignment

Faster + safer deploys on the path to 300K. Without this, a bad migration silently degrades prod until somebody (Al) notices the crash loop by SSH. The deploy turns red instead, which is the simple/fast/beautiful path.

## Risks

- `pm2 startOrRestart ecosystem.config.js` matches existing app by name `server`. First deploy with this change re-reads config and applies `max_restarts: 10` + `min_uptime: 60s` — a crash within the first 60s now counts as unstable and pm2 will give up after 10 attempts. That is the desired behaviour, but worth a watchful first deploy.
- `corepack enable` requires Node 16.10+. Prod is on 22.x — fine.

## Test plan

- [x] No app code changed; this is workflow + a new pm2 config file.
- [ ] First green deploy after merge: confirm `pm2 list` shows `server` online and `pm2 describe server` shows `max_restarts: 10`, `min uptime: 60s`.
- [ ] Confirm next deploy's GitHub Actions log shows the new "Waiting for /api/version to respond..." line and the "Health check passed after N attempts" line.

## Browser check
Browser check: not applicable — workflow + pm2 config only, no rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782216544&installation_id=132681956&pr_number=2711&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2711&signature=29f60fc26795e4f44dfbd70b56110add16df92ffaf03c2eb31f24b82a9f573bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->