### PR TITLE
feat: structured monthly-limit payload + ConversionResult component

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -15,7 +15,15 @@ jest.mock('../../../../usecases/jobs/NotifyUserUseCase');
 jest.mock('../../../../data_layer/JobRepository');
 jest.mock('../../../../data_layer/UsersRepository');
 jest.mock('../../../../data_layer/NotionRespository');
-jest.mock('../../../../usecases/users/CheckMonthlyCardLimitUseCase');
+jest.mock('../../../../usecases/users/CheckMonthlyCardLimitUseCase', () => {
+  const actual = jest.requireActual<typeof import('../../../../usecases/users/CheckMonthlyCardLimitUseCase')>(
+    '../../../../usecases/users/CheckMonthlyCardLimitUseCase'
+  );
+  return {
+    ...actual,
+    CheckMonthlyCardLimitUseCase: jest.fn(),
+  };
+});
 jest.mock('../../../../services/events/track', () => ({ track: jest.fn() }));
 
 import { APIResponseError, APIErrorCode } from '@notionhq/client';
@@ -26,6 +34,10 @@ import { CreateJobWorkSpaceUseCase } from '../../../../usecases/jobs/CreateJobWo
 import { SetJobFailedUseCase } from '../../../../usecases/jobs/SetJobFailedUseCase';
 import { CreateFlashcardsForJobUseCase } from '../../../../usecases/jobs/CreateFlashcardsForJobUseCase';
 import { NOTION_TOKEN_EXPIRED_REASON } from '../../../../usecases/jobs/jobFailureReason';
+import {
+  CheckMonthlyCardLimitUseCase,
+  MonthlyLimitError,
+} from '../../../../usecases/users/CheckMonthlyCardLimitUseCase';
 
 function makeUnauthorizedError(): APIResponseError {
   const err = Object.create(APIResponseError.prototype) as APIResponseError;
@@ -144,5 +156,38 @@ describe('performConversion — heavy pipeline', () => {
     await performConversion(mockDatabase, baseRequest);
 
     expect(markTokenInvalidMock).not.toHaveBeenCalled();
+  });
+
+  it('stores structured JSON with code monthly_limit when MonthlyLimitError is thrown', async () => {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: {},
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [1, 2, 3] }]),
+    }));
+    const limitError = new MonthlyLimitError(80, 100, 3, '2026-07-01T00:00:00.000Z');
+    (CheckMonthlyCardLimitUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(limitError),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(setJobFailedExecute).toHaveBeenCalledWith(
+      baseRequest.id,
+      baseRequest.owner,
+      expect.stringContaining('"code":"monthly_limit"')
+    );
+    const payload = JSON.parse(setJobFailedExecute.mock.calls[0][2] as string);
+    expect(payload).toMatchObject({
+      code: 'monthly_limit',
+      cards_used: 80,
+      limit: 100,
+    });
   });
 });

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -110,7 +110,13 @@ export default async function performConversion(
     } catch (error) {
       if (error instanceof MonthlyLimitError) {
         const setJobFailed = new SetJobFailedUseCase(jobRepository);
-        await setJobFailed.execute(id, owner, error.message);
+        const payload = JSON.stringify({
+          code: 'monthly_limit',
+          cards_used: error.cards_used,
+          limit: error.limit,
+          reset_on: error.reset_on,
+        });
+        await setJobFailed.execute(id, owner, payload);
         return;
       }
       throw error;

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -461,7 +461,7 @@ describe('DownloadsPage failure reason panel', () => {
     expect(screen.queryByText(/Your page title has a "\/" in it/)).not.toBeInTheDocument();
   });
 
-  it('shows Learn more link for empty deck errors', () => {
+  it('renders failure panel content for empty deck errors', () => {
     mockJobs = [
       buildJob({
         status: 'failed',
@@ -473,9 +473,7 @@ describe('DownloadsPage failure reason panel', () => {
     const statusButton = screen.getByRole('button', { name: /Show failure reason/i });
     fireEvent.click(statusButton);
 
-    const learnMoreLink = screen.getByText(/Learn more/);
-    expect(learnMoreLink).toBeInTheDocument();
-    expect(learnMoreLink).toHaveAttribute('href', '/documentation/help/common-problems');
+    expect(screen.queryByText(/Learn more/)).not.toBeInTheDocument();
   });
 
   it('does not show Learn more link for non-empty-deck errors', () => {

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -117,7 +117,6 @@ export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
         <ConversionResult
           variant="success"
           title={j.title}
-          cardCount={0}
           downloadKey={j.download_key}
           onDownload={() => { onDownload?.(); }}
         />

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -30,6 +30,8 @@ import { UpsellCard } from '../../components/UpsellCard';
 import JobResponse from '../../schemas/public/JobResponse';
 import { NotionColumnMappingModal } from '../../components/NotionColumnMappingModal/NotionColumnMappingModal';
 import { parseAmbiguousColumnsPayload, type FieldMapping } from '../../lib/fieldMapping/types';
+import { ConversionResult } from './components/ConversionResult/ConversionResult';
+import { parseMonthlyLimitPayload } from './components/ConversionResult/parseMonthlyLimitPayload';
 import styles from './DownloadsPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 
@@ -112,15 +114,13 @@ export function renderJobStatusCell(j: JobResponse, onDownload?: () => void) {
     }
     if (j.download_key != null) {
       return (
-        <a
-          href={`/api/download/u/${j.download_key}`}
-          className={styles.downloadAction}
-          aria-label={`Download ${j.title}`}
-          title="Download"
-          onClick={() => { onDownload?.(); fireAnalyticsEvent('deck_downloaded'); track('deck_downloaded'); }}
-        >
-          <DownloadIcon width={16} height={16} />
-        </a>
+        <ConversionResult
+          variant="success"
+          title={j.title}
+          cardCount={0}
+          downloadKey={j.download_key}
+          onDownload={() => { onDownload?.(); }}
+        />
       );
     }
     return null;
@@ -164,51 +164,29 @@ function isNotionTokenExpired(source: DeckRow['source'], reason: string | null):
 function renderFailurePanelContent(
   source: DeckRow['source'],
   reason: string,
-  onMapColumns: () => void
+  onMapColumns: () => void,
+  email?: string
 ): ReactNode {
-  if (isNotionTokenExpired(source, reason)) {
+  const monthlyLimit = parseMonthlyLimitPayload(reason);
+  if (monthlyLimit != null) {
     return (
-      <div>
-        <p>Notion connection expired. Reconnect to keep converting pages.</p>
-        <a href="/notion" className={sharedStyles.btnPrimary}>
-          Reconnect Notion
-        </a>
-      </div>
-    );
-  }
-  if (parseAmbiguousColumnsPayload(reason) != null) {
-    return (
-      <div>
-        <p>
-          This database has more than two columns. Pick which column should be the front and back of each card.
-        </p>
-        <button
-          type="button"
-          className={sharedStyles.btnPrimary}
-          onClick={onMapColumns}
-        >
-          Map columns
-        </button>
-      </div>
+      <ConversionResult
+        variant="paywalled"
+        title={null}
+        limit={monthlyLimit.limit}
+        email={email}
+      />
     );
   }
   return (
-    <>
-      {reason}
-      {isEmptyDeckError(reason) && (
-        <div>
-          <Link to="/documentation/help/common-problems" className={styles.failureLearnMore}>
-            Learn more →
-          </Link>
-        </div>
-      )}
-    </>
+    <ConversionResult
+      variant="failed"
+      title={null}
+      failureReason={reason}
+      source={source === 'dropbox' || source === 'drive' ? 'upload' : source}
+      onMapColumns={onMapColumns}
+    />
   );
-}
-
-function isEmptyDeckError(message: string | null): boolean {
-  if (message == null) return false;
-  return message.includes('No cards in this deck yet');
 }
 
 function formatUpdatedLabel(lastFetchedAt: Date | null): string {
@@ -491,7 +469,8 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                     {renderFailurePanelContent(
                                       row.source,
                                       row.job.job_reason_failure,
-                                      () => setMappingModalJob(row.job)
+                                      () => setMappingModalJob(row.job),
+                                      data?.user?.email ?? undefined
                                     )}
                                   </td>
                                 </tr>

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.module.css
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.module.css
@@ -1,0 +1,68 @@
+.success {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.deckName {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
+.cardCount {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.cardCountNumber {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.cardCountLabel {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.helperText {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.paywalled {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.paywallHeadline {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.paywallBody {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.paywallActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.seeAllPlans {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.seeAllPlans:hover {
+  color: var(--color-text-primary);
+}

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { ConversionResult } from './ConversionResult';
+import { parseMonthlyLimitPayload } from './parseMonthlyLimitPayload';
+
+vi.mock('../../../../lib/analytics/track', () => ({ track: vi.fn() }));
+vi.mock('../../../../lib/analytics/fireAnalyticsEvent', () => ({
+  fireAnalyticsEvent: vi.fn(),
+}));
+
+vi.mock('../../hooks/useJobs', () => ({ default: vi.fn() }));
+
+describe('parseMonthlyLimitPayload', () => {
+  it('parses valid JSON with code monthly_limit', () => {
+    const json = JSON.stringify({
+      code: 'monthly_limit',
+      cards_used: 80,
+      limit: 100,
+      reset_on: '2026-07-01T00:00:00.000Z',
+    });
+    expect(parseMonthlyLimitPayload(json)).toMatchObject({
+      code: 'monthly_limit',
+      cards_used: 80,
+      limit: 100,
+    });
+  });
+
+  it('returns null for plain text (old job format)', () => {
+    expect(parseMonthlyLimitPayload('Monthly card limit reached')).toBeNull();
+  });
+
+  it('returns null for JSON with wrong code', () => {
+    expect(parseMonthlyLimitPayload(JSON.stringify({ code: 'other' }))).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    expect(parseMonthlyLimitPayload(null)).toBeNull();
+  });
+});
+
+describe('ConversionResult — success variant', () => {
+  it('renders deck name, card count, and Download deck button', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="success"
+          title="Biology Chapter 4"
+          cardCount={42}
+          downloadKey="bio-ch4.apkg"
+          onDownload={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Biology Chapter 4')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Download Biology Chapter 4/ })).toBeInTheDocument();
+  });
+
+  it('truncates deck name at 40 chars and keeps full name in title attribute', () => {
+    const longName = 'A'.repeat(50);
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="success"
+          title={longName}
+          cardCount={10}
+          downloadKey="deck.apkg"
+          onDownload={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const nameEl = screen.getByTitle(longName);
+    expect(nameEl.textContent).toBe(`${'A'.repeat(40)}…`);
+  });
+
+  it('shows Ready to download helper text', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="success"
+          title="My deck"
+          cardCount={5}
+          downloadKey="deck.apkg"
+          onDownload={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Ready to download.')).toBeInTheDocument();
+  });
+});
+
+describe('ConversionResult — paywalled variant', () => {
+  it('shows Your monthly limit headline with the actual limit value from the payload', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="paywalled"
+          title="Big deck"
+          limit={100}
+          email="user@example.com"
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Your monthly limit: 100 cards')).toBeInTheDocument();
+  });
+
+  it('renders Upgrade to Unlimited CTA with ref=downloads-paywall', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="paywalled"
+          title="Big deck"
+          limit={100}
+          email="user@example.com"
+        />
+      </MemoryRouter>
+    );
+
+    const cta = screen.getByRole('link', { name: 'Upgrade to Unlimited' });
+    expect(cta.getAttribute('href')).toContain('ref=downloads-paywall');
+  });
+
+  it('renders See all plans link pointing to /pricing', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="paywalled"
+          title="Big deck"
+          limit={100}
+          email="user@example.com"
+        />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: 'See all plans' });
+    expect(link.getAttribute('href')).toBe('/pricing');
+  });
+});
+
+describe('ConversionResult — failed variant', () => {
+  it('renders the error message from classifyUploadError', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="failed"
+          title="Bad deck"
+          failureReason="too_large: file exceeds limit"
+          source="upload"
+          onMapColumns={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('link', { name: 'Upgrade to Unlimited' })).toBeNull();
+  });
+
+  it('renders notion token expired reconnect link when source is notion and reason is notion_token_expired', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="failed"
+          title="Notion page"
+          failureReason="notion_token_expired"
+          source="notion"
+          onMapColumns={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: 'Reconnect Notion' })).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -92,6 +92,24 @@ describe('ConversionResult — success variant', () => {
 
     expect(screen.getByText('Ready to download.')).toBeInTheDocument();
   });
+
+  it('omits the card count when it is unknown rather than showing 0', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="success"
+          title="My deck"
+          downloadKey="deck.apkg"
+          onDownload={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('My deck')).toBeInTheDocument();
+    expect(screen.getByText('Ready to download.')).toBeInTheDocument();
+    expect(screen.queryByText('cards')).not.toBeInTheDocument();
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
 });
 
 describe('ConversionResult — paywalled variant', () => {

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -1,0 +1,177 @@
+import { type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { classifyUploadError } from '../../../../components/errors/helpers/getErrorMessage';
+import { parseAmbiguousColumnsPayload } from '../../../../lib/fieldMapping/types';
+import { getSubscribeLink } from '../../../PricingPage/payment.links';
+import { fireAnalyticsEvent } from '../../../../lib/analytics/fireAnalyticsEvent';
+import { track } from '../../../../lib/analytics/track';
+import type { UploadErrorBody } from '../../../../types/UploadErrorBody';
+import sharedStyles from '../../../../styles/shared.module.css';
+import styles from './ConversionResult.module.css';
+
+type Source = 'notion' | 'upload' | 'dropbox' | 'drive';
+
+const NOTION_TOKEN_EXPIRED_REASON = 'notion_token_expired';
+
+interface SuccessProps {
+  variant: 'success';
+  title: string | null;
+  cardCount: number;
+  downloadKey: string;
+  onDownload: () => void;
+}
+
+interface ProcessingProps {
+  variant: 'processing';
+  children: ReactNode;
+}
+
+interface PaywalledProps {
+  variant: 'paywalled';
+  title: string | null;
+  limit: number;
+  email?: string;
+}
+
+interface FailedProps {
+  variant: 'failed';
+  title: string | null;
+  failureReason: string;
+  source: Source;
+  onMapColumns: () => void;
+}
+
+type ConversionResultProps =
+  | SuccessProps
+  | ProcessingProps
+  | PaywalledProps
+  | FailedProps;
+
+function truncateTitle(title: string): { display: string; full: string } {
+  if (title.length <= 40) return { display: title, full: title };
+  return { display: `${title.slice(0, 40)}…`, full: title };
+}
+
+function SuccessVariant({ title, cardCount, downloadKey, onDownload }: Omit<SuccessProps, 'variant'>) {
+  const resolvedTitle = title ?? 'Untitled deck';
+  const { display, full } = truncateTitle(resolvedTitle);
+
+  return (
+    <div className={styles.success}>
+      <span className={styles.deckName} title={full}>
+        {display}
+      </span>
+      <span className={styles.cardCount}>
+        <span className={styles.cardCountNumber}>{cardCount}</span>
+        {' '}
+        <span className={styles.cardCountLabel}>cards</span>
+      </span>
+      <span className={styles.helperText}>Ready to download.</span>
+      <a
+        href={`/api/download/u/${downloadKey}`}
+        className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+        aria-label={`Download ${full}`}
+        onClick={() => {
+          onDownload();
+          fireAnalyticsEvent('deck_downloaded');
+          track('deck_downloaded');
+        }}
+      >
+        Download deck
+      </a>
+    </div>
+  );
+}
+
+function PaywalledVariant({ limit, email }: Omit<PaywalledProps, 'variant' | 'title'>) {
+  const upgradeHref = `${getSubscribeLink(email)}&ref=downloads-paywall`;
+
+  return (
+    <div className={styles.paywalled}>
+      <p className={styles.paywallHeadline}>Your monthly limit: {limit} cards</p>
+      <p className={styles.paywallBody}>
+        This conversion didn&apos;t finish. Upgrade to keep converting — no cap, no wait.
+      </p>
+      <div className={styles.paywallActions}>
+        <a href={upgradeHref} className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}>
+          Upgrade to Unlimited
+        </a>
+        <Link to="/pricing" className={styles.seeAllPlans}>
+          See all plans
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function FailedVariant({ failureReason, source, onMapColumns }: Omit<FailedProps, 'variant' | 'title'>) {
+  if (source === 'notion' && failureReason === NOTION_TOKEN_EXPIRED_REASON) {
+    return (
+      <div>
+        <p>Notion connection expired. Reconnect to keep converting pages.</p>
+        <a href="/notion" className={sharedStyles.btnPrimary}>
+          Reconnect Notion
+        </a>
+      </div>
+    );
+  }
+
+  if (parseAmbiguousColumnsPayload(failureReason) != null) {
+    return (
+      <div>
+        <p>
+          This database has more than two columns. Pick which column should be the front and back of each card.
+        </p>
+        <button
+          type="button"
+          className={sharedStyles.btnPrimary}
+          onClick={onMapColumns}
+        >
+          Map columns
+        </button>
+      </div>
+    );
+  }
+
+  const errorBody: UploadErrorBody = { code: 'unknown', message: failureReason };
+  const friendly = classifyUploadError(errorBody);
+  return (
+    <p>
+      {friendly.detail ? `${friendly.title} ${friendly.detail}` : friendly.title}
+    </p>
+  );
+}
+
+export function ConversionResult(props: Readonly<ConversionResultProps>) {
+  if (props.variant === 'processing') {
+    return <>{props.children}</>;
+  }
+
+  if (props.variant === 'success') {
+    return (
+      <SuccessVariant
+        title={props.title}
+        cardCount={props.cardCount}
+        downloadKey={props.downloadKey}
+        onDownload={props.onDownload}
+      />
+    );
+  }
+
+  if (props.variant === 'paywalled') {
+    return (
+      <PaywalledVariant
+        limit={props.limit}
+        email={props.email}
+      />
+    );
+  }
+
+  return (
+    <FailedVariant
+      failureReason={props.failureReason}
+      source={props.source}
+      onMapColumns={props.onMapColumns}
+    />
+  );
+}

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -16,7 +16,7 @@ const NOTION_TOKEN_EXPIRED_REASON = 'notion_token_expired';
 interface SuccessProps {
   variant: 'success';
   title: string | null;
-  cardCount: number;
+  cardCount?: number;
   downloadKey: string;
   onDownload: () => void;
 }
@@ -61,11 +61,13 @@ function SuccessVariant({ title, cardCount, downloadKey, onDownload }: Omit<Succ
       <span className={styles.deckName} title={full}>
         {display}
       </span>
-      <span className={styles.cardCount}>
-        <span className={styles.cardCountNumber}>{cardCount}</span>
-        {' '}
-        <span className={styles.cardCountLabel}>cards</span>
-      </span>
+      {cardCount != null && cardCount > 0 && (
+        <span className={styles.cardCount}>
+          <span className={styles.cardCountNumber}>{cardCount}</span>
+          {' '}
+          <span className={styles.cardCountLabel}>cards</span>
+        </span>
+      )}
       <span className={styles.helperText}>Ready to download.</span>
       <a
         href={`/api/download/u/${downloadKey}`}

--- a/web/src/pages/DownloadsPage/components/ConversionResult/parseMonthlyLimitPayload.ts
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/parseMonthlyLimitPayload.ts
@@ -1,0 +1,34 @@
+export interface MonthlyLimitPayload {
+  code: 'monthly_limit';
+  cards_used: number;
+  limit: number;
+  reset_on?: string;
+}
+
+export function parseMonthlyLimitPayload(
+  jobReasonFailure: string | null
+): MonthlyLimitPayload | null {
+  if (jobReasonFailure == null) return null;
+  try {
+    const parsed = JSON.parse(jobReasonFailure) as unknown;
+    if (
+      typeof parsed !== 'object' ||
+      parsed == null ||
+      (parsed as Record<string, unknown>).code !== 'monthly_limit'
+    ) {
+      return null;
+    }
+    const p = parsed as Record<string, unknown>;
+    if (typeof p.cards_used !== 'number' || typeof p.limit !== 'number') {
+      return null;
+    }
+    return {
+      code: 'monthly_limit',
+      cards_used: p.cards_used,
+      limit: p.limit,
+      reset_on: typeof p.reset_on === 'string' ? p.reset_on : undefined,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-monthly-limit-upgrade-prompt.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-monthly-limit-upgrade-prompt.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-monthly-limit-upgrade-prompt",
+  "date": "2026-05-25",
+  "type": "feature",
+  "title": "Hitting your monthly card limit on a conversion now shows an upgrade option instead of a raw error"
+}


### PR DESCRIPTION
## What
Closes #960 and #2278. Two coupled changes in one PR: (1) when a job fails due to the monthly card limit, the server now stores a structured JSON payload instead of a plain error string; (2) the downloads page replaces ad-hoc failure rendering with a unified `ConversionResult` component that shows an upgrade panel for the paywall case and contextual copy for other failures.

## Why
Previously, hitting the monthly limit showed a raw error message. Users had no path to upgrade from within the downloads page. This PR surfaces the upgrade option exactly where the user experiences the block.

## How
**Server (`performConversion.ts`):** The `MonthlyLimitError` catch block now calls `JSON.stringify({ code: 'monthly_limit', cards_used, limit, reset_on })` and stores that as `job_reason_failure`. Backward-compat: old jobs with plain-text failure reasons still work because the web-side parser falls back gracefully.

**Web (`ConversionResult`):** One component, four layout variants via a `variant` discriminant:
- `success`: deck name (truncated at 40 chars), card count, "Ready to download.", labeled Download deck button
- `processing`: passthrough for the existing step indicator
- `paywalled`: parsed from `monthly_limit` JSON; shows `Your monthly limit: {N} cards` (N from actual payload), Upgrade to Unlimited CTA (ref=downloads-paywall), See all plans link  
- `failed`: notion token expired → Reconnect Notion; ambiguous columns → Map columns; everything else → `classifyUploadError` fallback

`parseMonthlyLimitPayload` mirrors `parseAmbiguousColumnsPayload`: try JSON.parse, validate `code === 'monthly_limit'`, return null for old plain-text jobs.

## Measuring success
In production: jobs with `job_reason_failure` containing `"code":"monthly_limit"` render the upgrade panel. Confirm with:
```sql
SELECT job_reason_failure FROM jobs WHERE job_reason_failure LIKE '%monthly_limit%' LIMIT 5;
```
Also: `paywall_upgrade_clicked` events with `ref=downloads-paywall` in the analytics dashboard.

## Testing
- Server: `performConversion.test.ts` — asserts `SetJobFailedUseCase.execute` receives JSON containing `code: 'monthly_limit'` (6 tests, all pass)
- Web: `ConversionResult.test.tsx` — 12 tests covering all 4 variants + `parseMonthlyLimitPayload` (JSON, plain text, null, wrong code inputs)
- `DownloadsPage.test.tsx` — updated 1 test whose contract changed (empty deck errors no longer show Learn more link; defers to `classifyUploadError`); all 31 pass

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Touches `web/src/` — Alexander verifies before merge.

## Changelog
"Hitting your monthly card limit on a conversion now shows an upgrade option instead of a raw error" — `2026-05-25-monthly-limit-upgrade-prompt.json`

## Risks
- Old jobs with plain-text `job_reason_failure` continue to render in the `failed` variant via fallback — no regression.
- The card count in the `success` variant is passed as `0` in the existing `renderJobStatusCell` integration (the DB doesn't return card count on the job row). This is a known gap: the success card count field exists on the component but is not populated from the API yet. The deck name and download link are correct.

## Goal alignment
Direct path: users who hit the limit see an upgrade CTA instead of a confusing error. Reduces churn at the paywall moment; supports the 300K-user growth goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782326610&installation_id=132681956&pr_number=2805&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2805&signature=35080a3e1c2f953bc23ec8e46f77c82228cdd8ca71820094218c8c37e42e602c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
