### PR TITLE
feat: list every 2anki tool on the logged-out homepage

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { lazy, ReactElement, useState } from 'react';
 import { CookiesProvider, useCookies } from 'react-cookie';
 import { HelmetProvider } from 'react-helmet-async';
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { AppShell } from './components/AppShell/AppShell';
 import { getErrorMessage } from './components/errors/helpers/getErrorMessage';
 import { SkeletonPage } from './components/Skeleton/Skeleton';
@@ -126,13 +126,16 @@ function RequireAuth({
   isLoading: boolean;
   children: ReactElement;
 }>) {
+  const location = useLocation();
   if (isLoading) {
     return <SkeletonPage />;
   }
-  if (!isLoggedIn) {
-    return <Navigate to="/login" replace />;
+  if (isLoggedIn) {
+    return children;
   }
-  return children;
+  const target = `${location.pathname}${location.search}`;
+  const loginUrl = target === '/' ? '/login' : `/login?redirect=${encodeURIComponent(target)}`;
+  return <Navigate to={loginUrl} replace />;
 }
 
 function AppContent({

--- a/web/src/pages/HomePage/HomePage.module.css
+++ b/web/src/pages/HomePage/HomePage.module.css
@@ -160,6 +160,91 @@
   margin: 0;
 }
 
+.featuresSection {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 0;
+}
+
+.featuresHeading {
+  font-size: var(--text-xl);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 1.25rem;
+}
+
+.featuresGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.featureCard {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+  padding: 1rem 1.125rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.featureCard:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.featureIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius-lg);
+  background: var(--color-primary-light);
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.featureText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.featureTitle {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.featureBody {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+@media (max-width: 959px) {
+  .featuresGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 639px) {
+  .featuresSection {
+    padding: 2rem 1rem 0;
+  }
+
+  .featuresGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
 .bottomSection {
   max-width: 960px;
   margin: 0 auto;

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -6,6 +6,14 @@ import { useSettingsCardsOptions } from '../../components/modals/SettingsModal/u
 import ArrowUpTrayIcon from '../../components/icons/ArrowUpTrayIcon';
 import SparklesIcon from '../../components/icons/SparklesIcon';
 import BookOpenIcon from '../../components/icons/BookOpenIcon';
+import ArrowLeftIcon from '../../components/icons/ArrowLeftIcon';
+import ArrowRightIcon from '../../components/icons/ArrowRightIcon';
+import CameraIcon from '../../components/icons/CameraIcon';
+import ChatBubbleIcon from '../../components/icons/ChatBubbleIcon';
+import PrinterIcon from '../../components/icons/PrinterIcon';
+import RectangleGroupIcon from '../../components/icons/RectangleGroupIcon';
+import ShareIcon from '../../components/icons/ShareIcon';
+import SwatchIcon from '../../components/icons/SwatchIcon';
 import { track } from '../../lib/analytics/track';
 import { ShowcaseSection } from './ShowcaseSection';
 import sharedStyles from '../../styles/shared.module.css';
@@ -41,6 +49,63 @@ const STEPS = [
     title: 'Study',
     body: 'Open the .apkg file in Anki or AnkiDroid. Your cards are ready to review.',
     Icon: BookOpenIcon,
+  },
+];
+
+const FEATURES = [
+  {
+    href: '/notion',
+    label: 'Notion to Anki',
+    body: 'Convert a Notion page into a deck — toggles become cards.',
+    Icon: ArrowRightIcon,
+  },
+  {
+    href: '/import',
+    label: 'Anki to Notion',
+    body: 'Turn an .apkg back into a Notion page you can keep editing.',
+    Icon: ArrowLeftIcon,
+  },
+  {
+    href: '/image-occlusion',
+    label: 'Image occlusion',
+    body: 'Mask labels on diagrams to make cards.',
+    Icon: RectangleGroupIcon,
+  },
+  {
+    href: '/photo-to-deck',
+    label: 'Photo to deck',
+    body: 'Snap a page, get a deck.',
+    Icon: CameraIcon,
+  },
+  {
+    href: '/mindmaps',
+    label: 'Mind maps',
+    body: 'Turn a mind map into structured cards.',
+    Icon: ShareIcon,
+  },
+  {
+    href: '/templates',
+    label: 'Note types',
+    body: 'Pick how the front and back of your cards look.',
+    Icon: SwatchIcon,
+  },
+  {
+    href: '/chat',
+    label: 'Chat',
+    body: 'Ask AI to write cards from your notes.',
+    Icon: ChatBubbleIcon,
+  },
+  {
+    href: '/print',
+    label: 'Print',
+    body: 'Print your deck on paper for offline study.',
+    Icon: PrinterIcon,
+  },
+  {
+    href: '/ankify',
+    label: 'Auto Sync',
+    body: 'Keep your Anki deck in sync with your Notion page.',
+    Icon: SparklesIcon,
   },
 ];
 
@@ -177,6 +242,23 @@ export function HomePage({
       </section>
 
       <ShowcaseSection />
+
+      <section className={styles.featuresSection}>
+        <p className={styles.featuresHeading}>Other ways to use 2anki</p>
+        <div className={styles.featuresGrid}>
+          {FEATURES.map((feature) => (
+            <Link key={feature.href} to={feature.href} className={styles.featureCard}>
+              <span className={styles.featureIcon}>
+                <feature.Icon width={22} height={22} />
+              </span>
+              <span className={styles.featureText}>
+                <span className={styles.featureTitle}>{feature.label}</span>
+                <span className={styles.featureBody}>{feature.body}</span>
+              </span>
+            </Link>
+          ))}
+        </div>
+      </section>
 
       <section id="walkthroughs" className={styles.bottomSection}>
         <p className={styles.walkHeading}>Walkthroughs</p>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-28-features-on-homepage.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-28-features-on-homepage.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-28-features-on-homepage",
+  "date": "2026-05-28",
+  "type": "feature",
+  "title": "Homepage now links to every 2anki tool — Notion sync, image occlusion, mind maps, chat, print, and more"
+}


### PR DESCRIPTION
2anki has 9 conversion tools beyond the upload hero — Notion to Anki, Anki to Notion, image occlusion, photo to deck, mind maps, note types, chat, print, Auto Sync. Every one of them is reachable only from the sidebar after login. Logged-out visitors can't see what 2anki actually does.

This adds an "Other ways to use 2anki" section under "See it in action" with one card per sidebar feature, linking to the matching route (e.g. `/import` for Anki → Notion, matching the sidebar).

3-column grid on desktop, 2-column tablet (≤959px), 1-column mobile (≤639px). Reuses existing landing tokens (`--color-primary-light`, `--radius-lg`, `--text-base`); no new design language.

**Plus a small `RequireAuth` fix.** Three of the nine cards (`/mindmaps`, `/chat`, `/ankify`) are gated by `requireAuth`. Before this PR, `RequireAuth` did `<Navigate to="/login" replace />` with no destination preserved — so an anon visitor who clicked "Mind maps", "Chat" or "Auto Sync" would land on the default post-login page, not where they intended. Login already honors `?redirect=<path>` (with open-redirect hardening in `useHandleLoginSubmit.ts:30`); the navigate call just wasn't populating it. Now `RequireAuth` passes the current path + search via `?redirect=<encodedPath>`, so the round-trip works for every gated route — not just the three I added. The bare home path is left as a clean `/login` to avoid noise.

Changelog entry: `2026-05-28-features-on-homepage.json`.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified by Al before issuing the merge directive. Agent verification: `pnpm --filter 2anki-web typecheck` + `lint` + full vitest (1305/1305) all green; all 9 icons + all 9 routes confirmed in App.tsx; CI rollup green across playwright, build, test, SonarCloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)