### PR TITLE
fix: surface a clear error and recovery hint when large Notion exports fail

### DIFF
--- a/web/src/components/errors/helpers/getErrorMessage.test.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.test.ts
@@ -116,10 +116,11 @@ describe('classifyUploadError', () => {
     expect(result.detail).toBe('Use .zip, .html, .md, .pdf, .docx, .xlsx, .pptx, or .csv.');
   });
 
-  test('too_large returns specific copy about splitting the file', () => {
+  test('too_large returns copy about splitting into subpages', () => {
     const body: UploadErrorBody = { code: 'too_large', message: 'original' };
     const result = classifyUploadError(body);
-    expect(result.title).toBe('This file is too large.');
+    expect(result.title).toBe('This export is too large to convert in one go.');
+    expect(result.detail).toMatch(/subpage/i);
   });
 
   test('password_protected_pdf returns specific copy about removing the password', () => {

--- a/web/src/components/errors/helpers/getErrorMessage.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.ts
@@ -134,8 +134,8 @@ const PER_CODE_COPY: Partial<Record<UploadErrorBody['code'], FriendlyError>> = {
     detail: 'Use .zip, .html, .md, .pdf, .docx, .xlsx, .pptx, or .csv.',
   },
   too_large: {
-    title: 'This file is too large.',
-    detail: 'Split it into smaller files and try again.',
+    title: 'This export is too large to convert in one go.',
+    detail: 'Split it into smaller Notion subpages and convert each one separately.',
   },
   password_protected_pdf: {
     title: 'This PDF is password-protected.',

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -193,4 +193,22 @@ describe('ConversionResult — failed variant', () => {
 
     expect(screen.getByRole('link', { name: 'Reconnect Notion' })).toBeInTheDocument();
   });
+
+  it('shows a subpages recovery hint when the server reports a too-large OOM failure', () => {
+    const tooLargeReason =
+      'This page is too large for us to convert in one go. Split it into smaller pages — or convert it section by section — and try again.';
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="failed"
+          title="Big Notion export"
+          failureReason={tooLargeReason}
+          source="notion"
+          onMapColumns={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/subpage/i)).toBeInTheDocument();
+  });
 });

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -135,7 +135,14 @@ function FailedVariant({ failureReason, source, onMapColumns }: Omit<FailedProps
     );
   }
 
-  const errorBody: UploadErrorBody = { code: 'unknown', message: failureReason };
+  const isTooLarge =
+    failureReason.includes('too large') ||
+    failureReason.includes('MemoryError') ||
+    failureReason.includes('Killed');
+  const errorBody: UploadErrorBody = {
+    code: isTooLarge ? 'too_large' : 'unknown',
+    message: failureReason,
+  };
   const friendly = classifyUploadError(errorBody);
   return (
     <p>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-26-large-export-recovery-hint.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-26-large-export-recovery-hint.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-26-large-export-recovery-hint",
+  "date": "2026-05-26",
+  "type": "fix",
+  "title": "Large Notion exports that fail now show a clear recovery hint — split into subpages and convert each one separately"
+}


### PR DESCRIPTION
## What
When a Notion export OOMs or is killed (exit 137, MemoryError, or 'Killed' in stderr), the conversion job stores a descriptive failure reason in the DB. The `FailedVariant` in `ConversionResult.tsx` was always wrapping this as `{ code: 'unknown', ... }`, so the `too_large` per-code copy — including the recovery hint — was never shown. Users saw the raw server message with no actionable guidance.

## Why
Closes #2503 (the reliability-win slice only — routing uploads through the conversion pool is a separate follow-up as noted in my status comment on the issue).

Users converting large Notion exports with many subpages hit OOM and received a generic 'check your connection' error. The real workaround is documented: split the export into subpages. Users need to see that hint.

## How
1. In `FailedVariant` (`ConversionResult.tsx`), detect the too-large server message substrings ('too large', 'MemoryError', 'Killed') and emit `code: 'too_large'` instead of always `'unknown'`.
2. Update `PER_CODE_COPY.too_large` in `getErrorMessage.ts` from generic file-split copy to Notion-subpage-specific copy: 'This export is too large to convert in one go. Split it into smaller Notion subpages and convert each one separately.'

No changes to the server error-detection logic — `buildPythonExitError` already correctly classifies OOM as `too-large` and `toUploadErrorCode` already maps it to `too_large`. The gap was purely in the web rendering path.

## Measuring success
A user who hits a too-large failure will see the subpages copy in the failure panel on /downloads. In telemetry: if `upload_error_chat_engaged` events drop for the 'too large' class of failures after deploy, that confirms users are self-serving on the hint rather than reaching for chat.

## Testing
- Unit tests added: `ConversionResult.test.tsx` — new case: too-large server message renders /subpage/i text
- Unit tests added: `getErrorMessage.test.ts` — updated too_large case asserts new title and subpage detail
- All 1249 web tests pass; server tsc + web typecheck + web lint all green

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Alexander to verify the failure panel on /downloads shows the new subpages copy for a failed large-export job.

## Changelog
"Large Notion exports that fail now show a clear recovery hint — split into subpages and convert each one separately"

## Risks
The text-match detection in FailedVariant is based on substrings from the server's message constants. If `buildPythonExitError.ts`'s TOO_LARGE_MESSAGE ever changes, the detection would stop matching. The two files are in different packages — the test covers the current strings. Rollback: revert the two changed web files; no server change, no migration.

## Goal alignment
Reduces support noise from a recurring class of failures, improving conversion reliability perception — directly supports the 300K-user goal by reducing churn from frustrated users hitting opaque errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782403253&installation_id=132681956&pr_number=2831&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2831&signature=cc67f5dba9d2197e740c8c110506055b8a73304324f6782e6bcf8edfcac988f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->