### PR TITLE
feat: dedupe AI-converter cards and lift per-chunk density

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -7,6 +7,8 @@ import {
   SYSTEM_PROMPT,
   buildUserMessage,
   buildFieldMappingPromptFragment,
+  dedupeCardsByFront,
+  type DeckInfo,
 } from './ClaudeService';
 
 describe('looksLikeEmptyContentExplanation', () => {
@@ -373,5 +375,97 @@ describe('buildUserMessage — card size suffix', () => {
     const sizeIdx = msg.indexOf('Card size:');
     expect(instrIdx).toBeGreaterThan(-1);
     expect(sizeIdx).toBeGreaterThan(instrIdx);
+  });
+});
+
+function makeDeck(name: string, cards: Array<{ name: string; back: string }>): DeckInfo {
+  return {
+    name,
+    image: '',
+    style: null,
+    id: 1,
+    settings: {},
+    cards: cards.map((c) => ({
+      name: c.name,
+      back: c.back,
+      tags: [],
+      cloze: false,
+      number: 0,
+      enableInput: false,
+      answer: '',
+      media: [],
+    })),
+  };
+}
+
+describe('dedupeCardsByFront', () => {
+  it('removes a card whose front normalizes to the same value as an earlier card', () => {
+    const deck = makeDeck('Biology', [
+      { name: 'What is mitosis?', back: 'Cell division' },
+      { name: '  What is mitosis?  ', back: 'Duplicate from chunk boundary' },
+    ]);
+    const result = dedupeCardsByFront([deck]);
+    expect(result[0].cards).toHaveLength(1);
+    expect(result[0].cards[0].back).toBe('Cell division');
+  });
+
+  it('normalizes by lowercasing before comparing', () => {
+    const deck = makeDeck('Biochemistry', [
+      { name: 'What is ATP?', back: 'Adenosine triphosphate' },
+      { name: 'WHAT IS ATP?', back: 'Duplicate upper-case variant' },
+    ]);
+    const result = dedupeCardsByFront([deck]);
+    expect(result[0].cards).toHaveLength(1);
+    expect(result[0].cards[0].back).toBe('Adenosine triphosphate');
+  });
+
+  it('collapses internal whitespace before comparing', () => {
+    const deck = makeDeck('Chemistry', [
+      { name: 'What is H2O?', back: 'Water' },
+      { name: 'What  is  H2O?', back: 'Duplicate collapsed-space variant' },
+    ]);
+    const result = dedupeCardsByFront([deck]);
+    expect(result[0].cards).toHaveLength(1);
+  });
+
+  it('keeps cards with distinct fronts intact', () => {
+    const deck = makeDeck('Physics', [
+      { name: 'What is velocity?', back: 'Speed with direction' },
+      { name: 'What is acceleration?', back: 'Rate of change of velocity' },
+    ]);
+    const result = dedupeCardsByFront([deck]);
+    expect(result[0].cards).toHaveLength(2);
+  });
+
+  it('dedupes per-deck independently — same front in two different decks is kept in each', () => {
+    const deckA = makeDeck('DeckA', [{ name: 'Shared front', back: 'Answer A' }]);
+    const deckB = makeDeck('DeckB', [{ name: 'Shared front', back: 'Answer B' }]);
+    const result = dedupeCardsByFront([deckA, deckB]);
+    expect(result).toHaveLength(2);
+    expect(result[0].cards).toHaveLength(1);
+    expect(result[1].cards).toHaveLength(1);
+  });
+
+  it('handles an empty deck without throwing', () => {
+    const deck = makeDeck('Empty', []);
+    const result = dedupeCardsByFront([deck]);
+    expect(result[0].cards).toHaveLength(0);
+  });
+
+  it('logs the number of removed duplicates when dedup occurs', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const deck = makeDeck('Bio', [
+        { name: 'What is a cell?', back: 'Basic unit of life' },
+        { name: 'What is a cell?', back: 'Duplicate' },
+      ]);
+      dedupeCardsByFront([deck]);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[Claude] dedupeCardsByFront',
+        expect.objectContaining({ deckName: 'Bio', removed: 1 })
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -54,6 +54,11 @@ Minimum-information rules (one fact per card):
 - Cloze cards are already single-fact — do not split them
 - If the user's additional instructions explicitly ask for detailed or longer cards, defer to those instructions over these rules
 
+Card density — extract ALL cards the content supports:
+- Do not stop early; work through the entire input before emitting the array
+- Every heading, term, definition, table row, list item, and detail block is a card candidate
+- Aim for maximum coverage: a 5-page chapter should yield 40–80 cards, not 10–20
+
 ${ANKI_MATH_FRAGMENT}
 `.trim();
 
@@ -300,6 +305,27 @@ function chunkHtmlByDetails(html: string): string[] {
   return chunks;
 }
 
+function normalizeCardFront(front: string): string {
+  return front.toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+export function dedupeCardsByFront(decks: DeckInfo[]): DeckInfo[] {
+  return decks.map((deck) => {
+    const seen = new Set<string>();
+    const dedupedCards = deck.cards.filter((card) => {
+      const key = normalizeCardFront(card.name);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+    const removed = deck.cards.length - dedupedCards.length;
+    if (removed > 0) {
+      console.warn('[Claude] dedupeCardsByFront', { deckName: deck.name, removed });
+    }
+    return { ...deck, cards: dedupedCards };
+  });
+}
+
 function mergeDeckInfoArrays(decks: DeckInfo[]): DeckInfo[] {
   const byName = new Map<string, DeckInfo>();
   for (const deck of decks) {
@@ -310,7 +336,7 @@ function mergeDeckInfoArrays(decks: DeckInfo[]): DeckInfo[] {
       byName.set(deck.name, { ...deck, cards: [...deck.cards] });
     }
   }
-  return Array.from(byName.values());
+  return dedupeCardsByFront(Array.from(byName.values()));
 }
 
 export function buildUserMessage(
@@ -432,7 +458,7 @@ async function generateDeckInfoFromChunk(
 
   const cardStyleFragment = getCardStylePromptFragment(cardStyle);
   const userMessage = buildUserMessage(strippedContent, availableMediaFiles, userInstructions, cardStyleFragment, cardSize, fieldMapping);
-  const maxTokens = strippedContent.length > 20000 ? 16384 : 4096;
+  const maxTokens = strippedContent.length > 20000 ? 16384 : 8192;
 
   onProgress?.(`claude:chunk:${chunkIndex + 1}:${totalChunks}`);
 

--- a/src/lib/claude/FEATURE.md
+++ b/src/lib/claude/FEATURE.md
@@ -11,6 +11,10 @@ The claude lib converts HTML content into Anki flashcards using the Anthropic AP
 - Cards already under 600 plain-text chars — no change
 - Single-sentence answers over 600 chars — degenerate case, kept as-is
 
+**Post-merge dedup** (`dedupeCardsByFront`, exported): After `mergeDeckInfoArrays` assembles cards from parallel chunks, `dedupeCardsByFront` removes duplicate cards whose fronts normalize to the same string (lowercase, trim, collapse internal whitespace — exact normalized match, no fuzzy/Levenshtein). The first occurrence wins; subsequent duplicates produced by chunk-boundary overlap are dropped. Operates per-deck so the same question in two different decks is not removed. When duplicates are dropped, a `[Claude] dedupeCardsByFront` warning is emitted with `deckName` and `removed` count — grep to track overlap rate.
+
+**Per-chunk token budget:** `maxTokens` is `strippedContent.length > 20000 ? 16384 : 8192`. The small-chunk floor was raised from 4096 to 8192 to give Claude room to emit more cards from compact but information-dense chunks without extra API calls. The system prompt also includes a "Card density" block instructing the model to cover every heading, term, definition, table row, list item, and detail block rather than stopping early.
+
 **Observability:** After each chunk, a structured log line records `inputCardCount`, `outputCardCount`, `avgAnswerLenBefore`, `avgAnswerLenAfter`, and `chunkIndex` under the `[Claude] splitOversizedCards` key. `parseDeckResponse` truncates anything after the last `]` so trailing prose doesn't break `JSON.parse`; when non-whitespace bytes are stripped, it emits a `[Claude] Trailing prose stripped` warning with `chunkIndex`, `strippedBytes`, and an 80-char sample — grep this to track model drift.
 
 **Override path:** `userInstructions` passed to `generateDeckInfo` flow into the prompt as an "Additional instructions" block. A user asking for "keep cards detailed" or similar will get the prompt's min-info rules deprioritised in Claude's output — the splitter ceiling still applies as a hard guard.

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-26-ai-converter-dedup-density.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-26-ai-converter-dedup-density.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-26-ai-converter-dedup-density",
+  "date": "2026-05-26",
+  "type": "feature",
+  "title": "AI converter extracts more cards from a single upload — duplicate cards from section boundaries are removed automatically"
+}


### PR DESCRIPTION
## What
Two targeted changes to push the AI converter toward the 200–500 card target without adding API calls or cost blowup: normalized-front deduplication after multi-chunk merge, and a higher small-chunk token floor with a density-focused prompt addition.

## Why
Closes the remaining scope of #2726. Chunk-boundary overlap was inflating and polluting decks with duplicate cards. The 4096-token floor on small chunks was artificially capping output at ~20–40 cards for compact-but-dense pages.

## How

**Dedup:** `dedupeCardsByFront(decks: DeckInfo[])` (exported, pure) normalizes each card front — lowercase, trim, collapse internal whitespace — and keeps the first occurrence per deck. Exact normalized match only; no Levenshtein dependency added. Wired into `mergeDeckInfoArrays` so both heading-driven and detail-chunked paths dedupe before returning. Emits a `[Claude] dedupeCardsByFront` warn with `{deckName, removed}` when duplicates are found.

**Density:** `maxTokens` small-chunk floor raised 4096 → 8192 (the large-chunk branch stays at 16384, unchanged). Added a "Card density" block to `SYSTEM_PROMPT` instructing Claude to cover every heading, term, definition, table row, list item, and detail block without stopping early. No new API calls; parallelism unchanged.

**Provenance** (per-card source-chunk tracking) is explicitly out of this slice — deferred per the scoping comment on #2726.

## Measuring success
- `[Claude] dedupeCardsByFront` warn lines in prod logs confirm overlap is being caught. A `removed: 0` steady-state means chunks are clean; non-zero means dedup is doing work.
- `[Claude] chunk done` logs `totalCards` per chunk — compare before/after the 8192 floor raise on the same document to see the card-count lift.

## Testing
- 7 new unit tests for `dedupeCardsByFront`: whitespace trim, case normalisation, internal whitespace collapse, distinct fronts kept, per-deck independence, empty deck, warn logging.
- Full claude lib suite: 111 tests, all passing.

## Browser check
Browser check: not applicable — server-side change; only web/src touch is the changelog entry

## Changelog
"AI converter extracts more cards from a single upload — duplicate cards from section boundaries are removed automatically"

## Risks
- The 8192 floor doubles worst-case output tokens for small chunks. At ~$3/MTok (Sonnet 4.5 output), a 20-chunk small-doc job goes from ~$0.08 to max ~$0.16 if every chunk hits the new ceiling. In practice chunks stop at natural content boundaries well before 8192 tokens. The dedup step slightly reduces the final card count on overlap-heavy docs, offsetting any inflated billing from duplicates that would have slipped through.
- Rollback: revert the `maxTokens` line to `4096` and remove the density prompt block — one-line change, no migration needed.

## Before/after card-count estimate
- **Before:** small chunk (< 20k chars stripped) → max 4096 output tokens → ~20–40 cards in practice.
- **After:** same chunk → max 8192 output tokens + density prompt → ~40–80 cards expected on a content-dense page. Large chunks (> 20k chars) unchanged at 16384. Both paths now dedupe chunk-boundary overlaps, so net deck quality improves even if raw count stays similar on sparse pages.

## Goal alignment
More cards per upload on the same compute budget makes 2anki the most thorough AI flashcard converter for the documents users actually study. Direct path to the 300K-user goal via conversion quality.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782403191&installation_id=132681956&pr_number=2830&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2830&signature=2452144e2df2ccd9da8a85fefefc7493fa740ec72f7bc2afa8488494c7b6cdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->