### PR TITLE
docs: correct blue-green Apache setup for the four prod vhosts

### DIFF
--- a/Documentation/deploy/blue-green.md
+++ b/Documentation/deploy/blue-green.md
@@ -19,7 +19,7 @@ that has to happen first. Flipping the workflow is a later PR — see
 | `ecosystem.blue-green.config.js` | repo | two apps: `server-blue` (`PORT=3000`), `server-green` (`PORT=3001`) |
 | `scripts/deploy-blue-green.sh` | repo | the cutover: start next color → health-check → swap Apache → drain old color |
 | `/etc/apache2/conf-2anki-upstream.conf` | prod, generated | one upstream block; rewritten by the script each deploy |
-| `2anki.net.conf` site config | prod, manual one-time edit | `Include`s the upstream file instead of a static `ProxyPass` |
+| four Apache vhosts (`000-2anki*`, `000-beta*`) | prod, manual one-time edit | each `Include`s the upstream file instead of a static `ProxyPass` — see [One-time Apache setup](#one-time-apache-setup) |
 | `~/.deploy_color` | prod, state | `blue` or `green` — the currently live color |
 
 `server-green` binds 3001 even though prod's `.env` sets `PORT=3000`: pm2 injects
@@ -28,20 +28,34 @@ false`, so the pm2 value wins. Confirmed against prod.
 
 ## One-time Apache setup
 
-In the prod site config (`/etc/apache2/sites-available/2anki.net.conf`), replace
-the static upstream:
+Prod does **not** have a single proxy vhost. Four enabled vhosts all proxy the
+same backend on `localhost:3000`:
+
+| vhost | serves |
+|---|---|
+| `000-2anki.conf` | `2anki.net` :80 |
+| `000-2anki-le-ssl.conf` | `2anki.net` :443 (the live site) |
+| `000-beta.conf` | `beta.2anki.net` :80 |
+| `000-beta-le-ssl.conf` | `beta.2anki.net` :443 |
+
+Every one of them must track the live color. The script flips a single upstream
+file, so the setup is: point **all four** vhosts at the *same* include. A
+cutover deletes the old color's port, so any vhost left hardcoded at `:3000`
+starts returning 502 the moment the live color moves to green — beta included.
+
+In each vhost, replace the two proxy lines:
 
 ```apache
-# before
-ProxyPass / http://127.0.0.1:3000/
-ProxyPassReverse / http://127.0.0.1:3000/
+# before (in every app-serving vhost)
+ProxyPass / http://localhost:3000/
+ProxyPassReverse / http://localhost:3000/
 
 # after
 Include /etc/apache2/conf-2anki-upstream.conf
 ```
 
 Seed the include file to point at the current live port (3000) so Apache has a
-valid config before the first script run:
+valid config before the first script run, then verify and reload:
 
 ```bash
 printf 'ProxyPass / http://127.0.0.1:3000/\nProxyPassReverse / http://127.0.0.1:3000/\n' \
@@ -49,8 +63,15 @@ printf 'ProxyPass / http://127.0.0.1:3000/\nProxyPassReverse / http://127.0.0.1:
 sudo apachectl configtest && sudo apachectl graceful
 ```
 
-The deploy user needs passwordless sudo for `tee`, `mv`, and `apachectl` on these
-paths (it already reloads Apache today).
+`127.0.0.1` and `localhost` are equivalent here; the script writes `127.0.0.1`
+to avoid IPv6-localhost resolution surprises. The deploy user already has
+passwordless sudo (`NOPASSWD: ALL`), so `tee`, `mv`, and `apachectl` work
+unattended.
+
+While you're in `sites-enabled/`, move the stale
+`000-2anki-le-ssl.conf.bak.*` backup out of the directory. Apache only loads
+`*.conf`, so it's inert today, but a backup that ends in `.conf` would silently
+load a second, conflicting vhost.
 
 ## First cutover (bootstrap)
 


### PR DESCRIPTION
## What

Corrects `Documentation/deploy/blue-green.md` to match the real prod Apache layout.

## Why

The runbook assumed one proxy vhost. The pre-cutover prep on the box (PR #2736 follow-up) found **four** enabled vhosts all proxying `localhost:3000`:

| vhost | serves |
|---|---|
| `000-2anki.conf` | 2anki.net :80 |
| `000-2anki-le-ssl.conf` | 2anki.net :443 (live) |
| `000-beta.conf` | beta.2anki.net :80 |
| `000-beta-le-ssl.conf` | beta.2anki.net :443 |

A cutover deletes the old color's port, so any vhost left hardcoded at `:3000` returns 502 the moment the live color moves to green — **beta would break**. The fix is to have all four `Include` the same upstream file, so one swap moves them together.

## How

- Document the four-vhost reality and the shared-`Include` requirement in the setup section + Pieces table.
- Note `localhost`/`127.0.0.1` equivalence and the `NOPASSWD: ALL` sudo already in place.
- Flag the stale `000-2anki-le-ssl.conf.bak.*` in `sites-enabled/` to tidy (inert today since Apache loads `*.conf` only).

## Testing

Doc-only. No code touched.

## Changelog / user docs

None — internal ops runbook, no user-visible behavior.

## Browser check

Not applicable — documentation only, no rendered output.

## Goal alignment

Keeps the deploy runbook honest so the blue-green rollout doesn't take beta down — reliability work toward scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782323765&installation_id=132681956&pr_number=2794&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2794&signature=a9db3f7e8093bdf3ad168e17cffaa1c4824e8857858cbae32d4efe7ddbce5bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->