### PR TITLE
feat: add DigitalOcean sponsorship attribution to footer and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ The trio is powered by Claude subagents in `.claude/agents/`. Use `/trio <task>`
 
 We'd love your help! See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get started, run the test gate, and submit a PR.
 
+## Supported by
+
+<p>This project is supported by:</p>
+<p>
+  <a href="https://www.digitalocean.com/?utm_medium=opensource&utm_source=2anki">
+    <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" width="201px" alt="DigitalOcean" />
+  </a>
+</p>
+
 ## License
 
 The code is licensed under the [MIT](./LICENSE) Copyright (c) 2020-2026, [Alexander Alemayhu](https://alemayhu.com). See [CREDITS.md](./CREDITS.md) for contributors.

--- a/web/src/components/Footer.module.css
+++ b/web/src/components/Footer.module.css
@@ -65,11 +65,37 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .copyright {
   font-size: var(--text-xs);
   color: var(--color-text-tertiary);
+}
+
+.bottomRight {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.sponsor {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+}
+
+.sponsorLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.sponsorLogo {
+  height: 18px;
+  width: auto;
+  display: block;
 }
 
 .githubLink {

--- a/web/src/components/Footer.test.tsx
+++ b/web/src/components/Footer.test.tsx
@@ -50,4 +50,16 @@ describe('Footer', () => {
       screen.queryByRole('link', { name: 'Documentation' })
     ).not.toBeInTheDocument();
   });
+
+  it('attributes the DigitalOcean sponsorship with a link to digitalocean.com', () => {
+    render(<Footer />);
+    const sponsor = screen.getByRole('link', {
+      name: 'Supported by DigitalOcean',
+    });
+    expect(sponsor).toHaveAttribute(
+      'href',
+      'https://www.digitalocean.com/?utm_medium=opensource&utm_source=2anki'
+    );
+    expect(screen.getByAltText('DigitalOcean')).toBeInTheDocument();
+  });
 });

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -32,13 +32,28 @@ function Footer() {
         <span className={styles.copyright}>
           {`© 2020–${currentYear} Alexander Alemayhu`}
         </span>
-        <a
-          href="https://github.com/2anki/server"
-          target="_blank"
-          rel="noreferrer"
-          className={styles.githubLink}
-          aria-label="GitHub"
-        >
+        <div className={styles.bottomRight}>
+          <a
+            href="https://www.digitalocean.com/?utm_medium=opensource&utm_source=2anki"
+            target="_blank"
+            rel="noreferrer"
+            className={styles.sponsor}
+            aria-label="Supported by DigitalOcean"
+          >
+            <span className={styles.sponsorLabel}>Supported by</span>
+            <img
+              src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg"
+              alt="DigitalOcean"
+              className={styles.sponsorLogo}
+            />
+          </a>
+          <a
+            href="https://github.com/2anki/server"
+            target="_blank"
+            rel="noreferrer"
+            className={styles.githubLink}
+            aria-label="GitHub"
+          >
           <svg
             viewBox="0 0 16 16"
             fill="currentColor"
@@ -48,6 +63,7 @@ function Footer() {
             <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" />
           </svg>
         </a>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## What

Adds the DigitalOcean sponsorship attribution (logo + link to digitalocean.com) to two surfaces, as required by DO's open-source sponsorship program:

- **Site-wide footer** — a quiet "Supported by [DO horizontal logo]" line in the bottom bar, next to the GitHub link. Visible on every page.
- **README** — DigitalOcean's verbatim "This project is supported by:" attribution snippet, in a new `## Supported by` section.

## Why

DO's program requires a logo + link back to `digitalocean.com` on **both** the website and the git repository as a deliverable for the credit grant. The badge the project carried in 2020 didn't survive the web rewrite, so the attribution was absent from the current tree — which is exactly what the program coordinator flagged when reviewing the renewal. This unblocks the grant.

## Implementation notes

- Logo + link follow DO's official attribution guide (`do.co/oss-attribution-guide`): horizontal blue SVG, `https://www.digitalocean.com/` link with the `utm_medium=opensource&utm_source=2anki` source param, and the recommended "supported by" wording.
- Uses DO's CDN-hosted SVG (their documented method — keeps the mark current/compliant). The CSP `img-src` is already `'self' data: blob: https:`, so **no CSP change** was needed.
- Blue variant chosen so the mark reads on both light and dark themes.

## Tests

- New Footer test asserts the attribution link resolves to the DO URL and the logo renders.
- Full web suite green (1295 tests), `tsc --noEmit` clean, Biome clean.

## Sonar

Manual `sonar-scanner` is blocked on this repo — SonarCloud **Automatic Analysis** is enabled and rejects manual runs. Sonar will analyze automatically on this push. The diff is 4 files (footer JSX/CSS/test + README), no new functions or complexity.

## Changelog

No changelog entry — this is a sponsor attribution badge, not a change to what a learner can do.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Visual check pending — I can't start the dev server per repo policy. Please run `pnpm dev`, confirm the footer "Supported by" logo renders (light + dark) and the README preview shows the DO badge, then tick the boxes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782480226&installation_id=132681956&pr_number=2849&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2849&signature=c1b79d48dee448a21fcb9a65cf4197af556275e0ae193300b68fd8d1b86ed60b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->