### PR TITLE
fix: show pass prices on the upgrade card and remove the dead anonymous button

### DIFF
--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -52,11 +52,11 @@ describe('UpsellCard', () => {
     mockUseCardUsage.mockReturnValue(null);
   });
 
-  it('renders three CTAs for free users', () => {
+  it('renders three CTAs with prices for free users', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     render(<UpsellCard surface="downloads_upsell" />);
-    expect(screen.getByRole('button', { name: 'Day Pass' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Week Pass' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Get Day Pass — $4' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Get Week Pass — $9' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Unlimited' })).toBeInTheDocument();
   });
 
@@ -69,7 +69,7 @@ describe('UpsellCard', () => {
   it('renders for anonymous users by default', () => {
     mockUseUserLocals.mockReturnValue(anonymousUser);
     render(<UpsellCard surface="downloads_upsell" />);
-    expect(screen.getByRole('button', { name: 'Day Pass' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Day Pass/ })).toBeInTheDocument();
   });
 
   it('hides for anonymous users when hideForAnonymous is true', () => {
@@ -83,7 +83,7 @@ describe('UpsellCard', () => {
   it('still shows for free logged-in users when hideForAnonymous is true', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     render(<UpsellCard surface="upload_success_upsell" hideForAnonymous />);
-    expect(screen.getByRole('button', { name: 'Day Pass' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Day Pass/ })).toBeInTheDocument();
   });
 
   it('uses the downloads surface headline on /downloads', () => {
@@ -116,7 +116,7 @@ describe('UpsellCard', () => {
     Object.defineProperty(globalThis, 'location', { writable: true, value: { href: '' } });
 
     render(<UpsellCard surface="downloads_upsell" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Day Pass' }));
+    fireEvent.click(screen.getByRole('button', { name: /Day Pass/ }));
 
     await waitFor(() => {
       expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
@@ -133,7 +133,7 @@ describe('UpsellCard', () => {
     Object.defineProperty(globalThis, 'location', { writable: true, value: { href: '' } });
 
     render(<UpsellCard surface="upload_success_upsell" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Week Pass' }));
+    fireEvent.click(screen.getByRole('button', { name: /Week Pass/ }));
 
     await waitFor(() => {
       expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
@@ -164,7 +164,7 @@ describe('UpsellCard', () => {
     );
 
     render(<UpsellCard surface="downloads_upsell" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Day Pass' }));
+    fireEvent.click(screen.getByRole('button', { name: /Day Pass/ }));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
@@ -172,7 +172,7 @@ describe('UpsellCard', () => {
 
     resolveCheckout({ status: 'error' });
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Day Pass' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Day Pass/ })).toBeInTheDocument();
     });
   });
 
@@ -181,7 +181,7 @@ describe('UpsellCard', () => {
     mockStartPassCheckout.mockReturnValue(new Promise(() => {}));
 
     render(<UpsellCard surface="downloads_upsell" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Day Pass' }));
+    fireEvent.click(screen.getByRole('button', { name: /Day Pass/ }));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();
@@ -192,7 +192,7 @@ describe('UpsellCard', () => {
     fireEvent(globalThis.window, pageshow);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Day Pass' })).toBeEnabled();
+      expect(screen.getByRole('button', { name: /Day Pass/ })).toBeEnabled();
     });
   });
 
@@ -209,7 +209,7 @@ describe('UpsellCard', () => {
     mockStartPassCheckout.mockReturnValue(new Promise(() => {}));
 
     const { unmount } = render(<UpsellCard surface="downloads_upsell" />);
-    fireEvent.click(screen.getByRole('button', { name: 'Day Pass' }));
+    fireEvent.click(screen.getByRole('button', { name: /Day Pass/ }));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Redirecting…' })).toBeDisabled();

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -5,7 +5,7 @@ import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { useCardUsage } from '../../lib/hooks/useCardUsage';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
-import { getSubscribeLink } from '../../pages/PricingPage/payment.links';
+import { getSubscribeLink, PASS_PRICES } from '../../pages/PricingPage/payment.links';
 import styles from './UpsellCard.module.css';
 
 type Surface = 'downloads_upsell' | 'upload_success_upsell';
@@ -108,7 +108,7 @@ export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProp
           onClick={() => handlePassClick('24h')}
           disabled={pendingKind != null}
         >
-          {pendingKind === '24h' ? 'Redirecting…' : 'Day Pass'}
+          {pendingKind === '24h' ? 'Redirecting…' : `Get Day Pass — ${PASS_PRICES['24h']}`}
         </button>
         <button
           type="button"
@@ -116,7 +116,7 @@ export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProp
           onClick={() => handlePassClick('7d')}
           disabled={pendingKind != null}
         >
-          {pendingKind === '7d' ? 'Redirecting…' : 'Week Pass'}
+          {pendingKind === '7d' ? 'Redirecting…' : `Get Week Pass — ${PASS_PRICES['7d']}`}
         </button>
         <span className={styles.dot} aria-hidden="true">·</span>
         <a

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -633,7 +633,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                 </div>
                 {showUpgradeFooter && !isGloballyEmpty && (
                   <div className={styles.upgradeFooter}>
-                    <UpsellCard surface="downloads_upsell" />
+                    <UpsellCard surface="downloads_upsell" hideForAnonymous />
                   </div>
                 )}
               </div>

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -12,7 +12,7 @@ import { PassCards } from './components/PassCards';
 import { PricingCard } from './components/PricingCard';
 import { UnlimitedCard } from './components/UnlimitedCard';
 import styles from './PricingPage.module.css';
-import { getLifetimeLink } from './payment.links';
+import { getLifetimeLink, PASS_PRICES } from './payment.links';
 import {
   AUTO_SYNC_LAUNCH_DATE,
   AUTO_SYNC_NEW_CHIP_DAYS,
@@ -296,7 +296,7 @@ export default function PricingPage({
         name: 'What is a Day Pass or Week Pass?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Day Pass ($4) gives 24 hours of unlimited access. Week Pass ($9) gives 7 days. Both are one-time payments, no subscription required.',
+          text: `Day Pass (${PASS_PRICES['24h']}) gives 24 hours of unlimited access. Week Pass (${PASS_PRICES['7d']}) gives 7 days. Both are one-time payments, no subscription required.`,
         },
       },
     ],

--- a/web/src/pages/PricingPage/payment.links.ts
+++ b/web/src/pages/PricingPage/payment.links.ts
@@ -1,3 +1,8 @@
+export const PASS_PRICES = {
+  '24h': '$4',
+  '7d': '$9',
+} as const;
+
 export const getSubscribeLink = (email?: string) => {
   const base =
     process.env.NODE_ENV === 'development'

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -814,7 +814,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
           Didn't get the file? Download it here.
         </button>
       )}
-      <UpsellCard surface="upload_success_upsell" />
+      <UpsellCard surface="upload_success_upsell" hideForAnonymous />
       <button
         type="button"
         className={formStyles.actionButton}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-pass-prices.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-pass-prices.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-pass-prices",
+  "date": "2026-05-25",
+  "type": "style",
+  "title": "Day Pass ($4) and Week Pass ($9) prices show on the upgrade card before checkout"
+}


### PR DESCRIPTION
## What

Two fixes to the upgrade card (`UpsellCard`), which wasn't converting:

1. **Price on the buttons** — `Get Day Pass — $4` / `Get Week Pass — $9`. Previously the buttons showed no price; you had to click through to Stripe to learn the cost. Prices come from one `PASS_PRICES` constant that also feeds the pricing-page FAQ, so the card and FAQ can't drift.
2. **Remove the dead anonymous button** — both mount sites now pass `hideForAnonymous`. Pass checkout is auth-gated, so an anonymous user clicking "Day Pass" got a silent 401 no-op. They no longer see a button they can't complete.

Held back on purpose: gating the card to users near the 100-card cap (the `useCardUsage` plumbing already exists on `main`). That's a separate bet pending session-recording analysis of where the funnel actually leaks.

## Testing

- 61 web tests pass (UpsellCard, PricingPage), web typecheck clean, Biome clean — re-verified after rebase on `origin/main`.
- Sonar: skipped local scan — change is label strings + a constant + a boolean prop, no new functions or complexity.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified against the Netlify deploy preview (deploy-preview-2812) in a real headless Chromium, with the API stubbed to a logged-in free user. `/downloads` rendered the card showing **Get Day Pass — $4** / **Get Week Pass — $9** and the Unlimited link; at 375px the actions stack cleanly and the card stays within the viewport (x=32, w=311). The only console errors were the Netlify preview banner's own CSP violations (`app.netlify.com` iframe) — unrelated to the app. The `/pricing` JSON-LD FAQ carries `Day Pass ($4)` / `Week Pass ($9)`. (Used the built preview rather than localhost:3000 — a more production-like artifact than the dev server.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
