### PR TITLE
fix: preserve ?redirect= through password login

### DIFF
--- a/src/controllers/helpers/getRedirect.test.ts
+++ b/src/controllers/helpers/getRedirect.test.ts
@@ -1,10 +1,10 @@
 import { Request } from 'express';
 import { getRedirect } from './getRedirect';
 
-// Mock Request object factory
-const createMockRequest = (redirectParam?: string): Request => {
+const createMockRequest = (redirectParam?: string, bodyRedirect?: string): Request => {
   return {
     query: redirectParam ? { redirect: redirectParam } : {},
+    body: bodyRedirect ? { redirect: bodyRedirect } : {},
   } as Request;
 };
 
@@ -32,6 +32,7 @@ describe('getRedirect security tests', () => {
       '/pricing',
       '/settings',
       '/anki',
+      '/card-options',
       '/search/results',
       '/templates/new',
     ];
@@ -114,6 +115,28 @@ describe('getRedirect security tests', () => {
 
     it('should block non-HTTPS external URLs (except localhost)', () => {
       const req = createMockRequest('http://2anki.net');
+      expect(getRedirect(req)).toBe('/notion');
+    });
+  });
+
+  describe('should read redirect from request body as fallback', () => {
+    it('returns body redirect when query param is absent', () => {
+      const req = createMockRequest(undefined, '/card-options');
+      expect(getRedirect(req)).toBe('/card-options');
+    });
+
+    it('prefers query param over body when both present', () => {
+      const req = createMockRequest('/upload', '/card-options');
+      expect(getRedirect(req)).toBe('/upload');
+    });
+
+    it('blocks invalid body redirect', () => {
+      const req = createMockRequest(undefined, '//evil.com');
+      expect(getRedirect(req)).toBe('/notion');
+    });
+
+    it('blocks javascript: scheme in body redirect', () => {
+      const req = createMockRequest(undefined, 'javascript:alert(1)');
       expect(getRedirect(req)).toBe('/notion');
     });
   });

--- a/src/controllers/helpers/getRedirect.ts
+++ b/src/controllers/helpers/getRedirect.ts
@@ -11,6 +11,7 @@ const ALLOWED_REDIRECT_PATHS = [
   '/pricing',
   '/settings',
   '/anki',
+  '/card-options',
 ];
 
 const isValidRedirectUrl = (url: string): boolean => {
@@ -51,9 +52,11 @@ const isValidRedirectUrl = (url: string): boolean => {
 };
 
 export const getRedirect = (req: Request): string => {
-  const redirectParam = req.query.redirect?.toString();
+  const queryRedirect = req.query.redirect?.toString();
+  const bodyRedirect = typeof req.body?.redirect === 'string' ? req.body.redirect : undefined;
+  const redirectParam = queryRedirect ?? bodyRedirect;
 
-  if (!redirectParam) {
+  if (redirectParam == null || redirectParam === '') {
     return '/notion';
   }
 
@@ -61,6 +64,5 @@ export const getRedirect = (req: Request): string => {
     return redirectParam;
   }
 
-  // If redirect URL is not valid, return safe default
   return '/notion';
 };

--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -50,7 +50,7 @@ describe('HomePage (anonymous)', () => {
     const link = screen.getByRole('link', {
       name: /create an account to turn it on/i,
     });
-    expect(link).toHaveAttribute('href', '/register');
+    expect(link).toHaveAttribute('href', '/register?redirect=/card-options');
   });
 
   it('renders the three how-it-works steps with icons', () => {

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -136,7 +136,7 @@ export function HomePage({
           <span className={sharedStyles.aiOffBadgeBody}>
             {' '}
             <Link
-              to="/register"
+              to="/register?redirect=/card-options"
               onClick={() => track('home_ai_anon_badge_clicked')}
             >
               Create an account to turn it on

--- a/web/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.test.ts
+++ b/web/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.test.ts
@@ -1,0 +1,134 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import React from 'react';
+import { useHandleLoginSubmit } from './useHandleLoginSubmit';
+
+const mockLogin = vi.fn();
+
+vi.mock('../../../../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    login: mockLogin,
+  }),
+}));
+
+vi.mock('../../../../../lib/data_layer/userPreferencesSync', () => ({
+  migrateToServer: vi.fn().mockResolvedValue(undefined),
+  hydrateFromServer: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('react-cookie', () => ({
+  useCookies: () => [undefined, vi.fn()],
+}));
+
+const originalLocation = globalThis.location;
+
+function setSearchParams(search: string) {
+  Object.defineProperty(globalThis, 'location', {
+    value: { ...originalLocation, search, href: '' },
+    writable: true,
+    configurable: true,
+  });
+}
+
+const fakeSubmitEvent = {
+  preventDefault: vi.fn(),
+  currentTarget: document.createElement('form'),
+} as unknown as React.FormEvent<HTMLFormElement>;
+
+beforeEach(() => {
+  mockLogin.mockReset();
+  Object.defineProperty(globalThis, 'location', {
+    value: { search: '', href: '' },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'location', {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe('useHandleLoginSubmit redirect behavior', () => {
+  it('uses server redirect when no URL ?redirect= param', async () => {
+    mockLogin.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ token: 'tok', redirect: '/notion' }),
+    });
+
+    const { result } = renderHook(() => useHandleLoginSubmit(vi.fn()));
+
+    await act(async () => {
+      await result.current.onSubmit(fakeSubmitEvent);
+    });
+
+    expect(globalThis.location.href).toBe('/notion');
+  });
+
+  it('uses URL ?redirect= as fallback when server response has no redirect', async () => {
+    setSearchParams('?redirect=%2Fcard-options');
+    mockLogin.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ token: 'tok' }),
+    });
+
+    const { result } = renderHook(() => useHandleLoginSubmit(vi.fn()));
+
+    await act(async () => {
+      await result.current.onSubmit(fakeSubmitEvent);
+    });
+
+    expect(globalThis.location.href).toBe('/card-options');
+  });
+
+  it('prefers server redirect over URL ?redirect= when server provides one', async () => {
+    setSearchParams('?redirect=%2Fcard-options');
+    mockLogin.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ token: 'tok', redirect: '/notion' }),
+    });
+
+    const { result } = renderHook(() => useHandleLoginSubmit(vi.fn()));
+
+    await act(async () => {
+      await result.current.onSubmit(fakeSubmitEvent);
+    });
+
+    expect(globalThis.location.href).toBe('/notion');
+  });
+
+  it('rejects open-redirect attempts from URL ?redirect= param', async () => {
+    setSearchParams('?redirect=%2F%2Fevil.com');
+    mockLogin.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ token: 'tok' }),
+    });
+
+    const { result } = renderHook(() => useHandleLoginSubmit(vi.fn()));
+
+    await act(async () => {
+      await result.current.onSubmit(fakeSubmitEvent);
+    });
+
+    expect(globalThis.location.href).not.toBe('//evil.com');
+  });
+
+  it('rejects javascript: scheme in URL ?redirect= param', async () => {
+    setSearchParams('?redirect=javascript%3Aalert(1)');
+    mockLogin.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ token: 'tok' }),
+    });
+
+    const { result } = renderHook(() => useHandleLoginSubmit(vi.fn()));
+
+    await act(async () => {
+      await result.current.onSubmit(fakeSubmitEvent);
+    });
+
+    expect(globalThis.location.href).not.toContain('javascript:');
+  });
+});

--- a/web/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.ts
+++ b/web/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.ts
@@ -22,6 +22,16 @@ interface LoginState {
   setPassword: React.Dispatch<SetStateAction<string>>;
 }
 
+const isSafeRedirect = (value: string): boolean =>
+  value.startsWith('/') && !value.startsWith('//') && !value.includes(':');
+
+const getUrlRedirect = (): string | undefined => {
+  const params = new URLSearchParams(globalThis.location.search);
+  const value = params.get('redirect');
+  if (value == null) return undefined;
+  return isSafeRedirect(value) ? value : undefined;
+};
+
 export const useHandleLoginSubmit = (onError: ErrorHandlerType): LoginState => {
   const [loading, setLoading] = useState(false);
   const [, setCookie] = useCookies(['token']);
@@ -39,7 +49,7 @@ export const useHandleLoginSubmit = (onError: ErrorHandlerType): LoginState => {
         setCookie('token', token);
         await migrateToServer();
         await hydrateFromServer();
-        globalThis.location.href = redirect ?? getSearchPath('anki');
+        globalThis.location.href = redirect ?? getUrlRedirect() ?? getSearchPath('anki');
       } else if (res.status === 401) {
         const data = await res.json().catch(() => ({})) as { message?: string; hint?: string };
         const base = 'Wrong email or password. Try again or reset your password.';

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -107,3 +107,11 @@ describe('UploadPage doc/docx hint', () => {
   });
 });
 
+describe('UploadPage AI badge anon link', () => {
+  it('links to /login?redirect=/card-options so user lands on card options after sign-in', () => {
+    renderPage();
+    const link = screen.getByRole('link', { name: /sign in to turn it on/i });
+    expect(link).toHaveAttribute('href', '/login?redirect=/card-options');
+  });
+});
+

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -133,7 +133,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
             <span className={styles.aiOffBadgeBody}>
               {' '}
               <Link
-                to="/login"
+                to="/login?redirect=/card-options"
                 onClick={() => track('upload_ai_anon_badge_clicked')}
               >
                 Sign in to turn it on

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-login-preserves-redirect.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-login-preserves-redirect.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-login-preserves-redirect",
+  "date": "2026-05-24",
+  "type": "fix",
+  "title": "Sign in from anywhere — you land back on the page you came from"
+}


### PR DESCRIPTION
## What
Password login now reads `?redirect=` from the URL and honors it after a successful sign-in. The "AI is off" badge on /upload and /home now includes `?redirect=/card-options` in its href, so clicking "Sign in to turn it on" brings the user back to card options after authenticating.

Magic-link login already handled this correctly (`MagicLinkPage.tsx:51`). Password login did not.

## Why
A user clicking "Sign in to turn it on" on /upload landed on the dashboard instead of /card-options, forcing them to navigate again. The fix closes that gap without any new UI.

## How
- **Server** (`getRedirect.ts`): added `/card-options` to `ALLOWED_REDIRECT_PATHS`; also reads `redirect` from `req.body` as a fallback when the query param is absent (POST body is the natural place for login params).
- **Client** (`useHandleLoginSubmit.ts`): after receiving the server response, falls back to URL `?redirect=` when the server doesn't echo one. Validates client-side: must start with `/`, must not start with `//`, must not contain `:`.
- **Badge links**: `UploadPage.tsx` anon badge → `/login?redirect=/card-options`; `HomePage.tsx` anon badge → `/register?redirect=/card-options` (RegisterForm already reads and honors `?redirect=`).

Open-redirect: `//evil.com` and `javascript:alert(1)` are rejected on both client and server before being used as a redirect target.

## Measuring success
After deploy: log line `Login attempt` followed by a response containing `redirect: /card-options` when the login POST has `?redirect=/card-options` in the query string. Client-side: after login from `/upload` the user's browser URL is `/card-options`.

## Testing
- Unit tests added: `src/controllers/helpers/getRedirect.test.ts` (4 new cases — /card-options allow, body fallback, body open-redirect rejection)
- Unit tests added: `web/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.test.ts` (5 new cases — URL fallback, server preference, open-redirect rejection)
- Existing tests updated: `HomePage.test.tsx`, `UploadPage.test.tsx` to assert the new href values

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: also tested with crafted /login?redirect=//evil.com — rejected, falls back to /search?q=anki.

## Changelog
"Sign in from anywhere — you land back on the page you came from"

## Risks
`getRedirect.ts` is also used by the register flow via `getRedirect(req)` in UsersController — that path passes `req.body` which already has register fields, not a redirect field. No collision: the body check only fires if `req.body.redirect` is a string. Existing register tests pass unmodified.

## Goal alignment
Reduces friction for users who discover AI via the upload badge. One fewer extra step between "I want AI" and "AI is configured" — directly supports conversion from free to paid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782247277&installation_id=132681956&pr_number=2760&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2760&signature=eea5a842ed33dde43cd763ca11108d817e578de6b42cee3d9b2b82a59ff9b883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->