### PR TITLE
feat: add Pleco to Anki landing page

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -135,6 +135,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://2anki.net/convert/pleco-to-anki</loc>
+    <lastmod>2026-05-30</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/answers/fsrs-explained</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(21);
+    expect(files).toHaveLength(22);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -111,8 +111,8 @@ describe('ConvertLandingPage', () => {
     );
   });
 
-  it('covers all 10 supported input types', () => {
-    expect(CONVERT_LANDING_PAGES.size).toBe(10);
+  it('covers all 11 supported input types', () => {
+    expect(CONVERT_LANDING_PAGES.size).toBe(11);
   });
 
   it('each config entry has a pathname under /convert/', () => {

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -260,6 +260,35 @@ const studystackToAnki: LandingCopy = {
   ],
 };
 
+const plecoToAnki: LandingCopy = {
+  pathname: '/convert/pleco-to-anki',
+  title: 'Pleco to Anki — move your flashcards to Anki | 2anki',
+  description:
+    'Move your Pleco flashcards to Anki. Export your userdict as a .txt file, upload it here, and download a .apkg deck with your Chinese vocabulary.',
+  h1: 'Move your Pleco flashcards to Anki',
+  subhead:
+    'Export your Pleco userdict as a .txt file, drop it here, and get a .apkg deck. Hanzi, pinyin, and definitions come across as basic cards.',
+  whatComesAcross: ankiFidelityProof,
+  faqs: [
+    {
+      q: 'Which Pleco export format works?',
+      a: 'The tab-separated .txt userdict export works through our CSV pipeline. The XML userdict export does not — it carries Pleco-specific scheduling and category metadata we do not parse. Export as .txt and you are set.',
+    },
+    {
+      q: 'How do I export the .txt file from Pleco?',
+      a: 'In the Pleco app, open the flashcards module, go to Import/Export, choose Export Cards, and select the text file format. Save the file to your device, then upload it here.',
+    },
+    {
+      q: 'Will hanzi, pinyin, and definitions all come across?',
+      a: 'Yes. Each row in the .txt export becomes one card: hanzi on the front, pinyin and the English definition on the back. Tone marks and traditional or simplified characters are preserved.',
+    },
+    {
+      q: 'Will my SRS progress and custom categories transfer?',
+      a: 'Card content transfers — the words and definitions. Pleco review history, scheduling, and custom categories stay in Pleco; Anki schedules the imported cards from scratch with its own algorithm.',
+    },
+  ],
+};
+
 const zorbiToAnki: LandingCopy = {
   pathname: '/convert/zorbi-to-anki',
   title: 'Zorbi to Anki — move your flashcards to Anki | 2anki',
@@ -299,5 +328,6 @@ export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['notion-tables-to-anki', notionTablesToAnki],
   ['lingvist-to-anki', lingvistToAnki],
   ['studystack-to-anki', studystackToAnki],
+  ['pleco-to-anki', plecoToAnki],
   ['zorbi-to-anki', zorbiToAnki],
 ]);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-pleco-landing-page.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-pleco-landing-page.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-pleco-landing-page",
+  "date": "2026-05-30",
+  "type": "feature",
+  "title": "Pleco to Anki — convert your .txt userdict export into a clean Anki deck"
+}


### PR DESCRIPTION
## What
Adds `/convert/pleco-to-anki`, the Pleco branded importer landing page. Driven entirely by the existing `convertLandingConfig.ts` shape — same renderer, same upload form, same fidelity proof block as the other Move-from pages (Lingvist, StudyStack, Zorbi).

## Why
Closes #2723, child of Wedge A #2719. Pleco's `.txt` userdict export drops straight into our CSV pipeline. r/Anki users searching "Pleco to Anki" should land on a page that tells them exactly which export format works — and which one does not — instead of bouncing on a broken promise.

## How
- One new `LandingCopy` entry in `web/src/pages/ConvertLandingPage/convertLandingConfig.ts`.
- Four FAQs per the issue: which format works (.txt yes / XML no), how to export from Pleco, what comes across, and the SRS-progress disclaimer.
- Bumped the existing landing-count assertions in `ConvertLandingPage.test.tsx` (10 → 11) and `prerenderLandingPages.test.ts` (21 → 22). The `/convert/:slug` router and the prerender script both pick the new entry up automatically.
- Changelog entry at `2026-05-30-pleco-landing-page.json`.

## Measuring success
- Look at Plausible for `/convert/pleco-to-anki` impressions and conversion to `/upload`.
- Google Search Console: weekly impressions for "pleco to anki" and clicks landing on the new path.

## Testing
- Unit tests updated: `ConvertLandingPage.test.tsx`, `prerenderLandingPages.test.ts`. All 1354 web vitest tests pass. Server tsc, web typecheck, web lint all green.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Page renders fully from config and matches Lingvist/StudyStack/Zorbi layout. FAQ section, upload form, and fidelity proof all render.

## Changelog
`2026-05-30-pleco-landing-page.json` — "Pleco to Anki — convert your .txt userdict export into a clean Anki deck"

## Risks
Pure additive content — single new key in the landing-page map. Rollback is reverting one commit.

## Goal alignment
Wedge A's bet is that branded `/<source>-to-anki` pages capture organic search traffic from learners migrating between flashcard tools. Pleco's r/Anki community is particularly active for Chinese learners; an honest page that names the .txt-vs-XML constraint up front earns trust instead of bouncing skeptics.

Closes #2723

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782726328&installation_id=132681956&pr_number=2900&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2900&signature=89d0d9fd66f1820d95dc538a7a357ba847cae4033d132b7b67458d00f3c54314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->