### PR TITLE
fix: per-code copy for malformed_notion, corrupted_apkg, empty_export

### DIFF
--- a/web/src/components/errors/helpers/getErrorMessage.test.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.test.ts
@@ -141,10 +141,31 @@ describe('classifyUploadError', () => {
     expect(result.title).toBe('Something broke.');
   });
 
-  test('malformed_notion falls back to the server message', () => {
+  test('malformed_notion returns specific copy (not the server message)', () => {
     const body: UploadErrorBody = { code: 'malformed_notion', message: 'Notion error.' };
     const result = classifyUploadError(body);
-    expect(result.title).toBe('Notion error.');
+    expect(result.title).toBe("This Notion export couldn't be parsed.");
+  });
+
+  it('malformed_notion returns specific copy about re-exporting from Notion', () => {
+    const body: UploadErrorBody = { code: 'malformed_notion', message: 'raw server text' };
+    const result = classifyUploadError(body);
+    expect(result.title).toBe("This Notion export couldn't be parsed.");
+    expect(result.detail).toBe('Re-export the page from Notion and try again.');
+  });
+
+  it('corrupted_apkg returns specific copy about re-exporting from Anki', () => {
+    const body: UploadErrorBody = { code: 'corrupted_apkg', message: 'raw server text' };
+    const result = classifyUploadError(body);
+    expect(result.title).toBe('This .apkg file is damaged.');
+    expect(result.detail).toBe('Re-export it from Anki, or send it to support@2anki.net.');
+  });
+
+  it('empty_export returns specific copy about checking page content', () => {
+    const body: UploadErrorBody = { code: 'empty_export', message: 'raw server text' };
+    const result = classifyUploadError(body);
+    expect(result.title).toBe("This export has no content we can turn into cards.");
+    expect(result.detail).toBe('Check the page has text or toggle blocks, then export again.');
   });
 
   test('empty message under an unknown code returns the parser-error spec copy', () => {

--- a/web/src/components/errors/helpers/getErrorMessage.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.ts
@@ -145,6 +145,18 @@ const PER_CODE_COPY: Partial<Record<UploadErrorBody['code'], FriendlyError>> = {
     title: "Part of this file has formatting we couldn't read.",
     detail: 'Open the source, remove or simplify the block that broke, and try again.',
   },
+  malformed_notion: {
+    title: "This Notion export couldn't be parsed.",
+    detail: 'Re-export the page from Notion and try again.',
+  },
+  corrupted_apkg: {
+    title: 'This .apkg file is damaged.',
+    detail: 'Re-export it from Anki, or send it to support@2anki.net.',
+  },
+  empty_export: {
+    title: 'This export has no content we can turn into cards.',
+    detail: 'Check the page has text or toggle blocks, then export again.',
+  },
 };
 
 export function classifyUploadError(body: UploadErrorBody): FriendlyError {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-clearer-upload-errors.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-clearer-upload-errors.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-clearer-upload-errors",
+  "date": "2026-05-25",
+  "type": "fix",
+  "title": "Clearer messages when a Notion export, .apkg file, or empty export can't be converted — each says what to do next"
+}


### PR DESCRIPTION
## What

Three `UploadErrorCode` values (`malformed_notion`, `corrupted_apkg`, `empty_export`) were missing from `PER_CODE_COPY` in `classifyUploadError`. They fell through to the raw server message string, which is implementation noise to the user. This adds specific, actionable copy for each.

## Why

Closes #2406. Users hitting a broken Notion export, a damaged .apkg, or an empty file saw whatever the server happened to return — no guidance on what to do. Each code now tells the user exactly what went wrong and what to do next.

## How

Added three entries to `PER_CODE_COPY` in `getErrorMessage.ts`, matching the exact shape (`{ title, detail }`) of the four existing entries. No new abstractions, no new files beyond the changelog entry.

The live render path is `extractErrorMessage` (HTTP response → `UploadErrorBody`) → `classifyUploadError` (code → friendly copy) → `UploadForm.tsx` (renders title + detail). `PER_CODE_COPY` is the right fix location.

## Measuring success

After deploy: trigger a `malformed_notion` upload error (malformed Notion zip) and confirm the UI shows "This Notion export couldn't be parsed. Re-export the page from Notion and try again." instead of a raw server string.

## Testing

- Unit tests updated: `getErrorMessage.test.ts`
  - Updated existing `malformed_notion` test to assert the corrected behavior (it was asserting the bug)
  - Added 3 new `it()` cases — one per new code — verifying title and detail copy
  - All 27 tests pass

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes:

## Changelog

"Clearer messages when a Notion export, .apkg file, or empty export can't be converted — each says what to do next"

## Risks

Low. Only adds entries to a lookup dict; no existing code paths change. The `unknown` and other existing codes are unaffected.

## Goal alignment

Reduces friction for users who hit conversion errors — clearer copy means fewer support emails and fewer users giving up before finding the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782326039&installation_id=132681956&pr_number=2802&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2802&signature=953363fd5ab9694a9791994be7e0abb61d1196004b69fc45e7955d4bd1976ed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
