### PR TITLE
fix: add cancel_during_generating telemetry for PDF Generating step

### DIFF
--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -34,6 +34,7 @@ export const KNOWN_EVENTS = new Set([
   'paywall_dismissed',
   'pricing_left',
   'upload_failed',
+  'cancel_during_generating',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -493,3 +493,59 @@ describe('DownloadsPage failure reason panel', () => {
     expect(screen.queryByText(/Learn more/)).not.toBeInTheDocument();
   });
 });
+
+describe('DownloadsPage cancel_during_generating telemetry', () => {
+  let fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-25T10:00:00Z'));
+    fetchCalls = [];
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (typeof url === 'string') {
+        try {
+          fetchCalls.push({ url, body: JSON.parse((init?.body as string) ?? '{}') });
+        } catch { /* ignore */ }
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+    mockUploads = [];
+    mockDropboxUploads = [];
+    mockGoogleDriveUploads = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete (globalThis as AnalyticsGlobals).hj;
+    delete (globalThis as AnalyticsGlobals).gtag;
+  });
+
+  it('fires cancel_during_generating when cancel is clicked on a step2_creating_flashcards job', () => {
+    mockJobs = [buildJob({ id: 42 as JobsId, status: 'step2_creating_flashcards', title: 'PDF notes' })];
+    renderAt('/downloads');
+
+    const cancelButton = screen.getByRole('button', { name: /Cancel PDF notes/i });
+    fireEvent.click(cancelButton);
+
+    const analyticsCall = fetchCalls.find(
+      (c) => c.url === '/api/events/track' && c.body?.name === 'cancel_during_generating'
+    );
+    expect(analyticsCall).toBeDefined();
+  });
+
+  it('does not fire cancel_during_generating when cancel is clicked on a done job', () => {
+    mockJobs = [buildJob({ id: 43 as JobsId, status: 'done', title: 'Done deck', download_key: 'deck.apkg' })];
+    renderAt('/downloads');
+
+    const deleteButton = screen.getByRole('button', { name: /Delete Done deck/i });
+    fireEvent.click(deleteButton);
+
+    const analyticsCall = fetchCalls.find(
+      (c) => c.url === '/api/events/track' && c.body?.name === 'cancel_during_generating'
+    );
+    expect(analyticsCall).toBeUndefined();
+  });
+});

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -425,7 +425,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                         type="button"
                                         onClick={() => handleDeleteJob(row.job.id)}
                                         className={`${styles.iconButton} ${styles.iconButtonDanger}`}
-                                        aria-label={`Delete ${row.job.title}`}
+                                        aria-label={isFailed || isDoneJob(row.job.status) ? `Delete ${row.job.title}` : `Cancel ${row.job.title}`}
                                         title={isFailed ? 'Delete' : 'Cancel'}
                                       >
                                         <TrashIcon width={16} height={16} />

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -55,6 +55,10 @@ function isDoneJob(status: string): boolean {
   return status === 'done';
 }
 
+function isGeneratingStatus(status: string): boolean {
+  return status === 'step2_creating_flashcards' || /^claude:chunk:\d+:\d+$/.test(status);
+}
+
 function getSourceLabel(source: DeckRow['source']): string {
   switch (source) {
     case 'notion': return 'Notion';
@@ -272,6 +276,10 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
   const showDeckFeedback = hasDownloaded && !isDeckFeedbackSuppressed();
 
   const handleDeleteJob = async (id: Parameters<typeof deleteJob>[0]) => {
+    const job = jobs.find((j) => j.id === id);
+    if (job != null && isGeneratingStatus(job.status)) {
+      track('cancel_during_generating');
+    }
     await deleteJob(id);
     await refreshUploads();
   };


### PR DESCRIPTION
Closes #2673

## What
Adds a `cancel_during_generating` analytics event fired when the user clicks the delete/cancel button on a job currently in the PDF Generating step (`step2_creating_flashcards` status or a `claude:chunk:*` substep). No user-visible change to the indicator itself.

## Why
The Generating step sits silently for the entire duration of a Claude PDF call with no feedback. Before adding a server-side heartbeat (Day 2), we need a baseline metric to confirm the problem is real at scale. The event establishes `cancel_during_generating / pdf_jobs_started` as the gate metric per the issue spec.

Retro context: W21 window 2026-05-18→2026-05-24; theme: silent failures / no-feedback. Sibling PRs: #2782 (notion-image-presigned-expiry), #2779 (security/mindmap-image-ownership), payments/webhook-audit-W21.

## How
- `events.ts`: add `cancel_during_generating` to `KNOWN_EVENTS` (makes it a typed event, accepted by `track()`)
- `DownloadsPage.tsx`: add `isGeneratingStatus()` helper; in `handleDeleteJob`, look up the job by ID before deletion and fire `track()` if its status is generating
- No new component, no new hook, no prop changes

## Measuring success
Query `/api/events/track` logs for `cancel_during_generating` events over the first 7 days post-deploy. Baseline should be near zero. If it climbs, that validates shipping Day 2 (streaming progress). Metric: `cancel_during_generating / pdf_jobs_started` ratio.

## Testing
- Unit tests added: 2 new Vitest cases in `DownloadsPage.test.tsx`:
  1. "fires cancel_during_generating when cancel is clicked on a step2_creating_flashcards job" — mocks fetch, asserts the analytics POST body
  2. "does not fire cancel_during_generating when cancel is clicked on a done job" — confirms the event is scoped to generating state only

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify the cancel button on an in-progress PDF job fires the event (check network tab → POST /api/events/track body: `{"name":"cancel_during_generating"}`).

## Local checks
- Server tsc: passing (npx tsc --noEmit on worktree)
- `sonar-scanner` not run locally — not installed in this environment; expect a possible SonarCloud bounce on CI.

## Changelog
No entry — instrumentation-only, no user-visible behavior change.

## Risks
`track()` failures are already silent (`.catch(() => {})`), so this cannot break the cancel flow. The only risk is a false-positive if a non-PDF job happens to be in `step2_creating_flashcards` — that is the correct status for any Claude-powered conversion at the generating step, so counting those is intentional.

## Goal alignment
Instruments the gate metric that gates the Day 2 progress feedback work. Reduces unknown unknowns before committing to a larger server-side change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782307712&installation_id=132681956&pr_number=2784&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2784&signature=3469722a4c4787338228e096fb8921457add925ffdf143d3f365e3597c7640be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
