### PR TITLE
style: OAuth providers as 3-column card grid on login + register

### DIFF
--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -95,11 +95,17 @@ function RegisterForm({ setErrorMessage, redirect, startTrial }: Props) {
         <h1 className={styles.formTitle}>
           {getVisibleText('navigation.register.title')}
         </h1>
-        <WithNotionLink text="Continue with Notion" />
-        <WithGoogleLink text={getVisibleText('navigation.register.google')} />
-        <WithMicrosoftLink
-          text={getVisibleText('navigation.register.microsoft')}
-        />
+        <div className={styles.oauthGrid}>
+          <WithGoogleLink
+            variant="card"
+            text={getVisibleText('navigation.register.google')}
+          />
+          <WithNotionLink variant="card" text="Continue with Notion" />
+          <WithMicrosoftLink
+            variant="card"
+            text={getVisibleText('navigation.register.microsoft')}
+          />
+        </div>
         <div className={styles.divider}>
           <span className={styles.dividerLabel}>or sign up with email</span>
         </div>

--- a/web/src/components/forms/WithGoogleLink.test.tsx
+++ b/web/src/components/forms/WithGoogleLink.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+import { WithGoogleLink } from './WithGoogleLink';
+
+describe('WithGoogleLink', () => {
+  it('renders a link to the Google sign-in endpoint', () => {
+    render(<WithGoogleLink text="Sign in with Google" />);
+    const link = screen.getByRole('link', { name: /Sign in with Google/i });
+    expect(link.getAttribute('href')).toContain(
+      'accounts.google.com/o/oauth2/v2/auth'
+    );
+  });
+
+  it('displays the provided text in row variant', () => {
+    render(<WithGoogleLink text="Sign up with Google" />);
+    expect(screen.getByText('Sign up with Google')).toBeInTheDocument();
+  });
+
+  it('card variant shows the short "Google" label and keeps the full text as accessible name', () => {
+    render(<WithGoogleLink text="Sign in with Google" variant="card" />);
+    expect(screen.getByText('Google')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Sign in with Google' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/forms/WithGoogleLink.tsx
+++ b/web/src/components/forms/WithGoogleLink.tsx
@@ -3,11 +3,20 @@ import styles from '../../styles/auth.module.css';
 
 interface WithGoogleLinkProps {
   text: string;
+  variant?: 'row' | 'card';
 }
 
-export function WithGoogleLink({ text }: Readonly<WithGoogleLinkProps>) {
+export function WithGoogleLink({
+  text,
+  variant = 'row',
+}: Readonly<WithGoogleLinkProps>) {
+  const isCard = variant === 'card';
   return (
-    <a href={getGoogleSignInUrl()} className={styles.googleButton}>
+    <a
+      href={getGoogleSignInUrl()}
+      className={isCard ? styles.oauthCard : styles.googleButton}
+      aria-label={isCard ? text : undefined}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 48 48"
@@ -32,7 +41,7 @@ export function WithGoogleLink({ text }: Readonly<WithGoogleLinkProps>) {
           d="M24.48 9.5288c3.5147 0 6.6628 1.2095 9.1495 3.5772l6.8638-6.8638C36.355 2.3924 30.9437 0 24.48 0 15.1393 0 7.0028 5.3925 3.0428 13.2807l8.0807 6.2353c1.877-5.642 7.1397-9.9872 13.3565-9.9872z"
         />
       </svg>
-      <span>{text}</span>
+      <span>{isCard ? 'Google' : text}</span>
     </a>
   );
 }

--- a/web/src/components/forms/WithMicrosoftLink.test.tsx
+++ b/web/src/components/forms/WithMicrosoftLink.test.tsx
@@ -18,4 +18,14 @@ describe('WithMicrosoftLink', () => {
     render(<WithMicrosoftLink text="Sign up with Microsoft" />);
     expect(screen.getByText('Sign up with Microsoft')).toBeInTheDocument();
   });
+
+  it('card variant shows the short "Microsoft" label and keeps the full text as accessible name', () => {
+    render(
+      <WithMicrosoftLink text="Sign in with Microsoft" variant="card" />
+    );
+    expect(screen.getByText('Microsoft')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Sign in with Microsoft' })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/components/forms/WithMicrosoftLink.tsx
+++ b/web/src/components/forms/WithMicrosoftLink.tsx
@@ -3,11 +3,20 @@ import styles from '../../styles/auth.module.css';
 
 interface WithMicrosoftLinkProps {
   text: string;
+  variant?: 'row' | 'card';
 }
 
-export function WithMicrosoftLink({ text }: Readonly<WithMicrosoftLinkProps>) {
+export function WithMicrosoftLink({
+  text,
+  variant = 'row',
+}: Readonly<WithMicrosoftLinkProps>) {
+  const isCard = variant === 'card';
   return (
-    <a href={getMicrosoftSignInUrl()} className={styles.microsoftButton}>
+    <a
+      href={getMicrosoftSignInUrl()}
+      className={isCard ? styles.oauthCard : styles.microsoftButton}
+      aria-label={isCard ? text : undefined}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 21 21"
@@ -20,7 +29,7 @@ export function WithMicrosoftLink({ text }: Readonly<WithMicrosoftLinkProps>) {
         <rect x="0" y="11" width="10" height="10" fill="#00A4EF" />
         <rect x="11" y="11" width="10" height="10" fill="#FFB900" />
       </svg>
-      <span>{text}</span>
+      <span>{isCard ? 'Microsoft' : text}</span>
     </a>
   );
 }

--- a/web/src/components/forms/WithNotionLink.test.tsx
+++ b/web/src/components/forms/WithNotionLink.test.tsx
@@ -14,4 +14,12 @@ describe('WithNotionLink', () => {
     render(<WithNotionLink text="Sign in with Notion" />);
     expect(screen.getByText('Sign in with Notion')).toBeInTheDocument();
   });
+
+  it('card variant shows the short "Notion" label and keeps the full text as accessible name', () => {
+    render(<WithNotionLink text="Continue with Notion" variant="card" />);
+    expect(screen.getByText('Notion')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Continue with Notion' })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/components/forms/WithNotionLink.tsx
+++ b/web/src/components/forms/WithNotionLink.tsx
@@ -2,11 +2,20 @@ import styles from '../../styles/auth.module.css';
 
 interface WithNotionLinkProps {
   text: string;
+  variant?: 'row' | 'card';
 }
 
-export function WithNotionLink({ text }: Readonly<WithNotionLinkProps>) {
+export function WithNotionLink({
+  text,
+  variant = 'row',
+}: Readonly<WithNotionLinkProps>) {
+  const isCard = variant === 'card';
   return (
-    <a href="/api/users/auth/notion/init" className={styles.notionButton}>
+    <a
+      href="/api/users/auth/notion/init"
+      className={isCard ? styles.oauthCard : styles.notionButton}
+      aria-label={isCard ? text : undefined}
+    >
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 24 24"
@@ -17,7 +26,7 @@ export function WithNotionLink({ text }: Readonly<WithNotionLinkProps>) {
       >
         <path d="M4.459 4.208c.746.606 1.026.56 2.428.466l13.215-.793c.28 0 .047-.28-.046-.326L17.86 1.968c-.42-.326-.981-.7-2.055-.607L3.01 2.295c-.466.046-.56.28-.374.466zm.793 3.08v13.904c0 .747.373 1.027 1.214.98l14.523-.84c.841-.046.935-.56.935-1.167V6.354c0-.606-.233-.933-.748-.887l-15.177.887c-.56.047-.747.327-.747.933zm14.337.745c.093.42 0 .84-.42.888l-.7.14v10.264c-.608.327-1.168.514-1.635.514-.748 0-.935-.234-1.495-.933l-4.577-7.186v6.952L12.21 19s0 .84-1.168.84l-3.222.186c-.093-.186 0-.653.327-.746l.84-.233V9.854L7.822 9.76c-.094-.42.14-1.026.793-1.073l3.456-.233 4.764 7.279v-6.44l-1.215-.139c-.093-.514.28-.887.747-.933zM1.936 1.035l13.31-.98c1.634-.14 2.055-.047 3.082.7l4.249 2.986c.7.513.934.653.934 1.213v16.378c0 1.026-.373 1.634-1.68 1.726l-15.458.934c-.98.047-1.448-.093-1.962-.747l-3.129-4.06c-.56-.747-.793-1.306-.793-1.96V2.667c0-.839.374-1.54 1.447-1.632z" />
       </svg>
-      <span>{text}</span>
+      <span>{isCard ? 'Notion' : text}</span>
     </a>
   );
 }

--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
@@ -79,14 +79,25 @@ describe('LoginForm', () => {
     expect(screen.queryByPlaceholderText('Password')).toBeNull();
   });
 
-  it('shows Google OAuth button on email step', () => {
+  it('shows Google OAuth card on email step', () => {
     renderLoginForm();
-    expect(screen.getByText('Sign in with Google')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Sign in with Google' })
+    ).toBeInTheDocument();
   });
 
-  it('shows Microsoft OAuth button on email step', () => {
+  it('shows Microsoft OAuth card on email step', () => {
     renderLoginForm();
-    expect(screen.getByText('Sign in with Microsoft')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Sign in with Microsoft' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows Notion OAuth card on email step', () => {
+    renderLoginForm();
+    expect(
+      screen.getByRole('link', { name: 'Continue with Notion' })
+    ).toBeInTheDocument();
   });
 
   it('shows Use password instead link on email step', () => {

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -128,16 +128,19 @@ function LoginForm() {
               </a>
             </p>
             <div className={styles.divider}>
-              <span className={styles.dividerLabel}>or</span>
+              <span className={styles.dividerLabel}>Or use a provider</span>
             </div>
-            <WithGoogleLink
-              text={getVisibleText('navigation.login.google')}
-            />
-            <WithNotionLink text="Continue with Notion" />
-            <WithMicrosoftLink
-              text={getVisibleText('navigation.login.microsoft')}
-            />
-            <div className={styles.divider} />
+            <div className={styles.oauthGrid}>
+              <WithGoogleLink
+                variant="card"
+                text={getVisibleText('navigation.login.google')}
+              />
+              <WithNotionLink variant="card" text="Continue with Notion" />
+              <WithMicrosoftLink
+                variant="card"
+                text={getVisibleText('navigation.login.microsoft')}
+              />
+            </div>
           </>
         ) : (
           <form onSubmit={onSubmit}>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-oauth-card-grid.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-oauth-card-grid.json
@@ -1,0 +1,1 @@
+{"id":"2026-05-24-oauth-card-grid","date":"2026-05-24","type":"style","title":"Sign in and sign up — Google, Notion, and Microsoft now appear as a card grid"}

--- a/web/src/styles/auth.module.css
+++ b/web/src/styles/auth.module.css
@@ -153,6 +153,53 @@
   box-shadow: var(--shadow-sm);
 }
 
+.oauthGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  margin: 0 0 1.5rem;
+}
+
+.oauthCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
+  padding: 0.75rem 0.5rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  box-shadow: var(--shadow-xs);
+  transition: all var(--transition-fast);
+}
+
+.oauthCard:hover {
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.oauthCard svg {
+  width: 24px;
+  height: 24px;
+  margin-bottom: 0.375rem;
+}
+
+@media (max-width: 320px) {
+  .oauthGrid {
+    gap: 0.25rem;
+  }
+  .oauthCard svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
 .submitButton {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Follow-up to #2710. Replaces the stacked Google/Notion/Microsoft buttons with a 3-column grid of square cards (icon on top, brand name below), inspired by Notion's login screen. Lands on **both** login and register in one PR so the two auth surfaces stay visually consistent.

- New `variant?: 'row' | 'card'` prop on each `WithXLink`. Default is `'row'` — any other consumer (forgot-password, etc.) is unaffected.
- In card mode, the visible label shortens to the brand name ("Google", "Notion", "Microsoft"); the full text becomes the link's `aria-label` so screen-reader UX is preserved.
- Two new shared classes in `auth.module.css`: `.oauthGrid` (3-col, 8px gap) and `.oauthCard` (80px min-height, brand-colored 24px icon, --radius-md, --shadow-xs lifting to --shadow-sm on hover). At ≤320px the gap and icon shrink slightly to fit.
- Login divider copy: "or" → "Or use a provider" (names the alternative now that OAuth has more visual weight). Register's "or sign up with email" is unchanged.
- Register's OAuth order is now Google → Notion → Microsoft to match login (was Notion → Google → Microsoft).

Magic-link CTA, email form, password flow, and all other auth surfaces are untouched.

## Test plan
- [ ] `pnpm --filter 2anki-web test` is green (1096/1096 locally)
- [ ] `pnpm --filter 2anki-web typecheck` is green
- [ ] `pnpm --filter 2anki-web lint` is green
- [ ] Visit /login — three OAuth cards render in a 3-col row, hover lifts the shadow, focus shows a ring
- [ ] Visit /register — same grid above the email form
- [ ] Visit /forgot — page unchanged (no consumer of the card variant)
- [ ] At 375px viewport — cards stay 3-col, readable
- [ ] Screen reader announces each card as "Sign in with Google" / "Continue with Notion" / "Sign in with Microsoft" (or the register equivalents)

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify in browser before flipping ready — I built this in a headless env and did not run pnpm dev.

## Sonar
`sonar-scanner` not installed in this env; the diff is CSS + a variant prop conditional + 6 new test cases. No new control flow, no taint sinks, no auth/payment logic. Expect a clean Sonar run, but flagging in case it bounces on cognitive complexity in the WithXLink components.

## Trio notes
Three agents weighed in in parallel before code:
- **PM**: ship login + register together (one PR) to avoid a 2-week visual mismatch on signup; track magic-link conversion for 7 days post-ship.
- **Designer**: 80px cards, 24px brand-colored icons, short labels, 3-col even at 375px (~93px per card).
- **Engineer**: option (a) variant prop on existing components (vs new components or parent-selector overrides), CSS in auth.module.css next to row classes, full text preserved in aria-label for screen readers.

All three converged. Alexander chose: login + register together, short labels with aria-label, rename the divider copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782216995&installation_id=132681956&pr_number=2713&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2713&signature=710aa1fda904cbf55bb0d25f17d590cc2a40a5251b974d0234787bc52b998dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->