### PR TITLE
fix: run denyFraming before routes so /login and / get the headers

### DIFF
--- a/src/routes/middleware/denyFraming.wireup.test.ts
+++ b/src/routes/middleware/denyFraming.wireup.test.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import http from 'http';
+import { denyFraming } from './denyFraming';
+
+interface AddressWithPort {
+  port: number;
+}
+
+async function fetchLoginHeaders(
+  buildApp: () => express.Express
+): Promise<Headers> {
+  const app = buildApp();
+  const server = http.createServer(app).listen(0);
+  try {
+    const port = (server.address() as AddressWithPort).port;
+    const res = await fetch(`http://127.0.0.1:${port}/login`);
+    return res.headers;
+  } finally {
+    server.close();
+  }
+}
+
+describe('denyFraming wire-up', () => {
+  it('sets headers on routes that respond inside earlier routers when denyFraming is mounted first', async () => {
+    const headers = await fetchLoginHeaders(() => {
+      const app = express();
+      app.use(denyFraming);
+      app.get('/login', (_req, res) => res.send('<html>spa</html>'));
+      return app;
+    });
+
+    expect(headers.get('x-frame-options')).toBe('DENY');
+    expect(headers.get('content-security-policy')).toBe(
+      "frame-ancestors 'none'"
+    );
+  });
+
+  it('does NOT set headers when denyFraming is mounted after the responding route (regression guard)', async () => {
+    const headers = await fetchLoginHeaders(() => {
+      const app = express();
+      app.get('/login', (_req, res) => res.send('<html>spa</html>'));
+      app.use(denyFraming);
+      return app;
+    });
+
+    expect(headers.get('x-frame-options')).toBeNull();
+    expect(headers.get('content-security-policy')).toBeNull();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -133,6 +133,7 @@ const serve = async () => {
   app.use(redirectNonCanonicalHosts);
   app.use(express.json({ limit: '50mb' }) as RequestHandler);
   app.use(cookieParser());
+  app.use(denyFraming);
   app.use(anonIdMiddleware);
   app.use(noindexNonCanonicalHosts);
   app.use(redirectConvertDuplicates);
@@ -186,7 +187,6 @@ const serve = async () => {
   app.use(mindmapRouter());
 
   app.use(wellKnownRouter());
-  app.use(denyFraming);
   app.use(rejectScannerProbes);
   app.use(defaultRouter());
 


### PR DESCRIPTION
## Problem

The clickjacking middleware shipped in #2873 only protected pages whose path fell through to the SPA catch-all at the end of the Express chain (`/security`, etc.). It did **not** protect `/login`, `/`, or any other path served by an earlier router or by `express.static`. The original PoC URL `https://2anki.net/login#login` is still iframe-able on prod today.

Root cause: in `server.ts`, `app.use(denyFraming)` sat at line 189 — after every feature router (including `usersRouter` at line 162, which registers `router.get('/login', …)` and finalizes the response inside `checkUser` → `sendIndex`). The response was already sent before the middleware could set the headers. Same shape for `/`: `express.static(BUILD_DIR)` at line 154 serves `index.html` via its default `index` option and finalizes the response before line 189.

The brief I gave the implementing agent for #2873 said "alongside `rejectScannerProbes`" — that was wrong. `rejectScannerProbes` is at the bottom of the chain; security headers need to run before anything that responds.

## Fix

Move `app.use(denyFraming)` from line 189 → line 136, right after `cookieParser()`. Now every downstream response — static, router, or SPA catch-all — carries both headers.

## Tests

- Existing `denyFraming.test.ts` (unit) still passes.
- New `denyFraming.wireup.test.ts` (integration) boots a tiny Express app and asserts the invariant in both directions:
  1. denyFraming mounted first → headers present on a `/login`-style route → ✓
  2. denyFraming mounted last → headers absent → ✓ (regression guard)
- Verified locally: typecheck clean, both middleware files green.

## Verification after deploy

curl each of these and confirm both `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` appear:
- `/login` (the original PoC target)
- `/` (SPA root)
- `/security` (was already working)
- `/.well-known/security.txt` (was not working pre-fix — now will)

## Why this is one PR

The diff is `+1 -1` in `server.ts` plus a small test file. No public API change. No code-review concern beyond "is the new position correct" — yes, before `anonIdMiddleware` and every later `app.use`.

No changelog entry — internal security hardening, no user-visible learning-capability change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782645348&installation_id=132681956&pr_number=2874&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2874&signature=431544a6944cb1317156df29cd2424d735ec0f6dc7ac09bbec11cfcf1cf7b969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->