### PR TITLE
feat: add pricing A/B funnel ops command

### DIFF
--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -12,6 +12,8 @@ function makeFakeRepository(): IEventsRepository {
     countByName: jest.fn(async () => 0),
     countDistinctUsers: jest.fn(async () => 0),
     countByNameForUser: jest.fn(async () => 0),
+    groupPaywallShownByVariantAndSurface: jest.fn(async () => []),
+    groupPaywallClicksByVariant: jest.fn(async () => []),
   };
 }
 

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -13,6 +13,7 @@ import { SendAbandonedCheckoutRecoveryUseCase } from '../usecases/ops/SendAbando
 import { IShowcaseRepository } from '../data_layer/ShowcaseRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 import { SyncStripeSubscriptionsUseCase } from '../usecases/ops/SyncStripeSubscriptionsUseCase';
+import { GetPricingAbFunnelUseCase } from '../usecases/ops/GetPricingAbFunnelUseCase';
 
 class OpsController {
   constructor(
@@ -28,7 +29,8 @@ class OpsController {
     private readonly getMindmapImageStatsUseCase?: GetMindmapImageStatsUseCase,
     private readonly getMindmapStorageMetricsUseCase?: GetMindmapStorageMetricsUseCase,
     private readonly deleteInactiveUsersUseCase?: DeleteInactiveUsersUseCase,
-    private readonly syncStripeSubscriptionsUseCase?: SyncStripeSubscriptionsUseCase
+    private readonly syncStripeSubscriptionsUseCase?: SyncStripeSubscriptionsUseCase,
+    private readonly getPricingAbFunnelUseCase?: GetPricingAbFunnelUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -257,6 +259,21 @@ class OpsController {
       res
         .status(500)
         .json({ message: 'Failed to load mindmap storage metrics' });
+    }
+  }
+
+  async getPricingAbFunnel(req: express.Request, res: express.Response) {
+    if (this.getPricingAbFunnelUseCase == null) {
+      res.status(500).json({ message: 'Pricing A/B funnel not configured' });
+      return;
+    }
+    try {
+      const window = typeof req.query.window === 'string' ? req.query.window : undefined;
+      const result = await this.getPricingAbFunnelUseCase.execute(window);
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getPricingAbFunnel failed', error);
+      res.status(500).json({ message: 'Failed to load pricing A/B funnel' });
     }
   }
 }

--- a/src/data_layer/EventsRepository.ts
+++ b/src/data_layer/EventsRepository.ts
@@ -12,6 +12,17 @@ export interface EventCountRow {
   count: number;
 }
 
+export interface PaywallShownByVariantRow {
+  variant: string | null;
+  surface: string | null;
+  distinct_users: number;
+}
+
+export interface PaywallClicksByVariantRow {
+  variant: string | null;
+  click_count: number;
+}
+
 export interface IEventsRepository {
   insertEvents(rows: EventRow[]): Promise<void>;
   countByName(name: string, since: Date): Promise<number>;
@@ -22,6 +33,12 @@ export interface IEventsRepository {
     userId: number | null,
     anonymousId: string | null
   ): Promise<number>;
+  groupPaywallShownByVariantAndSurface(
+    since: Date
+  ): Promise<PaywallShownByVariantRow[]>;
+  groupPaywallClicksByVariant(
+    since: Date
+  ): Promise<PaywallClicksByVariantRow[]>;
 }
 
 export class EventsRepository implements IEventsRepository {
@@ -73,6 +90,53 @@ export class EventsRepository implements IEventsRepository {
 
     const result = await query.count('id as count').first();
     return Number(result?.count ?? 0);
+  }
+
+  async groupPaywallShownByVariantAndSurface(
+    since: Date
+  ): Promise<PaywallShownByVariantRow[]> {
+    const rows = (await this.database(this.table)
+      .where('name', 'paywall_shown')
+      .where('created_at', '>=', since)
+      .select(
+        this.database.raw("props->>'variant' as variant"),
+        this.database.raw("props->>'surface' as surface")
+      )
+      .countDistinct(
+        this.database.raw(
+          "COALESCE(user_id::text, anonymous_id) as distinct_users"
+        )
+      )
+      .groupByRaw("props->>'variant', props->>'surface'")) as Array<{
+      variant: string | null;
+      surface: string | null;
+      distinct_users: string | number;
+    }>;
+
+    return rows.map((r) => ({
+      variant: r.variant ?? null,
+      surface: r.surface ?? null,
+      distinct_users: Number(r.distinct_users),
+    }));
+  }
+
+  async groupPaywallClicksByVariant(
+    since: Date
+  ): Promise<PaywallClicksByVariantRow[]> {
+    const rows = (await this.database(this.table)
+      .where('name', 'paywall_upgrade_clicked')
+      .where('created_at', '>=', since)
+      .select(this.database.raw("props->>'variant' as variant"))
+      .count('id as click_count')
+      .groupByRaw("props->>'variant'")) as Array<{
+      variant: string | null;
+      click_count: string | number;
+    }>;
+
+    return rows.map((r) => ({
+      variant: r.variant ?? null,
+      click_count: Number(r.click_count),
+    }));
   }
 }
 

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -41,7 +41,10 @@ import { MindmapRepository } from '../data_layer/MindmapRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 import { JobsMetricsRepository } from '../data_layer/JobsMetricsRepository';
 import { SyncStripeSubscriptionsUseCase } from '../usecases/ops/SyncStripeSubscriptionsUseCase';
+import { GetPricingAbFunnelUseCase } from '../usecases/ops/GetPricingAbFunnelUseCase';
+import { PricingAbFunnelService } from '../services/ops/PricingAbFunnelService';
 import { updateStripeSubscriptions } from '../lib/storage/jobs/helpers/updateStripeSubscriptions';
+import EventsRepository from '../data_layer/EventsRepository';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -103,7 +106,10 @@ const OpsRouter = () => {
       new InactivityEmailRepository(database),
       new UsersRepository(database)
     ),
-    new SyncStripeSubscriptionsUseCase(() => updateStripeSubscriptions())
+    new SyncStripeSubscriptionsUseCase(() => updateStripeSubscriptions()),
+    new GetPricingAbFunnelUseCase(
+      new PricingAbFunnelService({ eventsRepo: new EventsRepository(database) })
+    )
   );
 
   /**
@@ -392,6 +398,33 @@ const OpsRouter = () => {
    */
   router.post('/api/ops/sync-stripe-subscriptions', RequireOpsAccess, (req, res) =>
     controller.syncStripeSubscriptions(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/pricing-ab/funnel:
+   *   get:
+   *     summary: Pricing-page A/B test funnel by variant
+   *     description: |
+   *       Returns per-variant funnel metrics (users shown, upgrade clicks, paid conversions,
+   *       revenue) and a surface breakdown. Defaults to the last 30 days; pass ?window=7d|14d|30d|60d|90d
+   *       to change. Internal endpoint locked to the ops owner — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: query
+   *         name: window
+   *         schema:
+   *           type: string
+   *           enum: ['7d', '14d', '30d', '60d', '90d']
+   *         description: Lookback window. Defaults to 30d.
+   *     responses:
+   *       200:
+   *         description: Funnel payload
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/pricing-ab/funnel', RequireOpsAccess, (req, res) =>
+    controller.getPricingAbFunnel(req, res)
   );
 
   return router;

--- a/src/services/events/EventsSink.test.ts
+++ b/src/services/events/EventsSink.test.ts
@@ -10,6 +10,8 @@ function makeFakeRepository() {
     countByName: jest.fn(async () => 0),
     countDistinctUsers: jest.fn(async () => 0),
     countByNameForUser: jest.fn(async () => 0),
+    groupPaywallShownByVariantAndSurface: jest.fn(async () => []),
+    groupPaywallClicksByVariant: jest.fn(async () => []),
   };
   return { repo, inserted };
 }
@@ -81,6 +83,8 @@ describe('EventsSink', () => {
       countByName: jest.fn(async () => 0),
       countDistinctUsers: jest.fn(async () => 0),
       countByNameForUser: jest.fn(async () => 0),
+      groupPaywallShownByVariantAndSurface: jest.fn(async () => []),
+      groupPaywallClicksByVariant: jest.fn(async () => []),
     };
     const sink = new EventsSink(repo, { flushThreshold: 1 });
     sink.record(baseRow);

--- a/src/services/ops/PricingAbFunnelService.test.ts
+++ b/src/services/ops/PricingAbFunnelService.test.ts
@@ -1,0 +1,223 @@
+import { PricingAbFunnelService } from './PricingAbFunnelService';
+import { IEventsRepository } from '../../data_layer/EventsRepository';
+
+const VARIANT_SHOWN_ROWS = [
+  { variant: 'unlimited-first', surface: 'pricing_page', distinct_users: 120 },
+  { variant: 'passes-first', surface: 'pricing_page', distinct_users: 115 },
+  { variant: 'minimal', surface: 'pricing_page', distinct_users: 118 },
+  { variant: null, surface: 'upload_success_upsell', distinct_users: 400 },
+  { variant: null, surface: 'downloads_upsell', distinct_users: 200 },
+];
+
+const VARIANT_CLICK_ROWS = [
+  { variant: 'unlimited-first', click_count: 30 },
+  { variant: 'passes-first', click_count: 20 },
+  { variant: 'minimal', click_count: 15 },
+];
+
+const SESSIONS = [
+  {
+    id: 'cs_1',
+    metadata: { pricing_variant: 'unlimited-first' },
+    payment_status: 'paid',
+    status: 'complete',
+    amount_total: 3000,
+  },
+  {
+    id: 'cs_2',
+    metadata: { pricing_variant: 'unlimited-first' },
+    payment_status: 'unpaid',
+    status: 'expired',
+    amount_total: 3000,
+  },
+  {
+    id: 'cs_3',
+    metadata: { pricing_variant: 'passes-first' },
+    payment_status: 'paid',
+    status: 'complete',
+    amount_total: 1500,
+  },
+  {
+    id: 'cs_4',
+    metadata: { pricing_variant: 'minimal' },
+    payment_status: 'paid',
+    status: 'complete',
+    amount_total: 500,
+  },
+  {
+    id: 'cs_5',
+    metadata: { pricing_variant: 'minimal' },
+    payment_status: 'paid',
+    status: 'complete',
+    amount_total: 500,
+  },
+  {
+    id: 'cs_6',
+    metadata: {},
+    payment_status: 'paid',
+    status: 'complete',
+    amount_total: 9900,
+  },
+];
+
+function makeStripe(sessions: typeof SESSIONS, hasMore = false) {
+  return {
+    checkout: {
+      sessions: {
+        list: jest.fn().mockResolvedValue({ data: sessions, has_more: hasMore }),
+      },
+    },
+  };
+}
+
+function makeEventsRepo(
+  shownRows = VARIANT_SHOWN_ROWS,
+  clickRows = VARIANT_CLICK_ROWS
+): IEventsRepository & {
+  groupPaywallShownByVariantAndSurface: jest.Mock;
+  groupPaywallClicksByVariant: jest.Mock;
+} {
+  return {
+    insertEvents: jest.fn(),
+    countByName: jest.fn(),
+    countDistinctUsers: jest.fn(),
+    countByNameForUser: jest.fn(),
+    groupPaywallShownByVariantAndSurface: jest
+      .fn()
+      .mockResolvedValue(shownRows),
+    groupPaywallClicksByVariant: jest.fn().mockResolvedValue(clickRows),
+  };
+}
+
+describe('PricingAbFunnelService', () => {
+  describe('getMetrics', () => {
+    it('aggregates variant rows correctly', async () => {
+      const repo = makeEventsRepo();
+      const stripe = makeStripe(SESSIONS);
+      const service = new PricingAbFunnelService({
+        eventsRepo: repo,
+        stripeFactory: () => stripe as never,
+      });
+
+      const result = await service.getMetrics(new Date('2026-05-26T00:00:00Z'));
+
+      expect(result.variants).toHaveLength(3);
+      const unlimited = result.variants!.find(
+        (v) => v.variant === 'unlimited-first'
+      );
+      expect(unlimited).toMatchObject({
+        variant: 'unlimited-first',
+        users_shown: 120,
+        upgrade_clicks: 30,
+        paid_conversions: 1,
+        revenue_cents: 3000,
+      });
+      expect(unlimited?.upgrade_click_rate_pct).toBeCloseTo(25, 1);
+    });
+
+    it('handles a variant with no clicks or conversions', async () => {
+      const repo = makeEventsRepo(
+        [{ variant: 'minimal', surface: 'pricing_page', distinct_users: 50 }],
+        []
+      );
+      const stripe = makeStripe([]);
+      const service = new PricingAbFunnelService({
+        eventsRepo: repo,
+        stripeFactory: () => stripe as never,
+      });
+
+      const result = await service.getMetrics(new Date('2026-05-26T00:00:00Z'));
+
+      const minimal = result.variants!.find((v) => v.variant === 'minimal');
+      expect(minimal).toMatchObject({
+        variant: 'minimal',
+        users_shown: 50,
+        upgrade_clicks: 0,
+        upgrade_click_rate_pct: 0,
+        paid_conversions: 0,
+        revenue_cents: 0,
+      });
+    });
+
+    it('includes surface breakdown rows for no-variant events', async () => {
+      const repo = makeEventsRepo();
+      const stripe = makeStripe(SESSIONS);
+      const service = new PricingAbFunnelService({
+        eventsRepo: repo,
+        stripeFactory: () => stripe as never,
+      });
+
+      const result = await service.getMetrics(new Date('2026-05-26T00:00:00Z'));
+
+      expect(result.surface_breakdown!.length).toBeGreaterThan(0);
+      const upsell = result.surface_breakdown!.find(
+        (r) => r.surface === 'upload_success_upsell'
+      );
+      expect(upsell?.distinct_users).toBe(400);
+    });
+
+    it('paginates Stripe sessions when has_more is true', async () => {
+      const stripe = {
+        checkout: {
+          sessions: {
+            list: jest
+              .fn()
+              .mockResolvedValueOnce({
+                data: [
+                  {
+                    id: 'cs_a',
+                    metadata: { pricing_variant: 'minimal' },
+                    payment_status: 'paid',
+                    status: 'complete',
+                    amount_total: 100,
+                  },
+                ],
+                has_more: true,
+              })
+              .mockResolvedValueOnce({
+                data: [
+                  {
+                    id: 'cs_b',
+                    metadata: { pricing_variant: 'minimal' },
+                    payment_status: 'paid',
+                    status: 'complete',
+                    amount_total: 200,
+                  },
+                ],
+                has_more: false,
+              }),
+          },
+        },
+      };
+      const repo = makeEventsRepo([], []);
+      const service = new PricingAbFunnelService({
+        eventsRepo: repo,
+        stripeFactory: () => stripe as never,
+      });
+
+      const result = await service.getMetrics(new Date('2026-05-26T00:00:00Z'));
+
+      const minimal = result.variants!.find((v) => v.variant === 'minimal');
+      expect(minimal?.paid_conversions).toBe(2);
+      expect(minimal?.revenue_cents).toBe(300);
+      expect(stripe.checkout.sessions.list).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns null fields when events repo throws', async () => {
+      const repo = makeEventsRepo();
+      (repo.groupPaywallShownByVariantAndSurface as jest.Mock).mockRejectedValue(
+        new Error('DB down')
+      );
+      const stripe = makeStripe([]);
+      const service = new PricingAbFunnelService({
+        eventsRepo: repo,
+        stripeFactory: () => stripe as never,
+      });
+
+      const result = await service.getMetrics(new Date('2026-05-26T00:00:00Z'));
+
+      expect(result.variants).toBeNull();
+      expect(result.error).toBe('DB down');
+    });
+  });
+});

--- a/src/services/ops/PricingAbFunnelService.ts
+++ b/src/services/ops/PricingAbFunnelService.ts
@@ -1,0 +1,189 @@
+import type { Stripe } from 'stripe';
+
+import { getStripe } from '../../lib/integrations/stripe';
+import type {
+  IEventsRepository,
+  PaywallShownByVariantRow,
+  PaywallClicksByVariantRow,
+} from '../../data_layer/EventsRepository';
+
+export interface PricingVariantRow {
+  variant: string;
+  users_shown: number;
+  upgrade_clicks: number;
+  upgrade_click_rate_pct: number;
+  paid_conversions: number;
+  revenue_cents: number;
+}
+
+export interface SurfaceBreakdownRow {
+  surface: string;
+  distinct_users: number;
+}
+
+export interface PricingAbFunnelResponse {
+  variants: PricingVariantRow[] | null;
+  surface_breakdown: SurfaceBreakdownRow[] | null;
+  since: string;
+  as_of: string;
+  error?: string;
+}
+
+const STRIPE_PAGE_LIMIT = 100;
+const KNOWN_VARIANTS = ['unlimited-first', 'passes-first', 'minimal'];
+
+interface CheckoutSessionSummary {
+  variant: string | null;
+  paid: boolean;
+  amount_total: number;
+}
+
+interface PricingAbFunnelServiceDeps {
+  eventsRepo: IEventsRepository;
+  stripeFactory?: () => Stripe;
+}
+
+export class PricingAbFunnelService {
+  private readonly eventsRepo: IEventsRepository;
+  private readonly stripeFactory: () => Stripe;
+
+  constructor(deps: PricingAbFunnelServiceDeps) {
+    this.eventsRepo = deps.eventsRepo;
+    this.stripeFactory = deps.stripeFactory ?? (() => getStripe());
+  }
+
+  async getMetrics(since: Date): Promise<PricingAbFunnelResponse> {
+    const as_of = new Date().toISOString();
+    const sinceStr = since.toISOString();
+
+    let shownRows: PaywallShownByVariantRow[];
+    let clickRows: PaywallClicksByVariantRow[];
+
+    try {
+      [shownRows, clickRows] = await Promise.all([
+        this.eventsRepo.groupPaywallShownByVariantAndSurface(since),
+        this.eventsRepo.groupPaywallClicksByVariant(since),
+      ]);
+    } catch (err) {
+      return {
+        variants: null,
+        surface_breakdown: null,
+        since: sinceStr,
+        as_of,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    const sessions = await this.fetchSessions(since);
+
+    const variants = this.buildVariantRows(shownRows, clickRows, sessions);
+    const surface_breakdown = this.buildSurfaceBreakdown(shownRows);
+
+    return { variants, surface_breakdown, since: sinceStr, as_of };
+  }
+
+  private buildVariantRows(
+    shownRows: PaywallShownByVariantRow[],
+    clickRows: PaywallClicksByVariantRow[],
+    sessions: CheckoutSessionSummary[]
+  ): PricingVariantRow[] {
+    const shownByVariant = new Map<string, number>();
+    for (const row of shownRows) {
+      if (row.variant == null) continue;
+      const existing = shownByVariant.get(row.variant) ?? 0;
+      shownByVariant.set(row.variant, existing + row.distinct_users);
+    }
+
+    const clicksByVariant = new Map<string, number>();
+    for (const row of clickRows) {
+      if (row.variant == null) continue;
+      clicksByVariant.set(row.variant, row.click_count);
+    }
+
+    const conversionsByVariant = new Map<string, { count: number; revenue: number }>();
+    for (const session of sessions) {
+      if (session.variant == null || !session.paid) continue;
+      const existing = conversionsByVariant.get(session.variant) ?? {
+        count: 0,
+        revenue: 0,
+      };
+      existing.count += 1;
+      existing.revenue += session.amount_total;
+      conversionsByVariant.set(session.variant, existing);
+    }
+
+    const allVariants = new Set<string>([
+      ...KNOWN_VARIANTS,
+      ...shownByVariant.keys(),
+    ]);
+
+    return Array.from(allVariants).map((variant) => {
+      const users_shown = shownByVariant.get(variant) ?? 0;
+      const upgrade_clicks = clicksByVariant.get(variant) ?? 0;
+      const upgrade_click_rate_pct =
+        users_shown > 0 ? (upgrade_clicks / users_shown) * 100 : 0;
+      const conv = conversionsByVariant.get(variant) ?? { count: 0, revenue: 0 };
+      return {
+        variant,
+        users_shown,
+        upgrade_clicks,
+        upgrade_click_rate_pct,
+        paid_conversions: conv.count,
+        revenue_cents: conv.revenue,
+      };
+    });
+  }
+
+  private buildSurfaceBreakdown(
+    shownRows: PaywallShownByVariantRow[]
+  ): SurfaceBreakdownRow[] {
+    const surfaceMap = new Map<string, number>();
+    for (const row of shownRows) {
+      if (row.surface == null) continue;
+      const existing = surfaceMap.get(row.surface) ?? 0;
+      surfaceMap.set(row.surface, existing + row.distinct_users);
+    }
+    return Array.from(surfaceMap.entries()).map(([surface, distinct_users]) => ({
+      surface,
+      distinct_users,
+    }));
+  }
+
+  private async fetchSessions(since: Date): Promise<CheckoutSessionSummary[]> {
+    const stripe = this.stripeFactory();
+    const gteSeconds = Math.floor(since.getTime() / 1000);
+    const result: CheckoutSessionSummary[] = [];
+    let startingAfter: string | undefined;
+    let hasMore = true;
+
+    while (hasMore) {
+      const page = await stripe.checkout.sessions.list({
+        limit: STRIPE_PAGE_LIMIT,
+        created: { gte: gteSeconds },
+        starting_after: startingAfter,
+      });
+
+      for (const session of page.data) {
+        const variant =
+          typeof session.metadata?.pricing_variant === 'string' &&
+          session.metadata.pricing_variant.length > 0
+            ? session.metadata.pricing_variant
+            : null;
+        const paid =
+          session.payment_status === 'paid' || session.status === 'complete';
+        result.push({
+          variant,
+          paid,
+          amount_total: session.amount_total ?? 0,
+        });
+      }
+
+      hasMore = page.has_more === true && page.data.length > 0;
+      startingAfter = hasMore
+        ? page.data[page.data.length - 1].id ?? undefined
+        : undefined;
+    }
+
+    return result;
+  }
+}

--- a/src/usecases/events/TrackEventUseCase.test.ts
+++ b/src/usecases/events/TrackEventUseCase.test.ts
@@ -11,6 +11,8 @@ function makeFakeRepository() {
     countByName: jest.fn(async () => 0),
     countDistinctUsers: jest.fn(async () => 0),
     countByNameForUser: jest.fn(async () => 0),
+    groupPaywallShownByVariantAndSurface: jest.fn(async () => []),
+    groupPaywallClicksByVariant: jest.fn(async () => []),
   };
   return { repo, inserted };
 }

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -61,6 +61,8 @@ function makeEventsStub(usedThisMonth = 0): IEventsRepository {
     countByName: jest.fn().mockResolvedValue(0),
     countDistinctUsers: jest.fn().mockResolvedValue(0),
     countByNameForUser: jest.fn().mockResolvedValue(usedThisMonth),
+    groupPaywallShownByVariantAndSurface: jest.fn().mockResolvedValue([]),
+    groupPaywallClicksByVariant: jest.fn().mockResolvedValue([]),
   };
 }
 

--- a/src/usecases/ops/GetPricingAbFunnelUseCase.test.ts
+++ b/src/usecases/ops/GetPricingAbFunnelUseCase.test.ts
@@ -1,0 +1,61 @@
+import { GetPricingAbFunnelUseCase } from './GetPricingAbFunnelUseCase';
+import { PricingAbFunnelService, PricingAbFunnelResponse } from '../../services/ops/PricingAbFunnelService';
+
+describe('GetPricingAbFunnelUseCase', () => {
+  it('delegates to the service with a since date derived from the window param', async () => {
+    const fakeResponse: PricingAbFunnelResponse = {
+      variants: [],
+      surface_breakdown: [],
+      since: '2026-04-27T00:00:00.000Z',
+      as_of: '2026-05-27T00:00:00.000Z',
+    };
+    const service = {
+      getMetrics: jest.fn().mockResolvedValue(fakeResponse),
+    } as unknown as PricingAbFunnelService;
+    const useCase = new GetPricingAbFunnelUseCase(service);
+
+    const result = await useCase.execute('30d');
+
+    expect(result).toBe(fakeResponse);
+    expect((service.getMetrics as jest.Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a 30-day default when no window is provided', async () => {
+    const fakeResponse: PricingAbFunnelResponse = {
+      variants: [],
+      surface_breakdown: [],
+      since: '2026-04-27T00:00:00.000Z',
+      as_of: '2026-05-27T00:00:00.000Z',
+    };
+    const service = {
+      getMetrics: jest.fn().mockResolvedValue(fakeResponse),
+    } as unknown as PricingAbFunnelService;
+    const useCase = new GetPricingAbFunnelUseCase(service);
+
+    const result = await useCase.execute(undefined);
+
+    expect(result).toBe(fakeResponse);
+    expect((service.getMetrics as jest.Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a 7-day since date for the 7d window', async () => {
+    const fakeResponse: PricingAbFunnelResponse = {
+      variants: [],
+      surface_breakdown: [],
+      since: '2026-05-20T00:00:00.000Z',
+      as_of: '2026-05-27T00:00:00.000Z',
+    };
+    const service = {
+      getMetrics: jest.fn().mockResolvedValue(fakeResponse),
+    } as unknown as PricingAbFunnelService;
+    const useCase = new GetPricingAbFunnelUseCase(service);
+
+    await useCase.execute('7d');
+
+    const callArg: Date = (service.getMetrics as jest.Mock).mock.calls[0][0];
+    const now = new Date();
+    const diffDays = (now.getTime() - callArg.getTime()) / (1000 * 60 * 60 * 24);
+    expect(diffDays).toBeGreaterThanOrEqual(6.9);
+    expect(diffDays).toBeLessThan(8);
+  });
+});

--- a/src/usecases/ops/GetPricingAbFunnelUseCase.ts
+++ b/src/usecases/ops/GetPricingAbFunnelUseCase.ts
@@ -1,0 +1,27 @@
+import {
+  PricingAbFunnelService,
+  PricingAbFunnelResponse,
+} from '../../services/ops/PricingAbFunnelService';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+const WINDOW_DAYS: Record<string, number> = {
+  '7d': 7,
+  '14d': 14,
+  '30d': 30,
+  '60d': 60,
+  '90d': 90,
+};
+
+const DEFAULT_WINDOW = '30d';
+
+export class GetPricingAbFunnelUseCase {
+  constructor(private readonly service: PricingAbFunnelService) {}
+
+  execute(window: string | undefined): Promise<PricingAbFunnelResponse> {
+    const key = window != null && WINDOW_DAYS[window] != null ? window : DEFAULT_WINDOW;
+    const days = WINDOW_DAYS[key];
+    const since = new Date(Date.now() - days * SECONDS_PER_DAY * 1000);
+    return this.service.getMetrics(since);
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,24 +1,22 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { lazy, ReactElement, useState } from 'react';
+import { CookiesProvider, useCookies } from 'react-cookie';
 import { HelmetProvider } from 'react-helmet-async';
-
-import { useCookies, CookiesProvider } from 'react-cookie';
-import UploadPage from './pages/UploadPage';
-import HomePage from './pages/HomePage';
-import AboutPage from './pages/AboutPage/AboutPage';
-
-import isOfflineMode from './lib/isOfflineMode';
-import DebugPage from './pages/DebugPage';
-import { ContactPage } from './pages/ContactPage/ContactPage';
-import FavoritesPage from './pages/FavoritesPage';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { AppShell } from './components/AppShell/AppShell';
-import DeleteAccountPage from './pages/DeleteAccountPage';
 import { getErrorMessage } from './components/errors/helpers/getErrorMessage';
-import { reportClientError } from './lib/reportClientError';
-import { useUserLocals } from './lib/hooks/useUserLocals';
 import { SkeletonPage } from './components/Skeleton/Skeleton';
+import { useUserLocals } from './lib/hooks/useUserLocals';
+import isOfflineMode from './lib/isOfflineMode';
+import { reportClientError } from './lib/reportClientError';
+import AboutPage from './pages/AboutPage/AboutPage';
+import { ContactPage } from './pages/ContactPage/ContactPage';
+import DebugPage from './pages/DebugPage';
+import DeleteAccountPage from './pages/DeleteAccountPage';
+import FavoritesPage from './pages/FavoritesPage';
+import HomePage from './pages/HomePage';
 import NotFoundPage from './pages/NotFoundPage';
+import UploadPage from './pages/UploadPage';
 
 const RegisterPage = lazy(() => import('./pages/RegisterPage'));
 const SearchPage = lazy(() => import('./pages/SearchPage'));
@@ -62,15 +60,18 @@ const ConversionsTab = lazy(() => import('./pages/OpsPage/ConversionsTab'));
 const BusinessTab = lazy(() => import('./pages/OpsPage/BusinessTab'));
 const ShowcaseTab = lazy(() => import('./pages/OpsPage/ShowcaseTab'));
 const InterviewsTab = lazy(() => import('./pages/OpsPage/InterviewsTab'));
-const ContactMessagesTab = lazy(() => import('./pages/OpsPage/ContactMessagesTab'));
+const ContactMessagesTab = lazy(
+  () => import('./pages/OpsPage/ContactMessagesTab')
+);
 const CommandsTab = lazy(() => import('./pages/OpsPage/CommandsTab'));
+const PricingAbFunnelTab = lazy(
+  () => import('./pages/OpsPage/PricingAbFunnelTab')
+);
 const FeedbackPage = lazy(() => import('./pages/FeedbackPage/FeedbackPage'));
 const NotionToAnki = lazy(() => import('./pages/LandingPage/NotionToAnki'));
 const AnkiToNotion = lazy(() => import('./pages/LandingPage/AnkiToNotion'));
 const QuizletToAnki = lazy(() => import('./pages/LandingPage/QuizletToAnki'));
-const MarkdownToAnki = lazy(
-  () => import('./pages/LandingPage/MarkdownToAnki')
-);
+const MarkdownToAnki = lazy(() => import('./pages/LandingPage/MarkdownToAnki'));
 const PdfToAnki = lazy(() => import('./pages/LandingPage/PdfToAnki'));
 const UsmleAnki = lazy(() => import('./pages/LandingPage/UsmleAnki'));
 const NursingFlashcards = lazy(
@@ -106,7 +107,9 @@ const PhotoToFlashcardsPage = lazy(() =>
   }))
 );
 const ChatPage = lazy(() => import('./pages/Chat/ChatPage'));
-const NotionLandingPage = lazy(() => import('./pages/NotionLandingPage/NotionLandingPage'));
+const NotionLandingPage = lazy(
+  () => import('./pages/NotionLandingPage/NotionLandingPage')
+);
 const AnswersPage = lazy(() => import('./pages/AnswersPage/AnswersPage'));
 const LimitPage = lazy(() => import('./pages/LimitPage/LimitPage'));
 const SharedDeckPage = lazy(() => import('./pages/SharedDeckPage'));
@@ -156,21 +159,25 @@ function AppContent({
         error={error}
         isLoggedIn={isLoggedIn}
         email={data?.user?.email}
-        locals={data?.locals == null ? data?.locals : { ...data.locals, trial_started_at: data?.user?.trial_started_at ?? null, autoSyncActive: data?.autoSyncActive === true }}
+        locals={
+          data?.locals == null
+            ? data?.locals
+            : {
+                ...data.locals,
+                trial_started_at: data?.user?.trial_started_at ?? null,
+                autoSyncActive: data?.autoSyncActive === true,
+              }
+        }
         features={data?.features}
       >
         <Routes>
           <Route
             path="/favorites"
-            element={requireAuth(
-              <FavoritesPage setError={setErrorMessage} />
-            )}
+            element={requireAuth(<FavoritesPage setError={setErrorMessage} />)}
           />
           <Route
             path="/downloads"
-            element={requireAuth(
-              <DownloadsPage setError={setErrorMessage} />
-            )}
+            element={requireAuth(<DownloadsPage setError={setErrorMessage} />)}
           />
           <Route
             path="/uploads"
@@ -182,7 +189,10 @@ function AppContent({
           />
           <Route path="/print" element={<PrintPage />} />
           <Route path="/image-occlusion" element={<ImageOcclusionPage />} />
-          <Route path="/photo-to-deck" element={requireAuth(<PhotoToFlashcardsPage />)} />
+          <Route
+            path="/photo-to-deck"
+            element={requireAuth(<PhotoToFlashcardsPage />)}
+          />
           <Route path="/mindmaps" element={requireAuth(<MindmapsPage />)} />
           <Route path="/mindmaps/:id" element={requireAuth(<MindmapsPage />)} />
           <Route path="/chat" element={requireAuth(<ChatPage />)} />
@@ -192,14 +202,9 @@ function AppContent({
           />
           <Route
             path="/notion"
-            element={requireAuth(
-              <SearchPage setError={setErrorMessage} />
-            )}
+            element={requireAuth(<SearchPage setError={setErrorMessage} />)}
           />
-          <Route
-            path="/search"
-            element={<Navigate to="/notion" replace />}
-          />
+          <Route path="/search" element={<Navigate to="/notion" replace />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/auth/magic" element={<MagicLinkPage />} />
           <Route
@@ -230,7 +235,9 @@ function AppContent({
                 signupCountry={data?.user?.signup_country ?? null}
                 autoSyncCapReached={data?.autoSyncCapReached === true}
                 autoSyncActive={data?.autoSyncActive === true}
-                onTrialStarted={() => { refetch(); }}
+                onTrialStarted={() => {
+                  refetch();
+                }}
               />
             }
           />
@@ -256,16 +263,11 @@ function AppContent({
             />
           )}
           {NotionPreviewPage && (
-            <Route
-              path="/dev/notion-preview"
-              element={<NotionPreviewPage />}
-            />
+            <Route path="/dev/notion-preview" element={<NotionPreviewPage />} />
           )}
           <Route
             path="/import"
-            element={requireAuth(
-              <ImportPage setError={setErrorMessage} />
-            )}
+            element={requireAuth(<ImportPage setError={setErrorMessage} />)}
           />
           <Route path="/ankify" element={requireAuth(<AnkifyPage />)} />
           <Route
@@ -286,6 +288,7 @@ function AppContent({
             <Route path="interviews" element={<InterviewsTab />} />
             <Route path="messages" element={<ContactMessagesTab />} />
             <Route path="commands" element={<CommandsTab />} />
+            <Route path="pricing-ab" element={<PricingAbFunnelTab />} />
           </Route>
           <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
           <Route path="/settings" element={requireAuth(<AccountPage />)} />
@@ -318,9 +321,7 @@ function AppContent({
           />
           <Route
             path="/preview/:id"
-            element={requireAuth(
-              <PreviewPage setError={setErrorMessage} />
-            )}
+            element={requireAuth(<PreviewPage setError={setErrorMessage} />)}
           />
           <Route
             path="/preview/database/:id"
@@ -365,9 +366,7 @@ function AppContent({
           <Route
             path="/anki-from-medical-lecture-slides"
             element={
-              <AnkiFromMedicalLectureSlides
-                setErrorMessage={setErrorMessage}
-              />
+              <AnkiFromMedicalLectureSlides setErrorMessage={setErrorMessage} />
             }
           />
           <Route
@@ -386,9 +385,7 @@ function AppContent({
           <Route path="/answers/:slug" element={<AnswersPage />} />
           <Route
             path="/convert/:slug"
-            element={
-              <ConvertLandingPage setErrorMessage={setErrorMessage} />
-            }
+            element={<ConvertLandingPage setErrorMessage={setErrorMessage} />}
           />
           <Route path="/s/:token" element={<SharedDeckPage />} />
           <Route path="*" element={<NotFoundPage />} />

--- a/web/src/pages/OpsPage/OpsLayout.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.tsx
@@ -7,15 +7,56 @@ import styles from './OpsPage.module.css';
 const PAGE_TITLE = 'Ops · 2anki';
 
 const TABS = [
-  { to: '/ops', label: 'Engineering', match: (path: string) => path === '/ops' || path.startsWith('/ops?') },
-  { to: '/ops/errors', label: 'Errors', match: (path: string) => path.startsWith('/ops/errors') },
-  { to: '/ops/performance', label: 'Performance', match: (path: string) => path.startsWith('/ops/performance') },
-  { to: '/ops/conversions', label: 'Conversions', match: (path: string) => path.startsWith('/ops/conversions') },
-  { to: '/ops/business', label: 'Business', match: (path: string) => path.startsWith('/ops/business') },
-  { to: '/ops/showcase', label: 'Showcase', match: (path: string) => path.startsWith('/ops/showcase') },
-  { to: '/ops/interviews', label: 'Interviews', match: (path: string) => path.startsWith('/ops/interviews') },
-  { to: '/ops/messages', label: 'Messages', match: (path: string) => path.startsWith('/ops/messages') },
-  { to: '/ops/commands', label: 'Commands', match: (path: string) => path.startsWith('/ops/commands') },
+  {
+    to: '/ops',
+    label: 'Engineering',
+    match: (path: string) => path === '/ops' || path.startsWith('/ops?'),
+  },
+  {
+    to: '/ops/errors',
+    label: 'Errors',
+    match: (path: string) => path.startsWith('/ops/errors'),
+  },
+  {
+    to: '/ops/performance',
+    label: 'Performance',
+    match: (path: string) => path.startsWith('/ops/performance'),
+  },
+  {
+    to: '/ops/conversions',
+    label: 'Conversions',
+    match: (path: string) => path.startsWith('/ops/conversions'),
+  },
+  {
+    to: '/ops/business',
+    label: 'Business',
+    match: (path: string) => path.startsWith('/ops/business'),
+  },
+  {
+    to: '/ops/showcase',
+    label: 'Showcase',
+    match: (path: string) => path.startsWith('/ops/showcase'),
+  },
+  {
+    to: '/ops/interviews',
+    label: 'Interviews',
+    match: (path: string) => path.startsWith('/ops/interviews'),
+  },
+  {
+    to: '/ops/messages',
+    label: 'Messages',
+    match: (path: string) => path.startsWith('/ops/messages'),
+  },
+  {
+    to: '/ops/commands',
+    label: 'Commands',
+    match: (path: string) => path.startsWith('/ops/commands'),
+  },
+  {
+    to: '/ops/pricing-ab',
+    label: 'Pricing A/B',
+    match: (path: string) => path.startsWith('/ops/pricing-ab'),
+  },
 ];
 
 export default function OpsLayout() {

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -67,6 +67,7 @@
   flex-direction: column;
   gap: 0.5rem;
   padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
 }
 
 .cardTitle {

--- a/web/src/pages/OpsPage/PricingAbFunnelTab.tsx
+++ b/web/src/pages/OpsPage/PricingAbFunnelTab.tsx
@@ -1,0 +1,159 @@
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import { FUNNEL_WINDOWS, usePricingAbFunnel } from './usePricingAbFunnel';
+
+function fmt(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function fmtPct(n: number): string {
+  return `${n.toFixed(1)}%`;
+}
+
+function fmtRevenue(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export default function PricingAbFunnelTab() {
+  const { data, loading, error, window, setWindow, refresh } =
+    usePricingAbFunnel();
+
+  return (
+    <>
+      <p className={styles.panelTitle}>Pricing A/B funnel</p>
+      <p className={styles.panelSubtitle}>
+        Per-variant breakdown since PR #2828 (2026-05-26). Variants are sticky
+        in localStorage: unlimited-first, passes-first, minimal.
+      </p>
+
+      <div className={styles.tabHeader}>
+        <div className={styles.controls}>
+          <label htmlFor="funnel-window" className={styles.controlsLabel}>
+            Window
+          </label>
+          <select
+            id="funnel-window"
+            className={`${sharedStyles.select} ${styles.windowSelect}`}
+            value={window}
+            onChange={(e) =>
+              setWindow(e.target.value as (typeof FUNNEL_WINDOWS)[number])
+            }
+          >
+            {FUNNEL_WINDOWS.map((w) => (
+              <option key={w} value={w}>
+                {w}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={refresh}
+            disabled={loading}
+          >
+            {loading ? 'Loading' : 'Refresh'}
+          </button>
+        </div>
+        {data != null && (
+          <p className={styles.refreshHint}>
+            as of {new Date(data.as_of).toLocaleString()}
+          </p>
+        )}
+      </div>
+
+      {error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {error}
+        </div>
+      )}
+
+      {data?.error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {data.error}
+        </div>
+      )}
+
+      {data?.variants != null && (
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>Variant funnel</h2>
+          </div>
+          <div className={sharedStyles.surface}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Variant</th>
+                  <th className={styles.numeric}>Users shown</th>
+                  <th className={styles.numeric}>Upgrade clicks</th>
+                  <th className={styles.numeric}>Click rate</th>
+                  <th className={styles.numeric}>Paid conversions</th>
+                  <th className={styles.numeric}>Revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.variants.map((row) => (
+                  <tr key={row.variant}>
+                    <td>
+                      <code>{row.variant}</code>
+                    </td>
+                    <td className={styles.numeric}>{fmt(row.users_shown)}</td>
+                    <td className={styles.numeric}>
+                      {fmt(row.upgrade_clicks)}
+                    </td>
+                    <td className={styles.numeric}>
+                      {fmtPct(row.upgrade_click_rate_pct)}
+                    </td>
+                    <td className={styles.numeric}>
+                      {fmt(row.paid_conversions)}
+                    </td>
+                    <td className={styles.numeric}>
+                      {fmtRevenue(row.revenue_cents)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {data?.surface_breakdown != null && data.surface_breakdown.length > 0 && (
+        <section className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle}>Surface breakdown</h2>
+            <p className={styles.sectionHint}>
+              upload_success_upsell and downloads_upsell carry no variant —
+              expected
+            </p>
+          </div>
+          <div className={sharedStyles.surface}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>Surface</th>
+                  <th className={styles.numeric}>Distinct users</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.surface_breakdown.map((row) => (
+                  <tr key={row.surface}>
+                    <td>
+                      <code>{row.surface}</code>
+                    </td>
+                    <td className={styles.numeric}>
+                      {fmt(row.distinct_users)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {loading && data == null && (
+        <p className={styles.emptyHint}>Loading funnel data</p>
+      )}
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/pricingAbTypes.ts
+++ b/web/src/pages/OpsPage/pricingAbTypes.ts
@@ -1,0 +1,21 @@
+export interface PricingVariantRow {
+  variant: string;
+  users_shown: number;
+  upgrade_clicks: number;
+  upgrade_click_rate_pct: number;
+  paid_conversions: number;
+  revenue_cents: number;
+}
+
+export interface SurfaceBreakdownRow {
+  surface: string;
+  distinct_users: number;
+}
+
+export interface PricingAbFunnelResponse {
+  variants: PricingVariantRow[] | null;
+  surface_breakdown: SurfaceBreakdownRow[] | null;
+  since: string;
+  as_of: string;
+  error?: string;
+}

--- a/web/src/pages/OpsPage/usePricingAbFunnel.ts
+++ b/web/src/pages/OpsPage/usePricingAbFunnel.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useState } from 'react';
+import { PricingAbFunnelResponse } from './pricingAbTypes';
+
+const ALLOWED_WINDOWS = ['7d', '14d', '30d', '60d', '90d'] as const;
+type FunnelWindow = (typeof ALLOWED_WINDOWS)[number];
+
+interface UsePricingAbFunnelResult {
+  data: PricingAbFunnelResponse | null;
+  loading: boolean;
+  error: string | null;
+  window: FunnelWindow;
+  setWindow: (w: FunnelWindow) => void;
+  refresh: () => void;
+}
+
+export const FUNNEL_WINDOWS: readonly FunnelWindow[] = ALLOWED_WINDOWS;
+
+export function usePricingAbFunnel(): UsePricingAbFunnelResult {
+  const [data, setData] = useState<PricingAbFunnelResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentWindow, setCurrentWindow] = useState<FunnelWindow>('30d');
+  const [tick, setTick] = useState(0);
+
+  const refresh = useCallback(() => {
+    setTick((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/ops/pricing-ab/funnel?window=${currentWindow}`, {
+      credentials: 'include',
+    })
+      .then((res) => {
+        if (!res.ok) {
+          return res.json().then((body: { message?: string }) => {
+            throw new Error(body.message ?? `${res.status} ${res.statusText}`);
+          });
+        }
+        return res.json() as Promise<PricingAbFunnelResponse>;
+      })
+      .then((result) => {
+        if (!cancelled) {
+          setData(result);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentWindow, tick]);
+
+  return {
+    data,
+    loading,
+    error,
+    window: currentWindow,
+    setWindow: setCurrentWindow,
+    refresh,
+  };
+}


### PR DESCRIPTION
## What

Adds a **Pricing A/B** tab to the ops page (owner-only) that renders the pricing-variant funnel as an HTML table, so you can read which variant converts on demand instead of SSHing to prod.

- **Backend:** `GET /api/ops/pricing-ab/funnel` behind `RequireOpsAccess` (404 for non-owner). Funnel counts come from the `events` table (`props.variant` / `props.surface` via new `EventsRepository` methods); paid conversions + revenue come from Stripe checkout session `metadata.pricing_variant` (paginated). `?window=7d|14d|30d|60d|90d`, default 30d.
- **Frontend:** per-variant table (users shown, upgrade clicks, click rate, paid conversions, revenue) + a surface breakdown showing the no-variant upsell surfaces. Window selector + refresh.
- **Spacing fix:** adds `margin-bottom` between the cards on the ops Commands page (they were flush).

## Tests

- New service + usecase unit tests (Stripe mocked at the SDK boundary; pagination, conversion counting, error→null path covered).
- Updated 5 existing `IEventsRepository` mocks for the two new methods.
- Server tsc, web typecheck, biome lint clean. 241 server tests + 78 web (OpsPage) tests pass.

## Security review

`/security-review` run on this branch — no findings at confidence ≥ 8. Endpoint is owner-gated; knex.raw fragments are constant strings (no user input); the `?window` param is an allowlist lookup only; Stripe call is read-only with no user input; React auto-escapes the rendered table.

## Notes

- **No changelog entry** — internal admin tooling, reachable only by the ops owner.
- Sonar not run locally; expect the CI Sonar pass.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Note: verified by the ops owner on the authed `/ops/pricing-ab` view (previews/CI can't log in as owner).
