### PR TITLE
chore: promote engineer/designer/test-writer agents to opus

### DIFF
--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -2,7 +2,7 @@
 name: designer
 description: Makes UI/UX, copy, and visual consistency decisions for 2anki.net. Use for new screens, flow changes, microcopy, error states, empty states, onboarding, or any visual review. Takes a problem and returns a concrete design recommendation, not options.
 tools: Read, Write, Edit, Grep, Glob
-model: sonnet
+model: opus
 ---
 
 You are the **Designer** in the 2anki product trio. Your job is to make 2anki feel obvious, fast, and trustworthy — so users finish their first conversion, come back the next day, and tell a friend. The north-star goal is in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -2,7 +2,7 @@
 name: engineer
 description: Implements features and bug fixes for 2anki/server. Use for turning specs into code, writing tests, reviewing PRs, debugging production issues, refactoring, and any change that touches the codebase. Takes a spec or issue, produces working code with tests, opens a PR.
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: sonnet
+model: opus
 ---
 
 You are the **Engineer** in the 2anki product trio. Your job is to ship working code that moves us toward the 300K-user goal in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -2,7 +2,7 @@
 name: test-writer
 description: Writes Jest tests for a given source file in an isolated worktree. Reads the file, designs colocated tests against the public surface, runs them, and returns the diff. Does not touch source code.
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: sonnet
+model: opus
 isolation: worktree
 ---
 


### PR DESCRIPTION
## What
Bumps three of the four trio agents from `sonnet` to `opus` in their frontmatter `model:` field.

- `engineer` — sonnet → opus
- `designer` — sonnet → opus
- `test-writer` — sonnet → opus
- `pm` — already opus, unchanged
- `dead-code-auditor` — stays on haiku (read-only grep loop, opus would be wasted)

## Why
The trio's load-bearing output is judgment, not throughput:

- Engineer specs land as code that ships to users; opus catches subtler edge cases, weighs alternatives better, and notices when a spec is ambiguous instead of guessing. Paired with the worktree gate on auth/payments/webhook/migration paths, the quality lift is in the right place.
- Designer output drives copy, hierarchy, and visual consistency decisions that propagate everywhere. Opus is materially better at catching voice drift and "you're inventing a new pattern when one exists" — both are real risks today.
- Test-writer is the weakest case (mechanical for routine sources), but test contracts are load-bearing — a sloppy test pins the wrong behavior. Defensible.

`dead-code-auditor` is excluded on purpose: read-only grep + read with a tightly structured output, no judgment latitude. Opus would be ~30–50x cost vs haiku for negligible quality lift.

## How
Three frontmatter edits. No prose changes, no tool changes, no behavior changes beyond the model swap.

## Trade-offs
- Latency: opus is 2–3x slower than sonnet. Trio invocations (parallel) wait on the slowest agent.
- Cost: opus is roughly 5x per call. At solo-founder volume the absolute cost is small relative to the cost of a bad spec or shipped bug.

If trio latency becomes painful in practice, drop `test-writer` back to sonnet first — it's the weakest case for opus.

## Testing
N/A — agent prompt configuration.

## Changelog
No entry — internal-only, no user-visible behavior change.

## Risks
Low. Agent capabilities and prompts are unchanged; only the routing tier moves. Reverting is a one-line edit per agent.

## Goal alignment
Indirect — higher-quality trio output means fewer regression PRs and tighter specs, which compounds shipping speed over time.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782672641&installation_id=132681956&pr_number=2886&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2886&signature=f6231212d132b87599dc96355bc76567c20844b1a12502f992b9cad81662cde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->