### PR TITLE
fix: show deck feedback prompt only after a download

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -328,6 +328,61 @@ describe('renderJobStatusCell — URL construction', () => {
   });
 });
 
+describe('DownloadsPage deck feedback prompt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:00:00Z'));
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    localStorage.clear();
+    mockUploads = [];
+    mockDropboxUploads = [];
+    mockGoogleDriveUploads = [];
+    mockJobs = [
+      buildJob({
+        status: 'done',
+        type: 'page',
+        title: 'Pharmacology Ch. 4',
+        download_key: 'deck-abc123.apkg',
+      }),
+    ];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    localStorage.clear();
+    delete (globalThis as AnalyticsGlobals).hj;
+    delete (globalThis as AnalyticsGlobals).gtag;
+  });
+
+  it('hides the feedback prompt until a deck is downloaded', () => {
+    renderAt('/downloads');
+    expect(
+      screen.queryByText('Did this deck come out right?')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the feedback prompt after clicking a download link', () => {
+    renderAt('/downloads');
+    fireEvent.click(screen.getByLabelText('Download Pharmacology Ch. 4'));
+    expect(
+      screen.getByText('Did this deck come out right?')
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the feedback prompt hidden after download when suppressed', () => {
+    localStorage.setItem(
+      '2anki_deck_feedback_suppressed_until',
+      String(Date.now() + 60_000)
+    );
+    renderAt('/downloads');
+    fireEvent.click(screen.getByLabelText('Download Pharmacology Ch. 4'));
+    expect(
+      screen.queryByText('Did this deck come out right?')
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe('DownloadsPage failure reason panel', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -90,7 +90,7 @@ interface RenderJobStatusOptions {
   onToggle: () => void;
 }
 
-export function renderJobStatusCell(j: JobResponse) {
+export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
   if (isDoneJob(j.status)) {
     if (j.type === 'apkg_import') {
       let notionUrl: string | null = null;
@@ -113,7 +113,7 @@ export function renderJobStatusCell(j: JobResponse) {
           className={styles.downloadAction}
           aria-label={`Download ${j.title}`}
           title="Download"
-          onClick={() => { fireAnalyticsEvent('deck_downloaded'); track('deck_downloaded'); }}
+          onClick={() => { onDownload?.(); fireAnalyticsEvent('deck_downloaded'); track('deck_downloaded'); }}
         >
           <DownloadIcon width={16} height={16} />
         </a>
@@ -202,6 +202,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
   );
   const [expandedFailureJobId, setExpandedFailureJobId] = useState<number | string | null>(null);
   const [mappingModalJob, setMappingModalJob] = useState<JobResponse | null>(null);
+  const [hasDownloaded, setHasDownloaded] = useState(false);
 
   const rawFilter = searchParams.get('filter') ?? 'all';
   const activeFilter: FilterValue = VALID_FILTERS.has(rawFilter as FilterValue)
@@ -268,8 +269,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
   );
 
   const activeJobs = jobs.filter((j) => isActiveJob(j.status));
-  const hasDoneJob = jobs.some((j) => isDoneJob(j.status));
-  const showDeckFeedback = hasDoneJob && !isDeckFeedbackSuppressed();
+  const showDeckFeedback = hasDownloaded && !isDeckFeedbackSuppressed();
 
   const handleDeleteJob = async (id: Parameters<typeof deleteJob>[0]) => {
     await deleteJob(id);
@@ -386,7 +386,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                         onToggle: toggleFailurePanel,
                                       })
                                     ) : (
-                                      renderJobStatusCell(row.job)
+                                      renderJobStatusCell(row.job, () => setHasDownloaded(true))
                                     )}
                                     <div className={styles.secondaryActions}>
                                       {isDoneJob(row.job.status) && row.job.download_key != null && APKG_PATTERN.test(row.job.download_key) && (
@@ -499,7 +499,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                     className={styles.downloadAction}
                                     aria-label={`Download ${u.filename}`}
                                     title="Download"
-                                    onClick={() => { fireAnalyticsEvent('deck_downloaded'); track('deck_downloaded'); }}
+                                    onClick={() => { setHasDownloaded(true); fireAnalyticsEvent('deck_downloaded'); track('deck_downloaded'); }}
                                   >
                                     <DownloadIcon width={16} height={16} />
                                   </a>
@@ -619,8 +619,9 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                     <UpsellCard surface="downloads_upsell" />
                   </div>
                 )}
-                {showDeckFeedback && <DeckFeedbackPrompt />}
               </div>
+
+              {showDeckFeedback && <DeckFeedbackPrompt />}
 
               <div style={{ textAlign: 'right', marginTop: '0.5rem', fontSize: 'var(--text-xs)', color: 'var(--color-text-tertiary)' }}>
                 {formatUpdatedLabel(lastFetchedAt)}

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.module.css
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.module.css
@@ -1,7 +1,7 @@
 .card {
   position: relative;
-  margin-top: 1rem;
-  padding: 1rem 2.5rem 1rem 1rem;
+  margin-top: 0.75rem;
+  padding: 1rem 3rem 1rem 1.25rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   background: var(--color-bg-primary);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-deck-feedback-after-download.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-deck-feedback-after-download.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-deck-feedback-after-download",
+  "date": "2026-05-25",
+  "type": "fix",
+  "title": "The deck feedback prompt appears only after you download a deck"
+}


### PR DESCRIPTION
## What

The "Did this deck come out right?" prompt on **My decks** now appears **only after the user downloads a deck** this session — not on every visit. It also moves out of the table card into its own band below it, with tightened spacing so it no longer sits flush against the card edge.

## Why

The prompt was gated on `hasDoneJob` (any finished deck in the list), so it showed on every `/downloads` load for anyone who'd ever converted something — including people returning only to manage or delete old decks. You can't answer "did this deck come out right?" until you've actually pulled it into Anki, so download is the right moment to ask. Removing the always-on prompt is a net subtraction of noise for returning users.

## How

- New in-memory `hasDownloaded` boolean in `DownloadsPage`, flipped by the existing download `onClick` handlers (job rows + upload rows). Pure ephemeral UI state — resets on navigation, so the next session can ask again. No DB, per the localStorage/DB rule's carve-out.
- `renderJobStatusCell` takes an optional `onDownload` callback.
- Prompt moved outside `styles.card`; `margin-top` 1rem → 0.75rem and left padding aligned to the table cells.
- The 14-day localStorage suppression and the post-answer Day Pass upsell are **unchanged**.

## Trio

pm + designer + engineer reviewed in parallel before code. Agreed: trigger on download, move the prompt below the card, fix spacing, keep suppression + Day Pass intact. One conflict resolved — designer proposed a `lastDownloadedTitle` string, but the prompt copy never names the deck, so a boolean is the simpler equivalent.

## Tests

3 new cases in `DownloadsPage.test.tsx`: prompt hidden before download, shown after a download click, and stays hidden when suppressed. Full file 25/25. `pnpm typecheck` + `pnpm lint` clean.

Sonar not run locally — scanner/token not installed on this machine. Change is small (optional param, one state hook, a moved JSX node, CSS values); expect no new smells, but flagging in case of a bounce.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified locally by Alexander before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782287763&installation_id=132681956&pr_number=2767&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2767&signature=adf11a6c21a82be09701fe94f684e5de20c10ce9378ded5dcc3c2d54035d0419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
