### PR TITLE
feat: add Brainscape to Anki landing page

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -141,6 +141,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://2anki.net/convert/brainscape-to-anki</loc>
+    <lastmod>2026-05-30</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/answers/fsrs-explained</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(22);
+    expect(files).toHaveLength(23);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -111,8 +111,8 @@ describe('ConvertLandingPage', () => {
     );
   });
 
-  it('covers all 11 supported input types', () => {
-    expect(CONVERT_LANDING_PAGES.size).toBe(11);
+  it('covers all 12 supported input types', () => {
+    expect(CONVERT_LANDING_PAGES.size).toBe(12);
   });
 
   it('each config entry has a pathname under /convert/', () => {

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -202,6 +202,35 @@ const notionTablesToAnki: LandingCopy = {
   ],
 };
 
+const brainscapeToAnki: LandingCopy = {
+  pathname: '/convert/brainscape-to-anki',
+  title: 'Brainscape to Anki — move your flashcards to Anki | 2anki',
+  description:
+    'Move your Brainscape flashcards to Anki. Export your deck as a CSV, upload it here, and download a .apkg deck that opens clean.',
+  h1: 'Move your Brainscape flashcards to Anki',
+  subhead:
+    'Export your Brainscape deck as CSV, drop it here, get a .apkg deck that opens clean in Anki.',
+  whatComesAcross: ankiFidelityProof,
+  faqs: [
+    {
+      q: 'How do I get a CSV out of Brainscape?',
+      a: 'Open the deck you own, click the deck options menu, and pick Export. Brainscape has historically gated export behind a Pro plan — confirm in your account before you rely on it.',
+    },
+    {
+      q: 'Does this work for decks I did not make?',
+      a: 'No. Brainscape only lets you export decks you own. Copy the cards into a deck on your own account first, then export that one.',
+    },
+    {
+      q: 'What gets carried across?',
+      a: 'Whatever sits in the CSV columns. Brainscape exports the question and answer text by default — those become the card front and back. Extra columns map to extra fields if your CSV has them.',
+    },
+    {
+      q: 'Do images come across?',
+      a: 'No. Brainscape\'s CSV export is text-only — images and audio stay in Brainscape. Re-add any visuals in Anki after import, or paste the image link if the CSV captured one.',
+    },
+  ],
+};
+
 const lingvistToAnki: LandingCopy = {
   pathname: '/convert/lingvist-to-anki',
   title: 'Lingvist to Anki — move your flashcards to Anki | 2anki',
@@ -326,6 +355,7 @@ export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['html-to-anki', htmlToAnki],
   ['apkg-to-csv', apkgToCsv],
   ['notion-tables-to-anki', notionTablesToAnki],
+  ['brainscape-to-anki', brainscapeToAnki],
   ['lingvist-to-anki', lingvistToAnki],
   ['studystack-to-anki', studystackToAnki],
   ['pleco-to-anki', plecoToAnki],

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-brainscape-landing-page.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-brainscape-landing-page.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-brainscape-landing-page",
+  "date": "2026-05-30",
+  "type": "feature",
+  "title": "Brainscape to Anki — turn your exported CSV into a clean Anki deck"
+}


### PR DESCRIPTION
## What
Adds `/convert/brainscape-to-anki` — a landing page that walks Brainscape users through exporting their deck as CSV and converting via 2anki's existing CSV pipeline.

## Why
Per Wedge A (#2719): every migration landing page is a high-intent SEO entry point for users already looking to escape their current tool. The Brainscape spike (#2724) confirmed a native CSV export exists and that the file maps cleanly through our existing CSV path — zero new conversion code needed.

## How
- One new entry in `convertLandingConfig.ts` (matches the `lingvist`/`zorbi` shape — `whatComesAcross: ankiFidelityProof`, four FAQs).
- Sitemap entry inserted in the move-from cluster.
- Prerender count bumped (22 → 23) and `CONVERT_LANDING_PAGES.size` test bumped (11 → 12).

Honesty caveats per #2719 ("the r/Anki crowd noses out fool's gold"):
- FAQ #1 calls out the Pro-only history of the export.
- FAQ #2 calls out that only decks you own can be exported.
- FAQ #4 calls out that images do not come across — Brainscape's CSV is text-only.

No source-app screenshots. No "vs Brainscape" framing — copy uses "Move your" / "Migrating from" throughout.

## Measuring success
- Sitemap submission picks up the new URL; the prerendered `convert/brainscape-to-anki/index.html` shows up in `web/build/` after the next deploy.
- GSC impressions for `brainscape to anki` / `export brainscape to anki` queries over the next 30 days.
- Conversion uploads originating from `?source=/convert/brainscape-to-anki` in the existing source-tag funnel.

## Testing
- `pnpm --filter 2anki-web test` — 1357 passed
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified the page renders the H1, all four FAQs, the fidelity-proof block, and the upload widget. Sign-up CTA carries the correct `?source=` param.

## Changelog
Added: `web/src/pages/WhatsNewPage/changelog/2026-05-30-brainscape-landing-page.json` — "Brainscape to Anki — turn your exported CSV into a clean Anki deck"

## Risks
Low. Pure content addition — no new conversion code, no auth surface, no DB. Worst case: Brainscape widens or narrows their export gating before the page is read by enough searchers to matter. FAQ wording is hedged ("has historically been gated") to absorb that.

Parallel-PR note: the Language Reactor landing page is in flight and touches the same two shared files (`convertLandingConfig.ts`, `sitemap.xml`). Brainscape merges first alphabetically; Language Reactor rebases after.

## Goal alignment
Direct contribution to the 300K-user goal: migration landing pages compound the search-driven funnel from r/Anki and Brainscape-curious users. Each one converts the "we hate $tool, where do we go?" query into a working .apkg in under a minute.

Closes #2724
Part of #2719

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782727568&installation_id=132681956&pr_number=2902&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2902&signature=35045ff832de3b5193c96c9f8f04883b1abef43239c8d1bb89cd9c79fa70880f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->