### PR TITLE
refactor: memoize markmap bundles and drop unused markmap-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "markdown-it": "^14.1.1",
     "markdown-it-multimd-table": "^4.2.3",
     "markdown-it-task-lists": "^2.1.1",
-    "markmap-common": "^0.18.9",
     "markmap-view": "^0.18.12",
     "metascraper": "^5.50.1",
     "metascraper-description": "^5.50.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,6 @@ importers:
       markdown-it-task-lists:
         specifier: ^2.1.1
         version: 2.1.1
-      markmap-common:
-        specifier: ^0.18.9
-        version: 0.18.9
       markmap-view:
         specifier: ^0.18.12
         version: 0.18.12(markmap-common@0.18.9)
@@ -8078,7 +8075,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8130,7 +8127,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -8791,7 +8788,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11058,7 +11055,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -11724,10 +11721,6 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
@@ -12059,7 +12052,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -12141,7 +12134,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -13856,7 +13849,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -14887,7 +14880,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -14946,7 +14939,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1

--- a/src/usecases/mindmaps/mindmapToMarkmapHtml.test.ts
+++ b/src/usecases/mindmaps/mindmapToMarkmapHtml.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { mindmapToMarkmapHtml } from './mindmapToMarkmapHtml';
 
 const fiveNodeTree = {
@@ -86,5 +87,23 @@ describe('mindmapToMarkmapHtml', () => {
     const html = mindmapToMarkmapHtml(fiveNodeTree, '"><img src=x onerror=alert(1)>');
     expect(html).not.toContain('"><img');
     expect(html).toContain('&quot;&gt;&lt;img');
+  });
+
+  it('reads each bundle file at most once across multiple calls (memoized)', () => {
+    const readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+
+    mindmapToMarkmapHtml(fiveNodeTree, 'Call 1');
+    mindmapToMarkmapHtml(fiveNodeTree, 'Call 2');
+    mindmapToMarkmapHtml(fiveNodeTree, 'Call 3');
+
+    const bundleReadCount = readFileSyncSpy.mock.calls.filter(
+      (args) =>
+        typeof args[0] === 'string' &&
+        (args[0].includes('d3.min.js') || args[0].includes('markmap-view'))
+    ).length;
+
+    expect(bundleReadCount).toBeLessThanOrEqual(2);
+
+    readFileSyncSpy.mockRestore();
   });
 });

--- a/src/usecases/mindmaps/mindmapToMarkmapHtml.ts
+++ b/src/usecases/mindmaps/mindmapToMarkmapHtml.ts
@@ -5,24 +5,23 @@ import { MindmapData } from './MindmapData';
 import { escapeHtml } from './escapeHtml';
 import { mindmapToMarkmapTree } from './mindmapToMarkmapTree';
 
-function findPackageRoot(startFile: string): string {
-  let dir = path.dirname(startFile);
-  while (dir !== path.dirname(dir)) {
-    if (fs.existsSync(path.join(dir, 'package.json'))) return dir;
-    dir = path.dirname(dir);
-  }
-  throw new Error(`Cannot find package root for ${startFile}`);
-}
+let d3BundleCache: string | null = null;
+let markmapViewBundleCache: string | null = null;
 
 function readD3Bundle(): string {
-  const d3Main = require.resolve('d3');
-  const d3Root = findPackageRoot(d3Main);
-  return fs.readFileSync(path.join(d3Root, 'dist', 'd3.min.js'), 'utf-8');
+  if (d3BundleCache == null) {
+    const d3Root = path.resolve(path.dirname(require.resolve('d3')), '..');
+    d3BundleCache = fs.readFileSync(path.join(d3Root, 'dist', 'd3.min.js'), 'utf-8');
+  }
+  return d3BundleCache;
 }
 
 function readMarkmapViewBundle(): string {
-  const markmapBrowser = require.resolve('markmap-view/dist/browser/index.js');
-  return fs.readFileSync(markmapBrowser, 'utf-8');
+  if (markmapViewBundleCache == null) {
+    const markmapBrowser = require.resolve('markmap-view/dist/browser/index.js');
+    markmapViewBundleCache = fs.readFileSync(markmapBrowser, 'utf-8');
+  }
+  return markmapViewBundleCache;
 }
 
 export function mindmapToMarkmapHtml(


### PR DESCRIPTION
## What
Memoizes the d3 and markmap-view bundle file reads in `mindmapToMarkmapHtml` so each file is read from disk at most once per process lifetime. Removes `markmap-common` from `package.json` — it was declared as a direct dep but is only used transitively by `markmap-view` as a peer.

## Why
Closes #2593 and Closes #2592. Filed as follow-ups to PR #2590. Without memoization, every markmap export reads ~330 KB from `node_modules` on each call. The dep removal keeps `package.json` honest.

## How
- Added module-level `d3BundleCache` and `markmapViewBundleCache` with `null` sentinels (using `== null` check per the project rule).
- Path resolution now uses `require.resolve('d3')` + `path.dirname` + `path.resolve('..')` instead of the fragile `findPackageRoot` walk that walked up looking for `package.json` files — that approach could resolve to a parent workspace package.json under pnpm's hoisting layout.
- Ran `pnpm remove markmap-common` after confirming with `grep -r "markmap-common" src/` (zero hits) and `pnpm why markmap-common` (only a transitive peer of `markmap-view`).

## Measuring success
No regression: the existing test suite (8 tests) passes. The memoization test specifically asserts that `fs.readFileSync` is called ≤ 2 times across 3 consecutive invocations of `mindmapToMarkmapHtml`.

## Testing
- Unit tests added: memoization assertion in `mindmapToMarkmapHtml.test.ts` ("reads each bundle file at most once across multiple calls")
- `npx tsc --noEmit`: clean
- `pnpm test src/usecases/mindmaps/mindmapToMarkmapHtml.test.ts`: 8/8 passed

## Changelog
No entry — internal refactor/perf, no user-visible behavior change.

## Risks
None — the memoization is module-scoped (process lifetime), which is correct for static bundle files that never change between requests. The removed dep was unused; `markmap-view` brings it in as a peer so it remains resolvable.

## Goal alignment
Reduces per-request I/O on the mindmap export path. Keeps deps honest. Neither adds scale cost nor reduces it materially at current volume — this is maintenance hygiene.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782367159&installation_id=132681956&pr_number=2819&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2819&signature=2886e55d9961aea616969aaeb29e0d5b24baa520672f3917a8c4369574828875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->