### PR TITLE
perf: skip anon_id Set-Cookie on /assets/ and /templates/

### DIFF
--- a/src/routes/middleware/anonIdMiddleware.test.ts
+++ b/src/routes/middleware/anonIdMiddleware.test.ts
@@ -1,16 +1,16 @@
 import { Request, Response, NextFunction } from 'express';
 import { anonIdMiddleware } from './anonIdMiddleware';
 
-function makeReqRes(existingCookie?: string) {
+function makeReqRes(opts: { existingCookie?: string; path?: string } = {}) {
   const cookies: Record<string, string> = {};
-  if (existingCookie) {
-    cookies['anon_id'] = existingCookie;
+  if (opts.existingCookie) {
+    cookies['anon_id'] = opts.existingCookie;
   }
-  const req = { cookies } as unknown as Request;
+  const req = { cookies, path: opts.path ?? '/' } as unknown as Request;
   const setCookieArgs: Array<[string, string, object]> = [];
   const res = {
-    cookie: jest.fn((name: string, value: string, opts: object) => {
-      setCookieArgs.push([name, value, opts]);
+    cookie: jest.fn((name: string, value: string, options: object) => {
+      setCookieArgs.push([name, value, options]);
     }),
   } as unknown as Response;
   const next: NextFunction = jest.fn();
@@ -41,17 +41,41 @@ describe('anonIdMiddleware', () => {
   });
 
   it('preserves existing anon_id without setting a new one', () => {
-    const { req, res, next, setCookieArgs } = makeReqRes('existing-anon-id');
+    const { req, res, next, setCookieArgs } = makeReqRes({
+      existingCookie: 'existing-anon-id',
+    });
     anonIdMiddleware(req, res, next);
     expect(next).toHaveBeenCalled();
     expect(setCookieArgs).toHaveLength(0);
   });
 
   it('generates a different UUID on each call when no cookie exists', () => {
-    const { req: req1, res: res1, next: next1, setCookieArgs: c1 } = makeReqRes();
-    const { req: req2, res: res2, next: next2, setCookieArgs: c2 } = makeReqRes();
+    const { req: req1, res: res1, next: next1, setCookieArgs: c1 } =
+      makeReqRes();
+    const { req: req2, res: res2, next: next2, setCookieArgs: c2 } =
+      makeReqRes();
     anonIdMiddleware(req1, res1, next1);
     anonIdMiddleware(req2, res2, next2);
     expect(c1[0][1]).not.toBe(c2[0][1]);
+  });
+
+  it.each([
+    ['/assets/index-CcTRzipW.js'],
+    ['/assets/HomePage-BvtfqaPi.css'],
+    ['/templates/email-preview.html'],
+  ])('skips Set-Cookie on static path %s', (path) => {
+    const { req, res, next, setCookieArgs } = makeReqRes({ path });
+    anonIdMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(setCookieArgs).toHaveLength(0);
+  });
+
+  it('still sets Set-Cookie on non-static paths like /api/events', () => {
+    const { req, res, next, setCookieArgs } = makeReqRes({
+      path: '/api/events',
+    });
+    anonIdMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(setCookieArgs).toHaveLength(1);
   });
 });

--- a/src/routes/middleware/anonIdMiddleware.ts
+++ b/src/routes/middleware/anonIdMiddleware.ts
@@ -4,11 +4,18 @@ import { randomUUID } from 'crypto';
 const ANON_ID_COOKIE = 'anon_id';
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
+const SKIP_PREFIXES = ['/assets/', '/templates/'];
+
 export function anonIdMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
 ): void {
+  const path = req.path ?? '';
+  if (SKIP_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+    next();
+    return;
+  }
   const existing = req.cookies?.[ANON_ID_COOKIE];
   if (existing) {
     next();


### PR DESCRIPTION
## Summary

Tiny follow-up to #2728. The `anonIdMiddleware` was emitting `Set-Cookie: anon_id=...` on every response including hashed bundle assets (`/assets/index-<hash>.js`, `/assets/<page>.css`) and email templates (`/templates/*`). Skips both prefixes now — those responses are content-immutable, never per-user, and emitting `Set-Cookie` on them prevents any future edge cache from sharing the response across users.

## Safety analysis

| Scenario | Before | After | Verdict |
|---|---|---|---|
| First-visit lands on `/` | Cookie set on index.html response | Same — `/` not in skip list | ✅ |
| Existing user (has cookie) | Middleware no-ops; browser sends cookie regardless | Same | ✅ |
| Hits `/api/events` without prior HTML | `EventsRouter` mounts the middleware itself (line 20) → cookie set there | Same — independent mount | ✅ |
| Hypothetical deep-link to `/assets/foo.js` | Set-Cookie on response | No Set-Cookie; their next non-asset request sets it | ✅ — nobody deep-links to hashed bundles |

The only thing the previous behavior bought was a daily refresh of `Max-Age=1y` on the cookie, which is irrelevant given the cookie already persists a year.

## Test plan

- [x] 4 existing tests still pass (cookie set when absent, preserved when present, unique UUIDs, options correct)
- [x] 3 new tests (`it.each`) assert no Set-Cookie on `/assets/index-X.js`, `/assets/X.css`, `/templates/email.html`
- [x] 1 new test asserts Set-Cookie still fires on `/api/events`
- [x] 8/8 passing locally, `pnpm tsc --noEmit` clean

## Browser check

Browser check: not applicable — server-only middleware change, no `web/src/` files touched. No user-visible behavior change (cookie is still set on the next non-asset request).

No changelog entry — internal optimization, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782223472&installation_id=132681956&pr_number=2729&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2729&signature=7ca5c58b00c90ae2a96fce84805aee1a3e4d44d5a49cb2c1fd018fc4f2ed4cc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->