### PR TITLE
fix: allow Google AdSense ad-quality (SODAR) domain in CSP

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,7 +25,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="Content-Security-Policy"
-    content="script-src 'self' 'unsafe-inline' https://*.digitaloceanspaces.com https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com https://www.youtube.com https://www.youtube-nocookie.com; img-src 'self' data: blob: https:;">
+    content="script-src 'self' 'unsafe-inline' https://*.digitaloceanspaces.com https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com https://*.adtrafficquality.google; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com https://www.youtube.com https://www.youtube-nocookie.com https://*.adtrafficquality.google; img-src 'self' data: blob: https:;">
   <link rel="apple-touch-icon" href="/logo192.png" />
   <!--
       Notice the use of  in the tags above.


### PR DESCRIPTION
## Problem

The browser console showed:
> Loading the script `https://ep2.adtrafficquality.google/sodar/sodar2.js` violates … `script-src` … The action has been blocked.

That's AdSense's ad-traffic-quality (SODAR) script. Our CSP already allows the core AdSense domains (`pagead2.googlesyndication.com`, `*.googlesyndication.com`, `*.doubleclick.net`) but not `*.adtrafficquality.google`, so the fraud/quality script — and its verification frame — were blocked.

## Fix

Add `https://*.adtrafficquality.google` to `script-src` (the `sodar2.js` load) and `frame-src` (its verification iframe) in the `web/index.html` CSP meta. It's a Google-owned domain that completes the existing AdSense allowlist — no new third-party origin class.

## Not fixed (intentionally)

The other console errors — `Framing 'https://app.netlify.com/'` and the `app.netlify.com/cdp/` load — come from **Netlify's deploy-preview overlay**, which only runs on Netlify previews, not on production (Express-served `2anki.net`). I did **not** add `app.netlify.com` to the CSP: it would loosen the prod policy purely to silence a preview-only widget.

## Notes

- No changelog entry — no user-visible behavior change (affects ad-quality script loading, not the app UI).
- CSP errors only surface in a live browser (CI is silent on CSP), so confirm on this PR's deploy preview that `sodar2.js` no longer reports a CSP violation.
- Security: this only widens CSP by one Google AdSense domain; happy to run `/security-review` before merge if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782331156&installation_id=132681956&pr_number=2808&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2808&signature=d8922102be9407bde8f2277ba924d1395d2f1039b37f869984fd775a9e3b9637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->