### PR TITLE
fix: load deck-preview card images in the sandboxed iframe

### DIFF
--- a/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
@@ -1,11 +1,12 @@
-import { act, render } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, expect, it } from 'vitest';
-
-import { CardFrame } from './CardFrame';
 import type { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
+import { CardFrame } from './CardFrame';
 
-const buildCard = (overrides: Partial<ApkgPreviewCard> = {}): ApkgPreviewCard => ({
+const buildCard = (
+  overrides: Partial<ApkgPreviewCard> = {}
+): ApkgPreviewCard => ({
   id: 1,
   ord: 0,
   deckName: 'Sample Deck',
@@ -24,6 +25,15 @@ const getSrcDoc = (container: HTMLElement): string => {
   return iframe.getAttribute('srcdoc') ?? '';
 };
 
+// srcDoc is populated asynchronously (media is inlined as data URLs first), so
+// wait for the iframe to receive its document before asserting on it.
+const waitForSrcDoc = (container: HTMLElement): Promise<string> =>
+  waitFor(() => {
+    const srcDoc = getSrcDoc(container);
+    if (!srcDoc) throw new Error('srcdoc not populated yet');
+    return srcDoc;
+  });
+
 const getIframe = (container: HTMLElement): HTMLIFrameElement => {
   const iframe = container.querySelector('iframe');
   if (iframe == null) throw new Error('iframe not rendered');
@@ -38,43 +48,43 @@ describe('CardFrame sandbox', () => {
 });
 
 describe('CardFrame srcDoc', () => {
-  it('does not inject hardcoded background or foreground colors', () => {
+  it('does not inject hardcoded background or foreground colors', async () => {
     const card = buildCard({ css: '' });
     const { container } = render(<CardFrame card={card} />);
-    const srcDoc = getSrcDoc(container);
+    const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).not.toContain('background: #fff');
     expect(srcDoc).not.toContain('color: #111');
   });
 
-  it('includes color-scheme meta tag', () => {
+  it('includes color-scheme meta tag', async () => {
     const { container } = render(<CardFrame card={buildCard()} />);
-    const srcDoc = getSrcDoc(container);
+    const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('<meta name="color-scheme" content="light dark">');
   });
 
-  it('includes the resize-observer script', () => {
+  it('includes the resize-observer script', async () => {
     const { container } = render(<CardFrame card={buildCard()} />);
-    const srcDoc = getSrcDoc(container);
+    const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('ResizeObserver');
     expect(srcDoc).toContain('2anki-preview');
   });
 
-  it('leaves benign markup intact', () => {
+  it('leaves benign markup intact', async () => {
     const card = buildCard({
       front: '<p class="q"><strong>Q:</strong> What is spaced repetition?</p>',
     });
     const { container } = render(<CardFrame card={card} />);
-    const srcDoc = getSrcDoc(container);
+    const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('<p class="q">');
     expect(srcDoc).toContain('<strong>Q:</strong>');
   });
 
-  it('includes card scripts in srcDoc', () => {
+  it('includes card scripts in srcDoc', async () => {
     const card = buildCard({
       front: 'Hello<script>alert(1)</script> world',
     });
     const { container } = render(<CardFrame card={card} />);
-    const srcDoc = getSrcDoc(container);
+    const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('alert(1)');
   });
 });

--- a/web/src/pages/PreviewApkgPage/CardFrame.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.tsx
@@ -1,14 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
+import { fetchMediaAsDataUrl, inlineApkgMedia } from './inlineMedia';
 import styles from './PreviewApkgPage.module.css';
 
 interface CardFrameProps {
   card: ApkgPreviewCard;
 }
 
-function buildSrcDoc(card: ApkgPreviewCard, side: 'front' | 'back'): string {
-  const html = side === 'front' ? card.front : card.back;
-  const cardId = String(card.id);
+// Card HTML renders in a sandboxed iframe (allow-scripts, no allow-same-origin),
+// so its <img> requests to the cookie-authenticated media endpoint go out from a
+// null origin without credentials and 401. The authenticated parent fetches the
+// media here and inlines it as data: URLs, shared across cards via this cache.
+const mediaCache = new Map<string, string | null>();
+
+function buildSrcDoc(html: string, css: string, cardId: string): string {
   return `<!doctype html>
 <html>
 <head>
@@ -18,7 +23,7 @@ function buildSrcDoc(card: ApkgPreviewCard, side: 'front' | 'back'): string {
 <style>
   html, body { margin: 0; padding: 1rem; font-family: system-ui, sans-serif; }
   img, video { max-width: 100%; height: auto; }
-${card.css}
+${css}
 </style>
 </head>
 <body>
@@ -58,11 +63,20 @@ export function CardFrame({ card }: Readonly<CardFrameProps>) {
   const [frameHeight, setFrameHeight] = useState(DEFAULT_FRAME_HEIGHT);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
-  const srcDoc = useMemo(
-    () => buildSrcDoc(card, showBack ? 'back' : 'front'),
-    [card, showBack]
-  );
+  const [srcDoc, setSrcDoc] = useState('');
   const deckSegments = useMemo(() => resolveDeckSegments(card), [card]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const cardId = String(card.id);
+    const html = showBack ? card.back : card.front;
+    inlineApkgMedia(html, fetchMediaAsDataUrl, mediaCache).then((inlined) => {
+      if (!cancelled) setSrcDoc(buildSrcDoc(inlined, card.css, cardId));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [card, showBack]);
 
   useEffect(() => {
     setFrameHeight(DEFAULT_FRAME_HEIGHT);

--- a/web/src/pages/PreviewApkgPage/inlineMedia.test.ts
+++ b/web/src/pages/PreviewApkgPage/inlineMedia.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { extractApkgMediaUrls, inlineApkgMedia } from './inlineMedia';
+
+const HTML =
+  '<img src="/api/apkg/k1/media/a.png" /><hr/>' +
+  '<img src="/api/apkg/k1/media/a.png" />' +
+  '<img src="/api/apkg/k1/media/b.png" />' +
+  '<img src="https://cdn.example.com/x.png" />';
+
+describe('extractApkgMediaUrls', () => {
+  it('returns unique media URLs and ignores external/non-media URLs', () => {
+    expect(extractApkgMediaUrls(HTML)).toEqual([
+      '/api/apkg/k1/media/a.png',
+      '/api/apkg/k1/media/b.png',
+    ]);
+  });
+
+  it('matches URL-encoded filenames (spaces, dots)', () => {
+    const html =
+      '<img src="/api/apkg/1-x.apkg/media/Presentasjon%20uten%20tittel.pdf-page1-1.png" />';
+    expect(extractApkgMediaUrls(html)).toEqual([
+      '/api/apkg/1-x.apkg/media/Presentasjon%20uten%20tittel.pdf-page1-1.png',
+    ]);
+  });
+});
+
+describe('inlineApkgMedia', () => {
+  it('replaces media URLs with data URLs and fetches each unique URL once', async () => {
+    const loader = vi.fn(async (url: string) =>
+      url.endsWith('a.png')
+        ? 'data:image/png;base64,AAA'
+        : 'data:image/png;base64,BBB'
+    );
+    const out = await inlineApkgMedia(HTML, loader);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(out).toContain('src="data:image/png;base64,AAA"');
+    expect(out).toContain('src="data:image/png;base64,BBB"');
+    expect(out).not.toContain('/api/apkg/k1/media/');
+    expect(out).toContain('https://cdn.example.com/x.png');
+  });
+
+  it('leaves the URL in place when the loader fails (returns null)', async () => {
+    const loader = vi.fn(async () => null);
+    const out = await inlineApkgMedia(
+      '<img src="/api/apkg/k1/media/a.png" />',
+      loader
+    );
+    expect(out).toContain('/api/apkg/k1/media/a.png');
+  });
+
+  it('reuses a shared cache across calls so media is fetched once', async () => {
+    const loader = vi.fn(async () => 'data:image/png;base64,AAA');
+    const cache = new Map<string, string | null>();
+    const html = '<img src="/api/apkg/k1/media/a.png" />';
+    await inlineApkgMedia(html, loader, cache);
+    await inlineApkgMedia(html, loader, cache);
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/pages/PreviewApkgPage/inlineMedia.ts
+++ b/web/src/pages/PreviewApkgPage/inlineMedia.ts
@@ -1,0 +1,49 @@
+const MEDIA_URL_REGEX = /"(\/api\/apkg\/[^"]*\/media\/[^"]*)"/g;
+
+export function extractApkgMediaUrls(html: string): string[] {
+  const urls = new Set<string>();
+  for (const match of Array.from(html.matchAll(MEDIA_URL_REGEX))) {
+    urls.add(match[1]);
+  }
+  return Array.from(urls);
+}
+
+export async function fetchMediaAsDataUrl(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, { credentials: 'include' });
+    if (!response.ok) return null;
+    const blob = await response.blob();
+    return await new Promise<string | null>((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () =>
+        resolve(typeof reader.result === 'string' ? reader.result : null);
+      reader.onerror = () => resolve(null);
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function inlineApkgMedia(
+  html: string,
+  loadDataUrl: (url: string) => Promise<string | null>,
+  cache: Map<string, string | null> = new Map()
+): Promise<string> {
+  const urls = extractApkgMediaUrls(html);
+  await Promise.all(
+    urls.map(async (url) => {
+      if (!cache.has(url)) {
+        cache.set(url, await loadDataUrl(url));
+      }
+    })
+  );
+  let out = html;
+  for (const url of urls) {
+    const dataUrl = cache.get(url);
+    if (dataUrl) {
+      out = out.split(url).join(dataUrl);
+    }
+  }
+  return out;
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-28-preview-card-images.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-28-preview-card-images.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-28-preview-card-images",
+  "date": "2026-05-28",
+  "type": "fix",
+  "title": "Card images show in the deck preview"
+}


### PR DESCRIPTION
## What

Card images were broken in the deck preview. Root cause is **not** the server: I fetched the reported apkg and ran the real code — the media manifest maps the filenames to numeric entries, the bytes are present, `getMediaEntry` returns them, and the Content-Type resolves correctly. Everything server-side works.

The break is the renderer. Preview cards render in an iframe sandboxed `allow-scripts` with **no `allow-same-origin`**, so the card HTML's `<img src="/api/apkg/:key/media/…">` requests go out from a null origin **without the auth cookie** → the authenticated media endpoint 401s → broken images. (The cards themselves load because the authed parent fetches them with `credentials: 'include'`.)

`allow-same-origin` can't be added — combined with `allow-scripts` it would let untrusted Anki card HTML escape the sandbox. Instead, the authenticated parent now fetches each media file and inlines it as a `data:` URL before building the iframe `srcDoc`. The sandbox stays locked, and a shared cache fetches each file once across cards and flips.

## Tests

- New `inlineApkgMedia` / `extractApkgMediaUrls` unit tests (dedup, external-URL passthrough, failed-fetch passthrough, shared-cache reuse, URL-encoded filenames).
- Updated `CardFrame` tests for the now-async `srcDoc`.
- Web typecheck, biome, 21/21 PreviewApkgPage vitest pass.

## Supersedes #2853

#2853 misdiagnosed this — it concluded the service was correct (true) but shipped only characterization tests + a changelog *claiming* a fix, with no source change. Closed in favor of this real fix.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Verified on the live local reproduction — card images render in the preview.
