### PR TITLE
fix: set stripe_product_id and backfill customer on batch sync

### DIFF
--- a/src/lib/integrations/stripe.ts
+++ b/src/lib/integrations/stripe.ts
@@ -20,7 +20,7 @@ export const getCustomerId = (
   return customer?.id;
 };
 
-const extractProductId = (
+export const extractProductId = (
   subscription: StripeTypes.Subscription
 ): string | null => {
   const product = subscription.items?.data?.[0]?.price?.product;

--- a/src/lib/storage/jobs/helpers/updateStripeSubscriptions.test.ts
+++ b/src/lib/storage/jobs/helpers/updateStripeSubscriptions.test.ts
@@ -1,0 +1,158 @@
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
+const mockStripeInstance = {
+  subscriptions: {
+    list: jest.fn(),
+  },
+  customers: {
+    retrieve: jest.fn(),
+  },
+};
+
+const mockDbInstance = {
+  table: jest.fn(),
+};
+
+jest.mock('../../../integrations/stripe', () => ({
+  getStripe: () => mockStripeInstance,
+  extractProductId: jest.requireActual('../../../integrations/stripe').extractProductId,
+}));
+
+jest.mock('../../../../data_layer', () => ({
+  getDatabase: () => mockDbInstance,
+}));
+
+jest.mock('./reconcileActiveSubscriptions', () => ({
+  reconcileActiveSubscriptions: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { updateStripeSubscriptions } from './updateStripeSubscriptions';
+
+function buildSubscription(
+  productId: string | null | undefined = 'prod_autoSync789',
+  overrides: Partial<StripeTypes.Subscription> = {}
+): StripeTypes.Subscription {
+  return {
+    id: 'sub_test123',
+    status: 'active',
+    cancel_at_period_end: false,
+    cancel_at: null,
+    customer: 'cus_test456',
+    items: {
+      data: [
+        {
+          price: { product: productId } as StripeTypes.Price,
+        } as StripeTypes.SubscriptionItem,
+      ],
+      object: 'list',
+      has_more: false,
+      url: '',
+    },
+    ...overrides,
+  } as unknown as StripeTypes.Subscription;
+}
+
+type Spies = {
+  insertSpy: jest.Mock;
+  updateSubscriptionSpy: jest.Mock;
+  updateUsersSpy: jest.Mock;
+};
+
+function setupDbMock(existingRow: Record<string, unknown> | null): Spies {
+  const insertSpy = jest.fn().mockResolvedValue([1]);
+  const updateSubscriptionSpy = jest.fn().mockResolvedValue(1);
+  const updateUsersSpy = jest.fn().mockResolvedValue(1);
+
+  mockDbInstance.table.mockImplementation((tableName: string) => {
+    if (tableName === 'subscriptions') {
+      return {
+        where: jest.fn().mockReturnValue({
+          first: jest.fn().mockResolvedValue(existingRow),
+          update: updateSubscriptionSpy,
+        }),
+        insert: insertSpy,
+      };
+    }
+    if (tableName === 'users') {
+      return {
+        where: jest.fn().mockReturnValue({
+          update: updateUsersSpy,
+        }),
+      };
+    }
+    return { where: jest.fn().mockReturnThis(), update: jest.fn(), insert: jest.fn() };
+  });
+
+  return { insertSpy, updateSubscriptionSpy, updateUsersSpy };
+}
+
+function setupStripeMock(subscriptions: StripeTypes.Subscription[]) {
+  mockStripeInstance.subscriptions.list.mockResolvedValue({
+    data: subscriptions,
+    has_more: false,
+  });
+  mockStripeInstance.customers.retrieve.mockResolvedValue({
+    id: 'cus_test456',
+    email: 'user@example.com',
+    object: 'customer',
+  });
+}
+
+describe('updateStripeSubscriptions — batch provisioning fields', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('inserts stripe_product_id when creating a new subscription row', async () => {
+    const { insertSpy } = setupDbMock(null);
+    setupStripeMock([buildSubscription('prod_autoSync789')]);
+    await updateStripeSubscriptions();
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ stripe_product_id: 'prod_autoSync789' })
+    );
+  });
+
+  it('updates stripe_product_id when updating an existing subscription row', async () => {
+    const { updateSubscriptionSpy } = setupDbMock({
+      email: 'user@example.com',
+      active: true,
+      payload: '{}',
+    });
+    setupStripeMock([buildSubscription('prod_autoSync789')]);
+    await updateStripeSubscriptions();
+    expect(updateSubscriptionSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ stripe_product_id: 'prod_autoSync789' })
+    );
+  });
+
+  it('backfills users.stripe_customer_id for a new subscription', async () => {
+    const { updateUsersSpy } = setupDbMock(null);
+    setupStripeMock([buildSubscription()]);
+    await updateStripeSubscriptions();
+    expect(updateUsersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ stripe_customer_id: 'cus_test456' })
+    );
+  });
+
+  it('backfills users.stripe_customer_id when updating an existing subscription', async () => {
+    const { updateUsersSpy } = setupDbMock({
+      email: 'user@example.com',
+      active: true,
+      payload: '{}',
+    });
+    setupStripeMock([buildSubscription()]);
+    await updateStripeSubscriptions();
+    expect(updateUsersSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ stripe_customer_id: 'cus_test456' })
+    );
+  });
+
+  it('inserts stripe_product_id as null when product is absent from subscription', async () => {
+    const { insertSpy } = setupDbMock(null);
+    setupStripeMock([buildSubscription(null)]);
+    await updateStripeSubscriptions();
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ stripe_product_id: null })
+    );
+  });
+});

--- a/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
+++ b/src/lib/storage/jobs/helpers/updateStripeSubscriptions.ts
@@ -1,4 +1,4 @@
-import { getStripe } from '../../../integrations/stripe';
+import { getStripe, extractProductId } from '../../../integrations/stripe';
 import { getDatabase } from '../../../../data_layer';
 import { Knex } from 'knex';
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
@@ -84,6 +84,7 @@ async function updateExistingSubscription(
 ): Promise<void> {
   const statusChanged = existingActive !== shouldRemainActive;
   const payload = JSON.stringify(subscription);
+  const stripeProductId = extractProductId(subscription);
 
   if (statusChanged) {
     console.info(
@@ -92,12 +93,12 @@ async function updateExistingSubscription(
     await db
       .table('subscriptions')
       .where({ email })
-      .update({ active: shouldRemainActive, payload });
+      .update({ active: shouldRemainActive, payload, stripe_product_id: stripeProductId });
   } else {
     console.info(
       `Subscription status for ${email} remains ${shouldRemainActive ? 'active' : 'inactive'}`
     );
-    await db.table('subscriptions').where({ email }).update({ payload });
+    await db.table('subscriptions').where({ email }).update({ payload, stripe_product_id: stripeProductId });
   }
 }
 
@@ -118,6 +119,7 @@ async function createNewSubscription(
     email,
     active: shouldRemainActive,
     payload: JSON.stringify(subscription),
+    stripe_product_id: extractProductId(subscription),
   });
 }
 
@@ -158,6 +160,11 @@ async function updateSubscriptionRecord(
         shouldRemainActive
       );
     }
+
+    await db
+      .table('users')
+      .where({ email })
+      .update({ stripe_customer_id: customer.id });
   } catch (error) {
     console.error(
       'Error updating subscription record',


### PR DESCRIPTION
## What

The batch-sync path (`updateStripeSubscriptions`) was omitting `stripe_product_id` from every insert and update, and never writing `stripe_customer_id` back to the `users` table. A paying subscriber provisioned via the /ops sync button ended up with a NULL `stripe_product_id`, which caused `hasAnkifyAccess` to deny Auto-Sync access even though the subscription row was active and the payment was good.

## Why

`hasAnkifyAccess` gates the Auto-Sync feature on `s.active && s.stripe_product_id === AUTO_SYNC_PRODUCT_ID`. NULL `stripe_product_id` fails that check. The webhook path (`updateStoreSubscription`) already sets both fields correctly — the batch path did not.

## How

**Choice: option (b) — targeted change.**

Rationale: the batch path has valuable status-change logging ("status changed to active/inactive" vs "remains active/inactive") that would be lost in a delegation to `updateStoreSubscription`. The select-then-insert/update pattern is also semantically different from the webhook's `onConflict().merge()` approach. Delegating would conflate those semantics. Exporting `extractProductId` keeps the product-ID extraction logic in one place while preserving the batch path's behavior.

Specific changes:
- `src/lib/integrations/stripe.ts`: export `extractProductId` (one-line change; the parallel PR touching `WebhookRouter.ts` only reads `updateStoreSubscription`, it does not modify `stripe.ts`)
- `createNewSubscription`: include `stripe_product_id` in INSERT
- `updateExistingSubscription`: include `stripe_product_id` in both UPDATE branches (status-changed and status-unchanged)
- `updateSubscriptionRecord`: backfill `users.stripe_customer_id` after each insert/update, mirroring the webhook path

## Measuring success

After the next batch sync runs (triggered manually via /ops), the affected user's row in `subscriptions` will have a non-null `stripe_product_id` matching `AUTO_SYNC_PRODUCT_ID`, and their row in `users` will have `stripe_customer_id` populated. Query to confirm:

```sql
SELECT s.email, s.stripe_product_id, u.stripe_customer_id
FROM subscriptions s
JOIN users u ON u.email = s.email
WHERE s.active = true AND s.stripe_product_id IS NOT NULL;
```

## Testing

- Unit tests added: `src/lib/storage/jobs/helpers/updateStripeSubscriptions.test.ts` (5 tests)
  - inserts stripe_product_id on new subscription row
  - updates stripe_product_id on existing subscription row
  - backfills users.stripe_customer_id on new subscription
  - backfills users.stripe_customer_id on existing subscription
  - inserts stripe_product_id as null when product absent from subscription
- Mocking: Stripe SDK and DB mocked at the edge; `reconcileActiveSubscriptions` stubbed (out of scope); `extractProductId` uses the real implementation via `jest.requireActual`
- All 32 tests in `src/lib/storage/jobs/helpers/` pass

## Changelog

No entry — internal provisioning fix, no user-visible behavior change on the surface. The affected user will silently gain access they were already entitled to, but this doesn't warrant a What's New entry.

## Risks

- The `users.stripe_customer_id` UPDATE runs on every batch-sync iteration (not just on create). It is a no-op UPDATE if the value is already correct, so the only downside is one extra query per subscription per sync. Acceptable given sync is manual-only.
- The parallel PR (#2845, ops sync command) does not touch `stripe.ts` — no merge conflict expected.

## Sonar

Sonar scanner not run locally (no token configured in this worktree). No new HTTP calls, no user-controlled strings, no crypto — the new code is pure DB writes using existing safe patterns. Expecting CI Automatic Analysis to pass.

## Goal alignment

Paying subscribers gain the access they paid for. Broken provisioning is a direct churn risk — this closes the gap between what Stripe says and what the DB says.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782476828&installation_id=132681956&pr_number=2847&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2847&signature=c8f64b9fcb36035156ed9b15d9ee2dc96e8b9eeea7f8e5fcd513760f1f871b1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->