### PR TITLE
chore: gate review/audit findings behind quoted evidence + confidence

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -33,9 +33,15 @@ Check exclusively for:
 - Raw errors / stack traces leaked to res.send
 - New Math.random for IDs (Sonar S2245 — use crypto.randomUUID)
 
-Output under 200 words. Format:
-- **Blocking** — bullet list with file:line + the fix
-- **Nits** — bullet list
+Output under 200 words. **Evidence gate — every finding must clear it before you list it:**
+1. Quote the verbatim line you're reacting to, copied from `gh pr diff <n>`. If you can't quote it, it doesn't exist — drop it.
+2. Score your confidence 1–10 that this is a real issue on the line you quoted (not a guess about code you didn't see).
+3. Findings under 7 go in the **Low confidence** bucket, never in Blocking. A speculative "this might break if…" without a quoted line is a 0 — omit it.
+
+Format:
+- **Blocking** (confidence ≥ 7) — each bullet: `file:line` · the quoted line · the fix
+- **Nits** (confidence ≥ 7) — bullet list
+- **Low confidence** (< 7) — one line each, no fix; the synthesizer decides whether to surface
 - **No issues** if clean. Don't pad.
 ```
 
@@ -81,6 +87,7 @@ Output under 200 words. Same format as Fork A.
 
 Read the three (or two) summaries. Dedupe overlapping findings. Classify:
 
+- **Drop any finding that lacks a quoted line**, and drop the forks' **Low confidence** bucket unless a finding there is both concrete and quoted — a half-sure flag costs the contributor more than it saves. Never post a speculative finding as Blocking.
 - **Blocking** if any fork flagged it as blocking — bundled, with the file:line and the suggested fix in a `suggestion` code block where possible.
 - **Nits** — bundled separately, no code blocks unless trivial.
 - **First-time contributor?** Check `gh pr view <n> --json authorAssociation`. If `FIRST_TIME_CONTRIBUTOR` or `FIRST_TIMER`, add one warm sentence at the top.

--- a/.claude/skills/security-audit.md
+++ b/.claude/skills/security-audit.md
@@ -15,10 +15,12 @@ Scope:
 For each file, walk the security rule table. For every match, report:
 
 ```
-<path>:<line>  [CWE-xxx]  <one-line finding>
-  evidence:    <code snippet>
+<path>:<line>  [CWE-xxx]  (confidence N/10)  <one-line finding>
+  evidence:    <the verbatim line, copied from the file — not paraphrased>
   suggested:   <concrete fix in one sentence>
 ```
+
+The `evidence` line is a gate, not decoration: it must be the actual line as it appears in the file. If you can't quote the exact code, you're guessing — drop the finding. Score confidence 1–10 that the quoted line is genuinely the rule violation. List findings of 7+ as above; collect anything below 7 under a separate **Low confidence** heading at the end (one line each, no fix) so the reader can weigh them without mistaking them for confirmed issues.
 
 Pay particular attention to these stack-specific risks:
 

--- a/.claude/skills/simplify.md
+++ b/.claude/skills/simplify.md
@@ -25,8 +25,12 @@ Skip:
 
 Output format:
 ```
-<file>:<line>
-  smell:    <one phrase>
+<file>:<line>  (confidence N/10)
+  quoted:    <the verbatim line(s) you're reacting to, copied from the diff>
+  smell:     <one phrase>
   suggested: <concrete change in one sentence>
 ```
+
+`quoted` is a gate: if you can't copy the exact line the smell lives on, you're pattern-matching on something that isn't there — drop it. Score confidence 1–10 that this is a real simplification (not taste). List 7+ findings as above; put anything below 7 under a **Low confidence** heading at the end, one line each, so it's clearly separated from confirmed dead weight.
+
 End with the top three to fix first, in priority order.


### PR DESCRIPTION
## What

Adds one shared discipline — an **evidence gate** — to the three read-only finding-producers in `.claude/`: `/review-pr` (its 3 forks + synthesis), `/security-audit`, and `/simplify`. Every finding must now (1) quote the verbatim line it reacts to, and (2) carry a 1–10 confidence score. Findings under 7 are demoted to a **Low confidence** bucket instead of being surfaced as blocking, and the `/review-pr` synthesizer drops any finding that lacks a quoted line.

## Why

Mined from a study of four external skill repos — `obra/superpowers`, `garrytan/gstack`, `affaan-m/ecc`, `mattpocock/skills`. The "quote the exact motivating line before promoting a finding" gate appeared **independently in three of the four**, which is the strongest signal in the whole survey. It kills the most expensive review false-positive class: flagging code the reviewer never actually saw ("this field doesn't exist", "this might break if…"). gstack pairs it with confidence calibration; this PR adopts both.

Today the `/review-pr` forks emit `file:line + fix` with no evidence field and no confidence — exactly the gap the gate closes. `/security-audit` and `/simplify` already had an `evidence`/`smell` field; this turns it into a hard gate and adds the confidence split.

## How

Prose-only edits to three Markdown skill/command files. No code, no hooks, no settings touched.

## Testing

N/A — documentation/prompt changes to agent tooling. The gate is honor-system instruction, exercised the next time `/review-pr`, `/security-audit`, or `/simplify` runs.

Browser check: not applicable — no `web/src/` files, no rendered output.

## Changelog

No entry — internal tooling change, no user-visible behavior.

## Goal alignment

Tighter, evidence-backed reviews mean less time spent chasing phantom findings on contributor PRs — keeps the open-source review loop fast as the project scales toward 300K users.

## Not in this PR

The survey surfaced more (config-protection / gateguard PreToolUse hooks, a `/diagnose` upgrade to systematic-debugging, a spec "interfaces-not-file-paths" durability rule). Those are riskier (new hooks need their own tests) and are deliberately left for follow-up PRs. Note: the "CSO description rewrite" idea from superpowers/mattpocock was dropped on inspection — our skills are user-invoked slash commands, so a what-it-does description is correct for the menu; the auto-trigger concern doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782317581&installation_id=132681956&pr_number=2789&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2789&signature=6adf63db72112c460ae2b66664c3bbcf89af1aeaa664ea61fd388ea6fbb8a7cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->