### PR TITLE
feat: emit structured zero-cards event and link to /answers

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -46,6 +46,7 @@ import StorageHandler from '../lib/storage/StorageHandler';
 import { parseCollection } from '../services/ApkgPreviewService/parseCollection';
 import { extractApkg } from '../services/ApkgPreviewService/extractApkg';
 import RequireAnkifyAccess from './middleware/RequireAnkifyAccess';
+import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 
 const buildNotionExportClient = (token: string) => {
   const notion = new NotionClient({ auth: token });
@@ -339,7 +340,9 @@ const AnkifyRouter = () => {
     new NotionRepository(db),
     ankiConnectFactory,
     notionBlockChildrenFetcherFactory,
-    buildNotionPageMetaFetcher
+    buildNotionPageMetaFetcher,
+    fetch,
+    new ErrorEventRepository(db)
   );
 
   const controller = new AnkifyController(

--- a/src/routes/AnkifyWebhookRouter.ts
+++ b/src/routes/AnkifyWebhookRouter.ts
@@ -14,6 +14,7 @@ import { verifyNotionWebhookSignature } from '../lib/ankify/notionWebhookSignatu
 import { hasAnkifyAccess } from '../lib/ankify/access';
 import UsersRepository from '../data_layer/UsersRepository';
 import SubscriptionService from '../services/SubscriptionService';
+import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 
 const AnkifyWebhookRouter = () => {
   const router = express.Router();
@@ -34,7 +35,10 @@ const AnkifyWebhookRouter = () => {
     logs,
     notionRepo,
     ankiConnectFactory,
-    notionBlockChildrenFetcherFactory
+    notionBlockChildrenFetcherFactory,
+    undefined,
+    fetch,
+    new ErrorEventRepository(db)
   );
 
   router.post(

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -9,6 +9,7 @@ import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/
 import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import { AnkifySyncLogsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncLogsRepository';
 import { INotionRepository } from '../../data_layer/NotionRespository';
+import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
 import { WalkedNotionFlashcard } from '../../services/ankify/notionPageWalker';
 
@@ -827,5 +828,138 @@ describe('SyncNotionPageToRacUseCase', () => {
     ).rejects.toThrow('rate_limited');
 
     expect(repos.subscriptions.setEnabled).not.toHaveBeenCalled();
+  });
+
+  describe('zero-card structured event emission', () => {
+    const makeErrorEventRepo = (): jest.Mocked<IErrorEventRepository> => ({
+      insert: jest.fn().mockResolvedValue(undefined),
+      existsWithinWindow: jest.fn().mockResolvedValue(false),
+      listGroups: jest.fn().mockResolvedValue([]),
+      countGroups: jest.fn().mockResolvedValue(0),
+    });
+
+    it('emits ankify.zero_cards event when page produces no cards', async () => {
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+      const errorEventRepo = makeErrorEventRepo();
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [],
+        diagnostic: { blocks_scanned: 5, blocks_matched: 0, pattern_hits: {} },
+      });
+
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => [],
+        undefined,
+        fetch,
+        errorEventRepo
+      );
+
+      await useCase.execute({ owner: 42, notionPageId: 'page-abc', trigger: 'manual' });
+
+      expect(errorEventRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'server',
+          message: 'ankify.zero_cards',
+          context: expect.objectContaining({
+            user_id: 42,
+            source_type: 'notion_page',
+            parser_path: 'ankify/notionPageWalker',
+            reason_code: 'all_blocks_unmatched',
+            blocks_scanned: 5,
+          }),
+        })
+      );
+    });
+
+    it('derives reason_code empty_page when blocks_scanned is zero', async () => {
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+      const errorEventRepo = makeErrorEventRepo();
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [],
+        diagnostic: { blocks_scanned: 0, blocks_matched: 0, pattern_hits: {} },
+      });
+
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => [],
+        undefined,
+        fetch,
+        errorEventRepo
+      );
+
+      await useCase.execute({ owner: 42, notionPageId: 'page-empty', trigger: 'polling' });
+
+      expect(errorEventRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({ reason_code: 'empty_page' }),
+        })
+      );
+    });
+
+    it('does not emit zero_cards event when cards are produced', async () => {
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+      const errorEventRepo = makeErrorEventRepo();
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [sampleCard()],
+        diagnostic: { blocks_scanned: 1, blocks_matched: 1, pattern_hits: { toggle: 1 } },
+      });
+
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => [],
+        undefined,
+        fetch,
+        errorEventRepo
+      );
+
+      await useCase.execute({ owner: 42, notionPageId: 'page-with-cards', trigger: 'manual' });
+
+      expect(errorEventRepo.insert).not.toHaveBeenCalled();
+    });
+
+    it('does not throw if errorEventRepo is not provided', async () => {
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [],
+        diagnostic: { blocks_scanned: 3, blocks_matched: 0, pattern_hits: {} },
+      });
+
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      await expect(
+        useCase.execute({ owner: 42, notionPageId: 'page-no-repo', trigger: 'manual' })
+      ).resolves.not.toThrow();
+    });
   });
 });

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -1,9 +1,11 @@
+import crypto from 'node:crypto';
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
 import { AnkifySyncMappingsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncMappingsRepository';
 import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncConflictsRepository';
 import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import { AnkifySyncLogsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncLogsRepository';
 import { INotionRepository } from '../../data_layer/NotionRespository';
+import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
 import {
   AnkifyClient,
   AnkifyNotionSubscription,
@@ -78,6 +80,24 @@ const DECK_TITLE_FALLBACK = 'Untitled';
 
 export type AnkifyMediaFetcher = typeof fetch;
 
+export type AnkifyZeroReasonCode =
+  | 'empty_page'
+  | 'no_matching_blocks'
+  | 'all_blocks_unmatched';
+
+const deriveReasonCode = (diagnostic: SyncDiagnostic): AnkifyZeroReasonCode => {
+  if (diagnostic.blocks_scanned === 0) {
+    return 'empty_page';
+  }
+  if (
+    diagnostic.pattern_hits == null ||
+    Object.keys(diagnostic.pattern_hits).length === 0
+  ) {
+    return 'all_blocks_unmatched';
+  }
+  return 'no_matching_blocks';
+};
+
 const sanitizeDeckTitle = (title: string | null | undefined): string => {
   if (title == null) {
     return DECK_TITLE_FALLBACK;
@@ -125,7 +145,8 @@ export class SyncNotionPageToRacUseCase {
     private readonly ankiConnect: AnkiConnectFactory,
     private readonly notionFetcher: NotionFetcherFactory,
     private readonly notionPageMeta?: NotionPageMetaFetcher,
-    private readonly mediaFetcher: AnkifyMediaFetcher = fetch
+    private readonly mediaFetcher: AnkifyMediaFetcher = fetch,
+    private readonly errorEvents?: IErrorEventRepository
   ) {}
 
   private modelCache(clientId: number): Set<string> {
@@ -225,6 +246,44 @@ export class SyncNotionPageToRacUseCase {
     return { pageTitle, pageUrl, pageIcon };
   }
 
+  private emitZeroCardsEvent(
+    input: SyncNotionPageInput,
+    diagnostic: SyncDiagnostic
+  ): void {
+    if (this.errorEvents == null) {
+      return;
+    }
+    const reasonCode = deriveReasonCode(diagnostic);
+    const pageIdHash = crypto
+      .createHash('sha256')
+      .update(input.notionPageId)
+      .digest('hex');
+    this.errorEvents
+      .insert({
+        source: 'server',
+        message: 'ankify.zero_cards',
+        message_hash: crypto
+          .createHash('sha256')
+          .update(`ankify.zero_cards:${pageIdHash}:${input.owner}`)
+          .digest('hex'),
+        context: {
+          user_id: input.owner,
+          source_type: 'notion_page',
+          file_hash: pageIdHash,
+          input_chars: diagnostic.blocks_scanned,
+          ai_response_chars: 0,
+          parser_path: 'ankify/notionPageWalker',
+          reason_code: reasonCode,
+          blocks_scanned: diagnostic.blocks_scanned,
+          blocks_matched: diagnostic.blocks_matched,
+          trigger: input.trigger,
+        },
+      })
+      .catch((err) => {
+        console.error('[ankify-sync] failed to emit zero_cards event', err);
+      });
+  }
+
   private async runSync(args: {
     input: SyncNotionPageInput;
     token: string;
@@ -239,6 +298,10 @@ export class SyncNotionPageToRacUseCase {
       fetchChildren
     );
     result.diagnostic = diagnostic;
+
+    if (cards.length === 0) {
+      this.emitZeroCardsEvent(input, diagnostic);
+    }
 
     const ac = this.ankiConnect(
       input.ankiConnectHost ?? 'localhost',

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -697,7 +697,7 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                       ) : (
                         <>We couldn't read any content from this page.{' '}</>
                       )}
-                      <a href="/documentation" className={styles.zeroBannerLink}>
+                      <a href="/answers" className={styles.zeroBannerLink}>
                         What Ankify looks for →
                       </a>
                     </p>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-ankify-zero-cards-telemetry.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-ankify-zero-cards-telemetry.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-ankify-zero-cards-telemetry",
+  "date": "2026-05-25",
+  "type": "fix",
+  "title": "Ankify zero-card syncs now link to the answers page so you can see exactly what patterns work"
+}


### PR DESCRIPTION
## What
On a zero-card Ankify sync, emits a structured event to the self-hosted error_events table with `{user_id, source_type, file_hash, input_chars, ai_response_chars, parser_path, reason_code}` stored in the `context` column. Updates the zero-card UI banner link from `/documentation` to `/answers`.

## Why
Refs #2737 (merged). The diagnostic banner shipped in #2737 shows the user what happened, but we had no server-side telemetry on the zero-card class of failure. Without it we can't measure how common user-19374's pattern is or track improvements. The `/answers` link is more actionable than `/documentation`.

## How
- `SyncNotionPageToRacUseCase` gains an optional `IErrorEventRepository` parameter (last position, backward-compatible).
- On zero cards, calls `errorEvents.insert()` with `source: 'server'`, `message: 'ankify.zero_cards'`, and all structured fields in `context`. Fire-and-forget (`.catch` logged) — never throws.
- `deriveReasonCode(diagnostic)` maps the diagnostic to: `empty_page` (0 blocks scanned), `all_blocks_unmatched` (blocks scanned but 0 pattern hits), `no_matching_blocks` (pattern hits but 0 matched).
- `AnkifyRouter` and `AnkifyWebhookRouter` inject `new ErrorEventRepository(db)`.
- Banner link: `/documentation` → `/answers`.

## Retro context
W21 window 2026-05-18→2026-05-24. User-19374 class of failure: 6 syncs, 0 cards, no explanation, user bounced. #2737 added the UI-side diagnostic; this PR closes the server-side telemetry gap.

Sibling PR: payments/webhook-audit-W21

Deploy baseline PRs not to regress: #2734, #2717, #2711, #2714.

## Measuring success
`SELECT context FROM error_events WHERE message = 'ankify.zero_cards' AND created_at > now() - interval '1 hour'` — should show rows with `reason_code` populated after a zero-card sync in prod.

## Testing
- 4 new tests in `SyncNotionPageToRacUseCase.test.ts`:
  - emits event on zero cards
  - derives `empty_page` reason code
  - does not emit when cards are produced
  - does not throw if repo not provided
- All 21 tests pass

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Link target change only — no layout change. Alexander to verify /answers route loads the expected page.

## Changelog
Ankify zero-card syncs now link to the answers page so you can see exactly what patterns work

## Risks
- event write is fire-and-forget; a DB outage on the telemetry insert won't affect sync behavior.
- message_hash is keyed on page_id+user_id, so the same page/user pair generates the same hash. This means the dedup window in `IngestErrorEventUseCase` (which we do NOT use here) would suppress re-inserts — but we call `insert` directly, so every zero-card sync produces an event row.

## Goal alignment
Telemetry on the zero-card class enables data-driven improvements to Ankify, which is the gated feature behind Auto Sync subscriptions (/mo). Moves toward 300K users by reducing silent bounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782306886&installation_id=132681956&pr_number=2780&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2780&signature=67b651660c5461202db67e421032c848d68fe5fe1a0bf76131c56d61f56422c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Local checks
- New tests: 21 pass.
- `sonar-scanner` not run locally — not installed in this environment; expect a possible SonarCloud bounce on CI.
