### PR TITLE
chore: sync all versions to 2.0.0 for the v2 launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "notion2anki"
   ],
   "author": "Alexander Alemayhu",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -5,7 +5,7 @@ const options: swaggerJsdoc.Options = {
     openapi: '3.0.0',
     info: {
       title: '2anki Server API',
-      version: '1.2.1',
+      version: '2.0.0',
       description:
         'API documentation for 2anki server - Convert content to Anki flashcards',
       contact: {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2anki-web",
-  "version": "0.1.1",
+  "version": "2.0.0",
   "type": "module",
   "private": true,
   "packageManager": "pnpm@10.18.2",


### PR DESCRIPTION
Aligns the workspace on a single version ahead of the public v2 announcement on Product Hunt.

- `package.json` (server): `2.0.0-beta.1` → `2.0.0`
- `web/package.json`: `0.1.1` → `2.0.0`
- `src/config/swagger.ts` (OpenAPI doc): `1.2.1` → `2.0.0`

Drops the `-beta` tag so the shipped version reads as a real release. Not a dependency bump — only `version` fields changed, `pnpm-lock.yaml` is unaffected. The standalone `scripts/digitalocean` migration utility keeps its own `1.0.0` (separate tool, not the product).

After merge: tag `v2.0.0` on main and publish the GitHub release.

No changelog entry — internal version bump, no user-visible behavior change.

Browser check: not applicable — version metadata only, no rendered output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782426519&installation_id=132681956&pr_number=2842&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2842&signature=cb0ad7d8e73f3feaf8ac1f2cd180b6720a40620ad7448fad9cc16862da988fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->