### PR TITLE
fix: escape pipe in replaceAll so cloze content stops duplicating

### DIFF
--- a/src/lib/parser/helpers/handleClozeDeletions.test.ts
+++ b/src/lib/parser/helpers/handleClozeDeletions.test.ts
@@ -151,6 +151,33 @@ describe('#1411 — LaTeX inside cloze blocks', () => {
   });
 });
 
+describe('#412 — pipe characters inside cloze deletions', () => {
+  it('plain text with a pipe inside a cloze does not duplicate', () => {
+    const input = '<p>Use the <code>x|y</code> operator</p>';
+    const result = handleClozeDeletions(input);
+    const matches = result.match(/\{\{c\d+::/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(result).toBe('<p>Use the {{c1::x|y}} operator</p>');
+  });
+
+  it('KaTeX with a pipe inside a cloze does not duplicate', () => {
+    const input = '<p>The norm is <code>KaTex:\\|x\\|</code> here</p>';
+    const result = handleClozeDeletions(input);
+    const matches = result.match(/\{\{c\d+::/g) ?? [];
+    expect(matches.length).toBe(1);
+    expect(result).toBe('<p>The norm is {{c1::\\|x\\| }} here</p>');
+  });
+
+  it('multiple clozes each containing a pipe stay numbered correctly', () => {
+    const input = '<p><code>a|b</code> and <code>c|d</code></p>';
+    const result = handleClozeDeletions(input);
+    const matches = result.match(/\{\{c\d+::/g) ?? [];
+    expect(matches.length).toBe(2);
+    expect(result).toContain('{{c1::a|b}}');
+    expect(result).toContain('{{c2::c|d}}');
+  });
+});
+
 describe('#1094 — code tags become cloze deletions', () => {
   it('code tag in the summary (front) of a toggle becomes a cloze deletion', () => {
     const input = '<p>The speed of light is <code>299792458 m/s</code> in a vacuum.</p>';

--- a/src/lib/parser/helpers/replaceAll.test.ts
+++ b/src/lib/parser/helpers/replaceAll.test.ts
@@ -1,0 +1,21 @@
+import replaceAll from './replaceAll';
+
+describe('replaceAll', () => {
+  it('replaces every occurrence of a plain string', () => {
+    expect(replaceAll('a-b-c', '-', '+')).toBe('a+b+c');
+  });
+
+  it('escapes regex metacharacters in the search value', () => {
+    expect(replaceAll('a(b)c', '(b)', 'X')).toBe('aXc');
+  });
+
+  it('does not treat a pipe in the search value as alternation', () => {
+    expect(replaceAll('<code>x|y</code>', '<code>x|y</code>', '{{c1::x|y}}')).toBe(
+      '{{c1::x|y}}'
+    );
+  });
+
+  it('does not split on pipes when other text matches the right side', () => {
+    expect(replaceAll('foo|bar baz bar', 'foo|bar', 'Z')).toBe('Z baz bar');
+  });
+});

--- a/src/lib/parser/helpers/replaceAll.ts
+++ b/src/lib/parser/helpers/replaceAll.ts
@@ -3,7 +3,7 @@ export default function replaceAll(
   oldValue: string,
   newValue: string
 ): string {
-  const escaped = oldValue.replace(/[\\^$.*+?()[\]{}|/]/g, '\\$&');
+  const escaped = oldValue.replace(/[\\^$.*+?()[\]{}|/]/g, String.raw`\$&`);
   const reg = new RegExp(escaped, 'g');
   return original.replace(reg, newValue);
 }

--- a/src/lib/parser/helpers/replaceAll.ts
+++ b/src/lib/parser/helpers/replaceAll.ts
@@ -3,9 +3,7 @@ export default function replaceAll(
   oldValue: string,
   newValue: string
 ): string {
-  // escaping all special Characters
-  const escaped = oldValue.replace(/[{}()[\].?*+$^\\/]/g, '\\$&');
-  // creating regex with global flag
+  const escaped = oldValue.replace(/[\\^$.*+?()[\]{}|/]/g, '\\$&');
   const reg = new RegExp(escaped, 'g');
   return original.replace(reg, newValue);
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-cloze-pipe-character-renders-once.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-cloze-pipe-character-renders-once.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-cloze-pipe-character-renders-once",
+  "date": "2026-05-30",
+  "type": "fix",
+  "title": "Cloze deletions containing a pipe character render once"
+}


### PR DESCRIPTION
## What
Adds `|` (and other missing regex metacharacters) to the escape class in `src/lib/parser/helpers/replaceAll.ts` so that user content containing a pipe inside a `<code>`, `<strong>`, or `<del>` element stops duplicating when the parser rewrites it.

## Why
Closes #412. Reported in 2021, reopened after stale-bot close: pipe characters inside a cloze deletion render twice on the Anki card. The user worked around it with `\vert`.

Root cause: `replaceAll` did `oldValue.replace(/[{}()[\].?*+$^\\/]/g, '\\$&')` — every regex metacharacter except `|`. When the cloze pipeline asked it to replace `<code>x|y</code>`, the resulting regex `<code>x|y<\/code>` matched both `<code>x` **and** `y</code>` as alternations, so the replacement ran twice and the cloze was emitted twice.

Same blast radius: `<strong>` input-card detection in `DeckParser` and `<del>`-based tag stripping both used `replaceAll` and were equally exposed.

## How
- `replaceAll.ts`: switch the escape class to the standard MDN metacharacter set: `\ ^ $ . * + ? ( ) [ ] { } | /`.
- `replaceAll.test.ts` (new): direct unit tests covering pipe handling.
- `handleClozeDeletions.test.ts`: three #412 regression tests — plain pipe in cloze, KaTeX `\|x\|` norm in cloze, two clozes with pipes stay numbered.

## Measuring success
The three new `#412 — pipe characters inside cloze deletions` tests pass on green; they fail (matches.length = 2/3/4 instead of 1/1/2) on the prior `replaceAll`. Any future regression that swallows the escape will fail those tests deterministically.

## Testing
- Unit tests added: `src/lib/parser/helpers/replaceAll.test.ts` (4 cases) and 3 new `#412` cases in `handleClozeDeletions.test.ts`. All 25 tests in that pair of files pass.
- Server typecheck and web typecheck clean. Web Vitest: 1350/1350.
- Existing `DeckParser.test.ts` failures pre-date this branch and are `PythonExitError` from a missing Python venv — same failure count as `origin/main` minus the cases we fixed.

## Browser check
Browser check: not applicable — server-side parser fix; only `web/src/` file is a changelog JSON.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-30-cloze-pipe-character-renders-once.json` — "Cloze deletions containing a pipe character render once"

## Risks
Low. The escape class only adds characters; behaviour for inputs without those characters is identical. The two pre-existing `replaceAll` call sites in `DeckParser` (`<strong>` and `<del>`) were silently exposed to the same bug and now behave correctly.

Rollback: revert the single-line escape-class change.

## Goal alignment
Math-heavy decks (medicine, engineering, ML) are a core 2anki use case; cloze deletions that render twice broke the deck for those users and they had to manually rewrite formulas. Fixing this removes a long-standing reason to lose trust in the converter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782695050&installation_id=132681956&pr_number=2898&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2898&signature=fce711350c0d5e68cbc5307c6619b42e5c0b21ba97973f6f0c97d379e191a184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->