### PR TITLE
feat: instrument upsell funnel — dismissed, time-on-pricing, quota-at-shown

### DIFF
--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -17,6 +17,12 @@ vi.mock('../../lib/hooks/useUserLocals', () => ({
   useUserLocals: () => mockUseUserLocals(),
 }));
 
+const mockUseCardUsage = vi.fn();
+
+vi.mock('../../lib/hooks/useCardUsage', () => ({
+  useCardUsage: () => mockUseCardUsage(),
+}));
+
 const mockTrack = vi.fn();
 
 vi.mock('../../lib/analytics/track', () => ({
@@ -43,6 +49,7 @@ describe('UpsellCard', () => {
   beforeEach(() => {
     mockTrack.mockClear();
     mockStartPassCheckout.mockReset();
+    mockUseCardUsage.mockReturnValue(null);
   });
 
   it('renders three CTAs for free users', () => {
@@ -186,6 +193,57 @@ describe('UpsellCard', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Day Pass' })).toBeEnabled();
+    });
+  });
+
+  it('fires paywall_dismissed when unmounted without an upgrade click', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    const { unmount } = render(<UpsellCard surface="downloads_upsell" />);
+    mockTrack.mockClear();
+    unmount();
+    expect(mockTrack).toHaveBeenCalledWith('paywall_dismissed', { surface: 'downloads_upsell' });
+  });
+
+  it('does not fire paywall_dismissed when unmounted after an upgrade click', async () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    mockStartPassCheckout.mockReturnValue(new Promise(() => {}));
+
+    const { unmount } = render(<UpsellCard surface="downloads_upsell" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Day Pass' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
+    });
+
+    mockTrack.mockClear();
+    unmount();
+    expect(mockTrack).not.toHaveBeenCalledWith('paywall_dismissed', expect.anything());
+  });
+
+  it('does not fire paywall_dismissed for paying users (card never shown)', () => {
+    mockUseUserLocals.mockReturnValue(payingUser);
+    const { unmount } = render(<UpsellCard surface="downloads_upsell" />);
+    mockTrack.mockClear();
+    unmount();
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('includes quota_remaining in paywall_shown when card usage is available', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    mockUseCardUsage.mockReturnValue({ cards_used: 75, cards_limit: 100, unlimited: false, loading: false });
+    render(<UpsellCard surface="downloads_upsell" />);
+    expect(mockTrack).toHaveBeenCalledWith('paywall_shown', {
+      surface: 'downloads_upsell',
+      quota_remaining: 25,
+    });
+  });
+
+  it('omits quota_remaining from paywall_shown when card usage is not yet loaded', () => {
+    mockUseUserLocals.mockReturnValue(freeUser);
+    mockUseCardUsage.mockReturnValue(null);
+    render(<UpsellCard surface="downloads_upsell" />);
+    expect(mockTrack).toHaveBeenCalledWith('paywall_shown', {
+      surface: 'downloads_upsell',
     });
   });
 });

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { track } from '../../lib/analytics/track';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { useCardUsage } from '../../lib/hooks/useCardUsage';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
 import { getSubscribeLink } from '../../pages/PricingPage/payment.links';
@@ -29,14 +30,37 @@ const BODY: Record<Surface, string> = {
 export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProps) {
   const { data } = useUserLocals();
   const [pendingKind, setPendingKind] = useState<'24h' | '7d' | null>(null);
+  const upgradeClickedRef = useRef(false);
+  const shownFiredRef = useRef(false);
 
   const paying = isPayingUser(data?.locals);
   const isAnonymous = data?.user?.email == null;
   const suppress = paying || (hideForAnonymous && isAnonymous);
 
+  const cardUsage = useCardUsage(!suppress);
+  const quotaRemaining =
+    cardUsage != null && !cardUsage.loading
+      ? cardUsage.cards_limit - cardUsage.cards_used
+      : null;
+
   useEffect(() => {
     if (suppress) return;
-    track('paywall_shown', { surface });
+    if (shownFiredRef.current) return;
+    if (cardUsage?.loading) return;
+    shownFiredRef.current = true;
+    const props =
+      quotaRemaining == null
+        ? { surface }
+        : { surface, quota_remaining: quotaRemaining };
+    track('paywall_shown', props);
+  }, [suppress, surface, quotaRemaining, cardUsage]);
+
+  useEffect(() => {
+    if (suppress) return;
+    return () => {
+      if (upgradeClickedRef.current) return;
+      track('paywall_dismissed', { surface });
+    };
   }, [suppress, surface]);
 
   useEffect(() => {
@@ -54,6 +78,7 @@ export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProp
   const email = data?.user?.email;
 
   const handlePassClick = async (kind: '24h' | '7d') => {
+    upgradeClickedRef.current = true;
     track('paywall_upgrade_clicked', {
       surface,
       plan: kind === '24h' ? 'day_pass' : 'week_pass',
@@ -68,6 +93,7 @@ export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProp
   };
 
   const handleUnlimitedClick = () => {
+    upgradeClickedRef.current = true;
     track('paywall_upgrade_clicked', { surface, plan: 'unlimited' });
   };
 

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -31,6 +31,8 @@ export const KNOWN_EVENTS = new Set([
   'upload_ai_anon_badge_clicked',
   'home_ai_anon_badge_viewed',
   'home_ai_anon_badge_clicked',
+  'paywall_dismissed',
+  'pricing_left',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -25,6 +25,12 @@ vi.mock('../../components/TopMessage/TopMessage', () => ({
 
 vi.mock('../../lib/analytics/track', () => ({
   track: vi.fn(),
+}));
+
+const mockUseCardUsage = vi.fn();
+
+vi.mock('../../lib/hooks/useCardUsage', () => ({
+  useCardUsage: () => mockUseCardUsage(),
 }));
 
 type AnalyticsGlobals = {
@@ -256,6 +262,10 @@ describe('PricingPage pricing honesty', () => {
 });
 
 describe('PricingPage internal event tracking', () => {
+  beforeEach(() => {
+    mockUseCardUsage.mockReturnValue(null);
+  });
+
   it('tracks paywall_shown with surface=pricing_page on mount', async () => {
     const { track } = await import('../../lib/analytics/track');
     const trackMock = vi.mocked(track);
@@ -336,6 +346,67 @@ describe('PricingPage internal event tracking', () => {
         plan: 'unlimited',
       });
     });
+  });
+});
+
+describe('PricingPage pricing_left telemetry', () => {
+  beforeEach(() => {
+    mockUseCardUsage.mockReturnValue(null);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires pricing_left with seconds_on_page when unmounted', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    const { unmount } = renderAt('/pricing');
+    vi.advanceTimersByTime(8000);
+    act(() => { unmount(); });
+
+    expect(trackMock).toHaveBeenCalledWith('pricing_left', { seconds_on_page: 8 });
+  });
+
+  it('fires pricing_left with 0 seconds when unmounted immediately', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    const { unmount } = renderAt('/pricing');
+    act(() => { unmount(); });
+
+    expect(trackMock).toHaveBeenCalledWith('pricing_left', { seconds_on_page: 0 });
+  });
+});
+
+describe('PricingPage quota_remaining in paywall_shown', () => {
+  it('includes quota_remaining when card usage is available', async () => {
+    mockUseCardUsage.mockReturnValue({ cards_used: 60, cards_limit: 100, unlimited: false, loading: false });
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    renderAt('/pricing');
+
+    expect(trackMock).toHaveBeenCalledWith('paywall_shown', {
+      surface: 'pricing_page',
+      quota_remaining: 40,
+    });
+  });
+
+  it('omits quota_remaining when card usage is not loaded', async () => {
+    mockUseCardUsage.mockReturnValue(null);
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    renderAt('/pricing');
+
+    expect(trackMock).toHaveBeenCalledWith('paywall_shown', { surface: 'pricing_page' });
   });
 });
 

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useSearchParams } from 'react-router-dom';
 import TopMessage from '../../components/TopMessage/TopMessage';
 import { firePaywallEvent } from '../../lib/analytics/firePaywallEvent';
 import { track } from '../../lib/analytics/track';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { useCardUsage } from '../../lib/hooks/useCardUsage';
 import { getVisibleText } from '../../lib/text/getVisibleText';
 import { AutoSyncCard } from './components/AutoSyncCard';
 import { PassCards } from './components/PassCards';
@@ -83,6 +84,13 @@ export default function PricingPage({
   const showContextBanner =
     fromContext != null && !isLoggedIn ? false : fromContext != null;
   const isAutoSyncUpsell = searchParams.get('upsell') === 'auto-sync';
+  const enteredAtRef = useRef(Date.now());
+  const shownFiredRef = useRef(false);
+  const cardUsage = useCardUsage(true);
+  const quotaRemaining =
+    cardUsage != null && !cardUsage.loading
+      ? cardUsage.cards_limit - cardUsage.cards_used
+      : null;
 
   useEffect(() => {
     if (!isAutoSyncUpsell) return;
@@ -101,7 +109,32 @@ export default function PricingPage({
     trialState !== 'sent';
 
   useEffect(() => {
-    track('paywall_shown', { surface: 'pricing_page' });
+    if (shownFiredRef.current) return;
+    if (cardUsage?.loading) return;
+    shownFiredRef.current = true;
+    const props =
+      quotaRemaining == null
+        ? { surface: 'pricing_page' as const }
+        : { surface: 'pricing_page' as const, quota_remaining: quotaRemaining };
+    track('paywall_shown', props);
+  }, [cardUsage, quotaRemaining]);
+
+  useEffect(() => {
+    const enteredAt = enteredAtRef.current;
+    const leftFiredRef = { current: false };
+
+    const fireLeft = () => {
+      if (leftFiredRef.current) return;
+      leftFiredRef.current = true;
+      const seconds_on_page = Math.round((Date.now() - enteredAt) / 1000);
+      track('pricing_left', { seconds_on_page });
+    };
+
+    globalThis.addEventListener('pagehide', fireLeft);
+    return () => {
+      globalThis.removeEventListener('pagehide', fireLeft);
+      fireLeft();
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What
Three new analytics events on the paywall surfaces: `paywall_dismissed`, `pricing_left`, and an enriched `paywall_shown` payload that includes `quota_remaining`.

## Why
We can't tell "bounced immediately" from "read and decided not to buy" with current tracking. This is the instrument-first step before any UX changes.

## How
- **`paywall_dismissed`** — UpsellCard cleanup fires this when the component unmounts without a prior upgrade click. A `useRef` flag (`upgradeClickedRef`) set in all three click handlers (Day Pass, Week Pass, Unlimited) suppresses the event when the user did click through.
- **`pricing_left` with `seconds_on_page`** — PricingPage records `Date.now()` at mount, fires `pricing_left` with the elapsed seconds (rounded) in the effect cleanup and on `pagehide`. A once-guard (`leftFiredRef`) prevents double-fire on BFCache restore.
- **`quota_remaining` in `paywall_shown`** — both UpsellCard and PricingPage now call `useCardUsage` (the existing hook that fetches `/api/users/usage`). `paywall_shown` waits for the fetch to settle, then includes `quota_remaining = cards_limit - cards_used`. A `shownFiredRef` prevents re-firing as the usage state transitions from loading → loaded.

**Quota gap note**: quota data is available client-side via `useCardUsage` → `/api/users/usage`. It is NOT in the `useUserLocals` response, so a separate fetch runs per surface. The fetch is cheap (authenticated GET, existing endpoint) and fires only for non-paying users (UpsellCard suppresses for paying users; PricingPage always fetches since the page is quota-relevant for everyone).

## Measuring success
Query `name IN ('paywall_dismissed', 'pricing_left', 'paywall_shown')` in the events table after deploy. Confirm:
- `paywall_dismissed` rows appear with non-null `surface`
- `pricing_left` rows appear with numeric `seconds_on_page` (distribution should show a bimodal: fast bounces < 5s and considered visits > 30s)
- `paywall_shown` rows for `pricing_page` and both upsell surfaces include `quota_remaining` for logged-in free users

## Testing
- Unit tests added: 6 new cases in UpsellCard.test.tsx, 4 new cases in PricingPage.test.tsx
- All 19 UpsellCard tests pass, all 53 PricingPage tests pass
- Typecheck clean, Biome lint clean

Browser check: not applicable — internal analytics events only, no rendered change

## Changelog
No entry — internal instrumentation, no user-visible change.

## Risks
- `useCardUsage` adds a second in-flight request on pricing page mount. The existing sidebar already does this call; the extra fetch is parallel and silent on failure (the hook returns null on error, `paywall_shown` fires without `quota_remaining`).
- StrictMode double-mount: the `shownFiredRef` guards prevent duplicate `paywall_shown` fires. The `paywall_dismissed` guard relies on the ref surviving the double-mount cycle (it does — the unmount from the first mount doesn't trigger dismissed because the second mount resets nothing; the ref persists across the StrictMode pair).

## Goal alignment
Instrument-first analytics step for the pricing funnel. Gives us the data to make informed decisions on upsell copy and /pricing UX changes — direct path to conversion improvement at scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782250375&installation_id=132681956&pr_number=2764&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2764&signature=e79eb6778d416a1b84f144188bdd2e547a8477dd5c4e8252ee99ce8acd0c0d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->