### PR TITLE
chore: extend pre-push typecheck gate to the web workspace

### DIFF
--- a/.claude/hooks/pre-push-typecheck.py
+++ b/.claude/hooks/pre-push-typecheck.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
 """
-PreToolUse hook: run server `tsc --noEmit` before `git push` to a feature branch.
+PreToolUse hook: run the relevant typecheck/lint before `git push` to a
+feature branch, scoped to the workspace that actually changed.
 
 Goal: stop pushing red branches that then fail GH Actions and chew CI minutes.
-Skips pushes to main/master (safety.py blocks those anyway). Skips when tsc
-would cost more than it saves (no .ts changes since the last push).
+- Server `.ts` changed  → server `tsc --noEmit`.
+- Web `.ts`/`.tsx` changed → web typecheck + web Biome lint (the lint rules
+  mirror the SonarCloud findings that otherwise only surface post-push).
+Web vitest is intentionally left to `/check` and CI — it's the slow one and
+would make every push wait.
+
+Skips pushes to main/master (safety.py blocks those anyway). Skips a workspace
+when nothing in it changed since the last push.
 
 Bypass: CLAUDE_SKIP_TYPECHECK=1 git push ...
         CLAUDE_SKIP_SAFETY=1     git push ...   (also honored)
@@ -15,7 +22,9 @@ import re
 import subprocess
 import sys
 
-TIMEOUT_SECONDS = 120
+SERVER_TIMEOUT_SECONDS = 120
+WEB_TYPECHECK_TIMEOUT_SECONDS = 120
+WEB_LINT_TIMEOUT_SECONDS = 60
 
 
 def allow():
@@ -48,9 +57,9 @@ def push_targets_protected(cmd):
     return bool(PROTECTED_BRANCH.search(after))
 
 
-def has_ts_changes_against_origin():
-    """True if any tracked .ts/.tsx file differs from origin/main, or there are
-    uncommitted .ts/.tsx changes. False means tsc has nothing new to say."""
+def changed_ts_files():
+    """.ts/.tsx paths that differ from origin/main or are uncommitted.
+    Empty means there is nothing for tsc/lint to say."""
     try:
         committed = subprocess.run(
             ["git", "diff", "--name-only", "origin/main...HEAD"],
@@ -61,21 +70,20 @@ def has_ts_changes_against_origin():
             capture_output=True, text=True, timeout=10,
         ).stdout
     except Exception:
-        return True  # err on the side of running tsc
+        return None  # signal "couldn't tell" — caller errs toward running checks
     files = (committed + "\n" + working).splitlines()
-    return any(f.endswith((".ts", ".tsx")) for f in files)
+    return [f for f in files if f.endswith((".ts", ".tsx"))]
 
 
-def run_typecheck(project_dir):
+def run_check(label, cmd, cwd, timeout):
+    """True = passed, None = couldn't run (fail open), str = error output."""
     try:
         result = subprocess.run(
-            ["pnpm", "exec", "tsc", "--noEmit", "-p", "."],
-            cwd=project_dir,
-            capture_output=True, text=True, timeout=TIMEOUT_SECONDS,
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
         )
     except subprocess.TimeoutExpired:
         sys.stderr.write(
-            f"[pre-push-typecheck] tsc exceeded {TIMEOUT_SECONDS}s; allowing push.\n"
+            f"[pre-push-typecheck] {label} exceeded {timeout}s; allowing push.\n"
         )
         return None
     except FileNotFoundError:
@@ -83,7 +91,16 @@ def run_typecheck(project_dir):
         return None
     if result.returncode == 0:
         return True
-    return result.stdout or result.stderr or "(tsc produced no output)"
+    return result.stdout or result.stderr or "(no output)"
+
+
+def deny_for(label, output):
+    head = "\n".join(output.splitlines()[:30])
+    deny(
+        f"Refusing `git push` — {label} failed. First errors:\n\n"
+        f"{head}\n\n"
+        "Fix them, or bypass with CLAUDE_SKIP_TYPECHECK=1 if pushing a WIP branch."
+    )
 
 
 def main():
@@ -107,20 +124,44 @@ def main():
 
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
 
-    if not has_ts_changes_against_origin():
+    ts_files = changed_ts_files()
+    if ts_files is not None and not ts_files:
         allow()
 
-    sys.stderr.write("[pre-push-typecheck] running server tsc --noEmit...\n")
-    result = run_typecheck(project_dir)
-    if result is None or result is True:
-        allow()
+    # ts_files is None → "couldn't tell"; run both to be safe.
+    server_changed = ts_files is None or any(not f.startswith("web/") for f in ts_files)
+    web_changed = ts_files is None or any(f.startswith("web/") for f in ts_files)
 
-    head = "\n".join(result.splitlines()[:30])
-    deny(
-        "Refusing `git push` — server tsc --noEmit failed. First errors:\n\n"
-        f"{head}\n\n"
-        "Fix the type errors, or bypass with CLAUDE_SKIP_TYPECHECK=1 if pushing a WIP branch."
-    )
+    if server_changed:
+        sys.stderr.write("[pre-push-typecheck] running server tsc --noEmit...\n")
+        result = run_check(
+            "server tsc --noEmit",
+            ["pnpm", "exec", "tsc", "--noEmit", "-p", "."],
+            project_dir, SERVER_TIMEOUT_SECONDS,
+        )
+        if isinstance(result, str):
+            deny_for("server tsc --noEmit", result)
+
+    if web_changed:
+        sys.stderr.write("[pre-push-typecheck] running web typecheck...\n")
+        result = run_check(
+            "web typecheck",
+            ["pnpm", "--filter", "2anki-web", "typecheck"],
+            project_dir, WEB_TYPECHECK_TIMEOUT_SECONDS,
+        )
+        if isinstance(result, str):
+            deny_for("web typecheck", result)
+
+        sys.stderr.write("[pre-push-typecheck] running web lint (Biome)...\n")
+        result = run_check(
+            "web lint (Biome)",
+            ["pnpm", "--filter", "2anki-web", "lint"],
+            project_dir, WEB_LINT_TIMEOUT_SECONDS,
+        )
+        if isinstance(result, str):
+            deny_for("web lint (Biome)", result)
+
+    allow()
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/pre-push-typecheck.test.py
+++ b/.claude/hooks/pre-push-typecheck.test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "pre_push_typecheck",
+    os.path.join(HOOKS_DIR, "pre-push-typecheck.py"),
+)
+hook = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hook)
+
+
+def run_hook(command, tool_name="Bash", env=None, ts_files=None, check_results=None):
+    """ts_files: list of changed .ts/.tsx paths (or None = couldn't tell).
+    check_results: dict label -> True | str(error). Missing label defaults True."""
+    check_results = check_results or {}
+    stdin_data = json.dumps({"tool_name": tool_name, "tool_input": {"command": command}})
+    captured = {"checks": []}
+
+    def fake_allow():
+        captured["result"] = "allow"
+        sys.exit(0)
+
+    def fake_deny(reason):
+        captured["result"] = "deny"
+        captured["reason"] = reason
+        sys.exit(0)
+
+    def fake_changed_ts_files():
+        return ts_files
+
+    def fake_run_check(label, cmd, cwd, timeout):
+        captured["checks"].append(label)
+        return check_results.get(label, True)
+
+    with patch.object(hook, "allow", side_effect=fake_allow), \
+         patch.object(hook, "deny", side_effect=fake_deny), \
+         patch.object(hook, "changed_ts_files", side_effect=fake_changed_ts_files), \
+         patch.object(hook, "run_check", side_effect=fake_run_check), \
+         patch("sys.stdin") as mock_stdin, \
+         patch.dict(os.environ, env or {}, clear=False):
+        mock_stdin.read.return_value = stdin_data
+        try:
+            hook.main()
+        except SystemExit:
+            pass
+
+    return captured
+
+
+class TestPassThrough(unittest.TestCase):
+    def test_non_bash_tool_allows(self):
+        result = run_hook("git push", tool_name="Write")
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(result["checks"], [])
+
+    def test_non_push_command_allows(self):
+        result = run_hook("git status")
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(result["checks"], [])
+
+    def test_push_to_main_allows_without_checks(self):
+        result = run_hook("git push origin main", ts_files=["src/server.ts"])
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(result["checks"], [])
+
+    def test_env_bypass_allows(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            env={"CLAUDE_SKIP_TYPECHECK": "1"},
+            ts_files=["web/src/App.tsx"],
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(result["checks"], [])
+
+    def test_no_ts_changes_allows_without_checks(self):
+        result = run_hook("git push -u origin docs/x", ts_files=[])
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(result["checks"], [])
+
+
+class TestServerScope(unittest.TestCase):
+    def test_server_change_runs_only_server_check(self):
+        result = run_hook("git push -u origin fix/x", ts_files=["src/usecases/Convert.ts"])
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(result["checks"], ["server tsc --noEmit"])
+
+    def test_server_tsc_failure_denies(self):
+        result = run_hook(
+            "git push -u origin fix/x",
+            ts_files=["src/usecases/Convert.ts"],
+            check_results={"server tsc --noEmit": "Convert.ts:12 error TS2322"},
+        )
+        self.assertEqual(result["result"], "deny")
+        self.assertIn("server tsc --noEmit", result["reason"])
+        self.assertIn("TS2322", result["reason"])
+        self.assertIn("CLAUDE_SKIP_TYPECHECK=1", result["reason"])
+
+
+class TestWebScope(unittest.TestCase):
+    def test_web_change_runs_web_checks_not_server(self):
+        result = run_hook("git push -u origin feat/x", ts_files=["web/src/App.tsx"])
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(result["checks"], ["web typecheck", "web lint (Biome)"])
+
+    def test_web_typecheck_failure_denies_before_lint(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            ts_files=["web/src/App.tsx"],
+            check_results={"web typecheck": "App.tsx:3 error TS2304"},
+        )
+        self.assertEqual(result["result"], "deny")
+        self.assertIn("web typecheck", result["reason"])
+        self.assertEqual(result["checks"], ["web typecheck"])
+
+    def test_web_lint_failure_denies(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            ts_files=["web/src/App.tsx"],
+            check_results={"web lint (Biome)": "App.tsx:9 noNestedTernary"},
+        )
+        self.assertEqual(result["result"], "deny")
+        self.assertIn("web lint (Biome)", result["reason"])
+        self.assertIn("noNestedTernary", result["reason"])
+        self.assertEqual(result["checks"], ["web typecheck", "web lint (Biome)"])
+
+
+class TestBothScopes(unittest.TestCase):
+    def test_both_changed_runs_all_three(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            ts_files=["src/server.ts", "web/src/App.tsx"],
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(
+            result["checks"],
+            ["server tsc --noEmit", "web typecheck", "web lint (Biome)"],
+        )
+
+    def test_unknown_diff_runs_all_three(self):
+        result = run_hook("git push -u origin feat/x", ts_files=None)
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(
+            result["checks"],
+            ["server tsc --noEmit", "web typecheck", "web lint (Biome)"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`pre-push-typecheck.py` (PreToolUse hook on `git push`) ran **server `tsc` only**. This extends it to scope by the workspace that changed:

- server `.ts` changed → `server tsc --noEmit` *(unchanged)*
- web `.ts`/`.tsx` changed → `web typecheck` + `web Biome lint`

Both run only when their workspace actually changed, so single-workspace pushes don't pay for the other side.

## Why

A branch that broke web typecheck or a Biome rule pushed **clean** under the old gate, then failed in GitHub Actions — costing a full rebase + re-push + CI round-trip every time. The web `lint` step is Biome configured to **mirror the SonarCloud rules** (`noNestedTernary`, `noNegationElse`, `useOptionalChain`, `noUselessTernary`) that `.claude/rules/sonar.md` notes *"only surface after the push."* Running it at the push gate catches that whole class locally, automatically — not just when someone remembers `/check` or `sonar-scanner`.

Web **vitest stays out of the gate** on purpose — it's the slow one; `/check` and CI keep covering it. Push latency only grows when `web/src` changed, and only by typecheck + lint.

## How

Refactored the single `run_typecheck` into a generic `run_check(label, cmd, cwd, timeout)` and a `changed_ts_files()` seam, then split work by whether changed paths are under `web/`. Preserved every existing guarantee: fail-open when pnpm is missing or a check times out, `main`/`master` still deferred to `safety.py`, and `CLAUDE_SKIP_TYPECHECK=1` (and `CLAUDE_SKIP_SAFETY=1`) still bypass.

## Testing

Adds `pre-push-typecheck.test.py` — 12 colocated tests (same importlib/patch style as `check-duplicate-commit-message.test.py`) covering: pass-through cases (non-Bash, non-push, push-to-main, env bypass, no-ts-changes), server-only scope, web-only scope, both scopes, the "couldn't tell" diff fallback, and per-check denial (server tsc fail, web typecheck fail before lint, web lint fail). All green:

```
Ran 12 tests in 0.009s
OK
```

Also smoke-tested against the live repo: a non-push command and a `.py`-only push both return `{"continue": true}` with zero checks run.

Browser check: not applicable — hook tooling, no `web/src/` runtime output.

## Changelog

No entry — internal tooling change, no user-visible behavior.

## Goal alignment

Faster, tighter dev loop: fewer CI round-trips per branch keeps the path from change → merge short as the project scales toward 300K users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782318119&installation_id=132681956&pr_number=2790&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2790&signature=1f556aeee6fe09266d8e11c89b6fdfdfa4656f12175f9d31621d781ac099631d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->