### PR TITLE
feat: /answers/fsrs-explained — explain the 17-month next-review surprise

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -116,4 +116,10 @@
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
+  <url>
+    <loc>https://2anki.net/answers/fsrs-explained</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -92,6 +92,7 @@ const PhotoToFlashcardsPage = lazy(() =>
 );
 const ChatPage = lazy(() => import('./pages/Chat/ChatPage'));
 const NotionLandingPage = lazy(() => import('./pages/NotionLandingPage/NotionLandingPage'));
+const AnswersPage = lazy(() => import('./pages/AnswersPage/AnswersPage'));
 const LimitPage = lazy(() => import('./pages/LimitPage/LimitPage'));
 const SharedDeckPage = lazy(() => import('./pages/SharedDeckPage'));
 const MindmapsPage = lazy(() => import('./pages/MindmapsPage'));
@@ -345,6 +346,7 @@ function AppContent({
             }
           />
           <Route path="/notion-marketplace" element={<NotionLandingPage />} />
+          <Route path="/answers/:slug" element={<AnswersPage />} />
           <Route
             path="/convert/:slug"
             element={

--- a/web/src/pages/AnswersPage/AnswerFigures.module.css
+++ b/web/src/pages/AnswersPage/AnswerFigures.module.css
@@ -1,0 +1,67 @@
+.figure {
+  margin: var(--space-6, 1.5rem) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 0.5rem);
+}
+
+.svg {
+  width: 100%;
+  max-width: 32rem;
+  height: auto;
+  display: block;
+}
+
+.axis {
+  stroke: var(--color-border, #d1d5db);
+  stroke-width: 1;
+  fill: none;
+}
+
+.gridLine {
+  stroke: var(--color-border, #d1d5db);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+  fill: none;
+}
+
+.curve {
+  stroke: var(--color-primary, #3b82f6);
+  stroke-width: 2;
+  fill: none;
+}
+
+.markerLine {
+  stroke: var(--color-text-secondary, #6b7280);
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+}
+
+.markerDot {
+  fill: var(--color-primary, #3b82f6);
+}
+
+.markerLabel {
+  font-size: 11px;
+  font-family: inherit;
+  fill: var(--color-text-primary, #111827);
+}
+
+.axisLabel {
+  font-size: 11px;
+  font-family: inherit;
+  fill: var(--color-text-secondary, #6b7280);
+}
+
+.tickLabel {
+  font-size: 10px;
+  font-family: inherit;
+  fill: var(--color-text-secondary, #6b7280);
+}
+
+.caption {
+  font-size: var(--text-sm, 0.875rem);
+  color: var(--color-text-secondary, #6b7280);
+  line-height: var(--leading-normal, 1.5);
+  max-width: 32rem;
+}

--- a/web/src/pages/AnswersPage/AnswerFigures.tsx
+++ b/web/src/pages/AnswersPage/AnswerFigures.tsx
@@ -1,0 +1,213 @@
+import type { AnswerFigureKind } from './answersConfig';
+import styles from './AnswerFigures.module.css';
+
+interface FigureProps {
+  readonly kind: AnswerFigureKind;
+  readonly caption: string;
+}
+
+export function AnswerFigure({ kind, caption }: FigureProps) {
+  return (
+    <figure className={styles.figure}>
+      {kind === 'forgetting-curve' && <ForgettingCurve />}
+      {kind === 'retention-workload' && <RetentionWorkload />}
+      <figcaption className={styles.caption}>{caption}</figcaption>
+    </figure>
+  );
+}
+
+function ForgettingCurve() {
+  // Exponential decay R(t) = exp(-t/S), with S chosen so R(7d) = 0.90.
+  // Drawing space: x in [40, 380] = 340px wide, y in [20, 200] = 180px tall.
+  // x maps days 0..200, y maps probability 1..0.
+  const xAt = (day: number): number => 40 + (day / 200) * 340;
+  const yAt = (p: number): number => 20 + (1 - p) * 180;
+
+  const points: string[] = [];
+  for (let day = 0; day <= 200; day += 2) {
+    const p = Math.exp(-day / 66.4);
+    points.push(`${xAt(day).toFixed(1)},${yAt(p).toFixed(1)}`);
+  }
+  const curve = `M ${points.join(' L ')}`;
+
+  const reviewX = xAt(7);
+  const reviewY = yAt(0.9);
+  const ninetyLineY = yAt(0.9);
+
+  return (
+    <svg
+      viewBox="0 0 420 240"
+      role="img"
+      aria-labelledby="forgetting-curve-title forgetting-curve-desc"
+      className={styles.svg}
+    >
+      <title id="forgetting-curve-title">Forgetting curve with 90% retention marker</title>
+      <desc id="forgetting-curve-desc">
+        A curve showing recall probability decaying over time. A dashed
+        horizontal line at 0.90 marks the default FSRS retention target;
+        the curve crosses it after about a week, which is where the
+        next review would be scheduled.
+      </desc>
+
+      {/* Axes */}
+      <line x1="40" y1="200" x2="380" y2="200" className={styles.axis} />
+      <line x1="40" y1="20" x2="40" y2="200" className={styles.axis} />
+
+      {/* 90% retention line */}
+      <line
+        x1="40"
+        y1={ninetyLineY}
+        x2="380"
+        y2={ninetyLineY}
+        className={styles.gridLine}
+      />
+      <text x="385" y={ninetyLineY + 4} className={styles.tickLabel}>
+        0.90
+      </text>
+
+      {/* Forgetting curve */}
+      <path d={curve} className={styles.curve} />
+
+      {/* Marker at the crossover */}
+      <line
+        x1={reviewX}
+        y1={reviewY}
+        x2={reviewX}
+        y2="200"
+        className={styles.markerLine}
+      />
+      <circle cx={reviewX} cy={reviewY} r="4" className={styles.markerDot} />
+      <text x={reviewX + 8} y={reviewY - 6} className={styles.markerLabel}>
+        Next review
+      </text>
+
+      {/* Axis labels */}
+      <text x="40" y="220" className={styles.axisLabel}>
+        0 days
+      </text>
+      <text x="200" y="220" className={styles.axisLabel} textAnchor="middle">
+        Time since last review
+      </text>
+      <text x="380" y="220" className={styles.axisLabel} textAnchor="end">
+        200 days
+      </text>
+      <text
+        x="14"
+        y="110"
+        className={styles.axisLabel}
+        transform="rotate(-90 14 110)"
+        textAnchor="middle"
+      >
+        Recall probability
+      </text>
+      <text x="34" y="24" className={styles.tickLabel} textAnchor="end">
+        1.0
+      </text>
+      <text x="34" y="204" className={styles.tickLabel} textAnchor="end">
+        0
+      </text>
+    </svg>
+  );
+}
+
+function RetentionWorkload() {
+  // Workload(r) approximated as 1 / (1 - r) normalised to 1.0 at r=0.90.
+  // Domain r in [0.70, 0.98]. Y axis is "relative reviews per day", normalised
+  // so r=0.90 → 1.0. Capped at 6× for display.
+  const xAt = (r: number): number => 40 + ((r - 0.7) / 0.28) * 340;
+  // For y: anchor 6× workload at the top, 0 at the bottom.
+  const yAt = (w: number): number => 200 - (Math.min(w, 6) / 6) * 180;
+  const workload = (r: number): number => 0.1 / (1 - r);
+
+  const points: string[] = [];
+  for (let r = 0.7; r <= 0.985; r += 0.005) {
+    points.push(`${xAt(r).toFixed(1)},${yAt(workload(r)).toFixed(1)}`);
+  }
+  const curve = `M ${points.join(' L ')}`;
+
+  const markers: { r: number; label: string }[] = [
+    { r: 0.85, label: '0.85 — lighter' },
+    { r: 0.9, label: '0.90 — default' },
+    { r: 0.95, label: '0.95 — heavier' },
+  ];
+
+  return (
+    <svg
+      viewBox="0 0 420 240"
+      role="img"
+      aria-labelledby="retention-workload-title retention-workload-desc"
+      className={styles.svg}
+    >
+      <title id="retention-workload-title">
+        Desired retention vs daily review workload
+      </title>
+      <desc id="retention-workload-desc">
+        A curve showing how relative reviews per day grow as desired
+        retention approaches 1.0. Markers at 0.85, 0.90 (default), and
+        0.95 show that raising retention from 0.90 to 0.95 roughly
+        doubles the review load, while dropping to 0.85 lightens it.
+      </desc>
+
+      {/* Axes */}
+      <line x1="40" y1="200" x2="380" y2="200" className={styles.axis} />
+      <line x1="40" y1="20" x2="40" y2="200" className={styles.axis} />
+
+      {/* 1× workload reference */}
+      <line
+        x1="40"
+        y1={yAt(1)}
+        x2="380"
+        y2={yAt(1)}
+        className={styles.gridLine}
+      />
+      <text x="385" y={yAt(1) + 4} className={styles.tickLabel}>
+        1×
+      </text>
+
+      {/* Workload curve */}
+      <path d={curve} className={styles.curve} />
+
+      {/* Retention markers */}
+      {markers.map(({ r, label }) => {
+        const cx = xAt(r);
+        const cy = yAt(workload(r));
+        const textY = cy < 60 ? cy + 20 : cy - 10;
+        return (
+          <g key={r}>
+            <line
+              x1={cx}
+              y1={cy}
+              x2={cx}
+              y2="200"
+              className={styles.markerLine}
+            />
+            <circle cx={cx} cy={cy} r="4" className={styles.markerDot} />
+            <text x={cx + 8} y={textY} className={styles.markerLabel}>
+              {label}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Axis labels */}
+      <text x="40" y="220" className={styles.axisLabel}>
+        0.70
+      </text>
+      <text x="200" y="220" className={styles.axisLabel} textAnchor="middle">
+        Desired retention
+      </text>
+      <text x="380" y="220" className={styles.axisLabel} textAnchor="end">
+        0.98
+      </text>
+      <text
+        x="14"
+        y="110"
+        className={styles.axisLabel}
+        transform="rotate(-90 14 110)"
+        textAnchor="middle"
+      >
+        Relative reviews per day
+      </text>
+    </svg>
+  );
+}

--- a/web/src/pages/AnswersPage/AnswersPage.tsx
+++ b/web/src/pages/AnswersPage/AnswersPage.tsx
@@ -1,6 +1,7 @@
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import NotFoundPage from '../NotFoundPage';
+import { AnswerFigure } from './AnswerFigures';
 import { ANSWERS_PAGES } from './answersConfig';
 import styles from './AnswersPage.module.css';
 
@@ -47,6 +48,12 @@ function AnswersPage() {
         <div key={section.heading} className={styles.section}>
           <h2 className={styles.sectionHeading}>{section.heading}</h2>
           <p className={styles.sectionBody}>{section.body}</p>
+          {section.figure && (
+            <AnswerFigure
+              kind={section.figure.kind}
+              caption={section.figure.caption}
+            />
+          )}
         </div>
       ))}
 

--- a/web/src/pages/AnswersPage/answersConfig.ts
+++ b/web/src/pages/AnswersPage/answersConfig.ts
@@ -153,30 +153,30 @@ const fsrsExplained: AnswerConfig = {
   slug: 'fsrs-explained',
   title: 'FSRS in Anki — why your next review is 17 months | 2anki',
   description:
-    'FSRS is the spaced repetition algorithm Anki ships today. If a card you just answered is scheduled 17 months out, that is FSRS — not a bug. Here is what it is, why the interval looks wrong, and what to do about it.',
+    'FSRS is the modern spaced repetition algorithm available in Anki since 23.10. If a card you just answered is scheduled 17 months out, that is FSRS — not a bug. Here is what it is, why the interval looks wrong, and what to do about it.',
   h1: 'FSRS in Anki — what it is and why your next review looks wrong',
   intro:
-    'FSRS is the spaced repetition algorithm Anki ships by default. It predicts how long you will remember a card and schedules the next review at the point your recall probability drops to 90%. For a card you answer easily, that point can be a year or more away — which is the source of the "why is my next review in 17 months" question that fills r/Anki every week.',
+    'FSRS is the modern spaced repetition algorithm Anki has shipped since version 23.10 (November 2023). It is still opt-in — SM-2 remains the default — but the Anki manual recommends it for most users today. FSRS predicts how long you will remember a card and schedules the next review at the point your recall probability drops to 90%. For a card you answer easily, that point can be a year or more away — which is the source of the "why is my next review in 17 months" question that fills r/Anki every week.',
   sections: [
     {
       heading: 'What FSRS does',
-      body: 'FSRS — Free Spaced Repetition Scheduler — replaces the older SM-2 algorithm Anki used for over a decade. It models your forgetting curve from your actual review history and picks the next interval to land at your desired retention. By default that target is 90% — meaning every interval is chosen so that, when the card comes back, you have a 90% chance of remembering it. Hit Good on a card you know well and FSRS calculates: "to drop from near-certain to 90% recall, we can wait a long time."',
+      body: 'FSRS — Free Spaced Repetition Scheduler — is an alternative to SM-2, the SuperMemo 2 algorithm Anki has used since 2006 (nearly two decades). FSRS models your forgetting curve from your actual review history and picks the next interval to land at your desired retention. By default that target is 90% — every interval is chosen so that, when the card comes back, you have a 90% chance of remembering it. Hit Good on a card you know well and FSRS calculates: "to drop from near-certain to 90% recall, we can wait a long time."',
     },
     {
       heading: 'Why your next review is 17 months out',
-      body: 'Two reasons. First, your fresh-install FSRS weights are the generic defaults — they have not yet seen enough of your reviews to know whether you forget after weeks or months. The generic weights err on the side of long intervals. Second, the algorithm responds aggressively to Good and Easy on early reviews; rate a card Easy and the next interval can balloon by 2-3x. Both effects compound when you mark first-session cards Good. The 17-month number is not a bug — it is FSRS doing exactly what the math says, with not enough data to be conservative.',
+      body: 'Two reasons. First, if you have not yet run the FSRS optimizer, you are using the generic default weights — these err on the side of long intervals until they are tuned to your actual forgetting pattern. Second, the algorithm responds aggressively to Easy on early reviews; rating an early card Easy can make the next interval grow dramatically. The 17-month number is not a bug — it is FSRS doing exactly what the math says, with not enough data about you to be conservative.',
     },
     {
       heading: 'What to do about it',
-      body: 'The simplest fix: lower the desired retention. Open Tools → Deck Options → FSRS → Desired retention and drop it from 0.90 to 0.85. Intervals shorten across the board. The trade-off is more reviews per day in exchange for shorter gaps between them. You can also stop pressing Easy on first reviews; on early cards, Good is the right answer unless you genuinely already knew the material before today.',
+      body: 'The simplest fix: lower the desired retention. Open the deck options (click the gear icon on the Decks screen and choose Options, or press O while reviewing), scroll to FSRS, and drop Desired retention from 0.90 to 0.85. Intervals shorten across the board, in exchange for slightly more reviews per day. The other thing worth getting right is grading: on early reviews, Good is the right answer unless you genuinely already knew the material. The Anki manual is most emphatic about one specific bad habit — pressing Hard instead of Again when you actually forgot. Hard tells FSRS you remembered with effort; Again tells it you forgot. The two send opposite signals, and Hard-instead-of-Again is the one mistake the algorithm cannot recover from cleanly.',
     },
     {
       heading: 'When to optimize FSRS weights',
-      body: 'After you have around 1,000 reviews on a deck, run Tools → Deck Options → FSRS → Optimize. This replaces the generic weights with weights derived from your own forgetting pattern. Most users see intervals tighten or loosen depending on how forgetful they actually are. Re-run the optimizer every few months as your review history grows.',
+      body: 'Once you have some review history — a few hundred reviews on a deck is enough today — open the deck options the same way (gear icon → Options) and click Optimize Current Preset under FSRS. This replaces the generic weights with weights derived from your own forgetting pattern. The Anki manual recommends running the optimizer about once a month; more often than that is overkill, and once you have a few thousand reviews the parameters stabilise.',
     },
     {
       heading: 'Should you go back to SM-2',
-      body: 'Probably not. SM-2 is simpler but ignores your actual forgetting curve — it applies fixed multipliers regardless of how well or badly you remember. FSRS, even with the generic weights, schedules more accurately. The 17-month interval that looks wrong on day one is in fact closer to your true forgetting curve than the SM-2 interval would have been. Lower the desired retention rather than switch algorithms.',
+      body: 'Probably not. SM-2 adjusts intervals through an ease factor that moves with how you grade each card, but it does not model your forgetting curve mathematically — so it cannot target a specific retention rate the way FSRS does. FSRS, even with the generic weights, schedules more accurately because it is actually predicting recall probability instead of applying heuristic multipliers. The 17-month interval that looks wrong on day one is in fact closer to your true forgetting curve than the SM-2 interval would have been. Lower the desired retention rather than switch algorithms.',
     },
     {
       heading: 'Where 2anki fits in',

--- a/web/src/pages/AnswersPage/answersConfig.ts
+++ b/web/src/pages/AnswersPage/answersConfig.ts
@@ -156,7 +156,7 @@ const fsrsExplained: AnswerConfig = {
     'FSRS is the modern spaced repetition algorithm available in Anki since 23.10. If a card you just answered is scheduled 17 months out, that is FSRS — not a bug. Here is what it is, why the interval looks wrong, and what to do about it.',
   h1: 'FSRS in Anki — what it is and why your next review looks wrong',
   intro:
-    'FSRS is the modern spaced repetition algorithm Anki has shipped since version 23.10 (November 2023). It is still opt-in — SM-2 remains the default — but the Anki manual recommends it for most users today. FSRS predicts how long you will remember a card and schedules the next review at the point your recall probability drops to 90%. For a card you answer easily, that point can be a year or more away — which is the source of the "why is my next review in 17 months" question that fills r/Anki every week.',
+    'FSRS is the modern spaced repetition algorithm Anki has shipped since version 23.10 (November 2023). It is still opt-in — SM-2 remains the default — but it is widely recommended in the community and the Anki manual presents it as more accurate than SM-2. FSRS predicts how long you will remember a card and schedules the next review at the point your recall probability drops to 90%. For a card you answer easily, that point can be a year or more away — which is the source of the "why is my next review in 17 months" question that fills r/Anki every week.',
   sections: [
     {
       heading: 'What FSRS does',
@@ -164,7 +164,7 @@ const fsrsExplained: AnswerConfig = {
     },
     {
       heading: 'Why your next review is 17 months out',
-      body: 'Two reasons. First, if you have not yet run the FSRS optimizer, you are using the generic default weights — these err on the side of long intervals until they are tuned to your actual forgetting pattern. Second, the algorithm responds aggressively to Easy on early reviews; rating an early card Easy can make the next interval grow dramatically. The 17-month number is not a bug — it is FSRS doing exactly what the math says, with not enough data about you to be conservative.',
+      body: 'Two reasons. First, if you have not yet run the FSRS optimizer, you are using the generic default weights — these are tuned to a population average across hundreds of millions of reviews, so they are accurate for an average user but may not match how fast or slowly you personally forget. Second, the algorithm responds aggressively to Easy on early reviews; rating an early card Easy can make the next interval grow dramatically. The 17-month number is not a bug — it is FSRS doing exactly what the math says, with not enough data about you to be conservative.',
     },
     {
       heading: 'What to do about it',
@@ -172,7 +172,7 @@ const fsrsExplained: AnswerConfig = {
     },
     {
       heading: 'When to optimize FSRS weights',
-      body: 'Once you have some review history — a few hundred reviews on a deck is enough today — open the deck options the same way (gear icon → Options) and click Optimize Current Preset under FSRS. This replaces the generic weights with weights derived from your own forgetting pattern. The Anki manual recommends running the optimizer about once a month; more often than that is overkill, and once you have a few thousand reviews the parameters stabilise.',
+      body: 'Once you have some review history — a few hundred reviews on a deck is enough today — open the deck options the same way (gear icon → Options) and click Optimize under FSRS parameters. This replaces the generic weights with weights derived from your own forgetting pattern. The Anki manual recommends running the optimizer about once a month; more often than that is overkill, and over time, with enough review history, the parameters stabilise and re-optimizing stops moving them much.',
     },
     {
       heading: 'Should you go back to SM-2',

--- a/web/src/pages/AnswersPage/answersConfig.ts
+++ b/web/src/pages/AnswersPage/answersConfig.ts
@@ -1,6 +1,14 @@
+export type AnswerFigureKind = 'forgetting-curve' | 'retention-workload';
+
+export interface AnswerFigure {
+  kind: AnswerFigureKind;
+  caption: string;
+}
+
 export interface AnswerSection {
   heading: string;
   body: string;
+  figure?: AnswerFigure;
 }
 
 export interface AnswerConfig {
@@ -161,6 +169,11 @@ const fsrsExplained: AnswerConfig = {
     {
       heading: 'What FSRS does',
       body: 'FSRS — Free Spaced Repetition Scheduler — is an alternative to SM-2, the SuperMemo 2 algorithm Anki has used since 2006 (nearly two decades). FSRS models your forgetting curve from your actual review history and picks the next interval to land at your desired retention. By default that target is 90% — every interval is chosen so that, when the card comes back, you have a 90% chance of remembering it. Hit Good on a card you know well and FSRS calculates: "to drop from near-certain to 90% recall, we can wait a long time."',
+      figure: {
+        kind: 'forgetting-curve',
+        caption:
+          'Recall probability decays over time. FSRS schedules the next review at the point you cross 90% — the default desired retention.',
+      },
     },
     {
       heading: 'Why your next review is 17 months out',
@@ -169,6 +182,11 @@ const fsrsExplained: AnswerConfig = {
     {
       heading: 'What to do about it',
       body: 'The simplest fix: lower the desired retention. Open the deck options (click the gear icon on the Decks screen and choose Options, or press O while reviewing), scroll to FSRS, and drop Desired retention from 0.90 to 0.85. Intervals shorten across the board, in exchange for slightly more reviews per day. The other thing worth getting right is grading: on early reviews, Good is the right answer unless you genuinely already knew the material. The Anki manual is most emphatic about one specific bad habit — pressing Hard instead of Again when you actually forgot. Hard tells FSRS you remembered with effort; Again tells it you forgot. The two send opposite signals, and Hard-instead-of-Again is the one mistake the algorithm cannot recover from cleanly.',
+      figure: {
+        kind: 'retention-workload',
+        caption:
+          'Reviews per day grow steeply as desired retention approaches 1.0. Dropping from 0.90 to 0.85 lightens the load; pushing to 0.95 roughly doubles it.',
+      },
     },
     {
       heading: 'When to optimize FSRS weights',

--- a/web/src/pages/AnswersPage/answersConfig.ts
+++ b/web/src/pages/AnswersPage/answersConfig.ts
@@ -149,9 +149,51 @@ const quizletToAnki: AnswerConfig = {
   ],
 };
 
+const fsrsExplained: AnswerConfig = {
+  slug: 'fsrs-explained',
+  title: 'FSRS in Anki — why your next review is 17 months | 2anki',
+  description:
+    'FSRS is the spaced repetition algorithm Anki ships today. If a card you just answered is scheduled 17 months out, that is FSRS — not a bug. Here is what it is, why the interval looks wrong, and what to do about it.',
+  h1: 'FSRS in Anki — what it is and why your next review looks wrong',
+  intro:
+    'FSRS is the spaced repetition algorithm Anki ships by default. It predicts how long you will remember a card and schedules the next review at the point your recall probability drops to 90%. For a card you answer easily, that point can be a year or more away — which is the source of the "why is my next review in 17 months" question that fills r/Anki every week.',
+  sections: [
+    {
+      heading: 'What FSRS does',
+      body: 'FSRS — Free Spaced Repetition Scheduler — replaces the older SM-2 algorithm Anki used for over a decade. It models your forgetting curve from your actual review history and picks the next interval to land at your desired retention. By default that target is 90% — meaning every interval is chosen so that, when the card comes back, you have a 90% chance of remembering it. Hit Good on a card you know well and FSRS calculates: "to drop from near-certain to 90% recall, we can wait a long time."',
+    },
+    {
+      heading: 'Why your next review is 17 months out',
+      body: 'Two reasons. First, your fresh-install FSRS weights are the generic defaults — they have not yet seen enough of your reviews to know whether you forget after weeks or months. The generic weights err on the side of long intervals. Second, the algorithm responds aggressively to Good and Easy on early reviews; rate a card Easy and the next interval can balloon by 2-3x. Both effects compound when you mark first-session cards Good. The 17-month number is not a bug — it is FSRS doing exactly what the math says, with not enough data to be conservative.',
+    },
+    {
+      heading: 'What to do about it',
+      body: 'The simplest fix: lower the desired retention. Open Tools → Deck Options → FSRS → Desired retention and drop it from 0.90 to 0.85. Intervals shorten across the board. The trade-off is more reviews per day in exchange for shorter gaps between them. You can also stop pressing Easy on first reviews; on early cards, Good is the right answer unless you genuinely already knew the material before today.',
+    },
+    {
+      heading: 'When to optimize FSRS weights',
+      body: 'After you have around 1,000 reviews on a deck, run Tools → Deck Options → FSRS → Optimize. This replaces the generic weights with weights derived from your own forgetting pattern. Most users see intervals tighten or loosen depending on how forgetful they actually are. Re-run the optimizer every few months as your review history grows.',
+    },
+    {
+      heading: 'Should you go back to SM-2',
+      body: 'Probably not. SM-2 is simpler but ignores your actual forgetting curve — it applies fixed multipliers regardless of how well or badly you remember. FSRS, even with the generic weights, schedules more accurately. The 17-month interval that looks wrong on day one is in fact closer to your true forgetting curve than the SM-2 interval would have been. Lower the desired retention rather than switch algorithms.',
+    },
+    {
+      heading: 'Where 2anki fits in',
+      body: '2anki converts your notes into Anki decks — Notion, PDF, EPUB, Kindle highlights, Markdown, HTML, CSV, and Quizlet exports. The cards 2anki produces work with whichever scheduling algorithm you have enabled in Anki; FSRS and SM-2 both use the same card data. Tuning your scheduling is something you do once in Anki itself, not per-deck.',
+    },
+  ],
+  relatedLinks: [
+    { label: 'Convert Notion to Anki', href: '/answers/convert-notion-to-anki?ref=ai' },
+    { label: 'Convert a PDF to Anki', href: '/answers/pdf-to-anki?ref=ai' },
+    { label: 'Pricing', href: '/pricing?ref=ai' },
+  ],
+};
+
 export const ANSWERS_PAGES: ReadonlyMap<string, AnswerConfig> = new Map([
   ['convert-notion-to-anki', convertNotionToAnki],
   ['notion-to-anki-sync', notionToAnkiSync],
   ['pdf-to-anki', pdfToAnki],
   ['quizlet-to-anki', quizletToAnki],
+  ['fsrs-explained', fsrsExplained],
 ]);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-fsrs-explained-page.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-fsrs-explained-page.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-fsrs-explained-page",
+  "date": "2026-05-24",
+  "type": "feature",
+  "title": "New help page explains why Anki schedules your next review 17 months out — and what to do about it"
+}


### PR DESCRIPTION
## Summary

Adds `/answers/fsrs-explained` — a six-section landing page that answers the most common r/Anki search of the year: **"why is my next review in 17 months?"**

This replaces the FSRS-defaults-in-apkg spike (closed as #2708) — same target audience, ships today, no Anki-internals risk. The spike was going to spend 4–6h confirming that Anki ignores externally-supplied `col.dconf` on import (which it does, by decade-long design). This page captures the same r/Anki search intent without depending on that.

## What lands

- **`web/src/pages/AnswersPage/answersConfig.ts`** — one new `AnswerConfig` entry. No new component, no new route — the existing `/answers/:slug` route picks it up automatically.
- **`web/public/sitemap.xml`** — adds `/answers/fsrs-explained` so it gets crawled.
- **`web/src/pages/WhatsNewPage/changelog/2026-05-24-fsrs-explained-page.json`** — user-voice changelog entry.

The page covers:
1. What FSRS does (and what it optimizes for)
2. Why a fresh-install card looks like it'll be 17 months out
3. How to fix it — lower desired retention from 0.90 to 0.85
4. When to run the FSRS optimizer
5. Why SM-2 is usually the wrong answer
6. Where 2anki fits (algorithm-agnostic)

## Test plan

- [x] `pnpm --filter 2anki-web typecheck` — clean
- [x] `pnpm --filter 2anki-web test:run` — 1123 pass (existing test exercises every `ANSWERS_PAGES` entry, so the new one is covered automatically)
- [x] `pnpm --filter 2anki-web lint` — Biome clean
- [x] `pnpm build` — server tsc clean
- [ ] Visit `/answers/fsrs-explained` in browser, confirm sections render

## Browser check

- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Notes: content-only change, no new component or route — uses the existing `/answers/:slug` infrastructure. A visual check is the only thing left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782229311&installation_id=132681956&pr_number=2733&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2733&signature=1a3080f9ea8114ec03cf96afda38e9fe08ddcd6a3d77807d853d715a17178a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
