### PR TITLE
feat: email lapsed trial users with a count-aware upgrade nudge

### DIFF
--- a/migrations/20260527000000_trial_ended_emails.js
+++ b/migrations/20260527000000_trial_ended_emails.js
@@ -1,0 +1,14 @@
+exports.up = (knex) =>
+  knex.schema.createTable('trial_ended_emails', (table) => {
+    table.increments('id').primary();
+    table.integer('user_id').references('id').inTable('users').notNullable();
+    table.string('token', 128).notNullable().unique();
+    table
+      .timestamp('sent_at', { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+    table.index(['user_id']);
+  });
+
+exports.down = (knex) =>
+  knex.schema.dropTableIfExists('trial_ended_emails');

--- a/src/data_layer/TrialEndedEmailRepository.test.ts
+++ b/src/data_layer/TrialEndedEmailRepository.test.ts
@@ -1,0 +1,87 @@
+import { InMemoryTrialEndedEmailRepository } from './TrialEndedEmailRepository';
+
+describe('InMemoryTrialEndedEmailRepository', () => {
+  let repo: InMemoryTrialEndedEmailRepository;
+
+  beforeEach(() => {
+    repo = new InMemoryTrialEndedEmailRepository();
+  });
+
+  describe('getUsersToNotify', () => {
+    it('returns seeded users that have not been emailed', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt: new Date('2026-05-25T10:00:00Z') },
+        { id: 2, name: 'Bob', email: 'bob@example.com', trialStartedAt: new Date('2026-05-25T11:00:00Z') },
+      ]);
+
+      const users = await repo.getUsersToNotify();
+
+      expect(users).toEqual([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt: new Date('2026-05-25T10:00:00Z') },
+        { id: 2, name: 'Bob', email: 'bob@example.com', trialStartedAt: new Date('2026-05-25T11:00:00Z') },
+      ]);
+    });
+
+    it('excludes a user once a send has been recorded', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt: new Date('2026-05-25T10:00:00Z') },
+      ]);
+      await repo.recordSend(1, 'token-1');
+
+      const users = await repo.getUsersToNotify();
+
+      expect(users).toEqual([]);
+    });
+
+    it('caps the result at the given limit', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'A', email: 'a@example.com', trialStartedAt: new Date() },
+        { id: 2, name: 'B', email: 'b@example.com', trialStartedAt: new Date() },
+        { id: 3, name: 'C', email: 'c@example.com', trialStartedAt: new Date() },
+      ]);
+
+      const users = await repo.getUsersToNotify(2);
+
+      expect(users.map((u) => u.id)).toEqual([1, 2]);
+    });
+  });
+
+  describe('countDecksInTrialWindow', () => {
+    it('returns the seeded count for a user', async () => {
+      repo.seedDeckCount(7, 3);
+
+      const count = await repo.countDecksInTrialWindow(7);
+
+      expect(count).toBe(3);
+    });
+
+    it('returns 0 when no count is seeded', async () => {
+      const count = await repo.countDecksInTrialWindow(99);
+
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('recordSend and findByToken', () => {
+    it('resolves a recorded token to its user', async () => {
+      await repo.recordSend(42, 'token-42');
+
+      const result = await repo.findByToken('token-42');
+
+      expect(result).toEqual({ id: 1, userId: 42 });
+    });
+
+    it('returns null for an unknown token', async () => {
+      const result = await repo.findByToken('missing');
+
+      expect(result).toBeNull();
+    });
+
+    it('tracks every recorded user id', async () => {
+      await repo.recordSend(1, 't1');
+      await repo.recordSend(2, 't2');
+
+      expect(repo.getSentUserIds()).toEqual(new Set([1, 2]));
+    });
+  });
+});

--- a/src/data_layer/TrialEndedEmailRepository.ts
+++ b/src/data_layer/TrialEndedEmailRepository.ts
@@ -1,0 +1,147 @@
+import type { Knex } from 'knex';
+import { TRIAL_DURATION_MS } from '../lib/User/trialAccess';
+
+const LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface TrialLapsedUser {
+  id: number;
+  name: string;
+  email: string;
+  trialStartedAt: Date;
+}
+
+export interface ITrialEndedEmailRepository {
+  getUsersToNotify(limit?: number, now?: Date): Promise<TrialLapsedUser[]>;
+  countDecksInTrialWindow(userId: number, trialStartedAt: Date): Promise<number>;
+  recordSend(userId: number, token: string): Promise<void>;
+  findByToken(token: string): Promise<{ id: number; userId: number } | null>;
+}
+
+interface UserRow {
+  id: number;
+  name: string;
+  email: string;
+  trial_started_at: Date;
+}
+
+interface TrialEndedEmailRow {
+  id: number;
+  user_id: number;
+}
+
+export class TrialEndedEmailRepository implements ITrialEndedEmailRepository {
+  private readonly table = 'trial_ended_emails';
+
+  constructor(private readonly database: Knex) {}
+
+  async getUsersToNotify(limit = 500, now = new Date()): Promise<TrialLapsedUser[]> {
+    const lapsedBefore = new Date(now.getTime() - TRIAL_DURATION_MS);
+    const lookbackAfter = new Date(now.getTime() - LOOKBACK_MS);
+
+    const rows = await this.database<UserRow>('users')
+      .select('users.id', 'users.name', 'users.email', 'users.trial_started_at')
+      .whereNotNull('users.trial_started_at')
+      .where('users.trial_started_at', '<=', lapsedBefore)
+      .where('users.trial_started_at', '>', lookbackAfter)
+      .whereRaw('users.patreon IS NOT TRUE')
+      .whereNotExists(
+        this.database('subscriptions')
+          .where('subscriptions.active', true)
+          .whereRaw(
+            '(subscriptions.email = users.email OR subscriptions.linked_email = users.email)'
+          )
+          .limit(1)
+      )
+      .whereNotExists(
+        this.database(this.table)
+          .whereRaw('trial_ended_emails.user_id = users.id')
+          .limit(1)
+      )
+      .whereNotExists(
+        this.database('email_preferences')
+          .whereRaw('email_preferences.user_id = users.id')
+          .where('email_preferences.marketing_opt_out', true)
+          .limit(1)
+      )
+      .limit(limit);
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      email: row.email,
+      trialStartedAt: row.trial_started_at,
+    }));
+  }
+
+  async countDecksInTrialWindow(userId: number, trialStartedAt: Date): Promise<number> {
+    const windowEnd = new Date(trialStartedAt.getTime() + TRIAL_DURATION_MS);
+    const [row] = await this.database('uploads')
+      .where({ owner: userId })
+      .whereNotNull('filename')
+      .where('created_at', '>=', trialStartedAt)
+      .where('created_at', '<', windowEnd)
+      .count<Array<{ count: string }>>({ count: '*' });
+    return Number(row?.count ?? 0);
+  }
+
+  async recordSend(userId: number, token: string): Promise<void> {
+    await this.database(this.table).insert({ user_id: userId, token });
+  }
+
+  async findByToken(token: string): Promise<{ id: number; userId: number } | null> {
+    const row = await this.database<TrialEndedEmailRow>(this.table)
+      .select('id', 'user_id')
+      .where({ token })
+      .first();
+    if (row == null) {
+      return null;
+    }
+    return { id: row.id, userId: row.user_id };
+  }
+}
+
+export class InMemoryTrialEndedEmailRepository implements ITrialEndedEmailRepository {
+  private usersToReturn: TrialLapsedUser[] = [];
+  private readonly sentUserIds = new Set<number>();
+  private readonly deckCounts = new Map<number, number>();
+  private emails: Array<{ id: number; userId: number; token: string }> = [];
+  private nextId = 1;
+
+  seedUsers(users: TrialLapsedUser[]): void {
+    this.usersToReturn = users;
+  }
+
+  seedDeckCount(userId: number, count: number): void {
+    this.deckCounts.set(userId, count);
+  }
+
+  async getUsersToNotify(limit = 500): Promise<TrialLapsedUser[]> {
+    return this.usersToReturn
+      .filter((user) => !this.sentUserIds.has(user.id))
+      .slice(0, limit);
+  }
+
+  async countDecksInTrialWindow(userId: number): Promise<number> {
+    return this.deckCounts.get(userId) ?? 0;
+  }
+
+  async recordSend(userId: number, token: string): Promise<void> {
+    const id = this.nextId++;
+    this.emails.push({ id, userId, token });
+    this.sentUserIds.add(userId);
+  }
+
+  async findByToken(token: string): Promise<{ id: number; userId: number } | null> {
+    const found = this.emails.find((email) => email.token === token);
+    if (found == null) {
+      return null;
+    }
+    return { id: found.id, userId: found.userId };
+  }
+
+  getSentUserIds(): ReadonlySet<number> {
+    return this.sentUserIds;
+  }
+}
+
+export default TrialEndedEmailRepository;

--- a/src/lib/parser/canary/scheduleParserCanary.test.ts
+++ b/src/lib/parser/canary/scheduleParserCanary.test.ts
@@ -23,6 +23,7 @@ function makeEmailService(overrides: Partial<IEmailService> = {}): IEmailService
     sendReEngagementEmail: jest.fn(),
     sendInactivityWarningEmail: jest.fn(),
     sendAbandonedCheckoutRecoveryEmail: jest.fn(),
+    sendTrialEndedEmail: jest.fn().mockResolvedValue(undefined),
     sendParserCanaryAlert: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as IEmailService;

--- a/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
+++ b/src/lib/storage/jobs/helpers/sendReEngagementEmails.test.ts
@@ -15,6 +15,7 @@ function buildEmailService(): jest.Mocked<IEmailService> {
     sendReEngagementEmail: jest.fn().mockResolvedValue(undefined),
     sendInactivityWarningEmail: jest.fn().mockResolvedValue(undefined),
     sendAbandonedCheckoutRecoveryEmail: jest.fn().mockResolvedValue(undefined),
+    sendTrialEndedEmail: jest.fn().mockResolvedValue(undefined),
     sendParserCanaryAlert: jest.fn().mockResolvedValue(undefined),
   };
 }

--- a/src/lib/trial/jobs/scheduleTrialEndedEmails.test.ts
+++ b/src/lib/trial/jobs/scheduleTrialEndedEmails.test.ts
@@ -1,0 +1,64 @@
+import { scheduleTrialEndedEmails, TRIAL_ENDED_HOURLY_LIMIT } from './scheduleTrialEndedEmails';
+import type { SendTrialEndedEmailsUseCase } from '../../../usecases/ops/SendTrialEndedEmailsUseCase';
+import type { EventsSink } from '../../../services/events/EventsSink';
+
+function makeUseCase(
+  result = { count: 4, dryRun: false }
+): jest.Mocked<Pick<SendTrialEndedEmailsUseCase, 'execute'>> {
+  return { execute: jest.fn().mockResolvedValue(result) };
+}
+
+describe('scheduleTrialEndedEmails', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('runs the use case with the default hourly limit after one interval', async () => {
+    const useCase = makeUseCase();
+    const handle = scheduleTrialEndedEmails(
+      useCase as unknown as SendTrialEndedEmailsUseCase,
+      { intervalMs: 1000 }
+    );
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(useCase.execute).toHaveBeenCalledWith(false, TRIAL_ENDED_HOURLY_LIMIT);
+    clearInterval(handle);
+  });
+
+  it('does not fire before the interval elapses', () => {
+    const useCase = makeUseCase();
+    const handle = scheduleTrialEndedEmails(
+      useCase as unknown as SendTrialEndedEmailsUseCase,
+      { intervalMs: 1000 }
+    );
+
+    jest.advanceTimersByTime(999);
+
+    expect(useCase.execute).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('records an email_batch_sent event with the post_trial campaign and count', async () => {
+    const useCase = makeUseCase({ count: 4, dryRun: false });
+    const record = jest.fn();
+    const eventsSink = { record } as unknown as EventsSink;
+    const handle = scheduleTrialEndedEmails(
+      useCase as unknown as SendTrialEndedEmailsUseCase,
+      { intervalMs: 1000, eventsSink }
+    );
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(record).toHaveBeenCalledWith({
+      name: 'email_batch_sent',
+      props: { campaign: 'post_trial', count: 4 },
+    });
+    clearInterval(handle);
+  });
+});

--- a/src/lib/trial/jobs/scheduleTrialEndedEmails.ts
+++ b/src/lib/trial/jobs/scheduleTrialEndedEmails.ts
@@ -1,0 +1,32 @@
+import type { SendTrialEndedEmailsUseCase } from '../../../usecases/ops/SendTrialEndedEmailsUseCase';
+import type { EventsSink } from '../../../services/events/EventsSink';
+
+export const TRIAL_ENDED_HOURLY_LIMIT = 200;
+export const TRIAL_ENDED_INTERVAL_MS = 60 * 60 * 1000;
+
+export const scheduleTrialEndedEmails = (
+  useCase: SendTrialEndedEmailsUseCase,
+  options: { intervalMs?: number; limit?: number; eventsSink?: EventsSink } = {}
+): NodeJS.Timeout => {
+  const intervalMs = options.intervalMs ?? TRIAL_ENDED_INTERVAL_MS;
+  const limit = options.limit ?? TRIAL_ENDED_HOURLY_LIMIT;
+
+  const tick = async () => {
+    try {
+      const result = await useCase.execute(false, limit);
+      console.info(`[trial-ended] sent ${result.count} email(s)`);
+      if (options.eventsSink != null) {
+        options.eventsSink.record({
+          name: 'email_batch_sent',
+          props: { campaign: 'post_trial', count: result.count },
+        });
+      }
+    } catch (error) {
+      console.error('[trial-ended] hourly job failed:', error);
+    }
+  };
+
+  const handle = setInterval(tick, intervalMs);
+  handle.unref();
+  return handle;
+};

--- a/src/routes/EmailRedirectRouter.test.ts
+++ b/src/routes/EmailRedirectRouter.test.ts
@@ -4,6 +4,7 @@ import { AddressInfo } from 'node:net';
 
 import type { IInactivityEmailRepository } from '../data_layer/InactivityEmailRepository';
 import type { IReEngagementRepository } from '../data_layer/ReEngagementRepository';
+import type { ITrialEndedEmailRepository } from '../data_layer/TrialEndedEmailRepository';
 import type { EventsSink } from '../services/events/EventsSink';
 
 const mockInactivityRepo: jest.Mocked<Pick<IInactivityEmailRepository, 'findByToken'>> = {
@@ -11,6 +12,10 @@ const mockInactivityRepo: jest.Mocked<Pick<IInactivityEmailRepository, 'findByTo
 };
 
 const mockReEngagementRepo: jest.Mocked<Pick<IReEngagementRepository, 'findByToken'>> = {
+  findByToken: jest.fn().mockResolvedValue(null),
+};
+
+const mockTrialEndedRepo: jest.Mocked<Pick<ITrialEndedEmailRepository, 'findByToken'>> = {
   findByToken: jest.fn().mockResolvedValue(null),
 };
 
@@ -25,6 +30,9 @@ jest.mock('../data_layer/InactivityEmailRepository', () =>
 jest.mock('../data_layer/ReEngagementRepository', () =>
   jest.fn().mockImplementation(() => mockReEngagementRepo)
 );
+jest.mock('../data_layer/TrialEndedEmailRepository', () => ({
+  TrialEndedEmailRepository: jest.fn().mockImplementation(() => mockTrialEndedRepo),
+}));
 jest.mock('../services/events/eventsSinkInstance', () => ({
   getEventsSink: jest.fn(() => mockSink),
 }));
@@ -121,6 +129,18 @@ describe('EmailRedirectRouter', () => {
           name: 'email_clicked',
           user_id: 77,
           props: expect.objectContaining({ campaign: 'reengagement', email_id: 9 }),
+        })
+      );
+    });
+
+    it('records email_clicked with user_id when post_trial token resolves', async () => {
+      mockTrialEndedRepo.findByToken.mockResolvedValueOnce({ id: 12, userId: 88 });
+      await fetch(`${url}/r/email?t=trialtoken&c=post_trial&to=/pricing`, { redirect: 'manual' });
+      expect(mockSink.record).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'email_clicked',
+          user_id: 88,
+          props: expect.objectContaining({ campaign: 'post_trial', email_id: 12, destination: '/pricing' }),
         })
       );
     });

--- a/src/routes/EmailRedirectRouter.ts
+++ b/src/routes/EmailRedirectRouter.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import { getDatabase } from '../data_layer';
 import InactivityEmailRepository from '../data_layer/InactivityEmailRepository';
 import ReEngagementRepository from '../data_layer/ReEngagementRepository';
+import { TrialEndedEmailRepository } from '../data_layer/TrialEndedEmailRepository';
 import { getEventsSink } from '../services/events/eventsSinkInstance';
 
 const ALLOWED_EMAIL_DESTINATIONS = new Set(['/', '/upload', '/pricing', '/login']);
@@ -32,7 +33,7 @@ const EmailRedirectRouter = () => {
    *         name: c
    *         schema:
    *           type: string
-   *           enum: [inactivity, reengagement]
+   *           enum: [inactivity, reengagement, post_trial]
    *         description: Campaign — disambiguates which table to resolve the token against
    *       - in: query
    *         name: to
@@ -69,6 +70,12 @@ const EmailRedirectRouter = () => {
         }
       } else if (campaign === 'reengagement') {
         const result = await new ReEngagementRepository(database).findByToken(token).catch(() => null);
+        if (result != null) {
+          userId = result.userId;
+          emailId = result.id;
+        }
+      } else if (campaign === 'post_trial') {
+        const result = await new TrialEndedEmailRepository(database).findByToken(token).catch(() => null);
         if (result != null) {
           userId = result.userId;
           emailId = result.id;

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,13 +70,16 @@ import JobRepository from './data_layer/JobRepository';
 import { MagicTokenRepository } from './data_layer/MagicTokenRepository';
 import ReEngagementRepository from './data_layer/ReEngagementRepository';
 import InactivityEmailRepository from './data_layer/InactivityEmailRepository';
+import { TrialEndedEmailRepository } from './data_layer/TrialEndedEmailRepository';
 import UploadRepository from './data_layer/UploadRespository';
 import { updateStripeSubscriptions } from './lib/storage/jobs/helpers/updateStripeSubscriptions';
 import { scheduleReEngagementEmails } from './lib/reengagement/jobs/scheduleReEngagementEmails';
 import { scheduleInactivityWarnings } from './lib/inactivity/jobs/scheduleInactivityWarnings';
+import { scheduleTrialEndedEmails } from './lib/trial/jobs/scheduleTrialEndedEmails';
 import { scheduleParserCanary } from './lib/parser/canary/scheduleParserCanary';
 import { getDefaultEmailService } from './services/EmailService/EmailService';
 import { SendInactivityWarningsUseCase } from './usecases/ops/SendInactivityWarningsUseCase';
+import { SendTrialEndedEmailsUseCase } from './usecases/ops/SendTrialEndedEmailsUseCase';
 import { initConversionPool } from './lib/conversionPool';
 import { gracefulShutdown } from './lib/gracefulShutdown';
 
@@ -258,6 +261,11 @@ const serve = async () => {
   const uploadRepo = new UploadRepository(database);
   const sendInactivityWarningsUseCase = new SendInactivityWarningsUseCase(inactivityEmailRepo, emailService, uploadRepo);
   scheduleInactivityWarnings(sendInactivityWarningsUseCase, { eventsSink });
+
+  const trialEndedEmailRepo = new TrialEndedEmailRepository(database);
+  const sendTrialEndedEmailsUseCase = new SendTrialEndedEmailsUseCase(trialEndedEmailRepo, emailService);
+  scheduleTrialEndedEmails(sendTrialEndedEmailsUseCase, { eventsSink });
+
   scheduleParserCanary(emailService);
 };
 

--- a/src/services/EmailService/EmailService.test.ts
+++ b/src/services/EmailService/EmailService.test.ts
@@ -1,0 +1,86 @@
+const send = jest.fn().mockResolvedValue([{ statusCode: 202 }, {}]);
+
+jest.mock('@sendgrid/mail', () => ({
+  setApiKey: jest.fn(),
+  send,
+}));
+
+import { getDefaultEmailService } from './EmailService';
+
+interface SentMessage {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+describe('EmailService.sendTrialEndedEmail', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SENDGRID_API_KEY = 'test-key';
+    process.env.DOMAIN = 'https://2anki.net';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function lastMessage(): SentMessage {
+    const calls = send.mock.calls;
+    return calls[calls.length - 1][0] as SentMessage;
+  }
+
+  describe('when the user converted at least one deck', () => {
+    it('leads with the count and drives a single upgrade CTA to pricing', async () => {
+      const service = getDefaultEmailService();
+
+      await service.sendTrialEndedEmail('alice@example.com', 'tok-1', 3);
+
+      const msg = lastMessage();
+      expect(msg.to).toBe('alice@example.com');
+      expect(msg.subject).toBe('You made 3 decks during your 2anki trial');
+      expect(msg.html).toContain('You made 3 decks during that hour.');
+      expect(msg.html).toContain('Upgrade to continue');
+      expect(msg.html).toContain('c=post_trial&to=/pricing');
+      expect(msg.html).not.toContain('Make your first deck');
+      expect(msg.html).not.toContain('See pricing');
+    });
+
+    it('uses the singular noun for exactly one deck', async () => {
+      const service = getDefaultEmailService();
+
+      await service.sendTrialEndedEmail('alice@example.com', 'tok-1', 1);
+
+      expect(lastMessage().subject).toBe('You made 1 deck during your 2anki trial');
+    });
+  });
+
+  describe('when the user converted nothing', () => {
+    it('drives the converter as the primary CTA with pricing as a secondary link', async () => {
+      const service = getDefaultEmailService();
+
+      await service.sendTrialEndedEmail('bob@example.com', 'tok-2', 0);
+
+      const msg = lastMessage();
+      expect(msg.subject).toBe("Your 2anki trial ended — here's what stays free");
+      expect(msg.html).toContain('Your 1-hour trial just ended.');
+      expect(msg.html).not.toContain('during that hour');
+      expect(msg.html).toContain('Make your first deck');
+      expect(msg.html).toContain('c=post_trial&to=/upload');
+      expect(msg.html).toContain('See pricing');
+      expect(msg.html).toContain('c=post_trial&to=/pricing');
+    });
+  });
+
+  it('does not state a fixed free-tier card number', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendTrialEndedEmail('alice@example.com', 'tok-1', 2);
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('your monthly limit applies');
+    expect(msg.html).not.toContain('100 cards');
+  });
+});

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -15,6 +15,7 @@ import {
   SUBSCRIPTION_CANCELLED_TEMPLATE,
   SUBSCRIPTION_CANCELLATIONS_LOG_PATH,
   SUBSCRIPTION_SCHEDULED_CANCELLATION_TEMPLATE,
+  TRIAL_ENDED_TEMPLATE,
 } from './constants';
 import { isValidDeckName, addDeckNameSuffix } from '../../lib/anki/format';
 import { ClientResponse } from '@sendgrid/mail';
@@ -58,6 +59,7 @@ export interface IEmailService {
   ): Promise<void>;
   sendInactivityWarningEmail(to: string, token: string, lastConversion?: { deckName: string } | null): Promise<void>;
   sendAbandonedCheckoutRecoveryEmail(to: string): Promise<void>;
+  sendTrialEndedEmail(to: string, token: string, deckCount: number): Promise<void>;
   sendParserCanaryAlert(to: string, summary: string): Promise<void>;
 }
 
@@ -324,6 +326,57 @@ class EmailService implements IEmailService {
     }
   }
 
+  async sendTrialEndedEmail(
+    to: string,
+    token: string,
+    deckCount: number
+  ): Promise<void> {
+    const domain = process.env.DOMAIN ?? 'https://2anki.net';
+    const tokenParam = encodeURIComponent(token);
+    const pricingUrl = `${domain}/r/email?t=${tokenParam}&c=post_trial&to=/pricing`;
+
+    const madeDecks = deckCount > 0;
+    const noun = deckCount === 1 ? 'deck' : 'decks';
+
+    const subject = madeDecks
+      ? `You made ${deckCount} ${noun} during your 2anki trial`
+      : "Your 2anki trial ended — here's what stays free";
+    const lead = madeDecks
+      ? `Your 1-hour trial just ended. You made ${deckCount} ${noun} during that hour.`
+      : 'Your 1-hour trial just ended.';
+    const ctaLabel = madeDecks ? 'Upgrade to continue' : 'Make your first deck';
+    const ctaUrl = madeDecks
+      ? pricingUrl
+      : `${domain}/r/email?t=${tokenParam}&c=post_trial&to=/upload`;
+    const secondaryCta = madeDecks
+      ? ''
+      : `<p class="email-muted" style="text-align: center; margin: 0 0 24px; font-size: 13px;"><a href="${pricingUrl}" style="color: #6b7280;">See pricing</a></p>`;
+
+    const markup = TRIAL_ENDED_TEMPLATE.replaceAll('{{lead}}', lead)
+      .replaceAll('{{ctaLabel}}', ctaLabel)
+      .replaceAll('{{ctaUrl}}', ctaUrl)
+      .replaceAll('{{secondaryCta}}', secondaryCta);
+
+    const $ = cheerio.load(markup);
+    const text = $('body').text().replace(/\s+/g, ' ').trim();
+
+    const msg = {
+      to,
+      from: this.defaultSender,
+      subject,
+      text,
+      html: markup,
+      replyTo: 'support@2anki.net',
+    };
+
+    try {
+      await sgMail.send(msg);
+    } catch (error) {
+      console.error(`Failed to send trial-ended email to ${to}:`, error);
+      throw error;
+    }
+  }
+
   private loadCancellationsSent(): Set<string> {
     try {
       // Ensure .2anki directory exists
@@ -545,6 +598,10 @@ export class UnimplementedEmailService implements IEmailService {
 
   async sendAbandonedCheckoutRecoveryEmail(to: string): Promise<void> {
     console.info('sendAbandonedCheckoutRecoveryEmail not handled', to);
+  }
+
+  async sendTrialEndedEmail(to: string, token: string, deckCount: number): Promise<void> {
+    console.info('sendTrialEndedEmail not handled', to, token, deckCount);
   }
 
   async sendParserCanaryAlert(to: string, summary: string): Promise<void> {

--- a/src/services/EmailService/constants.ts
+++ b/src/services/EmailService/constants.ts
@@ -59,3 +59,8 @@ export const ABANDONED_CHECKOUT_RECOVERY_TEMPLATE = fs.readFileSync(
   path.join(EMAIL_TEMPLATES_DIRECTORY, 'abandoned-checkout-recovery.html'),
   'utf8'
 );
+
+export const TRIAL_ENDED_TEMPLATE = fs.readFileSync(
+  path.join(EMAIL_TEMPLATES_DIRECTORY, 'trial-ended.html'),
+  'utf8'
+);

--- a/src/services/EmailService/templates/trial-ended.html
+++ b/src/services/EmailService/templates/trial-ended.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>2anki.net — Your trial ended</title>
+  <style>
+    @media (prefers-color-scheme: dark) {
+      body { background-color: #1a1a1a !important; }
+      .email-card { background-color: #111827 !important; }
+      .email-header { color: #f9fafb !important; border-bottom-color: #374151 !important; }
+      .email-body p { color: #f9fafb !important; }
+      .email-cta a { background-color: #60a5fa !important; }
+      .email-footer { color: #6b7280 !important; border-top-color: #374151 !important; }
+      .email-muted a { color: #9ca3af !important; }
+    }
+    @media only screen and (max-width: 600px) {
+      .email-card { width: 100% !important; padding: 0 !important; }
+      .email-body { padding: 24px 16px !important; }
+      .email-header { padding: 16px !important; }
+      .email-footer { padding: 12px 16px !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px;">
+          <tr>
+            <td class="email-header" style="text-align: center; padding: 24px; border-bottom: 1px solid #e5e7eb;">
+              <img src="https://2anki.net/mascot/navbar-logo.png" alt="2anki" width="120" style="display: block; margin: 0 auto; height: auto;" />
+            </td>
+          </tr>
+          <tr>
+            <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
+              <p style="margin: 0 0 16px;">{{lead}}</p>
+              <p style="margin: 0 0 24px;">On the free plan, your monthly limit applies. Paid removes that ceiling — plus unlocks larger Notion exports, PDF support, and Print.</p>
+              <div style="text-align: center; margin: 0 0 24px;" class="email-cta">
+                <a href="{{ctaUrl}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">{{ctaLabel}}</a>
+              </div>
+              {{secondaryCta}}
+              <p style="margin: 0;">The 2anki Team</p>
+            </td>
+          </tr>
+          <tr>
+            <td class="email-footer" style="text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #9ca3af; padding: 16px 24px; border-top: 1px solid #e5e7eb;">
+              2anki.net — Turn what you study into Anki flashcards
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
@@ -23,6 +23,7 @@ function makeEmailService(): jest.Mocked<IEmailService> {
     sendReEngagementEmail: jest.fn(),
     sendInactivityWarningEmail: jest.fn(),
     sendAbandonedCheckoutRecoveryEmail: jest.fn().mockResolvedValue(undefined),
+    sendTrialEndedEmail: jest.fn().mockResolvedValue(undefined),
     sendParserCanaryAlert: jest.fn().mockResolvedValue(undefined),
   };
 }

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.test.ts
@@ -14,6 +14,7 @@ function makeEmailService(): jest.Mocked<IEmailService> {
     sendReEngagementEmail: jest.fn(),
     sendInactivityWarningEmail: jest.fn(),
     sendAbandonedCheckoutRecoveryEmail: jest.fn().mockResolvedValue(undefined),
+    sendTrialEndedEmail: jest.fn().mockResolvedValue(undefined),
     sendParserCanaryAlert: jest.fn().mockResolvedValue(undefined),
   };
 }

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -18,6 +18,7 @@ function makeEmailService(
     sendReEngagementEmail: jest.fn(),
     sendInactivityWarningEmail: jest.fn().mockResolvedValue(undefined),
     sendAbandonedCheckoutRecoveryEmail: jest.fn().mockResolvedValue(undefined),
+    sendTrialEndedEmail: jest.fn().mockResolvedValue(undefined),
     sendParserCanaryAlert: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };

--- a/src/usecases/ops/SendTrialEndedEmailsUseCase.test.ts
+++ b/src/usecases/ops/SendTrialEndedEmailsUseCase.test.ts
@@ -1,0 +1,141 @@
+import { SendTrialEndedEmailsUseCase } from './SendTrialEndedEmailsUseCase';
+import { InMemoryTrialEndedEmailRepository } from '../../data_layer/TrialEndedEmailRepository';
+import type { IEmailService } from '../../services/EmailService/EmailService';
+
+function makeEmailService(overrides: Partial<IEmailService> = {}): IEmailService {
+  return {
+    sendResetEmail: jest.fn(),
+    sendConversionEmail: jest.fn(),
+    sendConversionLinkEmail: jest.fn(),
+    sendContactEmail: jest.fn(),
+    sendSubscriptionCancelledEmail: jest.fn(),
+    sendSubscriptionScheduledCancellationEmail: jest.fn(),
+    sendHostedAnkiAccessRequestEmail: jest.fn(),
+    sendMagicLinkEmail: jest.fn(),
+    sendReEngagementEmail: jest.fn(),
+    sendInactivityWarningEmail: jest.fn().mockResolvedValue(undefined),
+    sendAbandonedCheckoutRecoveryEmail: jest.fn().mockResolvedValue(undefined),
+    sendTrialEndedEmail: jest.fn().mockResolvedValue(undefined),
+    sendParserCanaryAlert: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const trialStartedAt = new Date('2026-05-25T09:00:00Z');
+
+describe('SendTrialEndedEmailsUseCase', () => {
+  let repo: InMemoryTrialEndedEmailRepository;
+
+  beforeEach(() => {
+    repo = new InMemoryTrialEndedEmailRepository();
+  });
+
+  describe('dry run', () => {
+    it('returns the candidate count without sending', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt },
+        { id: 2, name: 'Bob', email: 'bob@example.com', trialStartedAt },
+      ]);
+      const emailService = makeEmailService();
+      const useCase = new SendTrialEndedEmailsUseCase(repo, emailService);
+
+      const result = await useCase.execute(true);
+
+      expect(result).toEqual({ count: 2, dryRun: true });
+      expect(emailService.sendTrialEndedEmail).not.toHaveBeenCalled();
+      expect(repo.getSentUserIds().size).toBe(0);
+    });
+  });
+
+  describe('live send', () => {
+    it('sends to each candidate and records the send', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt },
+        { id: 2, name: 'Bob', email: 'bob@example.com', trialStartedAt },
+      ]);
+      const emailService = makeEmailService();
+      const useCase = new SendTrialEndedEmailsUseCase(repo, emailService);
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 2, dryRun: false });
+      expect(emailService.sendTrialEndedEmail).toHaveBeenCalledTimes(2);
+      expect(repo.getSentUserIds()).toEqual(new Set([1, 2]));
+    });
+
+    it('passes the in-window deck count through to the email', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt },
+      ]);
+      repo.seedDeckCount(1, 3);
+      const emailService = makeEmailService();
+      const useCase = new SendTrialEndedEmailsUseCase(repo, emailService);
+
+      await useCase.execute(false);
+
+      expect(emailService.sendTrialEndedEmail).toHaveBeenCalledWith(
+        'alice@example.com',
+        expect.any(String),
+        3
+      );
+    });
+
+    it('passes a deck count of 0 when the user converted nothing', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt },
+      ]);
+      const emailService = makeEmailService();
+      const useCase = new SendTrialEndedEmailsUseCase(repo, emailService);
+
+      await useCase.execute(false);
+
+      expect(emailService.sendTrialEndedEmail).toHaveBeenCalledWith(
+        'alice@example.com',
+        expect.any(String),
+        0
+      );
+    });
+
+    it('records the send before attempting delivery so a failure still dedups', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt },
+      ]);
+      const emailService = makeEmailService({
+        sendTrialEndedEmail: jest.fn().mockRejectedValue(new Error('SendGrid down')),
+      });
+      const useCase = new SendTrialEndedEmailsUseCase(repo, emailService);
+
+      const result = await useCase.execute(false);
+
+      expect(result.count).toBe(0);
+      expect(repo.getSentUserIds()).toEqual(new Set([1]));
+    });
+
+    it('continues to the next user when one send fails', async () => {
+      repo.seedUsers([
+        { id: 1, name: 'Alice', email: 'alice@example.com', trialStartedAt },
+        { id: 2, name: 'Bob', email: 'bob@example.com', trialStartedAt },
+      ]);
+      const emailService = makeEmailService({
+        sendTrialEndedEmail: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('SendGrid down'))
+          .mockResolvedValueOnce(undefined),
+      });
+      const useCase = new SendTrialEndedEmailsUseCase(repo, emailService);
+
+      const result = await useCase.execute(false);
+
+      expect(result.count).toBe(1);
+      expect(emailService.sendTrialEndedEmail).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns zero when there are no candidates', async () => {
+      const useCase = new SendTrialEndedEmailsUseCase(repo, makeEmailService());
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 0, dryRun: false });
+    });
+  });
+});

--- a/src/usecases/ops/SendTrialEndedEmailsUseCase.ts
+++ b/src/usecases/ops/SendTrialEndedEmailsUseCase.ts
@@ -1,0 +1,40 @@
+import type { ITrialEndedEmailRepository } from '../../data_layer/TrialEndedEmailRepository';
+import type { IEmailService } from '../../services/EmailService/EmailService';
+
+export interface SendTrialEndedEmailsResult {
+  count: number;
+  dryRun: boolean;
+}
+
+export class SendTrialEndedEmailsUseCase {
+  constructor(
+    private readonly repo: ITrialEndedEmailRepository,
+    private readonly emailService: IEmailService
+  ) {}
+
+  async execute(dryRun: boolean, limit = 500): Promise<SendTrialEndedEmailsResult> {
+    const users = await this.repo.getUsersToNotify(limit);
+
+    if (dryRun) {
+      return { count: users.length, dryRun: true };
+    }
+
+    let sent = 0;
+    for (const user of users) {
+      const token = crypto.randomUUID();
+      await this.repo.recordSend(user.id, token);
+      try {
+        const deckCount = await this.repo.countDecksInTrialWindow(
+          user.id,
+          user.trialStartedAt
+        );
+        await this.emailService.sendTrialEndedEmail(user.email, token, deckCount);
+        sent++;
+      } catch (error) {
+        console.error(`[trial-ended] failed to email user ${user.id}:`, error);
+      }
+    }
+
+    return { count: sent, dryRun: false };
+  }
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-trial-ended-email.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-trial-ended-email.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-trial-ended-email",
+  "date": "2026-05-25",
+  "type": "feature",
+  "title": "Trial-ended email with a direct link to keep going after your free hour"
+}


### PR DESCRIPTION
## What this does

Sends a one-time **post-trial conversion email** ~1h after a user's fixed **1-hour** in-app trial ends. Until now a user got full access for 60 minutes, then silently reverted to free with no contact at the moment of highest intent. This closes that gap.

A literal "3 days left" email (the Read AI shape) is impossible here — the trial is 60 minutes, so an email can't be read before it ends. This is the honest adaptation: it fires once the trial is actually over and leads with what the user did during the hour.

## Count → CTA branch

The email counts the decks the user converted during the trial window `[trial_started_at, trial_started_at + 1h]` and branches the primary action on it:

- **Converted ≥1 deck** → lead names the count; single button **"Upgrade to continue"** → `/pricing`.
- **Converted nothing** → generic lead; primary button **"Make your first deck"** → `/upload`, with a lower-hierarchy **"See pricing"** link below. (Asking a distracted signup who made nothing to pay is the wrong ask — send them back to convert.)

Deck count is the cheap, accurate unit (one `uploads` row per conversion); a per-card count isn't cheaply queryable, so the copy says "decks".

## Recipient criteria (DB only — never calls `updateStripeSubscriptions`)

- `trial_started_at` non-null and trial fully lapsed (`≥ 1h` ago), **and**
- within a **7-day lookback** (so the first run doesn't flood every historical trial user), **and**
- not lifetime (`patreon IS NOT TRUE`), **and**
- no active `subscriptions` row (joined on `email`/`linked_email`, mirroring `InactivityEmailRepository`), **and**
- not already emailed (dedup via the new `trial_ended_emails` table), **and**
- not marketing-opted-out.

## Cadence

Hourly job (intent is freshest right after the hour), wired in `server.ts` next to the existing inactivity/re-engagement jobs with `.unref()`. Mirrors that machinery exactly: repository → use case → schedule helper, `email_batch_sent` event with `campaign: 'post_trial'`. Click-through is attributed through the existing `/r/email` redirect under a new `post_trial` campaign.

## Success metric

`/pricing` click-through rate on this email (clicks ÷ sends).

## Tests

- New: repository (in-memory dedup/findByToken/count), use case (dry-run, live send, record-before-send dedup, count pass-through, partial-failure), schedule helper (interval, limit, event), `EmailService.sendTrialEndedEmail` (count→CTA branch both ways, singular/plural, no fixed free-tier number), redirect-router `post_trial` attribution.
- Server tsc, web typecheck, web lint, web vitest (1224), and all affected server suites (62) green locally.

## Follow-up

`pnpm kanel` must be run against a DB that has the new table to emit `src/data_layer/public/TrialEndedEmails.ts`. I couldn't run it in this environment (no local Postgres). It's **not** blocking: the repository defines its row type inline (same as `InactivityEmailRepository`, which also doesn't import its generated type), nothing imports the generated file, and migrations run automatically on startup.

## Sonar

`sonar-scanner` not run locally — scanner not installed and `SONAR_TOKEN` unset in this environment. Self-reviewed for the usual smells: positive-first ternaries (no `if(!x){}else{}`), `== null` presence checks, no `any`/`@ts-ignore`, `crypto.randomUUID()` for the token, no nested ternaries. Expect a Sonar pass; flagging in case CI surfaces a maintainability nit.

Browser check: not applicable — only web/src change is a changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782332187&installation_id=132681956&pr_number=2811&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2811&signature=55f4eed94196833f287ed75e346dcd21efe8bc4b828e0de73a0a1fa44a82257d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->