### PR TITLE
feat: enable sign in with apple for everyone (centered, login mascot)

### DIFF
--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -1,5 +1,4 @@
 import { SyntheticEvent, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import TopMessage from '../TopMessage/TopMessage';
 import { ErrorHandlerType } from '../errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
@@ -26,7 +25,6 @@ function submitLabel(loading: boolean, startTrial: boolean | undefined): string 
 }
 
 function RegisterForm({ setErrorMessage, redirect, startTrial }: Props) {
-  const [searchParams] = useSearchParams();
   const [email, setEmail] = useState(localStorage.getItem('email') || '');
   const [tos, setTos] = useState(false);
   const [password, setPassword] = useState('');
@@ -104,13 +102,11 @@ function RegisterForm({ setErrorMessage, redirect, startTrial }: Props) {
             variant="card"
             text={getVisibleText('navigation.register.google')}
           />
-          {searchParams.get('apple') === 'true' && (
-            <WithAppleLink variant="card" text="Sign in with Apple" />
-          )}
           <WithMicrosoftLink
             variant="card"
             text={getVisibleText('navigation.register.microsoft')}
           />
+          <WithAppleLink variant="card" text="Sign in with Apple" />
         </div>
         <div className={styles.divider}>
           <span className={styles.dividerLabel}>or sign up with email</span>

--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.module.css
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.module.css
@@ -1,6 +1,6 @@
 .mascot {
   display: block;
-  width: 48px;
+  width: 96px;
   height: auto;
   margin: 0 auto 1.5rem;
 }

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -63,7 +63,7 @@ function LoginForm() {
   return (
     <div className={styles.formPage}>
       <img
-        src="/mascot/navbar-logo.png"
+        src="/mascot/Notion 1.png"
         alt=""
         className={loginStyles.mascot}
       />
@@ -137,13 +137,11 @@ function LoginForm() {
                 text={getVisibleText('navigation.login.google')}
               />
               <WithNotionLink variant="card" text="Continue with Notion" />
-              {searchParams.get('apple') === 'true' && (
-                <WithAppleLink variant="card" text="Sign in with Apple" />
-              )}
               <WithMicrosoftLink
                 variant="card"
                 text={getVisibleText('navigation.login.microsoft')}
               />
+              <WithAppleLink variant="card" text="Sign in with Apple" />
             </div>
           </>
         ) : (

--- a/web/src/styles/auth.module.css
+++ b/web/src/styles/auth.module.css
@@ -183,6 +183,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  grid-column: 2;
   min-height: 80px;
   padding: 0.75rem 0.5rem;
   font-size: var(--text-xs);


### PR DESCRIPTION
## What
Three small post-launch tweaks to the Apple sign-in shipped in #2695 / #2738:

1. Move Apple to position 4 (Google / Notion / Microsoft / Apple) and center it when it wraps to row 2.
2. Remove the `?apple=true` URL gate — Apple is now visible to everyone on `/login` and `/register`.
3. Swap the login page logo from the small navbar wordmark to the Notion 1 character mascot (sized at 96px so the character reads).

## Why
End-to-end Apple sign-in was validated in prod via the Share My Email path (user row + oauth_identities row both landed correctly with name and verified email), so the feature flag has served its purpose. Repositioning Apple as the last provider keeps the existing Google/Notion/Microsoft order intact and gives the lone wrapping card a centered placement instead of an awkward left-aligned tail.

## How
- `LoginForm` and `RegisterForm`: reorder the OAuth links so Apple renders after Microsoft; drop the `searchParams.get('apple') === 'true'` conditional.
- `RegisterForm`: drop the now-unused `useSearchParams` import + hook destructure.
- `auth.module.css`: add `grid-column: 2` to `.appleCard` so the standalone wrapping card sits in the middle column of the 3-column grid.
- `LoginForm/index.tsx`: swap the mascot `src` to `/mascot/Notion 1.png`.
- `LoginForm.module.css`: bump `.mascot` width from 48px to 96px so the character is recognizable instead of a thumbnail.

## Measuring success
- `/login` shows four provider cards: Google, Notion, Microsoft on row 1; Apple centered on row 2.
- Same on `/register`.
- The Notion mascot renders at 96px above the form card.
- No `?apple=true` needed in the URL.

## Testing
- `pnpm --filter 2anki-web typecheck` — clean.
- `pnpm --filter 2anki-web lint` — clean.
- `pnpm --filter 2anki-web test:run` — 1126 tests pass.

## Risks
- The Apple card's `grid-column: 2` is keyed to the 3-column grid; if anyone later changes the grid layout, the rule needs updating. Documented in the CSS by proximity (sits inside `.appleCard` next to the grid styles).
- Mascot at 96px is a visual judgment; if it feels too big, the bump is one line away.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified the four-card layout (Google/Notion/Microsoft row 1; Apple centered row 2) on `/login` and `/register`; mascot renders at 96px above the form card; no console errors at 375px.

## Goal alignment
Apple sign-in is now generally available — removes the last friction for Apple-device users picking up 2anki, supporting the path to 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782236733&installation_id=132681956&pr_number=2739&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2739&signature=c1dc01732f0aa049d9cc525f00e46df8d80389fa9abc1e0c410be62d4ec7d248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->