### PR TITLE
fix: quiet expected-state noise from prod error log and recover more cloze decks

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -89,6 +89,21 @@ describe('parseDeckResponse', () => {
     );
   });
 
+  it('recovers a cloze-only deck where every card has a: "" (cloze cards legitimately have no answer field)', () => {
+    const broken =
+      '[{"deck":"Cloze Test","cards":[{"q":"{{c1::Paris}} is the capital of France","a":"","cloze":true}]}]';
+    expect(() => JSON.parse(broken)).not.toThrow();
+    const withRepair = broken.slice(0, -2);
+    expect(() => JSON.parse(withRepair)).toThrow();
+    const clozeOnly = '[{"deck":"Cloze Test","cards":[{"q":"The {{c1::mitochondria}} is the powerhouse","a":"","cloze":true}]}';
+    const parsed = parseDeckResponse(clozeOnly, clozeOnly, 0);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].deck).toBe('Cloze Test');
+    expect(parsed[0].cards).toHaveLength(1);
+    expect(parsed[0].cards[0].q).toContain('mitochondria');
+    expect(parsed[0].cards[0].cloze).toBe(true);
+  });
+
   it('tolerates leading, interior, and trailing whitespace inside the JSON portion', () => {
     const padded = `  \n\t${deckJson}   \n  `;
     expect(parseDeckResponse(padded, padded, 0)).toEqual(deck);

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -385,7 +385,10 @@ function tryRepairDeckArray(toParse: string): unknown[] | null {
       if (!card || typeof card !== 'object') return false;
       const q = (card as { q?: unknown }).q;
       const a = (card as { a?: unknown }).a;
-      return typeof q === 'string' && q.length > 0 && typeof a === 'string' && a.length > 0;
+      const cloze = (card as { cloze?: unknown }).cloze;
+      const hasQ = typeof q === 'string' && q.length > 0;
+      const hasA = typeof a === 'string' && a.length > 0;
+      return hasQ && (hasA || cloze === true);
     });
   });
   return hasUsableCard ? candidate : null;
@@ -418,7 +421,7 @@ export function parseDeckResponse(
     const repaired = tryRepairDeckArray(toParse);
     if (repaired) {
       parsed = repaired;
-      console.warn('[Claude] Recovered malformed JSON via jsonrepair', { chunkIndex });
+      console.log('[Claude] Recovered malformed JSON via jsonrepair', { chunkIndex });
     } else {
       console.error('[Claude] Failed to parse response as JSON', {
         raw,

--- a/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.test.ts
@@ -159,19 +159,19 @@ describe('ApkgPreviewService.getCardsPage', () => {
   });
 
   describe('ord-out-of-range fallback', () => {
-    it('emits a warn log when a card ord exceeds the noteType template count', () => {
+    it('emits a debug log when a card ord exceeds the noteType template count', () => {
       const parsed = makeParsed(makeBadOrdClozeCollection());
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
 
       service.getCardsPage(parsed, 0, 10, 'http://example.com');
 
-      const templateOrdWarnings = warnSpy.mock.calls.filter(([msg]) =>
+      const templateOrdDebugs = debugSpy.mock.calls.filter(([msg]) =>
         String(msg).includes('template ord=')
       );
-      warnSpy.mockRestore();
+      debugSpy.mockRestore();
 
-      expect(templateOrdWarnings).toHaveLength(1);
-      expect(String(templateOrdWarnings[0][0])).toContain('n2a-cloze');
+      expect(templateOrdDebugs).toHaveLength(1);
+      expect(String(templateOrdDebugs[0][0])).toContain('n2a-cloze');
     });
 
     it('still renders the out-of-range card against ord=0 instead of dropping it', () => {

--- a/src/services/ApkgPreviewService/ApkgPreviewService.ts
+++ b/src/services/ApkgPreviewService/ApkgPreviewService.ts
@@ -160,7 +160,7 @@ export default class ApkgPreviewService {
       return null;
     }
     if (!foundTemplate) {
-      console.warn(`[apkg-preview] card ${cardId}: template ord=${templateOrd} not found in noteType "${noteType.name}" (has ${noteType.templates.length} templates) — rendering against ord=0`);
+      console.debug(`[apkg-preview] card ${cardId}: template ord=${templateOrd} not found in noteType "${noteType.name}" (has ${noteType.templates.length} templates) — rendering against ord=0`);
     }
     const deck = parsed.collection.decks.get(card.did);
 

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -35,6 +35,7 @@ export const KNOWN_EVENTS = new Set([
   'upload_ai_anon_badge_clicked',
   'home_ai_anon_badge_viewed',
   'home_ai_anon_badge_clicked',
+  'home_card_options_link_clicked',
   'tts_lang_injected',
   'paywall_dismissed',
   'pricing_left',

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-28-ai-cloze-recovery-completes.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-28-ai-cloze-recovery-completes.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-28-ai-cloze-recovery-completes",
+  "date": "2026-05-28",
+  "type": "fix",
+  "title": "AI conversions of pages with cloze deletions recover more cards when the response is malformed"
+}


### PR DESCRIPTION
## What
Four small prod log fixes bundled into one PR:

1. **ApkgPreviewService — demote template-ord log to `console.debug`**: the `warn` fired after the clamp-to-`templates[0]` fallback already handled the situation; the log was not actionable. Now a debug line operators only see if they opt in.
2. **AnalyticsEvents — register `home_card_options_link_clicked`**: the event was fired from the web client but missing from `KNOWN_EVENTS`, causing a spurious unknown-event warn on every click.
3. **ClaudeService — demote jsonrepair recovery log to `console.log`**: the recovery path is a success outcome; routing it through `console.warn` sent it to stderr and pm2's error log. No behavior change for callers.
4. **ClaudeService `tryRepairDeckArray` — accept cloze cards with `a: ""`**: the plausibility check `q.length > 0 && a.length > 0` rejected any repaired deck that contained only cloze cards. Cloze cards legitimately carry an empty `a` field per `SYSTEM_PROMPT`. The loosened check now passes when `cloze === true`, recovering decks that `jsonrepair` could fix but the plausibility guard was discarding.

## Why
Fixes 1, 2, 3 reduce error-log noise so real errors stand out. Fix 4 is user-visible: pages whose Claude response was slightly malformed but repairable now yield a complete cloze deck instead of throwing "Claude returned invalid JSON".

## How
- `console.warn` → `console.debug` on the post-fallback line in `renderCard`; test updated from `warnSpy` to `debugSpy`.
- Added `'home_card_options_link_clicked'` to `KNOWN_EVENTS` set, matching position in `web/src/lib/analytics/events.ts`.
- `console.warn` → `console.log` on the jsonrepair recovery line in `parseDeckResponse`.
- `tryRepairDeckArray` plausibility check now uses `hasQ && (hasA || cloze === true)` instead of `hasQ && hasA`.

## Measuring success
- **Fixes 1–3:** `pm2 logs` on prod shows the three specific log lines no longer appear in the error stream.
- **Fix 4:** After deploy, `grep '\[Claude\] Recovered malformed JSON via jsonrepair' /pm2/logs/out.log` should show recoveries that previously ended in `[Claude] Failed to parse response as JSON`.

## Testing
- Unit tests added: 1 new test in `ClaudeService.test.ts` for cloze-only deck recovery.
- Test updated: `ApkgPreviewService.test.ts` — renamed "emits a warn log" → "emits a debug log", spy changed from `console.warn` to `console.debug`.
- All 55 ClaudeService tests pass; all 10 ApkgPreviewService tests pass; server tsc clean; web typecheck clean; 1305 web vitest pass.

## Browser check
Browser check: not applicable — server-only changes; web/src diff is changelog only

## Changelog
`AI conversions of pages with cloze deletions recover more cards when the response is malformed` — added to `web/src/pages/WhatsNewPage/changelog/2026-05-28-ai-cloze-recovery-completes.json`.

Fixes 1–3 are internal operator-only (no user-visible change, no changelog entry).

## Risks
Fix 4 loosens the plausibility check — it now accepts a deck where every card has `a: ""` as long as `cloze: true` is set. A hypothetical pathological repair that produces all-cloze all-empty-q cards is already blocked by `q.length > 0`. No rollback concern: if the fix causes unexpected behavior, reverting `tryRepairDeckArray` to the old `&&` is a one-line revert.

## Goal alignment
Fix 4 directly recovers cards that were silently dropped — more decks succeed for users who write cloze-heavy pages. Fixes 1–3 keep the error log signal/noise ratio high so real production issues surface faster.

## Sonar
This diff touches only existing internal helpers and test updates — small, low cognitive-complexity changes. Sonar scanner not run locally (no `SONAR_TOKEN` configured in this worktree environment); noted here per `.claude/rules/sonar.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782551592&installation_id=132681956&pr_number=2857&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2857&signature=20cdc98467f6504b4fbd0ec66ca132d3611bfab4e9e08a9ba937ce25f962a04d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->