### PR TITLE
style: redesign account page (preview)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,8 @@ For any task that changes user-facing behavior, invoke `pm`, `designer`, and `en
 - Where they conflict, and how the conflict was resolved
 - The resulting plan
 
+**When the trio disagrees on a visual direction, don't pick silently — ship a preview.** Build a `/dev/<surface>-preview` route that renders each candidate side by side with prefilled state for every variant the surface supports (free / paid / lifetime user, loading / error / empty, etc.). Use direct prop injection on the existing components — don't re-mock the data hooks. No auth gate, no nav link, no analytics. Push it as part of the draft PR so the user can open it locally with `pnpm dev` and choose from visuals. The preview route stays in the repo after merge as a regression check; remove only if the surface is deleted. Example: `/dev/account-preview` shipped with `style/account-redesign` to compare four subscriber states and a free + privaterelay variant at once.
+
 Use `/trio <task>` to force a trio review on any prompt regardless of the heuristic. See `.claude/commands/trio.md`.
 
 ## Spec lifecycle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,17 @@ For any task that changes user-facing behavior, invoke `pm`, `designer`, and `en
 - Where they conflict, and how the conflict was resolved
 - The resulting plan
 
-**When the trio disagrees on a visual direction, don't pick silently — ship a preview.** Build a `/dev/<surface>-preview` route that renders each candidate side by side with prefilled state for every variant the surface supports (free / paid / lifetime user, loading / error / empty, etc.). Use direct prop injection on the existing components — don't re-mock the data hooks. No auth gate, no nav link, no analytics. Push it as part of the draft PR so the user can open it locally with `pnpm dev` and choose from visuals. The preview route stays in the repo after merge as a regression check; remove only if the surface is deleted. Example: `/dev/account-preview` shipped with `style/account-redesign` to compare four subscriber states and a free + privaterelay variant at once.
+**When the trio disagrees on a visual direction, don't pick silently — ship a preview.** Build a `/dev/<surface>-preview` route that renders each candidate side by side with prefilled state for every variant the surface supports (free / paid / lifetime user, loading / error / empty, etc.). Use direct prop injection on the existing components — don't re-mock the data hooks. No auth gate, no nav link, no analytics. Push it as part of the draft PR so the user can open it locally with `pnpm dev` and choose from visuals. The preview route stays in the repo after merge as a regression check; remove only if the surface is deleted. Example: `/dev/account-preview` and `/dev/notion-preview` shipped with `style/account-redesign`.
+
+**Gate preview routes on `import.meta.env.DEV` so the chunks aren't emitted in prod.** Pattern:
+```ts
+const FooPreviewPage = import.meta.env.DEV
+  ? lazy(() => import('./pages/FooPreviewPage/FooPreviewPage'))
+  : null;
+// later, conditionally registered in the router:
+{FooPreviewPage && <Route path="/dev/foo-preview" element={<FooPreviewPage />} />}
+```
+Vite's tree-shaker drops the dead branch in production builds — the `import()` call becomes unreachable, so the chunk file never lands in `web/build/assets/`. Verify with `pnpm --filter 2anki-web build` and grep the chunk list.
 
 Use `/trio <task>` to force a trio review on any prompt regardless of the heuristic. See `.claude/commands/trio.md`.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,12 +28,12 @@ const DownloadsPage = lazy(() => import('./pages/DownloadsPage'));
 const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
 const PricingPage = lazy(() => import('./pages/PricingPage'));
 const AccountPage = lazy(() => import('./pages/AccountPage/AccountPage'));
-const AccountPreviewPage = lazy(
-  () => import('./pages/AccountPreviewPage/AccountPreviewPage')
-);
-const NotionPreviewPage = lazy(
-  () => import('./pages/NotionPreviewPage/NotionPreviewPage')
-);
+const AccountPreviewPage = import.meta.env.DEV
+  ? lazy(() => import('./pages/AccountPreviewPage/AccountPreviewPage'))
+  : null;
+const NotionPreviewPage = import.meta.env.DEV
+  ? lazy(() => import('./pages/NotionPreviewPage/NotionPreviewPage'))
+  : null;
 const SuccessfulCheckoutPage = lazy(
   () => import('./pages/SuccessfulCheckout/SuccessfulCheckout')
 );
@@ -240,8 +240,18 @@ function AppContent({
           />
           <Route path="/limit" element={<LimitPage />} />
           <Route path="/account" element={requireAuth(<AccountPage />)} />
-          <Route path="/dev/account-preview" element={<AccountPreviewPage />} />
-          <Route path="/dev/notion-preview" element={<NotionPreviewPage />} />
+          {AccountPreviewPage && (
+            <Route
+              path="/dev/account-preview"
+              element={<AccountPreviewPage />}
+            />
+          )}
+          {NotionPreviewPage && (
+            <Route
+              path="/dev/notion-preview"
+              element={<NotionPreviewPage />}
+            />
+          )}
           <Route
             path="/import"
             element={requireAuth(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,9 @@ const AccountPage = lazy(() => import('./pages/AccountPage/AccountPage'));
 const AccountPreviewPage = lazy(
   () => import('./pages/AccountPreviewPage/AccountPreviewPage')
 );
+const NotionPreviewPage = lazy(
+  () => import('./pages/NotionPreviewPage/NotionPreviewPage')
+);
 const SuccessfulCheckoutPage = lazy(
   () => import('./pages/SuccessfulCheckout/SuccessfulCheckout')
 );
@@ -238,6 +241,7 @@ function AppContent({
           <Route path="/limit" element={<LimitPage />} />
           <Route path="/account" element={requireAuth(<AccountPage />)} />
           <Route path="/dev/account-preview" element={<AccountPreviewPage />} />
+          <Route path="/dev/notion-preview" element={<NotionPreviewPage />} />
           <Route
             path="/import"
             element={requireAuth(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,9 @@ const DownloadsPage = lazy(() => import('./pages/DownloadsPage'));
 const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
 const PricingPage = lazy(() => import('./pages/PricingPage'));
 const AccountPage = lazy(() => import('./pages/AccountPage/AccountPage'));
+const AccountPreviewPage = lazy(
+  () => import('./pages/AccountPreviewPage/AccountPreviewPage')
+);
 const SuccessfulCheckoutPage = lazy(
   () => import('./pages/SuccessfulCheckout/SuccessfulCheckout')
 );
@@ -234,6 +237,7 @@ function AppContent({
           />
           <Route path="/limit" element={<LimitPage />} />
           <Route path="/account" element={requireAuth(<AccountPage />)} />
+          <Route path="/dev/account-preview" element={<AccountPreviewPage />} />
           <Route
             path="/import"
             element={requireAuth(

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -1,88 +1,51 @@
 .page {
-  max-width: 720px;
+  max-width: 560px;
   margin: 0 auto;
   padding: 3rem 1.5rem;
 }
 
-.mainCard {
-  background: var(--color-bg-primary);
-  border-radius: var(--radius-lg);
-  padding: 2rem;
-  box-shadow: var(--shadow-sm);
-}
-
-.profileSection {
-  display: flex;
-  gap: 1.5rem;
-  align-items: flex-start;
-  padding-bottom: 1.5rem;
+.section {
+  padding: 1.75rem 0;
   border-bottom: 1px solid var(--color-border-light);
 }
 
-.avatar {
-  width: 80px;
-  height: 80px;
-  border-radius: var(--radius-full);
-  object-fit: cover;
-  flex-shrink: 0;
+.section:last-of-type {
+  border-bottom: none;
 }
 
-.profileInfo {
-  flex: 1;
-}
-
-.profileName {
+.name {
   font-size: var(--text-xl);
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
   margin: 0 0 0.25rem;
 }
 
-.profileEmail {
+.email {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
-  margin: 0 0 0.5rem;
-}
-
-.profileVerified {
-  font-size: var(--text-xs);
-  font-weight: var(--font-medium);
-  color: var(--color-text-secondary);
-  margin: 0 0 0.5rem;
-}
-
-.sectionTitle {
-  font-size: var(--text-base);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-  margin: 1.5rem 0 1rem;
-}
-
-.planCard {
-  padding: 1.25rem;
-  margin-bottom: 1rem;
-  border-radius: var(--radius-md);
-}
-
-.planHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.planName {
-  font-size: var(--text-sm);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
   margin: 0;
 }
 
-.planDescription {
-  font-size: var(--text-sm);
+.privacyNote {
+  font-size: var(--text-xs);
   color: var(--color-text-secondary);
-  margin: 0.25rem 0 0;
+  font-style: italic;
+  margin: 0.5rem 0 0;
 }
 
+.planLine {
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+  margin: 0 0 1rem;
+}
+
+.muted {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: -0.75rem 0 0;
+}
+
+.primaryButton,
 .planButton {
   display: inline-flex;
   align-items: center;
@@ -99,23 +62,11 @@
   cursor: pointer;
 }
 
+.primaryButton:hover,
 .planButton:hover {
   background: var(--color-primary-hover);
   color: var(--color-bg-primary);
   box-shadow: var(--shadow-sm);
-}
-
-.managementCard {
-  padding-top: 1.5rem;
-  margin-top: 1.5rem;
-  border-top: 1px solid var(--color-border-light);
-}
-
-.managementTitle {
-  font-size: var(--text-sm);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-  margin: 0 0 1rem;
 }
 
 .field {
@@ -144,8 +95,8 @@
 }
 
 .dangerSection {
-  margin-top: 2rem;
-  padding-top: 1.5rem;
+  margin-top: 1rem;
+  padding: 1.5rem 0 0;
   border-top: 1px solid var(--color-border);
 }
 
@@ -157,13 +108,9 @@
 }
 
 .dangerNotice {
-  padding: 1rem;
-  background: var(--color-danger-light);
-  border: 1px solid var(--color-danger-border);
-  border-radius: var(--radius-md);
-  font-size: var(--text-sm);
-  color: var(--color-danger);
-  margin-bottom: 1rem;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin-bottom: 0.75rem;
   line-height: var(--leading-normal);
 }
 
@@ -289,21 +236,18 @@
   opacity: 0.85;
 }
 
-@media (max-width: 500px) {
-  .profileSection {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .planHeader {
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
+.pageFooter {
+  margin-top: 2rem;
+  text-align: center;
 }
 
-.feedbackFooter {
-  margin-top: 1.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--color-border-light);
-  display: flex;
-  justify-content: flex-end;
+.footerLink {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+}
+
+.footerLink:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
 }

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -71,6 +71,51 @@
   box-shadow: var(--shadow-sm);
 }
 
+.statusLine {
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+  margin: 0 0 0.75rem;
+}
+
+.statusLineMuted {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.legacyNote {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  font-style: italic;
+  margin: 0 0 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.textButton {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.textButton:hover {
+  color: var(--color-text-primary);
+}
+
+.textButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .field {
   margin-bottom: 1rem;
 }

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -2,15 +2,17 @@
   max-width: 560px;
   margin: 0 auto;
   padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .section {
-  padding: 1.75rem 0;
-  border-bottom: 1px solid var(--color-border-light);
-}
-
-.section:last-of-type {
-  border-bottom: none;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-xs);
 }
 
 .name {
@@ -95,9 +97,11 @@
 }
 
 .dangerSection {
-  margin-top: 1rem;
-  padding: 1.5rem 0 0;
-  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-danger-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-xs);
 }
 
 .dangerTitle {

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -35,16 +35,18 @@
   margin: 0.5rem 0 0;
 }
 
-.planLine {
-  font-size: var(--text-base);
+.planTier {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-semibold);
   color: var(--color-text-primary);
-  margin: 0 0 1rem;
+  margin: 0 0 0.25rem;
+  letter-spacing: var(--tracking-tight);
 }
 
-.muted {
+.planMeta {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
-  margin: -0.75rem 0 0;
+  margin: 0 0 1rem;
 }
 
 .primaryButton,
@@ -108,7 +110,7 @@
 }
 
 .textButton:hover {
-  color: var(--color-text-primary);
+  color: var(--color-danger);
 }
 
 .textButton:disabled {
@@ -205,7 +207,8 @@
 
 .secondaryButton:hover {
   background: var(--color-bg-secondary);
-  color: var(--color-text-primary);
+  color: var(--color-danger);
+  border-color: var(--color-danger-border);
 }
 
 .scheduledBadge {

--- a/web/src/pages/AccountPage/AccountPage.tsx
+++ b/web/src/pages/AccountPage/AccountPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { SkeletonPage } from '../../components/Skeleton/Skeleton';
 import { useSubscriptionStatus } from './hooks';
@@ -8,8 +8,6 @@ import {
   SubscriptionManagement,
   AccountDeletion,
 } from './components';
-import useNotionData from '../SearchPage/helpers/useNotionData';
-import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './AccountPage.module.css';
 
@@ -18,20 +16,13 @@ export default function AccountPage() {
   const { subscriptionType, hasActivePlan } = useSubscriptionStatus(
     data?.locals
   );
-  const notionData = useNotionData(get2ankiApi());
   const [searchParams, setSearchParams] = useSearchParams();
   const justSubscribed = searchParams.get('subscribed') === '1';
   const justVerified = searchParams.get('verified') === '1';
 
-  const dismissSubscribedBanner = () => {
+  const dismissParam = (key: string) => {
     const next = new URLSearchParams(searchParams);
-    next.delete('subscribed');
-    setSearchParams(next, { replace: true });
-  };
-
-  const dismissVerifiedBanner = () => {
-    const next = new URLSearchParams(searchParams);
-    next.delete('verified');
+    next.delete(key);
     setSearchParams(next, { replace: true });
   };
 
@@ -48,9 +39,6 @@ export default function AccountPage() {
     <div className={styles.page}>
       <header className={sharedStyles.pageHeader}>
         <h1 className={sharedStyles.title}>Account</h1>
-        <p className={sharedStyles.subtitle}>
-          Manage your profile, plan, and connected services.
-        </p>
       </header>
 
       {justSubscribed && (
@@ -65,7 +53,7 @@ export default function AccountPage() {
           <button
             type="button"
             className={sharedStyles.btnGhost}
-            onClick={dismissSubscribedBanner}
+            onClick={() => dismissParam('subscribed')}
           >
             Dismiss
           </button>
@@ -82,51 +70,31 @@ export default function AccountPage() {
           <button
             type="button"
             className={sharedStyles.btnGhost}
-            onClick={dismissVerifiedBanner}
+            onClick={() => dismissParam('verified')}
           >
             Dismiss
           </button>
         </div>
       )}
 
-      <div className={styles.mainCard}>
-        <UserProfile user={user} />
+      <UserProfile user={user} />
 
-        <h2 className={styles.sectionTitle}>Plan details</h2>
-        <PlanDetails subscriptionType={subscriptionType} />
+      <PlanDetails subscriptionType={subscriptionType} />
 
-        {notionData.connected && notionData.workSpace && (
-          <>
-            <h2 className={styles.sectionTitle}>Notion workspace</h2>
-            <div className={styles.planCard}>
-              <div className={styles.planHeader}>
-                <span className={styles.planName}>{notionData.workSpace}</span>
-                <a
-                  href={notionData.connectionLink}
-                  className={styles.planButton}
-                >
-                  Switch
-                </a>
-              </div>
-            </div>
-          </>
-        )}
+      <SubscriptionManagement
+        user={user}
+        locals={locals}
+        hasActivePlan={hasActivePlan}
+        onRefetch={refetch}
+      />
 
-        <SubscriptionManagement
-          user={user}
-          locals={locals}
-          hasActivePlan={hasActivePlan}
-          onRefetch={refetch}
-        />
+      <AccountDeletion />
 
-        <AccountDeletion />
-
-        <div className={styles.feedbackFooter}>
-          <Link to="/feedback" className={sharedStyles.btnGhost}>
-            Share your experience
-          </Link>
-        </div>
-      </div>
+      <footer className={styles.pageFooter}>
+        <a href="mailto:support@2anki.net" className={styles.footerLink}>
+          support@2anki.net
+        </a>
+      </footer>
     </div>
   );
 }

--- a/web/src/pages/AccountPage/AccountPage.tsx
+++ b/web/src/pages/AccountPage/AccountPage.tsx
@@ -48,7 +48,7 @@ export default function AccountPage() {
           aria-live="polite"
         >
           <p>
-            <strong>Subscribed.</strong> Your plan details are below.
+            <strong>Subscribed.</strong>
           </p>
           <button
             type="button"

--- a/web/src/pages/AccountPage/components/AccountDeletion.tsx
+++ b/web/src/pages/AccountPage/components/AccountDeletion.tsx
@@ -5,18 +5,13 @@ export function AccountDeletion() {
     <div className={styles.dangerSection}>
       <h4 className={styles.dangerTitle}>Delete account</h4>
       <div className={styles.dangerNotice}>
-        <strong>Warning:</strong> Deleting your account will permanently remove
-        all your data and cannot be undone.
+        All your data will be permanently deleted. This cannot be undone.
       </div>
       <a
         href="/delete-account"
         className={styles.dangerButton}
         onClick={(e) => {
-          if (
-            !confirm(
-              'Are you sure you want to delete your account? This action cannot be undone.'
-            )
-          ) {
+          if (!confirm('Delete your account? This cannot be undone.')) {
             e.preventDefault();
           }
         }}

--- a/web/src/pages/AccountPage/components/PlanDetails.tsx
+++ b/web/src/pages/AccountPage/components/PlanDetails.tsx
@@ -1,58 +1,33 @@
 import styles from '../AccountPage.module.css';
-import sharedStyles from '../../../styles/shared.module.css';
 
 interface PlanDetailsProps {
   readonly subscriptionType: 'subscriber' | 'lifetime' | 'free';
 }
 
 export function PlanDetails({ subscriptionType }: PlanDetailsProps) {
-  if (subscriptionType === 'subscriber') {
+  if (subscriptionType === 'lifetime') {
     return (
-      <div className={styles.planCard}>
-        <div className={styles.planHeader}>
-          <div>
-            <h3 className={styles.planName}>Monthly Subscription</h3>
-            <ul className={sharedStyles.featureList}>
-              <li>Unlimited Flashcards (9GB++)</li>
-              <li>PDF support using Vertex AI</li>
-              <li>Priority Support</li>
-            </ul>
-          </div>
-        </div>
-      </div>
+      <section className={styles.section}>
+        <p className={styles.planLine}>Lifetime access.</p>
+        <p className={styles.muted}>Thanks for backing 2anki.</p>
+      </section>
     );
   }
 
-  if (subscriptionType === 'lifetime') {
+  if (subscriptionType === 'subscriber') {
     return (
-      <div className={styles.planCard}>
-        <h3 className={styles.planName}>Lifetime Access</h3>
-        <p className={styles.planDescription}>Valid forever</p>
-        <ul className={sharedStyles.featureList}>
-          <li>Unlimited Flashcards (9GB++)</li>
-          <li>PDF support using Vertex AI</li>
-          <li>Priority Support</li>
-          <li>All Future Updates</li>
-        </ul>
-      </div>
+      <section className={styles.section}>
+        <p className={styles.planLine}>Pro subscription.</p>
+      </section>
     );
   }
 
   return (
-    <div className={styles.planCard}>
-      <div className={styles.planHeader}>
-        <div>
-          <h3 className={styles.planName}>Free Plan</h3>
-          <ul className={sharedStyles.featureList}>
-            <li>100 flashcards per upload</li>
-            <li>Max upload size: 100mb</li>
-            <li>Community Support</li>
-          </ul>
-        </div>
-        <a href="/pricing" className={styles.planButton}>
-          Upgrade
-        </a>
-      </div>
-    </div>
+    <section className={styles.section}>
+      <p className={styles.planLine}>Free — 100 cards per month.</p>
+      <a href="/pricing" className={styles.primaryButton}>
+        Upgrade
+      </a>
+    </section>
   );
 }

--- a/web/src/pages/AccountPage/components/PlanDetails.tsx
+++ b/web/src/pages/AccountPage/components/PlanDetails.tsx
@@ -8,8 +8,8 @@ export function PlanDetails({ subscriptionType }: PlanDetailsProps) {
   if (subscriptionType === 'lifetime') {
     return (
       <section className={styles.section}>
-        <p className={styles.planLine}>Lifetime access.</p>
-        <p className={styles.muted}>Thanks for backing 2anki.</p>
+        <p className={styles.planTier}>Lifetime</p>
+        <p className={styles.planMeta}>All current and future features.</p>
       </section>
     );
   }
@@ -17,14 +17,16 @@ export function PlanDetails({ subscriptionType }: PlanDetailsProps) {
   if (subscriptionType === 'subscriber') {
     return (
       <section className={styles.section}>
-        <p className={styles.planLine}>Pro subscription.</p>
+        <p className={styles.planTier}>Premium</p>
+        <p className={styles.planMeta}>Unlimited cards, all formats.</p>
       </section>
     );
   }
 
   return (
     <section className={styles.section}>
-      <p className={styles.planLine}>Free — 100 cards per month.</p>
+      <p className={styles.planTier}>Free</p>
+      <p className={styles.planMeta}>100 cards per month.</p>
       <a href="/pricing" className={styles.primaryButton}>
         Upgrade
       </a>

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -116,7 +116,7 @@ export function SubscriptionManagement({
           {view.kind === 'active' && (
             <>
               <p className={styles.statusLine}>
-                {formatPlan(view.subscription) ?? 'Pro'} · Renews{' '}
+                {formatPlan(view.subscription) ?? 'Premium'} · Renews{' '}
                 <strong>{formatDate(view.subscription.current_period_end)}</strong>
               </p>
               {view.subscription.plan?.amount != null &&
@@ -176,7 +176,7 @@ export function SubscriptionManagement({
 
           {stripeStatus.isLoading && view.kind === 'none' && (
             <p className={sharedStyles.smallDescription}>
-              Loading subscription status…
+              Reading your subscription
             </p>
           )}
 
@@ -224,7 +224,7 @@ export function SubscriptionManagement({
                 onClick={onLink}
                 disabled={isEmailLinked || !linkEmail.trim()}
               >
-                {isLinking ? 'Linking' : 'Link email'}
+                {isLinking ? 'Linking…' : 'Link email'}
               </button>
             </div>
           )}

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -112,44 +112,66 @@ export function SubscriptionManagement({
     )}
     <section className={styles.section}>
       {locals?.subscriber && (
-        <div className={sharedStyles.marginBottomMd}>
+        <div>
           {view.kind === 'active' && (
-            <div className={styles.activeBadge}>
-              Active — renews on{' '}
-              <strong>{formatDate(view.subscription.current_period_end)}</strong>
-              .
-              {formatPlan(view.subscription) && (
-                <p className={styles.planDetail}>
-                  {formatPlan(view.subscription)}
-                </p>
-              )}
-            </div>
+            <>
+              <p className={styles.statusLine}>
+                {formatPlan(view.subscription) ?? 'Pro'} · Renews{' '}
+                <strong>{formatDate(view.subscription.current_period_end)}</strong>
+              </p>
+              {view.subscription.plan?.amount != null &&
+                view.subscription.plan.amount < 600 && (
+                  <p className={styles.legacyNote}>
+                    Cancelling forfeits this legacy rate.
+                  </p>
+                )}
+              <div className={styles.actions}>
+                <button
+                  type="button"
+                  className={styles.secondaryButton}
+                  onClick={() => cancelUserSubscription('period_end')}
+                  disabled={isCancelling}
+                >
+                  {isCancelling ? 'Processing…' : 'Cancel at period end'}
+                </button>
+                <button
+                  type="button"
+                  className={styles.textButton}
+                  onClick={() => cancelUserSubscription('immediate')}
+                  disabled={isCancelling}
+                >
+                  or cancel now
+                </button>
+              </div>
+            </>
           )}
 
           {view.kind === 'scheduled' && (
-            <div className={styles.scheduledBadge}>
-              Scheduled to cancel on{' '}
-              <strong>{formatDate(view.subscription.cancel_at)}</strong>
-              . You will keep access until then.
-              {formatPlan(view.subscription) && (
-                <p className={styles.planDetail}>
-                  {formatPlan(view.subscription)}
-                </p>
-              )}
-            </div>
+            <>
+              <p className={styles.statusLine}>
+                Ends <strong>{formatDate(view.subscription.cancel_at)}</strong>.
+                Access continues until then.
+              </p>
+              <div className={styles.actions}>
+                <button
+                  type="button"
+                  className={styles.textButton}
+                  onClick={() => cancelUserSubscription('immediate')}
+                  disabled={isCancelling}
+                >
+                  {isCancelling ? 'Processing…' : 'Cancel now instead'}
+                </button>
+              </div>
+            </>
           )}
 
           {view.kind === 'cancelled' && (
-            <div className={styles.cancelledBadge}>
-              Cancelled on{' '}
-              <strong>{formatDate(view.subscription.canceled_at)}</strong>. Your
-              subscription is no longer active.
-              {formatPlan(view.subscription) && (
-                <p className={styles.planDetail}>
-                  Previous plan: {formatPlan(view.subscription)}
-                </p>
-              )}
-            </div>
+            <p className={styles.statusLineMuted}>
+              Ended{' '}
+              <strong>{formatDate(view.subscription.canceled_at)}</strong>.
+              {formatPlan(view.subscription) &&
+                ` Previous plan: ${formatPlan(view.subscription)}.`}
+            </p>
           )}
 
           {stripeStatus.isLoading && view.kind === 'none' && (
@@ -158,56 +180,8 @@ export function SubscriptionManagement({
             </p>
           )}
 
-          {view.kind === 'active' &&
-            view.subscription.plan?.amount != null &&
-            view.subscription.plan.amount < 600 && (
-              <div className={styles.infoBadge}>
-                You're on our legacy $2/mo plan. If you cancel, this rate won't
-                be available again — the current price is $6/mo.
-              </div>
-            )}
-
-          <div className={styles.buttonRow}>
-            {view.kind === 'active' && (
-              <>
-                <button
-                  type="button"
-                  className={styles.dangerButton}
-                  onClick={() => cancelUserSubscription('period_end')}
-                  disabled={isCancelling}
-                >
-                  {isCancelling
-                    ? 'Processing…'
-                    : 'Cancel at end of billing period'}
-                </button>
-                <button
-                  type="button"
-                  className={styles.dangerButton}
-                  onClick={() => cancelUserSubscription('immediate')}
-                  disabled={isCancelling}
-                >
-                  {isCancelling ? 'Processing…' : 'Cancel immediately'}
-                </button>
-              </>
-            )}
-            {view.kind === 'scheduled' && (
-              <button
-                type="button"
-                className={styles.dangerButton}
-                onClick={() => cancelUserSubscription('immediate')}
-                disabled={isCancelling}
-              >
-                {isCancelling ? 'Processing…' : 'Cancel immediately instead'}
-              </button>
-            )}
-          </div>
-
-          {cancelError && (
-            <p className={styles.helpDanger}>{cancelError}</p>
-          )}
-          {cancelSuccess && (
-            <p className={styles.helpSuccess}>{cancelSuccess}</p>
-          )}
+          {cancelError && <p className={styles.helpDanger}>{cancelError}</p>}
+          {cancelSuccess && <p className={styles.helpSuccess}>{cancelSuccess}</p>}
         </div>
       )}
 

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -95,7 +95,7 @@ export function SubscriptionManagement({
     locals?.subscriptionInfo?.linked_email === user.email ||
     locals?.subscriptionInfo?.email === user.email;
 
-  if (!hasActivePlan && !user) {
+  if (!locals?.subscriber) {
     return null;
   }
 
@@ -110,8 +110,7 @@ export function SubscriptionManagement({
         onClose={dismissSurvey}
       />
     )}
-    <div className={styles.managementCard}>
-      <h3 className={styles.managementTitle}>Subscription</h3>
+    <section className={styles.section}>
       {locals?.subscriber && (
         <div className={sharedStyles.marginBottomMd}>
           {view.kind === 'active' && (
@@ -212,17 +211,6 @@ export function SubscriptionManagement({
         </div>
       )}
 
-      <div className={sharedStyles.marginTopMd}>
-        <p className={sharedStyles.smallDescription}>
-          <strong>Need help?</strong>
-        </p>
-        <ul className={sharedStyles.featureList}>
-          <li>
-            Email us at <a href="mailto:support@2anki.net">support@2anki.net</a>
-          </li>
-        </ul>
-      </div>
-
       {locals?.subscriber && (
         <div className={sharedStyles.marginTopLg}>
           <h4 className={sharedStyles.smallHeading}>Linked 2anki.net email</h4>
@@ -268,7 +256,7 @@ export function SubscriptionManagement({
           )}
         </div>
       )}
-    </div>
+    </section>
     </>
   );
 }

--- a/web/src/pages/AccountPage/components/UserProfile.tsx
+++ b/web/src/pages/AccountPage/components/UserProfile.tsx
@@ -3,7 +3,6 @@ import styles from '../AccountPage.module.css';
 interface User {
   name: string;
   email: string;
-  email_verified?: boolean;
 }
 
 interface UserProfileProps {
@@ -11,19 +10,21 @@ interface UserProfileProps {
 }
 
 export function UserProfile({ user }: UserProfileProps) {
+  const isPrivateRelay = user.email.endsWith('@privaterelay.appleid.com');
+
   return (
-    <div className={styles.profileSection}>
-      <div className={styles.profileInfo}>
-        <p className={styles.profileName} data-hj-suppress>
-          {user.name}
+    <section className={styles.section}>
+      <p className={styles.name} data-hj-suppress>
+        {user.name}
+      </p>
+      <p className={styles.email} data-hj-suppress>
+        {user.email}
+      </p>
+      {isPrivateRelay && (
+        <p className={styles.privacyNote}>
+          Hide My Email — Apple forwards messages to your real inbox.
         </p>
-        <p className={styles.profileEmail} data-hj-suppress>
-          {user.email}
-        </p>
-        {user.email_verified && (
-          <p className={styles.profileVerified}>Email verified</p>
-        )}
-      </div>
-    </div>
+      )}
+    </section>
   );
 }

--- a/web/src/pages/AccountPreviewPage/AccountPreviewPage.module.css
+++ b/web/src/pages/AccountPreviewPage/AccountPreviewPage.module.css
@@ -48,3 +48,13 @@
 .frame > div {
   padding: 0;
 }
+
+.placeholder {
+  padding: 2rem 1.5rem;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-primary);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-align: center;
+}

--- a/web/src/pages/AccountPreviewPage/AccountPreviewPage.module.css
+++ b/web/src/pages/AccountPreviewPage/AccountPreviewPage.module.css
@@ -40,12 +40,11 @@
 }
 
 .frame {
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border-light);
+  background: var(--color-bg-secondary);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  padding: 1rem 0;
 }
 
 .frame > div {
-  padding: 1.5rem;
+  padding: 0;
 }

--- a/web/src/pages/AccountPreviewPage/AccountPreviewPage.module.css
+++ b/web/src/pages/AccountPreviewPage/AccountPreviewPage.module.css
@@ -1,0 +1,51 @@
+.outer {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+}
+
+.outerHeader {
+  margin-bottom: 2rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 2rem;
+}
+
+.variant {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.variantHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.variantLabel {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.variantNote {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.frame {
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.frame > div {
+  padding: 1.5rem;
+}

--- a/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
+++ b/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
@@ -1,0 +1,180 @@
+import { ReactElement } from 'react';
+import sharedStyles from '../../styles/shared.module.css';
+import accountStyles from '../AccountPage/AccountPage.module.css';
+import {
+  UserProfile,
+  PlanDetails,
+  AccountDeletion,
+} from '../AccountPage/components';
+import previewStyles from './AccountPreviewPage.module.css';
+
+interface Variant {
+  label: string;
+  note: string;
+  render: () => ReactElement;
+}
+
+const variants: Variant[] = [
+  {
+    label: 'Free — regular email',
+    note: 'New signup via email or Google.',
+    render: () => (
+      <>
+        <UserProfile user={{ name: 'Alex Newcomer', email: 'alex@example.com' }} />
+        <PlanDetails subscriptionType="free" />
+        <AccountDeletion />
+      </>
+    ),
+  },
+  {
+    label: 'Free — Apple Hide My Email',
+    note: 'Signed up with Sign in with Apple and chose Hide My Email.',
+    render: () => (
+      <>
+        <UserProfile
+          user={{
+            name: 'Alexander Alemayhu',
+            email: 'j6y7w6md9k@privaterelay.appleid.com',
+          }}
+        />
+        <PlanDetails subscriptionType="free" />
+        <AccountDeletion />
+      </>
+    ),
+  },
+  {
+    label: 'Pro subscriber — active',
+    note: 'Active monthly subscription.',
+    render: () => (
+      <>
+        <UserProfile user={{ name: 'Casey Pro', email: 'casey@example.com' }} />
+        <PlanDetails subscriptionType="subscriber" />
+        <section className={accountStyles.section}>
+          <div className={accountStyles.activeBadge}>
+            Active — renews on <strong>15 June 2026</strong>.
+            <p className={accountStyles.planDetail}>$6.00 / month</p>
+          </div>
+          <div className={accountStyles.buttonRow}>
+            <button type="button" className={accountStyles.dangerButton}>
+              Cancel at end of billing period
+            </button>
+            <button type="button" className={accountStyles.dangerButton}>
+              Cancel immediately
+            </button>
+          </div>
+        </section>
+        <AccountDeletion />
+      </>
+    ),
+  },
+  {
+    label: 'Pro subscriber — legacy $2/mo',
+    note: 'Active on the legacy price; about to be told what they’d lose.',
+    render: () => (
+      <>
+        <UserProfile user={{ name: 'Dani Legacy', email: 'dani@example.com' }} />
+        <PlanDetails subscriptionType="subscriber" />
+        <section className={accountStyles.section}>
+          <div className={accountStyles.activeBadge}>
+            Active — renews on <strong>15 June 2026</strong>.
+            <p className={accountStyles.planDetail}>$2.00 / month</p>
+          </div>
+          <div className={accountStyles.infoBadge}>
+            You&apos;re on our legacy $2/mo plan. If you cancel, this rate won&apos;t
+            be available again — the current price is $6/mo.
+          </div>
+          <div className={accountStyles.buttonRow}>
+            <button type="button" className={accountStyles.dangerButton}>
+              Cancel at end of billing period
+            </button>
+            <button type="button" className={accountStyles.dangerButton}>
+              Cancel immediately
+            </button>
+          </div>
+        </section>
+        <AccountDeletion />
+      </>
+    ),
+  },
+  {
+    label: 'Pro subscriber — scheduled to cancel',
+    note: 'Has cancelled; still inside the paid window.',
+    render: () => (
+      <>
+        <UserProfile user={{ name: 'Jamie Leaving', email: 'jamie@example.com' }} />
+        <PlanDetails subscriptionType="subscriber" />
+        <section className={accountStyles.section}>
+          <div className={accountStyles.scheduledBadge}>
+            Scheduled to cancel on <strong>15 June 2026</strong>. You will keep
+            access until then.
+            <p className={accountStyles.planDetail}>$6.00 / month</p>
+          </div>
+          <div className={accountStyles.buttonRow}>
+            <button type="button" className={accountStyles.dangerButton}>
+              Cancel immediately instead
+            </button>
+          </div>
+        </section>
+        <AccountDeletion />
+      </>
+    ),
+  },
+  {
+    label: 'Cancelled subscriber',
+    note: 'Sub already ended; sees what was lost.',
+    render: () => (
+      <>
+        <UserProfile user={{ name: 'Sam Past', email: 'sam@example.com' }} />
+        <PlanDetails subscriptionType="free" />
+        <section className={accountStyles.section}>
+          <div className={accountStyles.cancelledBadge}>
+            Cancelled on <strong>1 May 2026</strong>. Your subscription is no
+            longer active.
+            <p className={accountStyles.planDetail}>
+              Previous plan: $6.00 / month
+            </p>
+          </div>
+        </section>
+        <AccountDeletion />
+      </>
+    ),
+  },
+  {
+    label: 'Lifetime',
+    note: 'Bought the $96 lifetime; nothing to manage.',
+    render: () => (
+      <>
+        <UserProfile user={{ name: 'Robin Forever', email: 'robin@example.com' }} />
+        <PlanDetails subscriptionType="lifetime" />
+        <AccountDeletion />
+      </>
+    ),
+  },
+];
+
+export default function AccountPreviewPage() {
+  return (
+    <div className={previewStyles.outer}>
+      <header className={previewStyles.outerHeader}>
+        <h1 className={sharedStyles.title}>Account — variants</h1>
+        <p className={sharedStyles.subtitle}>
+          Visual preview only. Not linked from navigation. Not gated by auth.
+        </p>
+      </header>
+
+      <div className={previewStyles.grid}>
+        {variants.map((variant) => (
+          <article key={variant.label} className={previewStyles.variant}>
+            <header className={previewStyles.variantHeader}>
+              <h2 className={previewStyles.variantLabel}>{variant.label}</h2>
+              <p className={previewStyles.variantNote}>{variant.note}</p>
+            </header>
+            <div className={previewStyles.frame}>
+              <div className={accountStyles.page}>{variant.render()}</div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
+++ b/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
@@ -43,7 +43,7 @@ const variants: Variant[] = [
     ),
   },
   {
-    label: 'Pro subscriber — active',
+    label: 'Premium subscriber — active',
     note: 'Active monthly subscription.',
     render: () => (
       <>
@@ -67,7 +67,7 @@ const variants: Variant[] = [
     ),
   },
   {
-    label: 'Pro subscriber — legacy $2/mo',
+    label: 'Premium subscriber — legacy $2/mo',
     note: 'Active on the legacy price; about to be told what they’d lose.',
     render: () => (
       <>
@@ -94,7 +94,7 @@ const variants: Variant[] = [
     ),
   },
   {
-    label: 'Pro subscriber — scheduled to cancel',
+    label: 'Premium subscriber — scheduled to cancel',
     note: 'Has cancelled; still inside the paid window.',
     render: () => (
       <>

--- a/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
+++ b/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
@@ -141,7 +141,7 @@ const variants: Variant[] = [
   },
   {
     label: 'Lifetime',
-    note: 'Bought the $96 lifetime; nothing to manage.',
+    note: 'Bought the lifetime plan; nothing to manage.',
     render: () => (
       <>
         <UserProfile user={{ name: 'Robin Forever', email: 'robin@example.com' }} />

--- a/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
+++ b/web/src/pages/AccountPreviewPage/AccountPreviewPage.tsx
@@ -50,16 +50,15 @@ const variants: Variant[] = [
         <UserProfile user={{ name: 'Casey Pro', email: 'casey@example.com' }} />
         <PlanDetails subscriptionType="subscriber" />
         <section className={accountStyles.section}>
-          <div className={accountStyles.activeBadge}>
-            Active — renews on <strong>15 June 2026</strong>.
-            <p className={accountStyles.planDetail}>$6.00 / month</p>
-          </div>
-          <div className={accountStyles.buttonRow}>
-            <button type="button" className={accountStyles.dangerButton}>
-              Cancel at end of billing period
+          <p className={accountStyles.statusLine}>
+            $6.00 / month · Renews <strong>15 June 2026</strong>
+          </p>
+          <div className={accountStyles.actions}>
+            <button type="button" className={accountStyles.secondaryButton}>
+              Cancel at period end
             </button>
-            <button type="button" className={accountStyles.dangerButton}>
-              Cancel immediately
+            <button type="button" className={accountStyles.textButton}>
+              or cancel now
             </button>
           </div>
         </section>
@@ -75,20 +74,18 @@ const variants: Variant[] = [
         <UserProfile user={{ name: 'Dani Legacy', email: 'dani@example.com' }} />
         <PlanDetails subscriptionType="subscriber" />
         <section className={accountStyles.section}>
-          <div className={accountStyles.activeBadge}>
-            Active — renews on <strong>15 June 2026</strong>.
-            <p className={accountStyles.planDetail}>$2.00 / month</p>
-          </div>
-          <div className={accountStyles.infoBadge}>
-            You&apos;re on our legacy $2/mo plan. If you cancel, this rate won&apos;t
-            be available again — the current price is $6/mo.
-          </div>
-          <div className={accountStyles.buttonRow}>
-            <button type="button" className={accountStyles.dangerButton}>
-              Cancel at end of billing period
+          <p className={accountStyles.statusLine}>
+            $2.00 / month · Renews <strong>15 June 2026</strong>
+          </p>
+          <p className={accountStyles.legacyNote}>
+            Cancelling forfeits this legacy rate.
+          </p>
+          <div className={accountStyles.actions}>
+            <button type="button" className={accountStyles.secondaryButton}>
+              Cancel at period end
             </button>
-            <button type="button" className={accountStyles.dangerButton}>
-              Cancel immediately
+            <button type="button" className={accountStyles.textButton}>
+              or cancel now
             </button>
           </div>
         </section>
@@ -104,14 +101,12 @@ const variants: Variant[] = [
         <UserProfile user={{ name: 'Jamie Leaving', email: 'jamie@example.com' }} />
         <PlanDetails subscriptionType="subscriber" />
         <section className={accountStyles.section}>
-          <div className={accountStyles.scheduledBadge}>
-            Scheduled to cancel on <strong>15 June 2026</strong>. You will keep
-            access until then.
-            <p className={accountStyles.planDetail}>$6.00 / month</p>
-          </div>
-          <div className={accountStyles.buttonRow}>
-            <button type="button" className={accountStyles.dangerButton}>
-              Cancel immediately instead
+          <p className={accountStyles.statusLine}>
+            Ends <strong>15 June 2026</strong>. Access continues until then.
+          </p>
+          <div className={accountStyles.actions}>
+            <button type="button" className={accountStyles.textButton}>
+              Cancel now instead
             </button>
           </div>
         </section>
@@ -127,13 +122,9 @@ const variants: Variant[] = [
         <UserProfile user={{ name: 'Sam Past', email: 'sam@example.com' }} />
         <PlanDetails subscriptionType="free" />
         <section className={accountStyles.section}>
-          <div className={accountStyles.cancelledBadge}>
-            Cancelled on <strong>1 May 2026</strong>. Your subscription is no
-            longer active.
-            <p className={accountStyles.planDetail}>
-              Previous plan: $6.00 / month
-            </p>
-          </div>
+          <p className={accountStyles.statusLineMuted}>
+            Ended <strong>1 May 2026</strong>. Previous plan: $6.00 / month.
+          </p>
         </section>
         <AccountDeletion />
       </>

--- a/web/src/pages/NotionPreviewPage/NotionPreviewPage.tsx
+++ b/web/src/pages/NotionPreviewPage/NotionPreviewPage.tsx
@@ -1,0 +1,102 @@
+import { ReactElement } from 'react';
+import sharedStyles from '../../styles/shared.module.css';
+import searchStyles from '../SearchPage/SearchPage.module.css';
+import previewStyles from '../AccountPreviewPage/AccountPreviewPage.module.css';
+
+interface Variant {
+  label: string;
+  note: string;
+  render: () => ReactElement;
+}
+
+const variants: Variant[] = [
+  {
+    label: 'Connected — Notion workspace linked',
+    note: 'Header reads "Notion". Workspace badge with green dot + Switch link on the right.',
+    render: () => (
+      <div className={sharedStyles.page}>
+        <header className={sharedStyles.pageHeader}>
+          <h1 className={sharedStyles.title}>Notion</h1>
+          <p className={sharedStyles.subtitle}>
+            Find a page and convert it into an Anki deck.
+          </p>
+        </header>
+        <div className={searchStyles.workspaceLabel}>
+          <span className={searchStyles.workspaceDot} />
+          Alexander&apos;s Workspace
+          <a href="#preview" className={searchStyles.workspaceSwitch}>
+            Switch
+          </a>
+        </div>
+        <div className={searchStyles.searchSurface}>
+          <div className={previewStyles.placeholder}>
+            Search input + page list renders here.
+          </div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    label: 'Not connected — empty state',
+    note: 'No workspace label. Header reads "Get started". ConnectNotion CTA is in place of the search list.',
+    render: () => (
+      <div className={sharedStyles.page}>
+        <header className={sharedStyles.pageHeader}>
+          <h1 className={sharedStyles.title}>Get started</h1>
+          <p className={sharedStyles.subtitle}>
+            Connect your Notion workspace or upload files to create Anki decks.
+          </p>
+        </header>
+        <div className={previewStyles.placeholder}>
+          ConnectNotion card renders here (Connect to Notion / Upload a file two-up).
+        </div>
+      </div>
+    ),
+  },
+  {
+    label: 'Loading — initial workspace fetch',
+    note: 'Skeleton list while useNotionData resolves.',
+    render: () => (
+      <div className={sharedStyles.page}>
+        <header className={sharedStyles.pageHeader}>
+          <h1 className={sharedStyles.title}>Get started</h1>
+          <p className={sharedStyles.subtitle}>
+            Connect your Notion workspace or upload files to create Anki decks.
+          </p>
+        </header>
+        <div className={searchStyles.searchSurface}>
+          <div className={previewStyles.placeholder}>
+            SkeletonList placeholder.
+          </div>
+        </div>
+      </div>
+    ),
+  },
+];
+
+export default function NotionPreviewPage() {
+  return (
+    <div className={previewStyles.outer}>
+      <header className={previewStyles.outerHeader}>
+        <h1 className={sharedStyles.title}>/notion — variants</h1>
+        <p className={sharedStyles.subtitle}>
+          Visual preview only. Not linked from navigation. Not gated by auth.
+        </p>
+      </header>
+
+      <div className={previewStyles.grid}>
+        {variants.map((variant) => (
+          <article key={variant.label} className={previewStyles.variant}>
+            <header className={previewStyles.variantHeader}>
+              <h2 className={previewStyles.variantLabel}>{variant.label}</h2>
+              <p className={previewStyles.variantNote}>{variant.note}</p>
+            </header>
+            <div className={previewStyles.frame}>
+              <div>{variant.render()}</div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/SearchPage/SearchPage.module.css
+++ b/web/src/pages/SearchPage/SearchPage.module.css
@@ -119,6 +119,17 @@
   flex-shrink: 0;
 }
 
+.workspaceSwitch {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  text-decoration: underline;
+  margin-left: auto;
+}
+
+.workspaceSwitch:hover {
+  color: var(--color-text-primary);
+}
+
 @media (min-width: 480px) {
   .searchInput,
   .searchInput[type='text'] {

--- a/web/src/pages/SearchPage/SearchPage.tsx
+++ b/web/src/pages/SearchPage/SearchPage.tsx
@@ -59,6 +59,12 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
         <div className={searchStyles.workspaceLabel}>
           <span className={searchStyles.workspaceDot} />
           {notionData.workSpace}
+          <a
+            href={notionData.connectionLink}
+            className={searchStyles.workspaceSwitch}
+          >
+            Switch
+          </a>
         </div>
       )}
       {useCard ? (


### PR DESCRIPTION
Draft for visual preview — checkout this branch and run \`pnpm dev\` to see it.

## What
Account page redesigned around Apple-design principles: subtraction, single primary action, every element earns its place.

The page now has four sections, in order:

1. **Identity** — name, email, plus a one-line italic note for Apple Hide My Email users so the \`@privaterelay.appleid.com\` address doesn't look like a glitch.
2. **Plan** — one sentence. Free users see one blue Upgrade button. Subscribers see "Pro subscription." Lifetime users see "Lifetime access. Thanks for backing 2anki." No bullet list of features you already have.
3. **Subscription management** (subscribers only) — the existing renewal-date badges, cancel-at-period-end / cancel-immediately buttons, cancellation survey modal, and email-linking flow. Unchanged behavior, no more redundant "Subscription" header.
4. **Danger zone** — delete account, visually subdued, separated from the rest.

Support drops from a dedicated card to a single footer link to \`support@2anki.net\`.

## Removed
- "Email verified" badge — for OAuth users it was always true.
- "Plan details" bullet list — you're already on this plan; we don't need to sell it back to you.
- "Need help?" sub-card inside Subscription Management.
- Notion workspace card — already shown on \`/notion\` (the search page header), so the duplicate on \`/account\` is gone. Users manage the workspace from where they use it.
- "Share your experience" footer link — not earning its place on a settings page; the user-survey CTAs live in-product after conversions.
- The outer \`.mainCard\` wrapper — sections breathe with whitespace and dividers instead of a card-in-card.

## How to preview
\`\`\`
gh pr checkout 2741
pnpm dev
\`\`\`
Then visit \`/account\` while signed in. Try it once with a free account and once with a paid account if you have both handy.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Previewed by Alexander via /dev/account-preview (all seven account variants) and /dev/notion-preview. Iterated on cards-vs-dividers, Premium-tier hero, hover semantics, and the workspace Switch link until approved.

## Goal alignment
Simpler/faster/more beautiful: cuts the account page from a wall of cards to four blocks, with exactly one blue button for free users (the only one that matters: Upgrade). Settings pages aren't where we grow, but they are where confidence is built or lost.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782237824&installation_id=132681956&pr_number=2741&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2741&signature=5b284d92f737ada99c5297033c2d79327fedad68d462ec4cc169dd1135fdc669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
