### PR TITLE
perf: ship-today scaling wins (upload cap, version SHA, pool)

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -17,10 +17,13 @@ jobs:
     steps:
       - name: SSH and run script
         uses: appleboy/ssh-action@v1.2.5
+        env:
+          GIT_SHA: ${{ github.sha }}
         with:
           host: 2anki.net
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: GIT_SHA
           script: |
             set -e
             set -o pipefail
@@ -48,21 +51,25 @@ jobs:
             pnpm --filter 2anki-web -C ${SERVER_DIR} build
 
             cd ${SERVER_DIR}
+            export GIT_SHA
             pm2 startOrRestart ecosystem.config.js --update-env
             pm2 save
 
-            echo "Waiting for /api/version on :3000 to respond..."
+            echo "Waiting for /api/version on :3000 to report sha=${GIT_SHA}..."
             HEALTHY=0
             for i in $(seq 1 15); do
-              if curl -fsS http://127.0.0.1:3000/api/version >/dev/null 2>&1; then
-                echo "Health check passed after ${i} attempts"
+              RESPONSE=$(curl -fsS http://127.0.0.1:3000/api/version 2>/dev/null || echo "")
+              ACTUAL_SHA=$(echo "$RESPONSE" | jq -r '.sha // empty' 2>/dev/null || echo "")
+              if [ -n "$ACTUAL_SHA" ] && [ "$ACTUAL_SHA" = "$GIT_SHA" ]; then
+                echo "Health check passed after ${i} attempts (sha=${ACTUAL_SHA})"
                 HEALTHY=1
                 break
               fi
               sleep 2
             done
             if [ "$HEALTHY" != "1" ]; then
-              echo "Health check failed — recent server logs:"
+              echo "Health check failed — expected sha=${GIT_SHA}, last response: ${RESPONSE}"
+              echo "Recent server logs:"
               pm2 logs server --lines 80 --nostream
               exit 1
             fi

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -12,6 +12,7 @@ module.exports = {
       node_args: '--max-old-space-size=16384',
       env: {
         NODE_ENV: 'production',
+        GIT_SHA: process.env.GIT_SHA,
       },
     },
   ],

--- a/src/KnexConfig.ts
+++ b/src/KnexConfig.ts
@@ -6,7 +6,7 @@ const KnexConfig: Knex.Config = {
     process.env.DATABASE_URL || 'postgresql://aa:focaccia@localhost:5432/n',
   pool: {
     min: 2,
-    max: 10,
+    max: 20,
   },
   migrations: {
     tableName: 'knex_migrations',

--- a/src/controllers/VersionController.ts
+++ b/src/controllers/VersionController.ts
@@ -5,7 +5,7 @@ class VersionController {
   constructor(private readonly service: VersionService) {}
 
   getVersionInfo(_req: express.Request, res: express.Response) {
-    res.status(200).send(this.service.getVersion());
+    res.status(200).json(this.service.getVersion());
   }
 }
 

--- a/src/routes/VersionRouter.ts
+++ b/src/routes/VersionRouter.ts
@@ -11,7 +11,9 @@ const VersionRouter = () => {
    * /api/version:
    *   get:
    *     summary: Get API version information
-   *     description: Returns the current version and build information of the API
+   *     description: Returns the running package version and the git SHA the
+   *       process was built from. Used by the deploy workflow to verify that
+   *       the new code is actually running (not a stale process).
    *     tags: [System]
    *     responses:
    *       200:
@@ -19,16 +21,16 @@ const VersionRouter = () => {
    *         content:
    *           application/json:
    *             schema:
-   *               $ref: '#/components/schemas/Version'
-   *             example:
-   *               version: "1.2.1"
-   *               build: "2024-08-04"
-   *       500:
-   *         description: Internal server error
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/Error'
+   *               type: object
+   *               properties:
+   *                 version:
+   *                   type: string
+   *                   example: "2.0.0"
+   *                 sha:
+   *                   type: string
+   *                   description: Git SHA (full 40-char) the build was created from,
+   *                     or "unknown" if GIT_SHA is unset in the runtime env.
+   *                   example: "9be7cb9bbcd7..."
    */
   router.get('/api/version', (req, res) => controller.getVersionInfo(req, res));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -124,7 +124,7 @@ const serve = async () => {
 
   app.use(webhookRouter());
   app.use(ankifyWebhookRouter());
-  app.use(express.json({ limit: '1000mb' }) as RequestHandler);
+  app.use(express.json({ limit: '50mb' }) as RequestHandler);
   app.use(cookieParser());
   app.use(anonIdMiddleware);
   app.use(noindexNonCanonicalHosts);

--- a/src/services/VersionService.test.ts
+++ b/src/services/VersionService.test.ts
@@ -1,0 +1,25 @@
+import VersionService from './VersionService';
+
+describe('VersionService', () => {
+  const originalSha = process.env.GIT_SHA;
+
+  afterEach(() => {
+    if (originalSha === undefined) {
+      delete process.env.GIT_SHA;
+    } else {
+      process.env.GIT_SHA = originalSha;
+    }
+  });
+
+  it('returns package.json version + GIT_SHA from env', () => {
+    process.env.GIT_SHA = 'a1b2c3d4e5f6';
+    const result = new VersionService().getVersion();
+    expect(result.sha).toBe('a1b2c3d4e5f6');
+    expect(result.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('falls back to "unknown" when GIT_SHA is unset (local dev)', () => {
+    delete process.env.GIT_SHA;
+    expect(new VersionService().getVersion().sha).toBe('unknown');
+  });
+});

--- a/src/services/VersionService.ts
+++ b/src/services/VersionService.ts
@@ -6,9 +6,17 @@ const appInfo = JSON.parse(
   fs.readFileSync(resolvePath(__dirname, '../../package.json')).toString()
 );
 
+export interface VersionInfo {
+  version: string;
+  sha: string;
+}
+
 class VersionService {
-  public getVersion(): string {
-    return `Notion to Anki v${appInfo.version}`;
+  public getVersion(): VersionInfo {
+    return {
+      version: appInfo.version,
+      sha: process.env.GIT_SHA ?? 'unknown',
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

Three independent, low-risk scaling improvements bundled into one PR. Each commit is self-contained — the bundle is for review velocity, not coupling.

1. **`perf: drop express.json limit from 1000mb to 50mb`** — Removes the single most-likely "site went down at 2am" failure mode. The 1000mb cap on the global JSON body parser meant a handful of concurrent oversized JSON POSTs could exhaust heap on the single-process Node worker. File uploads (HTML/MD/ZIP/PDF, apkg, PDF→Anki, images) are unaffected — they go through multer (multipart/form-data) with their own per-route `fileSize` caps (50–100 MB). The only route that legitimately needs a larger JSON body (image-occlusion photo-to-deck) already overrides the global with its own 20mb parser.

2. **`feat: include git SHA in /api/version for deploy verification`** — Closes the "deploy succeeded ≠ new code running" gap. `/api/version` now returns `{ version, sha }`. The deploy workflow propagates `${{ github.sha }}` as `GIT_SHA`, pm2 forwards it through `ecosystem.config.js`, and the post-restart health check asserts the response sha matches the expected sha (with `jq`). A stale process now fails loudly with `expected sha=X, last response Y` instead of silently passing.

3. **`perf: bump Knex pool max from 10 to 20`** — Verified on prod 2026-05-24: PG `max_connections` = 100, idle usage = 9. 91 connections of headroom. The default pool ceiling of 10 has been a silent bottleneck under any concurrent burst. Pure upside until pm2 moves to cluster mode (at which point this gets re-evaluated against `workers × pool_max`).

## Out of scope, applied separately over SSH

These are config-only changes that don't live in the repo. Applied directly on prod after this PR merges:

- **Apache `MaxRequestWorkers` 150 → 512** (Ubuntu default ceiling raise). Box has 31 GB RAM, ample headroom; current mpm_event config is the inherited Ubuntu default.
- **`Cache-Control: public, max-age=31536000, immutable`** on Vite's hashed `/assets/*.js` and `*.css`. `no-cache` on `index.html` so deploys propagate instantly. No vhost cache headers exist today — confirmed via `grep` on `/etc/apache2/sites-enabled/`.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm test src/services/VersionService.test.ts` — 2/2 passing, covers `GIT_SHA` set and unset
- [ ] After merge: confirm deploy workflow health check asserts the new sha and fails on stale process (will know on first post-merge deploy)
- [ ] After merge: SSH and apply Apache + Cache-Control config

## Browser check
Browser check: not applicable — server-only changes; no `web/src/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782222160&installation_id=132681956&pr_number=2728&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2728&signature=f74095157ba6ea4c5318357debf7b16b947802a159a58d4c23df11f1b40108d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->