### PR TITLE
fix: repair broken favicon and home-screen icon references

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,12 +21,15 @@
     })();
   </script>
   <link rel="canonical" href="https://2anki.net" />
-  <link rel="icon" href="/favicon.ico" />
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="manifest" href="/site.webmanifest" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
   <meta http-equiv="Content-Security-Policy"
     content="script-src 'self' 'unsafe-inline' https://*.digitaloceanspaces.com https://www.googletagmanager.com https://www.google-analytics.com https://static.hotjar.com https://script.hotjar.com https://www.dropbox.com https://apis.google.com https://accounts.google.com https://pagead2.googlesyndication.com https://*.googlesyndication.com https://*.doubleclick.net https://*.google.com https://*.adtrafficquality.google; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; frame-src https://*.doubleclick.net https://*.googlesyndication.com https://*.google.com https://www.youtube.com https://www.youtube-nocookie.com https://*.adtrafficquality.google; img-src 'self' data: blob: https:;">
-  <link rel="apple-touch-icon" href="/logo192.png" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   <!--
       Notice the use of  in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/web/public/site.webmanifest
+++ b/web/public/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"2anki.net","short_name":"2anki.net","icons":[{"src":"/android-chrome-191x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"2anki.net","short_name":"2anki.net","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-home-screen-icon.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-home-screen-icon.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-home-screen-icon",
+  "date": "2026-05-25",
+  "type": "fix",
+  "title": "Home screen and install icons show the 2anki mascot instead of a blank page"
+}


### PR DESCRIPTION
## What

Two icon references on the site pointed at files that don't exist, so the browser got the SPA's `index.html` (an HTML page) back instead of an image:

- **`apple-touch-icon` → `/logo192.png`** — leftover from the CRA→Vite migration; the file was never in `web/public/`. iOS Safari and "Add to Home Screen" rendered a broken/blank icon.
- **manifest → `/android-chrome-191x192.png`** — a `191`/`192` typo. The actual file is `android-chrome-192x192.png`, so the Android/PWA install icon was broken too.

The primary browser-tab favicon (`favicon.ico`) was always fine — this only affected the home-screen / installed-app icon.

## Changes

- `apple-touch-icon` → `/apple-touch-icon.png` (exists in `web/public/`)
- manifest icon `191x192` → `192x192` (matches the real file)
- Link the 16×16 / 32×32 PNG favicons and the web manifest from `index.html` (they shipped in `public/` but were never referenced)

## Verification

- `pnpm --filter 2anki-web build` — clean; confirmed `build/index.html` and the prerendered landing pages now reference `/apple-touch-icon.png`, and all seven referenced icon files land in `build/`.
- Confirmed the old paths returned `text/html` (SPA fallback) on prod, while the new targets return `image/png` / `application/manifest+json`.
- `pnpm --filter 2anki-web test` — 1228 passing, changelog loader green.

Browser check: not applicable — static `<link>` asset references only, no rendered component change; verified via build output and resolved asset paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782335619&installation_id=132681956&pr_number=2815&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2815&signature=2bdb558639b99ee8b242144eaa6abb517b856a3a8d2fb7d339984a09a6e63d8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->