### PR TITLE
fix: restore spacing between Photo to deck toggle options

### DIFF
--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
@@ -144,7 +144,7 @@
   cursor: pointer;
 }
 
-.checkboxRow + .checkboxRow {
+.densityHint + .checkboxRow {
   margin-top: var(--space-4);
 }
 


### PR DESCRIPTION
## What

On the Photo to deck page, the two toggle rows — *Show source image on the back of each card* and *Include multiple-choice questions* — had collapsed together: the second toggle sat directly under the first toggle's helper text with no separation, so it read as if the helper line belonged to the wrong toggle.

## Root cause

The vertical spacing between the two toggle groups relied on:

```css
.checkboxRow + .checkboxRow { margin-top: var(--space-4); }
```

A `.densityHint` helper `<p>` ("Helpful for diagrams, charts, and handwritten notes.") sits *between* the two `.checkboxRow` labels, so the adjacent-sibling selector never matched and the second toggle got no top margin. Changed it to `.densityHint + .checkboxRow` so the second group gets its margin back. One-line CSS selector fix; no markup or behavior change.

## Test

- `PhotoToFlashcardsPage.test.tsx` — 33 pass
- Biome clean on the changed file
- `sonar-scanner` not run locally (not installed) — CSS-only one-line change

No changelog entry — visual spacing polish, no behavior change.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: left for Alexander to verify in-browser.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782314351&installation_id=132681956&pr_number=2785&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2785&signature=37b461f69d0e353fec4e363e06b3611913c2f615a1e94902f472108a9d54289b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->