### PR TITLE
feat: add return-rate metric to /api/ops/return-rate/metrics

### DIFF
--- a/docs/analytics/ga4-bot-filter-checklist-W21.md
+++ b/docs/analytics/ga4-bot-filter-checklist-W21.md
@@ -1,0 +1,79 @@
+# GA4 bot-filter checklist — W21 (2026-05-18 → 2026-05-24)
+
+Property: **286902985** (2anki.net)
+
+Retro context: W21 new-user and Direct traffic totals are bot-distorted. Real human signal
+(returning-user traffic) is -12.6% week-over-week, not the headline -20% shown in the raw
+overview. This checklist applies a referrer-spam / bot filter to isolate the human baseline.
+
+---
+
+## Part 1 — Apply the filter
+
+> **PENDING — Alexander**
+
+1. Open [GA4 Admin](https://analytics.google.com/analytics/web/#/p286902985/admin) and select
+   property **286902985**.
+2. Go to **Data Settings → Data Filters**.
+3. Click **Create filter**.
+4. Choose **Bot and spam filtering**.
+   - Filter name: `W21-bot-filter` (or your preferred convention)
+   - Filter type: **Exclude** internal traffic is already separate; this step targets referrer
+     spam.
+5. Alternatively, create a **Custom filter** of type **Exclude** on dimension
+   `Session source / medium` matching the known spam patterns observed in W21:
+   - Contains `semalt`
+   - Contains `buttons-for-website`
+   - Contains `best-seo-solution`
+   - Contains `seopowa`
+   - Add any others from the Sessions by Source/Medium report with suspiciously round numbers
+     or < 0 s session duration.
+6. Set filter state to **Active**.
+7. Click **Save**.
+
+> Note: GA4 filters apply going forward. To retroactively clean W21 data, use the **Comparisons**
+> feature (step below) rather than expecting filtered-view backfill.
+
+---
+
+## Part 2 — Re-pull W21 numbers with a comparison segment
+
+> **PENDING — Alexander**
+
+1. In GA4, open **Reports → Acquisition → Traffic acquisition**.
+2. Set the date range to **2026-05-18 → 2026-05-24**.
+3. Click **Add comparison** (top of the report).
+4. Create a comparison segment that **excludes** the spam sources identified above:
+   - Dimension: `Session source` does not contain `semalt` (add each pattern as a separate
+     condition with AND logic).
+5. Note the **New users** and **Sessions** counts for the filtered vs unfiltered comparison.
+6. Record the delta in the table below.
+
+---
+
+## Part 3 — Compute the delta
+
+Fill in after step 2 above:
+
+| Metric | Raw (unfiltered) | Filtered | Delta |
+|--------|-----------------|---------|-------|
+| New users (W21) | — | — | — |
+| Sessions (W21) | — | — | — |
+| Returning users (W21) | — | — | — |
+| Direct sessions (W21) | — | — | — |
+
+Pre-filter retro note: raw new-user count was inflated; returning-user signal of **-12.6%** WoW is
+the more reliable signal and does not require bot-filter adjustment because bot traffic by
+definition has no returning-user cookie.
+
+---
+
+## Part 4 — Update the retro record
+
+> **PENDING — Alexander**
+
+Once the filtered numbers are in hand, update the W21 retro doc (or add a comment to issue #2778)
+with:
+- Filtered new-user count and % change from W20
+- Whether the Direct traffic spike collapses under the filter (expected: yes)
+- Revised WoW headline for the retro summary

--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import OpsController from './OpsController';
 import { GetOpsMetricsUseCase } from '../usecases/ops/GetOpsMetricsUseCase';
 import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUseCase';
+import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetricsUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -79,6 +80,93 @@ describe('OpsController.getBusinessMetrics', () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
     await controller.getBusinessMetrics(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+    errSpy.mockRestore();
+  });
+});
+
+describe('OpsController.getReturnRateMetrics', () => {
+  it('returns 500 when the use case is not configured', async () => {
+    const opsUseCase = {} as unknown as GetOpsMetricsUseCase;
+    const controller = new OpsController(opsUseCase);
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getReturnRateMetrics(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+
+  it('returns 200 with the use case result', async () => {
+    const fakeResult = {
+      overall: { '7d': 21, '14d': 34, '30d': 48 },
+      by_source_type: [
+        {
+          source_type: 'page',
+          cohort_size: 100,
+          returned_7d: 21,
+          returned_14d: 34,
+          returned_30d: 48,
+          return_rate_7d_pct: 21,
+          return_rate_14d_pct: 34,
+          return_rate_30d_pct: 48,
+        },
+      ],
+      as_of: '2026-05-25T00:00:00.000Z',
+    };
+    const opsUseCase = {} as unknown as GetOpsMetricsUseCase;
+    const returnRateUseCase = {
+      execute: jest.fn().mockResolvedValue(fakeResult),
+    } as unknown as GetReturnRateMetricsUseCase;
+    const controller = new OpsController(
+      opsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      returnRateUseCase
+    );
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getReturnRateMetrics(req, res);
+
+    expect((returnRateUseCase.execute as jest.Mock)).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(fakeResult);
+  });
+
+  it('responds 500 when the use case throws', async () => {
+    const opsUseCase = {} as unknown as GetOpsMetricsUseCase;
+    const returnRateUseCase = {
+      execute: jest.fn().mockRejectedValue(new Error('db down')),
+    } as unknown as GetReturnRateMetricsUseCase;
+    const controller = new OpsController(
+      opsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      returnRateUseCase
+    );
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await controller.getReturnRateMetrics(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -4,6 +4,7 @@ import { GetOpsMetricsUseCase } from '../usecases/ops/GetOpsMetricsUseCase';
 import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUseCase';
 import { GetConversionMetricsUseCase } from '../usecases/ops/GetConversionMetricsUseCase';
 import { GetPerformanceMetricsUseCase } from '../usecases/ops/GetPerformanceMetricsUseCase';
+import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetricsUseCase';
 import { PopulateShowcaseUseCase } from '../usecases/ops/PopulateShowcaseUseCase';
 import { SendInactivityWarningsUseCase } from '../usecases/ops/SendInactivityWarningsUseCase';
 import { SendAbandonedCheckoutRecoveryUseCase } from '../usecases/ops/SendAbandonedCheckoutRecoveryUseCase';
@@ -18,7 +19,8 @@ class OpsController {
     private readonly showcaseRepo?: IShowcaseRepository,
     private readonly sendInactivityWarningsUseCase?: SendInactivityWarningsUseCase,
     private readonly getPerformanceMetricsUseCase?: GetPerformanceMetricsUseCase,
-    private readonly sendAbandonedCheckoutRecoveryUseCase?: SendAbandonedCheckoutRecoveryUseCase
+    private readonly sendAbandonedCheckoutRecoveryUseCase?: SendAbandonedCheckoutRecoveryUseCase,
+    private readonly getReturnRateMetricsUseCase?: GetReturnRateMetricsUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -160,6 +162,20 @@ class OpsController {
     } catch (error) {
       console.error('[ops] sendInactivityWarnings failed', error);
       res.status(500).json({ message: 'Failed to run inactivity warnings' });
+    }
+  }
+
+  async getReturnRateMetrics(_req: express.Request, res: express.Response) {
+    if (this.getReturnRateMetricsUseCase == null) {
+      res.status(500).json({ message: 'Return-rate metrics not configured' });
+      return;
+    }
+    try {
+      const result = await this.getReturnRateMetricsUseCase.execute();
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getReturnRateMetrics failed', error);
+      res.status(500).json({ message: 'Failed to load return-rate metrics' });
     }
   }
 }

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -5,6 +5,7 @@ import { GetOpsMetricsUseCase } from '../usecases/ops/GetOpsMetricsUseCase';
 import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUseCase';
 import { GetConversionMetricsUseCase } from '../usecases/ops/GetConversionMetricsUseCase';
 import { GetPerformanceMetricsUseCase } from '../usecases/ops/GetPerformanceMetricsUseCase';
+import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetricsUseCase';
 import { SendAbandonedCheckoutRecoveryUseCase } from '../usecases/ops/SendAbandonedCheckoutRecoveryUseCase';
 import { PopulateShowcaseUseCase } from '../usecases/ops/PopulateShowcaseUseCase';
 import { ObservabilityRepository } from '../data_layer/ObservabilityRepository';
@@ -12,6 +13,7 @@ import { ObservabilityQueryService } from '../services/observability/Observabili
 import { BusinessMetricsService } from '../services/ops/BusinessMetricsService';
 import { ConversionMetricsService } from '../services/ops/ConversionMetricsService';
 import { PerformanceMetricsService } from '../services/ops/PerformanceMetricsService';
+import { ReturnRateMetricsService } from '../services/ops/ReturnRateMetricsService';
 import { BusinessMetricsCacheRepository } from '../data_layer/BusinessMetricsCacheRepository';
 import { CancellationFeedbackRepository } from '../data_layer/CancellationFeedbackRepository';
 import { EmojiFeedbackRepository } from '../data_layer/EmojiFeedbackRepository';
@@ -75,7 +77,8 @@ const OpsRouter = () => {
       emailService
     ),
     new GetPerformanceMetricsUseCase(performanceMetricsService),
-    new SendAbandonedCheckoutRecoveryUseCase(emailService)
+    new SendAbandonedCheckoutRecoveryUseCase(emailService),
+    new GetReturnRateMetricsUseCase(new ReturnRateMetricsService(database))
   );
 
   /**
@@ -249,6 +252,27 @@ const OpsRouter = () => {
     '/api/ops/send-abandoned-checkout-recovery',
     RequireOpsAccess,
     (req, res) => controller.sendAbandonedCheckoutRecovery(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/return-rate/metrics:
+   *   get:
+   *     summary: Post-completion return-rate metrics bucketed by source type
+   *     description: |
+   *       Internal endpoint locked to the ops owner. Returns the % of users who returned for a
+   *       second conversion within 7, 14, and 30 days of their prior successful conversion,
+   *       bucketed by source_type (page, database, conversion). Cohort window is the last 90 days.
+   *       Returns 404 for everyone else.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: Return-rate metrics payload
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/return-rate/metrics', RequireOpsAccess, (req, res) =>
+    controller.getReturnRateMetrics(req, res)
   );
 
   return router;

--- a/src/services/ops/ReturnRateMetricsService.test.ts
+++ b/src/services/ops/ReturnRateMetricsService.test.ts
@@ -1,0 +1,206 @@
+import knex, { Knex } from 'knex';
+
+import { ReturnRateMetricsService } from './ReturnRateMetricsService';
+
+async function makeDb(): Promise<Knex> {
+  const db = knex({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+  await db.schema.createTable('jobs', (t) => {
+    t.increments('id');
+    t.string('owner').notNullable();
+    t.string('object_id').notNullable();
+    t.string('title');
+    t.string('type');
+    t.string('status');
+    t.timestamp('created_at').defaultTo(db.fn.now());
+    t.timestamp('last_edited_time');
+    t.string('job_reason_failure');
+    t.integer('card_count');
+  });
+  return db;
+}
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  return d;
+}
+
+async function insertJob(
+  db: Knex,
+  attrs: {
+    owner: string;
+    object_id: string;
+    type: string;
+    status?: string;
+    created_at?: Date;
+  }
+) {
+  await db('jobs').insert({
+    owner: attrs.owner,
+    object_id: attrs.object_id,
+    type: attrs.type,
+    status: attrs.status ?? 'done',
+    created_at: attrs.created_at ?? new Date(),
+    last_edited_time: new Date(),
+  });
+}
+
+describe('ReturnRateMetricsService — graceful failure', () => {
+  it('returns null for all windows when the db throws', async () => {
+    const failing = { raw: jest.fn() } as unknown as Knex;
+    const service = new ReturnRateMetricsService(failing);
+    const result = await service.getMetrics();
+    expect(result.by_source_type).toBeNull();
+    expect(result.overall['7d']).toBeNull();
+    expect(result.overall['14d']).toBeNull();
+    expect(result.overall['30d']).toBeNull();
+  });
+});
+
+describe('ReturnRateMetricsService — return-rate windows', () => {
+  let db: Knex;
+  let service: ReturnRateMetricsService;
+
+  beforeEach(async () => {
+    db = await makeDb();
+    service = new ReturnRateMetricsService(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('counts a user who returned within 7 days as retained in all windows', async () => {
+    await insertJob(db, {
+      owner: 'u1',
+      object_id: 'j-first',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(20),
+    });
+    await insertJob(db, {
+      owner: 'u1',
+      object_id: 'j-second',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(15),
+    });
+
+    const result = await service.getMetrics();
+
+    expect(result.overall['7d']).toBeCloseTo(100, 5);
+    expect(result.overall['14d']).toBeCloseTo(100, 5);
+    expect(result.overall['30d']).toBeCloseTo(100, 5);
+  });
+
+  it('counts a user who only returned after 8 days as NOT in 7d window but in 14d', async () => {
+    await insertJob(db, {
+      owner: 'u2',
+      object_id: 'j-a',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(40),
+    });
+    await insertJob(db, {
+      owner: 'u2',
+      object_id: 'j-b',
+      type: 'page',
+      status: 'done',
+      created_at: new Date(daysAgo(40).getTime() + 8 * 24 * 60 * 60 * 1000),
+    });
+
+    const result = await service.getMetrics();
+
+    expect(result.overall['7d']).toBeCloseTo(0, 5);
+    expect(result.overall['14d']).toBeCloseTo(100, 5);
+    expect(result.overall['30d']).toBeCloseTo(100, 5);
+  });
+
+  it('excludes non-conversion job types from the cohort', async () => {
+    await insertJob(db, {
+      owner: 'u3',
+      object_id: 'j-c',
+      type: 'claude',
+      status: 'done',
+      created_at: daysAgo(10),
+    });
+    await insertJob(db, {
+      owner: 'u3',
+      object_id: 'j-d',
+      type: 'claude',
+      status: 'done',
+      created_at: daysAgo(5),
+    });
+
+    const result = await service.getMetrics();
+
+    expect(result.overall['7d']).toBeNull();
+    expect(result.overall['14d']).toBeNull();
+    expect(result.overall['30d']).toBeNull();
+  });
+
+  it('breaks down return rates by source_type', async () => {
+    await insertJob(db, {
+      owner: 'u4',
+      object_id: 'j-e',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(15),
+    });
+    await insertJob(db, {
+      owner: 'u4',
+      object_id: 'j-f',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(10),
+    });
+    await insertJob(db, {
+      owner: 'u5',
+      object_id: 'j-g',
+      type: 'conversion',
+      status: 'done',
+      created_at: daysAgo(15),
+    });
+
+    const result = await service.getMetrics();
+
+    const pageRow = result.by_source_type?.find((r) => r.source_type === 'page');
+    const convRow = result.by_source_type?.find((r) => r.source_type === 'conversion');
+    expect(pageRow?.cohort_size).toBe(1);
+    expect(pageRow?.returned_7d).toBe(1);
+    expect(convRow?.cohort_size).toBe(1);
+    expect(convRow?.returned_7d).toBe(0);
+  });
+
+  it('uses the last successful job as the cohort anchor, not the first', async () => {
+    await insertJob(db, {
+      owner: 'u6',
+      object_id: 'j-x1',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(50),
+    });
+    await insertJob(db, {
+      owner: 'u6',
+      object_id: 'j-x2',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(10),
+    });
+    await insertJob(db, {
+      owner: 'u6',
+      object_id: 'j-x3',
+      type: 'page',
+      status: 'done',
+      created_at: daysAgo(5),
+    });
+
+    const result = await service.getMetrics();
+
+    expect(result.overall['7d']).toBeCloseTo(100, 5);
+  });
+});

--- a/src/services/ops/ReturnRateMetricsService.ts
+++ b/src/services/ops/ReturnRateMetricsService.ts
@@ -1,0 +1,219 @@
+import { Knex } from 'knex';
+
+export interface ReturnRateWindow {
+  '7d': number | null;
+  '14d': number | null;
+  '30d': number | null;
+}
+
+export interface ReturnRateBySourceType {
+  source_type: string;
+  cohort_size: number;
+  returned_7d: number;
+  returned_14d: number;
+  returned_30d: number;
+  return_rate_7d_pct: number | null;
+  return_rate_14d_pct: number | null;
+  return_rate_30d_pct: number | null;
+}
+
+export interface ReturnRateMetricsResponse {
+  overall: ReturnRateWindow;
+  by_source_type: ReturnRateBySourceType[] | null;
+  as_of: string;
+}
+
+const CONVERSION_TYPES: string[] = ['page', 'database', 'conversion'];
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const LOOKBACK_DAYS = 90;
+
+interface CohortMember {
+  owner: string;
+  source_type: string;
+  last_success_at: string;
+}
+
+interface ReturnRecord {
+  owner: string;
+  source_type: string;
+  anchor_at: string;
+  first_return_at: string;
+}
+
+const pct = (num: number, denom: number): number | null => {
+  if (denom === 0) return null;
+  return (num / denom) * 100;
+};
+
+export class ReturnRateMetricsService {
+  constructor(private readonly database: Knex) {}
+
+  async getMetrics(): Promise<ReturnRateMetricsResponse> {
+    const now = new Date();
+    const as_of = now.toISOString();
+
+    let cohort: CohortMember[];
+    let returns: ReturnRecord[];
+
+    try {
+      [cohort, returns] = await Promise.all([
+        this.fetchCohort(now),
+        this.fetchReturns(now),
+      ]);
+    } catch {
+      return {
+        overall: { '7d': null, '14d': null, '30d': null },
+        by_source_type: null,
+        as_of,
+      };
+    }
+
+    if (cohort.length === 0) {
+      return {
+        overall: { '7d': null, '14d': null, '30d': null },
+        by_source_type: null,
+        as_of,
+      };
+    }
+
+    return this.compute(cohort, returns, as_of);
+  }
+
+  private fetchCohort(now: Date): Promise<CohortMember[]> {
+    const cutoff = new Date(now.getTime() - LOOKBACK_DAYS * SECONDS_PER_DAY * 1000);
+    return this.database('jobs')
+      .whereIn('type', CONVERSION_TYPES)
+      .where('status', 'done')
+      .where('created_at', '>=', cutoff)
+      .select(
+        'owner',
+        'type as source_type',
+        this.database.raw('MAX(created_at) as last_success_at')
+      )
+      .groupBy('owner', 'type') as Promise<CohortMember[]>;
+  }
+
+  private async fetchReturns(now: Date): Promise<ReturnRecord[]> {
+    const cutoff = new Date(now.getTime() - LOOKBACK_DAYS * SECONDS_PER_DAY * 1000);
+
+    const rows = (await this.database('jobs as j1')
+      .whereIn('j1.type', CONVERSION_TYPES)
+      .where('j1.status', 'done')
+      .where('j1.created_at', '>=', cutoff)
+      .select(
+        'j1.owner',
+        'j1.type as source_type',
+        'j1.created_at as anchor_at',
+        this.database.raw(
+          '(SELECT MIN(j2.created_at) FROM jobs j2' +
+            ' WHERE j2.owner = j1.owner' +
+            ' AND j2.type = j1.type' +
+            ' AND j2.status = ?' +
+            ' AND j2.created_at > j1.created_at' +
+            ') as first_return_at',
+          ['done']
+        )
+      )) as Array<{
+      owner: string;
+      source_type: string;
+      anchor_at: string;
+      first_return_at: string | null;
+    }>;
+
+    const seen = new Set<string>();
+    const result: ReturnRecord[] = [];
+
+    for (let i = rows.length - 1; i >= 0; i--) {
+      const row = rows[i];
+      if (row.first_return_at == null) continue;
+      const key = `${row.owner}::${row.source_type}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push({
+        owner: row.owner,
+        source_type: row.source_type,
+        anchor_at: row.anchor_at,
+        first_return_at: row.first_return_at,
+      });
+    }
+
+    return result;
+  }
+
+  private compute(
+    cohort: CohortMember[],
+    returns: ReturnRecord[],
+    as_of: string
+  ): ReturnRateMetricsResponse {
+    const returnMap = new Map<string, { gapMs: number }>();
+    for (const r of returns) {
+      const key = `${r.owner}::${r.source_type}`;
+      const gapMs = new Date(r.first_return_at).getTime() - new Date(r.anchor_at).getTime();
+      const existing = returnMap.get(key);
+      if (existing == null || gapMs < existing.gapMs) {
+        returnMap.set(key, { gapMs });
+      }
+    }
+
+    const sourceMap = new Map<
+      string,
+      { cohort: number; r7: number; r14: number; r30: number }
+    >();
+
+    let totalCohort = 0;
+    let totalR7 = 0;
+    let totalR14 = 0;
+    let totalR30 = 0;
+
+    for (const member of cohort) {
+      const key = `${member.owner}::${member.source_type}`;
+      const ret = returnMap.get(key);
+      const gapMs = ret?.gapMs ?? Infinity;
+
+      const returned7 = gapMs <= 7 * SECONDS_PER_DAY * 1000 ? 1 : 0;
+      const returned14 = gapMs <= 14 * SECONDS_PER_DAY * 1000 ? 1 : 0;
+      const returned30 = gapMs <= 30 * SECONDS_PER_DAY * 1000 ? 1 : 0;
+
+      totalCohort += 1;
+      totalR7 += returned7;
+      totalR14 += returned14;
+      totalR30 += returned30;
+
+      const existing = sourceMap.get(member.source_type) ?? {
+        cohort: 0,
+        r7: 0,
+        r14: 0,
+        r30: 0,
+      };
+      existing.cohort += 1;
+      existing.r7 += returned7;
+      existing.r14 += returned14;
+      existing.r30 += returned30;
+      sourceMap.set(member.source_type, existing);
+    }
+
+    const by_source_type: ReturnRateBySourceType[] = [];
+    for (const [source_type, counts] of sourceMap) {
+      by_source_type.push({
+        source_type,
+        cohort_size: counts.cohort,
+        returned_7d: counts.r7,
+        returned_14d: counts.r14,
+        returned_30d: counts.r30,
+        return_rate_7d_pct: pct(counts.r7, counts.cohort),
+        return_rate_14d_pct: pct(counts.r14, counts.cohort),
+        return_rate_30d_pct: pct(counts.r30, counts.cohort),
+      });
+    }
+
+    return {
+      overall: {
+        '7d': pct(totalR7, totalCohort),
+        '14d': pct(totalR14, totalCohort),
+        '30d': pct(totalR30, totalCohort),
+      },
+      by_source_type: by_source_type.length > 0 ? by_source_type : null,
+      as_of,
+    };
+  }
+}

--- a/src/usecases/ops/GetReturnRateMetricsUseCase.ts
+++ b/src/usecases/ops/GetReturnRateMetricsUseCase.ts
@@ -1,0 +1,12 @@
+import {
+  ReturnRateMetricsResponse,
+  ReturnRateMetricsService,
+} from '../../services/ops/ReturnRateMetricsService';
+
+export class GetReturnRateMetricsUseCase {
+  constructor(private readonly service: ReturnRateMetricsService) {}
+
+  execute(): Promise<ReturnRateMetricsResponse> {
+    return this.service.getMetrics();
+  }
+}


### PR DESCRIPTION
Refs #2778

## What

Adds `GET /api/ops/return-rate/metrics` to the ops dashboard. The endpoint returns the % of users who returned for a second successful conversion within 7, 14, and 30 days of their most recent prior successful conversion, broken down by `source_type` (page, database, conversion). Cohort window is the last 90 days of conversion data.

## Why

W21 retro (2026-05-18→2026-05-24) identified one-shot retention as the structural issue: 79% of prior-week converters did not return. This metric is the prerequisite for any nudge targeting the "I finished what I needed" cohort. The nudge itself is out of scope for this PR.

## Retro context

- W21 window: 2026-05-18 → 2026-05-24
- Returning-user signal: -12.6% WoW (the headline -20% is bot-distorted)
- Sibling PRs: #2779, payments/webhook-audit-W21, feat/ankify-silent-zero-structured-log

## How

Two Knex query passes over the existing `jobs` table — no migration needed:
1. Cohort pass: `MAX(created_at)` per `(owner, type)` for done jobs in the last 90 days.
2. Return pass: correlated subquery returning `MIN(next_job.created_at)` after the cohort anchor.

Both passes are joined in memory. The gap between anchor and first return determines which windows (7/14/30d) credit a return.

Layering: `ReturnRateMetricsService` (service) → `GetReturnRateMetricsUseCase` (use case) → `OpsController.getReturnRateMetrics` → `OpsRouter GET /api/ops/return-rate/metrics`.

## Sample JSON response

```json
{
  "overall": {
    "7d": 21.3,
    "14d": 34.7,
    "30d": 48.1
  },
  "by_source_type": [
    {
      "source_type": "page",
      "cohort_size": 1240,
      "returned_7d": 264,
      "returned_14d": 430,
      "returned_30d": 597,
      "return_rate_7d_pct": 21.3,
      "return_rate_14d_pct": 34.7,
      "return_rate_30d_pct": 48.1
    },
    {
      "source_type": "database",
      "cohort_size": 180,
      "returned_7d": 38,
      "returned_14d": 62,
      "returned_30d": 86,
      "return_rate_7d_pct": 21.1,
      "return_rate_14d_pct": 34.4,
      "return_rate_30d_pct": 47.8
    }
  ],
  "as_of": "2026-05-25T14:00:00.000Z"
}
```

## Measuring success

In production, `curl -s https://2anki.net/api/ops/return-rate/metrics` (with ops auth) should return a 200 with `overall["7d"]` matching the retro-period signal. The W21 baseline expectation: 7d return rate ≈ 21% (79% non-return = 1 - 0.21). If it reads higher, bot traffic inflated the denominator; if lower, the cohort window is catching stale users.

## Testing

- Unit tests added: `ReturnRateMetricsService.test.ts` (6 cases covering graceful failure, 7/14/30d windows, source_type breakdown, anchor semantics)
- Controller tests added: `OpsController.test.ts` (3 new cases: not-configured 500, success 200, use-case-throws 500)
- Total: 184 passing

## Local checks

`/check` passed: server tsc clean, web typecheck clean, web vitest 1167/1167, server tests 184/184.
`sonar-scanner` not run locally — not installed here; expect a possible SonarCloud bounce on CI.

Browser check: not applicable — backend metric endpoint, no rendered output

## Changelog

No entry — internal ops endpoint, no user-visible change.

## Risks

The correlated subquery (`MIN(j2.created_at) WHERE j2.owner = j1.owner AND j2.type = j1.type`) scans all matching rows per anchor job. On a large `jobs` table this is O(n²) in the worst case. Mitigation: the outer query is already filtered to 90 days and only `done` status. Add an index on `(owner, type, status, created_at)` if response time exceeds 2s on prod.

## Goal alignment

Direct prerequisite for the one-shot retention nudge. Without a measured baseline, any nudge experiment is uninterpretable. This moves the needle on the 300K-user goal by enabling data-driven retention work on the dominant churn pattern.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782307494&installation_id=132681956&pr_number=2783&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2783&signature=f66c40694a9e85d415a43abefeab543673faa9140023563f24312b2bb8ad7c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
