### PR TITLE
feat: emit pdf_print_options_used event on PDF export

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -6,8 +6,12 @@ import PdfRenderService from '../services/PdfRenderService';
 import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
+import ExportApkgToPdfUseCase from '../usecases/apkg/ExportApkgToPdfUseCase';
+import { track } from '../services/events/track';
 
 jest.mock('../usecases/apkg/ImportApkgToNotionUseCase');
+jest.mock('../usecases/apkg/ExportApkgToPdfUseCase');
+jest.mock('../services/events/track', () => ({ track: jest.fn() }));
 jest.mock('../lib/storage/StorageHandler', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({})),
@@ -16,6 +20,8 @@ jest.mock('node:fs/promises', () => ({
   readFile: jest.fn().mockResolvedValue(Buffer.from('fake')),
   unlink: jest.fn().mockResolvedValue(undefined),
 }));
+
+const trackMock = track as jest.Mock;
 
 function makeRes(locals: Record<string, unknown> = {}): Partial<Response> {
   return {
@@ -189,5 +195,148 @@ describe('ApkgController.importToNotion', () => {
     expect(res.status).toHaveBeenCalledWith(202);
     const executeCall = executeMock.mock.calls[0];
     expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 5000 });
+  });
+});
+
+describe('ApkgController.exportPdf — pdf_print_options_used event', () => {
+  beforeEach(() => {
+    trackMock.mockClear();
+    (ExportApkgToPdfUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        pdf: Buffer.from('fake-pdf'),
+        deckName: 'deck',
+        cardCount: 1,
+      }),
+    }));
+  });
+
+  function makePdfRes(locals: Record<string, unknown> = {}): Response {
+    const res = makeRes(locals) as Partial<Response> & {
+      setHeader?: jest.Mock;
+      send?: jest.Mock;
+    };
+    res.setHeader = jest.fn();
+    res.send = jest.fn();
+    return res as Response;
+  }
+
+  it('fires the event with all four booleans false when every option is default', async () => {
+    const controller = makeController();
+    const req = makeReq({ body: {} }) as Request;
+    const res = makePdfRes({ owner: 42 });
+
+    await controller.exportPdf(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('pdf_print_options_used', {
+      userId: 42,
+      props: {
+        backgroundColor: false,
+        paperSize: false,
+        orientation: false,
+        margins: false,
+      },
+    });
+  });
+
+  it('flags backgroundColor true when the user picks a non-default color', async () => {
+    const controller = makeController();
+    const req = makeReq({ body: { backgroundColor: '#ff0000' } }) as Request;
+    const res = makePdfRes({ owner: 42 });
+
+    await controller.exportPdf(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('pdf_print_options_used', {
+      userId: 42,
+      props: {
+        backgroundColor: true,
+        paperSize: false,
+        orientation: false,
+        margins: false,
+      },
+    });
+  });
+
+  it('flags paperSize true when the user picks a non-default size', async () => {
+    const controller = makeController();
+    const req = makeReq({ body: { paperSize: 'Letter' } }) as Request;
+    const res = makePdfRes({ owner: 42 });
+
+    await controller.exportPdf(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('pdf_print_options_used', {
+      userId: 42,
+      props: {
+        backgroundColor: false,
+        paperSize: true,
+        orientation: false,
+        margins: false,
+      },
+    });
+  });
+
+  it('flags orientation true when the user picks landscape', async () => {
+    const controller = makeController();
+    const req = makeReq({ body: { orientation: 'landscape' } }) as Request;
+    const res = makePdfRes({ owner: 42 });
+
+    await controller.exportPdf(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('pdf_print_options_used', {
+      userId: 42,
+      props: {
+        backgroundColor: false,
+        paperSize: false,
+        orientation: true,
+        margins: false,
+      },
+    });
+  });
+
+  it('flags margins true when the user picks a non-default margin', async () => {
+    const controller = makeController();
+    const req = makeReq({ body: { margins: 'wide' } }) as Request;
+    const res = makePdfRes({ owner: 42 });
+
+    await controller.exportPdf(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith('pdf_print_options_used', {
+      userId: 42,
+      props: {
+        backgroundColor: false,
+        paperSize: false,
+        orientation: false,
+        margins: true,
+      },
+    });
+  });
+
+  it('falls back to null userId when res.locals.owner is missing', async () => {
+    const controller = makeController();
+    const req = makeReq({ body: {} }) as Request;
+    const res = makePdfRes();
+
+    await controller.exportPdf(req, res);
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith(
+      'pdf_print_options_used',
+      expect.objectContaining({ userId: null })
+    );
+  });
+
+  it('does not fire when the request is rejected before parsePdfOptions succeeds', async () => {
+    const controller = makeController();
+    const req = makeReq({ body: { backgroundColor: 'not-a-hex' } }) as Request;
+    const res = makePdfRes({ owner: 42 });
+
+    await controller.exportPdf(req, res);
+
+    expect(trackMock).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
   });
 });

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -23,6 +23,7 @@ import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
 import { isPaying } from '../lib/isPaying';
 import { buildContentDisposition } from '../lib/buildContentDisposition';
+import { track } from '../services/events/track';
 
 const MEDIA_CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',
@@ -221,6 +222,16 @@ class ApkgController {
         res.status(400).json({ message: 'Invalid background color. Use a six-digit hex value like #ffffff.' });
         return;
       }
+      const ownerId = typeof res.locals.owner === 'number' ? res.locals.owner : null;
+      track('pdf_print_options_used', {
+        userId: ownerId,
+        props: {
+          backgroundColor: pdfOptions.backgroundColor !== DEFAULT_PDF_OPTIONS.backgroundColor,
+          paperSize: pdfOptions.paperSize !== DEFAULT_PDF_OPTIONS.paperSize,
+          orientation: pdfOptions.orientation !== DEFAULT_PDF_OPTIONS.orientation,
+          margins: pdfOptions.margins !== DEFAULT_PDF_OPTIONS.margins,
+        },
+      });
       const fs = await import('node:fs/promises');
       let fileBuffer: Buffer;
       try {

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -41,6 +41,7 @@ export const KNOWN_EVENTS = new Set([
   'pricing_left',
   'upload_failed',
   'cancel_during_generating',
+  'pdf_print_options_used',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;


### PR DESCRIPTION
## What
Adds a `pdf_print_options_used` analytics event that fires once per successful `POST /api/apkg/pdf` after `parsePdfOptions` accepts the request. Payload is four booleans naming which of `backgroundColor`, `paperSize`, `orientation`, `margins` differ from the defaults. No hex value, no filename, no user content — just the four flags plus `userId` (from `res.locals.owner`).

## Why
Closes #2298. PR #2296 shipped four user-configurable PDF print options; we agreed to measure adoption before keeping the UI. The decision rule from the issue:

> If <5% of paying users who hit `POST /api/apkg/pdf` send a non-default value (`backgroundColor !== '#ffffff'`) within 30 days, revert the color picker from `PrintForm.tsx` and the `backgroundColor` field from `parsePdfOptions` / `buildHtml`.

**Review checkpoint: 2026-06-14.**

## How
- New `pdf_print_options_used` entry in `KNOWN_EVENTS`.
- Single `track(...)` call inside `ApkgController.exportPdf`, placed after `parsePdfOptions` returns non-null (so rejected hex colors don't fire the event) and before the file read / use case execution.
- `userId` reads `res.locals.owner` (the existing auth-middleware convention in this codebase) with a `typeof === 'number'` guard, falling back to `null` for unauthenticated paths.
- The four prop keys (`backgroundColor`, `paperSize`, `orientation`, `margins`) don't match the `track.ts` PII strip pattern (`email|token|password|filename|content|title`), so they pass through as-is.

The brief specified `res.locals.user?.id ?? null`, but `res.locals.user` is never set anywhere in the codebase — the identifier lives at `res.locals.owner` (see `routes/middleware/configureUserLocal.ts` and `ErrorCaptureMiddleware.ts`). Using the actual convention so the field carries real data.

## Measuring success
Once deployed, the funnel query is:

```sql
SELECT
  COUNT(*) FILTER (WHERE (props->>'backgroundColor')::bool) AS bg_changed,
  COUNT(*) FILTER (WHERE (props->>'paperSize')::bool)        AS paper_changed,
  COUNT(*) FILTER (WHERE (props->>'orientation')::bool)      AS orient_changed,
  COUNT(*) FILTER (WHERE (props->>'margins')::bool)          AS margins_changed,
  COUNT(*)                                                   AS total_exports,
  COUNT(DISTINCT user_id) FILTER (WHERE user_id IS NOT NULL) AS paid_users
FROM events
WHERE name = 'pdf_print_options_used'
  AND created_at >= now() - interval '30 days';
```

Run this on or after 2026-06-14. If `bg_changed / total_exports < 5%` among paying users, revert the color picker per the issue's decision rule.

## Testing
- New `describe('ApkgController.exportPdf — pdf_print_options_used event', ...)` block in `ApkgController.test.ts`:
  - All-default body → 4 booleans all `false`, `userId: 42`, `track` called exactly once.
  - Each of the four options changed in isolation → matching boolean `true`, others `false`.
  - Missing `res.locals.owner` → `userId: null`.
  - Invalid hex color → 400 response, `track` not called.
- All 14 tests in `pnpm test src/controllers/ApkgController.test.ts` pass.
- `/check`: server tsc green, web typecheck green, web vitest 1353/1353, web lint clean.

Browser check: not applicable — server-side analytics, no rendered output.

## Changelog
No entry — internal-only telemetry, no user-visible behavior change.

## Risks
Low. The event sink (`getEventsSink()`) drops the record if props serialize over 1 KB; the four-boolean payload is well under that. If the event name lookup misses (e.g. typo), `track` is type-checked against `KnownEvent` and TS would fail the build — this PR already typechecks clean.

## Goal alignment
Doesn't directly move the 300K-user needle, but it's the data we need to decide whether print options stay or come out — keeping the UI lean serves the "simplest, fastest" mission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782726346&installation_id=132681956&pr_number=2901&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2901&signature=0cfa7980289aa372ae7deb9b2d8133487e812c035ac61973538b4e645ffd3e76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->