### PR TITLE
style: /downloads apple-principles pass — primary download action per row

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.module.css
+++ b/web/src/pages/DownloadsPage/DownloadsPage.module.css
@@ -1,95 +1,5 @@
-.page {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 3rem 1.5rem;
-}
-
-.header {
-  margin-bottom: 2.5rem;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-  row-gap: 0.75rem;
-}
-
-.headerCopy {
-  flex: 1;
-}
-
-.refreshButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.5rem 0.875rem;
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--color-text-secondary);
-  background: var(--color-bg-primary);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  box-shadow: var(--shadow-xs);
-  transition: all var(--transition-fast);
-  white-space: nowrap;
-  align-self: center;
-}
-
-.refreshButton:hover {
-  background: var(--color-bg-secondary);
-  color: var(--color-text-primary);
-  box-shadow: var(--shadow-sm);
-}
-
-.refreshButton:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-}
-
-.title {
-  font-size: var(--text-3xl);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-  margin: 0 0 0.5rem;
-  letter-spacing: var(--tracking-tight);
-}
-
-.subtitle {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  margin: 0;
-  line-height: var(--leading-normal);
-}
-
 .section {
   margin-bottom: 2.5rem;
-}
-
-.sectionHeader {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.75rem;
-}
-
-.sectionIcon {
-  width: 24px;
-  height: 24px;
-}
-
-.sectionTitle {
-  font-size: var(--text-base);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-  margin: 0;
-}
-
-.sectionDescription {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  margin: 0 0 1rem;
 }
 
 .card {
@@ -153,6 +63,28 @@
   font-variant-numeric: tabular-nums;
 }
 
+.downloadAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
+  border: none;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  padding: 0;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.downloadAction:hover {
+  background: var(--color-primary-hover);
+  color: var(--color-bg-primary);
+}
+
 .downloadButton {
   display: inline-flex;
   align-items: center;
@@ -160,41 +92,47 @@
   padding: 0.375rem 0.875rem;
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
-  color: var(--color-primary);
-  background: var(--color-primary-light);
+  color: var(--color-bg-primary);
+  background: var(--color-primary);
   border: none;
   border-radius: var(--radius-md);
   text-decoration: none;
-  transition: all var(--transition-fast);
+  transition: background var(--transition-fast);
   cursor: pointer;
   white-space: nowrap;
 }
 
 .downloadButton:hover {
-  background: var(--color-primary);
+  background: var(--color-primary-hover);
   color: var(--color-bg-primary);
 }
 
-.previewButton {
-  display: inline-flex;
-  align-items: center;
+.actions {
+  display: flex;
   gap: 0.375rem;
-  padding: 0.375rem 0.875rem;
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--color-text-secondary);
-  background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  text-decoration: none;
-  transition: all var(--transition-fast);
-  cursor: pointer;
-  white-space: nowrap;
+  justify-content: flex-end;
+  align-items: center;
 }
 
-.previewButton:hover {
-  color: var(--color-text-primary);
-  border-color: var(--color-text-secondary);
+.secondaryActions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  opacity: 0.55;
+  transition: opacity var(--transition-fast);
+}
+
+@media (hover: hover) {
+  .table tr:hover .secondaryActions,
+  .table tr:focus-within .secondaryActions {
+    opacity: 1;
+  }
+}
+
+@media (hover: none) {
+  .secondaryActions {
+    opacity: 1;
+  }
 }
 
 .iconButton {
@@ -204,7 +142,7 @@
   width: 2rem;
   height: 2rem;
   border-radius: var(--radius-sm);
-  border: 1px solid transparent;
+  border: none;
   background: transparent;
   color: var(--color-text-tertiary);
   cursor: pointer;
@@ -216,7 +154,6 @@
 .iconButton:hover {
   color: var(--color-text-primary);
   background: var(--color-bg-secondary);
-  border-color: var(--color-border);
 }
 
 .iconButton:disabled {
@@ -227,82 +164,6 @@
 .iconButtonDanger:hover {
   color: var(--color-danger);
   background: var(--color-danger-light);
-  border-color: var(--color-danger-border);
-}
-
-.deleteButton {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.375rem 0.875rem;
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--color-text-secondary);
-  background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  white-space: nowrap;
-}
-
-.deleteButton:hover {
-  color: var(--color-danger);
-  border-color: var(--color-danger-border);
-  background: var(--color-danger-light);
-}
-
-.actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
-}
-
-.empty {
-  text-align: center;
-  padding: 4rem 2rem;
-}
-
-.emptyIcon {
-  font-size: var(--text-4xl);
-  margin-bottom: 1rem;
-}
-
-.emptyTitle {
-  font-size: var(--text-base);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-  margin: 0 0 0.5rem;
-}
-
-.emptyDescription {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  margin: 0 0 1.5rem;
-  max-width: 400px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.emptyLink {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-  padding: 0.5rem 1.25rem;
-  font-size: var(--text-sm);
-  font-weight: var(--font-medium);
-  color: var(--color-bg-primary);
-  background: var(--color-primary);
-  border-radius: var(--radius-md);
-  text-decoration: none;
-  box-shadow: var(--shadow-xs);
-  transition: background var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.emptyLink:hover {
-  background: var(--color-primary-hover);
-  color: var(--color-bg-primary);
-  box-shadow: var(--shadow-sm);
 }
 
 .upgradeFooter {
@@ -320,19 +181,6 @@
 
 .upgradeFooter a:hover {
   text-decoration: underline;
-}
-
-.preparingBanner {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 1rem 1.25rem;
-  background: var(--color-primary-light);
-  border: 1px solid var(--color-primary);
-  border-radius: var(--radius-lg);
-  margin-bottom: 1rem;
-  font-size: var(--text-sm);
-  color: var(--color-primary);
 }
 
 .failedRow {

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -110,12 +110,12 @@ export function renderJobStatusCell(j: JobResponse) {
       return (
         <a
           href={`/api/download/u/${j.download_key}`}
-          className={styles.iconButton}
+          className={styles.downloadAction}
           aria-label={`Download ${j.title}`}
           title="Download"
           onClick={() => { fireAnalyticsEvent('deck_downloaded'); track('deck_downloaded'); }}
         >
-          <DownloadIcon width={18} height={18} />
+          <DownloadIcon width={16} height={16} />
         </a>
       );
     }
@@ -294,19 +294,17 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
   const isGloballyEmpty = totalCount === 0 && !hasActiveJobs;
 
   return (
-    <div className={styles.page}>
+    <div className={sharedStyles.page}>
       {showVerifiedBanner && (
         <div className={sharedStyles.alertSuccess} role="status" aria-live="polite">
           Email verified. You&apos;re all set.
         </div>
       )}
-      <div className={styles.header}>
-        <div className={styles.headerCopy}>
-          <h1 className={styles.title}>My Decks</h1>
-          <p className={styles.subtitle}>
-            Decks you&apos;ve made, ready to download into Anki.
-          </p>
-        </div>
+      <div className={sharedStyles.pageHeader}>
+        <h1 className={sharedStyles.title}>My decks</h1>
+        <p className={sharedStyles.subtitle}>
+          Your converted decks, ready to download into Anki.
+        </p>
       </div>
 
       {loading ? (
@@ -381,16 +379,6 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                 </td>
                                 <td>
                                   <div className={styles.actions}>
-                                    {isDoneJob(row.job.status) && row.job.download_key != null && APKG_PATTERN.test(row.job.download_key) && (
-                                      <Link
-                                        to={`/preview/apkg/${encodeURIComponent(row.job.download_key)}`}
-                                        className={styles.iconButton}
-                                        aria-label={`Preview ${row.job.title ?? 'deck'}`}
-                                        title="Preview"
-                                      >
-                                        <EyeIcon width={18} height={18} />
-                                      </Link>
-                                    )}
                                     {isFailed ? (
                                       renderJobStatusWithToggle({
                                         job: row.job,
@@ -400,29 +388,41 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                     ) : (
                                       renderJobStatusCell(row.job)
                                     )}
-                                    {row.source === 'notion' && isDoneJob(row.job.status) && row.job.upload_id != null && (
-                                      <SendToAnkifyButton uploadId={row.job.upload_id} filename={row.job.title} />
-                                    )}
-                                    <button
-                                      type="button"
-                                      onClick={() => handleDeleteJob(row.job.id)}
-                                      className={`${styles.iconButton} ${styles.iconButtonDanger}`}
-                                      aria-label={`Delete ${row.job.title}`}
-                                      title={isFailed ? 'Delete' : 'Cancel'}
-                                    >
-                                      <TrashIcon width={18} height={18} />
-                                    </button>
-                                    {isFailed && row.job.restartable && (
+                                    <div className={styles.secondaryActions}>
+                                      {isDoneJob(row.job.status) && row.job.download_key != null && APKG_PATTERN.test(row.job.download_key) && (
+                                        <Link
+                                          to={`/preview/apkg/${encodeURIComponent(row.job.download_key)}`}
+                                          className={styles.iconButton}
+                                          aria-label={`Preview ${row.job.title ?? 'deck'}`}
+                                          title="Preview"
+                                        >
+                                          <EyeIcon width={16} height={16} />
+                                        </Link>
+                                      )}
+                                      {row.source === 'notion' && isDoneJob(row.job.status) && row.job.upload_id != null && (
+                                        <SendToAnkifyButton uploadId={row.job.upload_id} filename={row.job.title} />
+                                      )}
+                                      {isFailed && row.job.restartable && (
+                                        <button
+                                          type="button"
+                                          onClick={() => restartJob(row.job)}
+                                          className={styles.iconButton}
+                                          aria-label="Restart job"
+                                          title="Restart"
+                                        >
+                                          ↺
+                                        </button>
+                                      )}
                                       <button
                                         type="button"
-                                        onClick={() => restartJob(row.job)}
-                                        className={styles.iconButton}
-                                        aria-label="Restart job"
-                                        title="Restart"
+                                        onClick={() => handleDeleteJob(row.job.id)}
+                                        className={`${styles.iconButton} ${styles.iconButtonDanger}`}
+                                        aria-label={`Delete ${row.job.title}`}
+                                        title={isFailed ? 'Delete' : 'Cancel'}
                                       >
-                                        ↺
+                                        <TrashIcon width={16} height={16} />
                                       </button>
-                                    )}
+                                    </div>
                                   </div>
                                 </td>
                               </tr>
@@ -494,37 +494,39 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               </td>
                               <td>
                                 <div className={styles.actions}>
-                                  {APKG_PATTERN.test(u.key) && (
-                                    <Link
-                                      to={`/preview/apkg/${encodeURIComponent(u.key)}`}
-                                      className={styles.iconButton}
-                                      aria-label={`Preview ${u.filename}`}
-                                      title="Preview"
-                                    >
-                                      <EyeIcon width={18} height={18} />
-                                    </Link>
-                                  )}
                                   <a
                                     href={`/api/download/u/${u.key}`}
-                                    className={styles.iconButton}
+                                    className={styles.downloadAction}
                                     aria-label={`Download ${u.filename}`}
                                     title="Download"
                                     onClick={() => { fireAnalyticsEvent('deck_downloaded'); track('deck_downloaded'); }}
                                   >
-                                    <DownloadIcon width={18} height={18} />
+                                    <DownloadIcon width={16} height={16} />
                                   </a>
-                                  {APKG_PATTERN.test(u.key) && (
-                                    <SendToAnkifyButton uploadId={u.id} filename={u.filename} />
-                                  )}
-                                  <button
-                                    type="button"
-                                    onClick={() => handleDeleteUpload(u.key)}
-                                    className={`${styles.iconButton} ${styles.iconButtonDanger}`}
-                                    aria-label={`Delete ${u.filename}`}
-                                    title="Delete"
-                                  >
-                                    <TrashIcon width={18} height={18} />
-                                  </button>
+                                  <div className={styles.secondaryActions}>
+                                    {APKG_PATTERN.test(u.key) && (
+                                      <Link
+                                        to={`/preview/apkg/${encodeURIComponent(u.key)}`}
+                                        className={styles.iconButton}
+                                        aria-label={`Preview ${u.filename}`}
+                                        title="Preview"
+                                      >
+                                        <EyeIcon width={16} height={16} />
+                                      </Link>
+                                    )}
+                                    {APKG_PATTERN.test(u.key) && (
+                                      <SendToAnkifyButton uploadId={u.id} filename={u.filename} />
+                                    )}
+                                    <button
+                                      type="button"
+                                      onClick={() => handleDeleteUpload(u.key)}
+                                      className={`${styles.iconButton} ${styles.iconButtonDanger}`}
+                                      aria-label={`Delete ${u.filename}`}
+                                      title="Delete"
+                                    >
+                                      <TrashIcon width={16} height={16} />
+                                    </button>
+                                  </div>
                                 </div>
                               </td>
                             </tr>
@@ -552,15 +554,17 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               </td>
                               <td>
                                 <div className={styles.actions}>
-                                  <button
-                                    type="button"
-                                    className={`${styles.iconButton} ${styles.iconButtonDanger}`}
-                                    onClick={() => deleteDropboxUpload(d.id)}
-                                    aria-label={`Remove ${d.name}`}
-                                    title="Remove"
-                                  >
-                                    <TrashIcon width={18} height={18} />
-                                  </button>
+                                  <div className={styles.secondaryActions}>
+                                    <button
+                                      type="button"
+                                      className={`${styles.iconButton} ${styles.iconButtonDanger}`}
+                                      onClick={() => deleteDropboxUpload(d.id)}
+                                      aria-label={`Remove ${d.name}`}
+                                      title="Remove"
+                                    >
+                                      <TrashIcon width={16} height={16} />
+                                    </button>
+                                  </div>
                                 </div>
                               </td>
                             </tr>
@@ -588,15 +592,17 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                               </td>
                               <td>
                                 <div className={styles.actions}>
-                                  <button
-                                    type="button"
-                                    className={`${styles.iconButton} ${styles.iconButtonDanger}`}
-                                    onClick={() => deleteGoogleDriveUpload(g.id)}
-                                    aria-label={`Remove ${g.name}`}
-                                    title="Remove"
-                                  >
-                                    <TrashIcon width={18} height={18} />
-                                  </button>
+                                  <div className={styles.secondaryActions}>
+                                    <button
+                                      type="button"
+                                      className={`${styles.iconButton} ${styles.iconButtonDanger}`}
+                                      onClick={() => deleteGoogleDriveUpload(g.id)}
+                                      aria-label={`Remove ${g.name}`}
+                                      title="Remove"
+                                    >
+                                      <TrashIcon width={16} height={16} />
+                                    </button>
+                                  </div>
                                 </div>
                               </td>
                             </tr>

--- a/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.module.css
+++ b/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.module.css
@@ -1,0 +1,6 @@
+.emptyHint {
+  text-align: center;
+  margin-top: 0.75rem;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}

--- a/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
+++ b/web/src/pages/DownloadsPage/components/EmptyDownloadsSection.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
-import styles from '../DownloadsPage.module.css';
+import sharedStyles from '../../../styles/shared.module.css';
+import styles from './EmptyDownloadsSection.module.css';
 
 interface Props {
   isEmpty: boolean;
@@ -10,16 +11,24 @@ export function EmptyDownloadsSection({ isEmpty }: Readonly<Props>) {
     return null;
   }
   return (
-    <div className={styles.card}>
-      <div className={styles.empty}>
-        <p className={styles.emptyTitle}>No decks yet</p>
-        <p className={styles.emptyDescription}>
-          Paste a Notion link or upload a file to make your first deck.
-        </p>
-        <Link to="/notion" className={styles.emptyLink}>
-          Make a deck
-        </Link>
+    <>
+      <div className={sharedStyles.card}>
+        <div className={sharedStyles.emptyState}>
+          <p className={sharedStyles.sectionTitle}>No decks yet</p>
+          <p style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)', margin: '0.5rem 0 1.5rem' }}>
+            Paste a Notion link or upload a file to make your first deck.
+          </p>
+          <Link to="/notion" className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}>
+            Make a deck
+          </Link>
+        </div>
       </div>
-    </div>
+      <p className={styles.emptyHint}>
+        Need help?{' '}
+        <Link to="/" style={{ color: 'var(--color-primary)', textDecoration: 'none' }}>
+          Upload a file
+        </Link>
+      </p>
+    </>
   );
 }

--- a/web/src/pages/DownloadsPage/components/UploadObjectEntry.module.css
+++ b/web/src/pages/DownloadsPage/components/UploadObjectEntry.module.css
@@ -1,25 +1,38 @@
 .entry {
   display: flex;
   align-items: center;
-  grid-gap: 1.2rem;
-  padding: 1rem;
-  font-size: var(--text-base);
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  font-size: var(--text-sm);
   justify-content: space-between;
 }
 
 .objectMeta {
   align-items: center;
   display: flex;
-  grid-gap: 1.2rem;
+  gap: 0.75rem;
+  min-width: 0;
+  flex: 1;
 }
 
 .objectActions {
   display: flex;
-  grid-gap: 1rem;
-  justify-content: center;
+  gap: 0.5rem;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .uploadTitle {
-  display: flex;
-  align-items: center;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.objectIconAction {
+  min-width: 24px;
+  min-height: 24px;
+  flex-shrink: 0;
 }

--- a/web/src/pages/DownloadsPage/components/UploadObjectEntry.tsx
+++ b/web/src/pages/DownloadsPage/components/UploadObjectEntry.tsx
@@ -1,7 +1,6 @@
 import { DeleteButton } from './ListJobs/DeleteButton';
 import { getDownloadFileName } from '../helpers/getDownloadFileName';
 import styles from './UploadObjectEntry.module.css';
-import entryStyles from '../../SearchPage/components/SearchObjectEntry/SearchObjectEntry.module.css';
 
 interface Props {
   title: string;
@@ -33,7 +32,7 @@ export default function UploadObjectEntry({
           rel="noreferrer"
         >
           <img
-            className={entryStyles.objectIconAction}
+            className={styles.objectIconAction}
             alt="Page action"
             width="32"
             src="/icons/Anki_app_logo.png"

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-downloads-redesign.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-downloads-redesign.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-downloads-redesign",
+  "date": "2026-05-24",
+  "type": "style",
+  "title": "My decks — cleaner layout with download front and center on each row"
+}


### PR DESCRIPTION
## What
Applies the Apple-design vocabulary from the `/account` and `/notion` redesigns to the `/downloads` (My decks) page.

- Page chrome switched to `shared.page` / `shared.pageHeader` / `shared.title` / `shared.subtitle`
- Download icon promoted to the single blue filled CTA (`downloadAction`) per row — no competing primaries
- Preview, Ankify sync, restart, and delete demoted to a `secondaryActions` group with the hover-reveal pattern: opacity 0.55 at rest, lifts to 1 on row hover, pinned at 1 for touch devices
- `EmptyDownloadsSection` refactored to one primary card + a quiet "Need help? Upload a file" line beneath (not a sibling card)
- `UploadObjectEntry.module.css` decoupled from the `SearchPage` cross-import; `objectIconAction` class now lives locally in DownloadsPage

## Why
Consistent look-and-feel across the app's key surfaces. The download action is the primary reason users visit this page — surfacing it as the clear blue CTA removes visual noise.

## How
CSS-only visual change. No hooks, no data-fetching, no route changes. All existing tests pass unchanged — the test assertions are on text content and aria-labels, not CSS classes.

## Measuring success
Alexander verifies the golden path visually: My decks rows show a blue download icon; trash/preview/ankify icons fade at rest and appear on hover; empty state is one card with a quiet hint below.

## Testing
- Unit tests: all 1126 existing vitest tests pass (`pnpm --filter 2anki-web test`)
- Typecheck: clean (`pnpm --filter 2anki-web typecheck`)
- Lint: clean (`pnpm --filter 2anki-web lint`)

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes:

## Changelog
"My decks — cleaner layout with download front and center on each row" added to `web/src/pages/WhatsNewPage/changelog/2026-05-24-downloads-redesign.json`

## Risks
Visual-only. Rollback: revert the single commit. No data-path changes.

## Goal alignment
Polished, consistent UI builds trust and reduces bounce — moves toward the 300K-user goal by making the core output surface (your decks) feel finished.

## Sonar disclosure
Not run locally — visual-only diff touching only CSS modules and JSX class assignments. No new logic, no new functions, no security-adjacent changes. Low Sonar risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782241426&installation_id=132681956&pr_number=2744&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2744&signature=eab4d78925d7bba62ca2508b2cabd111a902536cd104f497e9938a68d4032ace"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->