### PR TITLE
fix: fail empty conversions on the async path with a clear reason

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -33,7 +33,10 @@ import NotionRepository from '../../../../data_layer/NotionRespository';
 import { CreateJobWorkSpaceUseCase } from '../../../../usecases/jobs/CreateJobWorkSpaceUseCase';
 import { SetJobFailedUseCase } from '../../../../usecases/jobs/SetJobFailedUseCase';
 import { CreateFlashcardsForJobUseCase } from '../../../../usecases/jobs/CreateFlashcardsForJobUseCase';
-import { NOTION_TOKEN_EXPIRED_REASON } from '../../../../usecases/jobs/jobFailureReason';
+import {
+  NOTION_TOKEN_EXPIRED_REASON,
+  EMPTY_DECK_FAILURE_REASON,
+} from '../../../../usecases/jobs/jobFailureReason';
 import {
   CheckMonthlyCardLimitUseCase,
   MonthlyLimitError,
@@ -189,5 +192,28 @@ describe('performConversion — heavy pipeline', () => {
       cards_used: 80,
       limit: 100,
     });
+  });
+
+  it('marks job as failed with the empty-deck reason when decks have zero cards', async () => {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: {},
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [] }]),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(setJobFailedExecute).toHaveBeenCalledWith(
+      baseRequest.id,
+      baseRequest.owner,
+      EMPTY_DECK_FAILURE_REASON
+    );
   });
 });

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -17,6 +17,7 @@ import { BuildDeckForJobUseCase } from '../../../../usecases/jobs/BuildDeckForJo
 import { CompleteJobUseCase } from '../../../../usecases/jobs/CompleteJobUseCase';
 import { NotifyUserUseCase } from '../../../../usecases/jobs/NotifyUserUseCase';
 import {
+  EMPTY_DECK_FAILURE_REASON,
   isNotionUnauthorizedError,
   jobFailureReasonFromError,
 } from '../../../../usecases/jobs/jobFailureReason';
@@ -100,6 +101,12 @@ export default async function performConversion(
     }
 
     const cardCount = decks.reduce((acc, d) => acc + d.cards.length, 0);
+    if (cardCount === 0) {
+      const setJobFailed = new SetJobFailedUseCase(jobRepository);
+      await setJobFailed.execute(id, owner, EMPTY_DECK_FAILURE_REASON);
+      return;
+    }
+
     const checkMonthlyLimit = new CheckMonthlyCardLimitUseCase(usersRepository);
     try {
       await checkMonthlyLimit.execute({

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-empty-deck-guidance.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-empty-deck-guidance.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-empty-deck-guidance",
+  "date": "2026-05-25",
+  "type": "fix",
+  "title": "Uploads that produce no cards now explain why and how to fix it"
+}


### PR DESCRIPTION
## Problem

Diagnosed from prod: two real Notion **Markdown** uploads finished as **empty decks, silently**. Notion's Markdown export flattens toggles (the card primitive), and the markdown heuristics miss prose/bold-line pages → 0 cards. The **sync** upload path already surfaces this (`EmptyDeckError` → 400 `empty_export` with guidance), but the **async job path** (`performConversion`) never detected 0 cards — it built and delivered an empty `.apkg` and marked the job complete, with no explanation.

## Fix

Guard `performConversion`: right after the total `cardCount` is computed, if it's `0`, fail the job with the **existing** `EMPTY_DECK_FAILURE_REASON` ("No cards in this deck yet. 2anki turns Notion toggle blocks into flashcards… Wrap your key terms in toggles, then convert again") instead of building/notifying/completing. The frontend already renders that reason via `ConversionResult` on the Downloads page — no frontend change needed.

Server-only, reuses the existing message constant (no new copy, consistent with the `EmptyDeckError` path). Partial conversions (a zip where some decks have cards) are unaffected — the guard only fires when the **total** across all decks is 0.

## Tests

Extended `performConversion.test.ts`: a conversion whose decks total 0 cards marks the job failed with `EMPTY_DECK_FAILURE_REASON` (7/7 pass). `tsc` clean.

## Changelog

Added — user-visible: empty uploads now explain why instead of returning a silent empty deck.

Browser check: not applicable — server-side guard; the only `web/src/` file is the changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782332095&installation_id=132681956&pr_number=2810&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2810&signature=453229b3513b2947bc42f17e929f339fb4072355916699b786a0b9f17c023990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->