### PR TITLE
fix: bind react-flow chrome tokens to app theme vars

### DIFF
--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-mindmap-dark-contrast.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-mindmap-dark-contrast.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-mindmap-dark-contrast",
+  "date": "2026-05-25",
+  "type": "style",
+  "title": "Mind map canvas — background, edges, and minimap follow your active theme in dark and gold modes"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -417,7 +417,7 @@ button {
 
 /* =====================================================================
    REACT FLOW — bind library tokens to app design tokens so canvas
-   chrome (controls, etc.) follows the active theme.
+   chrome (controls, minimap, background, edges) follows the active theme.
    ===================================================================== */
 .react-flow {
   --xy-controls-button-background-color: var(--color-bg-secondary);
@@ -425,4 +425,17 @@ button {
   --xy-controls-button-color: var(--color-text-secondary);
   --xy-controls-button-color-hover: var(--color-text-primary);
   --xy-controls-button-border-color: var(--color-border);
+
+  --xy-background-color: var(--color-bg-primary);
+  --xy-background-pattern-dots-color: var(--color-border);
+  --xy-background-pattern-lines-color: var(--color-border);
+  --xy-background-pattern-cross-color: var(--color-border);
+
+  --xy-edge-stroke: var(--color-border);
+  --xy-edge-stroke-selected: var(--color-primary);
+
+  --xy-minimap-background-color: var(--color-bg-secondary);
+  --xy-minimap-mask-background-color: color-mix(in srgb, var(--color-bg-tertiary) 60%, transparent);
+  --xy-minimap-node-background-color: var(--color-bg-tertiary);
+  --xy-minimap-node-stroke-color: var(--color-border);
 }


### PR DESCRIPTION
## What
Extends the existing controls dark-mode fix to the remaining react-flow canvas chrome elements: background fill, background dot/line/cross pattern, edge strokes, and minimap (ready for when it's added).

## Why
Closes #2652. In dark mode (and gold/purple themes), the canvas background was always white and the dot pattern used a hardcoded near-grey (#91919a) that either disappeared or contrasted badly against the dark canvas.

## How
All overrides go through the `--xy-*` CSS custom property layer that react-flow exposes for theming, set on `.react-flow` in `base.css` — identical approach to the controls fix already in the file. No new CSS selectors, no JS changes, no new components.

- `--xy-background-color` → `--color-bg-primary` — canvas matches the page background
- `--xy-background-pattern-{dots,lines,cross}-color` → `--color-border` — pattern is theme-aware and subtle in every palette
- `--xy-edge-stroke` → `--color-border` — catches any edge that doesn't carry an inline style
- `--xy-edge-stroke-selected` → `--color-primary`
- `--xy-minimap-*` vars wired for forward-compat

Notes: attribution is already suppressed via `proOptions={{ hideAttribution: true }}`. Edge labels are not used in the current editor — no separate fix needed.

## Measuring success
Open the mindmap editor in dark mode, gold theme, and purple theme. The canvas background should match the sidebar/page, and the dot grid should be faintly visible rather than white-on-dark or absent.

## Testing
- Unit tests: no logic change; CSS-only. 140 test files / 1228 tests green.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: CSS-only change applied on `.react-flow`. Verified the dot pattern, canvas background, and edge colors adapt across dark, gold, and purple themes by reading the computed CSS variable values. The editor loads on desktop only (mobile path returns early with a notice).

## Changelog
"Mind map canvas — background, edges, and minimap follow your active theme in dark and gold modes" added to `web/src/pages/WhatsNewPage/changelog/2026-05-25-mindmap-dark-contrast.json`.

## Risks
Low — pure CSS custom property overrides on the `.react-flow` root; react-flow's own defaults remain unchanged for any consumer that doesn't see the override. Rollback: revert the 14-line addition in `base.css`.

## Goal alignment
Polishes the mindmap canvas for users on dark mode and themed palettes — improves the quality and legibility of a differentiating feature (mindmap export to Anki) that sets 2anki apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782335376&installation_id=132681956&pr_number=2814&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2814&signature=cf602ebe717ae984f62599869458674f8e0764f0b727d00a68c0e54dc0fcbd22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->