### PR TITLE
fix: show sign-in prompt in chat consent modal for logged-out users

### DIFF
--- a/web/src/components/ConsentModal/ConsentModal.test.tsx
+++ b/web/src/components/ConsentModal/ConsentModal.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import ConsentModal from './ConsentModal';
 
@@ -10,45 +11,74 @@ vi.mock('../../lib/backend/api', () => ({
 import { post } from '../../lib/backend/api';
 const mockPost = post as ReturnType<typeof vi.fn>;
 
+function renderModal(onAccept = vi.fn(), onDismiss = vi.fn()) {
+  return render(
+    <MemoryRouter>
+      <ConsentModal onAccept={onAccept} onDismiss={onDismiss} />
+    </MemoryRouter>
+  );
+}
+
 describe('ConsentModal', () => {
   beforeEach(() => {
     mockPost.mockReset();
   });
 
   it('renders the consent heading', () => {
-    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    renderModal();
     expect(screen.getByRole('heading', { name: 'Chat sends your messages to Anthropic' })).toBeInTheDocument();
   });
 
   it('renders the body copy', () => {
-    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    renderModal();
     expect(screen.getByText(/Your messages and any files you attach go to Anthropic/)).toBeInTheDocument();
   });
 
   it('renders the primary Start chatting button', () => {
-    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    renderModal();
     expect(screen.getByRole('button', { name: 'Start chatting' })).toBeInTheDocument();
   });
 
   it('renders the secondary Not now button', () => {
-    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    renderModal();
     expect(screen.getByRole('button', { name: 'Not now' })).toBeInTheDocument();
   });
 
-  it('POSTs to /api/chat/consent and calls onAccept when primary button is clicked', async () => {
+  it('POSTs to /api/chat/consent and calls onAccept when res.ok is true', async () => {
     mockPost.mockResolvedValueOnce({ ok: true, status: 204 });
     const onAccept = vi.fn();
-    render(<ConsentModal onAccept={onAccept} onDismiss={vi.fn()} />);
+    renderModal(onAccept);
     fireEvent.click(screen.getByRole('button', { name: 'Start chatting' }));
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith('/api/chat/consent', {});
-      expect(onAccept).toHaveBeenCalled();
+      expect(onAccept).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not call onAccept and shows sign-in prompt when res.ok is false', async () => {
+    mockPost.mockResolvedValueOnce({ ok: false, status: 401 });
+    const onAccept = vi.fn();
+    renderModal(onAccept);
+    fireEvent.click(screen.getByRole('button', { name: 'Start chatting' }));
+    await waitFor(() => {
+      expect(onAccept).not.toHaveBeenCalled();
+      expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    });
+  });
+
+  it('sign-in prompt links to /login', async () => {
+    mockPost.mockResolvedValueOnce({ ok: false, status: 401 });
+    renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Start chatting' }));
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'Sign in' });
+      expect(link).toHaveAttribute('href', '/login');
     });
   });
 
   it('calls onDismiss when Not now is clicked', () => {
     const onDismiss = vi.fn();
-    render(<ConsentModal onAccept={vi.fn()} onDismiss={onDismiss} />);
+    renderModal(vi.fn(), onDismiss);
     fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
     expect(onDismiss).toHaveBeenCalled();
   });
@@ -56,7 +86,7 @@ describe('ConsentModal', () => {
   it('disables Start chatting button while posting', async () => {
     let resolve!: (v: unknown) => void;
     mockPost.mockReturnValueOnce(new Promise((res) => { resolve = res; }));
-    render(<ConsentModal onAccept={vi.fn()} onDismiss={vi.fn()} />);
+    renderModal();
     fireEvent.click(screen.getByRole('button', { name: 'Start chatting' }));
     expect(screen.getByRole('button', { name: 'Start chatting' })).toBeDisabled();
     resolve({ ok: true, status: 204 });

--- a/web/src/components/ConsentModal/ConsentModal.tsx
+++ b/web/src/components/ConsentModal/ConsentModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { post } from '../../lib/backend/api';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './ConsentModal.module.css';
@@ -10,12 +11,17 @@ interface ConsentModalProps {
 
 export default function ConsentModal({ onAccept, onDismiss }: Readonly<ConsentModalProps>) {
   const [pending, setPending] = useState(false);
+  const [needsSignIn, setNeedsSignIn] = useState(false);
 
   const handleAccept = async () => {
     setPending(true);
     try {
-      await post('/api/chat/consent', {});
-      onAccept();
+      const res = await post('/api/chat/consent', {});
+      if (res.ok) {
+        onAccept();
+      } else {
+        setNeedsSignIn(true);
+      }
     } finally {
       setPending(false);
     }
@@ -34,6 +40,11 @@ export default function ConsentModal({ onAccept, onDismiss }: Readonly<ConsentMo
           <p className={styles.body}>
             Your messages and any files you attach go to Anthropic to generate replies. They aren't used to train models. 20 messages a month on the free plan.
           </p>
+          {needsSignIn && (
+            <p className={styles.body}>
+              <Link to="/login">Sign in</Link> to chat.
+            </p>
+          )}
           <div className={styles.actions}>
             <button
               type="button"

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-chat-signin-prompt.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-chat-signin-prompt.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-chat-signin-prompt",
+  "date": "2026-05-25",
+  "type": "fix",
+  "title": "Chat consent modal now shows a sign-in link for logged-out users instead of silently doing nothing"
+}


### PR DESCRIPTION
## What
When an anonymous (logged-out) user clicked 'Start chatting' in the consent modal, the POST to `/api/chat/consent` returned 401 but `post()` did not check `res.ok`, so `onAccept()` ran unconditionally. Because `hasConsented` can never become true for an anon user (it reads `chat_consent_at` from the user row), the modal re-asserted on every render — clicking did nothing, silently.

This PR checks `res.ok` after the consent POST. On a non-ok response it sets a `needsSignIn` flag and renders an inline prompt: **`Sign in` (link to /login) `to chat.`** instead of calling `onAccept()`.

## Why
Logged-out users hitting the chat panel had no actionable path forward — the modal looped without feedback. The fix turns a silent dead-end into a clear next step.

## How
- Added `needsSignIn` state to `ConsentModal.tsx`.
- `handleAccept` captures the `Response` from `post()`, calls `onAccept()` only when `res.ok`, otherwise sets `needsSignIn`.
- When `needsSignIn` is true, renders `<Link to="/login">Sign in</Link> to chat.` inline in the modal body.
- No changes to server routes, `ChatPanel`, or auth middleware — scope is exactly the modal.

## Measuring success
A logged-out user clicking 'Start chatting' now sees the sign-in prompt rendered in the modal body. Confirming in prod: if the console no longer shows silent re-renders of the consent modal for anon users, the fix is working.

## Testing
- Unit tests added: 2 new cases in `ConsentModal.test.tsx`
  - `res.ok = true` → `onAccept` called once (existing behavior confirmed)
  - `res.ok = false / 401` → `onAccept` not called, 'Sign in' link rendered at `/login`
- All 9 tests in the file pass; 1159 total web tests green.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes:

## Changelog
"Chat consent modal now shows a sign-in link for logged-out users instead of silently doing nothing" — added to `web/src/pages/WhatsNewPage/changelog/2026-05-25-chat-signin-prompt.json`.

## Risks
None. The only new behavior is when the API returns non-ok — previously this path was unreachable UX-wise (silent loop). Rollback: revert the three changed files.

## Goal alignment
Removing a silent dead-end for logged-out users who encounter the chat panel reduces friction on the path to registration — directly supports the 300K-user growth goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782290052&installation_id=132681956&pr_number=2768&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2768&signature=179d474d0fea90d709aad192e248364fd9268c040f620503904519812357f151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
