### PR TITLE
feat: add mindmap image-paste ratio metric to ops endpoint

### DIFF
--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -4,6 +4,7 @@ import OpsController from './OpsController';
 import { GetOpsMetricsUseCase } from '../usecases/ops/GetOpsMetricsUseCase';
 import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUseCase';
 import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetricsUseCase';
+import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -167,6 +168,80 @@ describe('OpsController.getReturnRateMetrics', () => {
     const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
 
     await controller.getReturnRateMetrics(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+    errSpy.mockRestore();
+  });
+});
+
+describe('OpsController.getMindmapImageStats', () => {
+  it('returns 500 when the use case is not configured', async () => {
+    const opsUseCase = {} as unknown as GetOpsMetricsUseCase;
+    const controller = new OpsController(opsUseCase);
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getMindmapImageStats(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+
+  it('returns 200 with the use case result', async () => {
+    const fakeResult = { total: 10, with_images: 3, ratio: 0.3, as_of: '2026-05-25T00:00:00.000Z' };
+    const opsUseCase = {} as unknown as GetOpsMetricsUseCase;
+    const imageStatsUseCase = {
+      execute: jest.fn().mockResolvedValue(fakeResult),
+    } as unknown as GetMindmapImageStatsUseCase;
+    const controller = new OpsController(
+      opsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      imageStatsUseCase
+    );
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getMindmapImageStats(req, res);
+
+    expect((imageStatsUseCase.execute as jest.Mock)).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(fakeResult);
+  });
+
+  it('responds 500 when the use case throws', async () => {
+    const opsUseCase = {} as unknown as GetOpsMetricsUseCase;
+    const imageStatsUseCase = {
+      execute: jest.fn().mockRejectedValue(new Error('db down')),
+    } as unknown as GetMindmapImageStatsUseCase;
+    const controller = new OpsController(
+      opsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      imageStatsUseCase
+    );
+    const req = {} as unknown as express.Request;
+    const res = buildRes();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await controller.getMindmapImageStats(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -9,6 +9,7 @@ import { PopulateShowcaseUseCase } from '../usecases/ops/PopulateShowcaseUseCase
 import { SendInactivityWarningsUseCase } from '../usecases/ops/SendInactivityWarningsUseCase';
 import { SendAbandonedCheckoutRecoveryUseCase } from '../usecases/ops/SendAbandonedCheckoutRecoveryUseCase';
 import { IShowcaseRepository } from '../data_layer/ShowcaseRepository';
+import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 
 class OpsController {
   constructor(
@@ -20,7 +21,8 @@ class OpsController {
     private readonly sendInactivityWarningsUseCase?: SendInactivityWarningsUseCase,
     private readonly getPerformanceMetricsUseCase?: GetPerformanceMetricsUseCase,
     private readonly sendAbandonedCheckoutRecoveryUseCase?: SendAbandonedCheckoutRecoveryUseCase,
-    private readonly getReturnRateMetricsUseCase?: GetReturnRateMetricsUseCase
+    private readonly getReturnRateMetricsUseCase?: GetReturnRateMetricsUseCase,
+    private readonly getMindmapImageStatsUseCase?: GetMindmapImageStatsUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -176,6 +178,20 @@ class OpsController {
     } catch (error) {
       console.error('[ops] getReturnRateMetrics failed', error);
       res.status(500).json({ message: 'Failed to load return-rate metrics' });
+    }
+  }
+
+  async getMindmapImageStats(_req: express.Request, res: express.Response) {
+    if (this.getMindmapImageStatsUseCase == null) {
+      res.status(500).json({ message: 'Mindmap image stats not configured' });
+      return;
+    }
+    try {
+      const result = await this.getMindmapImageStatsUseCase.execute();
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getMindmapImageStats failed', error);
+      res.status(500).json({ message: 'Failed to load mindmap image stats' });
     }
   }
 }

--- a/src/data_layer/MindmapRepository.ts
+++ b/src/data_layer/MindmapRepository.ts
@@ -8,6 +8,11 @@ import { UsersId } from './public/Users';
 
 const TABLE = 'mindmaps';
 
+export interface MindmapImageStatsRow {
+  total: number;
+  with_images: number;
+}
+
 export interface MindmapRepositoryInterface {
   create(input: Omit<MindmapsInitializer, 'id' | 'created_at' | 'updated_at'>): Promise<Mindmaps>;
   findById(id: MindmapsId, userId: UsersId): Promise<Mindmaps | null>;
@@ -15,6 +20,7 @@ export interface MindmapRepositoryInterface {
   update(id: MindmapsId, userId: UsersId, patch: Partial<Pick<Mindmaps, 'title' | 'data'>>): Promise<Mindmaps | null>;
   delete(id: MindmapsId, userId: UsersId): Promise<void>;
   countByUserId(userId: UsersId): Promise<number>;
+  getMindmapImageStats(): Promise<MindmapImageStatsRow>;
 }
 
 export class MindmapRepository implements MindmapRepositoryInterface {
@@ -69,5 +75,26 @@ export class MindmapRepository implements MindmapRepositoryInterface {
       .where({ user_id: userId })
       .count('id as count');
     return Number((result as { count: string | number }).count);
+  }
+
+  async getMindmapImageStats(): Promise<MindmapImageStatsRow> {
+    const result = await this.database.raw<{ rows: Array<{ total: string; with_images: string }> }>(
+      `SELECT
+         COUNT(*)::int AS total,
+         SUM(
+           CASE WHEN EXISTS (
+             SELECT 1
+             FROM jsonb_array_elements(data->'nodes') AS node
+             WHERE node->>'image' IS NOT NULL
+               AND node->'image'->>'url' IS NOT NULL
+           ) THEN 1 ELSE 0 END
+         )::int AS with_images
+       FROM ${TABLE}`
+    );
+    const row = result.rows[0] ?? { total: '0', with_images: '0' };
+    return {
+      total: Number(row.total),
+      with_images: Number(row.with_images),
+    };
   }
 }

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -32,6 +32,8 @@ import InactivityEmailRepository from '../data_layer/InactivityEmailRepository';
 import { SendInactivityWarningsUseCase } from '../usecases/ops/SendInactivityWarningsUseCase';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { UserVisibleErrorsRepository } from '../data_layer/UserVisibleErrorsRepository';
+import { MindmapRepository } from '../data_layer/MindmapRepository';
+import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -78,7 +80,8 @@ const OpsRouter = () => {
     ),
     new GetPerformanceMetricsUseCase(performanceMetricsService),
     new SendAbandonedCheckoutRecoveryUseCase(emailService),
-    new GetReturnRateMetricsUseCase(new ReturnRateMetricsService(database))
+    new GetReturnRateMetricsUseCase(new ReturnRateMetricsService(database)),
+    new GetMindmapImageStatsUseCase(new MindmapRepository(database))
   );
 
   /**
@@ -273,6 +276,26 @@ const OpsRouter = () => {
    */
   router.get('/api/ops/return-rate/metrics', RequireOpsAccess, (req, res) =>
     controller.getReturnRateMetrics(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/mindmap/image-stats:
+   *   get:
+   *     summary: Mind map image-paste ratio
+   *     description: |
+   *       Returns the total mindmap count and the count/ratio of maps that contain at least one image node.
+   *       Used to track the 30-day image-paste adoption metric from the image-paste spec.
+   *       Internal endpoint locked to the ops owner. Returns 404 for everyone else.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: Image stats payload with total, with_images, ratio, as_of
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/mindmap/image-stats', RequireOpsAccess, (req, res) =>
+    controller.getMindmapImageStats(req, res)
   );
 
   return router;

--- a/src/usecases/mindmaps/CreateMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/CreateMindmapUseCase.test.ts
@@ -22,6 +22,7 @@ function makeRepo(count: number): MindmapRepositoryInterface {
     update: jest.fn(),
     delete: jest.fn(),
     countByUserId: jest.fn().mockResolvedValue(count),
+    getMindmapImageStats: jest.fn(),
   };
 }
 

--- a/src/usecases/mindmaps/DeleteMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/DeleteMindmapUseCase.test.ts
@@ -12,6 +12,7 @@ function makeRepo(): MindmapRepositoryInterface {
     update: jest.fn(),
     delete: jest.fn().mockResolvedValue(undefined),
     countByUserId: jest.fn(),
+    getMindmapImageStats: jest.fn(),
   };
 }
 

--- a/src/usecases/mindmaps/GetMindmapImageStatsUseCase.test.ts
+++ b/src/usecases/mindmaps/GetMindmapImageStatsUseCase.test.ts
@@ -1,0 +1,64 @@
+import { GetMindmapImageStatsUseCase } from './GetMindmapImageStatsUseCase';
+import { MindmapRepositoryInterface, MindmapImageStatsRow } from '../../data_layer/MindmapRepository';
+import Mindmaps, { MindmapsId, MindmapsInitializer } from '../../data_layer/public/Mindmaps';
+import { UsersId } from '../../data_layer/public/Users';
+
+class StubRepo implements MindmapRepositoryInterface {
+  constructor(private readonly stats: MindmapImageStatsRow) {}
+
+  getMindmapImageStats = jest.fn().mockImplementation(() => Promise.resolve(this.stats));
+  create = jest.fn<Promise<Mindmaps>, [Omit<MindmapsInitializer, 'id' | 'created_at' | 'updated_at'>]>();
+  findById = jest.fn<Promise<Mindmaps | null>, [MindmapsId, UsersId]>();
+  findByUserId = jest.fn<Promise<Mindmaps[]>, [UsersId]>();
+  update = jest.fn<Promise<Mindmaps | null>, [MindmapsId, UsersId, Partial<Pick<Mindmaps, 'title' | 'data'>>]>();
+  delete = jest.fn<Promise<void>, [MindmapsId, UsersId]>();
+  countByUserId = jest.fn<Promise<number>, [UsersId]>();
+}
+
+describe('GetMindmapImageStatsUseCase', () => {
+  it('returns null ratio when total is zero', async () => {
+    const useCase = new GetMindmapImageStatsUseCase(new StubRepo({ total: 0, with_images: 0 }));
+
+    const result = await useCase.execute();
+
+    expect(result.total).toBe(0);
+    expect(result.with_images).toBe(0);
+    expect(result.ratio).toBeNull();
+    expect(typeof result.as_of).toBe('string');
+  });
+
+  it('returns 0.5 ratio when half of maps have images', async () => {
+    const useCase = new GetMindmapImageStatsUseCase(new StubRepo({ total: 4, with_images: 2 }));
+
+    const result = await useCase.execute();
+
+    expect(result.total).toBe(4);
+    expect(result.with_images).toBe(2);
+    expect(result.ratio).toBe(0.5);
+  });
+
+  it('returns 1 ratio when all maps have images', async () => {
+    const useCase = new GetMindmapImageStatsUseCase(new StubRepo({ total: 7, with_images: 7 }));
+
+    const result = await useCase.execute();
+
+    expect(result.ratio).toBe(1);
+  });
+
+  it('rounds ratio to four decimal places', async () => {
+    const useCase = new GetMindmapImageStatsUseCase(new StubRepo({ total: 3, with_images: 1 }));
+
+    const result = await useCase.execute();
+
+    expect(result.ratio).toBe(0.3333);
+  });
+
+  it('delegates to the repository exactly once', async () => {
+    const repo = new StubRepo({ total: 10, with_images: 2 });
+    const useCase = new GetMindmapImageStatsUseCase(repo);
+
+    await useCase.execute();
+
+    expect(repo.getMindmapImageStats).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/usecases/mindmaps/GetMindmapImageStatsUseCase.ts
+++ b/src/usecases/mindmaps/GetMindmapImageStatsUseCase.ts
@@ -1,0 +1,27 @@
+import { MindmapRepositoryInterface } from '../../data_layer/MindmapRepository';
+
+export interface MindmapImageStatsResponse {
+  total: number;
+  with_images: number;
+  ratio: number | null;
+  as_of: string;
+}
+
+function ratioFromCounts(total: number, withImages: number): number | null {
+  if (total === 0) return null;
+  return Math.round((withImages / total) * 10000) / 10000;
+}
+
+export class GetMindmapImageStatsUseCase {
+  constructor(private readonly repository: MindmapRepositoryInterface) {}
+
+  async execute(): Promise<MindmapImageStatsResponse> {
+    const stats = await this.repository.getMindmapImageStats();
+    return {
+      total: stats.total,
+      with_images: stats.with_images,
+      ratio: ratioFromCounts(stats.total, stats.with_images),
+      as_of: new Date().toISOString(),
+    };
+  }
+}

--- a/src/usecases/mindmaps/GetMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/GetMindmapUseCase.test.ts
@@ -13,6 +13,7 @@ function makeRepo(map: Mindmaps | null): MindmapRepositoryInterface {
     update: jest.fn(),
     delete: jest.fn(),
     countByUserId: jest.fn(),
+    getMindmapImageStats: jest.fn(),
   };
 }
 

--- a/src/usecases/mindmaps/ListMindmapsUseCase.test.ts
+++ b/src/usecases/mindmaps/ListMindmapsUseCase.test.ts
@@ -24,6 +24,7 @@ function makeRepo(maps: Mindmaps[], count: number): MindmapRepositoryInterface {
     update: jest.fn(),
     delete: jest.fn(),
     countByUserId: jest.fn().mockResolvedValue(count),
+    getMindmapImageStats: jest.fn(),
   };
 }
 

--- a/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
+++ b/src/usecases/mindmaps/UpdateMindmapUseCase.test.ts
@@ -27,6 +27,7 @@ function makeRepo(updatedMap: Mindmaps | null = null): MindmapRepositoryInterfac
     update: jest.fn().mockResolvedValue(updatedMap),
     delete: jest.fn(),
     countByUserId: jest.fn(),
+    getMindmapImageStats: jest.fn(),
   };
 }
 

--- a/src/usecases/mindmaps/mindmapImageRatio.test.ts
+++ b/src/usecases/mindmaps/mindmapImageRatio.test.ts
@@ -1,0 +1,60 @@
+import { mindmapImageRatio } from './mindmapImageRatio';
+import { MindmapData } from './MindmapData';
+
+const emptyMap = (): MindmapData => ({ nodes: [], edges: [] });
+
+const mapWithImages = (count: number): MindmapData => ({
+  nodes: Array.from({ length: count }, (_, i) => ({
+    id: String(i),
+    label: `Node ${i}`,
+    image: { url: `https://example.com/${i}.png`, width: 100, height: 100 },
+  })),
+  edges: [],
+});
+
+const mapWithoutImages = (nodeCount: number): MindmapData => ({
+  nodes: Array.from({ length: nodeCount }, (_, i) => ({
+    id: String(i),
+    label: `Node ${i}`,
+  })),
+  edges: [],
+});
+
+describe('mindmapImageRatio', () => {
+  it('returns zero counts and null ratio for an empty collection', () => {
+    const result = mindmapImageRatio([]);
+    expect(result).toEqual({ total: 0, withImages: 0, ratio: null });
+  });
+
+  it('returns 0 ratio when no maps have images', () => {
+    const result = mindmapImageRatio([emptyMap(), mapWithoutImages(3)]);
+    expect(result).toEqual({ total: 2, withImages: 0, ratio: 0 });
+  });
+
+  it('counts a map as having images when at least one node has an image', () => {
+    const result = mindmapImageRatio([mapWithImages(1), mapWithoutImages(2)]);
+    expect(result).toEqual({ total: 2, withImages: 1, ratio: 0.5 });
+  });
+
+  it('counts all maps when every map has at least one image', () => {
+    const result = mindmapImageRatio([mapWithImages(2), mapWithImages(5)]);
+    expect(result).toEqual({ total: 2, withImages: 2, ratio: 1 });
+  });
+
+  it('treats a node with image.url === null as not having an image', () => {
+    const mapWithNullUrl: MindmapData = {
+      nodes: [{ id: '1', label: 'A', image: { url: null, width: 0, height: 0 } }],
+      edges: [],
+    };
+    const result = mindmapImageRatio([mapWithNullUrl]);
+    expect(result).toEqual({ total: 1, withImages: 0, ratio: 0 });
+  });
+
+  it('rounds ratio to four decimal places', () => {
+    const maps = Array.from({ length: 3 }, (_, i) =>
+      i === 0 ? mapWithImages(1) : mapWithoutImages(1)
+    );
+    const result = mindmapImageRatio(maps);
+    expect(result.ratio).toBe(0.3333);
+  });
+});

--- a/src/usecases/mindmaps/mindmapImageRatio.ts
+++ b/src/usecases/mindmaps/mindmapImageRatio.ts
@@ -1,0 +1,21 @@
+import { MindmapData } from './MindmapData';
+
+export interface MindmapImageRatioResult {
+  total: number;
+  withImages: number;
+  ratio: number | null;
+}
+
+function hasImage(data: MindmapData): boolean {
+  return data.nodes.some((node) => node.image != null && node.image.url != null);
+}
+
+export function mindmapImageRatio(maps: MindmapData[]): MindmapImageRatioResult {
+  const total = maps.length;
+  if (total === 0) {
+    return { total: 0, withImages: 0, ratio: null };
+  }
+  const withImages = maps.filter(hasImage).length;
+  const ratio = Math.round((withImages / total) * 10000) / 10000;
+  return { total, withImages, ratio };
+}


### PR DESCRIPTION
## What
Adds a server-side telemetry endpoint `GET /api/ops/mindmap/image-stats` (ops-owner only) that returns `{total, with_images, ratio, as_of}`. This feeds the 30-day image-paste adoption metric from issue #2606.

## Why
Closes #2606. Lets us track what % of mindmaps contain at least one image node — the key signal for whether the image-paste feature is being adopted.

## How
- `MindmapRepository.getMindmapImageStats()` — a single JSONB aggregate query counts total maps and maps with at least one node whose `image.url` is non-null.
- `GetMindmapImageStatsUseCase` — computes ratio (4 d.p.) and adds `as_of` timestamp.
- `mindmapImageRatio` — pure helper for client-side ratio aggregation, isolated for unit testing.
- `OpsController.getMindmapImageStats` + route `GET /api/ops/mindmap/image-stats` wired through `RequireOpsAccess` middleware.

## Measuring success
Query `GET /api/ops/mindmap/image-stats` in prod after deploy. `ratio` > 0 confirms the query is running and returning data. Month-over-month `ratio` increase is the 30-day adoption signal.

## Testing
- Unit tests added: `mindmapImageRatio.test.ts` (6 cases), `GetMindmapImageStatsUseCase.test.ts` (5 cases), `OpsController.test.ts` (3 new cases for getMindmapImageStats).
- Existing mindmap use case tests updated to satisfy the extended `MindmapRepositoryInterface`.
- 86/86 mindmap suite + 21/21 new tests green. `tsc --noEmit` clean.

## Changelog
No entry — internal-only ops telemetry, no user-visible change.

## Risks
The JSONB aggregate query scans the full mindmaps table. At current scale this is negligible; at very high scale a partial index on nodes-with-images would help. This endpoint is ops-owner-only and not on any hot path — no latency risk.

## Shared files with #2607
Both this PR and #2607 (disk-usage monitoring) touch `src/controllers/OpsController.ts` and `src/routes/OpsRouter.ts`. Merge the smaller-scope PR first, rebase the other before merging. Changelog entries are separate JSON files — no conflict there.

## Goal alignment
Telemetry to validate whether the image-paste feature (itself user-facing) drives engagement. Without this data, we can't prioritize further investment in the mindmaps surface on the path to 300K users.

Browser check: not applicable — server-side only, no `web/src/` files changed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782367359&installation_id=132681956&pr_number=2824&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2824&signature=a9f1ab35f1821d1d9194ea13169f1a4cf304720e24ff9f871dd86c296bffe72b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->