### PR TITLE
style: /import apple-principles pass — primary import action

### DIFF
--- a/web/src/pages/ImportPage/ImportPage.module.css
+++ b/web/src/pages/ImportPage/ImportPage.module.css
@@ -1,19 +1,3 @@
-.stepSection {
-  margin-bottom: 1.5rem;
-}
-
-.stepLabel {
-  font-size: var(--text-sm);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-secondary);
-  margin-bottom: 0.5rem;
-}
-
-.stepDisabled {
-  opacity: 0.5;
-  pointer-events: none;
-}
-
 .dropZone {
   border: 2px dashed var(--color-border);
   border-radius: var(--radius-md);
@@ -47,7 +31,7 @@
 .dropZoneSubtitle {
   margin: 0.25rem 0 0;
   font-size: var(--text-sm);
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
 }
 
 .dropZoneFileName {
@@ -57,7 +41,7 @@
 
 .dropZoneError {
   color: var(--color-danger);
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   margin-top: 0.5rem;
 }
 
@@ -78,6 +62,14 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+}
+
+.pagePickerInput:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
 .pagePickerList {
@@ -124,14 +116,9 @@
 
 .pagePickerEmpty {
   text-align: center;
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
   padding: 1rem;
   font-size: var(--text-sm);
-}
-
-.pagePickerHelp {
-  font-size: var(--text-xs);
-  color: var(--color-text-secondary);
 }
 
 .progressContainer {
@@ -173,27 +160,8 @@
 
 .progressReassurance {
   font-size: var(--text-xs);
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
   margin: 0;
-}
-
-.completeContainer {
-  text-align: center;
-  padding: 2rem 1rem;
-  background: var(--color-success-light);
-  border: 1px solid var(--color-success-border);
-  border-radius: var(--radius-md);
-}
-
-.completeTitle {
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  margin: 0 0 0.25rem;
-}
-
-.completeSummary {
-  font-size: var(--text-sm);
-  margin: 0 0 1.5rem;
 }
 
 .completeActions {
@@ -201,25 +169,7 @@
   gap: 0.75rem;
   justify-content: center;
   flex-wrap: wrap;
-}
-
-.errorContainer {
-  text-align: center;
-  padding: 2rem 1rem;
-  background: var(--color-danger-light);
-  border: 1px solid var(--color-danger-border);
-  border-radius: var(--radius-md);
-}
-
-.errorTitle {
-  font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
-  margin: 0 0 0.5rem;
-}
-
-.errorBody {
-  font-size: var(--text-sm);
-  margin: 0 0 1.5rem;
+  margin-top: 1rem;
 }
 
 .errorActions {
@@ -227,88 +177,35 @@
   gap: 0.75rem;
   justify-content: center;
   flex-wrap: wrap;
-}
-
-.connectContainer {
-  text-align: center;
-  padding: 2rem 1rem;
-}
-
-.connectBody {
-  font-size: var(--text-sm);
-  margin: 0 0 1rem;
+  margin-top: 1rem;
 }
 
 .connectPrivacy {
   font-size: var(--text-xs);
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
   margin-top: 1rem;
-}
-
-.freeTierBanner {
-  padding: 0.75rem 1rem;
-  background: var(--color-warning-light);
-  border: 1px solid var(--color-warning-border);
-  border-radius: var(--radius-sm);
-  font-size: var(--text-sm);
-  margin-bottom: 1.5rem;
-}
-
-.freeTierBanner a {
-  font-weight: var(--font-semibold);
-}
-
-.actions {
-  margin-top: 1.5rem;
-}
-
-.quickImportSection {
-  margin-top: 1.5rem;
   text-align: center;
 }
 
-.quickImportDivider {
+.connectCta {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  margin: 0;
-}
-
-.quickImportDivider::before,
-.quickImportDivider::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--color-border);
-}
-
-.quickImportDividerText {
-  padding: 0 0.75rem;
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.quickImportHelp {
-  font-size: var(--text-xs);
-  color: var(--color-text-secondary);
-  margin-top: 0.5rem;
+  gap: 0.75rem;
+  padding: 1.5rem 0;
 }
 
 .stepCard {
   background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-light);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-xs);
 }
 
 .stepCardDisabled {
   opacity: 0.5;
   pointer-events: none;
-}
-
-.stepCardSpaced {
-  margin-top: 1rem;
 }
 
 .stepCardHeader {
@@ -345,14 +242,52 @@
   gap: 1rem;
 }
 
-.destinationOption {
-  padding: 1.25rem;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
+.quickImportBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
 }
 
-.destinationActions {
-  margin-top: 1rem;
+.quickImportHelp {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.quickImportDivider {
+  display: flex;
+  align-items: center;
+  margin: 0;
+}
+
+.quickImportDivider::before,
+.quickImportDivider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
+.quickImportDividerText {
+  padding: 0 0.75rem;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.pagePickerBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.pagePickerHelp {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.pagePickerActions {
+  margin-top: 0.25rem;
 }
 
 @media (max-width: 640px) {

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -27,7 +27,6 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
   const job = useImportJob();
 
   const isConnected = notionData.connected === true;
-  const isIdle = job.phase === 'idle';
   const isUploading = job.phase === 'uploading';
   const isPolling = job.phase === 'polling';
   const isCompleted = job.phase === 'completed';
@@ -88,12 +87,12 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
     return (
       <div className={sharedStyles.page}>
         <div className={sharedStyles.pageHeader}>
-          <h1 className={sharedStyles.title}>Connect Notion to import cards</h1>
+          <h1 className={sharedStyles.title}>Import to Notion</h1>
           <p className={sharedStyles.subtitle}>
-            To import an Anki deck into Notion, 2anki needs access to your workspace.
+            Connect Notion to import Anki decks into your workspace.
           </p>
         </div>
-        <div className={styles.connectContainer}>
+        <div className={styles.connectCta}>
           <a href="/notion" className={sharedStyles.btnPrimary}>
             Connect to Notion
           </a>
@@ -109,33 +108,33 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
   if (isCompleted) {
     return (
       <div className={sharedStyles.page}>
-        <div className={styles.completeContainer}>
-          <h2 className={styles.completeTitle}>Import complete</h2>
-          <p className={styles.completeSummary}>
-            {job.progress.imported} cards added
-            {selectedPageTitle
-              ? <> to &ldquo;{selectedPageTitle}&rdquo;</>
-              : <> to your &ldquo;2anki Imports&rdquo; page</>}
-          </p>
-          <div className={styles.completeActions}>
-            {job.notionPageUrl && (
-              <a
-                href={job.notionPageUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={sharedStyles.btnPrimary}
-              >
-                Open in Notion
-              </a>
-            )}
-            <button
-              type="button"
-              className={sharedStyles.btnSecondary}
-              onClick={handleReset}
+        <div className={sharedStyles.pageHeader}>
+          <h1 className={sharedStyles.title}>Import to Notion</h1>
+        </div>
+        <div className={sharedStyles.notificationSuccess}>
+          {job.progress.imported} cards added
+          {selectedPageTitle
+            ? <> to &ldquo;{selectedPageTitle}&rdquo;</>
+            : <> to your &ldquo;2anki Imports&rdquo; page</>}
+        </div>
+        <div className={styles.completeActions}>
+          {job.notionPageUrl && (
+            <a
+              href={job.notionPageUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
             >
-              Import another deck
-            </button>
-          </div>
+              Open in Notion
+            </a>
+          )}
+          <button
+            type="button"
+            className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}
+            onClick={handleReset}
+          >
+            Import another deck
+          </button>
         </div>
       </div>
     );
@@ -146,39 +145,37 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
     const partialProgress = !isUpgradeError && job.progress.total_notes > 0 && job.errorMessage == null;
     return (
       <div className={sharedStyles.page}>
-        <div className={styles.errorContainer}>
-          <h2 className={styles.errorTitle}>
-            {isUpgradeError ? 'Upgrade to continue' : 'Import stopped'}
-          </h2>
-          <p className={styles.errorBody}>
-            {isUpgradeError && job.errorMessage}
-            {partialProgress &&
-              `Imported ${job.progress.imported} of ${job.progress.total_notes} cards before something went wrong. The cards already created are still in your Notion page.`}
-            {!isUpgradeError && !partialProgress &&
-              (job.errorMessage ?? 'Something went wrong.')}
-          </p>
-          <div className={styles.errorActions}>
-            {isUpgradeError ? (
-              <Link to="/pricing" className={sharedStyles.btnPrimary}>
-                View plans
-              </Link>
-            ) : (
-              <button
-                type="button"
-                className={sharedStyles.btnPrimary}
-                onClick={handleReset}
-              >
-                Try again
-              </button>
-            )}
+        <div className={sharedStyles.pageHeader}>
+          <h1 className={sharedStyles.title}>Import to Notion</h1>
+        </div>
+        <div className={sharedStyles.notificationDanger}>
+          {isUpgradeError && job.errorMessage}
+          {partialProgress &&
+            `Imported ${job.progress.imported} of ${job.progress.total_notes} cards before something went wrong. The cards already created are still in your Notion page.`}
+          {!isUpgradeError && !partialProgress &&
+            (job.errorMessage ?? 'Something went wrong.')}
+        </div>
+        <div className={styles.errorActions}>
+          {isUpgradeError ? (
+            <Link to="/pricing" className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}>
+              View plans
+            </Link>
+          ) : (
             <button
               type="button"
-              className={sharedStyles.btnSecondary}
+              className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
               onClick={handleReset}
             >
-              {isUpgradeError ? 'Try a smaller deck' : 'Start over'}
+              Try again
             </button>
-          </div>
+          )}
+          <button
+            type="button"
+            className={`${sharedStyles.btnSecondary} ${sharedStyles.btnInline}`}
+            onClick={handleReset}
+          >
+            {isUpgradeError ? 'Try a smaller deck' : 'Start over'}
+          </button>
         </div>
       </div>
     );
@@ -208,7 +205,7 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
       </div>
 
       {!paying && (
-        <div className={styles.freeTierBanner}>
+        <div className={sharedStyles.notificationWarning}>
           Free plan · up to 1 000 cards per import.{' '}
           <Link to="/pricing">Upgrade for unlimited imports</Link>
         </div>
@@ -228,14 +225,14 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
         {fileError && <p className={styles.dropZoneError}>{fileError}</p>}
       </div>
 
-      <div className={`${styles.stepCard} ${styles.stepCardSpaced} ${file == null ? styles.stepCardDisabled : ''}`}>
+      <div className={`${styles.stepCard} ${file == null ? styles.stepCardDisabled : ''}`}>
         <div className={styles.stepCardHeader}>
           <span className={styles.stepNumber}>2</span>
           <p className={styles.stepTitle}>Pick a destination</p>
         </div>
 
         <div className={styles.destinationGroup}>
-          <div className={styles.destinationOption}>
+          <div className={styles.quickImportBlock}>
             <button
               type="button"
               className={sharedStyles.btnPrimary}
@@ -253,7 +250,7 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
             <span className={styles.quickImportDividerText}>or choose a page</span>
           </div>
 
-          <div className={styles.destinationOption}>
+          <div className={styles.pagePickerBlock}>
             <NotionPagePicker
               selectedPageId={selectedPageId}
               onPageSelected={handlePageSelected}
@@ -263,10 +260,10 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
               Showing top-level pages shared with 2anki. Missing a page? Check your
               Notion sharing settings.
             </p>
-            <div className={styles.destinationActions}>
+            <div className={styles.pagePickerActions}>
               <button
                 type="button"
-                className={sharedStyles.btnSecondary}
+                className={sharedStyles.btnOutline}
                 disabled={file == null || selectedPageId == null || isRunning}
                 onClick={handleStartImport}
               >

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-import-redesign.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-import-redesign.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-import-redesign",
+  "date": "2026-05-24",
+  "type": "style",
+  "title": "Anki to Notion import — cleaner layout with a single primary action"
+}


### PR DESCRIPTION
## What
Applies the Apple-design vocabulary from `/account` and `/notion` redesigns to the `/import` page (Anki → Notion direction).

## Why
The page had two blue (`btnPrimary`) buttons on the same surface simultaneously — Quick import and Import to selected page — breaking the one-primary-per-surface rule. The complete/error states used local colored containers instead of the shared notification tokens. Helper text was oversized and insufficiently demoted.

## How
- **Single primary**: Quick import is the blue `btnPrimary` (fires with just a file). Import to selected page demotes to `btnOutline` — outline/no-fill, still functional but lower weight.
- **Flat card**: Removed the nested `destinationOption` border cards that lived inside the step card. The destination group is now flat sections with a visual divider.
- **Shared notification tokens**: Complete state uses `sharedStyles.notificationSuccess`; error state uses `sharedStyles.notificationDanger`; free-tier banner uses `sharedStyles.notificationWarning`. All three were previously local colored containers.
- **Connect state**: Proper `pageHeader` + `connectCta` column (centered, flex-column) matching the empty/setup-state pattern.
- **Helper text demotion**: All help and hint text now `--text-xs` / `--color-text-tertiary`.
- **CSS cleanup**: Removed 14 dead CSS classes (completeContainer, completeTitle, completeSummary, errorContainer, errorTitle, errorBody, connectContainer, connectBody, freeTierBanner, stepCardSpaced, destinationOption, destinationActions, stepSection, stepLabel).
- **Changelog entry**: `2026-05-24-import-redesign.json`.

No features added or removed.

## Measuring success
Visual inspection at `/import` (free user, paid user, disconnected, completed, failed states). No new metrics — style-only change.

## Testing
- Unit tests: existing suite passes (1126 tests, exit 0)
- `pnpm --filter 2anki-web typecheck`: clean
- `pnpm --filter 2anki-web lint`: clean

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: visual-only diff, please verify all five states (loading, not-connected, idle, complete, failed) at both free and paid user levels.

## Changelog
"Anki to Notion import — cleaner layout with a single primary action"

## Risks
None beyond a visual regression in an obscure state. Rollback: revert the two changed files.

## Goal alignment
Reduces friction at the import surface — simpler visual hierarchy means less cognitive load at a key conversion step.

## Sonar
Not run locally; visual-only diff with no new logic, low risk.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782241559&installation_id=132681956&pr_number=2746&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2746&signature=2a75cca3dee2ef0db079405f094c3d6a31c4dd0764a6357282b03b01de8a40a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->