### PR TITLE
fix: make photo-to-deck handle large photos and any image format

### DIFF
--- a/src/controllers/PhotoToFlashcardsController.test.ts
+++ b/src/controllers/PhotoToFlashcardsController.test.ts
@@ -115,6 +115,68 @@ describe('PhotoToFlashcardsController mode forwarding', () => {
   });
 });
 
+describe('PhotoToFlashcardsController media type detection', () => {
+  function jpegBase64(): string {
+    return Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0, 0, 0, 0, 0]).toString(
+      'base64'
+    );
+  }
+
+  it('uses the media type detected from the bytes, not the client-declared one', async () => {
+    const useCase = makeUseCase();
+    const controller = new PhotoToFlashcardsController(useCase);
+    await controller.create(
+      makeReq({
+        imageBase64: jpegBase64(),
+        mediaType: 'image/png',
+        deckName: 'X',
+        width: 100,
+        height: 100,
+      }),
+      makeRes()
+    );
+    expect(useCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: 'image/jpeg' })
+    );
+  });
+
+  it('falls back to the declared type when the bytes are not a known image', async () => {
+    const useCase = makeUseCase();
+    const controller = new PhotoToFlashcardsController(useCase);
+    await controller.create(
+      makeReq({
+        imageBase64: 'abc',
+        mediaType: 'image/png',
+        deckName: 'X',
+        width: 100,
+        height: 100,
+      }),
+      makeRes()
+    );
+    expect(useCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ mediaType: 'image/png' })
+    );
+  });
+
+  it('rejects with 400 when neither the bytes nor the declared type are supported', async () => {
+    const useCase = makeUseCase();
+    const controller = new PhotoToFlashcardsController(useCase);
+    const res = makeRes();
+    await controller.create(
+      makeReq({
+        imageBase64: 'abc',
+        mediaType: 'application/pdf',
+        deckName: 'X',
+        width: 100,
+        height: 100,
+      }),
+      res
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(useCase.execute).not.toHaveBeenCalled();
+  });
+});
+
 describe('PhotoToFlashcardsController MCQ headers', () => {
   const baseBody = {
     imageBase64: 'abc',

--- a/src/controllers/PhotoToFlashcardsController.ts
+++ b/src/controllers/PhotoToFlashcardsController.ts
@@ -13,6 +13,7 @@ import {
 } from '../usecases/imageOcclusion/PhotoToFlashcardsUseCase';
 import type { VisionMediaType } from '../lib/claude/countVisionTokens';
 import { buildContentDisposition } from '../lib/buildContentDisposition';
+import { detectFileMime } from '../lib/detectFileMime';
 import { isPaying } from '../lib/isPaying';
 
 const ALLOWED_MEDIA_TYPES: VisionMediaType[] = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
@@ -67,14 +68,20 @@ export class PhotoToFlashcardsController {
       return;
     }
 
-    if (!isAllowedMediaType(body.mediaType)) {
+    // Trust the bytes, not the client-declared type: a JPEG uploaded as
+    // image/png makes Anthropic reject the message with a media_type mismatch.
+    const detectedMediaType = detectFileMime(
+      Buffer.from(imageBase64.slice(0, 64), 'base64')
+    );
+    const mediaType = isAllowedMediaType(detectedMediaType)
+      ? detectedMediaType
+      : body.mediaType;
+    if (!isAllowedMediaType(mediaType)) {
       res.status(400).json({
         message: `Unsupported image type. Use ${ALLOWED_MEDIA_TYPES.join(', ')}.`,
       });
       return;
     }
-
-    const mediaType = body.mediaType;
     const deckName =
       typeof body.deckName === 'string' && body.deckName.trim()
         ? body.deckName.trim()

--- a/web/src/lib/image/prepareImageForVision.test.ts
+++ b/web/src/lib/image/prepareImageForVision.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { approxBytesFromBase64, initialScale } from './prepareImageForVision';
+
+describe('approxBytesFromBase64', () => {
+  it('estimates decoded byte size from base64 length (3 bytes per 4 chars)', () => {
+    expect(approxBytesFromBase64('')).toBe(0);
+    expect(approxBytesFromBase64('AAAA')).toBe(3);
+    expect(approxBytesFromBase64('A'.repeat(8))).toBe(6);
+  });
+});
+
+describe('initialScale', () => {
+  it('returns 1 when the long edge is within the cap', () => {
+    expect(initialScale(1000, 800)).toBe(1);
+    expect(initialScale(1568, 1568)).toBe(1);
+  });
+
+  it('scales down so the long edge hits the cap', () => {
+    expect(initialScale(3136, 1000)).toBe(0.5);
+    expect(initialScale(1000, 3136)).toBe(0.5);
+  });
+});

--- a/web/src/lib/image/prepareImageForVision.ts
+++ b/web/src/lib/image/prepareImageForVision.ts
@@ -1,0 +1,79 @@
+// Anthropic's vision API caps each image at 5 MB (decoded) and downscales
+// anything larger than ~1568px on the long edge anyway. We re-encode every
+// upload to a JPEG that fits comfortably under both limits, which also gives
+// the request a deterministic media type regardless of the source format.
+
+const MAX_EDGE = 1568;
+const MAX_BYTES = 4_500_000;
+const QUALITY_STEPS = [0.85, 0.7, 0.55, 0.4];
+const MAX_SHRINK_ATTEMPTS = 4;
+
+export interface PreparedImage {
+  base64: string;
+  mediaType: 'image/jpeg';
+  width: number;
+  height: number;
+}
+
+export function approxBytesFromBase64(base64: string): number {
+  return Math.floor((base64.length * 3) / 4);
+}
+
+export function initialScale(width: number, height: number): number {
+  const longest = Math.max(width, height);
+  return longest > MAX_EDGE ? MAX_EDGE / longest : 1;
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('Could not read the image'));
+    };
+    img.src = url;
+  });
+}
+
+function encodeUnderCeiling(
+  img: HTMLImageElement,
+  width: number,
+  height: number
+): PreparedImage | null {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (ctx == null) throw new Error('Canvas is not supported in this browser');
+  ctx.drawImage(img, 0, 0, width, height);
+
+  for (const quality of QUALITY_STEPS) {
+    const base64 = canvas.toDataURL('image/jpeg', quality).split(',')[1] ?? '';
+    if (approxBytesFromBase64(base64) <= MAX_BYTES) {
+      return { base64, mediaType: 'image/jpeg', width, height };
+    }
+  }
+  return null;
+}
+
+export async function prepareImageForVision(file: File): Promise<PreparedImage> {
+  const img = await loadImage(file);
+  let scale = initialScale(img.naturalWidth, img.naturalHeight);
+
+  for (let attempt = 0; attempt < MAX_SHRINK_ATTEMPTS; attempt++) {
+    const width = Math.max(1, Math.round(img.naturalWidth * scale));
+    const height = Math.max(1, Math.round(img.naturalHeight * scale));
+    const result = encodeUnderCeiling(img, width, height);
+    if (result != null) return result;
+    scale *= 0.75;
+  }
+
+  throw new Error(
+    'Could not shrink this image enough. Try a smaller or lower-resolution photo.'
+  );
+}

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
@@ -7,6 +7,15 @@ vi.mock('../../lib/analytics/track', () => ({
   track: (...args: unknown[]) => mockTrack(...args),
 }));
 
+vi.mock('../../lib/image/prepareImageForVision', () => ({
+  prepareImageForVision: vi.fn(async () => ({
+    base64: 'YWJjMTIz',
+    mediaType: 'image/jpeg',
+    width: 800,
+    height: 600,
+  })),
+}));
+
 const FAKE_DATA_URL = 'data:image/jpeg;base64,YWJjMTIz';
 
 const mockUseUserLocals = vi.fn();

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -5,6 +5,7 @@ import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabe
 import { track } from '../../lib/analytics/track';
 import styles from '../../styles/shared.module.css';
 import pageStyles from './PhotoToFlashcardsPage.module.css';
+import { prepareImageForVision } from '../../lib/image/prepareImageForVision';
 
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 const MAX_SIZE_BYTES = 10 * 1024 * 1024;
@@ -39,36 +40,6 @@ function cardCountToDensity(count: number): Density {
   if (count <= 5) return 'sparse';
   if (count <= 10) return 'balanced';
   return 'dense';
-}
-
-async function fileToBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result as string;
-      resolve(result.split(',')[1] ?? '');
-    };
-    reader.onerror = () => reject(new Error('Failed to read file'));
-    reader.readAsDataURL(file);
-  });
-}
-
-async function getImageDimensions(
-  file: File
-): Promise<{ width: number; height: number }> {
-  return new Promise((resolve, reject) => {
-    const url = URL.createObjectURL(file);
-    const img = new Image();
-    img.onload = () => {
-      URL.revokeObjectURL(url);
-      resolve({ width: img.naturalWidth, height: img.naturalHeight });
-    };
-    img.onerror = () => {
-      URL.revokeObjectURL(url);
-      reject(new Error('Could not read image dimensions'));
-    };
-    img.src = url;
-  });
 }
 
 function downloadBlob(blob: Blob, filename: string): void {
@@ -173,10 +144,7 @@ export function PhotoToFlashcardsPage() {
     track('photo_upload_started', { source: uploadSource });
 
     try {
-      const [imageBase64, dimensions] = await Promise.all([
-        fileToBase64(file),
-        getImageDimensions(file),
-      ]);
+      const prepared = await prepareImageForVision(file);
 
       const baseName = file.name.replace(/\.[^.]+$/, '') || 'Photo deck';
       const name = deckName.trim() || baseName;
@@ -186,11 +154,11 @@ export function PhotoToFlashcardsPage() {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          imageBase64,
-          mediaType: file.type,
+          imageBase64: prepared.base64,
+          mediaType: prepared.mediaType,
           deckName: name,
-          width: dimensions.width,
-          height: dimensions.height,
+          width: prepared.width,
+          height: prepared.height,
           includeSourceImage,
           density,
           mode,

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-26-photo-to-deck-large-images.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-26-photo-to-deck-large-images.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-26-photo-to-deck-large-images",
+  "date": "2026-05-26",
+  "type": "fix",
+  "title": "Photo to deck resizes large photos automatically, so big images and any format convert"
+}


### PR DESCRIPTION
## What

Photo to deck was failing with two Anthropic 400s:
- `media_type` mismatch — a JPEG uploaded as `image/png` (the browser's `file.type` was wrong).
- `image exceeds 5 MB maximum: 6943624 bytes` — the 5 MB cap is **Anthropic's per-image API limit, not ours**, so we can't lift it; we shrink the image to fit instead.

## Changes

- **Client (`prepareImageForVision`)** — before upload, downscale to ≤1568px on the long edge (Anthropic's effective max) and re-encode as JPEG under ~4.5 MB, stepping quality down (and shrinking further) until it fits. The request now always sends a deterministic `image/jpeg` plus the resized dimensions. This fixes both errors for normal phone photos.
- **Server (`PhotoToFlashcardsController`)** — detect the media type from the image bytes (`detectFileMime`) instead of trusting the client-declared `mediaType`; fall back to the declared type only when undetectable. Defense-in-depth and matches the security rule "don't trust the uploaded MIME."

The existing 10 MB client-side gate and 413 server fallback stay as outer guards.

## Tests

- Server: `PhotoToFlashcardsController.test.ts` — detected type overrides the declared type (JPEG bytes sent as `image/png` → `image/jpeg`); falls back to declared when undetectable; rejects when neither is a supported image.
- Web: `prepareImageForVision.test.ts` — byte-size estimate and scale-to-cap math (the canvas encode itself needs a real browser, so the page tests mock `prepareImageForVision`).
- `/check` green: server tsc + jest, web typecheck + vitest (1290 passing).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: please verify on the preview — upload a large (>5 MB) photo and a JPEG, confirm both convert without the Anthropic 400 (the canvas resize only runs in a real browser, not jsdom). Tick before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782421439&installation_id=132681956&pr_number=2834&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2834&signature=2669041240efe9c75b43c9584884b3943f46caae15b72b724d392f48ccfea1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->