### PR TITLE
chore: add upload_failed telemetry on network/throw errors in UploadForm

### DIFF
--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -33,6 +33,7 @@ export const KNOWN_EVENTS = new Set([
   'home_ai_anon_badge_clicked',
   'paywall_dismissed',
   'pricing_left',
+  'upload_failed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -672,6 +672,46 @@ describe('UploadForm analytics events', () => {
     });
   });
 
+  it('tracks upload_failed with reason=network when fetch throws a TypeError', async () => {
+    const { track } = await import('../../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Failed to fetch')));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      const calls = trackMock.mock.calls.filter(([name]) => name === 'upload_failed');
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toMatchObject({ reason: 'network' });
+    });
+  });
+
+  it('tracks upload_failed with reason=other when fetch throws a non-network Error', async () => {
+    const { track } = await import('../../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Unexpected server error')));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      const calls = trackMock.mock.calls.filter(([name]) => name === 'upload_failed');
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toMatchObject({ reason: 'other' });
+    });
+  });
+
 });
 
 describe('limit state — start trial button', () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -632,6 +632,19 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
         setZoneState('success');
       }
     } catch (error) {
+      const isNetworkError =
+        error instanceof TypeError ||
+        (error instanceof Error && /fetch|network/i.test(error.message));
+      track('upload_failed', {
+        reason: isNetworkError ? 'network' : 'other',
+        message: (error instanceof Error ? error.message : String(error)).slice(0, 200),
+        fileSizeBytes: fileInputRef.current?.files?.[0]?.size ?? null,
+        fileExt: (() => {
+          const name = fileInputRef.current?.files?.[0]?.name ?? '';
+          const dot = name.lastIndexOf('.');
+          return dot >= 0 ? name.slice(dot).toLowerCase() : null;
+        })(),
+      });
       setLocalError(toFriendlyThrownError(error));
       setZoneState('error');
       return false;


### PR DESCRIPTION
## What
Fires `track('upload_failed', { reason, message, fileSizeBytes, fileExt })` in the `catch` branch of `handleSubmit` when the upload `fetch('/api/upload/file')` throws. Previously that branch set UI state and logged nothing, leaving every network-layer failure invisible in production analytics.

## Why
A real user outside of our primary markets hit the NETWORK_FALLBACK error message and we had zero signal on cause, file type, or size. This closes that blind spot without changing any user-visible behavior.

## How
- Reuses the same `isNetworkError` detection already present in `toFriendlyThrownError` (TypeError or Error with fetch/network in message).
- `fileExt` is derived via `lastIndexOf('.')` on the filename — the filename itself is never included (confidentiality rule).
- `message` is truncated to 200 chars.
- `'upload_failed'` added to `KnownEvent` in `events.ts` so the call is statically typed; no `any`.
- Two new Vitest tests cover the TypeError path (`reason: 'network'`) and generic Error path (`reason: 'other'`), both using `vi.stubGlobal('fetch', vi.fn().mockRejectedValue(...))`.

## Measuring success
Query the analytics backend for `upload_failed` events. First occurrence of the event confirms the instrumentation is live. A non-zero `reason: 'network'` rate with a specific `fileExt` distribution will tell us whether the Australia failures were browser-side or format-correlated.

## Testing
- Unit tests added: 2 new `it` blocks in `UploadForm.test.tsx` — one for TypeError (network), one for generic Error (other).
- Full suite: 1159 tests, 136 files, all passed.

## Browser check
Browser check: not applicable — adds analytics on the existing error path, no rendered output change

## Changelog
No entry — internal observability, no user-visible behavior change.

## Risks
Minimal. The call is fire-and-forget; if `track` throws internally it would surface as an unhandled promise rejection in the catch block — but `track` is synchronous in the current implementation. No new dependencies.

## Goal alignment
Diagnosing silent failures reduces churn from frustrated users who never convert successfully and never know why. Fixing the underlying causes (once we have signal) directly improves conversion rate toward the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782290068&installation_id=132681956&pr_number=2769&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2769&signature=4e6a798ee1f958d8ffaaac7ff6c50b894a5710cf760bba8a0976de0c065dce7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->