### PR TITLE
fix: validate {{field}} refs in user-authored templates

### DIFF
--- a/src/controllers/TemplatesController.test.ts
+++ b/src/controllers/TemplatesController.test.ts
@@ -217,6 +217,16 @@ describe('TemplatesController.getUserData', () => {
 });
 
 describe('TemplatesController.saveUserData', () => {
+  const validStarter = {
+    id: 'user-basic',
+    name: 'Custom Basic',
+    description: '',
+    baseType: 'basic',
+    noteType: validNoteType,
+    previewData: {},
+    tags: [],
+  };
+
   it('persists templates and hiddenIds arrays', async () => {
     const create = jest.fn().mockResolvedValue(undefined);
     const controller = new TemplatesController(
@@ -225,14 +235,67 @@ describe('TemplatesController.saveUserData', () => {
     const res = buildRes();
 
     await controller.saveUserData(
-      buildReq({ templates: [{ id: 'x' }], hiddenIds: ['cloze-modern'] }),
+      buildReq({ templates: [validStarter], hiddenIds: ['cloze-modern'] }),
       res
     );
 
     expect(create).toHaveBeenCalledWith(42, {
-      templates: [{ id: 'x' }],
+      templates: [validStarter],
       hiddenIds: ['cloze-modern'],
     });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('rejects a save when a template references a missing field', async () => {
+    const create = jest.fn().mockResolvedValue(undefined);
+    const controller = new TemplatesController(
+      buildService({ create }) as never
+    );
+    const res = buildRes();
+
+    const brokenStarter = {
+      ...validStarter,
+      noteType: {
+        ...validNoteType,
+        tmpls: [
+          {
+            name: 'Card 1',
+            ord: 0,
+            qfmt: '{{Front}}{{#text2 image}}{{text2 image}}{{/text2 image}}',
+            afmt: '{{Back}}',
+          },
+        ],
+      },
+    };
+
+    await controller.saveUserData(
+      buildReq({ templates: [brokenStarter], hiddenIds: [] }),
+      res
+    );
+
+    expect(create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error:
+        "Template references a field that doesn't exist: text2 image. Add the field or remove the reference.",
+      missing: ['text2 image'],
+      templateId: 'user-basic',
+    });
+  });
+
+  it('accepts entries without a noteType (skips validation)', async () => {
+    const create = jest.fn().mockResolvedValue(undefined);
+    const controller = new TemplatesController(
+      buildService({ create }) as never
+    );
+    const res = buildRes();
+
+    await controller.saveUserData(
+      buildReq({ templates: [{ id: 'x' }], hiddenIds: [] }),
+      res
+    );
+
+    expect(create).toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
@@ -379,5 +442,32 @@ describe('TemplatesController.exportTemplate', () => {
     await controller.exportTemplate(buildReq({ noteType: validNoteType }), res);
 
     expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('returns 400 when the noteType references a missing field', async () => {
+    const controller = new TemplatesController(buildService() as never);
+    const res = buildRes();
+
+    const brokenNoteType = {
+      ...validNoteType,
+      tmpls: [
+        {
+          name: 'Card 1',
+          ord: 0,
+          qfmt: '{{Front}}{{#text2 image}}{{text2 image}}{{/text2 image}}',
+          afmt: '{{Back}}',
+        },
+      ],
+    };
+
+    await controller.exportTemplate(buildReq({ noteType: brokenNoteType }), res);
+
+    expect(mockedExport).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error:
+        "Template references a field that doesn't exist: text2 image. Add the field or remove the reference.",
+      missing: ['text2 image'],
+    });
   });
 });

--- a/src/controllers/TemplatesController.ts
+++ b/src/controllers/TemplatesController.ts
@@ -6,6 +6,7 @@ import {
   AnkiNoteType,
   exportNoteTypeToApkg,
 } from '../lib/templates/exportNoteTypeToApkg';
+import { validateTemplateFields } from '../lib/templates/validateTemplateFields';
 import { getDefaultTemplates } from '../services/DefaultTemplatesService';
 import { getOfficialTemplates } from '../services/officialTemplates';
 import {
@@ -33,6 +34,30 @@ function isValidNoteType(value: unknown): value is AnkiNoteType {
     return false;
   }
   return true;
+}
+
+interface InvalidSavedTemplate {
+  templateId: string | undefined;
+  missing: string[];
+  message: string;
+}
+
+function findInvalidSavedTemplate(
+  templates: unknown[]
+): InvalidSavedTemplate | null {
+  for (const entry of templates) {
+    if (!entry || typeof entry !== 'object') continue;
+    const noteType = (entry as { noteType?: unknown }).noteType;
+    if (!isValidNoteType(noteType)) continue;
+    const result = validateTemplateFields(noteType);
+    if (result.ok) continue;
+    return {
+      templateId: (entry as { id?: string }).id,
+      missing: result.missing,
+      message: result.message,
+    };
+  }
+  return null;
 }
 
 function safeApkgFilename(name: string | undefined): string {
@@ -121,6 +146,16 @@ class TemplatesController {
     const templates = Array.isArray(body.templates) ? body.templates : [];
     const hiddenIds = Array.isArray(body.hiddenIds) ? body.hiddenIds : [];
 
+    const invalid = findInvalidSavedTemplate(templates);
+    if (invalid) {
+      res.status(400).json({
+        error: invalid.message,
+        missing: invalid.missing,
+        templateId: invalid.templateId,
+      });
+      return;
+    }
+
     try {
       await this.service.create(owner, { templates, hiddenIds });
       res.status(200).json({ ok: true });
@@ -192,6 +227,15 @@ class TemplatesController {
 
     if (!isValidNoteType(noteType)) {
       res.status(400).json({ error: 'Invalid note type' });
+      return;
+    }
+
+    const validation = validateTemplateFields(noteType);
+    if (!validation.ok) {
+      res.status(400).json({
+        error: validation.message,
+        missing: validation.missing,
+      });
       return;
     }
 

--- a/src/lib/templates/exportNoteTypeToApkg.test.ts
+++ b/src/lib/templates/exportNoteTypeToApkg.test.ts
@@ -3,6 +3,7 @@ import { unzipSync, strFromU8 } from 'fflate';
 const initSqlJs = require('sql.js');
 
 import { exportNoteTypeToApkg, AnkiNoteType } from './exportNoteTypeToApkg';
+import { TemplateFieldValidationError } from './validateTemplateFields';
 
 async function readColJson<T>(apkg: Buffer, column: 'decks' | 'models'): Promise<Record<string, T>> {
   const entries = unzipSync(new Uint8Array(apkg));
@@ -108,6 +109,24 @@ describe('exportNoteTypeToApkg', () => {
 
     expect(Object.values(decks)[0].name).toBe(
       '2anki::Abhiyan Bhandari (Night Mode — Cloze)'
+    );
+  });
+
+  it('refuses to build a deck when a template references a missing field', async () => {
+    const brokenNoteType: AnkiNoteType = {
+      ...basicNoteType,
+      tmpls: [
+        {
+          name: 'Card 1',
+          ord: 0,
+          qfmt: '{{Front}}{{#text2 image}}{{text2 image}}{{/text2 image}}',
+          afmt: '{{Back}}',
+        },
+      ],
+    };
+
+    await expect(exportNoteTypeToApkg(brokenNoteType)).rejects.toBeInstanceOf(
+      TemplateFieldValidationError
     );
   });
 });

--- a/src/lib/templates/exportNoteTypeToApkg.ts
+++ b/src/lib/templates/exportNoteTypeToApkg.ts
@@ -5,6 +5,11 @@ import path from 'node:path';
 const initSqlJs = require('sql.js');
 import { zipSync } from 'fflate';
 
+import {
+  TemplateFieldValidationError,
+  validateTemplateFields,
+} from './validateTemplateFields';
+
 const FIELD_SEPARATOR = '\x1f';
 
 function randomGuid(): string {
@@ -253,6 +258,11 @@ export async function exportNoteTypeToApkg(
   noteType: AnkiNoteType,
   previewData: PreviewData = {}
 ): Promise<Buffer> {
+  const validation = validateTemplateFields(noteType);
+  if (!validation.ok) {
+    throw new TemplateFieldValidationError(validation.missing, validation.message);
+  }
+
   const SQL = await initSqlJs({ locateFile: locateSqlWasm });
   const db = new SQL.Database();
 

--- a/src/lib/templates/validateTemplateFields.test.ts
+++ b/src/lib/templates/validateTemplateFields.test.ts
@@ -1,0 +1,151 @@
+import {
+  extractFieldRefs,
+  validateTemplateFields,
+} from './validateTemplateFields';
+
+describe('extractFieldRefs', () => {
+  it('extracts plain {{field}} references', () => {
+    expect(extractFieldRefs('{{Front}} and {{Back}}')).toEqual([
+      'Front',
+      'Back',
+    ]);
+  });
+
+  it('extracts {{#field}} section openers', () => {
+    expect(extractFieldRefs('{{#Hint}}{{Hint}}{{/Hint}}')).toEqual([
+      'Hint',
+      'Hint',
+      'Hint',
+    ]);
+  });
+
+  it('extracts {{^field}} inverted section openers', () => {
+    expect(extractFieldRefs('{{^Hint}}no hint{{/Hint}}')).toEqual([
+      'Hint',
+      'Hint',
+    ]);
+  });
+
+  it('strips filter prefixes like type:, cloze:, hint:', () => {
+    expect(
+      extractFieldRefs('{{type:Front}} {{cloze:Text}} {{hint:Notes}}')
+    ).toEqual(['Front', 'Text', 'Notes']);
+  });
+
+  it('strips chained filter prefixes (furigana:kanji:Text)', () => {
+    expect(extractFieldRefs('{{furigana:kanji:Text}}')).toEqual(['Text']);
+  });
+
+  it('includes FrontSide as a token so callers can exclude it', () => {
+    expect(extractFieldRefs('{{FrontSide}}<hr>{{Back}}')).toEqual([
+      'FrontSide',
+      'Back',
+    ]);
+  });
+
+  it('ignores empty tokens', () => {
+    expect(extractFieldRefs('{{}} {{ }}')).toEqual([]);
+  });
+});
+
+describe('validateTemplateFields', () => {
+  const baseNoteType = {
+    name: 'Basic',
+    tmpls: [{ name: 'Card 1', ord: 0, qfmt: '{{Front}}', afmt: '{{Back}}' }],
+    flds: [
+      { name: 'Front', ord: 0 },
+      { name: 'Back', ord: 1 },
+    ],
+    css: '',
+  };
+
+  it('passes when every reference resolves against flds', () => {
+    expect(validateTemplateFields(baseNoteType)).toEqual({ ok: true });
+  });
+
+  it('treats FrontSide as a built-in (does not flag it)', () => {
+    const noteType = {
+      ...baseNoteType,
+      tmpls: [
+        {
+          name: 'Card 1',
+          ord: 0,
+          qfmt: '{{Front}}',
+          afmt: '{{FrontSide}}<hr>{{Back}}',
+        },
+      ],
+    };
+    expect(validateTemplateFields(noteType)).toEqual({ ok: true });
+  });
+
+  it('strips filter prefixes before resolving the field', () => {
+    const noteType = {
+      ...baseNoteType,
+      tmpls: [
+        {
+          name: 'Card 1',
+          ord: 0,
+          qfmt: '{{type:Front}}',
+          afmt: '{{cloze:Back}}',
+        },
+      ],
+    };
+    expect(validateTemplateFields(noteType)).toEqual({ ok: true });
+  });
+
+  it('reports a missing field with a VOICE-compliant message', () => {
+    const noteType = {
+      ...baseNoteType,
+      tmpls: [
+        {
+          name: 'Card 1',
+          ord: 0,
+          qfmt: '{{Front}}{{#text2 image}}{{text2 image}}{{/text2 image}}',
+          afmt: '{{Back}}',
+        },
+      ],
+    };
+    const result = validateTemplateFields(noteType);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.missing).toEqual(['text2 image']);
+    expect(result.message).toBe(
+      "Template references a field that doesn't exist: text2 image. Add the field or remove the reference."
+    );
+  });
+
+  it('deduplicates repeated references to the same missing field', () => {
+    const noteType = {
+      ...baseNoteType,
+      tmpls: [
+        {
+          name: 'Card 1',
+          ord: 0,
+          qfmt: '{{Ghost}}{{#Ghost}}{{/Ghost}}',
+          afmt: '{{Ghost}}',
+        },
+      ],
+    };
+    const result = validateTemplateFields(noteType);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.missing).toEqual(['Ghost']);
+  });
+
+  it('lists every missing field across all card templates', () => {
+    const noteType = {
+      ...baseNoteType,
+      tmpls: [
+        { name: 'Card 1', ord: 0, qfmt: '{{Alpha}}', afmt: '{{Back}}' },
+        { name: 'Card 2', ord: 1, qfmt: '{{Beta}}', afmt: '{{Back}}' },
+      ],
+    };
+    const result = validateTemplateFields(noteType);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.missing).toEqual(['Alpha', 'Beta']);
+    expect(result.message).toBe(
+      "Template references fields that don't exist: Alpha, Beta. Add the fields or remove the references."
+    );
+  });
+});

--- a/src/lib/templates/validateTemplateFields.ts
+++ b/src/lib/templates/validateTemplateFields.ts
@@ -1,0 +1,72 @@
+const ANKI_BUILTIN_TOKENS = new Set(['FrontSide']);
+
+const FIELD_REF_PATTERN = /\{\{([^{}]+)\}\}/g;
+
+export function extractFieldRefs(html: string): string[] {
+  const refs: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = FIELD_REF_PATTERN.exec(html)) !== null) {
+    let name = match[1].trim();
+    if (name.startsWith('#') || name.startsWith('/') || name.startsWith('^')) {
+      name = name.slice(1).trim();
+    }
+    while (name.includes(':')) {
+      name = name.slice(name.indexOf(':') + 1).trim();
+    }
+    if (name === '') continue;
+    refs.push(name);
+  }
+  return refs;
+}
+
+interface CardTemplate {
+  qfmt: string;
+  afmt: string;
+}
+
+interface NoteField {
+  name: string;
+}
+
+interface NoteTypeShape {
+  tmpls: CardTemplate[];
+  flds: NoteField[];
+}
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; missing: string[]; message: string };
+
+export function validateTemplateFields(noteType: NoteTypeShape): ValidationResult {
+  const declared = new Set(noteType.flds.map((f) => f.name));
+  const missing: string[] = [];
+  const seen = new Set<string>();
+  for (const tmpl of noteType.tmpls) {
+    const refs = extractFieldRefs(`${tmpl.qfmt}\n${tmpl.afmt}`);
+    for (const ref of refs) {
+      if (ANKI_BUILTIN_TOKENS.has(ref)) continue;
+      if (declared.has(ref)) continue;
+      if (seen.has(ref)) continue;
+      seen.add(ref);
+      missing.push(ref);
+    }
+  }
+  if (missing.length === 0) return { ok: true };
+  return { ok: false, missing, message: buildMessage(missing) };
+}
+
+function buildMessage(missing: string[]): string {
+  if (missing.length === 1) {
+    return `Template references a field that doesn't exist: ${missing[0]}. Add the field or remove the reference.`;
+  }
+  return `Template references fields that don't exist: ${missing.join(', ')}. Add the fields or remove the references.`;
+}
+
+export class TemplateFieldValidationError extends Error {
+  readonly missing: string[];
+  constructor(missing: string[], message: string) {
+    super(message);
+    this.name = 'TemplateFieldValidationError';
+    this.missing = missing;
+  }
+}

--- a/src/services/officialTemplates.test.ts
+++ b/src/services/officialTemplates.test.ts
@@ -1,4 +1,5 @@
 import { getOfficialTemplates } from './officialTemplates';
+import { validateTemplateFields } from '../lib/templates/validateTemplateFields';
 
 describe('getOfficialTemplates', () => {
   const templates = getOfficialTemplates();
@@ -63,39 +64,13 @@ describe('getOfficialTemplates', () => {
   });
 
   it('only references fields that exist on the note type', () => {
-    const ankiBuiltinTokens = new Set(['FrontSide']);
     const failures: string[] = [];
     for (const template of templates) {
-      const declared = new Set(template.noteType.flds.map((f) => f.name));
-      for (const tmpl of template.noteType.tmpls) {
-        for (const ref of extractFieldRefs(tmpl.qfmt + tmpl.afmt)) {
-          if (ankiBuiltinTokens.has(ref)) continue;
-          if (declared.has(ref)) continue;
-          failures.push(
-            `${template.id}: references {{${ref}}} but flds are [${[...declared].join(', ')}]`,
-          );
-        }
+      const result = validateTemplateFields(template.noteType);
+      if (!result.ok) {
+        failures.push(`${template.id}: ${result.message}`);
       }
     }
     expect(failures).toEqual([]);
   });
 });
-
-function extractFieldRefs(html: string): string[] {
-  const refs: string[] = [];
-  const tokenPattern = /\{\{([^{}]+)\}\}/g;
-  let match: RegExpExecArray | null;
-  while ((match = tokenPattern.exec(html)) !== null) {
-    let name = match[1].trim();
-    if (name.startsWith('#') || name.startsWith('/') || name.startsWith('^')) {
-      name = name.slice(1).trim();
-    }
-    const colonIdx = name.indexOf(':');
-    if (colonIdx !== -1) {
-      name = name.slice(colonIdx + 1).trim();
-    }
-    if (name === '') continue;
-    refs.push(name);
-  }
-  return refs;
-}

--- a/web/src/lib/backend/templates.test.ts
+++ b/web/src/lib/backend/templates.test.ts
@@ -4,6 +4,8 @@ import {
   AiQuotaExceededError,
   NoteTypeStarter,
   aiModifyNoteType,
+  downloadNoteTypeApkg,
+  saveUserTemplate,
 } from './templates';
 
 const starter: NoteTypeStarter = {
@@ -112,6 +114,63 @@ describe('aiModifyNoteType error handling', () => {
       expect.objectContaining({
         message: expect.not.stringMatching(/502|Proxy Error/),
       })
+    );
+  });
+});
+
+describe('saveUserTemplate field-validation error', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces the server-sent error message when the API returns 400 with JSON', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(200, { templates: [], hiddenIds: [] })
+    );
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(400, {
+        error:
+          "Template references a field that doesn't exist: text2 image. Add the field or remove the reference.",
+        missing: ['text2 image'],
+        templateId: 'user-basic',
+      })
+    );
+
+    await expect(saveUserTemplate(starter)).rejects.toThrow(
+      "Template references a field that doesn't exist: text2 image. Add the field or remove the reference."
+    );
+  });
+});
+
+describe('downloadNoteTypeApkg field-validation error', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces the server-sent error message on 400', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse(400, {
+        error:
+          "Template references a field that doesn't exist: text2 image. Add the field or remove the reference.",
+        missing: ['text2 image'],
+      })
+    );
+
+    await expect(
+      downloadNoteTypeApkg(starter.noteType, starter.previewData)
+    ).rejects.toThrow(
+      "Template references a field that doesn't exist: text2 image. Add the field or remove the reference."
     );
   });
 });

--- a/web/src/lib/backend/templates.ts
+++ b/web/src/lib/backend/templates.ts
@@ -53,11 +53,26 @@ export async function downloadNoteTypeApkg(
     previewData,
   });
   if (!response.ok) {
+    const message = await readServerErrorMessage(response);
     throw new Error(
-      `Failed to export note type: ${response.status} ${response.statusText}`
+      message ??
+        `Failed to export note type: ${response.status} ${response.statusText}`
     );
   }
   return response.blob();
+}
+
+async function readServerErrorMessage(
+  response: Response
+): Promise<string | null> {
+  const contentType = response.headers.get('Content-Type') ?? '';
+  if (!contentType.includes('application/json')) return null;
+  try {
+    const body = (await response.clone().json()) as { error?: unknown };
+    return typeof body.error === 'string' ? body.error : null;
+  } catch {
+    return null;
+  }
 }
 
 export interface UserTemplatesPayload {
@@ -93,8 +108,10 @@ async function putUserTemplates(payload: UserTemplatesPayload): Promise<void> {
     body: JSON.stringify(payload),
   });
   if (!response.ok) {
+    const message = await readServerErrorMessage(response);
     throw new Error(
-      `Failed to save templates: ${response.status} ${response.statusText}`
+      message ??
+        `Failed to save templates: ${response.status} ${response.statusText}`
     );
   }
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-template-field-validation.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-template-field-validation.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-template-field-validation",
+  "date": "2026-05-30",
+  "type": "fix",
+  "title": "Note types — saving or downloading flags a template that references a field that doesn't exist, before you hit a broken card in Anki"
+}


### PR DESCRIPTION
## What
Catches the bug class where a user-edited Anki template references a `{{field}}` that doesn't exist on its note type. Today the mismatch ships into the downloaded `.apkg`; Anki's own validator only flags it at preview time, and the user sees a broken card with no signal from 2anki.

PR #2328 closed this for the **official** starters via a build-time test. This PR closes it for **user-authored** templates at both save and deck-generation.

## Why
Closes #2329. A returning creator hit this while filming a marketing walkthrough on the Abhiyan Night Mode template and couldn't finish the recording — from the user's perspective, 2anki produced a broken file.

At 300K users, every "2anki gave me a broken deck" report is a churn event. Catching the class at save/generate time is cheaper than supporting each instance.

## How
- New helper `src/lib/templates/validateTemplateFields.ts` parses `{{field}}`, `{{#field}}`, `{{/field}}`, `{{^field}}` references; strips filter prefixes (`type:`, `cloze:`, `hint:`, chained `furigana:kanji:Text`); treats `FrontSide` as an Anki built-in. Returns either `{ ok: true }` or `{ ok: false, missing, message }` — message follows VOICE.md.
- `TemplatesController.saveUserData` and `exportTemplate` validate before persisting / building; return 400 with the message + `missing` field list (and `templateId` on save). The save validation iterates entries with a `noteType`, so hidden-only saves and shaped non-noteType entries pass through unchanged.
- `exportNoteTypeToApkg` runs the same validation as defense-in-depth and throws `TemplateFieldValidationError` if a bad template slips past the controller.
- Web client (`saveUserTemplate`, `downloadNoteTypeApkg`) now reads the server's JSON `error` string and surfaces it. The EditorPage's existing `saveError` banner already renders `error.message`, so the user sees the specific missing-field text inline.
- `officialTemplates.test.ts` was duplicating `extractFieldRefs`; now imports the shared helper.

User-facing copy follows the issue's recommendation:
> Template references a field that doesn't exist: text2 image. Add the field or remove the reference.

For multiple missing fields:
> Template references fields that don't exist: Alpha, Beta. Add the fields or remove the references.

## Measuring success
Search prod logs for the new 400 responses from `PUT /api/templates/user` and `POST /api/templates/export`. The body shape is `{ error, missing, templateId? }`. A non-zero count after deploy means the validator is intercepting bad templates that would have produced broken downloads on `main`; a continued zero count after the rollout window means the bug class wasn't user-reachable before either — unlikely, given the originating signal.

The bigger downstream signal: support email volume mentioning "field not found" / "card won't preview" should drop to zero for new conversions.

## Testing
Unit tests added:
- `validateTemplateFields.test.ts` — 13 cases covering each reference type, filter prefixes (single and chained), the `FrontSide` exclusion, empty tokens, single/multi/missing-field messages, and dedupe.
- `TemplatesController.test.ts` — 400 + body shape for the bad-save case, no-noteType pass-through case, 400 on `exportTemplate` for a bad noteType.
- `exportNoteTypeToApkg.test.ts` — throws `TemplateFieldValidationError`.
- `web/src/lib/backend/templates.test.ts` — `saveUserTemplate` and `downloadNoteTypeApkg` surface the server's JSON `error` string instead of `Failed to save / export...`.

Server full suite was clean for everything that touched these paths; pre-existing unrelated failures in `runParserCanary.test.ts` and `DeckParser.test.ts` exist on `main` and are not blocked by this change.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: needs a manual run — open `/templates/edit/<id>`, delete a field that a template references, click Save, confirm the inline error reads `Template references a field that doesn't exist: <name>. Add the field or remove the reference.` Same flow for the Download button — should 400 with the same message rather than producing an `.apkg`.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-30-template-field-validation.json` — `Note types — saving or downloading flags a template that references a field that doesn't exist, before you hit a broken card in Anki`

## Sonar
`sonar-scanner` not run locally (no `SONAR_TOKEN` configured on this machine). The change is small and follows established patterns; expect Sonar to be clean, but flag any new findings on PR analysis.

## Risks
- Existing user-saved templates with bad field refs that previously persisted will now bounce on the next save. That's the intended behavior, but a user with a half-edited draft will see the new 400 and need to fix the reference before saving. Acceptable — they were going to download a broken deck otherwise.
- Templates created before this PR that already live in the user's saved payload are not retroactively cleaned. The download path catches them at export time, which is the same protection.
- The Anki built-in token allowlist is just `FrontSide` today; if Anki adds another (e.g. `Tags`), the validator will flag it as missing until we extend the constant. Mitigation: the constant is one set in one file.

## Goal alignment
Removes a category of "broken deck" support reports that scale with conversion volume — the cost-per-incident is constant while user count grows. Catching it at the editor save and at deck-gen brings the failure mode forward to a fixable moment (the editor banner) instead of a churnable one (Anki preview).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782695062&installation_id=132681956&pr_number=2899&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2899&signature=920064a96dbd47c94f99a0816aee4f5883ce3c50a4f64d5daf3fffd915804fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->