### PR TITLE
refactor: extract JobsMetricsRepository from ConversionMetricsService

### DIFF
--- a/src/data_layer/JobsMetricsRepository.test.ts
+++ b/src/data_layer/JobsMetricsRepository.test.ts
@@ -1,0 +1,152 @@
+import knex, { Knex } from 'knex';
+
+import { JobsMetricsRepository } from './JobsMetricsRepository';
+
+async function makeDb(): Promise<Knex> {
+  const db = knex({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+  await db.schema.createTable('jobs', (t) => {
+    t.increments('id');
+    t.string('owner').notNullable();
+    t.string('object_id').notNullable();
+    t.string('title');
+    t.string('type');
+    t.string('status');
+    t.timestamp('created_at').defaultTo(db.fn.now());
+    t.timestamp('last_edited_time');
+    t.string('job_reason_failure');
+    t.integer('card_count');
+  });
+  await db.schema.createTable('users', (t) => {
+    t.string('id').primary();
+    t.string('stripe_customer_id');
+  });
+  return db;
+}
+
+async function insertUser(db: Knex, id: string, stripeCustomerId: string | null) {
+  await db('users').insert({ id, stripe_customer_id: stripeCustomerId });
+}
+
+async function insertJob(
+  db: Knex,
+  attrs: {
+    owner: string;
+    object_id: string;
+    type: string;
+    status?: string;
+    created_at?: Date;
+    job_reason_failure?: string;
+  }
+) {
+  await db('jobs').insert({
+    owner: attrs.owner,
+    object_id: attrs.object_id,
+    type: attrs.type,
+    status: attrs.status ?? 'done',
+    created_at: attrs.created_at ?? new Date(),
+    last_edited_time: new Date(),
+    job_reason_failure: attrs.job_reason_failure ?? null,
+  });
+}
+
+describe('JobsMetricsRepository — counts cover the real Notion job types', () => {
+  let db: Knex;
+  let repo: JobsMetricsRepository;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+  beforeEach(async () => {
+    db = await makeDb();
+    repo = new JobsMetricsRepository(db);
+    await insertUser(db, 'free-user', null);
+    await insertUser(db, 'paid-user', 'cus_paid');
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('counts free conversions stored as type=page or type=database', async () => {
+    await insertJob(db, { owner: 'free-user', object_id: 'p-1', type: 'page' });
+    await insertJob(db, { owner: 'free-user', object_id: 'p-2', type: 'database' });
+    await insertJob(db, { owner: 'free-user', object_id: 'p-3', type: 'conversion' });
+
+    const count = await repo.countFreeConversions7d(sevenDaysAgo);
+
+    expect(count).toBe(3);
+  });
+
+  it('counts paid conversions stored as type=page or type=database', async () => {
+    await insertJob(db, { owner: 'paid-user', object_id: 'p-4', type: 'page' });
+    await insertJob(db, { owner: 'paid-user', object_id: 'p-5', type: 'database' });
+
+    const count = await repo.countPaidConversions7d(sevenDaysAgo);
+
+    expect(count).toBe(2);
+  });
+
+  it('ignores apkg_import and claude (ankify) jobs for free count', async () => {
+    await insertJob(db, { owner: 'free-user', object_id: 'a-1', type: 'apkg_import' });
+    await insertJob(db, { owner: 'free-user', object_id: 'a-2', type: 'claude' });
+
+    const count = await repo.countFreeConversions7d(sevenDaysAgo);
+
+    expect(count).toBe(0);
+  });
+
+  it('computes free success rate over page+database+conversion jobs', async () => {
+    await insertJob(db, { owner: 'free-user', object_id: 's-1', type: 'page', status: 'done' });
+    await insertJob(db, { owner: 'free-user', object_id: 's-2', type: 'database', status: 'done' });
+    await insertJob(db, { owner: 'free-user', object_id: 's-3', type: 'page', status: 'failed' });
+
+    const rate = await repo.computeFreeSuccessRate7d(sevenDaysAgo);
+
+    expect(rate).toBeCloseTo((2 / 3) * 100, 5);
+  });
+
+  it('returns null free success rate when there are no qualifying jobs', async () => {
+    const rate = await repo.computeFreeSuccessRate7d(sevenDaysAgo);
+
+    expect(rate).toBeNull();
+  });
+
+  it('returns null paid success rate when there are no qualifying jobs', async () => {
+    const rate = await repo.computePaidSuccessRate7d(sevenDaysAgo);
+
+    expect(rate).toBeNull();
+  });
+
+  it('groups top failure reasons across Notion job types', async () => {
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'f-1',
+      type: 'page',
+      status: 'failed',
+      job_reason_failure: 'rate limit',
+    });
+    await insertJob(db, {
+      owner: 'free-user',
+      object_id: 'f-2',
+      type: 'database',
+      status: 'failed',
+      job_reason_failure: 'rate limit',
+    });
+    await insertJob(db, {
+      owner: 'paid-user',
+      object_id: 'f-3',
+      type: 'page',
+      status: 'failed',
+      job_reason_failure: 'timeout',
+    });
+
+    const reasons = await repo.topFailureReasons7d(sevenDaysAgo);
+
+    expect(reasons).toEqual([
+      { reason: 'rate limit', count: 2 },
+      { reason: 'timeout', count: 1 },
+    ]);
+  });
+});

--- a/src/data_layer/JobsMetricsRepository.ts
+++ b/src/data_layer/JobsMetricsRepository.ts
@@ -19,81 +19,72 @@ export interface IJobsMetricsRepository {
 
 const NOTION_CONVERSION_TYPES: string[] = ['page', 'database', 'conversion'];
 
+type ConversionTier = 'free' | 'paid';
+
+const PAID_CUSTOMER_FILTER =
+  "users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''";
+const FREE_CUSTOMER_FILTER =
+  "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''";
+
 export class JobsMetricsRepository implements IJobsMetricsRepository {
   constructor(private readonly database: Knex) {}
 
-  async countFreeConversions7d(sevenDaysAgo: Date): Promise<number> {
-    const result = await this.database('jobs')
+  private conversionsForTier(
+    sevenDaysAgo: Date,
+    tier: ConversionTier
+  ): Knex.QueryBuilder {
+    return this.database('jobs')
       .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.status', 'done')
       .where('jobs.created_at', '>=', sevenDaysAgo)
       .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw(
-        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
-      )
+      .whereRaw(tier === 'paid' ? PAID_CUSTOMER_FILTER : FREE_CUSTOMER_FILTER);
+  }
+
+  private async countConversions7d(
+    sevenDaysAgo: Date,
+    tier: ConversionTier
+  ): Promise<number> {
+    const result = await this.conversionsForTier(sevenDaysAgo, tier)
+      .where('jobs.status', 'done')
       .count('jobs.id as count')
       .first();
 
     return result?.count ? Number(result.count) : 0;
+  }
+
+  private async computeSuccessRate7d(
+    sevenDaysAgo: Date,
+    tier: ConversionTier
+  ): Promise<number | null> {
+    const result = await this.conversionsForTier(sevenDaysAgo, tier)
+      .whereIn('jobs.status', ['done', 'failed'])
+      .select(
+        this.database.raw(
+          'COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done',
+          ['done']
+        ),
+        this.database.raw('COUNT(*) as total')
+      )
+      .first();
+
+    if (!result || Number(result.total) === 0) return null;
+    return (Number(result.done) / Number(result.total)) * 100;
+  }
+
+  async countFreeConversions7d(sevenDaysAgo: Date): Promise<number> {
+    return this.countConversions7d(sevenDaysAgo, 'free');
   }
 
   async countPaidConversions7d(sevenDaysAgo: Date): Promise<number> {
-    const result = await this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.status', 'done')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw(
-        "users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''"
-      )
-      .count('jobs.id as count')
-      .first();
-
-    return result?.count ? Number(result.count) : 0;
+    return this.countConversions7d(sevenDaysAgo, 'paid');
   }
 
   async computeFreeSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
-    const result = await this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw(
-        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
-      )
-      .whereIn('jobs.status', ['done', 'failed'])
-      .select(
-        this.database.raw(
-          'COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done',
-          ['done']
-        ),
-        this.database.raw('COUNT(*) as total')
-      )
-      .first();
-
-    if (!result || Number(result.total) === 0) return null;
-    return (Number(result.done) / Number(result.total)) * 100;
+    return this.computeSuccessRate7d(sevenDaysAgo, 'free');
   }
 
   async computePaidSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
-    const result = await this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw(
-        "users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''"
-      )
-      .whereIn('jobs.status', ['done', 'failed'])
-      .select(
-        this.database.raw(
-          'COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done',
-          ['done']
-        ),
-        this.database.raw('COUNT(*) as total')
-      )
-      .first();
-
-    if (!result || Number(result.total) === 0) return null;
-    return (Number(result.done) / Number(result.total)) * 100;
+    return this.computeSuccessRate7d(sevenDaysAgo, 'paid');
   }
 
   async topFailureReasons7d(

--- a/src/data_layer/JobsMetricsRepository.ts
+++ b/src/data_layer/JobsMetricsRepository.ts
@@ -1,0 +1,148 @@
+import type { Knex } from 'knex';
+
+import type {
+  ConversionErrorCount,
+  FailedConversionsWeekPoint,
+} from '../services/ops/ConversionMetricsService';
+
+export interface IJobsMetricsRepository {
+  countFreeConversions7d(sevenDaysAgo: Date): Promise<number>;
+  countPaidConversions7d(sevenDaysAgo: Date): Promise<number>;
+  computeFreeSuccessRate7d(sevenDaysAgo: Date): Promise<number | null>;
+  computePaidSuccessRate7d(sevenDaysAgo: Date): Promise<number | null>;
+  topFailureReasons7d(sevenDaysAgo: Date): Promise<ConversionErrorCount[]>;
+  failedConversionsWeekly(
+    earliestStart: Date,
+    weekEnd: Date
+  ): Promise<Array<{ weekStart: Date; count: number }>>;
+}
+
+const NOTION_CONVERSION_TYPES: string[] = ['page', 'database', 'conversion'];
+
+export class JobsMetricsRepository implements IJobsMetricsRepository {
+  constructor(private readonly database: Knex) {}
+
+  async countFreeConversions7d(sevenDaysAgo: Date): Promise<number> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.status', 'done')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
+      .whereRaw(
+        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
+      )
+      .count('jobs.id as count')
+      .first();
+
+    return result?.count ? Number(result.count) : 0;
+  }
+
+  async countPaidConversions7d(sevenDaysAgo: Date): Promise<number> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.status', 'done')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
+      .whereRaw(
+        "users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''"
+      )
+      .count('jobs.id as count')
+      .first();
+
+    return result?.count ? Number(result.count) : 0;
+  }
+
+  async computeFreeSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
+      .whereRaw(
+        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
+      )
+      .whereIn('jobs.status', ['done', 'failed'])
+      .select(
+        this.database.raw(
+          'COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done',
+          ['done']
+        ),
+        this.database.raw('COUNT(*) as total')
+      )
+      .first();
+
+    if (!result || Number(result.total) === 0) return null;
+    return (Number(result.done) / Number(result.total)) * 100;
+  }
+
+  async computePaidSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
+    const result = await this.database('jobs')
+      .join('users', 'jobs.owner', '=', 'users.id')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
+      .whereRaw(
+        "users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''"
+      )
+      .whereIn('jobs.status', ['done', 'failed'])
+      .select(
+        this.database.raw(
+          'COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done',
+          ['done']
+        ),
+        this.database.raw('COUNT(*) as total')
+      )
+      .first();
+
+    if (!result || Number(result.total) === 0) return null;
+    return (Number(result.done) / Number(result.total)) * 100;
+  }
+
+  async topFailureReasons7d(
+    sevenDaysAgo: Date
+  ): Promise<ConversionErrorCount[]> {
+    const results = await this.database('jobs')
+      .where('jobs.status', 'failed')
+      .where('jobs.created_at', '>=', sevenDaysAgo)
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
+      .whereNotNull('jobs.job_reason_failure')
+      .select('jobs.job_reason_failure as reason')
+      .count('jobs.id as count')
+      .groupBy('jobs.job_reason_failure')
+      .orderBy('count', 'desc')
+      .limit(10);
+
+    return (
+      results as Array<{ reason: string; count: number | string }>
+    ).map((row) => ({
+      reason: row.reason || 'Unknown',
+      count: Number(row.count),
+    }));
+  }
+
+  async failedConversionsWeekly(
+    earliestStart: Date,
+    weekEnd: Date
+  ): Promise<Array<{ weekStart: Date; count: number }>> {
+    const results = await this.database('jobs')
+      .where('jobs.status', 'failed')
+      .where('jobs.created_at', '>=', earliestStart)
+      .where('jobs.created_at', '<', weekEnd)
+      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
+      .select(
+        this.database.raw(
+          `DATE_TRUNC('week', jobs.created_at) AS week_start`
+        ),
+        this.database.raw('COUNT(*) as count')
+      )
+      .groupBy('week_start')
+      .orderBy('week_start', 'asc');
+
+    return (
+      results as Array<{ week_start: Date | string; count: number | string }>
+    ).map((row) => ({
+      weekStart: new Date(row.week_start),
+      count: Number(row.count),
+    }));
+  }
+}
+
+export type { ConversionErrorCount, FailedConversionsWeekPoint };

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -34,6 +34,7 @@ import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { UserVisibleErrorsRepository } from '../data_layer/UserVisibleErrorsRepository';
 import { MindmapRepository } from '../data_layer/MindmapRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
+import { JobsMetricsRepository } from '../data_layer/JobsMetricsRepository';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -49,7 +50,9 @@ const OpsRouter = () => {
     signupCountryRepository: new UsersRepository(database),
   });
 
-  const conversionMetricsService = new ConversionMetricsService(database);
+  const conversionMetricsService = new ConversionMetricsService(
+    new JobsMetricsRepository(database)
+  );
   const performanceMetricsService = new PerformanceMetricsService(
     database,
     new UserVisibleErrorsRepository(database)

--- a/src/services/ops/ConversionMetricsService.test.ts
+++ b/src/services/ops/ConversionMetricsService.test.ts
@@ -1,64 +1,33 @@
-import knex, { Knex } from 'knex';
-
+import type { IJobsMetricsRepository } from '../../data_layer/JobsMetricsRepository';
+import type { ConversionErrorCount } from './ConversionMetricsService';
 import { ConversionMetricsService } from './ConversionMetricsService';
 
-async function makeDb(): Promise<Knex> {
-  const db = knex({
-    client: 'better-sqlite3',
-    connection: { filename: ':memory:' },
-    useNullAsDefault: true,
-  });
-  await db.schema.createTable('jobs', (t) => {
-    t.increments('id');
-    t.string('owner').notNullable();
-    t.string('object_id').notNullable();
-    t.string('title');
-    t.string('type');
-    t.string('status');
-    t.timestamp('created_at').defaultTo(db.fn.now());
-    t.timestamp('last_edited_time');
-    t.string('job_reason_failure');
-    t.integer('card_count');
-  });
-  await db.schema.createTable('users', (t) => {
-    t.string('id').primary();
-    t.string('stripe_customer_id');
-  });
-  return db;
+function makeFailingRepo(): IJobsMetricsRepository {
+  return {
+    countFreeConversions7d: jest.fn().mockRejectedValue(new Error('db down')),
+    countPaidConversions7d: jest.fn().mockRejectedValue(new Error('db down')),
+    computeFreeSuccessRate7d: jest.fn().mockRejectedValue(new Error('db down')),
+    computePaidSuccessRate7d: jest.fn().mockRejectedValue(new Error('db down')),
+    topFailureReasons7d: jest.fn().mockRejectedValue(new Error('db down')),
+    failedConversionsWeekly: jest.fn().mockRejectedValue(new Error('db down')),
+  };
 }
 
-async function insertUser(db: Knex, id: string, stripeCustomerId: string | null) {
-  await db('users').insert({ id, stripe_customer_id: stripeCustomerId });
-}
-
-async function insertJob(
-  db: Knex,
-  attrs: {
-    owner: string;
-    object_id: string;
-    type: string;
-    status?: string;
-    created_at?: Date;
-    job_reason_failure?: string;
-  }
-) {
-  await db('jobs').insert({
-    owner: attrs.owner,
-    object_id: attrs.object_id,
-    type: attrs.type,
-    status: attrs.status ?? 'done',
-    created_at: attrs.created_at ?? new Date(),
-    last_edited_time: new Date(),
-    job_reason_failure: attrs.job_reason_failure ?? null,
-  });
+function makeStubRepo(overrides: Partial<IJobsMetricsRepository> = {}): IJobsMetricsRepository {
+  return {
+    countFreeConversions7d: jest.fn().mockResolvedValue(0),
+    countPaidConversions7d: jest.fn().mockResolvedValue(0),
+    computeFreeSuccessRate7d: jest.fn().mockResolvedValue(null),
+    computePaidSuccessRate7d: jest.fn().mockResolvedValue(null),
+    topFailureReasons7d: jest.fn().mockResolvedValue([]),
+    failedConversionsWeekly: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
 }
 
 describe('ConversionMetricsService — graceful failure', () => {
-  it('returns null for every metric when the db throws', async () => {
-    const failing = {
-      raw: jest.fn(),
-    } as unknown as Knex;
-    const service = new ConversionMetricsService(failing);
+  it('returns null for every metric when the repository throws', async () => {
+    const service = new ConversionMetricsService(makeFailingRepo());
     const metrics = await service.getMetrics();
 
     expect(metrics.free_conversions_7d).toBeNull();
@@ -70,88 +39,84 @@ describe('ConversionMetricsService — graceful failure', () => {
   });
 });
 
-describe('ConversionMetricsService — counts cover the real Notion job types', () => {
-  let db: Knex;
-  let service: ConversionMetricsService;
-
-  beforeEach(async () => {
-    db = await makeDb();
-    service = new ConversionMetricsService(db);
-    await insertUser(db, 'free-user', null);
-    await insertUser(db, 'paid-user', 'cus_paid');
-  });
-
-  afterEach(async () => {
-    await db.destroy();
-  });
-
-  it('counts free conversions stored as type=page or type=database', async () => {
-    await insertJob(db, { owner: 'free-user', object_id: 'p-1', type: 'page' });
-    await insertJob(db, { owner: 'free-user', object_id: 'p-2', type: 'database' });
-    await insertJob(db, { owner: 'free-user', object_id: 'p-3', type: 'conversion' });
+describe('ConversionMetricsService — shape assembly', () => {
+  it('passes through free conversion count from the repository', async () => {
+    const service = new ConversionMetricsService(
+      makeStubRepo({ countFreeConversions7d: jest.fn().mockResolvedValue(7) })
+    );
 
     const metrics = await service.getMetrics();
 
-    expect(metrics.free_conversions_7d).toBe(3);
+    expect(metrics.free_conversions_7d).toBe(7);
   });
 
-  it('counts paid conversions stored as type=page or type=database', async () => {
-    await insertJob(db, { owner: 'paid-user', object_id: 'p-4', type: 'page' });
-    await insertJob(db, { owner: 'paid-user', object_id: 'p-5', type: 'database' });
+  it('passes through paid conversion count from the repository', async () => {
+    const service = new ConversionMetricsService(
+      makeStubRepo({ countPaidConversions7d: jest.fn().mockResolvedValue(3) })
+    );
 
     const metrics = await service.getMetrics();
 
-    expect(metrics.paid_conversions_7d).toBe(2);
+    expect(metrics.paid_conversions_7d).toBe(3);
   });
 
-  it('ignores apkg_import and claude (ankify) jobs — those are separate flows', async () => {
-    await insertJob(db, { owner: 'free-user', object_id: 'a-1', type: 'apkg_import' });
-    await insertJob(db, { owner: 'free-user', object_id: 'a-2', type: 'claude' });
+  it('passes through free success rate from the repository', async () => {
+    const service = new ConversionMetricsService(
+      makeStubRepo({ computeFreeSuccessRate7d: jest.fn().mockResolvedValue(66.7) })
+    );
 
     const metrics = await service.getMetrics();
 
-    expect(metrics.free_conversions_7d).toBe(0);
-    expect(metrics.paid_conversions_7d).toBe(0);
+    expect(metrics.free_conversion_success_rate_7d).toBe(66.7);
   });
 
-  it('computes free success rate over page+database+conversion jobs', async () => {
-    await insertJob(db, { owner: 'free-user', object_id: 's-1', type: 'page', status: 'done' });
-    await insertJob(db, { owner: 'free-user', object_id: 's-2', type: 'database', status: 'done' });
-    await insertJob(db, { owner: 'free-user', object_id: 's-3', type: 'page', status: 'failed' });
+  it('passes through top failure reasons from the repository', async () => {
+    const reasons: ConversionErrorCount[] = [
+      { reason: 'rate limit', count: 5 },
+      { reason: 'timeout', count: 2 },
+    ];
+    const service = new ConversionMetricsService(
+      makeStubRepo({ topFailureReasons7d: jest.fn().mockResolvedValue(reasons) })
+    );
 
     const metrics = await service.getMetrics();
 
-    expect(metrics.free_conversion_success_rate_7d).toBeCloseTo((2 / 3) * 100, 5);
+    expect(metrics.conversion_errors_7d_top_reasons).toEqual(reasons);
   });
 
-  it('groups top failure reasons across Notion job types', async () => {
-    await insertJob(db, {
-      owner: 'free-user',
-      object_id: 'f-1',
-      type: 'page',
-      status: 'failed',
-      job_reason_failure: 'rate limit',
-    });
-    await insertJob(db, {
-      owner: 'free-user',
-      object_id: 'f-2',
-      type: 'database',
-      status: 'failed',
-      job_reason_failure: 'rate limit',
-    });
-    await insertJob(db, {
-      owner: 'paid-user',
-      object_id: 'f-3',
-      type: 'page',
-      status: 'failed',
-      job_reason_failure: 'timeout',
+  it('produces a 12-week time series with zeroes for weeks with no data', async () => {
+    const service = new ConversionMetricsService(
+      makeStubRepo({ failedConversionsWeekly: jest.fn().mockResolvedValue([]) })
+    );
+
+    const metrics = await service.getMetrics();
+
+    expect(metrics.failed_conversions_weekly).toHaveLength(12);
+    expect(
+      metrics.failed_conversions_weekly?.every((pt) => pt.count === 0)
+    ).toBe(true);
+  });
+
+  it('fills in counts for weeks that have data', async () => {
+    const now = new Date('2025-05-19T00:00:00.000Z');
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+
+    const currentMonday = new Date('2025-05-19T00:00:00.000Z');
+    const repo = makeStubRepo({
+      failedConversionsWeekly: jest.fn().mockResolvedValue([
+        { weekStart: currentMonday, count: 4 },
+      ]),
     });
 
+    const service = new ConversionMetricsService(repo);
     const metrics = await service.getMetrics();
 
-    expect(metrics.conversion_errors_7d_top_reasons).toEqual([
-      { reason: 'rate limit', count: 2 },
-      { reason: 'timeout', count: 1 },
-    ]);
+    const weekly = metrics.failed_conversions_weekly ?? [];
+    const lastPoint = weekly[weekly.length - 1];
+    expect(lastPoint?.count).toBe(4);
+    expect(lastPoint?.week).toBe('2025-05-19');
+
+    jest.useRealTimers();
   });
 });

--- a/src/services/ops/ConversionMetricsService.ts
+++ b/src/services/ops/ConversionMetricsService.ts
@@ -1,4 +1,4 @@
-import { Knex } from 'knex';
+import type { IJobsMetricsRepository } from '../../data_layer/JobsMetricsRepository';
 
 export type ConversionMetricKey =
   | 'free_conversions_7d'
@@ -30,15 +30,18 @@ export interface ConversionMetricsResponse {
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const WEEKLY_HISTORY_WEEKS = 12;
 
-const NOTION_CONVERSION_TYPES: string[] = ['page', 'database', 'conversion'];
-
 export class ConversionMetricsService {
-  constructor(private readonly database: Knex) {}
+  constructor(private readonly repository: IJobsMetricsRepository) {}
 
   async getMetrics(): Promise<ConversionMetricsResponse> {
     const now = new Date();
     const sevenDaysAgoMs = now.getTime() - 7 * SECONDS_PER_DAY * 1000;
     const sevenDaysAgo = new Date(sevenDaysAgoMs);
+
+    const weekStarts = this.lastNIsoWeekStartsUtc(now, WEEKLY_HISTORY_WEEKS);
+    const earliestStart = new Date(weekStarts[0]);
+    const lastStart = weekStarts[weekStarts.length - 1];
+    const weekEnd = new Date(lastStart + 7 * SECONDS_PER_DAY * 1000);
 
     const [
       freeConversions7d,
@@ -46,15 +49,20 @@ export class ConversionMetricsService {
       freeSuccessRate7d,
       paidSuccessRate7d,
       topErrors7d,
-      failedConversionsWeekly,
+      failedConversionsWeeklyRows,
     ] = await Promise.allSettled([
-      this.countFreeConversions7d(sevenDaysAgo),
-      this.countPaidConversions7d(sevenDaysAgo),
-      this.computeFreeSuccessRate7d(sevenDaysAgo),
-      this.computePaidSuccessRate7d(sevenDaysAgo),
-      this.topFailureReasons7d(sevenDaysAgo),
-      this.failedConversionsWeekly(now),
+      this.repository.countFreeConversions7d(sevenDaysAgo),
+      this.repository.countPaidConversions7d(sevenDaysAgo),
+      this.repository.computeFreeSuccessRate7d(sevenDaysAgo),
+      this.repository.computePaidSuccessRate7d(sevenDaysAgo),
+      this.repository.topFailureReasons7d(sevenDaysAgo),
+      this.repository.failedConversionsWeekly(earliestStart, weekEnd),
     ]);
+
+    const failedConversionsWeekly =
+      failedConversionsWeeklyRows.status === 'fulfilled'
+        ? this.buildWeeklyTimeSeries(weekStarts, failedConversionsWeeklyRows.value)
+        : null;
 
     return {
       free_conversions_7d:
@@ -67,105 +75,14 @@ export class ConversionMetricsService {
         paidSuccessRate7d.status === 'fulfilled' ? paidSuccessRate7d.value : null,
       conversion_errors_7d_top_reasons:
         topErrors7d.status === 'fulfilled' ? topErrors7d.value : null,
-      failed_conversions_weekly:
-        failedConversionsWeekly.status === 'fulfilled'
-          ? failedConversionsWeekly.value
-          : null,
+      failed_conversions_weekly: failedConversionsWeekly,
     };
   }
 
-  private async countFreeConversions7d(sevenDaysAgo: Date): Promise<number> {
-    const result = await this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.status', 'done')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw(
-        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
-      )
-      .count('jobs.id as count')
-      .first();
-
-    return result?.count ? Number(result.count) : 0;
-  }
-
-  private async countPaidConversions7d(sevenDaysAgo: Date): Promise<number> {
-    const result = await this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.status', 'done')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw("users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''")
-      .count('jobs.id as count')
-      .first();
-
-    return result?.count ? Number(result.count) : 0;
-  }
-
-  private async computeFreeSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
-    const result = await this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw(
-        "users.stripe_customer_id IS NULL OR users.stripe_customer_id = ''"
-      )
-      .whereIn('jobs.status', ['done', 'failed'])
-      .select(
-        this.database.raw('COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done', [
-          'done',
-        ]),
-        this.database.raw('COUNT(*) as total')
-      )
-      .first();
-
-    if (!result || Number(result.total) === 0) return null;
-    return (Number(result.done) / Number(result.total)) * 100;
-  }
-
-  private async computePaidSuccessRate7d(sevenDaysAgo: Date): Promise<number | null> {
-    const result = await this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereRaw("users.stripe_customer_id IS NOT NULL AND users.stripe_customer_id != ''")
-      .whereIn('jobs.status', ['done', 'failed'])
-      .select(
-        this.database.raw('COUNT(CASE WHEN jobs.status = ? THEN 1 END) as done', [
-          'done',
-        ]),
-        this.database.raw('COUNT(*) as total')
-      )
-      .first();
-
-    if (!result || Number(result.total) === 0) return null;
-    return (Number(result.done) / Number(result.total)) * 100;
-  }
-
-  private async topFailureReasons7d(
-    sevenDaysAgo: Date
-  ): Promise<ConversionErrorCount[]> {
-    const results = await this.database('jobs')
-      .where('jobs.status', 'failed')
-      .where('jobs.created_at', '>=', sevenDaysAgo)
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .whereNotNull('jobs.job_reason_failure')
-      .select('jobs.job_reason_failure as reason')
-      .count('jobs.id as count')
-      .groupBy('jobs.job_reason_failure')
-      .orderBy('count', 'desc')
-      .limit(10);
-
-    return (results as Array<{ reason: string; count: number | string }>).map((row) => ({
-      reason: row.reason || 'Unknown',
-      count: Number(row.count),
-    }));
-  }
-
-  private async failedConversionsWeekly(
-    now: Date
-  ): Promise<FailedConversionsWeekPoint[]> {
-    const weekStarts = this.lastNIsoWeekStartsUtc(now, WEEKLY_HISTORY_WEEKS);
+  private buildWeeklyTimeSeries(
+    weekStarts: number[],
+    rows: Array<{ weekStart: Date; count: number }>
+  ): FailedConversionsWeekPoint[] {
     const weekIndex = new Map<number, FailedConversionsWeekPoint>();
 
     for (const startMs of weekStarts) {
@@ -175,34 +92,17 @@ export class ConversionMetricsService {
       });
     }
 
-    const earliestStart = weekStarts[0];
-    const lastStart = weekStarts[weekStarts.length - 1];
-    const weekEnd = lastStart + 7 * SECONDS_PER_DAY * 1000;
-
-    const results = await this.database('jobs')
-      .where('jobs.status', 'failed')
-      .where('jobs.created_at', '>=', new Date(earliestStart))
-      .where('jobs.created_at', '<', new Date(weekEnd))
-      .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
-      .select(
-        this.database.raw(
-          `DATE_TRUNC('week', jobs.created_at) AS week_start`
-        ),
-        this.database.raw('COUNT(*) as count')
-      )
-      .groupBy('week_start')
-      .orderBy('week_start', 'asc');
-
-    for (const row of results) {
-      const weekStartMs = new Date(row.week_start).getTime();
-      const bucket = this.isoWeekStartUtcMs(weekStartMs);
+    for (const row of rows) {
+      const bucket = this.isoWeekStartUtcMs(row.weekStart.getTime());
       const existing = weekIndex.get(bucket);
       if (existing) {
-        existing.count = Number(row.count);
+        existing.count = row.count;
       }
     }
 
-    return weekStarts.map((startMs) => weekIndex.get(startMs) as FailedConversionsWeekPoint);
+    return weekStarts.map(
+      (startMs) => weekIndex.get(startMs) as FailedConversionsWeekPoint
+    );
   }
 
   private isoDate(ms: number): string {


### PR DESCRIPTION
## What
Extracts the six Knex queries from `ConversionMetricsService` into a new `JobsMetricsRepository` in `src/data_layer/`. The service now receives an `IJobsMetricsRepository` interface via constructor — no Knex import in the service layer.

## Why
Closes #2536. `ConversionMetricsService` was importing `Knex` directly, violating the rule in `src/services/CLAUDE.md`: services must receive repository interfaces via constructor, never import knex directly.

## How
- `src/data_layer/JobsMetricsRepository.ts`: new class with all six query methods; exports `IJobsMetricsRepository` interface
- `src/services/ops/ConversionMetricsService.ts`: accepts `IJobsMetricsRepository` in constructor; `failedConversionsWeekly` date-range args computed here and passed to repo; weekly time-series assembly extracted into `buildWeeklyTimeSeries`
- `src/services/ops/ConversionMetricsService.test.ts`: replaced sqlite schema setup with a fake repo; tests now cover assembly logic (pass-through counts, time-series zero-fill)
- `src/data_layer/JobsMetricsRepository.test.ts`: sqlite-backed tests covering all query methods that can run without `DATE_TRUNC` (`failedConversionsWeekly` uses Postgres-only syntax and is exercised via the service fake)
- `src/routes/OpsRouter.ts`: wires `new JobsMetricsRepository(database)` into `new ConversionMetricsService(...)`

> **Note:** Alexander has a parallel local implementation of this same refactor uncommitted in the main checkout (`JobsMetricsRepository.ts` + `ConversionMetricsService` changes). This PR is an independent clean implementation on its own branch. Please reconcile or discard the main-checkout version before merging.

## Measuring success
No user-visible behavior change. The ops metrics endpoint (`/ops/metrics/conversion`) continues to return the same JSON shape. Confirm with `curl` against prod after deploy — the response schema is unchanged.

## Testing
- Unit tests added: `src/data_layer/JobsMetricsRepository.test.ts` (7 tests, sqlite-backed)
- Unit tests updated: `src/services/ops/ConversionMetricsService.test.ts` (7 tests, fake repo)
- Both suites: all 14 tests pass
- `npx tsc --noEmit`: clean

## Changelog
No entry — pure internal refactor, no user-visible behavior change.

## Risks
Pure structural refactor — no query logic changed. The Postgres `DATE_TRUNC` query in `failedConversionsWeekly` was already there; it just moved files. If the weekly time series was silently broken before, it stays broken (no regression, no fix). Rollback: revert the squash commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782367191&installation_id=132681956&pr_number=2821&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2821&signature=b21316ac7acdc2e40ef3e9579d824c42937ceddad724893cf0ebde63429168f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->