### PR TITLE
fix: pass buttons stick on Redirecting after back navigation

### DIFF
--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -168,4 +168,24 @@ describe('UpsellCard', () => {
       expect(screen.getByRole('button', { name: 'Day Pass' })).toBeInTheDocument();
     });
   });
+
+  it('clears the Redirecting label when the page is restored from the back-forward cache', async () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    mockStartPassCheckout.mockReturnValue(new Promise(() => {}));
+
+    render(<UpsellCard surface="downloads_upsell" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Day Pass' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
+    });
+
+    const pageshow = new Event('pageshow');
+    Object.defineProperty(pageshow, 'persisted', { value: true });
+    fireEvent(globalThis.window, pageshow);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Day Pass' })).toBeEnabled();
+    });
+  });
 });

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -39,6 +39,16 @@ export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProp
     track('paywall_shown', { surface });
   }, [suppress, surface]);
 
+  useEffect(() => {
+    const resetOnRestore = (event: PageTransitionEvent) => {
+      if (event.persisted) {
+        setPendingKind(null);
+      }
+    };
+    globalThis.addEventListener('pageshow', resetOnRestore);
+    return () => globalThis.removeEventListener('pageshow', resetOnRestore);
+  }, []);
+
   if (suppress) return null;
 
   const email = data?.user?.email;

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-upsell-button-reset.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-upsell-button-reset.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-upsell-button-reset",
+  "date": "2026-05-24",
+  "type": "fix",
+  "title": "Pass buttons reset after you navigate back from checkout instead of staying on Redirecting"
+}


### PR DESCRIPTION
## Summary
- Day/Week Pass buttons set "Redirecting…" then full-page-redirect to Stripe. On back navigation the browser restores the page from bfcache with that state frozen, leaving the button stuck and disabled.
- A `pageshow` listener clears the pending state when the page is restored from the back-forward cache (`event.persisted`).

## Test
- New UpsellCard test: click Day Pass → "Redirecting…" → dispatch `pageshow` (persisted) → button returns to "Day Pass" and is enabled.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: clicked Day Pass, hit back, button reset to Day Pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782249754&installation_id=132681956&pr_number=2762&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2762&signature=9789b87e794c556cdf01af1e67966b13cc12c8f65e01298e7e685a9de75411b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->