### PR TITLE
fix: restore vertical spacing between Photo to deck sections

### DIFF
--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
@@ -1,3 +1,13 @@
+/* Shared .page has no gap; the section cards need this column layout for
+   vertical rhythm between them. Don't drop back to bare shared .page — that
+   collapses the cards together (regressed once in #2748). */
+.page {
+  composes: page from '../../styles/shared.module.css';
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
 .row {
   display: flex;
   align-items: center;

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -256,7 +256,7 @@ export function PhotoToFlashcardsPage() {
   };
 
   return (
-    <section className={styles.page} aria-label="Photo to deck">
+    <section className={pageStyles.page} aria-label="Photo to deck">
       <header className={styles.pageHeader}>
         <h1 className={styles.title}>Photo to deck</h1>
         <p className={styles.subtitle}>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-26-photo-to-deck-spacing.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-26-photo-to-deck-spacing.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-26-photo-to-deck-spacing",
+  "date": "2026-05-26",
+  "type": "style",
+  "title": "Photo to deck — even spacing between the sections again"
+}


### PR DESCRIPTION
## What

On **Photo to deck**, the section cards (mode picker, deck name + dropzone, card count, toggles) stacked flush against each other with no gap.

## Cause

The "apple-principles pass" (#2748) replaced the page's local flex-column container with the bare shared `styles.page` class. Shared `.page` is just max-width + padding — no `gap` — and shared `.sectionCard` has no `margin`, so nothing separated the cards. (Other section-card pages, e.g. Image Occlusion, keep their own flex-column-gap page container.)

## Fix

Restore a local `.page` that `composes` the shared one and adds `display: flex; flex-direction: column; gap: var(--space-5)` (1.25rem — the value it had before #2748). Added a comment so it isn't "simplified" back to the bare shared class a third time.

The earlier toggle-row gap fix (`.densityHint + .checkboxRow`) is untouched and still in place.

## Tests

- `/check` green: web typecheck + Biome + vitest (1287 passing). CSS-module `composes` resolves at build time.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: please verify on the preview that the four Photo to deck cards have even vertical spacing between them. Tick before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782422277&installation_id=132681956&pr_number=2836&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2836&signature=2deaf7f3aa7c1952dce1aa3b772226b181e93a813698f31daac1411399e4b718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->