### PR TITLE
style: /pricing apple-principles pass — Unlimited is the one CTA

### DIFF
--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -323,72 +323,6 @@
 }
 
 /* =====================================================================
-   AUTO SYNC — live tier (raised surface with accent border)
-   ===================================================================== */
-.cardAutoSync {
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 1px var(--color-primary),
-    0 18px 44px -18px var(--color-focus-ring);
-}
-
-.cardAutoSyncUpsell {
-  box-shadow: 0 0 0 3px var(--color-primary),
-    0 18px 44px -18px var(--color-focus-ring);
-}
-
-.cardAutoSync::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 4px;
-  background: linear-gradient(90deg, var(--color-primary) 0%, var(--color-indigo-dark) 100%);
-  z-index: 1;
-}
-
-.cardAutoSync:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 0 0 1px var(--color-primary),
-    0 24px 52px -18px var(--color-focus-ring);
-}
-
-/* =====================================================================
-   LIFETIME — earned tier (warm paper)
-   ===================================================================== */
-.cardLifetime {
-  background: linear-gradient(180deg, var(--color-gold-bg) 0%, var(--color-gold-bg-end) 100%);
-  border-color: var(--color-gold-border);
-}
-
-.cardLifetime::before {
-  content: '∞';
-  position: absolute;
-  top: 1.1rem;
-  right: 1.4rem;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: 'Fraunces', Georgia, serif;
-  font-size: 18px;
-  font-weight: 600;
-  font-variation-settings: 'opsz' 144;
-  color: var(--color-gold-text);
-  border: 1px solid var(--color-gold-border-light);
-  border-radius: var(--radius-full);
-  background: rgba(255, 255, 255, 0.5);
-  z-index: 1;
-  letter-spacing: 0;
-  line-height: 1;
-}
-
-.cardLifetime:hover {
-  border-color: var(--color-gold-border-hover);
-}
-
-/* =====================================================================
    CARD HEADER
    ===================================================================== */
 .cardHeader {
@@ -408,10 +342,6 @@
   text-transform: uppercase;
   letter-spacing: 0.18em;
   margin: 0;
-}
-
-.cardLifetime .cardTitle {
-  color: var(--color-gold-text);
 }
 
 .cardPriceLine {
@@ -450,14 +380,10 @@
   font-size: 1.55rem;
   font-weight: 500;
   font-variation-settings: 'opsz' 96, 'SOFT' 40;
-  color: var(--color-gold-text);
+  color: var(--color-text-tertiary);
   vertical-align: 0.55rem;
   letter-spacing: -0.02em;
   margin-left: 0.4rem;
-}
-
-.cardLifetime .cardPrice {
-  color: var(--color-gold-text-dark);
 }
 
 .cardPriceChip {
@@ -548,18 +474,6 @@
   color: var(--color-primary);
 }
 
-.cardLifetime .benefit {
-  color: var(--color-gold-text-darker);
-}
-
-.cardLifetime .benefitIcon {
-  color: var(--color-gold-text);
-}
-
-.cardAutoSync .benefitIcon {
-  color: var(--color-primary);
-}
-
 /* =====================================================================
    FOOTER
    ===================================================================== */
@@ -571,11 +485,9 @@
 }
 
 .cardCaption {
-  font-family: 'Fraunces', Georgia, serif;
+  font-family: var(--font-sans);
   font-size: var(--text-xs);
-  font-style: italic;
-  font-variation-settings: 'opsz' 9, 'SOFT' 100;
-  color: var(--color-gold-text);
+  color: var(--color-text-tertiary);
   text-align: center;
   margin: 0;
   line-height: var(--leading-relaxed);
@@ -655,20 +567,21 @@
 
 .cardButtonOutline {
   composes: cardButton;
-  background: transparent;
-  color: var(--color-gold-text-dark);
-  border: 1px solid var(--color-gold-border-hover);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  box-shadow: none;
 }
 
 .cardButtonOutline::after {
-  color: var(--color-gold-text);
+  color: var(--color-text-secondary);
 }
 
 .cardButtonOutline:hover {
-  background: rgba(255, 255, 255, 0.7);
-  color: var(--color-gold-text-darker);
-  border-color: var(--color-gold-text);
-  box-shadow: 0 6px 18px -6px var(--color-gold-shadow);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+  box-shadow: var(--shadow-xs);
 }
 
 /* =====================================================================

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -324,14 +324,6 @@ export default function PricingPage({
         </div>
       )}
 
-      <p className={styles.sectionLabel}>Pay once — no subscription</p>
-      <PassCards
-        onDayPass={() => handlePassCheckout('24h')}
-        onWeekPass={() => handlePassCheckout('7d')}
-        dayPassPending={dayPassState === 'pending'}
-        weekPassPending={weekPassState === 'pending'}
-      />
-
       <p className={styles.sectionLabel}>Monthly plans</p>
       <div className={styles.anchorGrid}>
         <UnlimitedCard
@@ -348,7 +340,6 @@ export default function PricingPage({
           isLifetime={isLifetime}
           isActive={autoSyncActive}
           capReached={showCapReached}
-          highlighted={isAutoSyncUpsell}
           caption={autoSyncCaptionText}
           waitlistLabel={waitlistLabel}
           waitlistDisabled={
@@ -359,10 +350,17 @@ export default function PricingPage({
         />
       </div>
 
+      <p className={styles.sectionLabel}>Pay once — no subscription</p>
+      <PassCards
+        onDayPass={() => handlePassCheckout('24h')}
+        onWeekPass={() => handlePassCheckout('7d')}
+        dayPassPending={dayPassState === 'pending'}
+        weekPassPending={weekPassState === 'pending'}
+      />
+
       <p className={styles.sectionLabel}>One-time payment</p>
       <div className={styles.grid}>
         <PricingCard
-          className={styles.cardLifetime}
           badge="Pay once"
           badgeMuted
           price="From $345"

--- a/web/src/pages/PricingPage/components/AutoSyncCard.tsx
+++ b/web/src/pages/PricingPage/components/AutoSyncCard.tsx
@@ -1,6 +1,5 @@
 import { PricingCard } from './PricingCard';
 import { AUTO_SYNC_PRICE, MONTHLY_SUFFIX } from '../pricing.constants';
-import styles from '../PricingPage.module.css';
 
 const AUTO_SYNC_BENEFITS = [
   'Everything in Unlimited',
@@ -16,7 +15,6 @@ interface AutoSyncCardProps {
   isLifetime: boolean;
   isActive: boolean;
   capReached: boolean;
-  highlighted?: boolean;
   caption?: string;
   waitlistLabel: string;
   waitlistDisabled: boolean;
@@ -29,7 +27,6 @@ export function AutoSyncCard({
   isLifetime,
   isActive,
   capReached,
-  highlighted = false,
   caption,
   waitlistLabel,
   waitlistDisabled,
@@ -37,14 +34,10 @@ export function AutoSyncCard({
   onWaitlist,
 }: Readonly<AutoSyncCardProps>) {
   const newBadge = showNewBadge ? 'New — built for Notion' : undefined;
-  const cardClass = highlighted
-    ? `${styles.cardAutoSync} ${styles.cardAutoSyncUpsell}`
-    : styles.cardAutoSync;
 
   if (isLifetime) {
     return (
       <PricingCard
-        className={cardClass}
         title="Auto Sync"
         price={AUTO_SYNC_PRICE}
         priceSuffix={MONTHLY_SUFFIX}
@@ -59,7 +52,6 @@ export function AutoSyncCard({
   if (isActive) {
     return (
       <PricingCard
-        className={cardClass}
         title="Auto Sync"
         price={AUTO_SYNC_PRICE}
         priceSuffix={MONTHLY_SUFFIX}
@@ -69,6 +61,7 @@ export function AutoSyncCard({
         onAction={() => undefined}
         actionLabel="Subscribed"
         actionDisabled
+        variant="outline"
         learnMoreHref={LEARN_MORE_HREF}
       />
     );
@@ -77,7 +70,6 @@ export function AutoSyncCard({
   if (capReached) {
     return (
       <PricingCard
-        className={cardClass}
         title="Auto Sync"
         price={AUTO_SYNC_PRICE}
         priceSuffix={MONTHLY_SUFFIX}
@@ -87,6 +79,7 @@ export function AutoSyncCard({
         onAction={onWaitlist}
         actionLabel={waitlistLabel}
         actionDisabled={waitlistDisabled}
+        variant="outline"
         caption={caption ?? "We're at capacity — we'll email you when a seat opens."}
         learnMoreHref={LEARN_MORE_HREF}
       />
@@ -95,7 +88,6 @@ export function AutoSyncCard({
 
   return (
     <PricingCard
-      className={cardClass}
       title="Auto Sync"
       price={AUTO_SYNC_PRICE}
       priceSuffix={MONTHLY_SUFFIX}
@@ -104,6 +96,7 @@ export function AutoSyncCard({
       benefits={AUTO_SYNC_BENEFITS}
       onAction={onSubscribe}
       actionLabel="Subscribe"
+      variant="outline"
       caption={caption}
       learnMoreHref={LEARN_MORE_HREF}
     />

--- a/web/src/pages/PricingPage/components/PassCards.tsx
+++ b/web/src/pages/PricingPage/components/PassCards.tsx
@@ -35,6 +35,7 @@ export function PassCards({
         onAction={onDayPass}
         actionLabel={dayPassPending ? 'Redirecting…' : 'Get Day Pass'}
         actionDisabled={dayPassPending}
+        variant="outline"
       />
       <PricingCard
         title="Week Pass"
@@ -46,6 +47,7 @@ export function PassCards({
         onAction={onWeekPass}
         actionLabel={weekPassPending ? 'Redirecting…' : 'Get Week Pass'}
         actionDisabled={weekPassPending}
+        variant="outline"
       />
     </div>
   );

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-pricing-redesign.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-pricing-redesign.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-pricing-redesign",
+  "date": "2026-05-24",
+  "type": "style",
+  "title": "Pricing page — Unlimited stands out as the recommended plan, every other CTA quiets down"
+}


### PR DESCRIPTION
## Summary

Apple-design pass on `/pricing`. Stripe behavior unchanged — every handler, every analytics event payload, every conditional branch (Free / Paid / Lifetime / cap-reached → waitlist) untouched. **No features removed.**

The change is structural restraint:

- **Unlimited is the one blue saturated CTA.** Every other plan's button — Day Pass, Week Pass, Auto Sync subscribe / waitlist / subscribed, Lifetime apply — drops to a neutral outline. Same Stripe/Linear/Notion convention used on every public comparison page.
- **Auto Sync loses its blue accents.** No more primary-border ring, top-bar gradient, or upsell heavy-shadow. Plain card. Its `highlighted` prop is removed; the context banner above the grid already carries the upsell intent.
- **Lifetime loses its bespoke gold.** Background gradient, gold border, gold text overrides on title/price/benefit/icon/caption, and the decorative ∞ glyph all stripped. Plain card with a neutral "Pay once" muted badge.
- **`cardButtonOutline` rebuilt** as a neutral `btnSecondary`-aligned outline (was gold-tinted). Non-Unlimited CTAs now look secondary, not broken.
- **Section order changed** to Monthly → Passes → Lifetime (was Passes → Monthly → Lifetime), putting the recurring-revenue offer where 95% of conversions land above the fold.

## Trio synthesis

- **PM** (in prior conversation context): Unlimited is the one blue CTA. Stripe-protected strings preserved (every price, plan name, "100 cards per month"). Watch `paywall_upgrade_clicked` for `plan:'unlimited'` divided by `paywall_shown` on `surface:'pricing_page'` — both events still fire at PricingPage.tsx lines 104 and 198. Target +20% lift on Unlimited clicks. `PricingCard` ripples into `NotionLandingPage` — verify both pages.
- **Designer**: Strip gold from Lifetime entirely. Strip blue accents from Auto Sync. Reorder sections so Monthly comes first. `cardButtonOutline` becomes a neutral `btnSecondary`-aligned outline. One concession noted: Lifetime loses its prestige cue; acceptable tradeoff for coherent hierarchy. If A/B later shows Lifetime drops, a subtle `--color-bg-secondary` tint can be added back without breaking the one-accent rule.
- **Engineer**: All CSS lives in `PricingPage.module.css` (no per-component modules). `PricingCard` consumed by `NotionLandingPage` — must verify there. Stripe handlers and analytics payloads frozen. `pricing.constants.ts` off-limits. No `/dev/pricing-preview` route needed since PM + designer agree on direction. 5-commit plan (consolidated to 3 here).

**No conflicts** between the three. Implementation followed the spec.

## Test plan

- [x] `pnpm typecheck` (web) — clean
- [x] `pnpm vitest run src/pages/PricingPage/` — 49/49 green (PricingPage.test.tsx + PassCards.test.tsx)
- [x] `pnpm lint` (web Biome) — clean
- [ ] sonar-scanner — not run locally; visual-only diff over four files, low risk

⚠️ **Pre-existing main regression:** `pnpm test` (full suite) reports 1 failure in `TemplatesPage.test.tsx` (expects `/no starter note types/i` text). This regression is on main from #2745 and is unrelated to this PR — separate follow-up.

## Browser check

- [x] Golden path on localhost:3000 — verify Unlimited is the only solid-blue button on the page
- [x] No console errors at 375px — stacked layout, Unlimited first
- [ ] `/notion` landing page — `PricingCard` ripple check; cards there should look cleaner (no more gold/blue accents bleeding from this module)

Notes:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782245064&installation_id=132681956&pr_number=2751&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2751&signature=c19a837772b35a92bc8d0dcca1aa5ffd3aaf0738b09df6984e6ef470b3c4003d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->