### PR TITLE
feat: delete free accounts 14 days after ignored inactivity warning

### DIFF
--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -5,6 +5,7 @@ import { GetOpsMetricsUseCase } from '../usecases/ops/GetOpsMetricsUseCase';
 import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUseCase';
 import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetricsUseCase';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
+import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -248,5 +249,64 @@ describe('OpsController.getMindmapImageStats', () => {
       expect.objectContaining({ message: expect.any(String) })
     );
     errSpy.mockRestore();
+  });
+});
+
+describe('OpsController.deleteInactiveUsers', () => {
+  const buildController = (useCase: DeleteInactiveUsersUseCase) =>
+    new OpsController(
+      {} as unknown as GetOpsMetricsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      useCase
+    );
+
+  it('defaults to a dry run when dryRun is not specified', async () => {
+    const useCase = {
+      execute: jest.fn().mockResolvedValue({ count: 5, dryRun: true }),
+    } as unknown as DeleteInactiveUsersUseCase;
+    const controller = buildController(useCase);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.deleteInactiveUsers(req, res);
+
+    expect((useCase.execute as jest.Mock)).toHaveBeenCalledWith(true);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ count: 5, dryRun: true });
+  });
+
+  it('deletes for real only when dryRun=false is passed', async () => {
+    const useCase = {
+      execute: jest.fn().mockResolvedValue({ count: 3, dryRun: false }),
+    } as unknown as DeleteInactiveUsersUseCase;
+    const controller = buildController(useCase);
+    const req = { query: { dryRun: 'false' } } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.deleteInactiveUsers(req, res);
+
+    expect((useCase.execute as jest.Mock)).toHaveBeenCalledWith(false);
+  });
+
+  it('returns 500 when the use case is not configured', async () => {
+    const controller = new OpsController({} as unknown as GetOpsMetricsUseCase);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.deleteInactiveUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
   });
 });

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -8,6 +8,7 @@ import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetric
 import { GetMindmapStorageMetricsUseCase } from '../usecases/ops/GetMindmapStorageMetricsUseCase';
 import { PopulateShowcaseUseCase } from '../usecases/ops/PopulateShowcaseUseCase';
 import { SendInactivityWarningsUseCase } from '../usecases/ops/SendInactivityWarningsUseCase';
+import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersUseCase';
 import { SendAbandonedCheckoutRecoveryUseCase } from '../usecases/ops/SendAbandonedCheckoutRecoveryUseCase';
 import { IShowcaseRepository } from '../data_layer/ShowcaseRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
@@ -24,7 +25,8 @@ class OpsController {
     private readonly sendAbandonedCheckoutRecoveryUseCase?: SendAbandonedCheckoutRecoveryUseCase,
     private readonly getReturnRateMetricsUseCase?: GetReturnRateMetricsUseCase,
     private readonly getMindmapImageStatsUseCase?: GetMindmapImageStatsUseCase,
-    private readonly getMindmapStorageMetricsUseCase?: GetMindmapStorageMetricsUseCase
+    private readonly getMindmapStorageMetricsUseCase?: GetMindmapStorageMetricsUseCase,
+    private readonly deleteInactiveUsersUseCase?: DeleteInactiveUsersUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -166,6 +168,21 @@ class OpsController {
     } catch (error) {
       console.error('[ops] sendInactivityWarnings failed', error);
       res.status(500).json({ message: 'Failed to run inactivity warnings' });
+    }
+  }
+
+  async deleteInactiveUsers(req: express.Request, res: express.Response) {
+    if (this.deleteInactiveUsersUseCase == null) {
+      res.status(500).json({ message: 'Inactive user deletion not configured' });
+      return;
+    }
+    try {
+      const dryRun = req.query.dryRun !== 'false';
+      const result = await this.deleteInactiveUsersUseCase.execute(dryRun);
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] deleteInactiveUsers failed', error);
+      res.status(500).json({ message: 'Failed to run inactive user deletion' });
     }
   }
 

--- a/src/data_layer/InactivityEmailRepository.ts
+++ b/src/data_layer/InactivityEmailRepository.ts
@@ -1,7 +1,10 @@
 import type { Knex } from 'knex';
 
+export const INACTIVITY_DELETION_GRACE_DAYS = 14;
+
 export interface IInactivityEmailRepository {
   getUsersToNotify(limit?: number): Promise<Array<{ id: number; name: string; email: string }>>;
+  getUsersToDelete(limit?: number): Promise<Array<{ id: number; email: string }>>;
   recordSend(userId: number, token: string): Promise<void>;
   findByToken(token: string): Promise<{ id: number; userId: number } | null>;
 }
@@ -59,6 +62,35 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
     return rows.map((row) => ({ id: row.id, name: row.name, email: row.email }));
   }
 
+  async getUsersToDelete(
+    limit = 100
+  ): Promise<Array<{ id: number; email: string }>> {
+    const rows = await this.database<UserRow>(`${this.table} as ie`)
+      .join('users as u', 'u.id', 'ie.user_id')
+      .select('u.id', 'u.email')
+      .whereRaw("ie.sent_at < now() - (? || ' days')::interval", [
+        INACTIVITY_DELETION_GRACE_DAYS,
+      ])
+      .where(function () {
+        this.whereNull('u.last_login_at').orWhereRaw(
+          'u.last_login_at < ie.sent_at'
+        );
+      })
+      .whereRaw('u.patreon IS NOT TRUE')
+      .whereNotExists(
+        this.database('subscriptions')
+          .where('subscriptions.active', true)
+          .whereRaw(
+            '(subscriptions.email = u.email OR subscriptions.linked_email = u.email)'
+          )
+          .limit(1)
+      )
+      .orderBy('ie.sent_at', 'asc')
+      .limit(limit);
+
+    return rows.map((row) => ({ id: row.id, email: row.email }));
+  }
+
   async recordSend(userId: number, token: string): Promise<void> {
     await this.database(this.table).insert({ user_id: userId, token });
   }
@@ -80,6 +112,7 @@ export class InMemoryInactivityEmailRepository
 {
   private usersToReturn: Array<{ id: number; name: string; email: string }> =
     [];
+  private usersToDelete: Array<{ id: number; email: string }> = [];
   private readonly sentUserIds = new Set<number>();
   private emails: Array<{ id: number; userId: number; token: string }> = [];
   private nextId = 1;
@@ -88,10 +121,20 @@ export class InMemoryInactivityEmailRepository
     this.usersToReturn = users;
   }
 
+  seedUsersToDelete(users: Array<{ id: number; email: string }>): void {
+    this.usersToDelete = users;
+  }
+
   async getUsersToNotify(limit = 500): Promise<
     Array<{ id: number; name: string; email: string }>
   > {
     return this.usersToReturn.filter((u) => !this.sentUserIds.has(u.id)).slice(0, limit);
+  }
+
+  async getUsersToDelete(limit = 100): Promise<
+    Array<{ id: number; email: string }>
+  > {
+    return this.usersToDelete.slice(0, limit);
   }
 
   async recordSend(userId: number, token: string): Promise<void> {
@@ -114,6 +157,7 @@ export class InMemoryInactivityEmailRepository
 
   clear(): void {
     this.usersToReturn = [];
+    this.usersToDelete = [];
     this.sentUserIds.clear();
     this.emails = [];
     this.nextId = 1;

--- a/src/lib/inactivity/jobs/scheduleInactiveUserDeletions.test.ts
+++ b/src/lib/inactivity/jobs/scheduleInactiveUserDeletions.test.ts
@@ -1,0 +1,46 @@
+import { scheduleInactiveUserDeletions, INACTIVE_USER_DELETION_DAILY_LIMIT } from './scheduleInactiveUserDeletions';
+import type { DeleteInactiveUsersUseCase } from '../../../usecases/ops/DeleteInactiveUsersUseCase';
+
+function makeUseCase(result = { count: 3, dryRun: false }): jest.Mocked<Pick<DeleteInactiveUsersUseCase, 'execute'>> {
+  return { execute: jest.fn().mockResolvedValue(result) };
+}
+
+describe('scheduleInactiveUserDeletions', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('calls execute with dryRun=false and the default limit after one interval', async () => {
+    const useCase = makeUseCase();
+    const handle = scheduleInactiveUserDeletions(useCase as unknown as DeleteInactiveUsersUseCase, { intervalMs: 1000 });
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(useCase.execute).toHaveBeenCalledWith(false, INACTIVE_USER_DELETION_DAILY_LIMIT);
+    clearInterval(handle);
+  });
+
+  it('respects a custom limit passed via options', async () => {
+    const useCase = makeUseCase();
+    const handle = scheduleInactiveUserDeletions(useCase as unknown as DeleteInactiveUsersUseCase, { intervalMs: 1000, limit: 25 });
+
+    jest.advanceTimersByTime(1000);
+    await Promise.resolve();
+
+    expect(useCase.execute).toHaveBeenCalledWith(false, 25);
+    clearInterval(handle);
+  });
+
+  it('does not fire before the interval elapses', () => {
+    const useCase = makeUseCase();
+    const handle = scheduleInactiveUserDeletions(useCase as unknown as DeleteInactiveUsersUseCase, { intervalMs: 1000 });
+
+    jest.advanceTimersByTime(999);
+
+    expect(useCase.execute).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+});

--- a/src/lib/inactivity/jobs/scheduleInactiveUserDeletions.ts
+++ b/src/lib/inactivity/jobs/scheduleInactiveUserDeletions.ts
@@ -1,0 +1,32 @@
+import type { DeleteInactiveUsersUseCase } from '../../../usecases/ops/DeleteInactiveUsersUseCase';
+import type { EventsSink } from '../../../services/events/EventsSink';
+
+export const INACTIVE_USER_DELETION_DAILY_LIMIT = 100;
+export const INACTIVE_USER_DELETION_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export const scheduleInactiveUserDeletions = (
+  useCase: DeleteInactiveUsersUseCase,
+  options: { intervalMs?: number; limit?: number; eventsSink?: EventsSink } = {}
+): NodeJS.Timeout => {
+  const intervalMs = options.intervalMs ?? INACTIVE_USER_DELETION_INTERVAL_MS;
+  const limit = options.limit ?? INACTIVE_USER_DELETION_DAILY_LIMIT;
+
+  const tick = async () => {
+    try {
+      const result = await useCase.execute(false, limit);
+      console.info(`[inactivity-deletions] deleted ${result.count} inactive account(s)`);
+      if (options.eventsSink != null) {
+        options.eventsSink.record({
+          name: 'inactive_users_deleted',
+          props: { count: result.count },
+        });
+      }
+    } catch (error) {
+      console.error('[inactivity-deletions] daily job failed:', error);
+    }
+  };
+
+  const handle = setInterval(tick, intervalMs);
+  handle.unref();
+  return handle;
+};

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -33,6 +33,7 @@ import { getDatabase } from '../data_layer';
 import RequireOpsAccess from './middleware/RequireOpsAccess';
 import InactivityEmailRepository from '../data_layer/InactivityEmailRepository';
 import { SendInactivityWarningsUseCase } from '../usecases/ops/SendInactivityWarningsUseCase';
+import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersUseCase';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { UserVisibleErrorsRepository } from '../data_layer/UserVisibleErrorsRepository';
 import { MindmapRepository } from '../data_layer/MindmapRepository';
@@ -94,7 +95,11 @@ const OpsRouter = () => {
     new SendAbandonedCheckoutRecoveryUseCase(emailService),
     new GetReturnRateMetricsUseCase(new ReturnRateMetricsService(database)),
     new GetMindmapImageStatsUseCase(new MindmapRepository(database)),
-    new GetMindmapStorageMetricsUseCase(mindmapStorageService)
+    new GetMindmapStorageMetricsUseCase(mindmapStorageService),
+    new DeleteInactiveUsersUseCase(
+      new InactivityEmailRepository(database),
+      new UsersRepository(database)
+    )
   );
 
   /**
@@ -215,6 +220,35 @@ const OpsRouter = () => {
    */
   router.post('/api/ops/send-inactivity-warnings', RequireOpsAccess, (req, res) =>
     controller.sendInactivityWarnings(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/delete-inactive-users:
+   *   post:
+   *     summary: Delete free accounts that ignored the inactivity warning
+   *     description: |
+   *       Deletes accounts that were warned 14+ days ago and still have not logged in
+   *       since the warning. Exempt: patreon=true (lifetime) and active Stripe subscribers.
+   *       Permanently removes the user and all their data (usage is snapshotted first).
+   *       Pass ?dryRun=false to delete; omit or pass ?dryRun=true to count candidates only.
+   *       Also runs as a daily background job, capped at 100 deletions per run.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: query
+   *         name: dryRun
+   *         schema:
+   *           type: string
+   *           enum: ['true', 'false']
+   *         description: Defaults to true. Pass false to actually delete accounts.
+   *     responses:
+   *       200:
+   *         description: Result with candidate/deleted count and dryRun flag
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post('/api/ops/delete-inactive-users', RequireOpsAccess, (req, res) =>
+    controller.deleteInactiveUsers(req, res)
   );
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,10 +75,13 @@ import UploadRepository from './data_layer/UploadRespository';
 import { updateStripeSubscriptions } from './lib/storage/jobs/helpers/updateStripeSubscriptions';
 import { scheduleReEngagementEmails } from './lib/reengagement/jobs/scheduleReEngagementEmails';
 import { scheduleInactivityWarnings } from './lib/inactivity/jobs/scheduleInactivityWarnings';
+import { scheduleInactiveUserDeletions } from './lib/inactivity/jobs/scheduleInactiveUserDeletions';
 import { scheduleTrialEndedEmails } from './lib/trial/jobs/scheduleTrialEndedEmails';
 import { scheduleParserCanary } from './lib/parser/canary/scheduleParserCanary';
 import { getDefaultEmailService } from './services/EmailService/EmailService';
 import { SendInactivityWarningsUseCase } from './usecases/ops/SendInactivityWarningsUseCase';
+import { DeleteInactiveUsersUseCase } from './usecases/ops/DeleteInactiveUsersUseCase';
+import UsersRepository from './data_layer/UsersRepository';
 import { SendTrialEndedEmailsUseCase } from './usecases/ops/SendTrialEndedEmailsUseCase';
 import { initConversionPool } from './lib/conversionPool';
 import { gracefulShutdown } from './lib/gracefulShutdown';
@@ -261,6 +264,9 @@ const serve = async () => {
   const uploadRepo = new UploadRepository(database);
   const sendInactivityWarningsUseCase = new SendInactivityWarningsUseCase(inactivityEmailRepo, emailService, uploadRepo);
   scheduleInactivityWarnings(sendInactivityWarningsUseCase, { eventsSink });
+
+  const deleteInactiveUsersUseCase = new DeleteInactiveUsersUseCase(inactivityEmailRepo, new UsersRepository(database));
+  scheduleInactiveUserDeletions(deleteInactiveUsersUseCase, { eventsSink });
 
   const trialEndedEmailRepo = new TrialEndedEmailRepository(database);
   const sendTrialEndedEmailsUseCase = new SendTrialEndedEmailsUseCase(trialEndedEmailRepo, emailService);

--- a/src/usecases/ops/DeleteInactiveUsersUseCase.test.ts
+++ b/src/usecases/ops/DeleteInactiveUsersUseCase.test.ts
@@ -1,0 +1,114 @@
+import { DeleteInactiveUsersUseCase, IInactiveUserDeleter } from './DeleteInactiveUsersUseCase';
+import { InMemoryInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
+
+function makeDeleter(overrides: Partial<IInactiveUserDeleter> = {}): jest.Mocked<IInactiveUserDeleter> {
+  return {
+    deleteUser: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as jest.Mocked<IInactiveUserDeleter>;
+}
+
+describe('DeleteInactiveUsersUseCase', () => {
+  let repo: InMemoryInactivityEmailRepository;
+
+  beforeEach(() => {
+    repo = new InMemoryInactivityEmailRepository();
+  });
+
+  describe('dry run', () => {
+    it('returns candidate count without deleting anyone', async () => {
+      repo.seedUsersToDelete([
+        { id: 1, email: 'alice@example.com' },
+        { id: 2, email: 'bob@example.com' },
+      ]);
+      const deleter = makeDeleter();
+      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+
+      const result = await useCase.execute(true);
+
+      expect(result).toEqual({ count: 2, dryRun: true });
+      expect(deleter.deleteUser).not.toHaveBeenCalled();
+    });
+
+    it('respects limit when counting candidates', async () => {
+      repo.seedUsersToDelete([
+        { id: 1, email: 'alice@example.com' },
+        { id: 2, email: 'bob@example.com' },
+        { id: 3, email: 'carol@example.com' },
+      ]);
+      const useCase = new DeleteInactiveUsersUseCase(repo, makeDeleter());
+
+      const result = await useCase.execute(true, 1);
+
+      expect(result).toEqual({ count: 1, dryRun: true });
+    });
+
+    it('returns zero when no candidates exist', async () => {
+      const useCase = new DeleteInactiveUsersUseCase(repo, makeDeleter());
+
+      const result = await useCase.execute(true);
+
+      expect(result).toEqual({ count: 0, dryRun: true });
+    });
+  });
+
+  describe('live delete', () => {
+    it('deletes each candidate by id and counts successes', async () => {
+      repo.seedUsersToDelete([
+        { id: 1, email: 'alice@example.com' },
+        { id: 2, email: 'bob@example.com' },
+      ]);
+      const deleter = makeDeleter();
+      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 2, dryRun: false });
+      expect(deleter.deleteUser).toHaveBeenCalledWith('1');
+      expect(deleter.deleteUser).toHaveBeenCalledWith('2');
+      expect(deleter.deleteUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('continues deleting remaining users when one deletion fails', async () => {
+      repo.seedUsersToDelete([
+        { id: 1, email: 'alice@example.com' },
+        { id: 2, email: 'bob@example.com' },
+      ]);
+      const deleter = makeDeleter({
+        deleteUser: jest
+          .fn()
+          .mockRejectedValueOnce(new Error('FK violation'))
+          .mockResolvedValueOnce(undefined),
+      });
+      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+
+      const result = await useCase.execute(false);
+
+      expect(result.count).toBe(1);
+      expect(deleter.deleteUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('deletes only up to the limit', async () => {
+      repo.seedUsersToDelete([
+        { id: 1, email: 'alice@example.com' },
+        { id: 2, email: 'bob@example.com' },
+        { id: 3, email: 'carol@example.com' },
+      ]);
+      const deleter = makeDeleter();
+      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+
+      const result = await useCase.execute(false, 2);
+
+      expect(result).toEqual({ count: 2, dryRun: false });
+      expect(deleter.deleteUser).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns zero when no candidates exist', async () => {
+      const useCase = new DeleteInactiveUsersUseCase(repo, makeDeleter());
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 0, dryRun: false });
+    });
+  });
+});

--- a/src/usecases/ops/DeleteInactiveUsersUseCase.ts
+++ b/src/usecases/ops/DeleteInactiveUsersUseCase.ts
@@ -1,0 +1,37 @@
+import type { IInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
+
+export interface IInactiveUserDeleter {
+  deleteUser(owner: string): Promise<unknown>;
+}
+
+export interface DeleteInactiveUsersResult {
+  count: number;
+  dryRun: boolean;
+}
+
+export class DeleteInactiveUsersUseCase {
+  constructor(
+    private readonly repo: IInactivityEmailRepository,
+    private readonly userDeleter: IInactiveUserDeleter
+  ) {}
+
+  async execute(dryRun: boolean, limit = 100): Promise<DeleteInactiveUsersResult> {
+    const users = await this.repo.getUsersToDelete(limit);
+
+    if (dryRun) {
+      return { count: users.length, dryRun: true };
+    }
+
+    let deleted = 0;
+    for (const user of users) {
+      try {
+        await this.userDeleter.deleteUser(String(user.id));
+        deleted++;
+      } catch (error) {
+        console.error(`[inactivity-delete] failed to delete user ${user.id}:`, error);
+      }
+    }
+
+    return { count: deleted, dryRun: false };
+  }
+}


### PR DESCRIPTION
## What

The inactivity warning email promises *"we'll remove your uploaded decks and files in 14 days if we don't see you"* — but nothing in the codebase enforced it. Users were warned once and then nothing happened. This implements the deletion.

A **daily background job** (capped at **100 deletions/run**) deletes free accounts that:
- were warned **14+ days ago** (`inactivity_emails.sent_at`), **and**
- still **haven't logged in since the warning** (`last_login_at` is NULL or older than `sent_at`), **and**
- are **not** lifetime (`patreon IS NOT TRUE`), **and**
- have **no active** Stripe subscription (by `email` or `linked_email`).

Each deletion runs the existing `deleteUser`: snapshots monthly usage into `deleted_user_usage`, deletes the user's rows across the owner tables, deletes the user (the `inactivity_emails` row cascades).

Also adds **`POST /api/ops/delete-inactive-users`** (ops-owner gated, **defaults to dry-run**; `?dryRun=false` to actually delete) so you can preview the candidate set from `/ops` before/independent of the daily job.

## Blast radius

Measured on prod: **0 deletable today** (earliest warning is exactly at the 14-day edge). It ramps as the ~8 997 existing warnings age past 14 days (~640/day were sent), which is why deletion is capped at 100/run and gated behind a dry-run-able ops endpoint. 92 already-returned users are correctly excluded.

## How / safety

- **No migration** — anchors on the existing `inactivity_emails.sent_at`; FK is already `ON DELETE CASCADE`.
- Eligibility query verified against **real Postgres** across edge cases: within-grace (excluded), returned-after-warning (excluded), patreon (excluded), logged-in-before-warning-but-still-inactive (included), never-logged-in (included).
- The subscription-exclusion clause is identical to the proven `getUsersToNotify` warning query.
- Tests: use case (dry-run/live/limit/continue-on-error), scheduler (interval/limit), controller endpoint (dry-run default + delegation + unconfigured). Server jest + tsc green.

## Decisions (confirmed with owner)
- **Full account deletion** (not just decks/files).
- **100/day cap**, real deletions, daily job, logged + `inactive_users_deleted` event.

## Notes
- **No changelog entry** — background data-lifecycle job, no in-app surface (active users see nothing; deleted users were inactive and pre-warned).
- **`sonar-scanner` not run locally** — not installed / no token in this environment.
- Destructive + irreversible: worth a **`/security-review`** before merge, and consider running the ops endpoint dry-run (`POST /api/ops/delete-inactive-users`) on prod first to eyeball the count as warnings start aging out.

Browser check: not applicable — server-only change, no rendered output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782425649&installation_id=132681956&pr_number=2841&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2841&signature=c9c943b08d3867054237ff3a71e18cd90371acf84221f9fc95222fec0d8276aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->