### PR TITLE
ci: deploy via blue-green cutover script

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -73,24 +73,13 @@ jobs:
 
             cd ${SERVER_DIR}
             export GIT_SHA
-            pm2 startOrRestart ecosystem.config.js --update-env
-            pm2 save
-
-            echo "Waiting for /api/version on :3000 to report sha=${GIT_SHA}..."
-            HEALTHY=0
-            for i in $(seq 1 15); do
-              RESPONSE=$(curl -fsS http://127.0.0.1:3000/api/version 2>/dev/null || echo "")
-              ACTUAL_SHA=$(echo "$RESPONSE" | jq -r '.sha // empty' 2>/dev/null || echo "")
-              if [ -n "$ACTUAL_SHA" ] && [ "$ACTUAL_SHA" = "$GIT_SHA" ]; then
-                echo "Health check passed after ${i} attempts (sha=${ACTUAL_SHA})"
-                HEALTHY=1
-                break
-              fi
-              sleep 2
-            done
-            if [ "$HEALTHY" != "1" ]; then
-              echo "Health check failed — expected sha=${GIT_SHA}, last response: ${RESPONSE}"
-              echo "Recent server logs:"
-              pm2 logs server --lines 80 --nostream
+            # Zero-downtime blue-green cutover: start the idle color, health-check
+            # it, atomically swap the Apache upstreams, drain the old color. The
+            # script health-checks the new color on its port and verifies the
+            # public URL reports ${GIT_SHA} before retiring the old one; it exits
+            # non-zero on any failure with the current color still serving.
+            bash scripts/deploy-blue-green.sh || {
+              echo "blue-green deploy failed — recent logs:"
+              pm2 logs --lines 80 --nostream
               exit 1
-            fi
+            }


### PR DESCRIPTION
## What

Replaces the single-color `pm2 startOrRestart` + `:3000` health-check step in `deploy.2anki.net.yml` with `bash scripts/deploy-blue-green.sh`.

## Why

Prod was bootstrapped to the **green** color (`server-green` on `:3001`; Apache HTTP + WebSocket includes point there) via a manual cutover that measured **140/140 200s** across the swap — zero downtime. The old single-color step now conflicts with that state: it would start `server` on `:3000`, health-check `:3000`, report success, while Apache still routes users to `:3001` (stale code) with two processes running duplicate schedulers. The automated deploy must match the blue-green layout.

## How

Each deploy now: reads `~/.deploy_color`, starts the idle color, health-checks it on its port, verifies `https://2anki.net/api/version` reports `${GIT_SHA}`, atomically swaps both Apache upstreams (HTTP + WS), `apachectl graceful`, then drains and deletes the old color. The script exits non-zero on any failure **with the current color still serving**, so a bad build can't take the site down. A failure also dumps `pm2 logs` for debugging.

## Validation

- The cutover mechanism is proven on prod: every `sudo`/`tee`/`mv`/`apachectl graceful` op already ran successfully over non-tty SSH (same context the deploy uses), and the manual green cutover measured 140/140 200s.
- The first automated run (triggered by merging this PR) flips green→blue: starts `server-blue` on the now-free `:3000`, verifies, swaps, drains `server-green`. I'm watching it.
- YAML validated locally.

## Testing

CI/infra change; no Jest surface. The deploy run this PR triggers is the end-to-end test.

## Changelog / user docs

None — CI/deploy pipeline, no user-visible behavior.

## Browser check

Not applicable — no `web/src`, no rendered output.

## Goal alignment

Completes zero-downtime deploys — no more 502s during the ~30 deploys/day. Reliability toward scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782324680&installation_id=132681956&pr_number=2800&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2800&signature=5100ab2297fa8113bdf323bfdf1860127e2f4523bf5cb5d9f9759a4c9b01096c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->