### PR TITLE
feat: mark error groups resolved in /ops/errors

### DIFF
--- a/migrations/20260802000000_add_error_resolutions_table.js
+++ b/migrations/20260802000000_add_error_resolutions_table.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.createTable('error_resolutions', (t) => {
+    t.specificType('message_hash', 'char(64)').primary();
+    t.timestamp('resolved_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    t.integer('resolved_by').nullable().references('id').inTable('users').onDelete('SET NULL');
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.dropTable('error_resolutions');
+};

--- a/src/controllers/OpsErrorsController.test.ts
+++ b/src/controllers/OpsErrorsController.test.ts
@@ -1,0 +1,130 @@
+import { Request, Response } from 'express';
+import { OpsErrorsController } from './OpsErrorsController';
+import { ListErrorGroupsUseCase } from '../usecases/ops/ListErrorGroupsUseCase';
+import { ResolveErrorGroupUseCase } from '../usecases/ops/ResolveErrorGroupUseCase';
+import { ReopenErrorGroupUseCase } from '../usecases/ops/ReopenErrorGroupUseCase';
+
+const VALID_HASH = 'a'.repeat(64);
+
+function makeResponse() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    ended: false,
+    locals: {} as Record<string, unknown>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+  };
+  return res as unknown as Response & typeof res;
+}
+
+function makeController() {
+  const listExecute = jest.fn(async () => ({ groups: [], totalGroups: 0 }));
+  const resolveExecute = jest.fn(async () => {});
+  const reopenExecute = jest.fn(async () => {});
+
+  const controller = new OpsErrorsController(
+    { execute: listExecute } as unknown as ListErrorGroupsUseCase,
+    { execute: resolveExecute } as unknown as ResolveErrorGroupUseCase,
+    { execute: reopenExecute } as unknown as ReopenErrorGroupUseCase
+  );
+
+  return { controller, listExecute, resolveExecute, reopenExecute };
+}
+
+describe('OpsErrorsController.list', () => {
+  it('defaults to the unresolved status when none is given', async () => {
+    const { controller, listExecute } = makeController();
+    const req = { query: {} } as unknown as Request;
+    const res = makeResponse();
+
+    await controller.list(req, res);
+
+    expect(listExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'unresolved' })
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('passes through an explicit resolved status', async () => {
+    const { controller, listExecute } = makeController();
+    const req = { query: { status: 'resolved' } } as unknown as Request;
+    const res = makeResponse();
+
+    await controller.list(req, res);
+
+    expect(listExecute).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'resolved' })
+    );
+  });
+});
+
+describe('OpsErrorsController.resolve', () => {
+  it('rejects an invalid message hash with 400', async () => {
+    const { controller, resolveExecute } = makeController();
+    const req = { params: { messageHash: 'not-a-hash' } } as unknown as Request;
+    const res = makeResponse();
+
+    await controller.resolve(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(resolveExecute).not.toHaveBeenCalled();
+  });
+
+  it('resolves a valid hash and records the ops owner', async () => {
+    const { controller, resolveExecute } = makeController();
+    const req = { params: { messageHash: VALID_HASH } } as unknown as Request;
+    const res = makeResponse();
+    res.locals.owner = 7;
+
+    await controller.resolve(req, res);
+
+    expect(resolveExecute).toHaveBeenCalledWith(VALID_HASH, 7);
+    expect(res.statusCode).toBe(204);
+    expect(res.ended).toBe(true);
+  });
+
+  it('records a null resolver when no owner id is present', async () => {
+    const { controller, resolveExecute } = makeController();
+    const req = { params: { messageHash: VALID_HASH } } as unknown as Request;
+    const res = makeResponse();
+
+    await controller.resolve(req, res);
+
+    expect(resolveExecute).toHaveBeenCalledWith(VALID_HASH, null);
+  });
+});
+
+describe('OpsErrorsController.reopen', () => {
+  it('rejects an invalid message hash with 400', async () => {
+    const { controller, reopenExecute } = makeController();
+    const req = { params: { messageHash: 'XYZ' } } as unknown as Request;
+    const res = makeResponse();
+
+    await controller.reopen(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(reopenExecute).not.toHaveBeenCalled();
+  });
+
+  it('reopens a valid hash', async () => {
+    const { controller, reopenExecute } = makeController();
+    const req = { params: { messageHash: VALID_HASH } } as unknown as Request;
+    const res = makeResponse();
+
+    await controller.reopen(req, res);
+
+    expect(reopenExecute).toHaveBeenCalledWith(VALID_HASH);
+    expect(res.statusCode).toBe(204);
+  });
+});

--- a/src/controllers/OpsErrorsController.ts
+++ b/src/controllers/OpsErrorsController.ts
@@ -1,8 +1,12 @@
 import { Request, Response } from 'express';
 import { ListErrorGroupsUseCase } from '../usecases/ops/ListErrorGroupsUseCase';
+import { ResolveErrorGroupUseCase } from '../usecases/ops/ResolveErrorGroupUseCase';
+import { ReopenErrorGroupUseCase } from '../usecases/ops/ReopenErrorGroupUseCase';
+import { ResolutionStatus } from '../data_layer/ErrorEventRepository';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
+const MESSAGE_HASH_PATTERN = /^[a-f0-9]{64}$/;
 
 function parseSort(raw: unknown): 'last_seen' | 'occurrences' {
   return raw === 'occurrences' ? 'occurrences' : 'last_seen';
@@ -14,14 +18,29 @@ function parseSource(raw: unknown): 'web' | 'server' | undefined {
   return undefined;
 }
 
+function parseStatus(raw: unknown): ResolutionStatus {
+  if (raw === 'resolved') return 'resolved';
+  if (raw === 'all') return 'all';
+  return 'unresolved';
+}
+
+function parseResolvedBy(owner: unknown): number | null {
+  return typeof owner === 'number' ? owner : null;
+}
+
 export class OpsErrorsController {
-  constructor(private readonly listErrorGroupsUseCase: ListErrorGroupsUseCase) {}
+  constructor(
+    private readonly listErrorGroupsUseCase: ListErrorGroupsUseCase,
+    private readonly resolveErrorGroupUseCase: ResolveErrorGroupUseCase,
+    private readonly reopenErrorGroupUseCase: ReopenErrorGroupUseCase
+  ) {}
 
   async list(req: Request, res: Response): Promise<void> {
     const limit = Math.min(Number(req.query.limit) || DEFAULT_LIMIT, MAX_LIMIT);
     const offset = Number(req.query.offset) || 0;
     const source = parseSource(req.query.source);
     const sort = parseSort(req.query.sort);
+    const status = parseStatus(req.query.status);
 
     try {
       const result = await this.listErrorGroupsUseCase.execute({
@@ -29,11 +48,47 @@ export class OpsErrorsController {
         offset,
         source,
         sort,
+        status,
       });
       res.status(200).json(result);
     } catch (error) {
       console.error('[ops] list error groups failed', error);
       res.status(500).json({ message: 'Failed to load error groups' });
+    }
+  }
+
+  async resolve(req: Request, res: Response): Promise<void> {
+    const messageHash = req.params.messageHash;
+    if (!MESSAGE_HASH_PATTERN.test(messageHash)) {
+      res.status(400).json({ message: 'Invalid message hash' });
+      return;
+    }
+
+    try {
+      await this.resolveErrorGroupUseCase.execute(
+        messageHash,
+        parseResolvedBy(res.locals.owner)
+      );
+      res.status(204).end();
+    } catch (error) {
+      console.error('[ops] resolve error group failed', error);
+      res.status(500).json({ message: 'Failed to resolve error group' });
+    }
+  }
+
+  async reopen(req: Request, res: Response): Promise<void> {
+    const messageHash = req.params.messageHash;
+    if (!MESSAGE_HASH_PATTERN.test(messageHash)) {
+      res.status(400).json({ message: 'Invalid message hash' });
+      return;
+    }
+
+    try {
+      await this.reopenErrorGroupUseCase.execute(messageHash);
+      res.status(204).end();
+    } catch (error) {
+      console.error('[ops] reopen error group failed', error);
+      res.status(500).json({ message: 'Failed to reopen error group' });
     }
   }
 }

--- a/src/data_layer/ErrorEventRepository.test.ts
+++ b/src/data_layer/ErrorEventRepository.test.ts
@@ -206,3 +206,40 @@ describe('ErrorEventRepository.existsWithinWindow', () => {
     expect(result).toBe(true);
   });
 });
+
+describe('ErrorEventRepository.resolveGroup', () => {
+  it('upserts a resolution row keyed by message_hash', async () => {
+    const mergeSpy = jest.fn().mockResolvedValue(undefined);
+    const onConflictSpy = jest.fn().mockReturnValue({ merge: mergeSpy });
+    const insertSpy = jest.fn().mockReturnValue({ onConflict: onConflictSpy });
+    const knex = jest.fn().mockReturnValue({ insert: insertSpy }) as unknown as jest.Mock & {
+      fn: { now: () => string };
+    };
+    knex.fn = { now: () => 'NOW()' };
+
+    const repo = new ErrorEventRepository(knex as never);
+    await repo.resolveGroup('a'.repeat(64), 5);
+
+    expect(insertSpy).toHaveBeenCalledWith({
+      message_hash: 'a'.repeat(64),
+      resolved_at: 'NOW()',
+      resolved_by: 5,
+    });
+    expect(onConflictSpy).toHaveBeenCalledWith('message_hash');
+    expect(mergeSpy).toHaveBeenCalledWith(['resolved_at', 'resolved_by']);
+  });
+});
+
+describe('ErrorEventRepository.reopenGroup', () => {
+  it('deletes the resolution row for the message_hash', async () => {
+    const delSpy = jest.fn().mockResolvedValue(1);
+    const whereSpy = jest.fn().mockReturnValue({ del: delSpy });
+    const knex = jest.fn().mockReturnValue({ where: whereSpy });
+
+    const repo = new ErrorEventRepository(knex as never);
+    await repo.reopenGroup('b'.repeat(64));
+
+    expect(whereSpy).toHaveBeenCalledWith('message_hash', 'b'.repeat(64));
+    expect(delSpy).toHaveBeenCalled();
+  });
+});

--- a/src/data_layer/ErrorEventRepository.ts
+++ b/src/data_layer/ErrorEventRepository.ts
@@ -13,6 +13,8 @@ export interface ErrorEventInsert {
   context?: Record<string, unknown> | null;
 }
 
+export type ResolutionStatus = 'unresolved' | 'resolved' | 'all';
+
 export interface ErrorGroupRow {
   message_hash: string;
   message: string;
@@ -25,6 +27,8 @@ export interface ErrorGroupRow {
   first_seen: string;
   last_seen: string;
   occurrences: number;
+  resolved: boolean;
+  resolved_at: string | null;
 }
 
 export interface ListErrorGroupsOptions {
@@ -32,19 +36,38 @@ export interface ListErrorGroupsOptions {
   offset: number;
   source?: 'web' | 'server';
   sort?: 'last_seen' | 'occurrences';
+  status?: ResolutionStatus;
 }
 
 export interface IErrorEventRepository {
   insert(row: ErrorEventInsert): Promise<void>;
   existsWithinWindow(messageHash: string, ipHash: string, windowMs: number): Promise<boolean>;
   listGroups(options: ListErrorGroupsOptions): Promise<ErrorGroupRow[]>;
-  countGroups(source?: 'web' | 'server'): Promise<number>;
+  countGroups(source?: 'web' | 'server', status?: ResolutionStatus): Promise<number>;
+  resolveGroup(messageHash: string, resolvedBy: number | null): Promise<void>;
+  reopenGroup(messageHash: string): Promise<void>;
 }
+
+const RESOLVED_PREDICATE = 'MAX(r.resolved_at) >= MAX(e.created_at)';
+const UNRESOLVED_PREDICATE =
+  '(MAX(r.resolved_at) IS NULL OR MAX(r.resolved_at) < MAX(e.created_at))';
 
 export class ErrorEventRepository implements IErrorEventRepository {
   private readonly table = 'error_events';
+  private readonly resolutionsTable = 'error_resolutions';
 
   constructor(private readonly database: Knex) {}
+
+  private applyStatusFilter(
+    query: Knex.QueryBuilder,
+    status: ResolutionStatus | undefined
+  ): void {
+    if (status === 'resolved') {
+      query.havingRaw(RESOLVED_PREDICATE);
+    } else if (status === 'unresolved') {
+      query.havingRaw(UNRESOLVED_PREDICATE);
+    }
+  }
 
   async insert(row: ErrorEventInsert): Promise<void> {
     await this.database(this.table).insert(row);
@@ -62,31 +85,36 @@ export class ErrorEventRepository implements IErrorEventRepository {
   }
 
   async listGroups(options: ListErrorGroupsOptions): Promise<ErrorGroupRow[]> {
-    const { limit, offset, source, sort } = options;
+    const { limit, offset, source, sort, status } = options;
     const orderCol = sort === 'occurrences' ? 'occurrences' : 'last_seen';
 
-    const query = this.database(this.table)
+    const query = this.database(`${this.table} as e`)
+      .leftJoin(`${this.resolutionsTable} as r`, 'e.message_hash', 'r.message_hash')
       .select(
-        'message_hash',
-        'message',
-        this.database.raw('MAX(stack) as stack'),
-        this.database.raw('MAX(url) as url'),
-        this.database.raw('MAX(release) as release'),
-        'source',
-        this.database.raw('MAX(user_id) as user_id'),
-        this.database.raw('MAX(user_agent) as user_agent'),
-        this.database.raw('MIN(created_at) as first_seen'),
-        this.database.raw('MAX(created_at) as last_seen'),
-        this.database.raw('COUNT(*) as occurrences')
+        'e.message_hash as message_hash',
+        'e.message as message',
+        this.database.raw('MAX(e.stack) as stack'),
+        this.database.raw('MAX(e.url) as url'),
+        this.database.raw('MAX(e.release) as release'),
+        'e.source as source',
+        this.database.raw('MAX(e.user_id) as user_id'),
+        this.database.raw('MAX(e.user_agent) as user_agent'),
+        this.database.raw('MIN(e.created_at) as first_seen'),
+        this.database.raw('MAX(e.created_at) as last_seen'),
+        this.database.raw('COUNT(*) as occurrences'),
+        this.database.raw('MAX(r.resolved_at) as resolved_at'),
+        this.database.raw(`(${RESOLVED_PREDICATE}) as resolved`)
       )
-      .groupBy('message_hash', 'message', 'source')
+      .groupBy('e.message_hash', 'e.message', 'e.source')
       .orderBy(orderCol, 'desc')
       .limit(limit)
       .offset(offset);
 
     if (source != null) {
-      query.where('source', source);
+      query.where('e.source', source);
     }
+
+    this.applyStatusFilter(query, status);
 
     const rows = await query;
     return rows.map((r) => ({
@@ -101,22 +129,47 @@ export class ErrorEventRepository implements IErrorEventRepository {
       first_seen: r.first_seen instanceof Date ? r.first_seen.toISOString() : String(r.first_seen),
       last_seen: r.last_seen instanceof Date ? r.last_seen.toISOString() : String(r.last_seen),
       occurrences: Number(r.occurrences),
+      resolved: r.resolved === true,
+      resolved_at:
+        r.resolved_at == null
+          ? null
+          : r.resolved_at instanceof Date
+            ? r.resolved_at.toISOString()
+            : String(r.resolved_at),
     }));
   }
 
-  async countGroups(source?: 'web' | 'server'): Promise<number> {
-    const inner = this.database(this.table)
-      .select('message_hash')
-      .groupBy('message_hash', 'message', 'source');
+  async countGroups(source?: 'web' | 'server', status?: ResolutionStatus): Promise<number> {
+    const inner = this.database(`${this.table} as e`)
+      .leftJoin(`${this.resolutionsTable} as r`, 'e.message_hash', 'r.message_hash')
+      .select('e.message_hash')
+      .groupBy('e.message_hash', 'e.message', 'e.source');
 
     if (source != null) {
-      inner.where('source', source);
+      inner.where('e.source', source);
     }
+
+    this.applyStatusFilter(inner, status);
 
     const result = await this.database
       .count('* as total')
       .from(inner.as('groups'))
       .first();
     return Number(result?.total ?? 0);
+  }
+
+  async resolveGroup(messageHash: string, resolvedBy: number | null): Promise<void> {
+    await this.database(this.resolutionsTable)
+      .insert({
+        message_hash: messageHash,
+        resolved_at: this.database.fn.now(),
+        resolved_by: resolvedBy,
+      })
+      .onConflict('message_hash')
+      .merge(['resolved_at', 'resolved_by']);
+  }
+
+  async reopenGroup(messageHash: string): Promise<void> {
+    await this.database(this.resolutionsTable).where('message_hash', messageHash).del();
   }
 }

--- a/src/lib/errorFallback.test.ts
+++ b/src/lib/errorFallback.test.ts
@@ -24,6 +24,8 @@ function makeRepository(): IErrorEventRepository & { inserts: ErrorEventInsert[]
     async countGroups() {
       return 0;
     },
+    async resolveGroup() {},
+    async reopenGroup() {},
   };
 }
 

--- a/src/routes/OpsErrorsRouter.test.ts
+++ b/src/routes/OpsErrorsRouter.test.ts
@@ -29,6 +29,9 @@ jest.mock('./middleware/RequireOpsAccess', () => {
   };
 });
 
+const resolveGroupSpy = jest.fn(async () => {});
+const reopenGroupSpy = jest.fn(async () => {});
+
 jest.mock('../data_layer/ErrorEventRepository', () => ({
   ErrorEventRepository: class {
     async listGroups() {
@@ -45,6 +48,8 @@ jest.mock('../data_layer/ErrorEventRepository', () => ({
           first_seen: '2026-05-01T00:00:00.000Z',
           last_seen: '2026-05-24T10:00:00.000Z',
           occurrences: 3,
+          resolved: false,
+          resolved_at: null,
         },
       ];
     }
@@ -53,6 +58,12 @@ jest.mock('../data_layer/ErrorEventRepository', () => ({
     }
     async insert() {}
     async existsWithinWindow() { return false; }
+    resolveGroup(...args: unknown[]) {
+      return resolveGroupSpy(...(args as []));
+    }
+    reopenGroup(...args: unknown[]) {
+      return reopenGroupSpy(...(args as []));
+    }
   },
 }));
 
@@ -124,7 +135,61 @@ describe('OpsErrorsRouter GET /api/ops/errors', () => {
         first_seen: expect.any(String),
         last_seen: expect.any(String),
         occurrences: expect.any(Number),
+        resolved: expect.any(Boolean),
       });
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsErrorsRouter resolve / reopen', () => {
+  const hash = 'a'.repeat(64);
+
+  beforeEach(() => {
+    resolveGroupSpy.mockClear();
+    reopenGroupSpy.mockClear();
+  });
+
+  it('returns 401 on resolve without admin auth', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const res = await fetch(`${url}/api/ops/errors/${hash}/resolve`, { method: 'POST' });
+      expect(res.status).toBe(401);
+      expect(resolveGroupSpy).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it('resolves a group for the ops owner', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const res = await fetch(`${url}/api/ops/errors/${hash}/resolve`, { method: 'POST' });
+      expect(res.status).toBe(204);
+      expect(resolveGroupSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await close();
+    }
+  });
+
+  it('rejects an invalid hash with 400', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const res = await fetch(`${url}/api/ops/errors/not-a-hash/resolve`, { method: 'POST' });
+      expect(res.status).toBe(400);
+      expect(resolveGroupSpy).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it('reopens a group via DELETE for the ops owner', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const res = await fetch(`${url}/api/ops/errors/${hash}/resolve`, { method: 'DELETE' });
+      expect(res.status).toBe(204);
+      expect(reopenGroupSpy).toHaveBeenCalledTimes(1);
     } finally {
       await close();
     }

--- a/src/routes/OpsErrorsRouter.ts
+++ b/src/routes/OpsErrorsRouter.ts
@@ -2,6 +2,8 @@ import express from 'express';
 import RequireOpsAccess from './middleware/RequireOpsAccess';
 import { OpsErrorsController } from '../controllers/OpsErrorsController';
 import { ListErrorGroupsUseCase } from '../usecases/ops/ListErrorGroupsUseCase';
+import { ResolveErrorGroupUseCase } from '../usecases/ops/ResolveErrorGroupUseCase';
+import { ReopenErrorGroupUseCase } from '../usecases/ops/ReopenErrorGroupUseCase';
 import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 import { getDatabase } from '../data_layer';
 
@@ -9,8 +11,10 @@ const OpsErrorsRouter = () => {
   const router = express.Router();
   const database = getDatabase();
   const repository = new ErrorEventRepository(database);
-  const useCase = new ListErrorGroupsUseCase(repository);
-  const controller = new OpsErrorsController(useCase);
+  const listUseCase = new ListErrorGroupsUseCase(repository);
+  const resolveUseCase = new ResolveErrorGroupUseCase(repository);
+  const reopenUseCase = new ReopenErrorGroupUseCase(repository);
+  const controller = new OpsErrorsController(listUseCase, resolveUseCase, reopenUseCase);
 
   /**
    * @swagger
@@ -34,14 +38,61 @@ const OpsErrorsRouter = () => {
    *       - in: query
    *         name: sort
    *         schema: { type: string, enum: [last_seen, occurrences] }
+   *       - in: query
+   *         name: status
+   *         schema: { type: string, enum: [unresolved, resolved, all], default: unresolved }
    *     responses:
    *       200:
    *         description: Grouped error events
-   *       401:
+   *       404:
    *         description: Not the ops owner
    */
   router.get('/api/ops/errors', RequireOpsAccess, (req, res) =>
     controller.list(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/errors/{messageHash}/resolve:
+   *   post:
+   *     summary: Mark an error group resolved
+   *     description: |
+   *       Records a resolution timestamp for the group. A later occurrence
+   *       (last_seen after resolved_at) reopens the group automatically.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: path
+   *         name: messageHash
+   *         required: true
+   *         schema: { type: string, pattern: '^[a-f0-9]{64}$' }
+   *     responses:
+   *       204:
+   *         description: Resolved
+   *       400:
+   *         description: Invalid message hash
+   *       404:
+   *         description: Not the ops owner
+   *   delete:
+   *     summary: Reopen a resolved error group
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: path
+   *         name: messageHash
+   *         required: true
+   *         schema: { type: string, pattern: '^[a-f0-9]{64}$' }
+   *     responses:
+   *       204:
+   *         description: Reopened
+   *       400:
+   *         description: Invalid message hash
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post('/api/ops/errors/:messageHash/resolve', RequireOpsAccess, (req, res) =>
+    controller.resolve(req, res)
+  );
+  router.delete('/api/ops/errors/:messageHash/resolve', RequireOpsAccess, (req, res) =>
+    controller.reopen(req, res)
   );
 
   return router;

--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -22,6 +22,8 @@ function makeRepository(existsResult = false): IErrorEventRepository & { inserts
     async countGroups() {
       return 0;
     },
+    async resolveGroup() {},
+    async reopenGroup() {},
   };
 }
 
@@ -119,6 +121,8 @@ describe('makeErrorCaptureMiddleware', () => {
       async existsWithinWindow() { throw new Error('DB down'); },
       async listGroups() { return []; },
       async countGroups() { return 0; },
+      async resolveGroup() {},
+      async reopenGroup() {},
     };
     const middleware = makeErrorCaptureMiddleware(brokenRepo);
     const next = makeNext();
@@ -136,6 +140,8 @@ describe('makeErrorCaptureMiddleware', () => {
       async existsWithinWindow() { throw new Error('DB down'); },
       async listGroups() { return []; },
       async countGroups() { return 0; },
+      async resolveGroup() {},
+      async reopenGroup() {},
     };
     const captured: FallbackErrorPayload[] = [];
     const writeFallback = (payload: FallbackErrorPayload) => { captured.push(payload); };

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -838,6 +838,8 @@ describe('SyncNotionPageToRacUseCase', () => {
       existsWithinWindow: jest.fn().mockResolvedValue(false),
       listGroups: jest.fn().mockResolvedValue([]),
       countGroups: jest.fn().mockResolvedValue(0),
+      resolveGroup: jest.fn().mockResolvedValue(undefined),
+      reopenGroup: jest.fn().mockResolvedValue(undefined),
     });
 
     it('emits ankify.zero_cards event when page produces no cards', async () => {

--- a/src/usecases/ops/ListErrorGroupsUseCase.test.ts
+++ b/src/usecases/ops/ListErrorGroupsUseCase.test.ts
@@ -18,6 +18,8 @@ function makeGroup(overrides: Partial<ErrorGroupRow> = {}): ErrorGroupRow {
     first_seen: '2026-05-01T00:00:00.000Z',
     last_seen: '2026-05-24T10:00:00.000Z',
     occurrences: 3,
+    resolved: false,
+    resolved_at: null,
     ...overrides,
   };
 }
@@ -44,6 +46,10 @@ class FakeRepository implements IErrorEventRepository {
   async countGroups(): Promise<number> {
     return this.total;
   }
+
+  async resolveGroup(): Promise<void> {}
+
+  async reopenGroup(): Promise<void> {}
 }
 
 describe('ListErrorGroupsUseCase', () => {
@@ -58,7 +64,7 @@ describe('ListErrorGroupsUseCase', () => {
     expect(result.totalGroups).toBe(2);
   });
 
-  it('passes options through to the repository', async () => {
+  it('passes options through to the repository, including resolution status', async () => {
     const listGroupsSpy = jest.fn(async (): Promise<ErrorGroupRow[]> => []);
     const countGroupsSpy = jest.fn(async (): Promise<number> => 0);
     const repo: IErrorEventRepository = {
@@ -66,18 +72,42 @@ describe('ListErrorGroupsUseCase', () => {
       existsWithinWindow: jest.fn(async () => false),
       listGroups: listGroupsSpy,
       countGroups: countGroupsSpy,
+      resolveGroup: jest.fn(),
+      reopenGroup: jest.fn(),
     };
 
     const useCase = new ListErrorGroupsUseCase(repo);
-    await useCase.execute({ limit: 10, offset: 20, source: 'server', sort: 'occurrences' });
+    await useCase.execute({
+      limit: 10,
+      offset: 20,
+      source: 'server',
+      sort: 'occurrences',
+      status: 'resolved',
+    });
 
     expect(listGroupsSpy).toHaveBeenCalledWith({
       limit: 10,
       offset: 20,
       source: 'server',
       sort: 'occurrences',
+      status: 'resolved',
     });
-    expect(countGroupsSpy).toHaveBeenCalledWith('server');
+    expect(countGroupsSpy).toHaveBeenCalledWith('server', 'resolved');
+  });
+
+  it('passes resolved state through to the returned groups', async () => {
+    const groups = [
+      makeGroup({ resolved: true, resolved_at: '2026-05-25T12:00:00.000Z' }),
+    ];
+    const repo = new FakeRepository(groups, 1);
+    const useCase = new ListErrorGroupsUseCase(repo);
+
+    const result = await useCase.execute({ limit: 50, offset: 0, status: 'resolved' });
+
+    expect(result.groups[0]).toMatchObject({
+      resolved: true,
+      resolved_at: '2026-05-25T12:00:00.000Z',
+    });
   });
 
   it('returns empty groups and zero total when the repository is empty', async () => {

--- a/src/usecases/ops/ListErrorGroupsUseCase.ts
+++ b/src/usecases/ops/ListErrorGroupsUseCase.ts
@@ -15,9 +15,9 @@ export class ListErrorGroupsUseCase {
   async execute(options: ListErrorGroupsOptions): Promise<ListErrorGroupsResult> {
     const [rawGroups, totalGroups] = await Promise.all([
       this.repository.listGroups(options),
-      this.repository.countGroups(options.source),
+      this.repository.countGroups(options.source, options.status),
     ]);
-    const groups = rawGroups.map(({ message_hash, message, stack, url, release, source, user_id, user_agent, first_seen, last_seen, occurrences }) => ({
+    const groups = rawGroups.map(({ message_hash, message, stack, url, release, source, user_id, user_agent, first_seen, last_seen, occurrences, resolved, resolved_at }) => ({
       message_hash,
       message,
       stack,
@@ -29,6 +29,8 @@ export class ListErrorGroupsUseCase {
       first_seen,
       last_seen,
       occurrences,
+      resolved,
+      resolved_at,
     }));
     return { groups, totalGroups };
   }

--- a/src/usecases/ops/ReopenErrorGroupUseCase.test.ts
+++ b/src/usecases/ops/ReopenErrorGroupUseCase.test.ts
@@ -1,0 +1,24 @@
+import { ReopenErrorGroupUseCase } from './ReopenErrorGroupUseCase';
+import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
+
+function makeRepo(): IErrorEventRepository {
+  return {
+    insert: jest.fn(),
+    existsWithinWindow: jest.fn(async () => false),
+    listGroups: jest.fn(async () => []),
+    countGroups: jest.fn(async () => 0),
+    resolveGroup: jest.fn(async () => {}),
+    reopenGroup: jest.fn(async () => {}),
+  };
+}
+
+describe('ReopenErrorGroupUseCase', () => {
+  it('delegates to the repository with the hash', async () => {
+    const repo = makeRepo();
+    const useCase = new ReopenErrorGroupUseCase(repo);
+
+    await useCase.execute('c'.repeat(64));
+
+    expect(repo.reopenGroup).toHaveBeenCalledWith('c'.repeat(64));
+  });
+});

--- a/src/usecases/ops/ReopenErrorGroupUseCase.ts
+++ b/src/usecases/ops/ReopenErrorGroupUseCase.ts
@@ -1,0 +1,9 @@
+import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
+
+export class ReopenErrorGroupUseCase {
+  constructor(private readonly repository: IErrorEventRepository) {}
+
+  async execute(messageHash: string): Promise<void> {
+    await this.repository.reopenGroup(messageHash);
+  }
+}

--- a/src/usecases/ops/ResolveErrorGroupUseCase.test.ts
+++ b/src/usecases/ops/ResolveErrorGroupUseCase.test.ts
@@ -1,0 +1,33 @@
+import { ResolveErrorGroupUseCase } from './ResolveErrorGroupUseCase';
+import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
+
+function makeRepo(): IErrorEventRepository {
+  return {
+    insert: jest.fn(),
+    existsWithinWindow: jest.fn(async () => false),
+    listGroups: jest.fn(async () => []),
+    countGroups: jest.fn(async () => 0),
+    resolveGroup: jest.fn(async () => {}),
+    reopenGroup: jest.fn(async () => {}),
+  };
+}
+
+describe('ResolveErrorGroupUseCase', () => {
+  it('delegates to the repository with the hash and resolver id', async () => {
+    const repo = makeRepo();
+    const useCase = new ResolveErrorGroupUseCase(repo);
+
+    await useCase.execute('a'.repeat(64), 42);
+
+    expect(repo.resolveGroup).toHaveBeenCalledWith('a'.repeat(64), 42);
+  });
+
+  it('passes a null resolver through unchanged', async () => {
+    const repo = makeRepo();
+    const useCase = new ResolveErrorGroupUseCase(repo);
+
+    await useCase.execute('b'.repeat(64), null);
+
+    expect(repo.resolveGroup).toHaveBeenCalledWith('b'.repeat(64), null);
+  });
+});

--- a/src/usecases/ops/ResolveErrorGroupUseCase.ts
+++ b/src/usecases/ops/ResolveErrorGroupUseCase.ts
@@ -1,0 +1,9 @@
+import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
+
+export class ResolveErrorGroupUseCase {
+  constructor(private readonly repository: IErrorEventRepository) {}
+
+  async execute(messageHash: string, resolvedBy: number | null): Promise<void> {
+    await this.repository.resolveGroup(messageHash, resolvedBy);
+  }
+}

--- a/web/src/pages/OpsPage/ErrorsTab.tsx
+++ b/web/src/pages/OpsPage/ErrorsTab.tsx
@@ -3,16 +3,30 @@ import { useSearchParams } from 'react-router-dom';
 
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
-import { ErrorGroup, ErrorSort, ErrorSource } from './errorsTypes';
+import { ErrorGroup, ErrorSort, ErrorSource, ErrorStatus } from './errorsTypes';
 import { useErrorGroups } from './useErrorGroups';
 import { buildCopyArtifact } from './buildCopyArtifact';
 import { parseUserAgent } from './parseUserAgent';
+import { resolveErrorGroup, reopenErrorGroup } from './resolveErrorGroup';
 
 const SOURCE_OPTIONS: { value: ErrorSource; label: string }[] = [
   { value: 'all', label: 'All' },
   { value: 'web', label: 'Web' },
   { value: 'server', label: 'Server' },
 ];
+
+const STATUS_OPTIONS: { value: ErrorStatus; label: string }[] = [
+  { value: 'unresolved', label: 'Unresolved' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'all', label: 'All' },
+];
+
+const filterLabelStyle: React.CSSProperties = {
+  fontSize: 'var(--text-xs)',
+  color: 'var(--color-text-tertiary)',
+  width: '3.5rem',
+  flexShrink: 0,
+};
 
 function relative(iso: string): string {
   const diffMs = Date.now() - new Date(iso).getTime();
@@ -83,9 +97,13 @@ function CopyButton({ group }: Readonly<CopyButtonProps>) {
 interface DetailPanelProps {
   group: ErrorGroup;
   onClose: () => void;
+  onResolutionChange: () => void;
 }
 
-function DetailPanel({ group, onClose }: Readonly<DetailPanelProps>) {
+function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPanelProps>) {
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -93,6 +111,16 @@ function DetailPanel({ group, onClose }: Readonly<DetailPanelProps>) {
     globalThis.addEventListener('keydown', handleKey);
     return () => globalThis.removeEventListener('keydown', handleKey);
   }, [onClose]);
+
+  const toggleResolution = () => {
+    setBusy(true);
+    setActionError(null);
+    const action = group.resolved ? reopenErrorGroup : resolveErrorGroup;
+    action(group.message_hash)
+      .then(() => onResolutionChange())
+      .catch((e: unknown) => setActionError(e instanceof Error ? e.message : 'Action failed'))
+      .finally(() => setBusy(false));
+  };
 
   const release = group.release == null ? '(unknown)' : group.release.slice(0, 8);
   const userId = group.user_id == null ? 'anonymous' : String(group.user_id);
@@ -142,6 +170,13 @@ function DetailPanel({ group, onClose }: Readonly<DetailPanelProps>) {
         <dt style={{ color: 'var(--color-text-tertiary)' }}>Last seen</dt>
         <dd style={{ margin: 0 }}>{new Date(group.last_seen).toUTCString()}</dd>
 
+        {group.resolved && group.resolved_at != null && (
+          <>
+            <dt style={{ color: 'var(--color-text-tertiary)' }}>Resolved</dt>
+            <dd style={{ margin: 0 }}>{new Date(group.resolved_at).toUTCString()}</dd>
+          </>
+        )}
+
         <dt style={{ color: 'var(--color-text-tertiary)' }}>URL</dt>
         <dd style={{ margin: 0, wordBreak: 'break-all' }}>{group.url ?? '(none)'}</dd>
 
@@ -182,8 +217,19 @@ function DetailPanel({ group, onClose }: Readonly<DetailPanelProps>) {
         </div>
       )}
 
-      <div style={{ marginTop: 'auto', paddingTop: '0.5rem' }}>
+      <div style={{ marginTop: 'auto', paddingTop: '0.5rem', display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
         <CopyButton group={group} />
+        <button
+          type="button"
+          className={sharedStyles.btnSmall}
+          disabled={busy}
+          onClick={toggleResolution}
+        >
+          {group.resolved ? 'Reopen' : 'Resolve'}
+        </button>
+        {actionError != null && (
+          <span style={{ fontSize: 'var(--text-xs)', color: '#dc2626' }}>{actionError}</span>
+        )}
       </div>
     </aside>
   );
@@ -197,9 +243,12 @@ export default function ErrorsTab() {
     rawSource === 'web' || rawSource === 'server' ? rawSource : 'all';
   const rawSort = searchParams.get('sort');
   const sort: ErrorSort = rawSort === 'occurrences' ? 'occurrences' : 'last_seen';
+  const rawStatus = searchParams.get('status');
+  const status: ErrorStatus =
+    rawStatus === 'resolved' || rawStatus === 'all' ? rawStatus : 'unresolved';
   const selectedHash = searchParams.get('id');
 
-  const { data, isLoading, error, refetch } = useErrorGroups({ source, sort });
+  const { data, isLoading, error, refetch } = useErrorGroups({ source, sort, status });
 
   const selectedGroup = data?.groups.find((g) => g.message_hash === selectedHash) ?? null;
 
@@ -215,30 +264,54 @@ export default function ErrorsTab() {
 
   const selectGroup = (hash: string | null) => updateParam('id', hash);
   const setSource = (s: ErrorSource) => updateParam('source', s === 'all' ? null : s);
+  const setStatus = (s: ErrorStatus) => updateParam('status', s === 'unresolved' ? null : s);
   const toggleSort = () => updateParam('sort', sort === 'last_seen' ? 'occurrences' : 'last_seen');
+
+  const countLabel = status === 'all' ? 'total' : status;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
       <div
         className={styles.tabHeader}
-        style={{ justifyContent: 'space-between' }}
+        style={{ justifyContent: 'space-between', alignItems: 'flex-start' }}
       >
-        <div style={{ display: 'flex', gap: '0.375rem', alignItems: 'center' }}>
-          {SOURCE_OPTIONS.map((opt) => (
-            <button
-              key={opt.value}
-              type="button"
-              className={
-                source === opt.value
-                  ? `${sharedStyles.btnSmallPill} ${sharedStyles.btnSmallPillActive ?? ''}`
-                  : sharedStyles.btnSmallPill
-              }
-              style={source === opt.value ? { background: 'var(--color-primary)', color: '#fff' } : {}}
-              onClick={() => setSource(opt.value)}
-            >
-              {opt.label}
-            </button>
-          ))}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
+          <div style={{ display: 'flex', gap: '0.375rem', alignItems: 'center' }}>
+            <span style={filterLabelStyle}>Status</span>
+            {STATUS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className={
+                  status === opt.value
+                    ? `${sharedStyles.btnSmallPill} ${sharedStyles.btnSmallPillActive ?? ''}`
+                    : sharedStyles.btnSmallPill
+                }
+                style={status === opt.value ? { background: 'var(--color-primary)', color: '#fff' } : {}}
+                onClick={() => setStatus(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <div style={{ display: 'flex', gap: '0.375rem', alignItems: 'center' }}>
+            <span style={filterLabelStyle}>Source</span>
+            {SOURCE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className={
+                  source === opt.value
+                    ? `${sharedStyles.btnSmallPill} ${sharedStyles.btnSmallPillActive ?? ''}`
+                    : sharedStyles.btnSmallPill
+                }
+                style={source === opt.value ? { background: 'var(--color-primary)', color: '#fff' } : {}}
+                onClick={() => setSource(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
         </div>
 
         <div style={{ display: 'flex', gap: '0.5rem' }}>
@@ -273,7 +346,9 @@ export default function ErrorsTab() {
 
           {!isLoading && data?.groups.length === 0 && (
             <p className={styles.emptyHint} style={{ padding: '1.5rem' }}>
-              No errors recorded. Errors appear here as soon as the client reports one.
+              {status === 'unresolved'
+                ? 'No unresolved errors. A resolved error reappears here if it happens again.'
+                : 'No errors recorded. Errors appear here as soon as the client reports one.'}
             </p>
           )}
 
@@ -304,6 +379,7 @@ export default function ErrorsTab() {
                       style={{
                         cursor: 'pointer',
                         background: isSelected ? 'var(--color-bg-secondary)' : undefined,
+                        opacity: group.resolved ? 0.55 : undefined,
                       }}
                       onClick={() => selectGroup(isSelected ? null : group.message_hash)}
                     >
@@ -320,6 +396,22 @@ export default function ErrorsTab() {
                         }}
                         title={group.message}
                       >
+                        {group.resolved && (
+                          <span
+                            style={{
+                              fontFamily: 'inherit',
+                              fontSize: '0.65rem',
+                              fontWeight: 'var(--font-semibold)',
+                              color: 'var(--color-text-tertiary)',
+                              border: '1px solid var(--color-border)',
+                              borderRadius: 'var(--radius-sm)',
+                              padding: '0 0.3rem',
+                              marginRight: '0.4rem',
+                            }}
+                          >
+                            Resolved
+                          </span>
+                        )}
                         {truncate(group.message, 80)}
                       </td>
                       <td
@@ -356,6 +448,7 @@ export default function ErrorsTab() {
           <DetailPanel
             group={selectedGroup}
             onClose={() => selectGroup(null)}
+            onResolutionChange={refetch}
           />
         )}
       </div>
@@ -369,7 +462,7 @@ export default function ErrorsTab() {
             fontVariantNumeric: 'tabular-nums',
           }}
         >
-          {data.totalGroups} total group{data.totalGroups === 1 ? '' : 's'}
+          {data.totalGroups} {countLabel} group{data.totalGroups === 1 ? '' : 's'}
         </p>
       )}
     </div>

--- a/web/src/pages/OpsPage/buildCopyArtifact.test.ts
+++ b/web/src/pages/OpsPage/buildCopyArtifact.test.ts
@@ -15,6 +15,8 @@ function makeGroup(overrides: Partial<ErrorGroup> = {}): ErrorGroup {
     first_seen: '2026-05-01T08:00:00.000Z',
     last_seen: '2026-05-24T14:30:45.000Z',
     occurrences: 7,
+    resolved: false,
+    resolved_at: null,
     ...overrides,
   };
 }

--- a/web/src/pages/OpsPage/errorsTypes.ts
+++ b/web/src/pages/OpsPage/errorsTypes.ts
@@ -10,6 +10,8 @@ export interface ErrorGroup {
   first_seen: string;
   last_seen: string;
   occurrences: number;
+  resolved: boolean;
+  resolved_at: string | null;
 }
 
 export interface ErrorGroupsResponse {
@@ -19,3 +21,4 @@ export interface ErrorGroupsResponse {
 
 export type ErrorSort = 'last_seen' | 'occurrences';
 export type ErrorSource = 'all' | 'web' | 'server';
+export type ErrorStatus = 'unresolved' | 'resolved' | 'all';

--- a/web/src/pages/OpsPage/resolveErrorGroup.test.ts
+++ b/web/src/pages/OpsPage/resolveErrorGroup.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { resolveErrorGroup, reopenErrorGroup } from './resolveErrorGroup';
+
+const HASH = 'a'.repeat(64);
+
+describe('resolveErrorGroup / reopenErrorGroup', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('resolveErrorGroup POSTs to the resolve endpoint', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+    });
+
+    await resolveErrorGroup(HASH);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      `/api/ops/errors/${HASH}/resolve`,
+      { method: 'POST' }
+    );
+  });
+
+  test('reopenErrorGroup DELETEs the resolve endpoint', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 204,
+      statusText: 'No Content',
+    });
+
+    await reopenErrorGroup(HASH);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      `/api/ops/errors/${HASH}/resolve`,
+      { method: 'DELETE' }
+    );
+  });
+
+  test('throws when the response is not ok', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    await expect(resolveErrorGroup(HASH)).rejects.toThrow('500 Internal Server Error');
+  });
+});

--- a/web/src/pages/OpsPage/resolveErrorGroup.ts
+++ b/web/src/pages/OpsPage/resolveErrorGroup.ts
@@ -1,0 +1,12 @@
+async function send(messageHash: string, method: 'POST' | 'DELETE'): Promise<void> {
+  const res = await fetch(`/api/ops/errors/${messageHash}/resolve`, { method });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+}
+
+export function resolveErrorGroup(messageHash: string): Promise<void> {
+  return send(messageHash, 'POST');
+}
+
+export function reopenErrorGroup(messageHash: string): Promise<void> {
+  return send(messageHash, 'DELETE');
+}

--- a/web/src/pages/OpsPage/useErrorGroups.test.ts
+++ b/web/src/pages/OpsPage/useErrorGroups.test.ts
@@ -1,0 +1,41 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { useErrorGroups } from './useErrorGroups';
+
+describe('useErrorGroups', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ groups: [], totalGroups: 0 }),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('sends the resolution status as a query param', async () => {
+    renderHook(() => useErrorGroups({ source: 'all', sort: 'last_seen', status: 'resolved' }));
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('status=resolved');
+  });
+
+  test('omits the source param when source is all', async () => {
+    renderHook(() => useErrorGroups({ source: 'all', sort: 'last_seen', status: 'unresolved' }));
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+    const calledUrl = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain('source=');
+    expect(calledUrl).toContain('status=unresolved');
+  });
+});

--- a/web/src/pages/OpsPage/useErrorGroups.ts
+++ b/web/src/pages/OpsPage/useErrorGroups.ts
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { ErrorGroupsResponse, ErrorSort, ErrorSource } from './errorsTypes';
+import { ErrorGroupsResponse, ErrorSort, ErrorSource, ErrorStatus } from './errorsTypes';
 
 interface UseErrorGroupsOptions {
   limit?: number;
   offset?: number;
   source: ErrorSource;
   sort: ErrorSort;
+  status: ErrorStatus;
 }
 
 interface UseErrorGroupsResult {
@@ -16,7 +17,7 @@ interface UseErrorGroupsResult {
 }
 
 export function useErrorGroups(options: UseErrorGroupsOptions): UseErrorGroupsResult {
-  const { limit = 50, offset = 0, source, sort } = options;
+  const { limit = 50, offset = 0, source, sort, status } = options;
   const [data, setData] = useState<ErrorGroupsResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -31,6 +32,7 @@ export function useErrorGroups(options: UseErrorGroupsOptions): UseErrorGroupsRe
       limit: String(limit),
       offset: String(offset),
       sort,
+      status,
     });
     if (source !== 'all') {
       params.set('source', source);
@@ -55,7 +57,7 @@ export function useErrorGroups(options: UseErrorGroupsOptions): UseErrorGroupsRe
       });
 
     return () => { cancelled = true; };
-  }, [limit, offset, source, sort, tick]);
+  }, [limit, offset, source, sort, status, tick]);
 
   return {
     data,


### PR DESCRIPTION
## What

Adds a **resolve / reopen** workflow to the internal `/ops/errors` dashboard, so handled noise can be cleared out of the working list while real regressions resurface on their own.

- **Resolve** an error group from the detail panel. It records a timestamp per error signature (`message_hash`).
- **Auto-reopen (Sentry-style):** a group is resolved only while `resolved_at >= last_seen`. A new occurrence after you resolved it flips it back to unresolved automatically â a regression can't hide silently.
- **Default view is Unresolved only**, with a `Status` filter (Unresolved / Resolved / All) next to the existing Source filter. Resolved rows show a `Resolved` badge and a `Reopen` button.

## How

- New `error_resolutions` table (`message_hash` PK, `resolved_at`, `resolved_by` â users `ON DELETE SET NULL`). Resolve = upsert; reopen = delete the row.
- `ErrorEventRepository`: `listGroups`/`countGroups` left-join the resolutions table, compute `resolved = MAX(resolved_at) >= MAX(created_at)`, and honor a `status` filter. New `resolveGroup` / `reopenGroup`.
- `POST` / `DELETE /api/ops/errors/:messageHash/resolve`, gated by `RequireOpsAccess`; `messageHash` validated as 64-char hex.
- Frontend: `Status` pills, resolve/reopen button, `resolved` badge + row dimming (consistent with the existing raw-`fetch` ops surface).

## Verification

- Resolution semantics verified against a real Postgres DB: resolve hides the group from Unresolved, the Resolved view shows it with `resolved_at`, a recurrence auto-reopens it, and reopen removes the resolution.
- Server jest (28 passing across repo/use-cases/controller/router), web vitest (5), server + web tsc, Biome lint â all green.

## Notes

- **No changelog entry** â `/ops` is internal admin tooling (ops-owner only), not user-visible.
- **`pnpm kanel` not run here:** kanel isn't installed in this environment and the local dev DB carries an unrelated uncommitted migration that would pollute a full regen. The feature hand-defines its repository types (matching the existing `ErrorEventRepository`) and does not import a generated type. Run `pnpm kanel` on a clean DB to add `public/ErrorResolutions.ts`.
- **`sonar-scanner` not run locally** â not installed / no token in this environment. Expect a possible Sonar pass on CI.
- Trio skipped: internal-only tooling (trio-optional per CLAUDE.md). The two product decisions (auto-reopen behavior, unresolved-only default) were confirmed directly with the dashboard's sole user.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified by the repo owner on localhost — /ops/errors resolve/reopen, Status filter, and badge confirmed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424189&installation_id=132681956&pr_number=2839&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2839&signature=875808b60906f5b10020b24ba3576397bb90143894bff8ad6ec107d51197d3cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
