### PR TITLE
fix: deploy health check curls :3000 not :2020

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -47,10 +47,10 @@ jobs:
             pm2 startOrRestart ecosystem.config.js --update-env
             pm2 save
 
-            echo "Waiting for /api/version to respond..."
+            echo "Waiting for /api/version on :3000 to respond..."
             HEALTHY=0
             for i in $(seq 1 15); do
-              if curl -fsS http://localhost:2020/api/version >/dev/null 2>&1; then
+              if curl -fsS http://127.0.0.1:3000/api/version >/dev/null 2>&1; then
                 echo "Health check passed after ${i} attempts"
                 HEALTHY=1
                 break


### PR DESCRIPTION
## Summary

- Production server listens on `PORT=3000` (set in `.env` on the prod box). #2711's health check hardcoded port `2020` (the dev mock-server port) by mistake.
- Result: the last two deploys exited 1 with the new "Health check failed" branch even though `pm2 startOrRestart` had already restarted the server cleanly. Prod is currently fine and serving traffic; only the deploy workflow status was wrong.
- One-line fix-forward: curl `:3000` (and use `127.0.0.1` instead of `localhost` so we never depend on /etc/hosts).

## Why fix-forward instead of revert

Reverting #2711 would also drop the `max_restarts` / `min_uptime` policy and the `ecosystem.config.js`. Those are working. Only the port is wrong.

## Test plan

- [ ] Merge.
- [ ] Wait for the next push to main to trigger a deploy.
- [ ] Confirm the GitHub Actions log shows `Health check passed after N attempts` and the workflow exits 0.
- [ ] `/deploy-status` confirms `server` online with the new commit.

## Browser check
Browser check: not applicable — workflow change only, no rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782217351&installation_id=132681956&pr_number=2714&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2714&signature=3e75e8b5118ddb3b191907980ef99a5bae92cf74f48bc603d38d9c10706ffab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->