### PR TITLE
chore: gate trio check and expand engineer worktree triggers

### DIFF
--- a/.claude/agents/_trio.md
+++ b/.claude/agents/_trio.md
@@ -21,9 +21,9 @@ pm, designer, and engineer work as a trio, not an assembly line. Decisions happe
 
 A trio feature is not done until: `/check` is green; SonarCloud Security Rating on new code is A (run `sonar-scanner` locally for HTTP / user-input / file-handling / auth changes); every user-facing flow has an error and a loading state; no `// TODO`, scaffolding, or stubs visible to users; no raw DB rows or stack traces in API responses (map to a typed shape); no `localStorage` unless Alexander asked or existing code already uses it for that purpose; if the schema changed, the migration exists and `pnpm kanel` has been rerun; the feature has been manually exercised on the golden path and one edge case.
 
-## Trio check (required)
+## Trio check
 
-End every substantive response with:
+For tasks that change user-visible behavior, end your response with:
 
 **Trio check:**
 - PM would challenge: [one line]
@@ -31,4 +31,6 @@ End every substantive response with:
 - Engineer would challenge: [one line]
 - My response: [one line each, or "agree — adjust accordingly"]
 
-If you can't fill in what another agent would challenge, you haven't pressure-tested your own view. Try harder before writing "nothing."
+Skip on pure refactors, test fixes, dependency bumps, CI/build issues, and internal-only changes — match the trio-required heuristic in `CLAUDE.md`. The ceremony exists to pressure-test product decisions, not to decorate every reply.
+
+When the check applies and you can't fill in what another agent would challenge, you haven't pressure-tested your own view. Try harder before writing "nothing."

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -45,9 +45,12 @@ Before the first `Edit`, `Write`, or `Bash` command that mutates files, check th
 
 - `src/services/AuthenticationService/**`
 - `src/services/StripeService/**`
+- `src/controllers/StripeController/**`
+- `src/routes/WebhookRouter.*`
 - `src/lib/Token.ts`
+- `src/server.ts` (boot wiring, startup jobs, middleware order)
 - `migrations/**`
-- Any path matching `**/auth/**` or `**/payments/**` (case-insensitive)
+- Any path matching `**/auth/**`, `**/payments/**`, or `**/webhook*/**` (case-insensitive)
 
 **Why:** Reverting a worktree is free; reverting a bad edit on the orchestrator's main checkout costs a force-revert and may require a re-deploy. The cost of `EnterWorktree` is seconds; the cost of a botched auth or payments change on main is hours.
 


### PR DESCRIPTION
## What
Two small tightenings to the trio agent setup in `.claude/agents/`.

- `_trio.md`: the `Trio check:` section is now scoped to tasks that change user-visible behavior, matching the trio-required heuristic already documented in `CLAUDE.md`. Pure refactors, CI/test fixes, dep bumps, and internal-only changes skip it.
- `engineer.md`: mandatory worktree triggers expanded to cover surfaces `CLAUDE.md` already calls "risky" but the agent's list missed — `src/controllers/StripeController/**`, `src/routes/WebhookRouter.*`, `src/server.ts` (boot wiring), and a broader `**/webhook*/**` glob alongside the existing `**/auth/**` and `**/payments/**`.

## Why
Surfaced by a review of `.claude/`:

- Trio check was firing on every substantive response regardless of task type, taxing one-line bug fixes with a four-line meta-block. The trio policy in `CLAUDE.md` already distinguishes trio-required from trio-optional tasks; the agents' shared protocol now matches.
- Engineer's worktree gate was narrower than the "risky changes" wording in `CLAUDE.md` — Stripe webhook handlers and `server.ts` boot wiring could be edited on the main checkout, where revert is expensive.

## How
Edit-only changes to two prompt files. No source code, no tests, no migrations.

## Testing
N/A — agent prompt configuration.

## Changelog
No entry — internal-only, no user-visible behavior change.

## Risks
Low. The Trio check is now suppressed on the same task classes `CLAUDE.md` already lists as trio-optional, so behavior on trio-required work is unchanged. The expanded worktree list can only add `EnterWorktree` calls; it never removes one.

## Goal alignment
Indirect — keeps the trio overhead proportional to product impact (less ceremony on routine work, more safety on hot paths), which keeps shipping speed up without trading away revert cost on auth/payments/webhook edits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782672461&installation_id=132681956&pr_number=2885&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2885&signature=5b23c1d3161d77d57d56ba15794b620800fbff9c2ae35f801e4c51ebfe3e2c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->