### PR TITLE
fix: escape deck title in markmap card HTML to prevent XSS

### DIFF
--- a/src/usecases/mindmaps/escapeHtml.ts
+++ b/src/usecases/mindmaps/escapeHtml.ts
@@ -1,0 +1,7 @@
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/usecases/mindmaps/mindmapToMarkmapHtml.test.ts
+++ b/src/usecases/mindmaps/mindmapToMarkmapHtml.test.ts
@@ -75,4 +75,16 @@ describe('mindmapToMarkmapHtml', () => {
     expect(html).not.toContain('<b>Bold</b>');
     expect(html).toContain('&lt;b&gt;');
   });
+
+  it('escapes HTML special characters in the deck title', () => {
+    const html = mindmapToMarkmapHtml(fiveNodeTree, '</title><script>alert(1)</script>');
+    expect(html).not.toContain('</title><script>');
+    expect(html).toContain('&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('escapes double-quotes in the deck title', () => {
+    const html = mindmapToMarkmapHtml(fiveNodeTree, '"><img src=x onerror=alert(1)>');
+    expect(html).not.toContain('"><img');
+    expect(html).toContain('&quot;&gt;&lt;img');
+  });
 });

--- a/src/usecases/mindmaps/mindmapToMarkmapHtml.ts
+++ b/src/usecases/mindmaps/mindmapToMarkmapHtml.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { MindmapData } from './MindmapData';
+import { escapeHtml } from './escapeHtml';
 import { mindmapToMarkmapTree } from './mindmapToMarkmapTree';
 
 function findPackageRoot(startFile: string): string {
@@ -40,7 +41,7 @@ export function mindmapToMarkmapHtml(
 <html>
 <head>
 <meta charset="utf-8">
-<title>${title}</title>
+<title>${escapeHtml(title)}</title>
 <style>
 html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: transparent; color: inherit; }
 svg#mindmap { width: 100%; height: 100%; display: block; color: inherit; }

--- a/src/usecases/mindmaps/mindmapToMarkmapTree.ts
+++ b/src/usecases/mindmaps/mindmapToMarkmapTree.ts
@@ -1,17 +1,10 @@
 import { MindmapData } from './MindmapData';
+import { escapeHtml } from './escapeHtml';
 
 export interface MarkmapTreeNode {
   content: string;
   children: MarkmapTreeNode[];
   payload?: { fold?: number };
-}
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }
 
 function buildNodeContent(

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-25-markmap-title-escape.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-25-markmap-title-escape.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-25-markmap-title-escape",
+  "date": "2026-05-25",
+  "type": "fix",
+  "title": "Mind map deck titles with HTML special characters render correctly"
+}


### PR DESCRIPTION
Closes #2591

## What

The deck title was interpolated raw into the `<title>` element of the generated markmap card HTML. A title containing `</title><script>…` would break out of the element. Self-XSS only (user's own deck name), but defense in depth.

Extracted `escapeHtml` into `src/usecases/mindmaps/escapeHtml.ts` so both `mindmapToMarkmapTree` and `mindmapToMarkmapHtml` share one implementation. Added two test cases that proved the unescaped path before the fix.

## Verification

- `npx tsc --noEmit` clean
- All 77 mindmap usecase tests pass (including 2 new XSS cases); `mindmapToMarkmapHtml.test.ts` 9/9
- Did not run `sonar-scanner` locally (small, focused change) — expect it clean; flag if it bounces

## Overlap

PR for #2592/#2593 also edits `mindmapToMarkmapHtml.ts` (the bundle-loading section, not the card-HTML/title section). This PR should merge first; that one rebases on top.

Browser check: not applicable — server-side HTML generation, only web/src change is a changelog JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782365226&installation_id=132681956&pr_number=2816&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2816&signature=6dd174e474cf21d808db2a663d8a78690bdbea77e478a7f57501827648cffa87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->