### PR TITLE
fix: align /templates empty-state test with shipped copy

### DIFF
--- a/web/src/pages/TemplatesPage/TemplatesPage.test.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.test.tsx
@@ -141,7 +141,7 @@ describe('TemplatesPage', () => {
     renderPage();
 
     expect(
-      await screen.findByText(/no starter note types/i)
+      await screen.findByText(/no note types yet/i)
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

The Apple-principles pass on /templates (#2745) replaced the empty state with a card titled "No note types yet" and body "Create your first note type to use custom card layouts in Anki." But the colocated test (`TemplatesPage.test.tsx:144`) was still looking for the prior `"no starter note types"` text. Result: the Web test job has been red on every PR since #2745 merged.

This is a one-line assertion update so the regex matches the shipped copy.

## Test plan

- [x] `pnpm vitest run src/pages/TemplatesPage/` — 48/48 green locally
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean

## Browser check

Browser check: not applicable — test-only change, no rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782245384&installation_id=132681956&pr_number=2752&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2752&signature=72d0a59c62ce98d246bd241b3f79262b45a4b69942c63fc8283379bd87eb5eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->