### PR TITLE
feat: add /ops command to sync Stripe subscriptions on demand

### DIFF
--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -12,6 +12,7 @@ import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersU
 import { SendAbandonedCheckoutRecoveryUseCase } from '../usecases/ops/SendAbandonedCheckoutRecoveryUseCase';
 import { IShowcaseRepository } from '../data_layer/ShowcaseRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
+import { SyncStripeSubscriptionsUseCase } from '../usecases/ops/SyncStripeSubscriptionsUseCase';
 
 class OpsController {
   constructor(
@@ -26,7 +27,8 @@ class OpsController {
     private readonly getReturnRateMetricsUseCase?: GetReturnRateMetricsUseCase,
     private readonly getMindmapImageStatsUseCase?: GetMindmapImageStatsUseCase,
     private readonly getMindmapStorageMetricsUseCase?: GetMindmapStorageMetricsUseCase,
-    private readonly deleteInactiveUsersUseCase?: DeleteInactiveUsersUseCase
+    private readonly deleteInactiveUsersUseCase?: DeleteInactiveUsersUseCase,
+    private readonly syncStripeSubscriptionsUseCase?: SyncStripeSubscriptionsUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -183,6 +185,29 @@ class OpsController {
     } catch (error) {
       console.error('[ops] deleteInactiveUsers failed', error);
       res.status(500).json({ message: 'Failed to run inactive user deletion' });
+    }
+  }
+
+  async syncStripeSubscriptions(_req: express.Request, res: express.Response) {
+    if (this.syncStripeSubscriptionsUseCase == null) {
+      res
+        .status(500)
+        .json({ message: 'Stripe subscription sync not configured' });
+      return;
+    }
+    try {
+      const result = this.syncStripeSubscriptionsUseCase.execute();
+      if (result.alreadyRunning) {
+        res.status(409).json({ message: 'A Stripe subscription sync is already running.' });
+        return;
+      }
+      res.status(202).json({
+        message:
+          'Stripe subscription sync started. It runs in the background — check the server logs for the result.',
+      });
+    } catch (error) {
+      console.error('[ops] syncStripeSubscriptions failed', error);
+      res.status(500).json({ message: 'Failed to start Stripe subscription sync' });
     }
   }
 

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -90,6 +90,10 @@ jest.mock('../lib/storage/StorageHandler', () => {
   };
 });
 
+jest.mock('../lib/storage/jobs/helpers/updateStripeSubscriptions', () => ({
+  updateStripeSubscriptions: jest.fn().mockResolvedValue(undefined),
+}));
+
 import OpsRouter from './OpsRouter';
 
 const opsAccessState = (globalThis as unknown as {
@@ -145,6 +149,36 @@ describe('OpsRouter /api/ops/business/metrics', () => {
           as_of: expect.any(String),
           cache_age_seconds: expect.any(Number),
         })
+      );
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsRouter /api/ops/sync-stripe-subscriptions', () => {
+  it('returns 404 for non-owner callers', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const response = await fetch(`${url}/api/ops/sync-stripe-subscriptions`, {
+        method: 'POST',
+      });
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns 202 and starts the sync for the ops owner', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/sync-stripe-subscriptions`, {
+        method: 'POST',
+      });
+      expect(response.status).toBe(202);
+      const body = await response.json();
+      expect(body).toEqual(
+        expect.objectContaining({ message: expect.any(String) })
       );
     } finally {
       await close();

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -40,6 +40,8 @@ import { UserVisibleErrorsRepository } from '../data_layer/UserVisibleErrorsRepo
 import { MindmapRepository } from '../data_layer/MindmapRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 import { JobsMetricsRepository } from '../data_layer/JobsMetricsRepository';
+import { SyncStripeSubscriptionsUseCase } from '../usecases/ops/SyncStripeSubscriptionsUseCase';
+import { updateStripeSubscriptions } from '../lib/storage/jobs/helpers/updateStripeSubscriptions';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -100,7 +102,8 @@ const OpsRouter = () => {
     new DeleteInactiveUsersUseCase(
       new InactivityEmailRepository(database),
       new UsersRepository(database)
-    )
+    ),
+    new SyncStripeSubscriptionsUseCase(() => updateStripeSubscriptions())
   );
 
   /**
@@ -364,6 +367,31 @@ const OpsRouter = () => {
    */
   router.get('/api/ops/mindmap/storage', RequireOpsAccess, (req, res) =>
     controller.getMindmapStorageMetrics(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/sync-stripe-subscriptions:
+   *   post:
+   *     summary: Sync subscriptions from Stripe into the database
+   *     description: |
+   *       Pulls every active Stripe subscription and upserts it into the subscriptions
+   *       table, then reconciles each active DB row against Stripe (deactivating any
+   *       that Stripe no longer reports active). Use this to provision a paying user
+   *       whose subscription did not land via webhook. Runs in the background and
+   *       returns immediately; watch the server logs for the result. Locked to the ops
+   *       owner — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     responses:
+   *       202:
+   *         description: Sync started in the background
+   *       409:
+   *         description: A sync is already running
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post('/api/ops/sync-stripe-subscriptions', RequireOpsAccess, (req, res) =>
+    controller.syncStripeSubscriptions(req, res)
   );
 
   return router;

--- a/src/usecases/ops/SyncStripeSubscriptionsUseCase.test.ts
+++ b/src/usecases/ops/SyncStripeSubscriptionsUseCase.test.ts
@@ -1,0 +1,69 @@
+import { SyncStripeSubscriptionsUseCase } from './SyncStripeSubscriptionsUseCase';
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('SyncStripeSubscriptionsUseCase', () => {
+  it('starts the sync and reports started on the first call', () => {
+    const runSync = jest.fn().mockResolvedValue(undefined);
+    const useCase = new SyncStripeSubscriptionsUseCase(runSync);
+
+    const result = useCase.execute();
+
+    expect(result).toEqual({ started: true, alreadyRunning: false });
+    expect(runSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a second call while a sync is still running', () => {
+    let resolveSync: () => void = () => undefined;
+    const runSync = jest.fn(
+      () => new Promise<void>((resolve) => {
+        resolveSync = resolve;
+      })
+    );
+    const useCase = new SyncStripeSubscriptionsUseCase(runSync);
+
+    const first = useCase.execute();
+    const second = useCase.execute();
+
+    expect(first).toEqual({ started: true, alreadyRunning: false });
+    expect(second).toEqual({ started: false, alreadyRunning: true });
+    expect(runSync).toHaveBeenCalledTimes(1);
+
+    resolveSync();
+  });
+
+  it('allows a new sync once the previous run finishes', async () => {
+    let resolveSync: () => void = () => undefined;
+    const runSync = jest.fn(
+      () => new Promise<void>((resolve) => {
+        resolveSync = resolve;
+      })
+    );
+    const useCase = new SyncStripeSubscriptionsUseCase(runSync);
+
+    useCase.execute();
+    resolveSync();
+    await flushMicrotasks();
+
+    const result = useCase.execute();
+
+    expect(result).toEqual({ started: true, alreadyRunning: false });
+    expect(runSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the lock even when the sync rejects', async () => {
+    const runSync = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('stripe down'))
+      .mockResolvedValueOnce(undefined);
+    const useCase = new SyncStripeSubscriptionsUseCase(runSync);
+
+    useCase.execute();
+    await flushMicrotasks();
+
+    const result = useCase.execute();
+
+    expect(result).toEqual({ started: true, alreadyRunning: false });
+    expect(runSync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/usecases/ops/SyncStripeSubscriptionsUseCase.ts
+++ b/src/usecases/ops/SyncStripeSubscriptionsUseCase.ts
@@ -1,0 +1,41 @@
+export interface SyncStripeSubscriptionsResult {
+  started: boolean;
+  alreadyRunning: boolean;
+}
+
+export type StripeSubscriptionSync = () => Promise<unknown>;
+
+/**
+ * Triggers the Stripe → DB subscription sync on demand from /ops.
+ *
+ * The sync paginates every active Stripe subscription and then reconciles each
+ * active DB row against Stripe, so it can run for minutes. Holding the HTTP
+ * request open that long risks a proxy timeout, so we fire it in the background
+ * and return immediately. A process-wide lock prevents overlapping runs from
+ * doubling the Stripe API load.
+ */
+export class SyncStripeSubscriptionsUseCase {
+  private running = false;
+
+  constructor(private readonly runSync: StripeSubscriptionSync) {}
+
+  execute(): SyncStripeSubscriptionsResult {
+    if (this.running) {
+      return { started: false, alreadyRunning: true };
+    }
+
+    this.running = true;
+    void this.runSync()
+      .then(() => {
+        console.info('[ops] stripe subscription sync finished');
+      })
+      .catch((error) => {
+        console.error('[ops] stripe subscription sync failed', error);
+      })
+      .finally(() => {
+        this.running = false;
+      });
+
+    return { started: true, alreadyRunning: false };
+  }
+}

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
+import { syncStripeSubscriptions } from './syncStripeSubscriptions';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
@@ -14,7 +15,9 @@ async function callInactivityWarnings(
   );
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
-    throw new Error(data.message ?? `${response.status} ${response.statusText}`);
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
   }
   return response.json();
 }
@@ -22,6 +25,8 @@ async function callInactivityWarnings(
 export default function CommandsTab() {
   const [status, setStatus] = useState<Status>('idle');
   const [message, setMessage] = useState('');
+  const [syncStatus, setSyncStatus] = useState<Status>('idle');
+  const [syncMessage, setSyncMessage] = useState('');
 
   const run = async (dryRun: boolean) => {
     setStatus('loading');
@@ -36,6 +41,19 @@ export default function CommandsTab() {
     } catch (error) {
       setStatus('error');
       setMessage(error instanceof Error ? error.message : 'Unknown error');
+    }
+  };
+
+  const runStripeSync = async () => {
+    setSyncStatus('loading');
+    setSyncMessage('');
+    try {
+      const result = await syncStripeSubscriptions();
+      setSyncStatus('success');
+      setSyncMessage(result.message);
+    } catch (error) {
+      setSyncStatus('error');
+      setSyncMessage(error instanceof Error ? error.message : 'Unknown error');
     }
   };
 
@@ -81,6 +99,37 @@ export default function CommandsTab() {
       {status === 'error' && message && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {message}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Stripe subscriptions</h2>
+        <p className={styles.panelSubtitle}>
+          Pulls active Stripe subscriptions into the database and reconciles
+          each active row against Stripe. Use this to provision a paying user
+          whose subscription did not land via webhook. Runs in the background —
+          check the server logs for the result.
+        </p>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={runStripeSync}
+            disabled={syncStatus === 'loading'}
+          >
+            {syncStatus === 'loading' ? 'Starting…' : 'Sync now'}
+          </button>
+        </div>
+      </section>
+
+      {syncStatus === 'success' && syncMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {syncMessage}
+        </div>
+      )}
+      {syncStatus === 'error' && syncMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {syncMessage}
         </div>
       )}
     </>

--- a/web/src/pages/OpsPage/syncStripeSubscriptions.test.ts
+++ b/web/src/pages/OpsPage/syncStripeSubscriptions.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { syncStripeSubscriptions } from './syncStripeSubscriptions';
+
+describe('syncStripeSubscriptions', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs to the sync endpoint and returns the message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 202,
+      statusText: 'Accepted',
+      json: () => Promise.resolve({ message: 'Sync started.' }),
+    });
+
+    const result = await syncStripeSubscriptions();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/sync-stripe-subscriptions',
+      { method: 'POST', credentials: 'include' }
+    );
+    expect(result).toEqual({ message: 'Sync started.' });
+  });
+
+  test('throws the server message when a sync is already running', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: 'Conflict',
+      json: () =>
+        Promise.resolve({
+          message: 'A Stripe subscription sync is already running.',
+        }),
+    });
+
+    await expect(syncStripeSubscriptions()).rejects.toThrow(
+      'A Stripe subscription sync is already running.'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(syncStripeSubscriptions()).rejects.toThrow(
+      '500 Internal Server Error'
+    );
+  });
+});

--- a/web/src/pages/OpsPage/syncStripeSubscriptions.ts
+++ b/web/src/pages/OpsPage/syncStripeSubscriptions.ts
@@ -1,0 +1,13 @@
+export async function syncStripeSubscriptions(): Promise<{ message: string }> {
+  const response = await fetch('/api/ops/sync-stripe-subscriptions', {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Why

A paying user's **active** Stripe subscription never landed in the `subscriptions` table — no webhook event flipped them active — so the app treated them as a free user. The only ways to provision were the Stripe webhook and the `STRIPE_SYNC_ON_STARTUP` batch; neither can be triggered on demand. When this happens again, support has no one-click recovery.

## What

A **Sync now** button under `/ops/commands` → `Stripe subscriptions` that runs the existing `updateStripeSubscriptions` batch (forward sync from Stripe + reconcile each active DB row).

- The batch paginates every active Stripe subscription and reconciles each active DB row one Stripe call at a time, so it can run for **minutes**. The endpoint fires it in the **background behind a process-wide lock** and returns `202` immediately, `409` if a sync is already running. The run summary lands in the server logs (`/deploy-status`).
- Locked to the ops owner via `RequireOpsAccess` (`404` for everyone else).

## Files
- `usecases/ops/SyncStripeSubscriptionsUseCase.ts` (+test) — lock + background fire
- `controllers/OpsController.ts` — `syncStripeSubscriptions` (202 / 409 / 500)
- `routes/OpsRouter.ts` (+test) — `POST /api/ops/sync-stripe-subscriptions`
- `web/.../OpsPage/syncStripeSubscriptions.ts` (+test) + `CommandsTab.tsx` — button + status banner

## Tests
Server: `SyncStripeSubscriptionsUseCase` (start / reject-while-running / lock-release / lock-release-on-reject) + `OpsRouter` (404 non-owner, 202 owner). Web: helper (202 message / 409 server message / status-text fallback). All green locally; server tsc + web tsc + biome clean.

## Not in this PR (deliberately kept off the payments surface — filed as follow-ups)
- The webhook doesn't handle `customer.subscription.created`, and `checkout.session.completed` doesn't provision subscriptions — so new subscribers depend on a well-timed `customer.subscription.updated` or the startup batch. Handling `.created` would make provisioning real-time.
- The batch path (`createNewSubscription`) leaves `stripe_product_id` and `users.stripe_customer_id` blank (the webhook's `updateStoreSubscription` sets both). Aligning them keeps Ankify access and the customer link correct for batch-provisioned rows.

## Sonar
Not run locally (no scanner/token on this machine). Change is small and low-complexity; expect the CI Automatic Analysis to cover it.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Notes: the button lives at `/ops/commands`, gated behind the ops-owner login — needs verification on your local dev server before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782475406&installation_id=132681956&pr_number=2845&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2845&signature=fe44445db8e36fd2fd29586bf9de29dde1661701be70ec2945886fcf20b104cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->