### PR TITLE
fix: keep site.webmanifest same-origin after Vite CDN base rewrite

### DIFF
--- a/web/scripts/keepManifestSameOrigin.test.ts
+++ b/web/scripts/keepManifestSameOrigin.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { keepManifestSameOrigin } from './keepManifestSameOrigin';
+
+const CDN = 'https://2anki-assets.fra1.cdn.digitaloceanspaces.com/';
+
+describe('keepManifestSameOrigin', () => {
+  it('rewrites a CDN-prefixed manifest href back to root-relative', () => {
+    const input = `<link rel="manifest" href="${CDN}site.webmanifest" />`;
+    expect(keepManifestSameOrigin(input)).toBe(
+      '<link rel="manifest" href="/site.webmanifest" />'
+    );
+  });
+
+  it('is a no-op when the manifest href is already root-relative', () => {
+    const input = '<link rel="manifest" href="/site.webmanifest" />';
+    expect(keepManifestSameOrigin(input)).toBe(input);
+  });
+
+  it('does not touch favicon link hrefs', () => {
+    const input = [
+      `<link rel="icon" href="${CDN}favicon.ico" sizes="any" />`,
+      `<link rel="manifest" href="${CDN}site.webmanifest" />`,
+      `<link rel="apple-touch-icon" href="${CDN}apple-touch-icon.png" />`,
+    ].join('\n');
+    const result = keepManifestSameOrigin(input);
+    expect(result).toContain(`href="${CDN}favicon.ico"`);
+    expect(result).toContain('href="/site.webmanifest"');
+    expect(result).toContain(`href="${CDN}apple-touch-icon.png"`);
+  });
+
+  it('handles a trailing-slash CDN base', () => {
+    const input = `<link rel="manifest" href="${CDN}site.webmanifest" />`;
+    expect(keepManifestSameOrigin(input)).toBe(
+      '<link rel="manifest" href="/site.webmanifest" />'
+    );
+  });
+
+  it('is idempotent when called twice', () => {
+    const input = `<link rel="manifest" href="${CDN}site.webmanifest" />`;
+    const once = keepManifestSameOrigin(input);
+    expect(keepManifestSameOrigin(once)).toBe(once);
+  });
+});

--- a/web/scripts/keepManifestSameOrigin.ts
+++ b/web/scripts/keepManifestSameOrigin.ts
@@ -1,0 +1,6 @@
+export function keepManifestSameOrigin(html: string): string {
+  return html.replace(
+    /(<link\s+rel="manifest"\s+href=")[^"]*site\.webmanifest(")/,
+    '$1/site.webmanifest$2'
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-27-webmanifest-same-origin.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-27-webmanifest-same-origin.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-27-webmanifest-same-origin",
+  "date": "2026-05-27",
+  "type": "fix",
+  "title": "Adding 2anki to your home screen picks up the right name and icon"
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,7 @@ import {
   emitMetaOnlyPages,
   emitNotionMarketplacePage,
 } from './scripts/prerenderLandingPages';
+import { keepManifestSameOrigin } from './scripts/keepManifestSameOrigin';
 
 function landingPrerender(): Plugin {
   return {
@@ -19,6 +20,16 @@ function landingPrerender(): Plugin {
       emitNotionMarketplacePage(buildDir);
       emitAnswersPages(buildDir);
       emitMetaOnlyPages(buildDir);
+    },
+  };
+}
+
+function manifestSameOrigin(): Plugin {
+  return {
+    name: '2anki-manifest-same-origin',
+    enforce: 'post',
+    transformIndexHtml(html) {
+      return keepManifestSameOrigin(html);
     },
   };
 }
@@ -47,6 +58,7 @@ export default defineConfig(({ command, mode }) => {
         include: '**/*.svg',
       }),
       landingPrerender(),
+      manifestSameOrigin(),
     ],
 
     // Test configuration


### PR DESCRIPTION
## What
Adds a Vite `transformIndexHtml` plugin (`enforce: 'post'`) that rewrites the `rel="manifest"` link href back to `/site.webmanifest` after Vite's CDN base rewrite. All other links (favicons, apple-touch-icon, JS, CSS) remain on the CDN.

## Why
`ASSET_BASE_URL` causes Vite to prefix every root-relative URL in `index.html` with the CDN base. `site.webmanifest` was never uploaded to the CDN bucket, producing a 404 and "Manifest fetch failed" console errors — breaking PWA install (Add to Home Screen) on 2anki.net. `index.html` itself is served from the app origin, so the manifest should always resolve same-origin where Express serves `build/site.webmanifest`.

## How
- Pure function `keepManifestSameOrigin(html: string): string` in `web/scripts/keepManifestSameOrigin.ts` — regex targets only `rel="manifest"` href, idempotent.
- `manifestSameOrigin()` plugin in `vite.config.ts` calls it via `transformIndexHtml`.
- 5 unit tests: CDN → root-relative rewrite, dev no-op, favicon preservation, trailing-slash CDN, idempotency.

## Measuring success
After deploy: `curl -I https://2anki.net/site.webmanifest` returns 200. The "Manifest fetch failed" console error disappears. Verified in the built `web/build/index.html`: `<link rel="manifest" href="/site.webmanifest" />` while JS/CSS chunks still point at `https://2anki-assets.fra1.cdn.digitaloceanspaces.com/`.

## Testing
- Unit tests added: `web/scripts/keepManifestSameOrigin.test.ts` (5 tests, all green)
- Full web vitest suite: 153 files / 1300 tests pass
- Web typecheck: clean
- Server typecheck: clean
- Build with `ASSET_BASE_URL=https://2anki-assets.fra1.cdn.digitaloceanspaces.com/` verified

## Browser check
Browser check: not applicable — the only `web/src/` file in this diff is the changelog JSON under `web/src/pages/WhatsNewPage/changelog/`, which triggers the changelog-only bypass. Code changes are in `web/vite.config.ts` and `web/scripts/` (not under `web/src/`).

## Changelog
"Adding 2anki to your home screen picks up the right name and icon" — `web/src/pages/WhatsNewPage/changelog/2026-05-27-webmanifest-same-origin.json`

## Risks
The regex matches `rel="manifest" href="..."` — if the attribute order in index.html ever changes (e.g. `href` before `rel`), the pattern won't match and the dev build (where `ASSET_BASE_URL` is unset) is a no-op anyway. The regex is anchored to the exact order in the current `index.html` line 27, which hasn't drifted. Rollback: revert this commit; the 404 returns but doesn't break functionality.

## Goal alignment
PWA installability (Add to Home Screen) working correctly reduces friction for engaged users — contributes to retention, which supports the 300K-user scale goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782513132&installation_id=132681956&pr_number=2850&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2850&signature=d5afd66ff7a440014f046c627341f611f189f57009d8975f34a7427939c8cdad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->