### PR TITLE
style: /documentation apple-principles pass — quiet docs chrome

### DIFF
--- a/web/src/pages/DocsPage/DocsPage.module.css
+++ b/web/src/pages/DocsPage/DocsPage.module.css
@@ -21,7 +21,7 @@
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1.5rem;
   font-size: var(--text-sm);
 }
 
@@ -32,7 +32,7 @@
 .sidebarGroup {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.25rem;
 }
 
 .sidebarGroupLabel {
@@ -41,7 +41,8 @@
   text-transform: uppercase;
   letter-spacing: var(--tracking-wider);
   color: var(--color-text-tertiary);
-  padding: 0 0.5rem;
+  padding: 0 0.625rem;
+  margin-bottom: 0.125rem;
 }
 
 .sidebarList {
@@ -61,12 +62,26 @@
 
 .sidebarLink {
   display: block;
-  padding: 0.375rem 0.5rem;
+  padding: 0.3125rem 0.625rem;
   border-radius: var(--radius-sm);
   color: var(--color-text-secondary);
   text-decoration: none;
   line-height: 1.35;
   transition: background var(--transition-fast), color var(--transition-fast);
+  position: relative;
+}
+
+.sidebarLink::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 25%;
+  bottom: 25%;
+  width: 2px;
+  background: var(--color-primary);
+  border-radius: 1px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
 }
 
 .sidebarLink:hover {
@@ -74,11 +89,20 @@
   color: var(--color-text-primary);
 }
 
+.sidebarLink:hover::before {
+  opacity: 0.4;
+}
+
 .sidebarLinkActive,
 .sidebarLinkActive:hover {
   background: var(--color-primary-light);
   color: var(--color-primary-hover);
   font-weight: var(--font-medium);
+}
+
+.sidebarLinkActive::before,
+.sidebarLinkActive:hover::before {
+  opacity: 1;
 }
 
 .main {
@@ -92,7 +116,7 @@
 .wipBanner {
   max-width: 760px;
   margin: 0 0 1.5rem;
-  padding: 0.5rem 0.875rem;
+  padding: 0.375rem 0.875rem;
   background: var(--color-warning-light);
   border: 1px solid var(--color-warning-border);
   border-radius: var(--radius-md);
@@ -101,7 +125,7 @@
   line-height: var(--leading-normal);
 }
 
-.main[data-legal="true"] .wipBanner {
+.main[data-legal='true'] .wipBanner {
   display: none;
 }
 
@@ -118,7 +142,7 @@
 .articleHeader {
   margin-bottom: 2rem;
   padding-bottom: 1.25rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border-light);
 }
 
 .articleTitle {
@@ -160,7 +184,7 @@
 .markdown h2 {
   font-size: var(--text-2xl);
   padding-bottom: 0.35rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border-light);
   margin-top: 2.5rem;
 }
 .markdown h3 { font-size: var(--text-xl); }
@@ -202,7 +226,7 @@
   max-width: 100%;
   height: auto;
   border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-light);
   display: block;
   margin: 1rem 0;
 }
@@ -224,7 +248,7 @@
 
 .markdown code {
   background: var(--color-bg-tertiary);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-light);
   border-radius: var(--radius-sm);
   padding: 0.1rem 0.35rem;
   font-size: 0.875em;
@@ -252,12 +276,12 @@
 }
 
 .markdown blockquote {
-  border-left: 3px solid var(--color-primary);
-  background: var(--color-primary-light);
+  border-left: 2px solid var(--color-border);
+  background: var(--color-bg-secondary);
   padding: 0.75rem 1rem;
   margin: 1rem 0;
-  border-radius: var(--radius-sm);
-  color: var(--color-text-primary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  color: var(--color-text-secondary);
 }
 
 .markdown blockquote p:last-child {
@@ -265,7 +289,7 @@
 }
 
 .markdown details {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-light);
   border-radius: var(--radius-md);
   padding: 0.75rem 1rem;
   margin: 1rem 0;
@@ -287,7 +311,7 @@
 .markdown th,
 .markdown td {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-light);
   text-align: left;
   vertical-align: top;
 }
@@ -299,7 +323,7 @@
 
 .markdown hr {
   border: none;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border-light);
   margin: 2rem 0;
 }
 
@@ -315,24 +339,31 @@
   padding: 0.25rem 0.625rem;
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-sm);
   color: var(--color-code-text);
   cursor: pointer;
-  transition: background var(--transition-fast);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+  opacity: 0;
+}
+
+.codeWrapper:hover .copyButton,
+.codeWrapper:focus-within .copyButton {
+  opacity: 1;
 }
 
 .copyButton:hover {
-  background: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 .callout {
   margin: 1rem 0;
   padding: 0.75rem 1rem;
-  border-left: 3px solid var(--color-primary);
-  background: var(--color-primary-light);
-  border-radius: var(--radius-sm);
+  border-left: 2px solid var(--color-primary);
+  background: var(--color-bg-secondary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 
 .callout > :first-child {
@@ -345,7 +376,7 @@
 
 .calloutNote {
   border-left-color: var(--color-primary);
-  background: var(--color-primary-light);
+  background: var(--color-bg-secondary);
 }
 
 .calloutTip {
@@ -361,9 +392,9 @@
 .markdown :global(.callout) {
   margin: 1rem 0;
   padding: 0.75rem 1rem;
-  border-left: 3px solid var(--color-primary);
-  background: var(--color-primary-light);
-  border-radius: var(--radius-sm);
+  border-left: 2px solid var(--color-primary);
+  background: var(--color-bg-secondary);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 }
 
 .markdown :global(.callout) > :first-child {
@@ -376,7 +407,7 @@
 
 .markdown :global(.callout-note) {
   border-left-color: var(--color-primary);
-  background: var(--color-primary-light);
+  background: var(--color-bg-secondary);
 }
 
 .markdown :global(.callout-tip) {
@@ -423,29 +454,29 @@
 .editFooter {
   margin-top: 3rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border-light);
 }
 
 .editLink {
   display: inline-block;
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
   text-decoration: none;
   transition: color var(--transition-fast);
 }
 
 .editLink:hover {
-  color: var(--color-text-link-hover);
+  color: var(--color-text-link);
 }
 
 .pager {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 1rem;
+  gap: 0.75rem;
   margin-top: 1.5rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border-light);
 }
 
 .pagerPrev,
@@ -454,10 +485,11 @@
   flex-direction: column;
   gap: 0.25rem;
   padding: 0.875rem 1rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-border-light);
   border-radius: var(--radius-md);
   text-decoration: none;
   color: var(--color-text-primary);
+  background: var(--color-bg-primary);
   transition: border-color var(--transition-fast), background var(--transition-fast);
 }
 
@@ -467,8 +499,8 @@
 
 .pagerPrev:hover,
 .pagerNext:hover {
-  border-color: var(--color-primary);
-  background: var(--color-primary-light);
+  border-color: var(--color-border);
+  background: var(--color-bg-secondary);
   color: var(--color-text-primary);
 }
 
@@ -482,11 +514,12 @@
 .pagerTitle {
   font-weight: var(--font-medium);
   color: var(--color-text-primary);
+  font-size: var(--text-sm);
 }
 
 .docsHomeHero {
   padding: 0 0 2rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border-light);
   margin-bottom: 2rem;
 }
 
@@ -515,8 +548,8 @@
 .docsHomeButtonSecondary {
   display: inline-flex;
   align-items: center;
-  padding: 0.65rem 1.25rem;
-  border-radius: var(--radius-full);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
   text-decoration: none;
@@ -536,10 +569,12 @@
 .docsHomeButtonSecondary {
   background: var(--color-bg-tertiary);
   color: var(--color-text-primary);
+  border: 1px solid var(--color-border-light);
 }
 
 .docsHomeButtonSecondary:hover {
-  background: var(--color-border);
+  background: var(--color-bg-secondary);
+  border-color: var(--color-border);
   color: var(--color-text-primary);
 }
 
@@ -548,15 +583,17 @@
 }
 
 .docsHomeSectionTitle {
-  font-size: var(--text-xl);
+  font-size: var(--text-xs);
   font-weight: var(--font-semibold);
-  margin: 0 0 1rem;
-  color: var(--color-text-primary);
+  margin: 0 0 0.75rem;
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
 }
 
 .homeGrid {
   display: grid;
-  gap: 0.875rem;
+  gap: 0.625rem;
   grid-template-columns: 1fr;
 }
 
@@ -568,8 +605,8 @@
 
 .homeCard {
   display: block;
-  padding: 1.125rem 1.25rem;
-  border: 1px solid var(--color-border);
+  padding: 1rem 1.125rem;
+  border: 1px solid var(--color-border-light);
   border-radius: var(--radius-md);
   background: var(--color-bg-primary);
   text-decoration: none;
@@ -578,12 +615,13 @@
 }
 
 .homeCard:hover {
-  border-color: var(--color-primary);
-  background: var(--color-primary-light);
+  border-color: var(--color-border);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
 }
 
 .homeCardTitle {
-  font-size: var(--text-base);
+  font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   margin: 0 0 0.25rem;
   color: var(--color-text-primary);
@@ -602,38 +640,50 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.375rem;
 }
 
 .popularList a {
   color: var(--color-text-link);
-  text-decoration: underline;
-  text-decoration-color: var(--color-focus-ring);
-  text-underline-offset: 2px;
-  font-size: var(--text-base);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  transition: color var(--transition-fast);
 }
 
 .popularList a:hover {
   color: var(--color-text-link-hover);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .docsHomeFooter {
   margin-top: 2rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border-light);
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
 }
 
 .menuButton {
-  display: inline-block;
-  padding: 0.5rem 0.875rem;
-  border: 1px solid var(--color-border);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--color-border-light);
   background: var(--color-bg-primary);
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
-  color: var(--color-text-primary);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
   margin-bottom: 1rem;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+  box-shadow: var(--shadow-xs);
+}
+
+.menuButton:hover {
+  border-color: var(--color-border);
+  color: var(--color-text-primary);
 }
 
 .drawerOverlay {
@@ -647,6 +697,8 @@
   position: absolute;
   inset: 0;
   background: var(--color-backdrop);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   border: none;
   padding: 0;
   cursor: pointer;
@@ -654,15 +706,14 @@
 
 .drawer {
   position: relative;
-  width: min(320px, 85vw);
+  width: min(300px, 85vw);
   height: 100vh;
   background: var(--color-bg-primary);
-  border-right: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-border-light);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-  animation: drawerSlideIn 0.18s ease-out;
+  animation: drawerSlideIn 0.2s ease-out;
 }
 
 @keyframes drawerSlideIn {
@@ -678,29 +729,33 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid var(--color-border);
+  padding: 0.875rem 1.25rem;
+  border-bottom: 1px solid var(--color-border-light);
   flex-shrink: 0;
 }
 
 .drawerTitle {
-  font-size: var(--text-base);
+  font-size: var(--text-sm);
   font-weight: var(--font-semibold);
   color: var(--color-text-primary);
+  letter-spacing: var(--tracking-tight);
 }
 
 .drawerClose {
   background: none;
   border: none;
-  font-size: var(--text-2xl);
+  font-size: 1.125rem;
   line-height: 1;
   cursor: pointer;
-  color: var(--color-text-secondary);
-  padding: 0.25rem 0.5rem;
+  color: var(--color-text-tertiary);
+  padding: 0.25rem 0.375rem;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .drawerClose:hover {
   color: var(--color-text-primary);
+  background: var(--color-bg-tertiary);
 }
 
 .sidebarDrawer {
@@ -713,7 +768,7 @@
 }
 
 :global([data-shell]) .menuButton {
-  display: inline-block;
+  display: inline-flex;
   justify-self: start;
 }
 
@@ -723,8 +778,8 @@
 
 @media (min-width: 901px) {
   .layout {
-    grid-template-columns: 260px minmax(0, 1fr);
-    gap: 2.5rem;
+    grid-template-columns: 240px minmax(0, 1fr);
+    gap: 3rem;
     padding: 2rem 1.5rem 4rem;
   }
   .menuButton {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-documentation-redesign.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-documentation-redesign.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-documentation-redesign",
+  "date": "2026-05-24",
+  "type": "style",
+  "title": "Documentation — cleaner sidebar, quieter code blocks, and a sharper mobile drawer"
+}


### PR DESCRIPTION
## Summary
- Apple-design restraint pass on DocsPage shell (sidebar, drawer, header, code blocks, callouts).
- Markdown content untouched — only the chrome.
- No new dependencies.

## Changes
- Sidebar: hover-reveal accent stripe via `::before` pseudo-element; active row uses `--color-primary-light` background matching the /chat pattern; group gap tightened to 0.25rem
- CodeBlock: copy button fades in on hover/focus-within (opacity 0 → 1), 1px border with lower opacity values — no heavy shadow
- Callout: 2px left border, `--color-bg-secondary` tint instead of `--color-primary-light` gradient — matches the muted register of the rest of the shell
- Drawer: `backdrop-filter: blur(4px)` on overlay, tighter header padding (0.875rem), smaller drawer width (300px vs 320px), close button gets hover bg
- WipBanner: compact padding (0.375rem top/bottom), `--color-border-light` used throughout for receding chrome
- Pager: lighter hover state (`--color-bg-secondary` instead of `--color-primary-light`), text-sm on pager titles
- Home cards: quieter hover (border + bg, no primary tint), section titles use xs+uppercase+tertiary color like sidebar group labels
- All borders switched to `--color-border-light` except the pre block which needs full contrast against dark bg

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: CSS-only change; all 33 DocsPage tests pass, typecheck clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782246039&installation_id=132681956&pr_number=2756&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2756&signature=3bb2659dbea224951df65bc78d74ca746b4cd89bf6f88dcc81b6467d37be1041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->