### PR TITLE
style: homepage AI badge with path to create an account

### DIFF
--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -29,6 +29,8 @@ export const KNOWN_EVENTS = new Set([
   'upload_ai_on_badge_clicked',
   'upload_ai_anon_badge_viewed',
   'upload_ai_anon_badge_clicked',
+  'home_ai_anon_badge_viewed',
+  'home_ai_anon_badge_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -44,6 +44,15 @@ describe('HomePage (anonymous)', () => {
     expect(screen.getByText(/open source/i)).toBeInTheDocument();
   });
 
+  it('shows the AI badge inviting anon visitors to create an account', () => {
+    renderHome();
+    const link = screen.getByRole('link', {
+      name: /create an account to turn it on/i,
+    });
+    expect(link).toHaveAttribute('href', '/register');
+    expect(screen.getByText('AI')).toBeInTheDocument();
+  });
+
   it('renders the three how-it-works steps with icons', () => {
     renderHome();
     expect(screen.getByText('Upload')).toBeInTheDocument();

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -1,12 +1,14 @@
-import { useMemo, useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, Navigate } from 'react-router-dom';
 import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { useSettingsCardsOptions } from '../../components/modals/SettingsModal/useSettingsCardsOptions';
 import ArrowUpTrayIcon from '../../components/icons/ArrowUpTrayIcon';
 import SparklesIcon from '../../components/icons/SparklesIcon';
 import BookOpenIcon from '../../components/icons/BookOpenIcon';
+import { track } from '../../lib/analytics/track';
 import { ShowcaseSection } from './ShowcaseSection';
+import sharedStyles from '../../styles/shared.module.css';
 import styles from './HomePage.module.css';
 
 const FEATURED_WALKTHROUGH_IDS = new Set(['jpR_grXWTTw', 'roQ3awaVa2E', 'UnTo_fN1jpc']);
@@ -109,6 +111,10 @@ export function HomePage({
   );
   const [showAll, setShowAll] = useState(false);
 
+  useEffect(() => {
+    if (!isLoggedIn) track('home_ai_anon_badge_viewed');
+  }, [isLoggedIn]);
+
   if (isLoggedIn) {
     return <Navigate to="/upload" replace />;
   }
@@ -140,6 +146,16 @@ export function HomePage({
             </svg>
             Open source
           </a>
+          <span className={styles.footerDot} aria-hidden="true" />
+          <span>
+            <span className={sharedStyles.badgePrimary}>AI</span>{' '}
+            <Link
+              to="/register"
+              onClick={() => track('home_ai_anon_badge_clicked')}
+            >
+              Create an account to turn it on
+            </Link>
+          </span>
         </div>
       </section>
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-home-ai-badge.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-home-ai-badge.json
@@ -1,0 +1,1 @@
+{"id":"2026-05-24-home-ai-badge","date":"2026-05-24","type":"style","title":"Homepage shows whether AI conversion is on, with a link to create an account"}


### PR DESCRIPTION
## Summary
Follow-up to the `/upload` AI badge work — anonymous visitors landing on `/` now see a quiet "AI · Create an account to turn it on" badge in the hero footer. Mirrors the badge from `/upload` but tuned for the cold-visitor context.

- **Placement**: inline in `.heroFooter`, after the GitHub link, separated by a `.footerDot`. Same row as "Free up to 100 cards per month". No new vertical scroll.
- **Visual**: `.badgePrimary` (blue, informational), **not** `.badgeWarning` (amber/yellow). Anon visitors have no setting that's "off" — the badge is an invitation, not a warning.
- **Copy**: drops the "AI is off" prefix from the `/upload` variant. On the homepage there's no setting to be off; opening with a negation tells the visitor the product is degraded.
- **Link target**: `/register` (not `/login`). Most homepage visitors don't have an account yet.
- **Analytics**: new `home_ai_anon_badge_viewed` / `home_ai_anon_badge_clicked` events — keeps the homepage funnel separate from `/upload`.

The signed-in path is unchanged (signed-in users still redirect from `/` to `/upload`).

## Test plan
- [x] `pnpm --filter 2anki-web test` is green (1097/1097 locally)
- [x] `pnpm --filter 2anki-web typecheck` is green
- [x] `pnpm --filter 2anki-web lint` is green
- [x] Visit `/` as anon — badge renders in the hero footer; clicking goes to `/register`
- [x] Network tab: `track` posts `home_ai_anon_badge_viewed` on load
- [x] Visit `/upload` — existing badge is unchanged

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Alexander authorized merge after reviewing the deploy preview (https://deploy-preview-2716--notion2anki.netlify.app).

## Sonar
`sonar-scanner` not installed in this env. Tiny diff (4 files, +30/-2 lines). Pre-existing risk: `HomePage.tsx:107` uses `Math.random()` for the mascot picker, which Sonar's `S2245` flags. Not touched here, but lives in the same file — a "new code" rescan may surface it.

## Trio notes
- **PM**: "Create an account to turn it on" + `/register`; new `home_ai_anon_*` events for clean funnel split.
- **Designer**: inline in `.heroFooter`, use `.badgePrimary` not `.badgeWarning`, drop the "AI is off" prefix.
- **Engineer**: duplicate inline (5 lines of JSX); no extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)