### PR TITLE
feat: add Favorites link to the sidebar

### DIFF
--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -131,6 +131,21 @@ describe('Sidebar your-stuff group', () => {
       'page'
     );
   });
+
+  it('shows Favorites for a logged-in user', () => {
+    renderSidebar();
+    expect(screen.getByRole('link', { name: 'Favorites' })).toHaveAttribute(
+      'href',
+      '/favorites'
+    );
+  });
+
+  it('hides Favorites when there is no signed-in account', () => {
+    renderSidebar({ email: null });
+    expect(
+      screen.queryByRole('link', { name: 'Favorites' })
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe('Sidebar help group', () => {

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -18,6 +18,7 @@ import CommandLineIcon from '../icons/CommandLineIcon';
 import CreditCardIcon from '../icons/CreditCardIcon';
 import PrinterIcon from '../icons/PrinterIcon';
 import SparklesIcon from '../icons/SparklesIcon';
+import StarIcon from '../icons/StarIcon';
 import UserCircleIcon from '../icons/UserCircleIcon';
 import SettingsIcon from '../icons/SettingsIcon';
 import WrenchIcon from '../icons/WrenchIcon';
@@ -170,6 +171,7 @@ export function Sidebar({
   const logoSrc = getLogoSrc(collapsed, theme);
   const showAnkify =
     locals?.patreon === true || locals?.autoSyncActive === true;
+  const showFavorites = email != null && email !== '';
   const paying = isPayingUser(locals);
   const showPricing = !paying;
   const showKi = features?.kiUI === true;
@@ -320,6 +322,17 @@ export function Sidebar({
           >
             {getVisibleText('navigation.myDecks')}
           </SidebarRow>
+          {showFavorites && (
+            <SidebarRow
+              href="/favorites"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={StarIcon}
+            >
+              Favorites
+            </SidebarRow>
+          )}
           <SidebarRow
             href="/card-options"
             pathname={pathname}

--- a/web/src/components/icons/StarIcon.tsx
+++ b/web/src/components/icons/StarIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function StarIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-24-favorites-sidebar.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-24-favorites-sidebar.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-24-favorites-sidebar",
+  "date": "2026-05-24",
+  "type": "feature",
+  "title": "Favorites — reach your starred Notion pages from the sidebar"
+}


### PR DESCRIPTION
## Summary
- The `/favorites` page had a route but no link anywhere — reachable only by typing the URL. Adds a sidebar row next to My Decks.
- Gated on a signed-in account (the page requires auth), which also avoids adding another anonymous `GET /api/favorite` 401 path.
- New `StarIcon` matching the existing icon set.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Favorites appears for logged-in users next to My Decks; absent when logged out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782251775&installation_id=132681956&pr_number=2766&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2766&signature=7b26cd5a453e53bf3694429ede37bb8f5ebb521967d4f41478c6b2fed9cef714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->