### PR TITLE
fix: allow DO Spaces CDN in CSP script-src (HOTFIX — site down)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="Content-Security-Policy"
-    content="script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com https://www.youtube.com https://www.youtube-nocookie.com; img-src 'self' data: blob: https:;">
+    content="script-src 'self' 'unsafe-inline' https://*.digitaloceanspaces.com https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com https://www.youtube.com https://www.youtube-nocookie.com; img-src 'self' data: blob: https:;">
   <link rel="apple-touch-icon" href="/logo192.png" />
   <!--
       Notice the use of  in the tags above.


### PR DESCRIPTION
## HOTFIX — production is currently down (white page)

After #2731 merged and deployed, every page returns a white screen. Browser console shows:

> Loading the script '<url>' violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline' …"

The Vite-emitted `<script src="https://2anki-assets.fra1.cdn.digitaloceanspaces.com/...">` is blocked by the CSP meta tag in \`web/index.html\` because it only allowed analytics + ad-tech origins.

## Fix

Add \`https://*.digitaloceanspaces.com\` to \`script-src\` in \`web/index.html\`. Wildcard so any future Spaces region works without another CSP change.

## Why minimal

Only \`script-src\` is touched. \`style-src\`, \`font-src\`, \`connect-src\` are not introduced — they were previously unset in this CSP, which means unrestricted under spec. Adding them now risks blocking other currently-working things.

## Browser check

Browser check: not applicable — emergency hotfix to restore the site. Will verify by loading https://2anki.net/ in a browser the moment this lands and the deploy completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782228005&installation_id=132681956&pr_number=2732&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2732&signature=3a56afb4ee3f96042e836e6476ba29a2cbd49b116e26c0eaa4409e5a317b8448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->