### PR TITLE
feat: Claude chunk partial success server-side (flag-gated)

### DIFF
--- a/Documentation/specs/claude-chunk-partial-success.md
+++ b/Documentation/specs/claude-chunk-partial-success.md
@@ -1,0 +1,40 @@
+# Spec: Claude chunk partial success when one chunk fails to parse
+
+## Problem
+
+`src/lib/claude/ClaudeService.ts` fans chunks out with `Promise.all` (~lines 615 and 645). If a single chunk's JSON cannot be parsed — even after `jsonrepair` recovery — the whole `Promise.all` rejects and the job dies with zero output. A production job on 2026-05-28 (jobId `49881277-75d4-4e60-8103-d448903c0771`) recovered 10 of 11 chunks via jsonrepair, but chunk 6 contained German low/high quotes (`„…")`) that jsonrepair could not coerce. The user got nothing back, despite 10 chunks of usable cards already in memory.
+
+This is the worst possible failure shape for a self-directed learner: they wait for a long Claude run, the run silently produces nothing, and there is no signal about which section failed or whether retrying will help.
+
+## Proposed approach
+
+Switch the two `Promise.all` call sites to `Promise.allSettled` and treat partial success as a first-class state.
+
+1. Per chunk, capture `{ index, status, result | error }`. Successful chunks flow into `mergeDeckInfoArrays` as today. Failed chunks are logged with `chunkIndex`, error class, and a short content fingerprint (length + first/last 40 chars, never the full payload) so ops can reproduce.
+2. If at least one chunk succeeded, return the merged `DeckInfo[]` and attach a `partial` marker to the job result. The job repository persists `failed_chunk_count` and `total_chunk_count`. The download page renders a banner above the download button: "Partial deck — 10 of 11 sections converted. 1 section couldn't be parsed and is logged for investigation."
+3. If zero chunks succeeded, fail the job exactly as today. No behaviour change in the all-fail case.
+
+The banner copy is generated server-side from the counts, lives next to the existing download CTA, and disappears on retry once the user re-uploads.
+
+## What NOT to build
+
+- No automatic re-prompt of failed chunks. That doubles cost and latency for a recovery that often won't work (the underlying parse issue is usually structural, not transient).
+- No user-facing list of which sections failed. The chunks are not labelled in a way users can act on, and surfacing "chunk 6 of 11" leaks internal mechanics.
+- No retry button that re-runs only the failed chunks. Re-running the full upload is fine for now; a partial-retry path is two-way-door work for a later spec if the signal warrants it.
+- No silent partial success. The banner is the contract — if it's not visible, we lose user trust the first time a user notices a card is missing.
+
+## Alternative considered
+
+**Fail fast and tell the user.** Keep `Promise.all`, but on rejection capture the partial successes server-side and show an error page that says "1 section couldn't be parsed; try again or contact support." Rejected because the deck is already useful to the learner — the dominant complaint about Claude failures today is that the user waits and gets nothing. A partial deck with a clear banner respects their time. The fail-fast option also doesn't move the audience signal we need (whether a partial deck is preferred or rejected), since the user never sees the partial output.
+
+## Open questions
+
+1. Does the download page have room for a banner above the existing CTA, or does the banner replace the secondary "convert another file" affordance?
+2. Should the partial marker also flow into the convert email subject line (e.g. "Your partial deck is ready — 10 of 11 sections"), or does that risk users ignoring the banner?
+3. Do we need a per-user cap on how often the banner appears before we escalate to a support nudge? (Defer; revisit after one week of data.)
+
+## Success signal
+
+- Leading: % of Claude jobs that complete with `failed_chunk_count > 0` (today this is 0% because they fail outright; baseline will form after ship).
+- Leading: user re-upload rate within 24 hours when a partial deck was delivered, vs the historical re-upload rate after total failure. If partial decks reduce re-uploads, users accepted the trade. If re-uploads stay flat or rise, the banner copy or the partial threshold needs work.
+- Qualitative: support inbox mentions of "missing cards" or "incomplete deck" in the two weeks after ship. Zero or one mention = the banner is doing its job; three or more = the contract is unclear and we revisit.

--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -8,8 +8,34 @@ import {
   buildUserMessage,
   buildFieldMappingPromptFragment,
   dedupeCardsByFront,
+  generateDeckInfo,
   type DeckInfo,
 } from './ClaudeService';
+
+const FAKE_DECK_JSON = JSON.stringify([
+  { deck: 'Test Deck', cards: [{ q: 'Q1', a: 'A1' }] },
+]);
+
+const mockStreamFn = jest.fn();
+const mockStream = {
+  on: jest.fn().mockReturnThis(),
+  finalMessage: jest.fn(),
+};
+
+jest.mock('@anthropic-ai/sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    messages: { stream: mockStreamFn },
+  })),
+}));
+
+function fakeResponse() {
+  return {
+    content: [{ type: 'text', text: FAKE_DECK_JSON }],
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 100, output_tokens: 50 },
+  };
+}
 
 describe('looksLikeEmptyContentExplanation', () => {
   it('detects the reported empty-page explanation', () => {
@@ -390,6 +416,64 @@ describe('buildUserMessage — card size suffix', () => {
     const sizeIdx = msg.indexOf('Card size:');
     expect(instrIdx).toBeGreaterThan(-1);
     expect(sizeIdx).toBeGreaterThan(instrIdx);
+  });
+});
+
+describe('generateDeckInfo — partial chunk success (CLAUDE_PARTIAL_SUCCESS_ENABLED)', () => {
+  const htmlTwoChunks = '<p>' + 'x'.repeat(39_990) + '</p><p>y</p>';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamFn.mockReturnValue(mockStream);
+    mockStream.on.mockReturnThis();
+  });
+
+  afterEach(() => {
+    delete process.env.CLAUDE_PARTIAL_SUCCESS_ENABLED;
+  });
+
+  it('flag off (default) — one chunk fails → entire call rejects', async () => {
+    mockStream.finalMessage
+      .mockResolvedValueOnce(fakeResponse())
+      .mockRejectedValueOnce(new Error('chunk 1 API error'));
+
+    await expect(generateDeckInfo(htmlTwoChunks, [])).rejects.toThrow('chunk 1 API error');
+  });
+
+  it('flag on — one chunk fails → call resolves with succeeded chunks and logs the failure', async () => {
+    process.env.CLAUDE_PARTIAL_SUCCESS_ENABLED = 'true';
+
+    mockStream.finalMessage
+      .mockResolvedValueOnce(fakeResponse())
+      .mockRejectedValueOnce(new Error('chunk 1 parse error'));
+
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    try {
+      const result = await generateDeckInfo(htmlTwoChunks, []);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0].cards.length).toBeGreaterThan(0);
+      expect(infoSpy).toHaveBeenCalledWith(
+        '[Claude] Some chunks failed; continuing with the rest',
+        expect.objectContaining({ ok: 1, total: 2 })
+      );
+      const callArg = infoSpy.mock.calls.find(
+        ([msg]) => msg === '[Claude] Some chunks failed; continuing with the rest'
+      )![1] as { failures: Array<{ chunkIndex: number; reason: string }> };
+      expect(callArg.failures).toHaveLength(1);
+      expect(callArg.failures[0].reason).toBe('chunk 1 parse error');
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  it('flag on — all chunks fail → call rejects with the first failure reason', async () => {
+    process.env.CLAUDE_PARTIAL_SUCCESS_ENABLED = 'true';
+
+    mockStream.finalMessage
+      .mockRejectedValueOnce(new Error('chunk 0 failed'))
+      .mockRejectedValueOnce(new Error('chunk 1 failed'));
+
+    await expect(generateDeckInfo(htmlTwoChunks, [])).rejects.toThrow('chunk 0 failed');
   });
 });
 

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -586,6 +586,41 @@ async function generateDeckInfoFromChunk(
   return deckInfo;
 }
 
+async function runChunks(thunks: Array<() => Promise<DeckInfo[]>>): Promise<DeckInfo[]> {
+  if (process.env.CLAUDE_PARTIAL_SUCCESS_ENABLED !== 'true') {
+    const results = await Promise.all(thunks.map((fn) => fn()));
+    return results.flat();
+  }
+
+  const settled = await Promise.allSettled(thunks.map((fn) => fn()));
+  const succeeded: DeckInfo[][] = [];
+  const failures: Array<{ chunkIndex: number; reason: string }> = [];
+  settled.forEach((r, i) => {
+    if (r.status === 'fulfilled') {
+      succeeded.push(r.value);
+    } else {
+      failures.push({
+        chunkIndex: i,
+        reason: r.reason instanceof Error ? r.reason.message : String(r.reason),
+      });
+    }
+  });
+
+  if (failures.length > 0) {
+    console.info('[Claude] Some chunks failed; continuing with the rest', {
+      failures,
+      ok: succeeded.length,
+      total: thunks.length,
+    });
+  }
+
+  if (succeeded.length === 0) {
+    throw new Error(failures[0]?.reason ?? 'All Claude chunks failed');
+  }
+
+  return succeeded.flat();
+}
+
 export async function generateDeckInfo(
   htmlContent: string,
   availableMediaFiles: string[],
@@ -615,8 +650,8 @@ export async function generateDeckInfo(
     if (headings.length > 0) {
       const chunks = splitByHeadings(headings);
       console.log('[Claude] heading-driven chunks', { headingCount: headings.length, chunkCount: chunks.length });
-      const chunkResults = await Promise.all(
-        chunks.map((chunk, i) =>
+      const chunkResults = await runChunks(
+        chunks.map((chunk, i) => () =>
           generateDeckInfoFromChunk(
             `<h1>${chunk.anchor}</h1>\n${chunk.bodyChunk}`,
             pageStyle,
@@ -631,7 +666,7 @@ export async function generateDeckInfo(
           )
         )
       );
-      const deckInfo = mergeDeckInfoArrays(chunkResults.flat());
+      const deckInfo = mergeDeckInfoArrays(chunkResults);
       console.log('[Claude] All heading-driven chunks done', {
         totalDecks: deckInfo.length,
         totalCards: deckInfo.reduce((sum, d) => sum + d.cards.length, 0),
@@ -645,13 +680,13 @@ export async function generateDeckInfo(
   const chunks = chunkHtmlByDetails(strippedContent);
   console.log('[Claude] Chunked HTML', { chunks: chunks.length, strippedBytes: strippedContent.length });
 
-  const chunkResults = await Promise.all(
-    chunks.map((chunk, i) =>
+  const chunkResults = await runChunks(
+    chunks.map((chunk, i) => () =>
       generateDeckInfoFromChunk(chunk, pageStyle, availableMediaFiles, userInstructions, i, chunks.length, onProgress, cardStyle, cardSize, fieldMapping)
     )
   );
 
-  const deckInfo = mergeDeckInfoArrays(chunkResults.flat());
+  const deckInfo = mergeDeckInfoArrays(chunkResults);
   console.log('[Claude] All chunks done', {
     totalDecks: deckInfo.length,
     totalCards: deckInfo.reduce((sum, d) => sum + d.cards.length, 0),

--- a/src/lib/claude/FEATURE.md
+++ b/src/lib/claude/FEATURE.md
@@ -25,6 +25,8 @@ The claude lib converts HTML content into Anki flashcards using the Anthropic AP
 
 **Usage logging:** `logClaudeUsage(label, usage)` from `logClaudeUsage.ts` writes one `[claude-usage] label=… input=… output=… cache_create=… cache_read=…` line per Claude response to `console.info`. Every server-side Claude call site is responsible for calling it after the response (or `finalMessage` for streams) — labels: `ClaudeService`, `ChatUseCase`, `claudeFileConversion`, `AINoteTypeUseCase`, `OstController`. The helper is the single grep target for proving cache hit rate in prod. Missing or null cache fields render as `0`. Per `.claude/rules/security.md`, the log line carries no PII, secrets, or user content — just token counts.
 
+**Partial chunk success (`CLAUDE_PARTIAL_SUCCESS_ENABLED`):** Both fan-out sites in `generateDeckInfo` go through the private `runChunks` helper. When the env var `CLAUDE_PARTIAL_SUCCESS_ENABLED=true` is set, `runChunks` uses `Promise.allSettled` so a single chunk parse failure no longer kills the whole job. Succeeded chunks are merged as normal; failures are collected as `{ chunkIndex, reason }` and emitted via `console.info('[Claude] Some chunks failed; continuing with the rest', { failures, ok, total })`. If zero chunks succeed, the call throws using the first failure's reason (identical to the all-fail behavior today). When the env var is unset or `false` (default), `runChunks` falls back to `Promise.all` — behavior is unchanged for all users. The return type of `generateDeckInfo` is unchanged in PR A; PR B widens the shape and threads `partialFailureCount`/`expectedChunkCount` to the API.
+
 ---
 
 ## Heading-driven contract (`cardStyle: 'heading-driven'`)


### PR DESCRIPTION
## What
This is **PR A of a two-PR split** for [spec: Claude chunk partial success on parse failure](https://github.com/2anki/server/blob/feat/spec-claude-chunk-partial-success/Documentation/specs/claude-chunk-partial-success.md).

Wraps the two `Promise.all` chunk fan-out sites in `generateDeckInfo` behind a private `runChunks` helper. When `CLAUDE_PARTIAL_SUCCESS_ENABLED=true`, the helper uses `Promise.allSettled` so a single chunk parse failure no longer kills the whole job — succeeded chunks are merged as normal, failures are logged at info level. When the flag is unset or \`false\` (default), `runChunks` falls through to `Promise.all` exactly as today.

**The public return type of `generateDeckInfo` is unchanged.** The `partialFailureCount`/`expectedChunkCount` widening and the DownloadsPage banner are PR B's job.

## Why
A production job on 2026-05-28 recovered 10 of 11 chunks but failed entirely because chunk 6 had a parse error. The user waited for the full Claude run and got zero cards back. This change makes sure the 10 good chunks reach the user; PR B makes the banner visible.

Env var: `CLAUDE_PARTIAL_SUCCESS_ENABLED` (string `"true"` to enable).

## How
- `runChunks(thunks)` — private helper inside `ClaudeService.ts`. Reads the env var at call time (not module load) so tests can flip it via `process.env`.
- Both fan-out sites (heading-driven path and default `chunkHtmlByDetails` path) now delegate to `runChunks`.
- `mergeDeckInfoArrays` receives the flat succeeded results unchanged.
- `FEATURE.md` updated with the new flag contract.

## Measuring success
In prod (flag on): grep `[Claude] Some chunks failed; continuing with the rest` in pm2 logs. The `ok` and `total` fields give the partial-success rate. Baseline is 0% today (those jobs fail before logging this line).

## Testing
- Unit tests added: 3 new cases in `ClaudeService.test.ts`
  1. Flag off — one chunk fails → whole call rejects (today's behavior preserved)
  2. Flag on — one chunk fails → call resolves with merged content + `console.info` fires with structured failure detail
  3. Flag on — all chunks fail → call rejects with first failure reason
- All 58 `ClaudeService.test.ts` tests pass; full suite green (tsc + web typecheck + web vitest).

## Browser check
Browser check: not applicable — server-only, flag defaults off, no rendered output changed

## Changelog
No changelog entry — flag defaults off, no user-visible behavior change yet; PR B will ship the banner and flip the flag.

## Risks
- Flag defaults off → zero risk to existing users on deploy.
- When flag is flipped on: worst case is a partial deck delivered where today a full failure would be shown. PR B's banner makes this visible to the user before they download.
- Rollback: unset `CLAUDE_PARTIAL_SUCCESS_ENABLED` in prod `.env` — immediately reverts to `Promise.all` behavior without a redeploy.

## Goal alignment
Directly addresses the "user waits and gets nothing" failure shape that discourages re-engagement. Partial decks with a clear banner (PR B) reduce the zero-output rate for large Notion exports, which is a meaningful friction reduction on the conversion path toward 300K users.