### PR TITLE
security: gate mindmap image route and validate s3Key ownership

### DIFF
--- a/src/controllers/MindmapController.ts
+++ b/src/controllers/MindmapController.ts
@@ -210,6 +210,13 @@ export class MindmapController {
 
   async serveImage(req: Request, res: Response): Promise<void> {
     const { userId, mapId, file } = req.params;
+    const authenticatedUserId = res.locals.owner as number;
+
+    if (Number(userId) !== authenticatedUserId) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+
     const s3Key = `mindmaps/${userId}/${mapId}/${file}`;
 
     const exists = await this.storage.objectExists(s3Key);

--- a/src/routes/MindmapRouter.test.ts
+++ b/src/routes/MindmapRouter.test.ts
@@ -55,13 +55,19 @@ jest.mock('../services/SubscriptionService', () => ({
   },
 }));
 
+let mockAuthOwner: number | null = 42;
+
 jest.mock('./middleware/RequireAuthentication', () => {
   const middleware = (
     _req: express.Request,
     res: express.Response,
     next: express.NextFunction
   ) => {
-    res.locals.owner = 42;
+    if (mockAuthOwner == null) {
+      res.status(401).json({ message: 'Authentication required' });
+      return;
+    }
+    res.locals.owner = mockAuthOwner;
     res.locals.email = 'tester@example.com';
     res.locals.patreon = null;
     next();
@@ -94,6 +100,7 @@ describe('MindmapRouter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAuthOwner = 42;
     mockGetUserActiveSubscriptions.mockResolvedValue([]);
     mockGetPresignedUrl.mockResolvedValue('https://spaces.example.com/presigned');
     mockObjectExists.mockResolvedValue(false);
@@ -333,6 +340,27 @@ describe('MindmapRouter', () => {
       expect(res.status).toBe(410);
       const body = await res.json();
       expect(body.code).toBe('image_missing');
+    });
+
+    it('returns 401 when not authenticated', async () => {
+      mockAuthOwner = null;
+
+      const res = await fetch(`${url}/api/mindmaps/images/42/map-1/img.png`);
+
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 cross-tenant: authenticated as user 42 but requesting user 99 image', async () => {
+      mockObjectExists.mockResolvedValue(true);
+      mockGetPresignedUrl.mockResolvedValue('https://spaces.example.com/presigned-img');
+
+      const res = await fetch(`${url}/api/mindmaps/images/99/map-1/img.png`, {
+        redirect: 'manual',
+      });
+
+      expect(res.status).toBe(403);
+      expect(mockObjectExists).not.toHaveBeenCalled();
+      expect(mockGetPresignedUrl).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/routes/MindmapRouter.ts
+++ b/src/routes/MindmapRouter.ts
@@ -318,8 +318,10 @@ const MindmapRouter = () => {
    *       410:
    *         description: Image no longer available
    */
-  router.get('/api/mindmaps/images/:userId/:mapId/:file', (req, res) =>
-    controller.serveImage(req, res)
+  router.get(
+    '/api/mindmaps/images/:userId/:mapId/:file',
+    RequireAuthentication,
+    (req, res) => controller.serveImage(req, res)
   );
 
   return router;

--- a/src/usecases/mindmaps/GetMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/GetMindmapUseCase.test.ts
@@ -106,4 +106,20 @@ describe('GetMindmapUseCase', () => {
     expect(nodes[0].image?.missing).toBe(true);
     expect(nodes[0].image?.url).toBeNull();
   });
+
+  it('rejects cross-tenant s3Key: key belongs to user 99, map belongs to user 1', async () => {
+    const data: MindmapData = {
+      nodes: [{ id: 'e', label: 'Node', image: { url: 'mindmaps/99/other-map/uuid.png', width: 10, height: 10 } }],
+      edges: [],
+    };
+    const map = makeMap(data);
+    const storage = makeStorage();
+    const useCase = new GetMindmapUseCase(makeRepo(map), storage);
+
+    const result = await useCase.execute('map-1' as MindmapsId, 1 as UsersId);
+    const nodes = (result!.data as MindmapData).nodes;
+    expect(nodes[0].image?.missing).toBe(true);
+    expect(nodes[0].image?.url).toBeNull();
+    expect(storage.getPresignedUrl).not.toHaveBeenCalled();
+  });
 });

--- a/src/usecases/mindmaps/GetMindmapUseCase.ts
+++ b/src/usecases/mindmaps/GetMindmapUseCase.ts
@@ -17,7 +17,9 @@ function isS3Key(value: string): boolean {
 
 async function resolveImage(
   image: MindmapImageMeta,
-  storage: StorageHandler
+  storage: StorageHandler,
+  userId: UsersId,
+  mapId: MindmapsId
 ): Promise<MindmapImageMeta> {
   const { url } = image;
   if (url == null) {
@@ -27,6 +29,10 @@ async function resolveImage(
     return { url: null, width: image.width, height: image.height, missing: true };
   }
   if (isS3Key(url)) {
+    const expectedPrefix = `${S3_KEY_PREFIX}${userId}/${mapId}/`;
+    if (!url.startsWith(expectedPrefix)) {
+      return { url: null, width: image.width, height: image.height, missing: true };
+    }
     const presignedUrl = await storage.getPresignedUrl(url).catch(() => null);
     if (presignedUrl == null) {
       return { url: null, width: image.width, height: image.height, missing: true };
@@ -50,7 +56,7 @@ export class GetMindmapUseCase {
     const resolvedNodes = await Promise.all(
       data.nodes.map(async (node) => {
         if (node.image == null) return node;
-        const resolvedImage = await resolveImage(node.image, this.storage);
+        const resolvedImage = await resolveImage(node.image, this.storage, userId, id);
         return { ...node, image: resolvedImage };
       })
     );

--- a/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
@@ -182,4 +182,47 @@ describe('UpdateMindmapUseCase', () => {
     const savedImage = saved.data.nodes[0].image!;
     expect(savedImage.url).toBe('mindmaps/1/map-1/uuid.png');
   });
+
+  it('rejects cross-tenant s3Key: key for user 99 in map belonging to user 1', async () => {
+    const repo = makeRepo(makeMap(1));
+    const useCase = new UpdateMindmapUseCase(repo);
+
+    await useCase.execute({
+      id: 'map-1' as MindmapsId,
+      userId: 1 as UsersId,
+      data: {
+        nodes: [{ id: 'a', label: 'n', image: { url: 'mindmaps/99/other-map/uuid.png', width: 10, height: 10 } }],
+        edges: [],
+      },
+      user: FREE_USER,
+      subscriptions: [],
+    });
+
+    const saved = (repo.update as jest.Mock).mock.calls[0][2] as { data: MindmapData };
+    const savedImage = saved.data.nodes[0].image!;
+    expect(savedImage.url).toBeNull();
+    expect(savedImage.missing).toBe(true);
+  });
+
+  it('rejects cross-tenant presigned URL: key prefix for user 99', async () => {
+    const presigned = 'https://bucket.spaces.digitaloceanspaces.com/mindmaps/99/other-map/uuid.png?X-Amz-Signature=abc';
+    const repo = makeRepo(makeMap(1));
+    const useCase = new UpdateMindmapUseCase(repo);
+
+    await useCase.execute({
+      id: 'map-1' as MindmapsId,
+      userId: 1 as UsersId,
+      data: {
+        nodes: [{ id: 'a', label: 'n', image: { url: presigned, width: 10, height: 10 } }],
+        edges: [],
+      },
+      user: FREE_USER,
+      subscriptions: [],
+    });
+
+    const saved = (repo.update as jest.Mock).mock.calls[0][2] as { data: MindmapData };
+    const savedImage = saved.data.nodes[0].image!;
+    expect(savedImage.url).toBeNull();
+    expect(savedImage.missing).toBe(true);
+  });
 });

--- a/src/usecases/mindmaps/UpdateMindmapUseCase.ts
+++ b/src/usecases/mindmaps/UpdateMindmapUseCase.ts
@@ -13,7 +13,11 @@ export const FREE_NODE_LIMIT = 50;
 const LEGACY_PREFIX = '/api/mindmaps/images/';
 const S3_KEY_PREFIX = 'mindmaps/';
 
-function sanitizeImageUrl(image: MindmapImageMeta): MindmapImageMeta {
+function sanitizeImageUrl(
+  image: MindmapImageMeta,
+  userId: UsersId,
+  mapId: MindmapsId
+): MindmapImageMeta {
   const { url } = image;
   if (url == null) {
     return { ...image, missing: true, url: null };
@@ -21,24 +25,32 @@ function sanitizeImageUrl(image: MindmapImageMeta): MindmapImageMeta {
   if (url.startsWith(LEGACY_PREFIX)) {
     return { url: null, width: image.width, height: image.height, missing: true };
   }
+  const expectedPrefix = `${S3_KEY_PREFIX}${userId}/${mapId}/`;
   if (url.startsWith(S3_KEY_PREFIX)) {
+    if (!url.startsWith(expectedPrefix)) {
+      return { url: null, width: image.width, height: image.height, missing: true };
+    }
     return { ...image, url };
   }
   const s3KeyMatch = url.match(/[?#]/);
   const rawPath = s3KeyMatch != null ? url.slice(0, s3KeyMatch.index) : url;
   const keyStart = rawPath.indexOf(S3_KEY_PREFIX);
   if (keyStart !== -1) {
-    return { ...image, url: rawPath.slice(keyStart) };
+    const s3Key = rawPath.slice(keyStart);
+    if (!s3Key.startsWith(expectedPrefix)) {
+      return { url: null, width: image.width, height: image.height, missing: true };
+    }
+    return { ...image, url: s3Key };
   }
   return { url: null, width: image.width, height: image.height, missing: true };
 }
 
-function sanitizeData(data: MindmapData): MindmapData {
+function sanitizeData(data: MindmapData, userId: UsersId, mapId: MindmapsId): MindmapData {
   return {
     ...data,
     nodes: data.nodes.map((node) => {
       if (node.image == null) return node;
-      return { ...node, image: sanitizeImageUrl(node.image) };
+      return { ...node, image: sanitizeImageUrl(node.image, userId, mapId) };
     }),
   };
 }
@@ -66,7 +78,7 @@ export class UpdateMindmapUseCase {
 
     const patch: Partial<Pick<Mindmaps, 'title' | 'data'>> = {};
     if (title != null) patch.title = title;
-    if (data != null) patch.data = sanitizeData(data);
+    if (data != null) patch.data = sanitizeData(data, userId, id);
 
     return this.repo.update(id, userId, patch);
   }


### PR DESCRIPTION
Closes #2691
Closes #2692

## Retro context

W21 window 2026-05-18→2026-05-24. Carried-over security debt: cross-tenant mindmap image access. Both issues were filed as risk:low (UUID unguessability makes exploitation narrow), but closing them removes the exposure entirely at low cost.

Sibling PRs in this fan-out:
- payments/webhook-audit-W21
- feat/ankify-silent-zero-structured-log
- security/mindmap-image-ownership (this PR)

Related baseline PRs: #2734, #2717, #2711, #2714

## What

Three coordinated fixes on the same surface (mindmap image serving + S3 key resolution):

1. `GET /api/mindmaps/images/:userId/:mapId/:file` now requires authentication (`RequireAuthentication` added in `MindmapRouter.ts`). Previously the only unauthenticated route in the router.
2. `MindmapController.serveImage` checks `Number(req.params.userId) === res.locals.owner` before touching storage. Cross-tenant requests 403 without any S3 call.
3. `sanitizeImageUrl` (UpdateMindmapUseCase) and `resolveImage` (GetMindmapUseCase) now validate that the s3Key prefix matches `mindmaps/<authUserId>/<mapId>/`. A foreign-prefixed key is returned as `missing: true` without reaching storage.

## Why

#2691: the route was unauthenticated; a known URL could be re-minted by any visitor.
#2692: an authenticated attacker who already holds a victim's full s3Key (two 122-bit UUIDs) could poison their own map data and have the server mint a presigned URL for foreign S3 content.

## How

Auth check lives in the route middleware (`RequireAuthentication`) — not in the controller, per the project rule that auth checks belong in `routes/middleware/`.

Ownership check in `serveImage` is a single numeric comparison on `res.locals.owner` (trusted, set by middleware) vs `Number(req.params.userId)`.

Prefix validation in `sanitizeImageUrl` / `resolveImage` threads `userId` and `mapId` (both already available at the call site) through to the check. Zero new parameters on the public `execute()` APIs.

## Measuring success

A cross-tenant request `GET /api/mindmaps/images/<other-userId>/...` now returns 403 (visible in Express access logs as `403 GET /api/mindmaps/images/...`). An unauthenticated request returns 401. Zero S3 calls for either case — confirmed by the test assertions on `mockObjectExists` and `mockGetPresignedUrl`.

## Testing

- Unit tests added: `UpdateMindmapUseCase.test.ts` — 2 new cross-tenant cases (bare s3Key, presigned URL with foreign prefix)
- Unit tests added: `GetMindmapUseCase.test.ts` — 1 new cross-tenant case (foreign-prefix s3Key, no storage call)
- Integration test added: `MindmapRouter.test.ts` — 401 (unauthenticated), 403 (cross-tenant: authed as user 42, requesting user 99 image, no S3 call)

Total: 31 tests pass, 0 failures.

## Changelog

No entry — security hardening, no user-visible behavior change.

## Risks

Routes that previously worked unauthenticated now require a session. No client code calls this endpoint — `sanitizeImageUrl` in UpdateMindmapUseCase strips legacy `/api/mindmaps/images/` URLs to `missing: true` (post-#2686). The endpoint is legacy-only.

Rollback: revert the `RequireAuthentication` addition to the one route and remove the numeric comparison in `serveImage`.

## Goal alignment

Closing security debt keeps the trust bar high as we grow toward 300K users. A cross-tenant data leak, however narrow the exploit, would be a reputational cost we cannot afford at scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782306832&installation_id=132681956&pr_number=2779&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2779&signature=54026dedd91495da6faf5c10340913055d8a066025afed40e199d6fd7407828c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Local checks
- `pnpm test` on affected files: 31 passed, 0 failures.
- `sonar-scanner` not run locally — not installed in this environment (no SONAR_TOKEN). Expect a possible SonarCloud bounce on CI; resolve any new-code smells before merge.
