### PR TITLE
ci: build and serve the web app on Netlify deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,20 @@
   publish = "deploy/netlify-redirect"
   command = "echo 'redirect-only site; no build'"
 
-[[redirects]]
+# Production stays a redirect-only mirror — bounce everything to the real app.
+[[context.production.redirects]]
   from = "/*"
   to = "https://2anki.net/:splat"
   status = 301
   force = true
+
+# Deploy previews and branch deploys build and serve the real web app, so the
+# frontend can be tested on a Netlify URL. Production is unaffected: its publish
+# dir still meta-refreshes to 2anki.net even without the redirect rule above.
+[context.deploy-preview]
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter 2anki-web build"
+  publish = "web/build"
+
+[context.branch-deploy]
+  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter 2anki-web build"
+  publish = "web/build"

--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,3 +1,3 @@
-/*   /index.html   200
 /api/*  https://2anki.net/:splat  200
 /tm https://templates.2anki.net 200
+/*   /index.html   200


### PR DESCRIPTION
## Why

The `notion2anki` Netlify site is a **redirect-only mirror** — it publishes a meta-refresh stub (`deploy/netlify-redirect/`) and force-301s every path to `https://2anki.net`. That redirect fires on *all* contexts, so deploy previews bounce straight to production and the frontend can't be tested on a Netlify URL.

## What changed

- **Scope the force-redirect to the production context** (`[[context.production.redirects]]`) instead of globally.
- **Deploy previews + branch deploys now build the real app** (`pnpm --filter 2anki-web build`) and publish `web/build`.
- **Reordered `web/public/_redirects`** so the `/api/*` proxy and `/tm` rule precede the SPA catch-all (Netlify is first-match-wins; the `/*` line was shadowing them — harmless until now because `web/build` was never published).

## Safety

Production is unaffected either way: its publish dir still meta-refreshes to 2anki.net even if Netlify doesn't honor the context-scoped redirect. The only new behavior is that previews build the app.

## Validation

I **can't verify Netlify's build behavior without deploying**, so the gate is **this PR's own deploy preview**: confirm it builds `web/build` and serves the app (not the redirect stub) before merging. Once merged, the wave preview branches (#2796/#2798/#2799) rebase on main to get testable previews.

No changelog entry — deploy/build tooling, no user-visible app change. No browser-check gate — no `web/src/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782326586&installation_id=132681956&pr_number=2804&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2804&signature=86d21adb6c7ca6a4f9ba5f70de3ea7bc0c97eb2156508f5eb1048592c75058e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->