### PR TITLE
fix: pin pnpm@10.18.2 and fail-fast in deploy SSH script

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -22,6 +22,9 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            set -e
+            set -o pipefail
+
             SERVER_DIR=~/src/github.com/2anki/2anki.net
 
             export NVM_DIR="$HOME/.nvm"
@@ -30,7 +33,8 @@ jobs:
             nvm use $(cat ${SERVER_DIR}/.nvmrc)
 
             node --version
-            corepack enable
+            npm install -g pnpm@10.18.2 --force
+            pnpm --version
 
             git -C ${SERVER_DIR} fetch origin main
             git -C ${SERVER_DIR} reset --hard origin/main


### PR DESCRIPTION
## Summary

#2711's `corepack enable` change silently broke every pnpm step in the deploy — the box has pnpm 11.3.0 system-installed, PATH resolved to that, and pnpm 11.3.0 saw the `packageManager: pnpm@10.18.2` pin and aborted with `[ERROR] This project is configured to use 10.18.2`. No `set -e` meant the SSH script marched past the errors, `pm2 startOrRestart` ran against the **old compiled JS**, and the `/api/version` health check passed because that endpoint exists in both old and new code.

Result: deploys reported green for hours while prod served stale code.

## Fix

- `npm install -g pnpm@10.18.2 --force` at the top of the script. Explicit version pin, overwrites whatever is on the box, and `pnpm --version` is echoed for log verification.
- `set -e` + `set -o pipefail` at the very top so any non-zero exit aborts the deploy loudly instead of marching past silent failures. This would have caught #2711's regression at the very first pnpm call.

## Why fix-forward (not revert)

The `ecosystem.config.js` policy + health check from #2711 are working correctly. Only the pnpm-via-corepack swap was wrong.

## Notes on current prod state

Prod was manually rebuilt + restarted at ~12:39 UTC after I diagnosed this; the new code from #2704 is live now. This PR fixes the workflow itself so the next push to main actually deploys.

## Test plan

- [ ] Merge.
- [ ] Trigger a deploy (any push to main).
- [ ] GitHub Actions log shows `pnpm 10.18.2` echoed.
- [ ] `set -e` aborts on any future error.
- [ ] `/deploy-status` confirms server running new code.

## Browser check
Browser check: not applicable — workflow change only, no rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782218450&installation_id=132681956&pr_number=2717&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2717&signature=0960b1b2ecb40d4e4e5295b7e016bfabc1ea0981e6a44ae09adb0e2ba2c75c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->