### PR TITLE
fix: restore green CI after #2709 TTS auto-detect landed

### DIFF
--- a/create_deck/helpers/test_get_model_front_tts.py
+++ b/create_deck/helpers/test_get_model_front_tts.py
@@ -31,6 +31,8 @@ def _mcq_descriptor():
 
 
 class TestApplyFrontTts:
+    """Unit tests for `_apply_front_tts` over each model type."""
+
     def test_basic_injects_front_field(self):
         assert _apply_front_tts("X", "basic", "ja") == "{{tts ja:Front}}\nX"
 
@@ -48,6 +50,8 @@ class TestApplyFrontTts:
 
 
 class TestGetModelFrontLangIntegration:
+    """End-to-end checks that `get_model` threads `front_lang` into templates."""
+
     def test_basic_prepends_tts_when_lang_set(self):
         model = get_model(_basic_descriptor(), front_lang="ja")
         assert "{{tts ja:Front}}" in model.templates[0]["qfmt"]

--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -194,6 +194,7 @@ describe('SettingsController', () => {
       'mcq-tts-question': '',
       'mcq-tts-correct-answer': '',
       'mcq-tts-extra': '',
+      'tts-auto-detect': 'false',
     });
   });
 });


### PR DESCRIPTION
## Summary

#2709 landed on main but left two CI workflows red:

- **Server** — `CardOptionsController.test.ts` server fixture was missing the new `'tts-auto-detect': 'false'` key that #2709 added to `CardOption.LoadDefaultOptions()`. `toStrictEqual` diverged on every run.
- **Create Deck** — two pytest test classes (`TestApplyFrontTts`, `TestGetModelFrontLangIntegration`) in `create_deck/helpers/test_get_model_front_tts.py` were missing class docstrings, so pylint failed with `C0115`.

Both fixes are test-only. No runtime behaviour changes.

## Test plan

- [x] `pnpm test src/controllers/CardOptionsController/CardOptionsController.test.ts` — 7/7 pass locally
- [x] AST check confirms both Python classes now carry docstrings
- [ ] Server + Create Deck workflows go green on this PR

## Browser check
Browser check: not applicable — test-only changes, no rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782225443&installation_id=132681956&pr_number=2730&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2730&signature=7db8e21e6fb9381995e613a8a4113b1464b5205feb77057745a95493a6d79595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->