### PR TITLE
chore: blue-green deploy also swaps the Ankify WebSocket upstream

### DIFF
--- a/Documentation/deploy/blue-green.md
+++ b/Documentation/deploy/blue-green.md
@@ -18,8 +18,9 @@ that has to happen first. Flipping the workflow is a later PR — see
 |---|---|---|
 | `ecosystem.blue-green.config.js` | repo | two apps: `server-blue` (`PORT=3000`), `server-green` (`PORT=3001`) |
 | `scripts/deploy-blue-green.sh` | repo | the cutover: start next color → health-check → swap Apache → drain old color |
-| `/etc/apache2/conf-2anki-upstream.conf` | prod, generated | one upstream block; rewritten by the script each deploy |
-| four Apache vhosts (`000-2anki*`, `000-beta*`) | prod, manual one-time edit | each `Include`s the upstream file instead of a static `ProxyPass` — see [One-time Apache setup](#one-time-apache-setup) |
+| `/etc/apache2/conf-2anki-upstream.conf` | prod, generated | HTTP `ProxyPass`/`ProxyPassReverse`; rewritten by the script each deploy |
+| `/etc/apache2/conf-2anki-ws-upstream.conf` | prod, generated | the Ankify WebSocket `RewriteRule` (`/v/*`); rewritten by the script each deploy |
+| four Apache vhosts (`000-2anki*`, `000-beta*`) | prod, manual one-time edit | each `Include`s the upstream file(s) instead of static directives — see [One-time Apache setup](#one-time-apache-setup) |
 | `~/.deploy_color` | prod, state | `blue` or `green` — the currently live color |
 
 `server-green` binds 3001 even though prod's `.env` sets `PORT=3000`: pm2 injects
@@ -38,12 +39,18 @@ same backend on `localhost:3000`:
 | `000-beta.conf` | `beta.2anki.net` :80 |
 | `000-beta-le-ssl.conf` | `beta.2anki.net` :443 |
 
-Every one of them must track the live color. The script flips a single upstream
-file, so the setup is: point **all four** vhosts at the *same* include. A
-cutover deletes the old color's port, so any vhost left hardcoded at `:3000`
-starts returning 502 the moment the live color moves to green — beta included.
+Every one of them must track the live color, because a cutover deletes the old
+color's port — any vhost (or rewrite) left hardcoded at `:3000` returns 502 the
+moment the live color moves to green, beta included.
 
-In each vhost, replace the two proxy lines:
+There are **two** kinds of upstream reference, so the script flips two include
+files:
+
+- **HTTP** — `ProxyPass`/`ProxyPassReverse`, present in all four vhosts.
+- **WebSocket** — the Ankify `/v/*` `RewriteRule` (`ws://localhost:3000`),
+  present only in the live `000-2anki-le-ssl.conf`.
+
+In all four vhosts, replace the two proxy lines with the HTTP include:
 
 ```apache
 # before (in every app-serving vhost)
@@ -54,12 +61,27 @@ ProxyPassReverse / http://localhost:3000/
 Include /etc/apache2/conf-2anki-upstream.conf
 ```
 
-Seed the include file to point at the current live port (3000) so Apache has a
-valid config before the first script run, then verify and reload:
+In `000-2anki-le-ssl.conf` only, also replace the WebSocket rewrite block with
+the WS include:
+
+```apache
+# before
+RewriteEngine on
+RewriteCond %{HTTP:Upgrade} =websocket [NC]
+RewriteRule ^/v/(.*)$ ws://localhost:3000/v/$1 [P,L]
+
+# after
+Include /etc/apache2/conf-2anki-ws-upstream.conf
+```
+
+Seed both include files at the current live port (3000) so Apache has a valid
+config before the first script run, then verify and reload:
 
 ```bash
 printf 'ProxyPass / http://127.0.0.1:3000/\nProxyPassReverse / http://127.0.0.1:3000/\n' \
   | sudo tee /etc/apache2/conf-2anki-upstream.conf
+printf 'RewriteEngine on\nRewriteCond %%{HTTP:Upgrade} =websocket [NC]\nRewriteRule ^/v/(.*)$ ws://127.0.0.1:3000/v/$1 [P,L]\n' \
+  | sudo tee /etc/apache2/conf-2anki-ws-upstream.conf
 sudo apachectl configtest && sudo apachectl graceful
 ```
 
@@ -110,15 +132,15 @@ scripts/deploy-blue-green.sh
 ```
 
 What it does: reads `~/.deploy_color`, starts the other color, waits up to 30s
-for its `/api/version` to report `GIT_SHA`, atomically swaps the Apache include,
-`apachectl graceful`, verifies `https://2anki.net/api/version` reports the new
-sha, then drains and deletes the old color (SIGINT → the graceful-shutdown
-handler, bounded by `kill_timeout`), and writes the new color to `~/.deploy_color`.
+for its `/api/version` to report `GIT_SHA`, rewrites both Apache includes (HTTP
+and WebSocket) to the new port, `apachectl graceful` once, verifies
+`https://2anki.net/api/version` reports the new sha, then drains and deletes the
+old color (SIGINT → the graceful-shutdown handler, bounded by `kill_timeout`),
+and writes the new color to `~/.deploy_color`.
 
 If the new color fails its health check, the script deletes it and exits non-zero
 — the current color never stopped serving. If the post-swap public check fails,
-it rolls the Apache include back to the previous upstream and reloads before
-exiting.
+it rewrites both includes back to the old color's port, reloads, and exits.
 
 ## Dry-run
 
@@ -135,6 +157,7 @@ For a real cutover against a non-prod box, override the paths:
 SERVER_DIR=/path/to/checkout \
 DEPLOY_COLOR_FILE=/tmp/deploy_color \
 UPSTREAM_CONF=/tmp/upstream.conf \
+WS_UPSTREAM_CONF=/tmp/ws-upstream.conf \
 PUBLIC_HEALTH_URL=http://localhost/api/version \
 GIT_SHA=<sha> scripts/deploy-blue-green.sh
 ```
@@ -146,7 +169,8 @@ GIT_SHA=<sha> scripts/deploy-blue-green.sh
 | `GIT_SHA` | *(required)* | sha the health checks must match |
 | `SERVER_DIR` | `~/src/github.com/2anki/2anki.net` | repo checkout on the box |
 | `DEPLOY_COLOR_FILE` | `~/.deploy_color` | live-color state file |
-| `UPSTREAM_CONF` | `/etc/apache2/conf-2anki-upstream.conf` | generated Apache include |
+| `UPSTREAM_CONF` | `/etc/apache2/conf-2anki-upstream.conf` | generated HTTP proxy include |
+| `WS_UPSTREAM_CONF` | `/etc/apache2/conf-2anki-ws-upstream.conf` | generated WebSocket (`/v/*`) include |
 | `ECOSYSTEM` | `$SERVER_DIR/ecosystem.blue-green.config.js` | pm2 app definitions |
 | `PUBLIC_HEALTH_URL` | `https://2anki.net/api/version` | post-swap verification URL |
 | `DEPLOY_LOCK_FILE` | `~/.2anki-deploy.lock` | flock target |

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 SERVER_DIR="${SERVER_DIR:-$HOME/src/github.com/2anki/2anki.net}"
 STATE_FILE="${DEPLOY_COLOR_FILE:-$HOME/.deploy_color}"
 UPSTREAM_CONF="${UPSTREAM_CONF:-/etc/apache2/conf-2anki-upstream.conf}"
+WS_UPSTREAM_CONF="${WS_UPSTREAM_CONF:-/etc/apache2/conf-2anki-ws-upstream.conf}"
 LOCK_FILE="${DEPLOY_LOCK_FILE:-$HOME/.2anki-deploy.lock}"
 ECOSYSTEM="${ECOSYSTEM:-$SERVER_DIR/ecosystem.blue-green.config.js}"
 PUBLIC_HEALTH_URL="${PUBLIC_HEALTH_URL:-https://2anki.net/api/version}"
@@ -49,6 +50,22 @@ wait_for_sha() {
   return 1
 }
 
+# Rewrite both Apache upstream includes to point at $1 (a port). The HTTP include
+# is shared by every app vhost; the WebSocket include is referenced only by the
+# live :443 vhost (Ankify /v/* proxy). Each temp file lives in the target's own
+# directory so the mv is a same-filesystem rename — no half-written include is
+# ever read. The caller runs `apachectl graceful` once afterwards so both apply
+# together.
+swap_upstreams() {
+  local port="$1"
+  printf 'ProxyPass / http://127.0.0.1:%s/\nProxyPassReverse / http://127.0.0.1:%s/\n' \
+    "$port" "$port" | run sudo tee "${UPSTREAM_CONF}.new" >/dev/null
+  run sudo mv "${UPSTREAM_CONF}.new" "$UPSTREAM_CONF"
+  printf 'RewriteEngine on\nRewriteCond %%{HTTP:Upgrade} =websocket [NC]\nRewriteRule ^/v/(.*)$ ws://127.0.0.1:%s/v/$1 [P,L]\n' \
+    "$port" | run sudo tee "${WS_UPSTREAM_CONF}.new" >/dev/null
+  run sudo mv "${WS_UPSTREAM_CONF}.new" "$WS_UPSTREAM_CONF"
+}
+
 # Serialize against a concurrent deploy. To also serialize against the certbot
 # renewal hook's Apache reload, point both at a shared root-writable lock path
 # via DEPLOY_LOCK_FILE (see the doc).
@@ -66,11 +83,13 @@ CURRENT="$(cat "$STATE_FILE" 2>/dev/null || echo blue)"
 if [ "$CURRENT" = "blue" ]; then
   NEXT=green
   NEXT_PORT=3001
+  CURRENT_PORT=3000
 else
   NEXT=blue
   NEXT_PORT=3000
+  CURRENT_PORT=3001
 fi
-log "current=$CURRENT next=$NEXT port=$NEXT_PORT sha=$GIT_SHA"
+log "current=$CURRENT (:$CURRENT_PORT) next=$NEXT (:$NEXT_PORT) sha=$GIT_SHA"
 
 cd "$SERVER_DIR"
 export GIT_SHA
@@ -84,25 +103,16 @@ if ! wait_for_sha "http://127.0.0.1:$NEXT_PORT$HEALTH_PATH"; then
   exit 1
 fi
 
-# Atomically swap Apache's upstream. The temp file lives in the target's own
-# directory so the mv is a same-filesystem rename — no half-written include can
-# be read mid-swap.
-PREV_CONF="$(cat "$UPSTREAM_CONF" 2>/dev/null || echo '')"
-NEW_CONF="${UPSTREAM_CONF}.new"
-printf 'ProxyPass / http://127.0.0.1:%s/\nProxyPassReverse / http://127.0.0.1:%s/\n' \
-  "$NEXT_PORT" "$NEXT_PORT" | run sudo tee "$NEW_CONF" >/dev/null
-run sudo mv "$NEW_CONF" "$UPSTREAM_CONF"
+# Swap both Apache upstreams (HTTP + WebSocket) to the new color, then one
+# graceful reload applies them together.
+swap_upstreams "$NEXT_PORT"
 run sudo apachectl graceful
 
 # Verify the swap took effect through Apache before retiring the old color.
 if ! wait_for_sha "$PUBLIC_HEALTH_URL"; then
-  log "post-swap check failed at $PUBLIC_HEALTH_URL — rolling back Apache"
-  if [ -n "$PREV_CONF" ]; then
-    printf '%s\n' "$PREV_CONF" | run sudo tee "$UPSTREAM_CONF" >/dev/null
-    run sudo apachectl graceful
-  else
-    log "no previous upstream captured — check Apache config manually"
-  fi
+  log "post-swap check failed at $PUBLIC_HEALTH_URL — rolling back to :$CURRENT_PORT"
+  swap_upstreams "$CURRENT_PORT"
+  run sudo apachectl graceful
   run pm2 delete "server-$NEXT"
   exit 1
 fi


### PR DESCRIPTION
## What

The blue-green deploy script now swaps **two** Apache upstream includes — HTTP and WebSocket — instead of one. Plus the matching runbook updates.

## Why

Pre-cutover inspection of the live prod vhost found a second hardcoded upstream the spec missed. `000-2anki-le-ssl.conf` proxies the Ankify `/v/*` WebSocket path:

```apache
RewriteRule ^/v/(.*)$ ws://localhost:3000/v/$1 [P,L]
```

That `:3000` is independent of the HTTP `ProxyPass`. A cutover that flips only the HTTP include deletes the old port and leaves WebSocket traffic pointed at a dead backend. Ankify has 0 subscribers today so nothing breaks now — but it's a latent 502 for the first Ankify user, and the WS session proxy is the exact surface the spec flagged as sensitive (it's a reason cluster mode was rejected).

## How

- New `WS_UPSTREAM_CONF` (`/etc/apache2/conf-2anki-ws-upstream.conf`). A `swap_upstreams <port>` helper rewrites both includes; the script calls it once for the new port, then a single `apachectl graceful` applies both together.
- Rollback re-runs `swap_upstreams <old-port>` rather than restoring captured file contents — simpler and symmetric with the forward path.
- Runbook: documents both includes, which vhost includes which (HTTP in all four, WS only in the live :443 vhost), the two-file seed step, and the `WS_UPSTREAM_CONF` env var.

## Testing

- `bash -n` clean.
- `DRY_RUN=1` traced both directions: writes both `.new` files, both `mv`s, one graceful reload, correct rollback target.
- Verified the rendered include content byte-for-byte — `%{HTTP:Upgrade}` and literal `$1` survive the `printf` escaping, port substituted correctly, matches the existing prod WS block (modulo `localhost`→`127.0.0.1`).
- No automated test: shell cutover script, no Jest surface (same as the parent PR #2736).

## Changelog / user docs

None — internal deploy tooling, not wired into the automated workflow, no user-visible behavior.

## Browser check

Not applicable — infra tooling, no `web/src`, no rendered output.

## Goal alignment

Keeps the zero-downtime deploy correct for the WebSocket path before it ships — reliability work toward scale; no effect on the conversion experience.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782324147&installation_id=132681956&pr_number=2795&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2795&signature=cbbcfa90b7c8426104acf3ba8da6c51c4d3c65f76bdff23670d05393b1830354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->