### PR TITLE
docs: open finished PRs ready for review, not draft

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Every PR is checked against both — does it make the experience simpler/faster/
 - Always rebase on `origin/main` before opening a PR.
 - One PR per feature. Never stack PRs — the deploy pipeline pulls a single branch.
 - Push pattern: `git push -u origin <branch>` — never bare `git push`, never to `main`. The `safety.py` hook blocks both.
-- When a unit of work is done, ship it: commit, push, open a draft PR with `gh pr create --draft`.
+- When a unit of work is done, ship it: commit, push, and open the PR **ready for review** with `gh pr create` — not `--draft`. A finished unit of work handed to Alexander is something he's meant to look at, so it goes up ready. Reserve `--draft` for work that genuinely isn't reviewable yet: a `/spec-draft-pr` spec awaiting `/implement`, or a WIP you've explicitly flagged as WIP.
 - **Before flipping a PR ready (or before pushing a non-trivial code change), run `sonar-scanner` locally.** `/check` does not run SonarCloud's rule engine; cognitive complexity, nesting depth, redundant type assertions, and a11y smells only surface after the push. See `.claude/rules/sonar.md` for setup and the exact command. Skip only for pure doc/dep/test/typo changes.
 - Before `gh pr merge`: every `statusCheckRollup` entry must be non-FAILURE (not just required ones). The `check-merge-status.py` hook enforces this.
 - Touching auth, payments, or external-API integration? Run `/security-review` before merge.


### PR DESCRIPTION
## What

Flips the default in `CLAUDE.md` from "open a draft PR with `gh pr create --draft`" to **open the PR ready for review** with `gh pr create`. Scopes `--draft` to the cases where it's a genuine state: a `/spec-draft-pr` spec awaiting `/implement`, or explicitly-flagged WIP.

## Why

Direct feedback from Alexander: a finished unit of work handed over for review shouldn't sit in draft — if he's meant to look at it, it goes up ready. The old default produced exactly that friction (e.g. #2789 and #2790 landed as drafts). The `/spec-draft-pr` → `/implement` → `gh pr ready` lifecycle is left intact — there, draft genuinely means "spec, not yet implemented."

## How

One-line change to the Git section of `CLAUDE.md`. No code.

Browser check: not applicable — documentation only.

## Changelog

No entry — internal contributor guidance, no user-visible behavior.

This PR is itself opened ready, not draft — eating the dog food.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782318567&installation_id=132681956&pr_number=2791&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2791&signature=db7c74616d4620d0389735660b9808cad247b0cd9e4ce7b0e3308bc37f01f22e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->