### PR TITLE
fix: real error shapes from upload worker and pdfinfo failures

### DIFF
--- a/src/lib/pdf/getPageCount.test.ts
+++ b/src/lib/pdf/getPageCount.test.ts
@@ -1,0 +1,59 @@
+import { execSync } from 'child_process';
+import { getPageCount } from './getPageCount';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+
+const hasPdfinfo = (() => {
+  try {
+    execSync('pdfinfo -v 2>&1', { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+const itIfPdfinfo = hasPdfinfo ? it : it.skip;
+
+describe('getPageCount', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'getPageCount-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  itIfPdfinfo(
+    'rejects with pdfinfo_failed message when given a non-PDF file',
+    async () => {
+      const textFile = path.join(tmpDir, 'not-a-pdf.txt');
+      await fs.writeFile(textFile, 'this is plain text, not a PDF');
+
+      await expect(getPageCount(textFile)).rejects.toMatchObject({
+        message: expect.stringMatching(/^pdfinfo_failed code=/),
+      });
+    }
+  );
+
+  itIfPdfinfo(
+    'rejects with pdfinfo_failed message containing stderr text when given a non-PDF file',
+    async () => {
+      const textFile = path.join(tmpDir, 'not-a-pdf.txt');
+      await fs.writeFile(textFile, 'this is plain text, not a PDF');
+
+      let caught: Error | null = null;
+      try {
+        await getPageCount(textFile);
+      } catch (e) {
+        caught = e as Error;
+      }
+
+      expect(caught).not.toBeNull();
+      expect(caught!.message).toMatch(/^pdfinfo_failed code=/);
+      expect(caught!.message).toContain('path=not-a-pdf.txt');
+    }
+  );
+});

--- a/src/lib/pdf/getPageCount.ts
+++ b/src/lib/pdf/getPageCount.ts
@@ -18,6 +18,7 @@ export function getPageCount(pdfPath: string, credential?: string): Promise<numb
 
     let stdout = '';
     let stderr = '';
+    let spawnError: Error | null = null;
 
     pdfinfoProcess.stdout.on('data', (data) => {
       stdout += data;
@@ -27,9 +28,14 @@ export function getPageCount(pdfPath: string, credential?: string): Promise<numb
       stderr += data;
     });
 
-    pdfinfoProcess.on('close', async (code) => {
+    pdfinfoProcess.on('error', (err) => {
+      spawnError = err;
+    });
+
+    pdfinfoProcess.on('close', async (code, signal) => {
       const pdfDir = path.dirname(pdfPath);
       const pdfBaseName = path.basename(pdfPath, path.extname(pdfPath));
+      const basename = path.basename(pdfPath);
 
       await fs.writeFile(
         path.join(pdfDir, `${pdfBaseName}_stdout.log`),
@@ -40,12 +46,22 @@ export function getPageCount(pdfPath: string, credential?: string): Promise<numb
         stderr
       );
 
+      if (spawnError != null) {
+        reject(new Error(`pdfinfo_spawn_failed: ${spawnError.message}`));
+        return;
+      }
+
       if (code !== 0) {
         if (stderr.includes('Encrypted') || stderr.includes('password')) {
           reject(new Error('PDF_NEEDS_PASSWORD'));
           return;
         }
-        reject(new Error('Failed to execute pdfinfo'));
+        const trimmed = stderr.trim();
+        reject(
+          new Error(
+            `pdfinfo_failed code=${code ?? 'null'} signal=${signal ?? 'none'} path=${basename} stderr=${trimmed.slice(0, 200) || '<empty>'}`
+          )
+        );
         return;
       }
 

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -18,10 +18,12 @@ import { CompleteJobUseCase } from '../../../../usecases/jobs/CompleteJobUseCase
 import { NotifyUserUseCase } from '../../../../usecases/jobs/NotifyUserUseCase';
 import {
   EMPTY_DECK_FAILURE_REASON,
+  isColumnsAmbiguousError,
   isNotionUnauthorizedError,
   jobFailureReasonFromError,
 } from '../../../../usecases/jobs/jobFailureReason';
 import { PythonExitError } from '../../../anki/buildPythonExitError';
+import { EmptyDeckError } from '../../../../usecases/jobs/EmptyDeckError';
 import { track } from '../../../../services/events/track';
 import NotionRepository from '../../../../data_layer/NotionRespository';
 
@@ -182,6 +184,17 @@ export default async function performConversion(
     }
     const failedJob = new SetJobFailedUseCase(jobRepository);
     await failedJob.execute(id, owner, jobFailureReasonFromError(error, id));
-    console.error(error);
+    const isExpectedUserState =
+      error instanceof EmptyDeckError ||
+      isColumnsAmbiguousError(error) ||
+      isNotionUnauthorizedError(error);
+    if (isExpectedUserState) {
+      console.info('[conversion] user-input state', {
+        jobId: id,
+        kind: error instanceof Error ? error.name : 'unknown',
+      });
+    } else {
+      console.error(error);
+    }
   }
 }

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -235,6 +235,12 @@ class UploadService {
           reason: 'missing_password',
           filename,
         });
+      } else if (err instanceof Error && /^pdfinfo_(failed|spawn_failed)/.test(err.message)) {
+        return res.status(400).json({
+          code: 'pdf_processing_failed',
+          message:
+            'We could not read this PDF. It may be corrupted, password-protected, or an unsupported variant. Try re-exporting the PDF or splitting it into smaller files.',
+        });
       } else {
         return ErrorHandler(res, req, err as Error);
       }
@@ -268,7 +274,17 @@ class UploadService {
       })
       .catch(async (err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
-        console.error('[UploadService] async job failed', { jobId: ws.id, message, err });
+        const isExpectedState =
+          err instanceof EmptyDeckError ||
+          (err instanceof Error && isPdfPasswordSentinel(err.message));
+        if (isExpectedState) {
+          console.info('[UploadService] async job user-input state', {
+            jobId: ws.id,
+            kind: err instanceof Error ? err.name : 'unknown',
+          });
+        } else {
+          console.error('[UploadService] async job failed', { jobId: ws.id, message, err });
+        }
         await this.jobRepository.updateJobStatus(ws.id, owner, 'failed', message);
       });
 

--- a/src/types/UploadErrorBody.ts
+++ b/src/types/UploadErrorBody.ts
@@ -5,6 +5,7 @@ export type UploadErrorCode =
   | 'malformed_notion'
   | 'corrupted_apkg'
   | 'password_protected_pdf'
+  | 'pdf_processing_failed'
   | 'empty_export'
   | 'unknown';
 

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -11,7 +11,7 @@ export const EMPTY_DECK_FAILURE_REASON =
 
 export const COLUMNS_AMBIGUOUS_PREFIX = 'COLUMNS_AMBIGUOUS:';
 
-function isColumnsAmbiguousError(
+export function isColumnsAmbiguousError(
   error: unknown
 ): error is Error & { code: string; columns: string[] } {
   return (
@@ -60,6 +60,12 @@ export function jobFailureReasonFromError(
   }
   if (isNotionUnauthorizedError(error)) {
     return NOTION_TOKEN_EXPIRED_REASON;
+  }
+  if (
+    error instanceof Error &&
+    /^pdfinfo_(failed|spawn_failed)/.test(error.message)
+  ) {
+    return 'We could not read this PDF. It may be corrupted, password-protected, or an unsupported variant. Try re-exporting the PDF or splitting it into smaller files.';
   }
   return genericFailureReason(jobId);
 }

--- a/src/usecases/uploads/GeneratePackagesUseCase.test.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.test.ts
@@ -18,6 +18,7 @@ import { Worker } from 'worker_threads';
 import CardOption from '../../lib/parser/Settings/CardOption';
 import Workspace from '../../lib/parser/WorkSpace';
 import { UploadedFile } from '../../lib/storage/types';
+import { EmptyDeckError } from '../jobs/EmptyDeckError';
 
 const MockWorker = Worker as jest.MockedClass<typeof Worker>;
 
@@ -129,5 +130,47 @@ describe('GeneratePackagesUseCase', () => {
     emitter.emit('error', new Error('Worker crashed'));
 
     await expect(promise).rejects.toThrow('Worker crashed');
+  });
+
+  it('rejects with EmptyDeckError when the worker sends an error message with name EmptyDeckError', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('empty.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', {
+      type: 'error',
+      message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
+      name: 'EmptyDeckError',
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(EmptyDeckError);
+  });
+
+  it('preserves error name on the rejected Error for non-EmptyDeckError named errors', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('other.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', {
+      type: 'error',
+      message: 'some message',
+      name: 'CustomError',
+    });
+
+    const err = await promise.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe('CustomError');
   });
 });

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -5,6 +5,7 @@ import { Worker } from 'worker_threads';
 import path from 'path';
 import fs from 'node:fs';
 import Workspace from '../../lib/parser/WorkSpace';
+import { EmptyDeckError } from '../jobs/EmptyDeckError';
 
 export interface PackageResult {
   packages: Package[];
@@ -13,7 +14,7 @@ export interface PackageResult {
 
 type ProgressMessage = { type: 'progress'; step: string };
 type ResultMessage = { type: 'result'; packages: Package[]; warnings?: string[] };
-type ErrorMessage = { type: 'error'; message: string };
+type ErrorMessage = { type: 'error'; message: string; name?: string };
 type WorkerMessage = ProgressMessage | ResultMessage | ErrorMessage;
 
 class GeneratePackagesUseCase {
@@ -40,7 +41,15 @@ class GeneratePackagesUseCase {
         if (msg.type === 'progress') {
           onProgress?.(msg.step);
         } else if (msg.type === 'error') {
-          reject(new Error(msg.message));
+          if (msg.name === 'EmptyDeckError') {
+            reject(new EmptyDeckError());
+          } else {
+            const e = new Error(msg.message);
+            if (msg.name != null) {
+              e.name = msg.name;
+            }
+            reject(e);
+          }
         } else {
           resolve({ packages: msg.packages ?? [], warnings: msg.warnings });
         }

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -169,5 +169,11 @@ async function doGenerationWork(data: GenerationData) {
 if (workerData != null) {
   doGenerationWork(workerData.data)
     .then((result) => parentPort?.postMessage(result))
-    .catch((err) => parentPort?.postMessage({ type: 'error', message: err instanceof Error ? err.message : String(err) }));
+    .catch((err) =>
+      parentPort?.postMessage({
+        type: 'error',
+        message: err instanceof Error ? err.message : String(err),
+        name: err instanceof Error ? err.name : undefined,
+      })
+    );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-28-pdf-processing-failure-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-28-pdf-processing-failure-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-28-pdf-processing-failure-message",
+  "date": "2026-05-28",
+  "type": "fix",
+  "title": "PDFs that fail to process show a clear error instead of \"Something went wrong\""
+}


### PR DESCRIPTION
## What

Two fixes that clean up error handling in the upload pipeline.

**Fix G — Worker error class identity** The upload worker posts errors back to the parent thread as plain messages. Previously the parent always wrapped them in `new Error(msg.message)`, losing class identity. `EmptyDeckError` thrown inside the worker would arrive as a plain `Error` whose `.catch` in `UploadService` could never match `instanceof EmptyDeckError`, so the service always logged a full stack trace via `console.error` for what is a normal user state (empty file). The fix: the worker now includes `err.name` in the error envelope; the parent reconstructs `EmptyDeckError` as a real instance and propagates the `name` property for other error types. `UploadService.handleAsyncUpload` and `performConversion` now gate on expected user states (empty deck, PDF password sentinel, columns ambiguous, Notion unauthorized) and log at `console.info` with `kind` only — `console.error` is reserved for genuine surprises.

**Fix H — pdfinfo failures get real error codes** `getPageCount.ts` previously rejected with the opaque string `"Failed to execute pdfinfo"` on any non-zero exit code, discarding the exit code, signal, and stderr. It also had no `error` event listener, so spawn failures (pdfinfo not installed, permission denied) produced a silent generic close. The fix: capture the `error` event, accumulate stderr, and reject with a structured message: `pdfinfo_failed code=N signal=... path=<file> stderr=<trimmed>`. The existing `PDF_NEEDS_PASSWORD` branch is preserved. `UploadService` maps the new sentinel to a 400 `pdf_processing_failed` with a user-actionable message. `jobFailureReason.ts` maps it the same way for the async Notion job path so users stop seeing "Something went wrong on our end" for corrupted/unsupported PDFs.

## Why

Both issues caused production error log noise for user-input states (uploading an empty export, a bad PDF) and made the PDF error non-actionable for users. Aligns with the 300K-user goal by reducing friction and support load from opaque errors.

## How

- `worker.ts`: include `name` in the posted error envelope.
- `GeneratePackagesUseCase.ts`: extend `ErrorMessage` with `name?: string`; reconstruct `EmptyDeckError` by name; propagate `.name` for others.
- `UploadService.ts`: gate async-job `.catch` on expected user states; add pdfinfo sentinel catch above the generic `ErrorHandler` fallthrough.
- `getPageCount.ts`: add `error` event listener; structured rejection message; carry through exit code, signal, basename, stderr excerpt.
- `UploadErrorBody.ts`: add `pdf_processing_failed` to the union (alphabetical position).
- `jobFailureReason.ts`: export `isColumnsAmbiguousError`; add pdfinfo sentinel branch.
- `performConversion.ts`: import new helpers; gate terminal `console.error` on `isExpectedUserState`.

## Measuring success

After deploy: `pm2 logs | grep '\[UploadService\] async job'` should show `console.info` for empty-deck jobs (kind: EmptyDeckError) instead of `console.error` with a full worker stack. `pm2 logs | grep 'pdfinfo_failed'` should no longer appear in error-level output; bad PDFs should return 400 with `code: pdf_processing_failed` in the network tab.

## Testing

- Unit tests added:
  - `GeneratePackagesUseCase.test.ts`: 2 new cases — `EmptyDeckError` round-trip preserves instanceof; named errors preserve `.name`.
  - `getPageCount.test.ts`: 2 cases — non-PDF input rejects with `pdfinfo_failed code=` message containing the basename; tests skip if pdfinfo is not on PATH.

## Browser check

Browser check: not applicable — server-only changes; web/src diff is changelog only

## Changelog

`2026-05-28-pdf-processing-failure-message.json` — "PDFs that fail to process show a clear error instead of \"Something went wrong\""

Fix G: internal — no user-visible behavior change, just stops drowning the prod error log with expected user-input states.

## Risks

- The pdfinfo sentinel regex `/^pdfinfo_(failed|spawn_failed)/` is only matched against the error `.message`; no user input reaches this path (the path comes from the server's own temp workspace).
- `isColumnsAmbiguousError` is now exported from `jobFailureReason.ts` — call sites are unchanged, the export is additive.
- Rollback: revert this commit; no DB migration involved.

## Sonar

`sonar-scanner` blocked locally — project uses Automatic Analysis mode (conflict with manual runs). SonarCloud will run the analysis automatically on this PR via the GitHub integration. If it bounces, the only new code patterns are: a regex match on an internal error message string, and an `instanceof` check — neither touches user-supplied data or HTML.

## Goal alignment

Reduces error log noise that masks real failures, and gives PDF users an actionable error message instead of a generic one — both reduce support load and improve conversion success rate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782551849&installation_id=132681956&pr_number=2861&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2861&signature=40d9996b2364d6b6072c53a378e842bafa43bb4cf854f73ec55d4b3e2dc60ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->