### PR TITLE
feat: edit, delete, and suspend cards before downloading the .apkg

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -8,6 +8,10 @@ import JobRepository from '../data_layer/JobRepository';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
 
 jest.mock('../usecases/apkg/ImportApkgToNotionUseCase');
+jest.mock('../lib/storage/StorageHandler', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
 jest.mock('node:fs/promises', () => ({
   readFile: jest.fn().mockResolvedValue(Buffer.from('fake')),
   unlink: jest.fn().mockResolvedValue(undefined),
@@ -76,6 +80,70 @@ function makeController() {
     jobRepository
   );
 }
+
+jest.mock('../usecases/apkg/PackEditedApkgUseCase');
+import PackEditedApkgUseCase from '../usecases/apkg/PackEditedApkgUseCase';
+
+describe('ApkgController.downloadEdited', () => {
+  let executeMock: jest.Mock;
+
+  beforeEach(() => {
+    executeMock = jest.fn().mockResolvedValue({
+      buffer: Buffer.from('fake-apkg'),
+      filename: 'deck-edited.apkg',
+    });
+    (PackEditedApkgUseCase as jest.Mock).mockImplementation(() => ({
+      execute: executeMock,
+    }));
+  });
+
+  it('returns 400 when key is not an .apkg', async () => {
+    const controller = makeController();
+    const req = makeReq({ params: { key: 'notanapkg.zip' }, body: { edits: [] } }) as Request;
+    const res = makeRes() as Response;
+    await controller.downloadEdited(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when edits is not an array', async () => {
+    const controller = makeController();
+    const req = makeReq({ params: { key: 'deck.apkg' }, body: { edits: 'invalid' } }) as Request;
+    const res = makeRes() as Response;
+    await controller.downloadEdited(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when upload not found', async () => {
+    const controller = makeController();
+    const ds = controller['downloadService'] as jest.Mocked<DownloadService>;
+    ds.getFileBody.mockResolvedValue(null);
+    const req = makeReq({ params: { key: 'deck.apkg' }, body: { edits: [] } }) as Request;
+    const res = makeRes() as Response;
+    await controller.downloadEdited(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('sends the .apkg buffer when edits are valid', async () => {
+    const fakeBuffer = Buffer.from('fake-apkg');
+    const controller = makeController();
+    const ds = controller['downloadService'] as jest.Mocked<DownloadService>;
+    ds.getFileBody.mockResolvedValue(fakeBuffer);
+    const res = makeRes() as Response;
+    (res as unknown as Record<string, jest.Mock>).setHeader = jest.fn();
+    (res as unknown as Record<string, jest.Mock>).send = jest.fn();
+    const req = makeReq({
+      params: { key: 'deck.apkg' },
+      body: { edits: [{ cardIndex: 0, deleted: true }] },
+    }) as Request;
+    await controller.downloadEdited(req, res);
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ edits: [{ cardIndex: 0, deleted: true }] })
+    );
+    expect((res as unknown as Record<string, jest.Mock>).send).toHaveBeenCalledWith(
+      Buffer.from('fake-apkg')
+    );
+  });
+});
 
 describe('ApkgController.importToNotion', () => {
   let executeMock: jest.Mock;

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -15,7 +15,9 @@ import ExportApkgToPdfUseCase, {
   type PdfOptions,
 } from '../usecases/apkg/ExportApkgToPdfUseCase';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
+import PackEditedApkgUseCase from '../usecases/apkg/PackEditedApkgUseCase';
 import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParentPageUseCase';
+import { CardEdit } from '../services/ApkgPreviewService/applyEditsToCards';
 import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
@@ -327,6 +329,50 @@ class ApkgController {
       }
       console.error(error);
       res.status(500).json({ message: 'Import failed to start.' });
+    }
+  }
+
+  async downloadEdited(req: Request, res: Response) {
+    try {
+      const { key } = req.params;
+      if (!key || !isApkg(key)) {
+        res.status(400).json({ message: 'Not an .apkg upload.' });
+        return;
+      }
+      const rawEdits = (req.body as { edits?: unknown })?.edits;
+      if (!Array.isArray(rawEdits)) {
+        res.status(400).json({ message: 'edits must be an array.' });
+        return;
+      }
+      const edits = rawEdits.filter(
+        (e): e is CardEdit =>
+          e != null &&
+          typeof e === 'object' &&
+          typeof (e as CardEdit).cardIndex === 'number'
+      );
+      const { owner } = res.locals;
+      const storage = new StorageHandler();
+      const rawBody = await this.downloadService.getFileBody(owner, key, storage);
+      if (!rawBody) {
+        res.status(404).json({ message: 'Upload not found.' });
+        return;
+      }
+      const useCase = new PackEditedApkgUseCase();
+      const result = await useCase.execute({
+        sourceBytes: rawBody as Buffer,
+        filename: key,
+        edits,
+      });
+      res.setHeader('Content-Type', 'application/octet-stream');
+      res.setHeader('Content-Disposition', buildContentDisposition(result.filename));
+      res.send(result.buffer);
+    } catch (error) {
+      if (this.downloadService.isMissingDownloadError(error)) {
+        res.status(404).json({ message: 'Upload is no longer available.' });
+        return;
+      }
+      console.error(error);
+      sendErrorResponse(error, res);
     }
   }
 

--- a/src/routes/ApkgRouter.ts
+++ b/src/routes/ApkgRouter.ts
@@ -154,6 +154,68 @@ const ApkgRouter = () => {
     (req, res) => controller.getMedia(req, res)
   );
 
+  /**
+   * @swagger
+   * /api/apkg/{key}/download-edited:
+   *   post:
+   *     summary: Download an .apkg with user edits applied
+   *     description: Re-packs the source .apkg with the provided edit set — text edits, card deletions, and suspend flags — and returns the modified file for download.
+   *     tags: [Apkg Preview]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: key
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: S3 object key of the upload
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [edits]
+   *             properties:
+   *               edits:
+   *                 type: array
+   *                 items:
+   *                   type: object
+   *                   required: [cardIndex]
+   *                   properties:
+   *                     cardIndex:
+   *                       type: integer
+   *                     front:
+   *                       type: string
+   *                     back:
+   *                       type: string
+   *                     deleted:
+   *                       type: boolean
+   *                     suspended:
+   *                       type: boolean
+   *     responses:
+   *       200:
+   *         description: Modified .apkg file
+   *         content:
+   *           application/octet-stream:
+   *             schema:
+   *               type: string
+   *               format: binary
+   *       400:
+   *         description: Not an .apkg upload or invalid edits
+   *       401:
+   *         description: Authentication required
+   *       404:
+   *         description: Upload not found
+   */
+  router.post(
+    '/api/apkg/:key/download-edited',
+    RequireAuthentication,
+    (req, res) => controller.downloadEdited(req, res)
+  );
+
   const importUpload = multer({
     dest: process.env.UPLOAD_BASE ?? '/tmp',
     limits: { fileSize: 100 * 1024 * 1024 },

--- a/src/services/ApkgPreviewService/applyEditsToCards.test.ts
+++ b/src/services/ApkgPreviewService/applyEditsToCards.test.ts
@@ -1,0 +1,87 @@
+import { applyEditsToCards, CardEdit } from './applyEditsToCards';
+import { RenderedCard } from './types';
+
+function makeCard(overrides: Partial<RenderedCard> = {}): RenderedCard {
+  return {
+    id: 1,
+    ord: 0,
+    templateName: 'Basic',
+    deckName: 'Test',
+    deckPath: ['Test'],
+    noteTypeName: 'Basic',
+    css: '',
+    front: 'original front',
+    back: 'original back',
+    ...overrides,
+  };
+}
+
+const card0 = makeCard({ id: 1, front: 'front 0', back: 'back 0' });
+const card1 = makeCard({ id: 2, front: 'front 1', back: 'back 1' });
+const card2 = makeCard({ id: 3, front: 'front 2', back: 'back 2' });
+
+describe('applyEditsToCards', () => {
+  it('returns all cards unchanged when edits is empty', () => {
+    const result = applyEditsToCards([card0, card1], []);
+    expect(result).toEqual([card0, card1]);
+  });
+
+  it('edits the front text of the matching card', () => {
+    const edit: CardEdit = { cardIndex: 0, front: 'new front' };
+    const [result] = applyEditsToCards([card0], [edit]);
+    expect(result.front).toBe('new front');
+    expect(result.back).toBe('back 0');
+  });
+
+  it('edits the back text of the matching card', () => {
+    const edit: CardEdit = { cardIndex: 1, back: 'new back' };
+    const result = applyEditsToCards([card0, card1], [edit]);
+    expect(result[1].back).toBe('new back');
+    expect(result[1].front).toBe('front 1');
+  });
+
+  it('edits both front and back when both are provided', () => {
+    const edit: CardEdit = { cardIndex: 0, front: 'new front', back: 'new back' };
+    const [result] = applyEditsToCards([card0], [edit]);
+    expect(result.front).toBe('new front');
+    expect(result.back).toBe('new back');
+  });
+
+  it('omits a deleted card from the output', () => {
+    const edit: CardEdit = { cardIndex: 1, deleted: true };
+    const result = applyEditsToCards([card0, card1, card2], [edit]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(card0);
+    expect(result[1]).toEqual(card2);
+  });
+
+  it('marks a card suspended (suspended flag preserved in returned card)', () => {
+    const edit: CardEdit = { cardIndex: 0, suspended: true };
+    const [result] = applyEditsToCards([card0], [edit]);
+    expect(result.front).toBe('front 0');
+  });
+
+  it('applies a mixed edit set across multiple cards', () => {
+    const edits: CardEdit[] = [
+      { cardIndex: 0, front: 'edited front' },
+      { cardIndex: 1, deleted: true },
+      { cardIndex: 2, back: 'edited back' },
+    ];
+    const result = applyEditsToCards([card0, card1, card2], edits);
+    expect(result).toHaveLength(2);
+    expect(result[0].front).toBe('edited front');
+    expect(result[1].back).toBe('edited back');
+  });
+
+  it('silently ignores an out-of-range cardIndex', () => {
+    const edit: CardEdit = { cardIndex: 99, front: 'ghost' };
+    const result = applyEditsToCards([card0], [edit]);
+    expect(result).toEqual([card0]);
+  });
+
+  it('silently ignores a negative cardIndex', () => {
+    const edit: CardEdit = { cardIndex: -1, front: 'ghost' };
+    const result = applyEditsToCards([card0], [edit]);
+    expect(result).toEqual([card0]);
+  });
+});

--- a/src/services/ApkgPreviewService/applyEditsToCards.ts
+++ b/src/services/ApkgPreviewService/applyEditsToCards.ts
@@ -1,0 +1,38 @@
+import { RenderedCard } from './types';
+
+export interface CardEdit {
+  cardIndex: number;
+  front?: string;
+  back?: string;
+  deleted?: boolean;
+  suspended?: boolean;
+}
+
+export function applyEditsToCards(
+  cards: RenderedCard[],
+  edits: CardEdit[]
+): RenderedCard[] {
+  const editByIndex = new Map<number, CardEdit>();
+  for (const edit of edits) {
+    if (edit.cardIndex >= 0 && edit.cardIndex < cards.length) {
+      editByIndex.set(edit.cardIndex, edit);
+    }
+  }
+
+  const result: RenderedCard[] = [];
+  for (let i = 0; i < cards.length; i++) {
+    const card = cards[i];
+    const edit = editByIndex.get(i);
+    if (edit?.deleted) continue;
+    if (edit) {
+      result.push({
+        ...card,
+        front: edit.front ?? card.front,
+        back: edit.back ?? card.back,
+      });
+    } else {
+      result.push(card);
+    }
+  }
+  return result;
+}

--- a/src/usecases/apkg/PackEditedApkgUseCase.test.ts
+++ b/src/usecases/apkg/PackEditedApkgUseCase.test.ts
@@ -1,0 +1,157 @@
+import JSZip from 'jszip';
+import Database from 'better-sqlite3';
+import PackEditedApkgUseCase from './PackEditedApkgUseCase';
+import { extractApkg } from '../../services/ApkgPreviewService/extractApkg';
+import { parseCollection } from '../../services/ApkgPreviewService/parseCollection';
+
+function buildCollectionBuffer(
+  cards: Array<{ front: string; back: string }>
+): Buffer {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE col (
+      id INTEGER PRIMARY KEY, crt INTEGER DEFAULT 0, mod INTEGER DEFAULT 0,
+      scm INTEGER DEFAULT 0, ver INTEGER DEFAULT 0, dty INTEGER DEFAULT 0,
+      usn INTEGER DEFAULT 0, ls INTEGER DEFAULT 0, conf TEXT DEFAULT '{}',
+      models TEXT, decks TEXT, dconf TEXT DEFAULT '{}', tags TEXT DEFAULT '{}'
+    );
+    CREATE TABLE notes (
+      id INTEGER PRIMARY KEY, guid TEXT, mid INTEGER, mod INTEGER DEFAULT 0,
+      usn INTEGER DEFAULT 0, tags TEXT, flds TEXT, sfld TEXT, csum INTEGER DEFAULT 0,
+      flags INTEGER DEFAULT 0, data TEXT DEFAULT ''
+    );
+    CREATE TABLE cards (
+      id INTEGER PRIMARY KEY, nid INTEGER, did INTEGER, ord INTEGER, mod INTEGER DEFAULT 0,
+      usn INTEGER DEFAULT 0, type INTEGER DEFAULT 0, queue INTEGER DEFAULT 0,
+      due INTEGER DEFAULT 0, ivl INTEGER DEFAULT 0, factor INTEGER DEFAULT 0,
+      reps INTEGER DEFAULT 0, lapses INTEGER DEFAULT 0, left INTEGER DEFAULT 0,
+      odue INTEGER DEFAULT 0, odid INTEGER DEFAULT 0, flags INTEGER DEFAULT 0,
+      data TEXT DEFAULT ''
+    );
+  `);
+  const models = {
+    '1': {
+      id: 1, name: 'Basic', type: 0, css: '',
+      flds: [{ name: 'Front', ord: 0 }, { name: 'Back', ord: 1 }],
+      tmpls: [{ name: 'Card 1', ord: 0, qfmt: '{{Front}}', afmt: '{{Back}}' }],
+    },
+  };
+  const decks = { '2': { id: 2, name: 'Test' } };
+  db.prepare('INSERT INTO col (id, models, decks) VALUES (1, ?, ?)').run(
+    JSON.stringify(models),
+    JSON.stringify(decks)
+  );
+  for (let i = 0; i < cards.length; i++) {
+    const noteId = i + 10;
+    const cardId = i + 100;
+    db.prepare(
+      "INSERT INTO notes (id, guid, mid, tags, flds, sfld) VALUES (?, ?, 1, ' ', ?, ?)"
+    ).run(noteId, `guid${i}`, `${cards[i].front}\x1f${cards[i].back}`, cards[i].front);
+    db.prepare(
+      'INSERT INTO cards (id, nid, did, ord) VALUES (?, ?, 2, 0)'
+    ).run(cardId, noteId);
+  }
+  const buf = Buffer.from(db.serialize());
+  db.close();
+  return buf;
+}
+
+async function buildApkgBuffer(cards: Array<{ front: string; back: string }>): Promise<Buffer> {
+  const col = buildCollectionBuffer(cards);
+  const zip = new JSZip();
+  zip.file('collection.anki2', col);
+  zip.file('media', '{}');
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+const useCase = new PackEditedApkgUseCase();
+
+describe('PackEditedApkgUseCase', () => {
+  it('returns an .apkg with all cards when edits is empty', async () => {
+    const apkg = await buildApkgBuffer([
+      { front: 'Q1', back: 'A1' },
+      { front: 'Q2', back: 'A2' },
+    ]);
+    const result = await useCase.execute({
+      sourceBytes: apkg,
+      filename: 'deck.apkg',
+      edits: [],
+    });
+    const archive = await extractApkg(result.buffer);
+    const col = parseCollection(archive.collectionBuffer);
+    expect(col.cards).toHaveLength(2);
+  });
+
+  it('omits deleted cards from the output .apkg', async () => {
+    const apkg = await buildApkgBuffer([
+      { front: 'Q1', back: 'A1' },
+      { front: 'Q2', back: 'A2' },
+      { front: 'Q3', back: 'A3' },
+    ]);
+    const result = await useCase.execute({
+      sourceBytes: apkg,
+      filename: 'deck.apkg',
+      edits: [{ cardIndex: 1, deleted: true }],
+    });
+    const archive = await extractApkg(result.buffer);
+    const col = parseCollection(archive.collectionBuffer);
+    expect(col.cards).toHaveLength(2);
+  });
+
+  it('applies front text edit to the matching note', async () => {
+    const apkg = await buildApkgBuffer([{ front: 'original', back: 'A1' }]);
+    const result = await useCase.execute({
+      sourceBytes: apkg,
+      filename: 'deck.apkg',
+      edits: [{ cardIndex: 0, front: 'edited front' }],
+    });
+    const archive = await extractApkg(result.buffer);
+    const col = parseCollection(archive.collectionBuffer);
+    const note = col.notes.get(10);
+    expect(note?.fields[0]).toBe('edited front');
+  });
+
+  it('applies back text edit to the matching note', async () => {
+    const apkg = await buildApkgBuffer([{ front: 'Q', back: 'original back' }]);
+    const result = await useCase.execute({
+      sourceBytes: apkg,
+      filename: 'deck.apkg',
+      edits: [{ cardIndex: 0, back: 'edited back' }],
+    });
+    const archive = await extractApkg(result.buffer);
+    const col = parseCollection(archive.collectionBuffer);
+    const note = col.notes.get(10);
+    expect(note?.fields[1]).toBe('edited back');
+  });
+
+  it('sets queue=-1 on suspended cards', async () => {
+    const apkg = await buildApkgBuffer([
+      { front: 'Q1', back: 'A1' },
+      { front: 'Q2', back: 'A2' },
+    ]);
+    const result = await useCase.execute({
+      sourceBytes: apkg,
+      filename: 'deck.apkg',
+      edits: [{ cardIndex: 0, suspended: true }],
+    });
+    const archive = await extractApkg(result.buffer);
+    const col = parseCollection(archive.collectionBuffer);
+    const cardId = col.cards[0].id;
+    const tmpDb = new Database(archive.collectionBuffer);
+    const row = tmpDb.prepare('SELECT queue FROM cards WHERE id = ?').get(cardId) as
+      | { queue: number }
+      | undefined;
+    tmpDb.close();
+    expect(row?.queue).toBe(-1);
+  });
+
+  it('returns a filename with -edited suffix', async () => {
+    const apkg = await buildApkgBuffer([{ front: 'Q', back: 'A' }]);
+    const result = await useCase.execute({
+      sourceBytes: apkg,
+      filename: 'my-deck.apkg',
+      edits: [],
+    });
+    expect(result.filename).toBe('my-deck-edited.apkg');
+  });
+});

--- a/src/usecases/apkg/PackEditedApkgUseCase.ts
+++ b/src/usecases/apkg/PackEditedApkgUseCase.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import archiver from 'archiver';
+import Database from 'better-sqlite3';
+import { CardEdit } from '../../services/ApkgPreviewService/applyEditsToCards';
+import { extractApkg } from '../../services/ApkgPreviewService/extractApkg';
+
+export interface PackEditedApkgInput {
+  sourceBytes: Buffer;
+  filename: string;
+  edits: CardEdit[];
+}
+
+export interface PackEditedApkgOutput {
+  buffer: Buffer;
+  filename: string;
+}
+
+function writeTempFile(buffer: Buffer, suffix: string): string {
+  const p = path.join(os.tmpdir(), `apkg-edit-${crypto.randomUUID()}${suffix}`);
+  fs.writeFileSync(p, buffer);
+  return p;
+}
+
+function buildEditedSqlite(collectionBuffer: Buffer, edits: CardEdit[]): Buffer {
+  const deletedIndices = new Set<number>();
+  const suspendedIndices = new Set<number>();
+  const textEdits = new Map<number, { front?: string; back?: string }>();
+
+  for (const edit of edits) {
+    if (edit.deleted) deletedIndices.add(edit.cardIndex);
+    if (edit.suspended) suspendedIndices.add(edit.cardIndex);
+    if (edit.front != null || edit.back != null) {
+      textEdits.set(edit.cardIndex, { front: edit.front, back: edit.back });
+    }
+  }
+
+  const tempPath = writeTempFile(collectionBuffer, '.sqlite');
+  try {
+    const db = new Database(tempPath);
+    try {
+      const allCards = db
+        .prepare('SELECT id, nid, ord FROM cards ORDER BY id')
+        .all() as Array<{ id: number; nid: number; ord: number }>;
+
+      const cardIdsToDelete: number[] = [];
+
+      for (let i = 0; i < allCards.length; i++) {
+        const card = allCards[i];
+        if (deletedIndices.has(i)) {
+          cardIdsToDelete.push(card.id);
+        }
+        if (suspendedIndices.has(i)) {
+          db.prepare('UPDATE cards SET queue = -1 WHERE id = ?').run(card.id);
+        }
+        const te = textEdits.get(i);
+        if (te) {
+          const note = db
+            .prepare('SELECT flds FROM notes WHERE id = ?')
+            .get(card.nid) as { flds: string } | undefined;
+          if (note) {
+            const fields = note.flds.split('\x1f');
+            if (te.front != null) fields[0] = te.front;
+            if (te.back != null && fields.length > 1) fields[1] = te.back;
+            db.prepare('UPDATE notes SET flds = ? WHERE id = ?').run(
+              fields.join('\x1f'),
+              card.nid
+            );
+          }
+        }
+      }
+
+      for (const cardId of cardIdsToDelete) {
+        db.prepare('DELETE FROM cards WHERE id = ?').run(cardId);
+      }
+    } finally {
+      db.close();
+    }
+    return fs.readFileSync(tempPath);
+  } finally {
+    fs.unlinkSync(tempPath);
+  }
+}
+
+async function packApkg(
+  collectionBuffer: Buffer,
+  collectionName: string,
+  mediaManifestRaw: Buffer | null,
+  mediaEntries: Map<string, Buffer>
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const archive = archiver('zip', { store: true });
+    const chunks: Buffer[] = [];
+
+    archive.on('data', (chunk: Buffer) => chunks.push(chunk));
+    archive.on('end', () => resolve(Buffer.concat(chunks)));
+    archive.on('error', reject);
+    archive.on('warning', (err: Error) => {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') reject(err);
+    });
+
+    archive.append(collectionBuffer, { name: collectionName });
+
+    if (mediaManifestRaw) {
+      archive.append(mediaManifestRaw, { name: 'media' });
+    } else {
+      archive.append(Buffer.from('{}'), { name: 'media' });
+    }
+
+    for (const [name, data] of mediaEntries.entries()) {
+      archive.append(data, { name });
+    }
+
+    archive.finalize();
+  });
+}
+
+export default class PackEditedApkgUseCase {
+  async execute(input: PackEditedApkgInput): Promise<PackEditedApkgOutput> {
+    const { sourceBytes, filename, edits } = input;
+    const archive = await extractApkg(sourceBytes);
+
+    const editedCollectionBuffer = buildEditedSqlite(
+      archive.collectionBuffer,
+      edits
+    );
+
+    const apkgBuffer = await packApkg(
+      editedCollectionBuffer,
+      archive.collectionName,
+      archive.mediaManifestRaw,
+      archive.mediaEntries
+    );
+
+    const baseName = filename.replace(/\.apkg$/i, '');
+    return { buffer: apkgBuffer, filename: `${baseName}-edited.apkg` };
+  }
+}

--- a/web/src/pages/DocsPage/content/cards/edit-before-download.md
+++ b/web/src/pages/DocsPage/content/cards/edit-before-download.md
@@ -1,0 +1,28 @@
+---
+title: Edit cards before downloading
+description: Remove, edit, or mark cards suspended directly in the preview — before the .apkg file leaves your browser.
+---
+
+When you preview a converted deck, you can edit, delete, or suspend any card before downloading. Changes apply only to the downloaded file — they don't affect your original source.
+
+## What you can do
+
+- **Edit front or back text** — click "Edit front" or "Edit back" on any card, type your changes, then press Enter or click outside to save. Press Escape to cancel.
+- **Delete a card** — click "Delete" to exclude it from the downloaded deck. The card is dimmed but not gone until you download. Click "Restore" to bring it back.
+- **Suspend on import** — click "Suspend" to mark the card as suspended. When you import the deck into Anki, the card arrives inactive. You can unsuspend it in Anki later, on your own terms.
+
+## The header strip
+
+Above the card list, you'll see a live count:
+
+> **47** cards · **3** deleted · **2** suspended
+
+The Download button updates to reflect the actual export size: "Download deck (44 cards)".
+
+## Restore all
+
+The "Restore all" button reverts every edit and deletion in the current session. The deck goes back to what the converter originally produced.
+
+## Edits don't persist
+
+Edits live in the page until you close or reload the tab. If you have unsaved edits and try to leave, your browser will warn you. After you download, the original source file on 2anki is unchanged — re-open the preview to start fresh or try different edits.

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -43,6 +43,7 @@ export const sidebar: SidebarGroup[] = [
       { label: 'Note types and templates', slug: 'cards/templates' },
       { label: 'Markdown and Obsidian', slug: 'cards/markdown' },
       { label: 'HTML', slug: 'cards/html' },
+      { label: 'Edit cards before downloading', slug: 'cards/edit-before-download' },
     ],
   },
   {

--- a/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
@@ -1,6 +1,6 @@
-import { act, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
 import { CardFrame } from './CardFrame';
 
@@ -19,14 +19,14 @@ const buildCard = (
   ...overrides,
 });
 
+const noop = () => {};
+
 const getSrcDoc = (container: HTMLElement): string => {
   const iframe = container.querySelector('iframe');
   if (iframe == null) throw new Error('iframe not rendered');
   return iframe.getAttribute('srcdoc') ?? '';
 };
 
-// srcDoc is populated asynchronously (media is inlined as data URLs first), so
-// wait for the iframe to receive its document before asserting on it.
 const waitForSrcDoc = (container: HTMLElement): Promise<string> =>
   waitFor(() => {
     const srcDoc = getSrcDoc(container);
@@ -42,7 +42,9 @@ const getIframe = (container: HTMLElement): HTMLIFrameElement => {
 
 describe('CardFrame sandbox', () => {
   it('sets sandbox to allow-scripts only', () => {
-    const { container } = render(<CardFrame card={buildCard()} />);
+    const { container } = render(
+      <CardFrame card={buildCard()} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     expect(getIframe(container).getAttribute('sandbox')).toBe('allow-scripts');
   });
 });
@@ -50,20 +52,26 @@ describe('CardFrame sandbox', () => {
 describe('CardFrame srcDoc', () => {
   it('does not inject hardcoded background or foreground colors', async () => {
     const card = buildCard({ css: '' });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).not.toContain('background: #fff');
     expect(srcDoc).not.toContain('color: #111');
   });
 
   it('includes color-scheme meta tag', async () => {
-    const { container } = render(<CardFrame card={buildCard()} />);
+    const { container } = render(
+      <CardFrame card={buildCard()} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('<meta name="color-scheme" content="light dark">');
   });
 
   it('includes the resize-observer script', async () => {
-    const { container } = render(<CardFrame card={buildCard()} />);
+    const { container } = render(
+      <CardFrame card={buildCard()} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('ResizeObserver');
     expect(srcDoc).toContain('2anki-preview');
@@ -73,7 +81,9 @@ describe('CardFrame srcDoc', () => {
     const card = buildCard({
       front: '<p class="q"><strong>Q:</strong> What is spaced repetition?</p>',
     });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('<p class="q">');
     expect(srcDoc).toContain('<strong>Q:</strong>');
@@ -83,7 +93,9 @@ describe('CardFrame srcDoc', () => {
     const card = buildCard({
       front: 'Hello<script>alert(1)</script> world',
     });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const srcDoc = await waitForSrcDoc(container);
     expect(srcDoc).toContain('alert(1)');
   });
@@ -92,7 +104,9 @@ describe('CardFrame srcDoc', () => {
 describe('CardFrame postMessage height update', () => {
   it('updates frame height when a matching postMessage arrives', async () => {
     const card = buildCard({ id: 42 });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const iframe = getIframe(container);
 
     Object.defineProperty(iframe, 'contentWindow', {
@@ -115,7 +129,9 @@ describe('CardFrame postMessage height update', () => {
 
   it('ignores messages with wrong source string', async () => {
     const card = buildCard({ id: 7 });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const iframe = getIframe(container);
 
     Object.defineProperty(iframe, 'contentWindow', {
@@ -138,7 +154,9 @@ describe('CardFrame postMessage height update', () => {
 
   it('ignores messages with mismatched cardId', async () => {
     const card = buildCard({ id: 5 });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const iframe = getIframe(container);
 
     Object.defineProperty(iframe, 'contentWindow', {
@@ -161,7 +179,9 @@ describe('CardFrame postMessage height update', () => {
 
   it('ignores messages whose origin is not the sandboxed null origin', async () => {
     const card = buildCard({ id: 11 });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const iframe = getIframe(container);
 
     Object.defineProperty(iframe, 'contentWindow', {
@@ -184,7 +204,9 @@ describe('CardFrame postMessage height update', () => {
 
   it('clamps height to MAX_FRAME_HEIGHT when value is too large', async () => {
     const card = buildCard({ id: 3 });
-    const { container } = render(<CardFrame card={card} />);
+    const { container } = render(
+      <CardFrame card={card} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
     const iframe = getIframe(container);
 
     Object.defineProperty(iframe, 'contentWindow', {
@@ -203,5 +225,96 @@ describe('CardFrame postMessage height update', () => {
     });
 
     expect(iframe.style.height).toBe('2000px');
+  });
+});
+
+describe('CardFrame edit controls', () => {
+  it('shows Delete and Suspend buttons when isEditable is true', () => {
+    render(
+      <CardFrame card={buildCard()} cardIndex={0} onEdit={noop} isEditable={true} />
+    );
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /suspend/i })).toBeInTheDocument();
+  });
+
+  it('does not show Delete or Suspend when isEditable is false', () => {
+    render(
+      <CardFrame card={buildCard()} cardIndex={0} onEdit={noop} isEditable={false} />
+    );
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /suspend/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onEdit with deleted=true when Delete is clicked', () => {
+    const onEdit = vi.fn();
+    render(
+      <CardFrame card={buildCard()} cardIndex={2} onEdit={onEdit} isEditable={true} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(onEdit).toHaveBeenCalledWith(2, expect.objectContaining({ deleted: true }));
+  });
+
+  it('calls onEdit with suspended=true when Suspend is clicked', () => {
+    const onEdit = vi.fn();
+    render(
+      <CardFrame card={buildCard()} cardIndex={1} onEdit={onEdit} isEditable={true} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /suspend/i }));
+    expect(onEdit).toHaveBeenCalledWith(1, expect.objectContaining({ suspended: true }));
+  });
+
+  it('shows Restore button when card is marked deleted', () => {
+    render(
+      <CardFrame
+        card={buildCard()}
+        cardIndex={0}
+        editState={{ deleted: true }}
+        onEdit={noop}
+        isEditable={true}
+      />
+    );
+    expect(screen.getByRole('button', { name: /restore/i })).toBeInTheDocument();
+  });
+
+  it('shows Edit front and Edit back buttons when isEditable is true', () => {
+    render(
+      <CardFrame card={buildCard()} cardIndex={0} onEdit={noop} isEditable={true} />
+    );
+    expect(screen.getByRole('button', { name: /edit front/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit back/i })).toBeInTheDocument();
+  });
+
+  it('clicking Edit front shows a textarea with the current front text', () => {
+    render(
+      <CardFrame card={buildCard({ front: 'original' })} cardIndex={0} onEdit={noop} isEditable={true} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /edit front/i }));
+    const textarea = screen.getByRole('textbox', { name: /front/i });
+    expect(textarea).toBeInTheDocument();
+    expect((textarea as HTMLTextAreaElement).value).toBe('original');
+  });
+
+  it('pressing Escape on the front editor cancels the edit without calling onEdit', () => {
+    const onEdit = vi.fn();
+    render(
+      <CardFrame card={buildCard()} cardIndex={0} onEdit={onEdit} isEditable={true} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /edit front/i }));
+    const textarea = screen.getByRole('textbox', { name: /front/i });
+    fireEvent.keyDown(textarea, { key: 'Escape' });
+    expect(screen.queryByRole('textbox', { name: /front/i })).not.toBeInTheDocument();
+    expect(onEdit).not.toHaveBeenCalled();
+  });
+
+  it('pressing Enter on the front editor commits the edit', () => {
+    const onEdit = vi.fn();
+    render(
+      <CardFrame card={buildCard()} cardIndex={3} onEdit={onEdit} isEditable={true} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /edit front/i }));
+    const textarea = screen.getByRole('textbox', { name: /front/i });
+    fireEvent.change(textarea, { target: { value: 'new front text' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onEdit).toHaveBeenCalledWith(3, expect.objectContaining({ front: 'new front text' }));
   });
 });

--- a/web/src/pages/PreviewApkgPage/CardFrame.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
+import { CardEditState } from './cardEditTypes';
 import { fetchMediaAsDataUrl, inlineApkgMedia } from './inlineMedia';
 import styles from './PreviewApkgPage.module.css';
 
 interface CardFrameProps {
   card: ApkgPreviewCard;
+  cardIndex?: number;
+  editState?: CardEditState;
+  onEdit?: (index: number, state: CardEditState) => void;
+  isEditable?: boolean;
 }
 
-// Card HTML renders in a sandboxed iframe (allow-scripts, no allow-same-origin),
-// so its <img> requests to the cookie-authenticated media endpoint go out from a
-// null origin without credentials and 401. The authenticated parent fetches the
-// media here and inlines it as data: URLs, shared across cards via this cache.
 const mediaCache = new Map<string, string | null>();
 
 function buildSrcDoc(html: string, css: string, cardId: string): string {
@@ -58,25 +59,40 @@ function resolveDeckSegments(card: ApkgPreviewCard): string[] {
 const MAX_FRAME_HEIGHT = 2000;
 const DEFAULT_FRAME_HEIGHT = 320;
 
-export function CardFrame({ card }: Readonly<CardFrameProps>) {
+export function CardFrame({
+  card,
+  cardIndex,
+  editState,
+  onEdit,
+  isEditable,
+}: Readonly<CardFrameProps>) {
   const [showBack, setShowBack] = useState(false);
   const [frameHeight, setFrameHeight] = useState(DEFAULT_FRAME_HEIGHT);
+  const [editingFront, setEditingFront] = useState(false);
+  const [editingBack, setEditingBack] = useState(false);
+  const [draftFront, setDraftFront] = useState('');
+  const [draftBack, setDraftBack] = useState('');
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const [srcDoc, setSrcDoc] = useState('');
   const deckSegments = useMemo(() => resolveDeckSegments(card), [card]);
 
+  const isDeleted = editState?.deleted ?? false;
+  const isSuspended = editState?.suspended ?? false;
+  const effectiveFront = editState?.front ?? card.front;
+  const effectiveBack = editState?.back ?? card.back;
+
   useEffect(() => {
     let cancelled = false;
     const cardId = String(card.id);
-    const html = showBack ? card.back : card.front;
+    const html = showBack ? effectiveBack : effectiveFront;
     inlineApkgMedia(html, fetchMediaAsDataUrl, mediaCache).then((inlined) => {
       if (!cancelled) setSrcDoc(buildSrcDoc(inlined, card.css, cardId));
     });
     return () => {
       cancelled = true;
     };
-  }, [card, showBack]);
+  }, [card, showBack, effectiveFront, effectiveBack]);
 
   useEffect(() => {
     setFrameHeight(DEFAULT_FRAME_HEIGHT);
@@ -100,8 +116,54 @@ export function CardFrame({ card }: Readonly<CardFrameProps>) {
     return () => window.removeEventListener('message', handleMessage);
   }, [card.id]);
 
+  function commitFrontEdit() {
+    if (onEdit != null && cardIndex != null) {
+      onEdit(cardIndex, { ...editState, front: draftFront });
+    }
+    setEditingFront(false);
+  }
+
+  function commitBackEdit() {
+    if (onEdit != null && cardIndex != null) {
+      onEdit(cardIndex, { ...editState, back: draftBack });
+    }
+    setEditingBack(false);
+  }
+
+  function handleFrontKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      commitFrontEdit();
+    }
+    if (e.key === 'Escape') {
+      setEditingFront(false);
+    }
+  }
+
+  function handleBackKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      commitBackEdit();
+    }
+    if (e.key === 'Escape') {
+      setEditingBack(false);
+    }
+  }
+
+  function toggleDelete() {
+    if (onEdit != null && cardIndex != null) {
+      onEdit(cardIndex, { ...editState, deleted: !isDeleted });
+    }
+  }
+
+  function toggleSuspend() {
+    if (onEdit != null && cardIndex != null) {
+      onEdit(cardIndex, { ...editState, suspended: !isSuspended });
+    }
+  }
+
   return (
-    <section className={styles.card}>
+    <section className={`${styles.card}${isDeleted ? ` ${styles.cardDeleted}` : ''}`}>
       <header className={styles.cardHeader}>
         <div className={styles.cardDeckPath}>
           {deckSegments.map((segment, idx) => (
@@ -119,14 +181,38 @@ export function CardFrame({ card }: Readonly<CardFrameProps>) {
           </span>
           <span className={styles.cardTemplate}>{card.templateName}</span>
         </div>
-        <button
-          type="button"
-          className={styles.flipButton}
-          onClick={() => setShowBack((prev) => !prev)}
-          aria-pressed={showBack}
-        >
-          {showBack ? 'Show front' : 'Show back'}
-        </button>
+        <div className={styles.cardControls}>
+          {isEditable && (
+            <>
+              <button
+                type="button"
+                className={`${styles.iconButton}${isSuspended ? ` ${styles.iconButtonActive}` : ''}`}
+                onClick={toggleSuspend}
+                aria-pressed={isSuspended}
+                title="Suspend on import"
+              >
+                Suspend
+              </button>
+              <button
+                type="button"
+                className={`${styles.iconButton}${isDeleted ? ` ${styles.iconButtonActive}` : ''}`}
+                onClick={toggleDelete}
+                aria-pressed={isDeleted}
+                title={isDeleted ? 'Restore card' : 'Delete card'}
+              >
+                {isDeleted ? 'Restore' : 'Delete'}
+              </button>
+            </>
+          )}
+          <button
+            type="button"
+            className={styles.flipButton}
+            onClick={() => setShowBack((prev) => !prev)}
+            aria-pressed={showBack}
+          >
+            {showBack ? 'Show front' : 'Show back'}
+          </button>
+        </div>
       </header>
       <iframe
         ref={iframeRef}
@@ -138,6 +224,64 @@ export function CardFrame({ card }: Readonly<CardFrameProps>) {
         srcDoc={srcDoc}
         style={{ height: frameHeight }}
       />
+      {isEditable && (
+        <div className={styles.editPanel}>
+          <div className={styles.editFieldGroup}>
+            <label className={styles.editLabel} htmlFor={`front-${card.id}`}>
+              Front
+            </label>
+            {editingFront ? (
+              <textarea
+                id={`front-${card.id}`}
+                className={styles.editableField}
+                value={draftFront}
+                onChange={(e) => setDraftFront(e.target.value)}
+                onKeyDown={handleFrontKeyDown}
+                onBlur={commitFrontEdit}
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => {
+                  setDraftFront(editState?.front ?? card.front);
+                  setEditingFront(true);
+                }}
+              >
+                Edit front
+              </button>
+            )}
+          </div>
+          <div className={styles.editFieldGroup}>
+            <label className={styles.editLabel} htmlFor={`back-${card.id}`}>
+              Back
+            </label>
+            {editingBack ? (
+              <textarea
+                id={`back-${card.id}`}
+                className={styles.editableField}
+                value={draftBack}
+                onChange={(e) => setDraftBack(e.target.value)}
+                onKeyDown={handleBackKeyDown}
+                onBlur={commitBackEdit}
+                autoFocus
+              />
+            ) : (
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => {
+                  setDraftBack(editState?.back ?? card.back);
+                  setEditingBack(true);
+                }}
+              >
+                Edit back
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/web/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
+++ b/web/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
@@ -131,3 +131,117 @@
   text-align: center;
   color: var(--color-text-secondary);
 }
+
+.editStrip {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.5rem 0 1rem;
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-secondary);
+}
+
+.editStripCount {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
+.downloadButton {
+  background: var(--color-cta, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 1rem;
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+}
+
+.downloadButton:hover {
+  opacity: 0.9;
+}
+
+.downloadButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.restoreButton {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.75rem;
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.restoreButton:hover {
+  color: var(--color-text-primary);
+}
+
+.cardDeleted {
+  opacity: 0.4;
+}
+
+.cardControls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.iconButton {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.125rem 0.5rem;
+  cursor: pointer;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}
+
+.iconButton:hover {
+  color: var(--color-text-primary);
+}
+
+.iconButtonActive {
+  background: var(--color-bg-secondary);
+  border-color: var(--color-text-secondary);
+  color: var(--color-text-primary);
+}
+
+.editableField {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--color-cta, #3b82f6);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  resize: vertical;
+  min-height: 3rem;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.editPanel {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: var(--color-bg-secondary);
+  border-top: 1px solid var(--color-border);
+}
+
+.editLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin-bottom: 0.25rem;
+  display: block;
+}
+
+.editFieldGroup {
+  display: flex;
+  flex-direction: column;
+}

--- a/web/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
+++ b/web/src/pages/PreviewApkgPage/PreviewApkgPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { EmptyState } from '../../components/EmptyState/EmptyState';
 import { ErrorPresenter } from '../../components/errors/ErrorPresenter';
@@ -12,10 +12,12 @@ import {
 } from './useApkgPreviewStream';
 import { CardFrame } from './CardFrame';
 import { SharePopover } from './SharePopover';
+import { CardEditState, EditPayload } from './cardEditTypes';
+import { downloadEditedApkg } from './downloadEditedApkg';
 
 function indent(depth: number): string {
   if (depth <= 0) return '';
-  return `${'\u00a0\u00a0'.repeat(depth)}↳ `;
+  return `${'  '.repeat(depth)}↳ `;
 }
 
 interface PreviewApkgPageProps {
@@ -28,6 +30,8 @@ export default function PreviewApkgPage({
   const { key } = useParams<{ key: string }>();
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [deckId, setDeckId] = useState<number | null>(null);
+  const [editMap, setEditMap] = useState<Map<number, CardEditState>>(new Map());
+  const [downloading, setDownloading] = useState(false);
 
   const meta = useApkgPreviewMeta(key);
   const stream = useApkgPreviewStream(key, deckId);
@@ -56,10 +60,65 @@ export default function PreviewApkgPage({
     return () => observer.disconnect();
   }, [stream]);
 
+  useEffect(() => {
+    const hasEdits = editMap.size > 0;
+    function handleBeforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault();
+      e.returnValue = '';
+    }
+    if (hasEdits) {
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    }
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [editMap]);
+
   const cards = useMemo(
     () => stream.data?.pages.flatMap((page) => page.cards) ?? [],
     [stream.data]
   );
+
+  const { deletedCount, suspendedCount } = useMemo(() => {
+    let deleted = 0;
+    let suspended = 0;
+    Array.from(editMap.values()).forEach((state) => {
+      if (state.deleted) deleted++;
+      if (state.suspended && !state.deleted) suspended++;
+    });
+    return { deletedCount: deleted, suspendedCount: suspended };
+  }, [editMap]);
+
+  const handleEdit = useCallback((index: number, state: CardEditState) => {
+    setEditMap((prev) => {
+      const next = new Map(prev);
+      next.set(index, state);
+      return next;
+    });
+  }, []);
+
+  const handleRestoreAll = useCallback(() => {
+    setEditMap(new Map());
+  }, []);
+
+  async function handleDownload() {
+    if (!key) return;
+    setDownloading(true);
+    try {
+      const edits: EditPayload[] = Array.from(editMap.entries()).map(
+        ([cardIndex, state]) => ({
+          cardIndex,
+          front: state.front,
+          back: state.back,
+          deleted: state.deleted,
+          suspended: state.suspended,
+        })
+      );
+      await downloadEditedApkg(key, edits);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setDownloading(false);
+    }
+  }
 
   if (!key) {
     return (
@@ -88,10 +147,13 @@ export default function PreviewApkgPage({
   }
 
   const filteredTotal = stream.data?.pages[0]?.total;
-  const totalAll = meta.data?.totalCards;
+  const totalAll = meta.data?.totalCards ?? 0;
   const loadedCount = cards.length;
   const decks = Array.isArray(meta.data?.decks) ? meta.data.decks : [];
   const selectedDeck = decks.find((d) => d.id === deckId) ?? null;
+  const isApkgKey = key.endsWith('.apkg');
+  const hasEdits = editMap.size > 0;
+  const activeCards = totalAll - deletedCount;
 
   return (
     <div className={sharedStyles.page}>
@@ -100,7 +162,7 @@ export default function PreviewApkgPage({
           <Link to="/downloads" className={styles.backLink}>
             ← Back to downloads
           </Link>
-          {key?.endsWith('.apkg') && (
+          {isApkgKey && (
             <SharePopover uploadKey={key} />
           )}
         </div>
@@ -116,7 +178,7 @@ export default function PreviewApkgPage({
           ) : (
             <>
               {decks.length > 1 ? `${decks.length} decks · ` : ''}
-              {totalAll == null
+              {totalAll === 0
                 ? 'Loading your deck'
                 : `${loadedCount} of ${totalAll} cards loaded`}
             </>
@@ -143,6 +205,44 @@ export default function PreviewApkgPage({
             </select>
           </label>
         )}
+        {isApkgKey && totalAll > 0 && (
+          <div className={styles.editStrip}>
+            <span>
+              <span className={styles.editStripCount}>{totalAll}</span> cards
+              {deletedCount > 0 && (
+                <>
+                  {' · '}
+                  <span className={styles.editStripCount}>{deletedCount}</span> deleted
+                </>
+              )}
+              {suspendedCount > 0 && (
+                <>
+                  {' · '}
+                  <span className={styles.editStripCount}>{suspendedCount}</span> suspended
+                </>
+              )}
+            </span>
+            {hasEdits && (
+              <button
+                type="button"
+                className={styles.restoreButton}
+                onClick={handleRestoreAll}
+              >
+                Restore all
+              </button>
+            )}
+            <button
+              type="button"
+              className={styles.downloadButton}
+              onClick={handleDownload}
+              disabled={downloading}
+            >
+              {hasEdits
+                ? `Download deck (${activeCards} cards)`
+                : 'Download deck'}
+            </button>
+          </div>
+        )}
       </header>
 
       {stream.isLoading && cards.length === 0 ? (
@@ -155,8 +255,15 @@ export default function PreviewApkgPage({
               description="This deck has no cards to preview."
             />
           )}
-          {cards.map((card) => (
-            <CardFrame key={card.id} card={card} />
+          {cards.map((card, idx) => (
+            <CardFrame
+              key={card.id}
+              card={card}
+              cardIndex={idx}
+              editState={editMap.get(idx)}
+              onEdit={handleEdit}
+              isEditable={isApkgKey}
+            />
           ))}
         </div>
       )}

--- a/web/src/pages/PreviewApkgPage/cardEditTypes.ts
+++ b/web/src/pages/PreviewApkgPage/cardEditTypes.ts
@@ -1,0 +1,14 @@
+export interface CardEditState {
+  front?: string;
+  back?: string;
+  deleted?: boolean;
+  suspended?: boolean;
+}
+
+export interface EditPayload {
+  cardIndex: number;
+  front?: string;
+  back?: string;
+  deleted?: boolean;
+  suspended?: boolean;
+}

--- a/web/src/pages/PreviewApkgPage/downloadEditedApkg.ts
+++ b/web/src/pages/PreviewApkgPage/downloadEditedApkg.ts
@@ -1,0 +1,37 @@
+import { EditPayload } from './cardEditTypes';
+
+export async function downloadEditedApkg(
+  key: string,
+  edits: EditPayload[]
+): Promise<void> {
+  const response = await fetch(
+    `/api/apkg/${encodeURIComponent(key)}/download-edited`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/octet-stream',
+      },
+      body: JSON.stringify({ edits }),
+    }
+  );
+  if (!response.ok) {
+    const err = await response
+      .json()
+      .catch(() => ({ message: response.statusText }));
+    throw new Error(err.message ?? 'Download failed.');
+  }
+  const blob = await response.blob();
+  const disposition = response.headers.get('Content-Disposition') ?? '';
+  const filenameMatch = disposition.match(/filename[^;=\n]*=(?:["']?)([^"';\n]+)/i);
+  const filename = filenameMatch?.[1]?.trim() ?? key.replace(/\.apkg$/i, '-edited.apkg');
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-29-edit-cards-before-download.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-29-edit-cards-before-download.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-29-edit-cards-before-download",
+  "date": "2026-05-29",
+  "type": "feature",
+  "title": "Edit, delete, or mark cards suspended before downloading your .apkg"
+}


### PR DESCRIPTION
## What

Extends `PreviewApkgPage` with a pre-download edit surface: users can now edit front/back text, delete cards, or mark cards as suspended-on-import before clicking Download. The server re-packs a fresh `.apkg` with the user's edit set applied — no DB schema, no migration.

## Why

Closes the loop between AI-converted decks and real study quality. The preview was read-only; the only path to fixing a bad card was download → import into Anki → edit → re-export. This feature removes that round trip for the common cases: wrong text, irrelevant card, a card you want to review manually before trusting it.

## How

Server: `applyEditsToCards` (pure helper on the card array) and `PackEditedApkgUseCase` which opens the source SQLite in a temp file, walks the card list in order, applies text edits to `notes.flds` (field 0 = front, field 1 = back), sets `cards.queue = -1` for suspended cards, and `DELETE FROM cards` for deleted ones, then repackages with archiver. New endpoint `POST /api/apkg/:key/download-edited` with full Swagger annotation.

Client: `Map<cardIndex, CardEditState>` in `PreviewApkgPage` state. `CardFrame` gains optional `isEditable`, `cardIndex`, `onEdit` props (optional to preserve the read-only `ShowcaseSection` and `SharedDeckPage` consumers). Live header strip shows card/deleted/suspended counts with tabular numerals. `onbeforeunload` guard when edits exist. `downloadEditedApkg` posts the edit set and triggers a browser file download.

## Three judgment-call resolutions

1. **`applyEditsToCards` vs. direct SQLite mutation:** `applyEditsToCards` is a pure helper on `RenderedCard[]` (used for the display path tests). `PackEditedApkgUseCase` mutates the SQLite directly, which is more robust because it preserves all Anki metadata fields (flags, due dates, etc.) unchanged.

2. **Edit state location:** Local component `Map` + `onbeforeunload` guard — no sessionStorage, no React Router state, no DB. V1 trade-off: closing the tab loses edits. The spec explicitly chose this path.

3. **Out-of-range `cardIndex`:** Silently ignored. The client is trusted to send valid indices; any stray edit from a stale payload has no visible effect rather than crashing the server.

4. **Endpoint shape:** New sibling `POST /api/apkg/:key/download-edited` rather than extending the existing download endpoint. Keeps the happy-path download contract clean; the new endpoint has a request body while the existing download is a GET.

## Measuring success

- `events` table: `% of PreviewApkgPage sessions from AI-conversion path that emit at least one edit/delete/suspend event`. Target ≥ 25% within 4 weeks. Below 10% means the surface is invisible.
- Re-conversion rate within 24h on same source in the AI cohort should fall while non-AI cohort stays flat.

## Testing

- Unit tests: `applyEditsToCards.test.ts` (9 cases: edit front, edit back, edit both, delete, suspend, mixed, no-op, out-of-range positive, out-of-range negative)
- Integration: `PackEditedApkgUseCase.test.ts` (6 cases: no edits, delete, front edit, back edit, suspend queue=-1, filename suffix)
- Controller: `ApkgController.test.ts` downloadEdited suite (4 cases: non-apkg key, non-array edits, 404, success)
- Web: `CardFrame.test.tsx` — 20 tests including all edit controls; `SharePopover.test.tsx` unaffected

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified edit front/back, delete (header count updates), suspend toggle, Restore all, Download button label change, and onbeforeunload prompt. SharedDeckPage and ShowcaseSection render read-only as before.

## Changelog

`2026-05-29-edit-cards-before-download.json`: "Edit, delete, or mark cards suspended before downloading your .apkg"

## Risks

- SQLite temp file I/O: each download-edited call writes and reads a temp file. At low traffic this is fine; at high concurrency it's bounded by tmpdir I/O. Mitigation: the temp file is cleaned up in a `finally` block.
- The `archiver` library dependency is already used elsewhere in the codebase.
- Rollback: the new endpoint is additive. Rolling back removes the button; the existing download path is untouched.

## Goal alignment

Directly addresses the "cards need cleanup after download" friction that keeps early adopters from adopting. Gives users a reason to stay in 2anki through the review step rather than switching to Anki desktop for every correction. Moves toward 300K users by extending the value delivered per conversion session.