### PR TITLE
feat: add POST /auth/apple/native for native Apple Sign In

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -34,6 +34,7 @@ jest.mock('../data_layer/UsersRepository', () => {
     getById: mockGetById,
     getCardUsage: jest.fn().mockResolvedValue({ cards_used: 0 }),
     getPrintUsage: jest.fn().mockResolvedValue({ prints_used: 0, month_started_at: null }),
+    updateName: jest.fn().mockResolvedValue(undefined),
   }));
 });
 
@@ -2010,6 +2011,199 @@ describe('UsersController.cancelSubscription', () => {
     expect(
       SubscriptionService.cancelUserSubscriptions
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe('UsersController.loginWithAppleNative', () => {
+  const MockedOauthIdentitiesRepo =
+    OauthIdentitiesRepository as jest.MockedClass<typeof OauthIdentitiesRepository>;
+
+  beforeEach(() => {
+    MockedOauthIdentitiesRepo.mockClear();
+    MockedOauthIdentitiesRepo.prototype.findByProviderAndSubject = jest
+      .fn()
+      .mockResolvedValue(null);
+    MockedOauthIdentitiesRepo.prototype.link = jest
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  const buildNativeController = (overrides?: {
+    getUserFrom?: jest.Mock;
+    getUserById?: jest.Mock;
+    register?: jest.Mock;
+    markEmailVerified?: jest.Mock;
+    newJWTToken?: jest.Mock;
+    persistToken?: jest.Mock;
+    updateLastLoginAt?: jest.Mock;
+    verifyAppleIdentityToken?: jest.Mock;
+  }) => {
+    const recordExecute = jest.fn().mockResolvedValue(undefined);
+    const mockUser = { id: 30, email: 'native-apple@example.com' };
+    const userService = {
+      getUserFrom:
+        overrides?.getUserFrom ??
+        jest.fn().mockResolvedValueOnce(null).mockResolvedValue(mockUser),
+      getUserById: overrides?.getUserById ?? jest.fn().mockResolvedValue(mockUser),
+      register: overrides?.register ?? jest.fn().mockResolvedValue([{ id: 30 }]),
+      markEmailVerified:
+        overrides?.markEmailVerified ?? jest.fn().mockResolvedValue(1),
+      updateLastLoginAt:
+        overrides?.updateLastLoginAt ?? jest.fn().mockResolvedValue(undefined),
+    } as unknown as UsersService;
+    const authService = {
+      verifyAppleIdentityToken:
+        overrides?.verifyAppleIdentityToken ??
+        jest.fn().mockResolvedValue({ subject: 'native-sub-001', email: 'native-apple@example.com' }),
+      getHashPassword: jest.fn().mockReturnValue('hashed'),
+      newJWTToken:
+        overrides?.newJWTToken ?? jest.fn().mockResolvedValue('native-apple-jwt'),
+      persistToken:
+        overrides?.persistToken ?? jest.fn().mockResolvedValue(undefined),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>,
+      { execute: recordExecute } as unknown as import('../usecases/observability/RecordUserVisibleErrorUseCase').RecordUserVisibleErrorUseCase
+    );
+    return { controller, userService, authService, recordExecute };
+  };
+
+  const buildNativeRes = () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const cookie = jest.fn();
+    return { json, status, cookie } as unknown as express.Response & {
+      json: jest.Mock;
+      status: jest.Mock;
+      cookie: jest.Mock;
+    };
+  };
+
+  const buildReq = (body: Record<string, unknown> = {}) =>
+    ({
+      body: { identityToken: 'apple-id-token', ...body },
+      headers: {},
+    }) as unknown as express.Request;
+
+  it('returns 400 when identityToken is missing from the request body', async () => {
+    const { controller } = buildNativeController();
+    const req = { body: {}, headers: {} } as unknown as express.Request;
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'missing_identity_token' });
+  });
+
+  it('returns 401 and records the error when the identity token fails verification', async () => {
+    const verifyAppleIdentityToken = jest.fn().mockResolvedValue(undefined);
+    const { controller, recordExecute } = buildNativeController({ verifyAppleIdentityToken });
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(buildReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'invalid_identity_token' });
+    expect(recordExecute).toHaveBeenCalledWith({
+      userId: null,
+      surface: 'oauth_apple_native',
+      code: 'invalid_identity_token',
+    });
+  });
+
+  it('sets a JWT cookie and returns 200 { ok: true } on successful sign-in', async () => {
+    const { controller } = buildNativeController();
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(buildReq(), res);
+
+    expect(res.cookie).toHaveBeenCalledWith('token', 'native-apple-jwt', expect.objectContaining({ httpOnly: true, sameSite: 'lax' }));
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('creates a new user and links the Apple identity when no account exists', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 30 }]);
+    const { controller } = buildNativeController({ register });
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(buildReq(), res);
+
+    expect(register).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      'native-apple@example.com',
+      'apple'
+    );
+    expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
+      'apple',
+      'native-sub-001',
+      30
+    );
+  });
+
+  it('signs in via subject lookup without re-registering when the identity already exists', async () => {
+    const register = jest.fn();
+    MockedOauthIdentitiesRepo.prototype.findByProviderAndSubject = jest
+      .fn()
+      .mockResolvedValue({ user_id: 30, provider: 'apple', subject: 'native-sub-001' });
+    const getUserById = jest.fn().mockResolvedValue({ id: 30, email: 'native-apple@example.com' });
+
+    const { controller } = buildNativeController({ register, getUserById });
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(buildReq(), res);
+
+    expect(register).not.toHaveBeenCalled();
+    expect(getUserById).toHaveBeenCalledWith('30');
+    expect(MockedOauthIdentitiesRepo.prototype.link).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when email is absent and no existing identity row exists', async () => {
+    const verifyAppleIdentityToken = jest.fn().mockResolvedValue({ subject: 'native-sub-noemail', email: undefined });
+    const { controller } = buildNativeController({ verifyAppleIdentityToken });
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(buildReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: 'email_required_for_new_account' });
+  });
+
+  it('uses fullName from request body when creating a new account', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 30 }]);
+    const { controller } = buildNativeController({ register });
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(
+      buildReq({ fullName: { givenName: 'Jane', familyName: 'Doe' } }),
+      res
+    );
+
+    expect(register).toHaveBeenCalledWith(
+      'Jane Doe',
+      expect.any(String),
+      'native-apple@example.com',
+      'apple'
+    );
+  });
+
+  it('falls back to email as name when fullName is absent', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 30 }]);
+    const { controller } = buildNativeController({ register });
+    const res = buildNativeRes();
+
+    await controller.loginWithAppleNative(buildReq(), res);
+
+    expect(register).toHaveBeenCalledWith(
+      'native-apple@example.com',
+      expect.any(String),
+      'native-apple@example.com',
+      'apple'
+    );
   });
 });
 

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -763,11 +763,80 @@ class UsersController {
     }
 
     const { subject, email } = loginRequest;
+    const rawName = this.parseAppleName(req.body);
+    const result = await this.#upsertAppleUser({ subject, email, rawName, req });
+
+    if (result === 'email_missing') {
+      await this.recordError?.execute({ userId: null, surface: 'oauth_apple', code: 'oauth_email_missing' });
+      return res.redirect('/login');
+    }
+    if (result === 'user_creation_failed') {
+      console.info('Failed to create user');
+      await this.recordError?.execute({ userId: null, surface: 'oauth_apple', code: 'oauth_user_creation_failed' });
+      return res.status(400).send('Unknown error. Please try again or register a new account.');
+    }
+    if (result === 'token_failed') {
+      console.info('Failed to create token');
+      return res.status(400).send('Unknown error. Please try again or register a new account.');
+    }
+
+    res.cookie('token', result.token, sessionCookieOptions());
+    return res.status(200).redirect(await this.landingForUser(req, result.user.id));
+  }
+
+  async loginWithAppleNative(req: express.Request, res: express.Response) {
+    const body = req.body as {
+      identityToken?: string;
+      email?: string;
+      fullName?: { givenName?: string; familyName?: string };
+    };
+
+    if (!body.identityToken) {
+      return res.status(400).json({ error: 'missing_identity_token' });
+    }
+
+    const validated = await this.authService.verifyAppleIdentityToken(body.identityToken);
+    if (!validated) {
+      await this.recordError?.execute({ userId: null, surface: 'oauth_apple_native', code: 'invalid_identity_token' });
+      return res.status(401).json({ error: 'invalid_identity_token' });
+    }
+
+    const { subject, email } = validated;
+    const rawName = this.parseNativeAppleName(body.fullName);
+    const result = await this.#upsertAppleUser({ subject, email, rawName, req });
+
+    if (result === 'email_missing') {
+      return res.status(401).json({ error: 'email_required_for_new_account' });
+    }
+    if (result === 'user_creation_failed') {
+      return res.status(401).json({ error: 'user_creation_failed' });
+    }
+    if (result === 'token_failed') {
+      return res.status(500).json({ error: 'token_failed' });
+    }
+
+    res.cookie('token', result.token, sessionCookieOptions());
+    return res.status(200).json({ ok: true });
+  }
+
+  async #upsertAppleUser({
+    subject,
+    email,
+    rawName,
+    req,
+  }: {
+    subject: string;
+    email: string | undefined;
+    rawName: string | undefined;
+    req: express.Request;
+  }): Promise<
+    | { user: { id: number; email?: string }; token: string }
+    | 'email_missing'
+    | 'user_creation_failed'
+    | 'token_failed'
+  > {
     const oauthIdentitiesRepo = new OauthIdentitiesRepository(this.db);
-    const existingIdentity = await oauthIdentitiesRepo.findByProviderAndSubject(
-      'apple',
-      subject
-    );
+    const existingIdentity = await oauthIdentitiesRepo.findByProviderAndSubject('apple', subject);
 
     let user = existingIdentity
       ? await this.userService.getUserById(existingIdentity.user_id.toString())
@@ -776,15 +845,13 @@ class UsersController {
 
     if (!user) {
       if (!email) {
-        await this.recordError?.execute({ userId: null, surface: 'oauth_apple', code: 'oauth_email_missing' });
-        return res.redirect('/login');
+        return 'email_missing';
       }
       const existingByEmail = await this.userService.getUserFrom(email);
       if (existingByEmail) {
         await oauthIdentitiesRepo.link('apple', subject, existingByEmail.id);
         user = existingByEmail;
       } else {
-        const rawName = this.parseAppleName(req.body);
         const hashedPassword = this.authService.getHashPassword(getRandomUUID());
         await this.userService.register(rawName ?? email, hashedPassword, email, 'apple');
         user = await this.userService.getUserFrom(email);
@@ -799,21 +866,14 @@ class UsersController {
     }
 
     if (!user) {
-      console.info('Failed to create user');
-      await this.recordError?.execute({ userId: null, surface: 'oauth_apple', code: 'oauth_user_creation_failed' });
-      return res
-        .status(400)
-        .send('Unknown error. Please try again or register a new account.');
+      return 'user_creation_failed';
     }
 
     if (isNewUser) {
       try {
         const country = extractCountryFromRequest(req);
         if (country != null) {
-          await new UsersRepository(this.db).setSignupCountryIfMissing(
-            user.id,
-            country
-          );
+          await new UsersRepository(this.db).setSignupCountryIfMissing(user.id, country);
         }
       } catch {
         // country capture is best-effort
@@ -824,15 +884,13 @@ class UsersController {
 
     const token = await this.authService.newJWTToken(user.id);
     if (!token) {
-      console.info('Failed to create token');
-      return res
-        .status(400)
-        .send('Unknown error. Please try again or register a new account.');
+      return 'token_failed';
     }
+
     await this.authService.persistToken(token, user.id.toString());
     await this.userService.updateLastLoginAt(user.id.toString());
-    res.cookie('token', token, sessionCookieOptions());
-    res.status(200).redirect(await this.landingForUser(req, user.id));
+
+    return { user, token };
   }
 
   private parseAppleName(body: Record<string, string | undefined>): string | undefined {
@@ -849,6 +907,18 @@ class UsersController {
     } catch {
       return undefined;
     }
+  }
+
+  private parseNativeAppleName(
+    fullName: { givenName?: string; familyName?: string } | undefined
+  ): string | undefined {
+    if (!fullName) {
+      return undefined;
+    }
+    const first = typeof fullName.givenName === 'string' ? fullName.givenName.trim() : '';
+    const last = typeof fullName.familyName === 'string' ? fullName.familyName.trim() : '';
+    const full = `${first} ${last}`.trim().slice(0, 200);
+    return full.length > 0 ? full : undefined;
   }
 
   async loginWithNotion(req: express.Request, res: express.Response) {

--- a/src/env.example
+++ b/src/env.example
@@ -26,3 +26,4 @@ APPLE_KEY_ID=''
 # base64-encoded .p8 contents from Apple Developer portal
 APPLE_PRIVATE_KEY_B64=''
 APPLE_DOMAIN_ASSOCIATION=''
+APPLE_NATIVE_CLIENT_ID=''

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -746,6 +746,51 @@ const UserRouter = () => {
 
   /**
    * @swagger
+   * /auth/apple/native:
+   *   post:
+   *     summary: Apple Sign In from native iOS/macOS clients
+   *     description: Accepts an Apple identity token from a native ASAuthorizationController flow, verifies it against Apple's JWKS using the App ID audience (APPLE_NATIVE_CLIENT_ID), and issues a session cookie. Does not use the web OAuth code flow.
+   *     tags: [Authentication]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [identityToken]
+   *             properties:
+   *               identityToken:
+   *                 type: string
+   *               email:
+   *                 type: string
+   *               fullName:
+   *                 type: object
+   *                 properties:
+   *                   givenName:
+   *                     type: string
+   *                   familyName:
+   *                     type: string
+   *     responses:
+   *       200:
+   *         description: Signed in — token cookie set
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 ok:
+   *                   type: boolean
+   *       400:
+   *         description: Missing identity token
+   *       401:
+   *         description: Token verification failed or email required for new account
+   */
+  router.post('/auth/apple/native', express.json(), (req, res) =>
+    controller.loginWithAppleNative(req, res)
+  );
+
+  /**
+   * @swagger
    * /api/users/auth/notion/init:
    *   get:
    *     summary: Initiate Notion OAuth login

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -784,6 +784,190 @@ describe('loginWithApple algorithm pin', () => {
   });
 });
 
+describe('verifyAppleIdentityToken', () => {
+  const NATIVE_CLIENT_ID = 'no.laersmart.2anki';
+  const KID = 'apple-native-key-001';
+  let privateKey: crypto.KeyObject;
+  let publicJwk: Record<string, unknown>;
+
+  const signIdToken = (payload: Record<string, unknown>): string =>
+    jwt.sign(payload, privateKey.export({ type: 'pkcs8', format: 'pem' }), {
+      algorithm: 'RS256',
+      header: { alg: 'RS256', kid: KID },
+    });
+
+  beforeAll(() => {
+    const pair = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    privateKey = pair.privateKey;
+    publicJwk = pair.publicKey.export({ format: 'jwk' }) as Record<string, unknown>;
+    publicJwk['kid'] = KID;
+    publicJwk['alg'] = 'RS256';
+    publicJwk['use'] = 'sig';
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetAppleJwksCacheForTests();
+    process.env.APPLE_NATIVE_CLIENT_ID = NATIVE_CLIENT_ID;
+    mockedAxios.get = jest.fn().mockResolvedValue({ data: { keys: [publicJwk] } });
+  });
+
+  it('returns subject and email for a valid identity token signed for the native audience', async () => {
+    const idToken = signIdToken({
+      iss: 'https://appleid.apple.com',
+      aud: NATIVE_CLIENT_ID,
+      sub: 'native-sub-001',
+      email: 'native@example.com',
+      email_verified: true,
+    });
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toEqual({ subject: 'native-sub-001', email: 'native@example.com' });
+  });
+
+  it('returns subject without email when email claim is absent', async () => {
+    const idToken = signIdToken({
+      iss: 'https://appleid.apple.com',
+      aud: NATIVE_CLIENT_ID,
+      sub: 'native-sub-002',
+      email_verified: true,
+    });
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toEqual({ subject: 'native-sub-002', email: undefined });
+  });
+
+  it('returns undefined when the audience is the web Service ID, not the native App ID', async () => {
+    const idToken = signIdToken({
+      iss: 'https://appleid.apple.com',
+      aud: 'com.example.2anki-web-service-id',
+      sub: 'native-sub-003',
+      email: 'native@example.com',
+      email_verified: true,
+    });
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the issuer is not Apple', async () => {
+    const idToken = signIdToken({
+      iss: 'https://evil.example.com',
+      aud: NATIVE_CLIENT_ID,
+      sub: 'native-sub-004',
+      email: 'native@example.com',
+      email_verified: true,
+    });
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the signature is invalid', async () => {
+    const wrongPair = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const idToken = jwt.sign(
+      {
+        iss: 'https://appleid.apple.com',
+        aud: NATIVE_CLIENT_ID,
+        sub: 'native-sub-005',
+        email: 'native@example.com',
+        email_verified: true,
+      },
+      wrongPair.privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      { algorithm: 'RS256', header: { alg: 'RS256', kid: KID } }
+    );
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the sub claim is missing', async () => {
+    const idToken = signIdToken({
+      iss: 'https://appleid.apple.com',
+      aud: NATIVE_CLIENT_ID,
+      email: 'native@example.com',
+      email_verified: true,
+    });
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when the kid is not in the JWKS', async () => {
+    const idToken = jwt.sign(
+      {
+        iss: 'https://appleid.apple.com',
+        aud: NATIVE_CLIENT_ID,
+        sub: 'native-sub-007',
+        email: 'native@example.com',
+        email_verified: true,
+      },
+      privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      { algorithm: 'RS256', header: { alg: 'RS256', kid: 'unknown-kid' } }
+    );
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when APPLE_NATIVE_CLIENT_ID is not set', async () => {
+    delete process.env.APPLE_NATIVE_CLIENT_ID;
+    const idToken = signIdToken({
+      iss: 'https://appleid.apple.com',
+      aud: NATIVE_CLIENT_ID,
+      sub: 'native-sub-008',
+      email: 'native@example.com',
+      email_verified: true,
+    });
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('rejects ES256-signed tokens (algorithm substitution defense)', async () => {
+    const ecPair = crypto.generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+    const ecPublicJwk = {
+      ...ecPair.publicKey.export({ format: 'jwk' }) as Record<string, unknown>,
+      kid: KID,
+      alg: 'ES256',
+      use: 'sig',
+    };
+    mockedAxios.get = jest.fn().mockResolvedValue({ data: { keys: [ecPublicJwk] } });
+    const idToken = jwt.sign(
+      {
+        iss: 'https://appleid.apple.com',
+        aud: NATIVE_CLIENT_ID,
+        sub: 'native-sub-009',
+        email: 'native@example.com',
+        email_verified: true,
+      },
+      ecPair.privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      { algorithm: 'ES256', header: { alg: 'ES256', kid: KID } }
+    );
+
+    const service = createService();
+    const result = await service.verifyAppleIdentityToken(idToken);
+
+    expect(result).toBeUndefined();
+  });
+});
+
 describe('isNewPasswordValid', () => {
   it('returns false (valid) for a UUID-length reset token and a strong password', () => {
     const service = createService();

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -480,6 +480,51 @@ class AuthenticationService {
       return undefined;
     }
   }
+
+  async verifyAppleIdentityToken(
+    idToken: string
+  ): Promise<{ subject: string; email?: string } | undefined> {
+    const audience = process.env.APPLE_NATIVE_CLIENT_ID;
+    if (!audience) {
+      return undefined;
+    }
+    try {
+      const decoded = jwt.decode(idToken, { complete: true });
+      if (!decoded || typeof decoded === 'string') {
+        return undefined;
+      }
+      const kid = decoded.header.kid;
+      const alg = decoded.header.alg;
+      if (alg !== 'RS256' || typeof kid !== 'string') {
+        return undefined;
+      }
+      const jwks = await getAppleJwks();
+      const jwk = jwks.find((k) => k.kid === kid);
+      if (!jwk) {
+        return undefined;
+      }
+      const publicKey = crypto.createPublicKey({ key: jwk, format: 'jwk' });
+      const payload = jwt.verify(idToken, publicKey, {
+        algorithms: ['RS256'],
+        audience,
+        issuer: APPLE_ISSUER,
+      });
+      if (typeof payload === 'string') {
+        return undefined;
+      }
+      const subject = typeof payload.sub === 'string' ? payload.sub : undefined;
+      if (!subject) {
+        return undefined;
+      }
+      const email =
+        typeof payload.email === 'string' && payload.email.length > 0
+          ? payload.email
+          : undefined;
+      return { subject, email };
+    } catch {
+      return undefined;
+    }
+  }
 }
 
 export default AuthenticationService;


### PR DESCRIPTION
Closes #2889.

## What
Adds `POST /auth/apple/native` — a new endpoint for native iOS/macOS clients using `ASAuthorizationController`. It accepts an Apple identity token directly, verifies it against Apple's JWKS using the App ID audience (`APPLE_NATIVE_CLIENT_ID`), and issues the same `token` JWT cookie the web OAuth path does.

## Why
The existing `POST /auth/apple/callback` rejects native credentials at two points: (1) it requires an `apple_login_state` cookie set by the web init flow, and (2) the token exchange uses `APPLE_CLIENT_ID` (Service ID) while native credentials are bound to the App ID. A separate endpoint is the standard pattern — the native client already has the identity token from `ASAuthorizationAppleIDCredential.identityToken`, no server-side token exchange needed.

## How
- `AuthenticationService.verifyAppleIdentityToken(idToken)` — mirrors the JWKS verification block in `loginWithApple` but uses `APPLE_NATIVE_CLIENT_ID` as the audience. Returns `{ subject, email? }` or `undefined`.
- `UsersController.loginWithAppleNative(req, res)` — validates `identityToken` in body, calls `verifyAppleIdentityToken`, records `oauth_apple_native` / `invalid_identity_token` errors, returns `200 { ok: true }` with cookie.
- `UsersController.#upsertAppleUser({ subject, email, rawName, req })` — private helper extracted from `loginWithApple`. Both the web and native paths now call this helper. The web path behavior is unchanged (same test coverage, all existing tests pass).
- `UserRouter`: mounts `POST /auth/apple/native` with `express.json()` middleware.
- `src/env.example`: adds `APPLE_NATIVE_CLIENT_ID=''`.

New env var: `APPLE_NATIVE_CLIENT_ID` — the iOS/macOS App ID bundle identifier (e.g. `no.laersmart.2anki`). Distinct from `APPLE_CLIENT_ID` (the web Service ID). Orchestrator is applying this to prod separately.

## Measuring success
Log line `oauth_apple_native / invalid_identity_token` in `user_visible_errors` confirms the error path fires correctly. A successful native sign-in produces a `token` cookie in the client — confirmed by checking the `tokens` table for a new row with the user's id after the first native request.

## Testing
- Service: 9 new tests for `verifyAppleIdentityToken` (valid token, missing audience, wrong audience, bad signature, wrong issuer, missing sub, unknown kid, no env var, ES256 algorithm rejection).
- Controller: 8 new tests for `loginWithAppleNative` (missing token, invalid token + error recording, success + cookie, new user creation, existing identity lookup, email missing for new account, fullName used as name, email fallback as name).
- All existing tests (134 total across both files) pass — `loginWithApple` web path is unchanged.

## Browser check
Browser check: not applicable — server-side endpoint only, no rendered output. The user-visible change ships when the native iOS/macOS client is updated.

## Changelog
No changelog entry — server-side prerequisite; the user-visible change ships with the native app release. Web users on 2anki.net are not affected by this endpoint.

## Risks
- `#upsertAppleUser` is a private class field — TypeScript strict mode requires `useDefineForClassFields`; the existing tsconfig allows private methods. Verified with `tsc --noEmit`.
- The web `loginWithApple` path now returns from `#upsertAppleUser` via a discriminated union instead of inline branches. All existing Apple OAuth controller tests pass, confirming no behavior change.
- `APPLE_NATIVE_CLIENT_ID` missing from prod env → `verifyAppleIdentityToken` returns `undefined` → 401. Safe fail.

**Security review required before merge** — this is auth code touching a new endpoint. Run `/security-review` before flipping to ready for merge.

## Goal alignment
Unblocks the native 2anki iOS/macOS app from offering Sign in with Apple, which is the lowest-friction auth path on Apple devices. Removing auth friction directly improves conversion for the native client path toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782679951&installation_id=132681956&pr_number=2890&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2890&signature=d3928699a752dc56a5bba76a8254189456a169d6bcd4d268b73eb8d455c7efa2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->