### PR TITLE
docs: save drafted emails as .txt files in Downloads

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Every PR is checked against both — does it make the experience simpler/faster/
 - The Ankify feature is gated to users with `users.patreon = true` (lifetime). Use `hasAnkifyAccess` from `src/lib/ankify/access.ts`; don't reintroduce hard-coded emails.
 - Notion webhook receiver in `routes/AnkifyWebhookRouter.ts` is intentionally inactive; polling at 5 min carries the story today.
 - The prod box checks out this repo at `/home/alemayhu/src/github.com/2anki/2anki.net` (legacy name).
+- **Writing an email means creating a `.txt` file in the user's Downloads** — `/mnt/c/Users/alexa/Downloads/` on this WSL box (the Windows Downloads, where uploaded `.eml` files land) — not just printing the draft in chat. Use `reply-<name>.txt` for support replies. Offline Downloads files may carry reporter names/emails; commits, PRs, and issues may not (see `.claude/rules/support-confidentiality.md`).
 
 ## The trio
 
@@ -101,7 +102,7 @@ Three sub-agents in `.claude/agents/`:
 
 Default: `pm` produces a spec → `designer` validates UX (only if user-facing) → `engineer` implements and ships. For tiny fixes, skip to engineer. Read-only audits go through `dead-code-auditor` (haiku); isolated feature work through `test-writer` (sonnet, worktree).
 
-Trio conventions: be opinionated (one recommendation, not five options); specs fit on one page; say what *not* to build; reply to support email *as a draft for Alexander to send*.
+Trio conventions: be opinionated (one recommendation, not five options); specs fit on one page; say what *not* to build; reply to support email *as a draft for Alexander to send*, saved as a `.txt` file in Downloads (see Gotchas).
 
 ## Trio review policy
 


### PR DESCRIPTION
Codifies a working convention: when asked to write an email, write it to a `.txt` file in the user's Downloads folder (the Windows Downloads on this WSL box, where uploaded `.eml` files land) rather than only printing the draft in chat.

- Adds a Gotcha with the concrete path and the `reply-<name>.txt` naming for support replies.
- Cross-references `support-confidentiality.md`: offline Downloads files may carry reporter names/emails; commits/PRs/issues may not.
- Tags the trio support-reply line to point at the Gotcha.

No changelog entry — internal config/docs only, no user-visible behavior change.

Browser check: not applicable — docs-only change, no `web/src/` files and no rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782475204&installation_id=132681956&pr_number=2844&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2844&signature=e86fb38dc761ed20dd5bc6e8949240c09f543ec4be17739dee795682434cf45a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->