### PR TITLE
chore: remove unused IsDebug helper and empty isLoginPage file

### DIFF
--- a/src/lib/debug/index.ts
+++ b/src/lib/debug/index.ts
@@ -1,6 +1,0 @@
-/**
- *  If the default bucket is not set, we can safely assume we are running in debug mode.
- * @returns boolean
- */
-export const IsDebug = () =>
-  process.env.SPACES_DEFAULT_BUCKET_NAME === undefined;


### PR DESCRIPTION
## What
Two dead-code removals surfaced by `dead-code-auditor`:

- `src/lib/debug/index.ts` — `IsDebug()` was a one-line env check for `SPACES_DEFAULT_BUCKET_NAME` with zero importers across the repo.
- `web/src/components/NavigationBar/helpers/isLoginPage.ts` — empty file (no exports). NavigationBar computes the equivalent via a local `isResolved` variable instead.

`preserveFilesForDebugging` in the same `src/lib/debug/` folder is unaffected.

## Why
Both helpers were unreferenced. Keeping them costs nothing in runtime but adds noise to greps, IDE autocomplete, and future audits.

## How
`git rm` on the two files. Pre-deletion grep confirmed no references outside the files themselves.

## Testing
`/check` clean: server tsc, web typecheck, 1307 vitest tests, web Biome lint. No tests had to change because no code depended on either file.

## Browser check
Browser check: not applicable — deletes a file with no exports; no rendered output changes.

## Changelog
No entry — internal-only, no user-visible behavior change.

## Risks
Minimal. If something dynamically imported `IsDebug` via a string the grep would miss it, but there's no `import(...)` or string-based reference in the codebase. Reverting is one `git revert` away.

## Goal alignment
Indirect — cleaner module graph compounds shipping speed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782676042&installation_id=132681956&pr_number=2888&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2888&signature=d5d7d66f4d174ea8bd07343ae3ea3f57faa5547120ff9820146b794c42fdb8e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->