### PR TITLE
fix: clean Notion-unauthorized error copy with working link

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -281,6 +281,62 @@ describe('NotionController', () => {
     });
   });
 
+  describe('search — Unauthorized', () => {
+    it('returns structured JSON with notion_unauthorized code — no HTML in message', async () => {
+      const unauthorizedError = new APIResponseError({
+        code: APIErrorCode.Unauthorized,
+        message: 'API token is invalid.',
+        status: 401,
+        rawBodyText: '',
+        headers: {},
+      } as any);
+      service = {
+        getNotionLinkInfo: jest.fn().mockResolvedValue({ isConnected: true }),
+        search: jest.fn().mockRejectedValue(unauthorizedError),
+        getNotionAuthorizationLink: jest.fn().mockReturnValue('https://notion.so/oauth'),
+        getClientId: jest.fn().mockReturnValue('client-abc'),
+      } as any;
+      controller = new NotionController(service);
+      req = { body: { query: 'test' }, params: {}, query: {} };
+
+      await controller.search(req as express.Request, res as express.Response);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      const body = (res.json as jest.Mock).mock.calls[0]?.[0];
+      expect(body.code).toBe('notion_unauthorized');
+      expect(body.message).not.toMatch(/<a /);
+      expect(body.message).not.toMatch(/href/);
+    });
+  });
+
+  describe('searchTopLevelPages — Unauthorized', () => {
+    it('returns structured JSON with notion_unauthorized code — no HTML in message', async () => {
+      const unauthorizedError = new APIResponseError({
+        code: APIErrorCode.Unauthorized,
+        message: 'API token is invalid.',
+        status: 401,
+        rawBodyText: '',
+        headers: {},
+      } as any);
+      service = {
+        getNotionLinkInfo: jest.fn().mockResolvedValue({ isConnected: true }),
+        searchTopLevelPages: jest.fn().mockRejectedValue(unauthorizedError),
+        getNotionAuthorizationLink: jest.fn().mockReturnValue('https://notion.so/oauth'),
+        getClientId: jest.fn().mockReturnValue('client-abc'),
+      } as any;
+      controller = new NotionController(service);
+      req = { body: { query: 'test' }, params: {}, query: {} };
+
+      await controller.searchTopLevelPages(req as express.Request, res as express.Response);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      const body = (res.json as jest.Mock).mock.calls[0]?.[0];
+      expect(body.code).toBe('notion_unauthorized');
+      expect(body.message).not.toMatch(/<a /);
+      expect(body.message).not.toMatch(/href/);
+    });
+  });
+
   describe('getNotionLink', () => {
     it('returns the OAuth link with isConnected=false when the caller is anonymous', async () => {
       service = {

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -105,33 +105,19 @@ class NotionController {
 
   async search(req: Request, res: Response) {
     try {
-      // Check for Notion connection first
       const linkInfo = await this.service.getNotionLinkInfo(res.locals.owner);
       if (!linkInfo.isConnected) {
-        const renewalLink = this.service.getNotionAuthorizationLink(
-          this.service.getClientId()
-        );
-        return res.status(401).json({
-          message: `Notion is not connected. Please connect your account <a href='${renewalLink}'>here</a>.`,
-        });
+        return res.status(401).json({ code: 'notion_unauthorized', message: 'Notion is not connected.' });
       }
 
-      // Proceed with search if connected
       const query = req.body.query.toString() || '';
       const result = await this.service.search(query, getOwner(res));
       res.json(result);
     } catch (err) {
-      if (err instanceof APIResponseError) {
-        if (err.code === APIErrorCode.Unauthorized) {
-          const renewalLink = this.service.getNotionAuthorizationLink(
-            this.service.getClientId()
-          );
-          err.message += `You can renew it <a href='${renewalLink}'>here</a>.`;
-        }
-        sendErrorResponse(err, res);
-      } else {
-        sendErrorResponse(err, res);
+      if (err instanceof APIResponseError && err.code === APIErrorCode.Unauthorized) {
+        return res.status(401).json({ code: 'notion_unauthorized', message: 'API token is invalid.' });
       }
+      sendErrorResponse(err, res);
     }
   }
 
@@ -139,12 +125,7 @@ class NotionController {
     try {
       const linkInfo = await this.service.getNotionLinkInfo(res.locals.owner);
       if (!linkInfo.isConnected) {
-        const renewalLink = this.service.getNotionAuthorizationLink(
-          this.service.getClientId()
-        );
-        return res.status(401).json({
-          message: `Notion is not connected. Please connect your account <a href='${renewalLink}'>here</a>.`,
-        });
+        return res.status(401).json({ code: 'notion_unauthorized', message: 'Notion is not connected.' });
       }
 
       const query =
@@ -155,17 +136,10 @@ class NotionController {
       );
       res.json(result);
     } catch (err) {
-      if (err instanceof APIResponseError) {
-        if (err.code === APIErrorCode.Unauthorized) {
-          const renewalLink = this.service.getNotionAuthorizationLink(
-            this.service.getClientId()
-          );
-          err.message += `You can renew it <a href='${renewalLink}'>here</a>.`;
-        }
-        sendErrorResponse(err, res);
-      } else {
-        sendErrorResponse(err, res);
+      if (err instanceof APIResponseError && err.code === APIErrorCode.Unauthorized) {
+        return res.status(401).json({ code: 'notion_unauthorized', message: 'API token is invalid.' });
       }
+      sendErrorResponse(err, res);
     }
   }
 

--- a/web/src/components/errors/ErrorPresenter.tsx
+++ b/web/src/components/errors/ErrorPresenter.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { classifyError } from './helpers/getErrorMessage';
 import { useDismissed } from './helpers/useDismissed';
 import styles from '../../styles/shared.module.css';
@@ -14,7 +15,7 @@ export function ErrorPresenter({ error, onRetry }: Readonly<ErrorPresenterProps>
     return null;
   }
 
-  const { title, detail } = classifyError(error);
+  const { title, detail, actionLink } = classifyError(error);
 
   return (
     <article className={styles.alertInfo}>
@@ -25,6 +26,11 @@ export function ErrorPresenter({ error, onRetry }: Readonly<ErrorPresenterProps>
         {detail && <p className={styles.smallDescription}>{detail}</p>}
       </div>
       <div className={styles.modalFooter}>
+        {actionLink && (
+          <Link to={actionLink.to} className={styles.btnPrimary} onClick={() => setDismissed(true)}>
+            {actionLink.text}
+          </Link>
+        )}
         {onRetry && (
           <button
             type="button"

--- a/web/src/components/errors/helpers/getErrorMessage.test.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.test.ts
@@ -65,6 +65,25 @@ describe('classifyError', () => {
   });
 });
 
+describe('classifyError — notion_unauthorized', () => {
+  it('new structured code returns reconnect copy', () => {
+    const result = classifyError({ code: 'notion_unauthorized', message: 'API token is invalid.' });
+    expect(result.title).toBe('Your Notion connection expired');
+    expect(result.detail).toBe('Reconnect Notion on the upload page to keep converting.');
+  });
+
+  it('legacy text "api token is invalid" (case-insensitive) returns reconnect copy', () => {
+    const result = classifyError(new Error('API token is invalid.'));
+    expect(result.title).toBe('Your Notion connection expired');
+    expect(result.detail).toBe('Reconnect Notion on the upload page to keep converting.');
+  });
+
+  it('action link path is /upload', () => {
+    const result = classifyError({ code: 'notion_unauthorized', message: '' });
+    expect(result.actionLink).toEqual({ text: 'Go to the upload page', to: '/upload' });
+  });
+});
+
 describe('getErrorMessage', () => {
   test('returns plain text — no HTML', () => {
     const msg = getErrorMessage(new Error('Failed to fetch'));

--- a/web/src/components/errors/helpers/getErrorMessage.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.ts
@@ -6,6 +6,7 @@ export type ErrorHandlerType = (error: unknown) => void;
 interface FriendlyError {
   title: string;
   detail?: string;
+  actionLink?: { text: string; to: string };
 }
 
 const FALLBACK: FriendlyError = {
@@ -28,7 +29,23 @@ function toText(error: unknown): string {
   return '';
 }
 
+const NOTION_UNAUTHORIZED: FriendlyError = {
+  title: 'Your Notion connection expired',
+  detail: 'Reconnect Notion on the upload page to keep converting.',
+  actionLink: { text: 'Go to the upload page', to: '/upload' },
+};
+
+function isNotionUnauthorized(error: unknown): boolean {
+  if (error != null && typeof error === 'object' && 'code' in error) {
+    return (error as { code: unknown }).code === 'notion_unauthorized';
+  }
+  const raw = toText(error).toLowerCase();
+  return raw.includes('api token is invalid');
+}
+
 export function classifyError(error: unknown): FriendlyError {
+  if (isNotionUnauthorized(error)) return NOTION_UNAUTHORIZED;
+
   const raw = toText(error);
 
   if (!raw) return FALLBACK;

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-notion-reconnect-error.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-notion-reconnect-error.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-notion-reconnect-error",
+  "date": "2026-05-24",
+  "type": "fix",
+  "title": "Notion reconnect — clearer message and a working link when your connection expires"
+}


### PR DESCRIPTION
## What
Server stopped concatenating raw HTML into Notion-unauthorized error messages. Client recognises the structured error code and renders friendly copy plus a React Router `Link` to `/upload`.

## Why
Users hitting an expired Notion token saw "API token is invalid.You can renew it here" — a broken sentence with no working link (the anchor was stripped by `classifyError`/`stripHtmlTags`).

## How
- `NotionController.search` and `searchTopLevelPages`: replace HTML-concatenated err.message mutation with a direct `res.status(401).json({ code: 'notion_unauthorized', message: '...' })` response. No more HTML in error payloads.
- `sendErrorResponse.ts`: untouched — the structured response bypasses it entirely.
- `getErrorMessage.ts`: new `isNotionUnauthorized` guard matches `{ code: 'notion_unauthorized' }` (new server) or `'api token is invalid'` text (legacy/existing). Returns title, detail, and `actionLink: { text: 'Go to the upload page', to: '/upload' }`.
- `ErrorPresenter.tsx`: renders `actionLink` as a `<Link>` from react-router-dom when present, above the retry button.
- Backwards-compatible: legacy plain-text response from an older server version is matched by the text pattern.

## Measuring success
Reproduce with an expired Notion token: the error card shows "Your Notion connection expired" with a clickable "Go to the upload page" link instead of the broken sentence.

## Testing
- Unit tests added: 2 server (search + searchTopLevelPages return structured code, no HTML), 3 client (new code, legacy text, actionLink shape)
- All 14 NotionController tests pass; 21 web getErrorMessage tests pass; full web suite 1129/1129 green

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes:

## Changelog
"Notion reconnect — clearer message and a working link when your connection expires"

## Risks
The `{ code, message }` shape is a new contract. Any client-side code that checked for the old concatenated HTML message text would silently fall through to the new structured handler — no regression risk. Rollback: revert the controller lines; the client falls back to `FALLBACK`.

## Goal alignment
Removes a confusing error that blocked Notion users from reconnecting — directly reduces friction on the Notion import path, the primary conversion flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782247159&installation_id=132681956&pr_number=2759&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2759&signature=0955e9b869fde76bb16457b8b628e18c0507fb3a371e230ba668ce7d18af146f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->