### PR TITLE
fix: keep mindmap collapse button on-screen, scroll shortcuts

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapEditor.module.css
+++ b/web/src/pages/MindmapsPage/MindmapEditor.module.css
@@ -24,12 +24,13 @@
 
 .collapseToggle {
   position: absolute;
-  right: -12px;
+  right: 0.75rem;
   top: 1rem;
   z-index: 5;
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
   width: 24px;
   height: 24px;
   display: flex;
@@ -128,6 +129,20 @@
 .shortcuts {
   padding-top: var(--space-2);
   border-top: 1px solid var(--color-border);
+}
+
+.shortcuts[open] {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.shortcutsBody {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
 }
 
 .shortcutsSummary {

--- a/web/src/pages/MindmapsPage/MindmapEditor.tsx
+++ b/web/src/pages/MindmapsPage/MindmapEditor.tsx
@@ -893,30 +893,32 @@ export function MindmapEditor() {
 
         <details className={styles.shortcuts}>
           <summary className={styles.shortcutsSummary}>Keyboard shortcuts</summary>
-          {SHORTCUT_GROUPS.map((group) => (
-            <div key={group.label} className={styles.shortcutGroup}>
-              <p className={styles.shortcutGroupLabel}>{group.label}</p>
-              {group.items.map((item) => (
-                <div key={item.action} className={styles.shortcutRow}>
-                  <span className={styles.shortcutKeys}>
-                    {item.keys.map((key) => (
-                      <kbd key={key} className={styles.shortcutKey}>
-                        {key}
-                      </kbd>
-                    ))}
-                  </span>
-                  <span className={styles.shortcutAction}>{item.action}</span>
-                </div>
-              ))}
-            </div>
-          ))}
-          <button
-            type="button"
-            onClick={() => setShowMarkdownModal(true)}
-            className={styles.shortcutNoteBtn}
-          >
-            Markdown works in node labels
-          </button>
+          <div className={styles.shortcutsBody}>
+            {SHORTCUT_GROUPS.map((group) => (
+              <div key={group.label} className={styles.shortcutGroup}>
+                <p className={styles.shortcutGroupLabel}>{group.label}</p>
+                {group.items.map((item) => (
+                  <div key={item.action} className={styles.shortcutRow}>
+                    <span className={styles.shortcutKeys}>
+                      {item.keys.map((key) => (
+                        <kbd key={key} className={styles.shortcutKey}>
+                          {key}
+                        </kbd>
+                      ))}
+                    </span>
+                    <span className={styles.shortcutAction}>{item.action}</span>
+                  </div>
+                ))}
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => setShowMarkdownModal(true)}
+              className={styles.shortcutNoteBtn}
+            >
+              Markdown works in node labels
+            </button>
+          </div>
         </details>
 
         <div className={styles.primaryAction}>


### PR DESCRIPTION
Two clipping bugs on the mindmap sidebar shipped earlier today.

## What changed
- **Collapse button** sat at `right: -12px` and was clipped by the sidebar's `overflow: hidden` (load-bearing for the width:0 collapse animation), so only a half circle showed. Moved it fully inside the top-right corner and added `box-shadow: var(--shadow-sm)` so it reads as a control.
- **Keyboard shortcuts** panel had no height bound — open, it ran past the fixed-height sidebar and pushed the Download deck button off-screen. Open now, the `<details>` fills the remaining sidebar height and scrolls its body internally; the summary and Download deck stay pinned.

## Checks
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web test src/pages/MindmapsPage/MindmapEditor.test.tsx` — 8/8 pass
- `pnpm --filter 2anki-web lint` — clean
- Sonar: not run — CSS tweak plus a wrapper div, no new logic or complexity.

No changelog entry — polish on the sidebar shipped earlier today, not a separate user-facing capability.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs a visual pass — I can't start the dev server. Open a mindmap, expand Keyboard shortcuts (list should scroll, Download deck stays visible), and check the collapse button is a full circle top-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782319194&installation_id=132681956&pr_number=2792&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2792&signature=74145e172c799a7bfaf56d8fdcc072776c4b695340bb703a58be8e0d181f4a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->