### PR TITLE
refactor: swap readFileSync for async fs.promises in UploadService

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import fs from 'node:fs';
 import path from 'path';
 import express from 'express';
 
@@ -21,12 +22,28 @@ jest.mock('../services/SubscriptionService', () => ({
   default: { findActiveStripeSubscriptions: jest.fn().mockResolvedValue([]) },
 }));
 
+let mockWorkspaceLocation = '';
+let mockWorkspaceId = 'test-ws-id';
+jest.mock('../lib/parser/WorkSpace', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      get id() { return mockWorkspaceId; },
+      get location() { return mockWorkspaceLocation; },
+    })),
+  };
+});
+
 const mockStorageDelete = jest.fn().mockResolvedValue(true);
+const mockStorageUploadFile = jest.fn().mockResolvedValue(undefined);
+const mockStorageUniqify = jest.fn().mockReturnValue('test-key.apkg');
 jest.mock('../lib/storage/StorageHandler', () => {
   return {
     __esModule: true,
     default: jest.fn().mockImplementation(() => ({
       delete: mockStorageDelete,
+      uploadFile: mockStorageUploadFile,
+      uniqify: mockStorageUniqify,
     })),
   };
 });
@@ -351,5 +368,65 @@ describe('UploadService.deleteUpload — cascade', () => {
     await service.deleteUpload(7, 'k.apkg');
 
     expect(jobRepository.deleteJobByObjectId).not.toHaveBeenCalled();
+  });
+});
+
+describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    mockStorageUploadFile.mockClear();
+    mockStorageUniqify.mockClear();
+    MockGeneratePackagesUseCase.mockClear();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'promote-claude-test-'));
+    mockWorkspaceLocation = tmpDir;
+    mockWorkspaceId = 'test-promote-id';
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads the apkg file and passes its contents to StorageHandler.uploadFile', async () => {
+    const apkgContents = Buffer.from('fake-apkg-binary-contents');
+    const apkgPath = path.join(tmpDir, 'my-deck.apkg');
+    fs.writeFileSync(apkgPath, apkgContents);
+
+    let resolveUpload!: () => void;
+    const uploadCalled = new Promise<void>((r) => { resolveUpload = r; });
+    mockStorageUploadFile.mockImplementationOnce((_key: string, _buf: Buffer) => {
+      resolveUpload();
+      return Promise.resolve(undefined);
+    });
+
+    const repo: IUploadRepository = {
+      ...buildRepository(),
+      update: jest.fn().mockResolvedValue([]),
+    };
+    const jobRepository = {
+      create: jest.fn().mockResolvedValue(undefined),
+      updateJobStatus: jest.fn().mockResolvedValue(undefined),
+      findJobById: jest.fn().mockResolvedValue(null),
+      deleteJob: jest.fn().mockResolvedValue(undefined),
+    } as unknown as JobRepository;
+
+    MockGeneratePackagesUseCase.mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        packages: [{ name: 'my-deck', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 }],
+      }),
+    }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
+
+    const service = new UploadService(repo, jobRepository);
+    const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+
+    await uploadCalled;
+
+    expect(mockStorageUploadFile).toHaveBeenCalledTimes(1);
+    const [, uploadedBuffer] = mockStorageUploadFile.mock.calls[0] as [string, Buffer];
+    expect(Buffer.compare(uploadedBuffer, apkgContents)).toBe(0);
   });
 });

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -126,14 +126,14 @@ class UploadService {
   }
 
   private async promoteClaudeJobToUpload(objectId: string, workspaceDir: string, owner: string): Promise<void> {
-    const files = fs.readdirSync(workspaceDir);
+    const files = await fs.promises.readdir(workspaceDir);
     const apkgFilename = files.find((f) => f.endsWith('.apkg'));
     if (!apkgFilename) {
       throw new Error('No APKG file found in workspace');
     }
     await this.jobRepository.updateJobStatus(objectId, owner, 'step3_building_deck', '');
     const apkgPath = path.join(workspaceDir, apkgFilename);
-    const apkgBuffer = fs.readFileSync(apkgPath);
+    const apkgBuffer = await fs.promises.readFile(apkgPath);
     const storage = new StorageHandler();
     const key = storage.uniqify(objectId, owner, 200, 'apkg');
     await storage.uploadFile(key, apkgBuffer);
@@ -160,7 +160,7 @@ class UploadService {
 
     const deckInfoArrays: DeckInfo[][] = [];
     for (const htmlFile of htmlFiles) {
-      const content = fs.readFileSync(htmlFile, 'utf8');
+      const content = await fs.promises.readFile(htmlFile, 'utf8');
       const deckInfo = await generateDeckInfo(content, mediaFiles, undefined, onProgress);
       deckInfoArrays.push(deckInfo);
     }


### PR DESCRIPTION
Closes #2429

Swaps the synchronous `readFileSync` in `UploadService.promoteClaudeJobToUpload` for `await fs.promises.readFile`, keeping behavior identical and unblocking the event loop during the read.

## Verification
- `npx tsc --noEmit` clean
- `UploadService.test.ts` 10/10 pass

No changelog entry — internal refactor, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782366822&installation_id=132681956&pr_number=2817&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2817&signature=bd1f611136df9ab628c6a75ee16b6ffb5e4bec60e9d04192f88a41aab6eda6ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->