### PR TITLE
fix: return structured JSON for multer upload errors

### DIFF
--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -1,4 +1,7 @@
 import express from 'express';
+import multer from 'multer';
+
+jest.mock('../../lib/misc/GetUploadHandler');
 
 jest.mock('../../lib/integrations/stripe', () => ({
   getStripe: jest.fn().mockReturnValue({
@@ -12,6 +15,7 @@ jest.mock('../../services/SubscriptionService', () => ({
   default: { findActiveStripeSubscriptions: jest.fn().mockResolvedValue([]) },
 }));
 
+import { getUploadHandler } from '../../lib/misc/GetUploadHandler';
 import { INotionRepository } from '../../data_layer/NotionRespository';
 import { IUploadRepository } from '../../data_layer/UploadRespository';
 import NotionTokens from '../../data_layer/public/NotionTokens';
@@ -104,6 +108,69 @@ describe('Upload file', () => {
     expect(capturedStatus).toBe(400);
     expect(jsonSpy).toHaveBeenCalledWith(
       expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+});
+
+describe('Upload file — multer error handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns 413 with code=too_large when multer LIMIT_FILE_SIZE fires', async () => {
+    const multerError = new multer.MulterError('LIMIT_FILE_SIZE');
+    (getUploadHandler as jest.Mock).mockImplementation(
+      () =>
+        (_req: express.Request, _res: express.Response, cb: (err?: unknown) => void) => {
+          cb(multerError);
+        }
+    );
+
+    const jsonSpy = jest.fn();
+    let capturedStatus = 0;
+
+    const repository = {
+      deleteUpload: jest.fn(),
+      getUploadsByOwner: jest.fn().mockResolvedValue([]),
+      findByIdAndOwner: jest.fn().mockResolvedValue(null),
+      findByKey: jest.fn().mockResolvedValue(null),
+      findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue([]),
+      getLastUploadForUser: jest.fn().mockResolvedValue(null),
+    };
+    const notionRepository: INotionRepository = {
+      getNotionData: jest.fn() as INotionRepository['getNotionData'],
+      saveNotionToken: jest.fn() as INotionRepository['saveNotionToken'],
+      getNotionToken: jest.fn() as INotionRepository['getNotionToken'],
+      deleteBlocksByOwner: jest.fn() as INotionRepository['deleteBlocksByOwner'],
+      deleteNotionData: jest.fn() as INotionRepository['deleteNotionData'],
+    };
+    const uploadService = new UploadService(repository, {} as JobRepository);
+    const notionService = new NotionService(notionRepository);
+    const controller = new UploadController(uploadService, notionService);
+
+    await new Promise<void>((resolve) => {
+      const fakeRes = {
+        locals: {},
+        status: (code: number) => {
+          capturedStatus = code;
+          return {
+            json: (body: unknown) => {
+              jsonSpy(body);
+              resolve();
+            },
+          };
+        },
+      } as unknown as express.Response;
+      controller.file({} as express.Request, fakeRes);
+    });
+
+    expect(capturedStatus).toBe(413);
+    expect(jsonSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'too_large',
+        message: expect.stringContaining('50 MB'),
+      })
     );
   });
 });

--- a/src/controllers/Upload/UploadController.ts
+++ b/src/controllers/Upload/UploadController.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import fs from 'node:fs';
+import multer from 'multer';
 
 import { getOwner } from '../../lib/User/getOwner';
 import NotionService from '../../services/NotionService';
@@ -76,6 +77,12 @@ class UploadController {
       const handleUploadEndpoint = getUploadHandler(res);
 
       handleUploadEndpoint(req, res, async (error) => {
+        if (error instanceof multer.MulterError && error.code === 'LIMIT_FILE_SIZE') {
+          return res.status(413).json({
+            code: 'too_large',
+            message: 'Upload failed — file is over the 50 MB limit. Try splitting it.',
+          });
+        }
         if (isLimitError(error)) {
           return handleUploadLimitError(req, res, error instanceof Error ? error : null);
         }

--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import multer from 'multer';
 
 import ErrorHandler from './ErrorHandler';
 import { PythonExitError } from '../../lib/anki/buildPythonExitError';
@@ -134,6 +135,54 @@ describe('ErrorHandler', () => {
 
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ code: 'malformed_notion' })
+    );
+  });
+
+  test('emits code=too_large for multer LIMIT_FILE_SIZE', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    const err = new multer.MulterError('LIMIT_FILE_SIZE');
+
+    await ErrorHandler(res as unknown as express.Response, req, err);
+
+    expect(res.statusCode).toBe(413);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'too_large',
+        message: expect.stringContaining('50 MB'),
+      })
+    );
+  });
+
+  test('emits code=unsupported_format for multer LIMIT_UNEXPECTED_FILE', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    const err = new multer.MulterError('LIMIT_UNEXPECTED_FILE');
+
+    await ErrorHandler(res as unknown as express.Response, req, err);
+
+    expect(res.statusCode).toBe(415);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'unsupported_format',
+        message: expect.stringContaining('.zip'),
+      })
+    );
+  });
+
+  test('emits code=unknown with multer message for other MulterErrors', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    const err = new multer.MulterError('LIMIT_PART_COUNT');
+
+    await ErrorHandler(res as unknown as express.Response, req, err);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'unknown' })
     );
   });
 

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -1,5 +1,6 @@
 import express from 'express';
 import fs from 'fs';
+import multer from 'multer';
 import nodemailer from 'nodemailer';
 import { UploadedFile } from '../../lib/storage/types';
 import { isLimitError } from '../../lib/misc/isLimitError';
@@ -100,8 +101,32 @@ export default async function ErrorHandler(
     return;
   }
 
+  if (err instanceof multer.MulterError) {
+    const multerBody = toMulterErrorBody(err);
+    res.status(multerBody.status).json({ code: multerBody.code, message: multerBody.message });
+    return;
+  }
+
   const code: UploadErrorCode =
     err instanceof PythonExitError ? toUploadErrorCode(err.kind) : 'unknown';
   const body: UploadErrorBody = { code, message: err.message };
   res.status(400).json(body);
+}
+
+function toMulterErrorBody(err: multer.MulterError): { status: number; code: UploadErrorCode; message: string } {
+  if (err.code === 'LIMIT_FILE_SIZE') {
+    return {
+      status: 413,
+      code: 'too_large',
+      message: 'Upload failed — file is over the 50 MB limit. Try splitting it.',
+    };
+  }
+  if (err.code === 'LIMIT_UNEXPECTED_FILE') {
+    return {
+      status: 415,
+      code: 'unsupported_format',
+      message: 'This file type isn\'t supported. Use .zip, .html, .md, .csv, or .apkg.',
+    };
+  }
+  return { status: 400, code: 'unknown', message: err.message };
 }

--- a/web/src/pages/UploadPage/helpers/extractErrorMessage.test.ts
+++ b/web/src/pages/UploadPage/helpers/extractErrorMessage.test.ts
@@ -31,6 +31,16 @@ describe('extractErrorMessage', () => {
     expect(result.code).toBe('unknown');
   });
 
+  test('extracts code=unsupported_format when server sends that code', async () => {
+    const response = jsonResponse({
+      code: 'unsupported_format',
+      message: "This file type isn't supported. Use .zip, .html, .md, .csv, or .apkg.",
+    });
+    const result = await extractErrorMessage(response);
+    expect(result.code).toBe('unsupported_format');
+    expect(result.message).toContain('.zip');
+  });
+
   test('strips HTML tags from plain-text error response', async () => {
     const response = textResponse(
       '<p>Could not create a deck using your file</p>'

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-upload-error-messages.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-upload-error-messages.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-upload-error-messages",
+  "date": "2026-05-24",
+  "type": "fix",
+  "title": "Upload errors say what went wrong — file too large or unsupported type — instead of a generic message"
+}


### PR DESCRIPTION
## What
Map multer's `LIMIT_FILE_SIZE` and `LIMIT_UNEXPECTED_FILE` errors to structured JSON responses (`{ code, message }`) instead of HTML pages or redirects. This eliminates the `REJECTED_FALLBACK` catch-all for file-size and file-type rejections.

## Why
When a file exceeded the multer size limit on `/api/upload/file`, the error was caught by `isLimitError` (which matched `'File too large'`) and redirected to `/limit`. The browser followed the redirect, got HTML, `extractErrorMessage` couldn't parse it, and the user saw `REJECTED_FALLBACK`: "The server rejected the upload. Try again…". Same problem for unsupported file type — multer's `LIMIT_UNEXPECTED_FILE` reached `ErrorHandler` with `code: 'unknown'`.

After this fix, users see:
- **File too large**: "Upload failed — file is over the 50 MB limit. Try splitting it."
- **Unsupported type**: "This file type isn't supported. Use .zip, .html, .md, .csv, or .apkg."

Both strings are already handled by `classifyUploadError` which had per-code copy for `too_large` and `unsupported_format` — the server just wasn't sending those codes.

## How
Two changes:

1. **`UploadController.file()`**: check `err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE'` *before* `isLimitError` in the multer callback, and return a 413 JSON body. The redirect to `/limit` is preserved for app-level card-count limits.

2. **`ErrorHandler.tsx`**: detect `multer.MulterError` and map:
   - `LIMIT_FILE_SIZE` → 413 + `code: 'too_large'`
   - `LIMIT_UNEXPECTED_FILE` → 415 + `code: 'unsupported_format'`
   - anything else → 400 + `code: 'unknown'`

The client-side `extractErrorMessage` and `classifyUploadError` needed no changes — they already handled these codes.

## Measuring success
When a user uploads a file over the limit, they see the specific error copy instead of REJECTED_FALLBACK. Confirm via the `code` field in the network response: a 413 with `{ code: 'too_large', message: 'Upload failed — file is over the 50 MB limit...' }` in the response body.

## Testing
- Unit tests added: 3 new tests in `ErrorHandler.test.ts` (LIMIT_FILE_SIZE, LIMIT_UNEXPECTED_FILE, other MulterError), 1 new test in `UploadController.test.ts` (multer error → 413 JSON), 1 new test in `extractErrorMessage.test.ts` (unsupported_format code round-trips)
- All 10 affected tests pass; 1136 web tests pass; server tsc clean; web typecheck clean; Biome lint clean

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Error display uses existing components — no new rendering paths.

## Changelog
"Upload errors say what went wrong — file too large or unsupported type — instead of a generic message"

## Risks
The `LIMIT_FILE_SIZE` branch in `UploadController.file()` now returns JSON instead of redirecting to `/limit`. This is intentional: multer's own file-size rejection (hitting the 50 MB multer config limit) is different from the app-level card/upload quota. Existing quota redirect logic is unchanged.

## Goal alignment
Removes friction in the upload failure path — specific error messages reduce support volume and re-upload abandonment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782250518&installation_id=132681956&pr_number=2765&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2765&signature=9474870fa279068601f5221177faa943f5e629564fbe8ce5f52f552c805a1674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->