### PR TITLE
chore: graceful shutdown drains HTTP, workers, and DB before exit

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -9,6 +9,9 @@ module.exports = {
       watch: false,
       max_restarts: 10,
       min_uptime: '60s',
+      // Window for src/server.ts graceful shutdown to drain HTTP, Piscina,
+      // and Knex before pm2 escalates to SIGKILL.
+      kill_timeout: 30000,
       node_args: '--max-old-space-size=16384',
       env: {
         NODE_ENV: 'production',

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -61,11 +61,28 @@ export async function runConversion(
   await getConversionPool().run(request);
 }
 
-export async function shutdownConversionPool(): Promise<void> {
+export async function shutdownConversionPool(
+  options: { timeoutMs?: number } = {}
+): Promise<void> {
   if (!pool) return;
   const handle = pool;
   pool = null;
-  await handle.destroy();
+  const drain = handle.close();
+  if (options.timeoutMs == null) {
+    await drain;
+    return;
+  }
+  const timeout = new Promise<'timeout'>((resolve) => {
+    const t = setTimeout(() => resolve('timeout'), options.timeoutMs);
+    t.unref();
+  });
+  const winner = await Promise.race([drain.then(() => 'drained' as const), timeout]);
+  if (winner === 'timeout') {
+    console.error(
+      `Conversion pool did not drain within ${options.timeoutMs}ms — forcing destroy`
+    );
+    await handle.destroy();
+  }
 }
 
 let workerKnex: Knex | null = null;

--- a/src/lib/gracefulShutdown.test.ts
+++ b/src/lib/gracefulShutdown.test.ts
@@ -1,0 +1,140 @@
+jest.mock('./conversionPool', () => ({
+  __esModule: true,
+  shutdownConversionPool: jest.fn(),
+}));
+
+import type http from 'http';
+import type { Knex } from 'knex';
+import { shutdownConversionPool } from './conversionPool';
+import {
+  gracefulShutdown,
+  POOL_DRAIN_TIMEOUT_MS,
+  SHUTDOWN_TIMEOUT_MS,
+  resetGracefulShutdownStateForTesting,
+} from './gracefulShutdown';
+
+function fakeServer(): {
+  server: http.Server;
+  calls: { close: number; idle: number };
+} {
+  const calls = { close: 0, idle: 0 };
+  const server = {
+    close: (cb?: () => void) => {
+      calls.close += 1;
+      if (cb) cb();
+      return server;
+    },
+    closeIdleConnections: () => {
+      calls.idle += 1;
+    },
+  } as unknown as http.Server;
+  return { server, calls };
+}
+
+function fakeDatabase(overrides: { destroy?: () => Promise<void> } = {}): {
+  db: Knex;
+  destroyCalls: { count: number };
+} {
+  const destroyCalls = { count: 0 };
+  const db = {
+    destroy:
+      overrides.destroy ??
+      (() => {
+        destroyCalls.count += 1;
+        return Promise.resolve();
+      }),
+  } as unknown as Knex;
+  return { db, destroyCalls };
+}
+
+describe('gracefulShutdown', () => {
+  let exitSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+  const drainMock = shutdownConversionPool as jest.Mock;
+
+  beforeEach(() => {
+    drainMock.mockReset();
+    drainMock.mockResolvedValue(undefined);
+    resetGracefulShutdownStateForTesting();
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('drains HTTP, conversion pool, and DB pool, then exits 0', async () => {
+    const { server, calls } = fakeServer();
+    const { db, destroyCalls } = fakeDatabase();
+
+    await gracefulShutdown('SIGTERM', server, db);
+
+    expect(calls.idle).toBe(1);
+    expect(calls.close).toBe(1);
+    expect(drainMock).toHaveBeenCalledWith({
+      timeoutMs: POOL_DRAIN_TIMEOUT_MS,
+    });
+    expect(destroyCalls.count).toBe(1);
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('still exits 0 if the conversion pool drain throws', async () => {
+    drainMock.mockRejectedValue(new Error('drain failed'));
+    const { server } = fakeServer();
+    const { db } = fakeDatabase();
+
+    await gracefulShutdown('SIGINT', server, db);
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Conversion pool drain failed:',
+      expect.any(Error)
+    );
+  });
+
+  it('still exits 0 if database.destroy throws', async () => {
+    const { server } = fakeServer();
+    const { db } = fakeDatabase({
+      destroy: () => Promise.reject(new Error('pool teardown failed')),
+    });
+
+    await gracefulShutdown('SIGINT', server, db);
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Database pool teardown failed:',
+      expect.any(Error)
+    );
+  });
+
+  it('is idempotent — a second signal during drain is a no-op', async () => {
+    let release: (() => void) | null = null;
+    drainMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      })
+    );
+    const { server } = fakeServer();
+    const { db } = fakeDatabase();
+
+    const first = gracefulShutdown('SIGTERM', server, db);
+    const second = gracefulShutdown('SIGINT', server, db);
+
+    release!();
+    await Promise.all([first, second]);
+
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(drainMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains the pool with a budget below the hard shutdown ceiling', () => {
+    expect(POOL_DRAIN_TIMEOUT_MS).toBeLessThan(SHUTDOWN_TIMEOUT_MS);
+  });
+});

--- a/src/lib/gracefulShutdown.ts
+++ b/src/lib/gracefulShutdown.ts
@@ -1,0 +1,52 @@
+import type http from 'http';
+import type { Knex } from 'knex';
+import { shutdownConversionPool } from './conversionPool';
+
+// pm2 sends SIGINT then escalates to SIGKILL after kill_timeout (set to
+// 30s in ecosystem.config.js). Reserve a safety margin so process.exit
+// fires before pm2's SIGKILL lands.
+export const SHUTDOWN_TIMEOUT_MS = 25_000;
+export const POOL_DRAIN_TIMEOUT_MS = 20_000;
+
+let shuttingDown = false;
+
+export function resetGracefulShutdownStateForTesting(): void {
+  shuttingDown = false;
+}
+
+export async function gracefulShutdown(
+  signal: string,
+  server: http.Server,
+  database: Knex
+): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.info(`${signal} received — draining HTTP, conversion pool, DB pool`);
+
+  const hardExit = setTimeout(() => {
+    console.error(
+      `Graceful shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms — forcing exit`
+    );
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  hardExit.unref();
+
+  server.closeIdleConnections?.();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+
+  try {
+    await shutdownConversionPool({ timeoutMs: POOL_DRAIN_TIMEOUT_MS });
+  } catch (err) {
+    console.error('Conversion pool drain failed:', err);
+  }
+
+  try {
+    await database.destroy();
+  } catch (err) {
+    console.error('Database pool teardown failed:', err);
+  }
+
+  clearTimeout(hardExit);
+  console.info(`${signal} drain complete — exiting cleanly`);
+  process.exit(0);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import express, { RequestHandler } from 'express';
 import cookieParser from 'cookie-parser';
 import * as dotenv from 'dotenv';
 import morgan from 'morgan';
+import type { Knex } from 'knex';
 
 const localEnvFile = path.join(__dirname, '../.env');
 if (existsSync(localEnvFile)) {
@@ -73,12 +74,10 @@ import { scheduleInactivityWarnings } from './lib/inactivity/jobs/scheduleInacti
 import { scheduleParserCanary } from './lib/parser/canary/scheduleParserCanary';
 import { getDefaultEmailService } from './services/EmailService/EmailService';
 import { SendInactivityWarningsUseCase } from './usecases/ops/SendInactivityWarningsUseCase';
-import {
-  initConversionPool,
-  shutdownConversionPool,
-} from './lib/conversionPool';
+import { initConversionPool } from './lib/conversionPool';
+import { gracefulShutdown } from './lib/gracefulShutdown';
 
-function registerSignalHandlers(server: http.Server) {
+function registerSignalHandlers(server: http.Server, database: Knex) {
   process.on('uncaughtException', (error) => {
     writeFallbackError({
       source: 'server',
@@ -104,17 +103,14 @@ function registerSignalHandlers(server: http.Server) {
     process.exit(1);
   });
 
-  const drainAndClose = (signal: string) => {
-    console.debug(`${signal} signal received: closing HTTP server`);
-    server.close(() => {
-      console.debug('HTTP server closed');
-    });
-    shutdownConversionPool().catch((err) => {
-      console.error('Conversion pool shutdown failed:', err);
+  const handle = (signal: 'SIGTERM' | 'SIGINT') => {
+    gracefulShutdown(signal, server, database).catch((err) => {
+      console.error('gracefulShutdown threw, forcing exit:', err);
+      process.exit(1);
     });
   };
-  process.on('SIGTERM', () => drainAndClose('SIGTERM'));
-  process.on('SIGINT', () => drainAndClose('SIGINT'));
+  process.on('SIGTERM', () => handle('SIGTERM'));
+  process.on('SIGINT', () => handle('SIGINT'));
 }
 
 const serve = async () => {
@@ -215,7 +211,7 @@ const serve = async () => {
   server.listen(port, () => {
     console.info(`Running on http://localhost:${port}`);
   });
-  registerSignalHandlers(server);
+  registerSignalHandlers(server, database);
 
   await setupDatabase(database);
 


### PR DESCRIPTION
## Summary

Fixes the SIGINT/SIGTERM handler in `src/server.ts` that was supposed to gracefully drain the process during a pm2 restart but in practice never managed to exit cleanly. Every deploy was hitting pm2's `kill_timeout` (default 1600ms) and getting SIGKILLed — visible as `code [0] via signal [SIGKILL]` in `~/.pm2/pm2.log`, ~30 times/day.

## What it does today (broken)

| Surface | Behavior |
|---|---|
| HTTP | `server.close()` called but never awaited; idle keep-alive sockets blocked it |
| Conversion pool | `shutdownConversionPool()` fire-and-forget + Piscina `.destroy()` killed workers immediately |
| DB pool | Never torn down |
| Process exit | Handler never called `process.exit(0)` — the Knex pool kept the event loop alive, pm2 escalated to SIGKILL |
| In-flight HTTP | Cut mid-flight on every deploy |
| In-progress conversions | Worker threads + Python subprocesses died; jobs marked `interrupted` on next boot |

## What it does now

- Re-entrancy guard so a second signal during drain is a no-op
- `server.closeIdleConnections()` drops idle keep-alives so `server.close()` isn't held by them
- `shutdownConversionPool({ timeoutMs: 20_000 })` uses Piscina's `.close()` to drain in-flight tasks, races against `.destroy()` if it doesn't finish in 20s
- `await database.destroy()` closes the Knex pool cleanly
- `process.exit(0)` when drain finishes
- Hard-fail `process.exit(1)` after 25s if anything hangs
- pm2 `kill_timeout` bumped from 1600ms (default) to 30000ms in `ecosystem.config.js` so the OS gives the handler time to run

Shutdown logic lives in its own file (`src/lib/gracefulShutdown.ts`) so it can be unit-tested without dragging `server.ts`'s whole router graph through ts-jest (it pulls in ESM-only `http-proxy-middleware`).

## What this means for users

Mid-flight uploads, conversions, and other in-flight HTTP requests now get up to ~20 seconds to complete during a deploy instead of getting cut. In-progress Notion conversions either finish before the drain window expires (best case) or get the same `interrupted` recovery they get today (status quo).

## Browser check

Not applicable — backend signal-handling change with no rendered output. New unit tests cover the drain, error paths, idempotency, and timeout budget invariants (`src/lib/gracefulShutdown.test.ts`).

## Test plan

- [x] `pnpm test src/lib/` — 85 suites, 661 tests pass
- [x] `pnpm tsc --noEmit` clean
- [ ] After merge: `~/.pm2/pm2.log` should start showing `exited with code [0] via signal [SIGINT]` (or no signal at all) instead of `via signal [SIGKILL]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782229422&installation_id=132681956&pr_number=2734&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2734&signature=237fc791671bcf307430500e02165c30be469df298b702500b8f809b5a655937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->