### PR TITLE
fix: preserve non-ASCII characters in uploaded filenames

### DIFF
--- a/src/lib/misc/GetUploadHandler.ts
+++ b/src/lib/misc/GetUploadHandler.ts
@@ -3,13 +3,43 @@ import multer from 'multer';
 import { getUploadLimits } from './getUploadLimits';
 import { getMaxUploadCount } from './getMaxUploadCount';
 import { isPaying } from '../isPaying';
+import { decodeMultipartFilename } from './decodeMultipartFilename';
 
-export const getUploadHandler = (res: express.Response) => {
+type UploadHandler = (
+  req: express.Request,
+  res: express.Response,
+  callback: (error?: Error) => void
+) => void;
+
+function withNormalizedFilenames(handler: express.RequestHandler): UploadHandler {
+  return (req, res, callback) => {
+    handler(req, res, (error?: unknown) => {
+      if (error instanceof Error) {
+        callback(error);
+        return;
+      }
+      const files = req.files as Express.Multer.File[] | undefined;
+      if (files) {
+        for (const file of files) {
+          file.originalname = decodeMultipartFilename(file.originalname);
+        }
+      }
+      if (req.file) {
+        req.file.originalname = decodeMultipartFilename(req.file.originalname);
+      }
+      callback();
+    });
+  };
+}
+
+export const getUploadHandler = (res: express.Response): UploadHandler => {
   const paying = isPaying(res.locals);
   const maxUploadCount = getMaxUploadCount(paying);
 
-  return multer({
+  const handler = multer({
     limits: getUploadLimits(paying),
     dest: process.env.UPLOAD_BASE,
   }).array('pakker', maxUploadCount);
+
+  return withNormalizedFilenames(handler);
 };

--- a/src/lib/misc/decodeMultipartFilename.test.ts
+++ b/src/lib/misc/decodeMultipartFilename.test.ts
@@ -1,0 +1,22 @@
+import { decodeMultipartFilename } from './decodeMultipartFilename';
+
+describe('decodeMultipartFilename', () => {
+  it('recovers Chinese characters from latin1-decoded UTF-8 bytes', () => {
+    const mojibake = Buffer.from('中文.md', 'utf8').toString('latin1');
+    expect(decodeMultipartFilename(mojibake)).toBe('中文.md');
+  });
+
+  it('leaves ASCII filenames unchanged', () => {
+    expect(decodeMultipartFilename('Biology.md')).toBe('Biology.md');
+  });
+
+  it('handles accented characters', () => {
+    const mojibake = Buffer.from('résumé.html', 'utf8').toString('latin1');
+    expect(decodeMultipartFilename(mojibake)).toBe('résumé.html');
+  });
+
+  it('handles Japanese filenames', () => {
+    const mojibake = Buffer.from('日本語.zip', 'utf8').toString('latin1');
+    expect(decodeMultipartFilename(mojibake)).toBe('日本語.zip');
+  });
+});

--- a/src/lib/misc/decodeMultipartFilename.ts
+++ b/src/lib/misc/decodeMultipartFilename.ts
@@ -1,0 +1,3 @@
+export function decodeMultipartFilename(name: string): string {
+  return Buffer.from(name, 'latin1').toString('utf8');
+}

--- a/src/routes/UploadRouter.ts
+++ b/src/routes/UploadRouter.ts
@@ -4,6 +4,7 @@ import path from 'path';
 
 import RequireAllowedOrigin from './middleware/RequireAllowedOrigin';
 import RequireAuthentication from './middleware/RequireAuthentication';
+import { normalizeUploadFilenames } from './middleware/normalizeUploadFilenames';
 import UploadController from '../controllers/Upload/UploadController';
 import JobController from '../controllers/JobController';
 import JobService from '../services/JobService';
@@ -111,6 +112,7 @@ const UploadRouter = () => {
         cb(null, path.extname(file.originalname).toLowerCase() === '.pdf');
       },
     }).single('file'),
+    normalizeUploadFilenames,
     (req, res) => uploadController.retryPdfWithCredential(req, res)
   );
 

--- a/src/routes/middleware/normalizeUploadFilenames.ts
+++ b/src/routes/middleware/normalizeUploadFilenames.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import { decodeMultipartFilename } from '../../lib/misc/decodeMultipartFilename';
+
+export function normalizeUploadFilenames(
+  req: express.Request,
+  _res: express.Response,
+  next: express.NextFunction
+): void {
+  if (req.files) {
+    const files = req.files as Express.Multer.File[];
+    for (const file of files) {
+      file.originalname = decodeMultipartFilename(file.originalname);
+    }
+  }
+
+  if (req.file) {
+    req.file.originalname = decodeMultipartFilename(req.file.originalname);
+  }
+
+  next();
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-27-non-ascii-filenames.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-27-non-ascii-filenames.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-27-non-ascii-filenames",
+  "date": "2026-05-27",
+  "type": "fix",
+  "title": "Uploads with Chinese, Japanese, Korean, or accented filenames keep their original characters"
+}


### PR DESCRIPTION
## What

Uploaded filenames containing Chinese, Japanese, Korean, or accented characters showed up as mojibake (e.g. `ä¸­æ–‡.md`) in the upload result and were used as the deck name. multer decodes the multipart `originalname` as latin1, so the UTF-8 bytes the browser sent were mis-decoded.

This is **not** an apkg limitation — .apkg fully supports these scripts. The fix decodes `originalname` from latin1 back to UTF-8 at the upload boundary (a shared `normalizeUploadFilenames` middleware on the PDF-retry route, and a wrapper around the array handler in `getUploadHandler`), so every downstream consumer (result title, deck name, download filename) sees the user's real filename.

## Tests

- New `decodeMultipartFilename` unit tests: Chinese, Japanese, accented, and ASCII-unchanged cases.
- Server tsc clean; 56 upload-area tests pass.

## Notes

- Backend-only behavioural change. The only `web/src/` file in the diff is the changelog entry, so the browser-attestation gate is exempt (changelog-only `web/src/` diff).
- Touches the file-upload boundary — `/security-review` is warranted before merge. Extension/size/path validation is unchanged; this only corrects the character encoding of the display name.
- Sonar not run locally for this small isolated change; expect the CI Sonar pass.

Browser check: not applicable — backend encoding fix; the only web/src file is the changelog entry.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782513384&installation_id=132681956&pr_number=2851&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2851&signature=7a4f861c0b13bd60e5d68146caeefdf1a50663448f0d91fdba92ed68a3f40f30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->