### PR TITLE
fix: correct distinct-count alias in pricing A/B funnel query

### DIFF
--- a/src/data_layer/EventsRepository.test.ts
+++ b/src/data_layer/EventsRepository.test.ts
@@ -1,3 +1,4 @@
+import knexLib, { Knex } from 'knex';
 import { EventsRepository, EventRow } from './EventsRepository';
 
 interface FakeStore {
@@ -124,5 +125,50 @@ describe('EventsRepository', () => {
     const since = new Date('2026-01-01');
     const result = await repo.countByNameForUser('upload_error_chat_engaged', since, null, null);
     expect(result).toBe(0);
+  });
+});
+
+function captureGeneratedSql(): { db: Knex; getSql: () => string } {
+  const pg = knexLib({ client: 'pg' });
+  let sql = '';
+  const db = ((table: string) => {
+    const qb = pg(table);
+    (qb as unknown as { then: unknown }).then = (
+      onFulfilled?: (value: unknown) => unknown
+    ) => {
+      sql = qb.toString();
+      return Promise.resolve([]).then(onFulfilled);
+    };
+    return qb;
+  }) as unknown as Knex;
+  (db as unknown as { raw: Knex['raw'] }).raw = pg.raw.bind(pg);
+  return { db, getSql: () => sql };
+}
+
+describe('EventsRepository SQL generation', () => {
+  it('aliases the distinct-user count outside the aggregate, not inside count()', async () => {
+    const { db, getSql } = captureGeneratedSql();
+    const repo = new EventsRepository(db);
+
+    await repo.groupPaywallShownByVariantAndSurface(new Date('2026-05-01'));
+
+    const sql = getSql();
+    expect(sql).toContain(
+      'count(distinct COALESCE(user_id::text, anonymous_id)) as distinct_users'
+    );
+    // Regression guard: the broken form put the alias inside count(...), which
+    // Postgres rejects with "syntax error at or near \"as\"".
+    expect(sql).not.toContain('anonymous_id) as distinct_users)');
+  });
+
+  it('generates a valid grouped click count', async () => {
+    const { db, getSql } = captureGeneratedSql();
+    const repo = new EventsRepository(db);
+
+    await repo.groupPaywallClicksByVariant(new Date('2026-05-01'));
+
+    const sql = getSql();
+    expect(sql).toContain('count("id") as "click_count"');
+    expect(sql).toContain("group by props->>'variant'");
   });
 });

--- a/src/data_layer/EventsRepository.ts
+++ b/src/data_layer/EventsRepository.ts
@@ -100,11 +100,9 @@ export class EventsRepository implements IEventsRepository {
       .where('created_at', '>=', since)
       .select(
         this.database.raw("props->>'variant' as variant"),
-        this.database.raw("props->>'surface' as surface")
-      )
-      .countDistinct(
+        this.database.raw("props->>'surface' as surface"),
         this.database.raw(
-          "COALESCE(user_id::text, anonymous_id) as distinct_users"
+          'count(distinct COALESCE(user_id::text, anonymous_id)) as distinct_users'
         )
       )
       .groupByRaw("props->>'variant', props->>'surface'")) as Array<{


### PR DESCRIPTION
## What

The ops **Pricing A/B** tab returned a 500 — `syntax error at or near "as"`. The paywall-shown funnel query aliased the distinct-user count *inside* the aggregate:

```
count(distinct COALESCE(user_id::text, anonymous_id) as distinct_users)   ← invalid
```

Postgres rejects that. Fix moves the alias outside the aggregate by expressing the count as a raw select column:

```
count(distinct COALESCE(user_id::text, anonymous_id)) as distinct_users   ← valid
```

## Why CI didn't catch it

The `PricingAbFunnelService` tests mock `IEventsRepository`, so the real SQL never ran — and the repo's existing fake-knex helper strips aliases with `.split(' as ')`, masking the malformed output. Same shape as past SQLite/Postgres divergences: green tests, broken prod.

## Test

Added an `EventsRepository` test that builds the query with a real **pg-dialect** knex and asserts on the generated SQL (alias outside `count(...)`). Verified it **fails** on the old code (captured SQL matches the prod error exactly) and **passes** on the fix. tsc clean; 6/6 repo tests pass.

## Notes

- Backend-only; only reachable surface is the owner-only `/ops/pricing-ab`, so no changelog and no user impact.
- No `web/src/` files — browser attestation not applicable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782515683&installation_id=132681956&pr_number=2854&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2854&signature=5d8e9a92fb27b7dc1ff1cb292426837da5ec788726241e342464c9943c68d9ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->