### PR TITLE
feat: add /security page, frame-ancestors header, and security.txt

### DIFF
--- a/src/routes/WellKnownRouter.ts
+++ b/src/routes/WellKnownRouter.ts
@@ -15,5 +15,35 @@ export default function wellKnownRouter() {
     }
   );
 
+  /**
+   * @swagger
+   * /.well-known/security.txt:
+   *   get:
+   *     summary: RFC 9116 security disclosure metadata
+   *     description: Plain-text contact and policy details for security researchers.
+   *     tags: [WellKnown]
+   *     responses:
+   *       200:
+   *         description: security.txt response
+   *         content:
+   *           text/plain:
+   *             schema:
+   *               type: string
+   */
+  router.get('/.well-known/security.txt', (_req, res) => {
+    const expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1);
+    const body = [
+      'Contact: mailto:support@2anki.net',
+      `Expires: ${expires.toISOString()}`,
+      'Acknowledgments: https://2anki.net/security',
+      'Policy: https://2anki.net/security',
+      'Preferred-Languages: en',
+      '',
+    ].join('\r\n');
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.send(body);
+  });
+
   return router;
 }

--- a/src/routes/middleware/denyFraming.test.ts
+++ b/src/routes/middleware/denyFraming.test.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import { denyFraming } from './denyFraming';
+
+function mockReq(): Request {
+  return {} as Request;
+}
+
+function mockRes(): { headers: Record<string, string>; setHeader: jest.Mock } {
+  const headers: Record<string, string> = {};
+  return {
+    headers,
+    setHeader: jest.fn((name: string, value: string) => {
+      headers[name] = value;
+    }),
+  };
+}
+
+describe('denyFraming', () => {
+  it('sets X-Frame-Options to DENY', () => {
+    const res = mockRes();
+    const next = jest.fn();
+    denyFraming(mockReq(), res as unknown as Response, next as NextFunction);
+    expect(res.headers['X-Frame-Options']).toBe('DENY');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('sets Content-Security-Policy frame-ancestors to none', () => {
+    const res = mockRes();
+    const next = jest.fn();
+    denyFraming(mockReq(), res as unknown as Response, next as NextFunction);
+    expect(res.headers['Content-Security-Policy']).toBe("frame-ancestors 'none'");
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/src/routes/middleware/denyFraming.ts
+++ b/src/routes/middleware/denyFraming.ts
@@ -1,0 +1,7 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function denyFraming(_req: Request, res: Response, next: NextFunction) {
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Content-Security-Policy', "frame-ancestors 'none'");
+  next();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import {
 import templatesRouter from './routes/TemplatesRouter';
 import defaultRouter from './routes/DefaultRouter';
 import rejectScannerProbes from './routes/middleware/rejectScannerProbes';
+import { denyFraming } from './routes/middleware/denyFraming';
 import { noindexNonCanonicalHosts } from './routes/middleware/noindexNonCanonicalHosts';
 import { redirectNonCanonicalHosts } from './routes/middleware/redirectNonCanonicalHosts';
 import { redirectConvertDuplicates } from './routes/middleware/redirectConvertDuplicates';
@@ -185,6 +186,7 @@ const serve = async () => {
   app.use(mindmapRouter());
 
   app.use(wellKnownRouter());
+  app.use(denyFraming);
   app.use(rejectScannerProbes);
   app.use(defaultRouter());
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -114,6 +114,7 @@ const AnswersPage = lazy(() => import('./pages/AnswersPage/AnswersPage'));
 const LimitPage = lazy(() => import('./pages/LimitPage/LimitPage'));
 const SharedDeckPage = lazy(() => import('./pages/SharedDeckPage'));
 const MindmapsPage = lazy(() => import('./pages/MindmapsPage'));
+const SecurityPage = lazy(() => import('./pages/SecurityPage/SecurityPage'));
 
 const queryClient = new QueryClient();
 
@@ -296,6 +297,7 @@ function AppContent({
           <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
           <Route path="/settings" element={requireAuth(<AccountPage />)} />
           <Route path="/about" element={<AboutPage />} />
+          <Route path="/security" element={<SecurityPage />} />
           <Route path="/whats-new" element={<WhatsNewPage />} />
           <Route path="/documentation" element={<DocsPage />} />
           <Route path="/documentation/*" element={<DocsPage />} />

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -26,6 +26,7 @@ function Footer() {
           <a href="/documentation/misc/privacy-policy">
             {getVisibleText('navigation.legal.privacy')}
           </a>
+          <a href="/security">Security</a>
         </div>
       </div>
       <div className={styles.bottom}>

--- a/web/src/pages/SecurityPage/SecurityPage.module.css
+++ b/web/src/pages/SecurityPage/SecurityPage.module.css
@@ -1,0 +1,21 @@
+.section {
+  margin-block: 1.5rem;
+}
+
+.section h2 {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 0.5rem;
+}
+
+.section p {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  margin: 0 0 0.75rem;
+}
+
+.section p:last-child {
+  margin-bottom: 0;
+}

--- a/web/src/pages/SecurityPage/SecurityPage.tsx
+++ b/web/src/pages/SecurityPage/SecurityPage.tsx
@@ -1,0 +1,65 @@
+import styles from '../../styles/shared.module.css';
+import pageStyles from './SecurityPage.module.css';
+
+export default function SecurityPage() {
+  return (
+    <div className={styles.page}>
+      <h1 className={styles.title}>Security</h1>
+
+      <section className={pageStyles.section}>
+        <h2>Report a vulnerability</h2>
+        <p>Email support@2anki.net with details of what you found.</p>
+      </section>
+
+      <section className={pageStyles.section}>
+        <h2>What to include</h2>
+        <p>
+          A clear write-up of the issue, steps to reproduce it, what you were
+          able to access or affect, and how severe you think it is. A working
+          proof of concept is helpful but not required.
+        </p>
+      </section>
+
+      <section className={pageStyles.section}>
+        <h2>Scope</h2>
+        <p>
+          In scope: 2anki.net and its subdomains, the API, authentication flows,
+          file upload and conversion, user data, and the 2anki/server GitHub
+          repository.
+        </p>
+        <p>
+          Out of scope: third-party services we integrate with (Notion, Stripe,
+          Anthropic, AnkiWeb), social engineering, physical attacks, denial of
+          service without a working amplification proof of concept, automated
+          scanner output without a reproducible exploit, missing security headers
+          or version disclosure without demonstrated impact, and findings on
+          forks or preview deploys.
+        </p>
+      </section>
+
+      <section className={pageStyles.section}>
+        <h2>Response time</h2>
+        <p>
+          We acknowledge reports within 5 business days. We aim to resolve
+          critical issues within 30 days. This is best-effort — 2anki is a
+          small team. If you have not heard back in a week, follow up at the
+          same address.
+        </p>
+      </section>
+
+      <section className={pageStyles.section}>
+        <h2>Rewards</h2>
+        <p>
+          No monetary bounty. If you would like to be credited, say so in your
+          report and we will add your name to the acknowledgements below once
+          the issue is resolved.
+        </p>
+      </section>
+
+      <section className={pageStyles.section}>
+        <h2>Acknowledgements</h2>
+        <p>No reports yet.</p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds three security-posture artifacts in one PR: a `denyFraming` middleware that sets `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` on every response; a `/.well-known/security.txt` endpoint per RFC 9116; and a `/security` page with a responsible-disclosure policy, linked from the Footer Legal column.

## Why
Security researchers looking to report a vulnerability currently have no documented channel. A missing `security.txt` is a common scanner finding that generates noise. The `/security` page gives reporters a clear scope, contact, and SLA without any external dependency.

## How
- `denyFraming` middleware is two `setHeader` calls and a `next()`. Mounted immediately before `rejectScannerProbes` in `server.ts`. Frame-surface audit in the brief confirmed no third party embeds 2anki.net: `CardFrame`/`EditorPage` use `srcDoc` (no HTTP request), YouTube is us embedding them, Stripe Checkout is a redirect, OAuth flows are popups.
- `security.txt` handler lives in `WellKnownRouter` alongside the existing Apple domain-association endpoint. `Expires` is computed at request time (now + 1 year ISO 8601).
- `SecurityPage` uses `styles.page` from shared CSS + a local `.section` rule for `margin-block`. Six sections verbatim from the trio-approved copy. No auth gate. Lazy-loaded from `App.tsx`, link in Footer Legal column.

## Measuring success
`curl -s -o /dev/null -w "%{http_code}" https://2anki.net/.well-known/security.txt` returns 200. `curl -I https://2anki.net/ | grep -i x-frame` shows `X-Frame-Options: DENY`.

## Testing
- Unit tests added: `src/routes/middleware/denyFraming.test.ts` — 2 `it` blocks asserting both headers set and `next()` called.
- All 13 middleware test suites pass (90 tests).
- Server tsc: clean.
- Web typecheck: clean.
- Web vitest: 1305/1305 pass.
- Web Biome lint: clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: /security renders six sections with left-aligned h1, sentence-case h2s, prose paragraphs. Footer Legal column shows Terms / Privacy / Security in the correct order. /.well-known/security.txt returns plain text with all five RFC 9116 fields.

## Changelog
No changelog entry — internal trust artifact for researchers, no user-visible learning-capability change.

## Risks
`frame-ancestors 'none'` blocks any future requirement to embed 2anki.net in an iframe on a third-party domain. No such requirement exists today — the iframes in `CardFrame` and `EditorPage` are us embedding others, not the reverse. If an embed requirement emerges, change `denyFraming` to an allowlist rather than reverting the header.

## Goal alignment
No direct funnel impact. Security posture reduces the risk of trust-destroying incidents that would stall growth toward 300K users. A published disclosure policy is also a credibility signal for institutional and professional users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782643607&installation_id=132681956&pr_number=2873&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2873&signature=2e2971a9f66173cf27c039a6670780cab87942abde501cdccc674c3ffc19905d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->