### PR TITLE
feat: serve /assets/* from DigitalOcean Spaces CDN

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -19,11 +19,16 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           GIT_SHA: ${{ github.sha }}
+          ASSET_BASE_URL: ${{ secrets.ASSET_BASE_URL }}
+          SPACES_ASSETS_ACCESS_KEY_ID: ${{ secrets.SPACES_ASSETS_ACCESS_KEY_ID }}
+          SPACES_ASSETS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_ASSETS_SECRET_ACCESS_KEY }}
+          SPACES_ASSETS_BUCKET: ${{ secrets.SPACES_ASSETS_BUCKET }}
+          SPACES_ASSETS_REGION: ${{ secrets.SPACES_ASSETS_REGION }}
         with:
           host: 2anki.net
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: GIT_SHA
+          envs: GIT_SHA,ASSET_BASE_URL,SPACES_ASSETS_ACCESS_KEY_ID,SPACES_ASSETS_SECRET_ACCESS_KEY,SPACES_ASSETS_BUCKET,SPACES_ASSETS_REGION
           script: |
             set -e
             set -o pipefail
@@ -47,8 +52,24 @@ jobs:
             pnpm --dir ${SERVER_DIR} exec puppeteer browsers install chrome
             pip install -r ${SERVER_DIR}/create_deck/requirements.txt
 
+            if ! command -v aws >/dev/null 2>&1; then
+              echo "Installing aws-cli to ~/.local/bin..."
+              pip install --user awscli
+            fi
+            export PATH="$HOME/.local/bin:$PATH"
+            aws --version
+
             pnpm --dir ${SERVER_DIR} run build
-            pnpm --filter 2anki-web -C ${SERVER_DIR} build
+            ASSET_BASE_URL="$ASSET_BASE_URL" pnpm --filter 2anki-web -C ${SERVER_DIR} build
+
+            echo "Syncing web/build/assets/ to s3://${SPACES_ASSETS_BUCKET}/assets/..."
+            AWS_ACCESS_KEY_ID="$SPACES_ASSETS_ACCESS_KEY_ID" \
+            AWS_SECRET_ACCESS_KEY="$SPACES_ASSETS_SECRET_ACCESS_KEY" \
+            aws s3 sync ${SERVER_DIR}/web/build/assets/ s3://${SPACES_ASSETS_BUCKET}/assets/ \
+              --endpoint-url="https://${SPACES_ASSETS_REGION}.digitaloceanspaces.com" \
+              --cache-control "public, max-age=31536000, immutable" \
+              --acl public-read \
+              --size-only
 
             cd ${SERVER_DIR}
             export GIT_SHA

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -29,7 +29,14 @@ export default defineConfig(({ command, mode }) => {
   // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
   const env = loadEnv(mode, process.cwd(), '');
 
+  const rawAssetBaseUrl = process.env.ASSET_BASE_URL || '/';
+  const base = rawAssetBaseUrl.endsWith('/')
+    ? rawAssetBaseUrl
+    : `${rawAssetBaseUrl}/`;
+
   return {
+    base,
+
     plugins: [
       react(),
       svgr({


### PR DESCRIPTION
## Summary

Moves the dominant bandwidth surface — Vite's hashed bundle assets (`/assets/*.js`, `*.css`, ~770 KB total per cold visitor with brotli-on, ~170 KB JS bundle alone) — off the droplet and onto DigitalOcean Spaces CDN. The droplet stays responsible for `index.html` (~3 KB) and the API only.

At our current 1–4 K daily peak this is comfortable; at a Reddit-blast spike (1500–5000 concurrent) the droplet's NIC + Apache `MaxRequestWorkers 400` becomes the cliff. This PR moves the bandwidth-heavy responses to DO's edge network so the droplet only handles the tiny stuff.

## What changed

1. **`web/vite.config.ts`** — reads `ASSET_BASE_URL` at build time, sets it as the Vite `base` so `index.html` embeds absolute CDN URLs in `<script>` and `<link>` tags. Defaults to `/` if unset (local dev, fallback safety). Defensive trailing-slash normalization since Vite requires base to end with `/`.

2. **`.github/workflows/deploy.2anki.net.yml`** —
   - Passes 5 new env vars from secrets through the SSH script.
   - Builds the web workspace with `ASSET_BASE_URL` exported.
   - Installs `aws-cli` to `~/.local/bin` if missing (one-time, idempotent).
   - `aws s3 sync` uploads `web/build/assets/` to `s3://2anki-assets/assets/` via the S3-compatible Spaces endpoint with `--cache-control "public, max-age=31536000, immutable" --acl public-read --size-only`.
   - Sync happens **before** pm2 restart so we never serve an `index.html` that references assets the CDN doesn't have yet.
   - Existing `/api/version` GIT_SHA assertion still gates health check — unchanged.

## ⚠️ Prerequisite: CORS configuration on the bucket

Vite emits `<script type="module" crossorigin src="...">` for module bundles. The `crossorigin` attribute means the browser uses CORS mode — if the CDN response lacks `Access-Control-Allow-Origin`, the script fails to load and **the site goes white**. This is a one-time bucket setting that **must be applied before this PR merges**.

In the DO Spaces UI for `2anki-assets` → CORS Configurations → Add:

```json
{
  "AllowedOrigins": ["*"],
  "AllowedMethods": ["GET", "HEAD"],
  "AllowedHeaders": ["*"],
  "MaxAgeSeconds": 3600
}
```

Wildcard origin is fine here — the bucket only contains public, immutable, build-output assets. There's no auth state to leak.

(Alternative if you want explicit origins: `["https://2anki.net", "https://www.2anki.net", "https://beta.2anki.net"]`. I went with `*` for simplicity since these assets are deliberately public.)

## Rollback / failure modes

- **CORS forgot**: site goes white on first deploy. Recovery: apply CORS in DO UI (1 minute, takes effect immediately on the CDN). No code change needed; existing browser sessions retry on refresh.
- **`aws s3 sync` fails**: deploy fails before pm2 restart. Old code keeps running. Investigate the workflow logs (likely a creds or bucket-permissions issue).
- **`ASSET_BASE_URL` unset/wrong on first deploy**: `index.html` gets emitted with `/` base → assets load same-origin → fall back to old behavior. No outage; the CDN sync still runs in parallel.

To fully roll back: revert this commit. Old `index.html` (same-origin asset URLs) is emitted by the next deploy. Bucket can be emptied at leisure.

## Test plan

- [x] `pnpm typecheck` clean in `web/`
- [x] Vite config defensively appends `/` if `ASSET_BASE_URL` is missing it
- [x] Server tsc clean (no server-side changes affect it)
- [ ] **Manual: confirm CORS is set on the bucket** (see Prerequisite above)
- [ ] After CORS + merge: load `https://2anki.net/` in a browser, confirm Network tab shows `/assets/*.js` requests going to `2anki-assets.fra1.cdn.digitaloceanspaces.com`, no CORS errors in console
- [ ] After CORS + merge: confirm `/api/version` health check still asserts the new SHA (existing deploy verification)
- [ ] After CORS + merge: confirm mobile viewport (375px) renders cleanly

## Browser check

Browser check: not applicable — the change only swaps the origin of static asset responses; rendered output and JS behavior are byte-identical to current. Will verify post-deploy via the test plan above before considering shipped.

## Changelog

No entry — internal infrastructure change. Users see the same site; only the CDN endpoint for static files changes, which is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782225480&installation_id=132681956&pr_number=2731&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2731&signature=68764ff278b354d31e62774f0674880ca4b2b8c2b50d68c5200356f859dc7795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->