### PR TITLE
fix: hide Send to Anki on /downloads for non-Ankify users

### DIFF
--- a/web/src/pages/DownloadsPage/components/SendToAnkifyButton.test.tsx
+++ b/web/src/pages/DownloadsPage/components/SendToAnkifyButton.test.tsx
@@ -63,17 +63,10 @@ describe('SendToAnkifyButton', () => {
     mockLocalsData = undefined;
   });
 
-  it('routes free users to the Auto Sync upsell on click and never calls the API', async () => {
+  it('renders nothing for non-Ankify users', () => {
     mockLocalsData = { locals: { patreon: false }, autoSyncActive: false };
-    renderButton();
-    const button = screen.getByRole('button', { name: /send to my anki/i });
-    fireEvent.click(button);
-    expect(navigateMock).toHaveBeenCalledWith('/pricing?upsell=auto-sync');
-    expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
-      surface: 'ankify_button',
-      plan: 'auto_sync',
-    });
-    expect(dispatchMock).not.toHaveBeenCalled();
+    const { container } = renderButton();
+    expect(container.firstChild).toBeNull();
     expect(listClientsMock).not.toHaveBeenCalled();
   });
 

--- a/web/src/pages/DownloadsPage/components/SendToAnkifyButton.tsx
+++ b/web/src/pages/DownloadsPage/components/SendToAnkifyButton.tsx
@@ -1,7 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
 
-import { track } from '../../../lib/analytics/track';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import { useUserLocals } from '../../../lib/hooks/useUserLocals';
 
@@ -15,7 +13,6 @@ export default function SendToAnkifyButton({ uploadId, filename }: Props) {
   const hasAccess =
     data?.locals?.patreon === true || data?.autoSyncActive === true;
   const api = get2ankiApi();
-  const navigate = useNavigate();
 
   const { data: clients } = useQuery({
     queryKey: ['ankify-clients'],
@@ -27,31 +24,25 @@ export default function SendToAnkifyButton({ uploadId, filename }: Props) {
     mutationFn: () => api.dispatchUploadToAnkify(Number(uploadId)),
   });
 
-  const handleClick = () => {
-    if (!hasAccess) {
-      track('paywall_upgrade_clicked', { surface: 'ankify_button', plan: 'auto_sync' });
-      navigate('/pricing?upsell=auto-sync');
-      return;
-    }
-    dispatch.mutate();
-  };
+  if (!hasAccess) {
+    return null;
+  }
 
   const hasActive = (clients ?? []).some((c) => c.status === 'active');
-  const disabled = hasAccess && (dispatch.isPending || !hasActive);
+  const disabled = dispatch.isPending || !hasActive;
 
   const label = (() => {
-    if (!hasAccess) return 'Send to my Anki';
     if (dispatch.isPending) return 'Sending to your Anki…';
     if (dispatch.isSuccess) {
-      const data = dispatch.data;
+      const result = dispatch.data;
       const parts = [];
-      if (data.created > 0) parts.push(`${data.created} new`);
-      if (data.updated > 0) parts.push(`${data.updated} updated`);
+      if (result.created > 0) parts.push(`${result.created} new`);
+      if (result.updated > 0) parts.push(`${result.updated} updated`);
       const counts = parts.length > 0 ? parts.join(', ') : 'Sent';
       let sync = '';
-      if (data.anki_web_sync === 'synced') {
+      if (result.anki_web_sync === 'synced') {
         sync = ' · synced to AnkiWeb';
-      } else if (data.anki_web_sync === 'failed') {
+      } else if (result.anki_web_sync === 'failed') {
         sync = ' · AnkiWeb sync skipped';
       }
       return `${counts}${sync}`;
@@ -61,7 +52,6 @@ export default function SendToAnkifyButton({ uploadId, filename }: Props) {
   })();
 
   const title = (() => {
-    if (!hasAccess) return 'Auto Sync sends decks straight to your Anki — see plans';
     if (!hasActive) return 'Set up your Anki on the Ankify page first';
     if (dispatch.isError) return (dispatch.error as Error).message;
     if (dispatch.isSuccess && dispatch.data.anki_web_sync === 'failed') {
@@ -73,7 +63,7 @@ export default function SendToAnkifyButton({ uploadId, filename }: Props) {
   return (
     <button
       type="button"
-      onClick={handleClick}
+      onClick={() => dispatch.mutate()}
       disabled={disabled}
       title={title}
       style={{

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-downloads-send-to-anki-ankify-only.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-downloads-send-to-anki-ankify-only.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-downloads-send-to-anki-ankify-only",
+  "date": "2026-05-24",
+  "type": "fix",
+  "title": "Downloads — Send to Anki button now only appears for Auto Sync subscribers"
+}


### PR DESCRIPTION
## What
The Send to Anki button was rendering for all users on the /downloads page. For non-Ankify users, clicking it navigated to `/pricing?upsell=auto-sync`. A feature button that silently redirects to a paywall feels deceptive — users expect a functional action, not a sales prompt.

## Why
Pure subtraction. The button now returns `null` when the user lacks Auto Sync access. Auto Sync remains discoverable on /pricing; it does not need representation in every download row.

## How
`SendToAnkifyButton` gains an early return — `if (!hasAccess) return null`. The paywall navigation path and its `track()` call are removed. Dead `!hasAccess` branches in the `label` and `title` IIFEs are cleaned up. The `useNavigate` import is dropped.

The test that asserted paywall navigation is replaced with one asserting `container.firstChild` is `null` for non-Ankify users.

## Measuring success
No `paywall_upgrade_clicked` events from the `ankify_button` surface in production analytics after this ships.

## Testing
- Unit tests updated: `SendToAnkifyButton.test.tsx` — replaced paywall-navigation assertion with null-render assertion; all 3 tests pass.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes:

## Changelog
"Downloads — Send to Anki button now only appears for Auto Sync subscribers"

## Risks
None — pure subtraction. Ankify users are unaffected; their path is unchanged.

## Goal alignment
Removes a trust-eroding pattern. Users who feel tricked leave; removing the trap improves retention on the free tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782246806&installation_id=132681956&pr_number=2757&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2757&signature=4461c82ff02b330833c00e7d8f6aea6c922e408e43a2856bbc75b6f0cd7ab088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->