### PR TITLE
fix: credit upload_error_chat_resolved_retry for anonymous users

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -23,8 +23,6 @@ import {
 } from '../../../../usecases/jobs/jobFailureReason';
 import { PythonExitError } from '../../../anki/buildPythonExitError';
 import { track } from '../../../../services/events/track';
-import { EventsRepository } from '../../../../data_layer/EventsRepository';
-import { EventsQueryService } from '../../../../services/events/EventsQueryService';
 import NotionRepository from '../../../../data_layer/NotionRespository';
 
 type CardCountBucket = '<50' | '50-499' | '500+';
@@ -166,19 +164,6 @@ export default async function performConversion(
         card_count_bucket: toCardCountBucket(cardCount),
       },
     });
-
-    const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000);
-    const eventsRepo = new EventsRepository(database);
-    const eventsQuery = new EventsQueryService(eventsRepo);
-    const priorEngagement = await eventsQuery.countByNameForUser(
-      'upload_error_chat_engaged',
-      thirtyMinutesAgo,
-      userId,
-      null
-    );
-    if (priorEngagement > 0) {
-      track('upload_error_chat_resolved_retry', { userId });
-    }
   } catch (error) {
     if (error instanceof PythonExitError) {
       console.error('[conversion] python crash', {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -712,6 +712,92 @@ describe('UploadForm analytics events', () => {
     });
   });
 
+  it('fires upload_error_chat_resolved_retry when chat was engaged and a subsequent conversion succeeds', async () => {
+    const { track } = await import('../../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    const failResponse = {
+      redirected: false,
+      status: 400,
+      clone: () => ({ json: () => Promise.reject(new Error('not json')) }),
+      text: () => Promise.resolve('Bad request'),
+      headers: new Headers({ 'Content-Type': 'text/plain' }),
+    };
+    const successResponse = {
+      redirected: false,
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': 'attachment; filename="deck.apkg"',
+        'X-Card-Count': '5',
+      }),
+      blob: () => Promise.resolve(new Blob(['fake'])),
+    };
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(failResponse)
+      .mockResolvedValue(successResponse);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('button[aria-controls="error-state-chat-panel"]')).not.toBeNull();
+    });
+
+    const toggle = container.querySelector('button[aria-controls="error-state-chat-panel"]') as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+
+    trackMock.mockClear();
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      const calls = trackMock.mock.calls.filter(([name]) => name === 'upload_error_chat_resolved_retry');
+      expect(calls).toHaveLength(1);
+    });
+  });
+
+  it('does not fire upload_error_chat_resolved_retry when error chat was never engaged', async () => {
+    const { track } = await import('../../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': 'attachment; filename="deck.apkg"',
+        'X-Card-Count': '5',
+      }),
+      blob: () => Promise.resolve(new Blob(['fake'])),
+    }));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(container.querySelector('[class*="successPrimary"]')).not.toBeNull();
+    });
+
+    const calls = trackMock.mock.calls.filter(([name]) => name === 'upload_error_chat_resolved_retry');
+    expect(calls).toHaveLength(0);
+  });
+
 });
 
 describe('limit state — start trial button', () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -377,6 +377,12 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
   }, [zoneState]);
 
   useEffect(() => {
+    if (zoneState === 'success' && showErrorInlineChat) {
+      track('upload_error_chat_resolved_retry');
+    }
+  }, [zoneState, showErrorInlineChat]);
+
+  useEffect(() => {
     if (zoneState === 'emptyDeck') {
       track('upload_empty_deck_chat_shown');
     }


### PR DESCRIPTION
## What
Moves the `upload_error_chat_resolved_retry` analytics event from server-side to client-side, making it fire for both anonymous and logged-in users without a DB migration.

## Why
87% of `upload_error_chat_engaged` events come from anonymous users (user_id NULL, anonymous_id present). The server-side fire in `performConversion.ts` hardcoded `anonymousId: null`, so `resolved_retry` could never be credited for those sessions. In a 7-day window: 8 engaged events, 7 anonymous, 0 resolved_retry recorded.

## How
The client already has all the information needed:
- `showErrorInlineChat` tracks whether the error chat was opened in this session
- `zoneState === 'success'` observes when a retry conversion succeeds

A single `useEffect` fires the event when both are true. The `track()` helper posts to `/api/events/track` with `credentials: 'include'`, so the server-side `TrackEventUseCase` stamps the cookie-based `anonymous_id` — covering both anonymous and logged-in users uniformly.

The server-side fire and its `EventsRepository`/`EventsQueryService` imports in `performConversion.ts` are removed to prevent double-counting.

No DB migration required.

## Measuring success
After deploy: query `SELECT count(*) FROM events WHERE name = 'upload_error_chat_resolved_retry'` over a 7-day window. Expect non-zero counts correlating with `upload_error_chat_engaged` events that share the same `anonymous_id`.

## Testing
- Unit tests added: two new cases in `UploadForm.test.tsx`
  1. fires `upload_error_chat_resolved_retry` when chat was engaged and a subsequent conversion succeeds
  2. does not fire when the error chat was never engaged
- Existing performConversion server tests: all 7 pass

## Browser check
Browser check: not applicable — analytics instrumentation, no rendered output

## Changelog
No changelog entry — internal instrumentation fix, no user-visible behavior change.

## Risks
None for users. Analytics-only. If the component is unmounted between the error state and the retry success (e.g., page navigation), the event won't fire — acceptable, since that session discontinuity is a real break in the funnel.

## Goal alignment
Fixes a blind spot in funnel measurement for 87% of the audience. Accurate `resolved_retry` data lets us validate whether the error chat actually converts users back to success — directly informing whether to invest more in that feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782408509&installation_id=132681956&pr_number=2832&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2832&signature=3047fe1b0b3dda50bc28298a7352a86785eccef09139c61b5afead185e3663a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->