### PR TITLE
feat: open /card-options to anonymous users and surface it on the home page

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -1,3 +1,3 @@
-/api/*  https://2anki.net/:splat  200
+/api/*  https://2anki.net/api/:splat  200
 /tm https://templates.2anki.net 200
 /*   /index.html   200

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -299,9 +299,7 @@ function AppContent({
           />
           <Route
             path="/card-options"
-            element={requireAuth(
-              <CardOptionsPage setErrorMessage={setErrorMessage} />
-            )}
+            element={<CardOptionsPage setErrorMessage={setErrorMessage} />}
           />
           <Route path="/templates" element={<TemplatesPage />} />
           <Route

--- a/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { CardOptionsForm } from './CardOptionsForm';
+
+const mockResetUserCardOptions = vi.fn();
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    resetUserCardOptions: mockResetUserCardOptions,
+    deleteSettings: vi.fn().mockResolvedValue(undefined),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  }),
+}));
+
+vi.mock('../../lib/backend/getSettingsCardOptions', () => ({
+  getSettingsCardOptions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../../lib/backend/templates', () => ({
+  getUserTemplates: vi.fn().mockResolvedValue({ templates: [], hiddenIds: [] }),
+  getOfficialNoteTypes: vi.fn().mockResolvedValue([]),
+  getDefaultNoteTypes: vi.fn().mockResolvedValue([]),
+}));
+
+function renderForm(
+  isLoggedIn: boolean,
+  spies: { onReset: () => void; setError: () => void }
+) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CardOptionsForm
+          pageId={null}
+          isLoggedIn={isLoggedIn}
+          onReset={spies.onReset}
+          setError={spies.setError}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('CardOptionsForm reset for the account-default view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResetUserCardOptions.mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  it('resets anonymous users without calling the auth-only server endpoint', async () => {
+    const onReset = vi.fn();
+    const setError = vi.fn();
+    renderForm(false, { onReset, setError });
+    const resetButton = await screen.findByRole('button', {
+      name: 'Reset to defaults',
+    });
+    fireEvent.click(resetButton);
+    await waitFor(() => {
+      expect(onReset).toHaveBeenCalledTimes(1);
+    });
+    expect(mockResetUserCardOptions).not.toHaveBeenCalled();
+    expect(setError).not.toHaveBeenCalled();
+  });
+
+  it('calls the server reset for logged-in users', async () => {
+    const onReset = vi.fn();
+    const setError = vi.fn();
+    renderForm(true, { onReset, setError });
+    const resetButton = await screen.findByRole('button', {
+      name: 'Reset to defaults',
+    });
+    fireEvent.click(resetButton);
+    await waitFor(() => {
+      expect(mockResetUserCardOptions).toHaveBeenCalledTimes(1);
+    });
+    expect(setError).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -34,6 +34,7 @@ import type { FieldMapping } from '../../lib/cardFields/types';
 interface Props {
   pageTitle?: string | null;
   pageId: string | null;
+  isLoggedIn?: boolean;
   onSaved?: (event?: SyntheticEvent) => void;
   onReset?: () => void;
   setError: ErrorHandlerType;
@@ -161,6 +162,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
     {
       pageTitle,
       pageId,
+      isLoggedIn = true,
       onSaved,
       onReset,
       setError,
@@ -402,7 +404,7 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
     const resetStore = async () => {
       if (pageId) {
         await get2ankiApi().deleteSettings(pageId);
-      } else {
+      } else if (isLoggedIn) {
         try {
           await get2ankiApi().resetUserCardOptions();
         } catch {

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -31,6 +31,7 @@ export const KNOWN_EVENTS = new Set([
   'upload_ai_anon_badge_clicked',
   'home_ai_anon_badge_viewed',
   'home_ai_anon_badge_clicked',
+  'home_card_options_link_clicked',
   'paywall_dismissed',
   'pricing_left',
   'upload_failed',

--- a/web/src/lib/backend/api.ts
+++ b/web/src/lib/backend/api.ts
@@ -16,6 +16,7 @@ const NON_AUTH_PATHS = [
   '/users/r/',
   '/auth/magic',
   '/upload',
+  '/card-options',
   '/pricing',
   '/about',
   '/contact',

--- a/web/src/pages/CardOptionsPage/CardOptionsPage.test.tsx
+++ b/web/src/pages/CardOptionsPage/CardOptionsPage.test.tsx
@@ -4,10 +4,27 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 
 import CardOptionsPage from './CardOptionsPage';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
 
 vi.mock('../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => mockApi,
 }));
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: vi.fn(),
+}));
+
+const mockUseUserLocals = vi.mocked(useUserLocals);
+
+function setLoggedIn(loggedIn: boolean) {
+  mockUseUserLocals.mockReturnValue({
+    data: loggedIn ? ({ user: { id: 42 } } as never) : undefined,
+    isLoading: false,
+    error: null,
+    isError: !loggedIn,
+    refetch: vi.fn(),
+  });
+}
 
 const cardOptionsFormProps = vi.fn();
 vi.mock('../../components/CardOptionsForm/CardOptionsForm', () => ({
@@ -43,6 +60,7 @@ describe('CardOptionsPage per-page list', () => {
     vi.clearAllMocks();
     cardOptionsFormProps.mockClear();
     mockNavigate.mockClear();
+    setLoggedIn(true);
     mockApi.listSettings.mockResolvedValue({ items: [] });
     mockApi.deleteSettings.mockResolvedValue(undefined);
     mockApi.deleteRules.mockResolvedValue(undefined);
@@ -55,6 +73,37 @@ describe('CardOptionsPage per-page list', () => {
       expect(screen.getByTestId('card-options-form')).toBeInTheDocument();
     });
     expect(screen.queryByText('Pages with custom settings')).not.toBeInTheDocument();
+  });
+
+  it('renders the form and a device-local notice for anonymous users', async () => {
+    setLoggedIn(false);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId('card-options-form')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Your settings are saved on this device/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Sign in' })).toHaveAttribute(
+      'href',
+      '/login?redirect=/card-options'
+    );
+    expect(cardOptionsFormProps).toHaveBeenCalledWith(
+      expect.objectContaining({ isLoggedIn: false })
+    );
+  });
+
+  it('omits the device-local notice for logged-in users', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByTestId('card-options-form')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/Your settings are saved on this device/i)
+    ).not.toBeInTheDocument();
+    expect(cardOptionsFormProps).toHaveBeenCalledWith(
+      expect.objectContaining({ isLoggedIn: true })
+    );
   });
 
   it('shows the pages section with empty state when arriving from /notion', async () => {

--- a/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
+++ b/web/src/pages/CardOptionsPage/CardOptionsPage.tsx
@@ -4,6 +4,7 @@ import { CardOptionsForm } from '../../components/CardOptionsForm/CardOptionsFor
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { useDialog } from '../../lib/hooks/useDialog';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './CardOptionsPage.module.css';
 
@@ -48,6 +49,8 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
   const [params] = useSearchParams();
   const location = useLocation();
   const navigate = useNavigate();
+  const { data: userLocals } = useUserLocals();
+  const isLoggedIn = userLocals?.user?.id != null;
   const [perPageItems, setPerPageItems] = useState<PerPageItem[]>([]);
   const [pendingResetIds, setPendingResetIds] = useState<Set<string>>(new Set());
   const [rowError, setRowError] = useState<string | null>(null);
@@ -163,6 +166,13 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
               )}{' '}
               <Link to="/documentation">Read the docs</Link> for a full
               explanation of each option.
+            </p>
+          )}
+          {pageId == null && !isLoggedIn && (
+            <p className={sharedStyles.smallDescription}>
+              Your settings are saved on this device.{' '}
+              <Link to="/login?redirect=/card-options">Sign in</Link> to keep
+              them across browsers and devices.
             </p>
           )}
           {pageId != null && (
@@ -315,6 +325,7 @@ export default function CardOptionsPage({ setErrorMessage }: Readonly<Props>) {
         <CardOptionsForm
           pageId={pageId}
           pageTitle={pageTitle}
+          isLoggedIn={isLoggedIn}
           onSaved={shouldReturnAfterSave ? goBack : undefined}
           onReset={shouldReturnAfterSave ? goBack : undefined}
           setError={setErrorMessage}

--- a/web/src/pages/HomePage/HomePage.module.css
+++ b/web/src/pages/HomePage/HomePage.module.css
@@ -36,6 +36,24 @@
   color: var(--color-text-link);
 }
 
+.formOptionsRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.cardOptionsLink {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-link);
+  text-decoration: none;
+}
+
+.cardOptionsLink:hover {
+  text-decoration: underline;
+}
+
 .heroFooter {
   display: flex;
   align-items: center;

--- a/web/src/pages/HomePage/HomePage.module.css
+++ b/web/src/pages/HomePage/HomePage.module.css
@@ -36,14 +36,20 @@
   color: var(--color-text-link);
 }
 
-.formOptionsRow {
+.heroControls {
   display: flex;
-  justify-content: flex-end;
-  margin-top: 0.75rem;
-  margin-bottom: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 1rem auto 0.75rem;
+}
+
+.heroAiBadge {
+  margin: 0;
 }
 
 .cardOptionsLink {
+  flex-shrink: 0;
   font-size: var(--text-sm);
   font-weight: var(--font-medium);
   color: var(--color-text-link);

--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -53,6 +53,12 @@ describe('HomePage (anonymous)', () => {
     expect(link).toHaveAttribute('href', '/register?redirect=/card-options');
   });
 
+  it('links to card options above the upload form so anon visitors can configure first', () => {
+    renderHome();
+    const link = screen.getByRole('link', { name: 'Card options' });
+    expect(link).toHaveAttribute('href', '/card-options');
+  });
+
   it('renders the three how-it-works steps with icons', () => {
     renderHome();
     expect(screen.getByText('Upload')).toBeInTheDocument();

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -144,6 +144,15 @@ export function HomePage({
             .
           </span>
         </div>
+        <div className={styles.formOptionsRow}>
+          <Link
+            to="/card-options"
+            className={styles.cardOptionsLink}
+            onClick={() => track('home_card_options_link_clicked')}
+          >
+            Card options
+          </Link>
+        </div>
         <UploadForm setErrorMessage={setErrorMessage} />
       </section>
 

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -131,20 +131,23 @@ export function HomePage({
         <p className={styles.heroSubtitle}>
           Drop a Notion page and get a deck you don&apos;t have to fix — proper cloze, atomic cards, the right note types. PDF, Quizlet, Markdown, HTML, and CSV too.
         </p>
-        <div className={sharedStyles.aiOffBadge} role="status">
-          <span className={sharedStyles.badgeWarning}>AI is off</span>
-          <span className={sharedStyles.aiOffBadgeBody}>
-            {' '}
-            <Link
-              to="/register?redirect=/card-options"
-              onClick={() => track('home_ai_anon_badge_clicked')}
-            >
-              Create an account to turn it on
-            </Link>
-            .
-          </span>
-        </div>
-        <div className={styles.formOptionsRow}>
+        <div className={styles.heroControls}>
+          <div
+            className={`${sharedStyles.aiOffBadge} ${styles.heroAiBadge}`}
+            role="status"
+          >
+            <span className={sharedStyles.badgeWarning}>AI is off</span>
+            <span className={sharedStyles.aiOffBadgeBody}>
+              {' '}
+              <Link
+                to="/register?redirect=/card-options"
+                onClick={() => track('home_ai_anon_badge_clicked')}
+              >
+                Create an account to turn it on
+              </Link>
+              .
+            </span>
+          </div>
           <Link
             to="/card-options"
             className={styles.cardOptionsLink}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-26-card-options-without-an-account.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-26-card-options-without-an-account.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-26-card-options-without-an-account",
+  "date": "2026-05-26",
+  "type": "fix",
+  "title": "Card options — set your deck name, template, and card types without signing in"
+}


### PR DESCRIPTION
## What

`/card-options` is now reachable without an account, and logged-out visitors get a quiet link to it on the home page. It was the only door to conversion settings (deck name, template, card types, font size, toggle mode, card size) after the inline settings modal was retired — but the route was wrapped in `requireAuth`, so the ~87% of users who convert without signing in were bounced to `/login` and couldn't tune how their uploads convert.

## Why this is safe for anon

- The default-options form is already **localStorage-backed** — `serverSave` short-circuits to `true` when there's no `pageId`, and every field persists via `saveValueInLocalStorage`. These settings already drive anonymous conversions at upload time.
- The option-metadata endpoint `GET /api/settings/card-options` is **public**.
- The per-page "Pages with custom settings" section and note-type calls degrade gracefully (`.catch`) and stay hidden/empty for anon.

## Changes

1. **Open the route** — drop `requireAuth` from `/card-options` (`App.tsx`).
2. **Add `/card-options` to `NON_AUTH_PATHS`** (`api.ts`). Without this, the background 401 from the auth-only `/api/settings/list` call fires `redirectToLogin()` *before* the page's `.catch` runs, hard-redirecting anon visitors to `/login`.
3. **Guard the auth-only `resetUserCardOptions()`** backend call behind `isLoggedIn` (`CardOptionsForm`). "Reset to defaults" clears local settings for anon instead of failing with a misleading error. New optional `isLoggedIn` prop defaults to `true`, so existing callers are unaffected.
4. **Anon-only notice** under the subtitle: "Your settings are saved on this device. Sign in to keep them across browsers and devices." Logged-in defaults already sync server-side via `userPreferencesSync`, so the line is anon-only.
5. **Home-page discovery link** — a quiet, right-aligned tertiary "Card options" link in the hero, directly above the upload drop zone (`HomePage`). Logged-out visitors otherwise have no way to find the now-open page. Restrained on purpose so it doesn't compete with the primary "drop a file" CTA. Home page only (`/upload` already exposes it via the AI badge "Settings" link + nav). Tracks `home_card_options_link_clicked`.
6. **Netlify deploy-preview proxy fix** (`web/public/_redirects`) — the `/api/*` proxy rewrote to `https://2anki.net/:splat`, but Netlify's `:splat` drops the `/api` prefix, so `/api/settings/card-options` was proxied to `https://2anki.net/settings/card-options` and fell through to the prod SPA's `index.html` → "Unexpected token '<'... is not valid JSON" on the preview. Fixed to `https://2anki.net/api/:splat`. Latent since #2804; only surfaced now because `/card-options` is the first anon-reachable page that calls `/api` on a preview. (Note: authenticated calls still won't work on previews — the token cookie is scoped to `2anki.net`, not the netlify.app origin — but the anon card-options page only needs the public endpoint.)

## Trio

pm + designer + engineer reviewed both the access change and the home-page link in parallel.
- **Access change:** agreement to open the route, keep Premium options visible with badge, fix the anon reset bug.
- **Home-page link:** owner asked for upper-right above the form; designer reconciled it as a quiet right-aligned tertiary link inside the hero column; **pm dissented** — would prefer a secondary link *below* the drop zone and sees the higher-leverage win as a card-options entry point on the empty/wrong-deck **result screen** (logged as a separate follow-up). Shipped the owner's placement in the designer's restrained treatment, which blunts the "competes with upload" concern. Easy to flip to below-form if preferred.

## Out of scope (deliberate)

- **Premium-badged options** (AI flashcards, Vertex PDF, image-quiz) stay visible with their badge. AI is already hard-`false` for anon at upload, so toggling one is a no-op — no paywall leak.
- The retired inline `SettingsModal` is not revived.
- The result-screen card-options entry point (pm's idea) is a separate spec.

## Tests

- `CardOptionsPage.test.tsx` — anon render shows the form + device-local notice with the correct sign-in link; logged-in omits it; `isLoggedIn` prop is threaded.
- `CardOptionsForm.test.tsx` (new) — reset for anon skips the auth-only server call and surfaces no error; logged-in reset still calls it.
- `HomePage.test.tsx` — the "Card options" link renders above the form and points to `/card-options`.
- `robots.test.ts` `Disallow: /card-options` left as-is (app UI, not SEO content).

`/check` green (server tsc + web typecheck + web lint + full vitest, 1287 passing). Production build succeeds. No changelog entry beyond the existing `card-options-without-an-account.json` — the home link is the discovery affordance for that same already-announced capability. No api.ts unit test for the `NON_AUTH_PATHS` entry (module-private helpers; testing would need exported internals or a brittle jsdom navigation mock). SonarCloud runs via Automatic Analysis on this PR.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified by Al on the Netlify deploy preview across iterations — anon `/card-options` loads its option groups (no "Unexpected token" toast, after the `_redirects` proxy fix), and the AI badge + Card options link sit aligned on one row above the upload form.