### PR TITLE
fix: mindmap editor no longer jumps on save

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+const mockSetNodes = vi.fn();
+const mockSetEdges = vi.fn();
 
 const { mockUploadMindmapImage, mockUseMindmapById, mockUseUpdateMindmap } = vi.hoisted(() => ({
   mockUploadMindmapImage: vi.fn(),
@@ -21,8 +24,8 @@ vi.mock('@xyflow/react', () => ({
   ReactFlow: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-testid': 'react-flow' }, children),
   Controls: () => null,
   Background: () => null,
-  useNodesState: () => [[], vi.fn(), vi.fn()],
-  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  useNodesState: () => [[], mockSetNodes, vi.fn()],
+  useEdgesState: () => [[], mockSetEdges, vi.fn()],
   addEdge: vi.fn(),
   ConnectionMode: { Loose: 'loose' },
 }));
@@ -82,6 +85,46 @@ describe('MindmapEditor', () => {
     const { MindmapEditor } = await import('./MindmapEditor');
     render(createElement(MindmapEditor), { wrapper });
     expect(screen.getByTestId('react-flow')).toBeDefined();
+  });
+
+  it('seeds nodes with an array on first load, then uses a functional updater on re-fetch', async () => {
+    const mapWithNodes = {
+      ...baseMap,
+      data: {
+        nodes: [{ id: 'n1', label: 'Root', position: { x: 10, y: 20 } }],
+        edges: [],
+      },
+    };
+    mockUseMindmapById.mockReturnValue({ data: mapWithNodes, isLoading: false });
+
+    const { MindmapEditor } = await import('./MindmapEditor');
+    const { rerender } = render(createElement(MindmapEditor), { wrapper });
+
+    await waitFor(() => {
+      expect(mockSetNodes).toHaveBeenCalled();
+    });
+
+    const firstCallArg = mockSetNodes.mock.calls[0][0];
+    expect(Array.isArray(firstCallArg)).toBe(true);
+
+    mockSetNodes.mockClear();
+
+    const refetchedMap = {
+      ...mapWithNodes,
+      updated_at: new Date(Date.now() + 1000).toISOString(),
+    };
+    mockUseMindmapById.mockReturnValue({ data: refetchedMap, isLoading: false });
+
+    await act(async () => {
+      rerender(createElement(MindmapEditor));
+    });
+
+    await waitFor(() => {
+      expect(mockSetNodes).toHaveBeenCalled();
+    });
+
+    const refetchCallArg = mockSetNodes.mock.calls[0][0];
+    expect(typeof refetchCallArg).toBe('function');
   });
 
   it('paste image event triggers upload and node creation', async () => {

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -155,9 +155,18 @@ export function MindmapEditor() {
   const [toast, setToast] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; nodeId: string | null; edgeId?: string; flowX?: number; flowY?: number } | null>(null);
-  const [rfInstance, setRfInstance] = useState<ReactFlowInstance | null>(null);
+  const [rfInstance, setRfInstanceState] = useState<ReactFlowInstance | null>(null);
+
+  const setRfInstance = useCallback((instance: ReactFlowInstance) => {
+    setRfInstanceState(instance);
+    if (fitViewPending.current) {
+      fitViewPending.current = false;
+      instance.fitView({ duration: 0 });
+    }
+  }, []);
   const titleRef = useRef<HTMLHeadingElement>(null);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fitViewPending = useRef(false);
 
   useEffect(() => {
     setIsMobile(window.innerWidth < 768);
@@ -178,8 +187,34 @@ export function MindmapEditor() {
     updateMindmap.mutate({ title: trimmed });
   }
 
+  const seededMapId = useRef<string | null>(null);
+
   useEffect(() => {
     if (map == null) return;
+
+    if (seededMapId.current === map.id) {
+      setNodes((current) =>
+        current.map((n) => {
+          const serverNode = map.data.nodes.find((sn) => sn.id === n.id);
+          if (serverNode == null) return n;
+          const dataChanged =
+            serverNode.label !== (n.data as { label?: string }).label ||
+            (serverNode.color ?? null) !== (n.data as { color?: string | null }).color;
+          if (!dataChanged) return n;
+          return {
+            ...n,
+            data: { ...n.data, label: serverNode.label, color: serverNode.color ?? null },
+            style:
+              serverNode.color == null
+                ? NODE_STYLE
+                : { ...NODE_STYLE, borderColor: serverNode.color, boxShadow: `0 0 0 1px ${serverNode.color}` },
+          };
+        })
+      );
+      return;
+    }
+
+    seededMapId.current = map.id;
 
     const someHasPosition = map.data.nodes.some((n) => n.position != null);
 
@@ -202,10 +237,15 @@ export function MindmapEditor() {
     const initialNodes = someHasPosition ? rfNodes : layoutGraph(rfNodes, rfEdges);
     setNodes(initialNodes);
     setEdges(rfEdges);
+    if (rfInstance == null) {
+      fitViewPending.current = true;
+    } else {
+      rfInstance.fitView({ duration: 0 });
+    }
     if (initialNodes.length === 1) {
       setSelectedNodeId(initialNodes[0].id);
     }
-  }, [map, setNodes, setEdges]);
+  }, [map, setNodes, setEdges, rfInstance]);
 
   const persistData = useCallback(
     (ns: Node[], es: Edge[]) => {
@@ -785,7 +825,6 @@ export function MindmapEditor() {
           connectionMode={ConnectionMode.Loose}
           snapToGrid
           snapGrid={[20, 20]}
-          fitView
         >
           <Controls />
           <Background />

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-mindmap-smooth.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-mindmap-smooth.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-mindmap-smooth",
+  "date": "2026-05-24",
+  "type": "fix",
+  "title": "Mindmap editor holds its position instead of jumping when you edit a node"
+}


### PR DESCRIPTION
## What
Removes the viewport jump and node position reset that occurred every time a node was saved in the mindmap editor.

## Why
Hotjar recordings showed the canvas visibly snapping after every edit. Every save triggered a mutation which invalidated the React Query cache, causing `useMindmapById` to refetch. The seed effect ran unconditionally on every new `map` reference — overwriting positions with server data and re-running the static `fitView` prop.

## How
- Added a `seededMapId` ref. The load effect now seeds nodes (array assignment + fitView) only on first load for a given map id. Subsequent refetches for the same id use a functional `setNodes` updater that patches only label/color/style in-place, leaving user-arranged positions untouched.
- Removed the static `fitView` prop from `<ReactFlow>`. Initial fitView is now called programmatically once, either via the `onInit` callback (if instance is ready before data arrives) or directly in the seed effect (if data arrives first).
- `snapToGrid` remains; the position-reset was the cause of the jump, not the grid snap.

## Measuring success
In production: Hotjar recordings no longer show the canvas snapping after node edits. No `setNodes` calls with an array argument after the initial load.

## Testing
- Unit test added: verifies the seed effect calls `setNodes` with an array on first load, and with a functional updater on re-fetch (not an array that would reset positions).
- All 3 MindmapEditor tests pass.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: user runs the dev server; attestation is honor-system.

## Changelog
"Mindmap editor holds its position instead of jumping when you edit a node"

## Risks
- First-load fitView: if `onInit` fires before map data is ready, `fitViewPending` is set and the `onInit` handler fires it. If map data arrives before `onInit`, the seed effect calls `rfInstance.fitView` directly. Both paths are covered.
- Rollback: revert this commit restores the previous behavior.

## Goal alignment
Reduces friction in the mindmap editor — maps are a retention-driving feature. Smooth editing increases session length and likelihood of export.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782250252&installation_id=132681956&pr_number=2763&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2763&signature=18fc5181a50fa6ba2178ba632150cfecf94d1cc7e3a61aeebf4dd4271bd10805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->