### PR TITLE
fix: sync analytics allowlist with web; drop open-source link from /

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -23,6 +23,17 @@ export const KNOWN_EVENTS = new Set([
   'sidebar_auto_minimize_fired',
   'sidebar_auto_minimize_reverted',
   'card_size_selected',
+  'notion_column_mapping_submitted',
+  'database_preview_viewed',
+  'convert_clicked_from_preview',
+  'upload_ai_off_badge_viewed',
+  'upload_ai_off_badge_clicked',
+  'upload_ai_on_badge_viewed',
+  'upload_ai_on_badge_clicked',
+  'upload_ai_anon_badge_viewed',
+  'upload_ai_anon_badge_clicked',
+  'home_ai_anon_badge_viewed',
+  'home_ai_anon_badge_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -38,14 +38,10 @@ describe('HomePage (anonymous)', () => {
     expect(screen.getByText(/drop your files here/i)).toBeInTheDocument();
   });
 
-  it('shows the open source link in the hero footer', () => {
-    renderHome();
-    expect(screen.getByText(/open source/i)).toBeInTheDocument();
-  });
-
-  it('does not anchor visitors to the free-tier card limit in the hero', () => {
+  it('keeps the hero focused on conversion — no free-tier limit or open-source brag in the hero', () => {
     renderHome();
     expect(screen.queryByText(/100 cards per month/i)).toBeNull();
+    expect(screen.queryByText(/open source/i)).toBeNull();
   });
 
   it('shows the AI-off badge inviting anon visitors to create an account', () => {

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -145,19 +145,6 @@ export function HomePage({
           </span>
         </div>
         <UploadForm setErrorMessage={setErrorMessage} />
-        <div className={styles.heroFooter}>
-          <a
-            href="https://github.com/2anki/server"
-            target="_blank"
-            rel="noreferrer"
-            className={styles.githubLink}
-          >
-            <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14" aria-hidden="true">
-              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
-            </svg>
-            Open source
-          </a>
-        </div>
       </section>
 
       <section className={styles.stepsSection}>


### PR DESCRIPTION
## Summary
Two same-day cleanups bundled — both surfaced while watching `/deploy-status` after PR #2716 + #2718 went out.

### 1. Sync the backend analytics allowlist with the web frontend
`POST /api/events/track` was returning **400 in tight loops** on prod for every real user, visible in `pm2 logs`. Root cause: `src/types/AnalyticsEvents.ts` (the backend `KNOWN_EVENTS` set) had drifted **11 events** behind `web/src/lib/analytics/events.ts`. Pages rendered fine — the failed POSTs are swallowed by the analytics path on the frontend — but every event was being dropped silently.

Added to backend:
- `notion_column_mapping_submitted`, `database_preview_viewed`, `convert_clicked_from_preview`
- `upload_ai_off_badge_viewed/clicked`, `upload_ai_on_badge_viewed/clicked`, `upload_ai_anon_badge_viewed/clicked`
- `home_ai_anon_badge_viewed/clicked` (the two from PR #2716 that prompted the discovery)

The two sets are now identical for every event the web frontend can fire. Backend-only events (`email_clicked`, `email_batch_sent`, `vision_photo_converted`) stay backend-only.

### 2. Remove the "Open source" GitHub link from the homepage hero
After the prior removal of "Free up to 100 cards per month", the only thing left in `.heroFooter` was this repo link. An anon visitor coming to convert notes doesn't need the open-source brag next to the dropzone. The whole `.heroFooter` div is removed — the repo is still discoverable through the site chrome.

## Test plan
- [x] `pnpm --filter 2anki-web test` is green (1115/1115)
- [x] `pnpm --filter 2anki-web typecheck` + `pnpm --filter 2anki-web lint` are green
- [x] Server `tsc --noEmit` is green
- [x] Server `pnpm test src/controllers/EventsController.test.ts` — 15/15 (validates the new event keys against `KNOWN_EVENTS`)
- [ ] After merge + deploy, watch `pm2 logs` for `POST /api/events/track HTTP/1.1" 400` — should drop to zero for `home_ai_anon_*` and `upload_ai_*` payloads.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Alexander authorized merge-without-waiting earlier in the thread. Diff is constrained to the allowlist + JSX removal; nothing else moves visually on `/` beyond the GitHub link disappearing from the hero.

## Sonar
`sonar-scanner` not installed in this env. 3-file diff, +13/-19 lines. Pure additions to a typed `Set<string>` literal + JSX deletion + test assertion flip.

## No new changelog entry
The analytics fix is invisible to users (broken tracking → working tracking, no UX delta). The open-source link removal is small enough that the just-shipped homepage-refresh entries cover the user-visible state of the hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782220067&installation_id=132681956&pr_number=2727&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2727&signature=11ebb870234a22cca2fdb6e81f47385fa21019bfe639681ae3c6e30ad22c0da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->