### PR TITLE
feat: add Language Reactor to Anki landing page

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -147,6 +147,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://2anki.net/convert/language-reactor-to-anki</loc>
+    <lastmod>2026-05-30</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/answers/fsrs-explained</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(23);
+    expect(files).toHaveLength(24);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -111,8 +111,8 @@ describe('ConvertLandingPage', () => {
     );
   });
 
-  it('covers all 12 supported input types', () => {
-    expect(CONVERT_LANDING_PAGES.size).toBe(12);
+  it('covers all 13 supported input types', () => {
+    expect(CONVERT_LANDING_PAGES.size).toBe(13);
   });
 
   it('each config entry has a pathname under /convert/', () => {

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -347,6 +347,35 @@ const zorbiToAnki: LandingCopy = {
   ],
 };
 
+const languageReactorToAnki: LandingCopy = {
+  pathname: '/convert/language-reactor-to-anki',
+  title: 'Language Reactor to Anki — move your saved phrases to Anki | 2anki',
+  description:
+    'Move your Language Reactor saves to Anki. Export the zip from Language Reactor, upload it here, and download a .apkg deck with your phrases, images, and audio.',
+  h1: 'Move your Language Reactor saves to Anki',
+  subhead:
+    'Drop the export zip from Language Reactor — your saved phrases, images, and audio come across as a clean .apkg you can study on any device.',
+  whatComesAcross: ankiFidelityProof,
+  faqs: [
+    {
+      q: 'How do I export from Language Reactor?',
+      a: 'Open the Language Reactor extension, go to your saved phrases, and use the Export option to download a ZIP. The ZIP contains a CSV of your phrases together with the images and audio captured from the source video and subtitles.',
+    },
+    {
+      q: "What's in the export?",
+      a: 'Your saved phrases become cards — the phrase on the front, the translation and context on the back. Images and audio captured from the source video come across embedded so each card keeps its sentence audio and screenshot.',
+    },
+    {
+      q: 'Why do the thumbnails look blank in Anki on my phone?',
+      a: 'Language Reactor stores card thumbnails using CSS background-image URLs. Anki desktop renders these; Anki mobile on iOS and Android does not. The phrase, translation, and audio still work — only the thumbnail image is missing on mobile. Workaround: study these cards on desktop, or wait for the automatic rewrite that turns background-image into a regular img tag (planned).',
+    },
+    {
+      q: 'Does the sentence audio stay paired with the right card?',
+      a: 'Yes. Each audio clip is named in the export so it stays attached to the phrase it came from. After import, tapping the play button on a card plays the original line from the source video.',
+    },
+  ],
+};
+
 export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['notion-to-anki', notionToAnki],
   ['pdf-to-anki', pdfToAnki],
@@ -360,4 +389,5 @@ export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['studystack-to-anki', studystackToAnki],
   ['pleco-to-anki', plecoToAnki],
   ['zorbi-to-anki', zorbiToAnki],
+  ['language-reactor-to-anki', languageReactorToAnki],
 ]);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-language-reactor-landing-page.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-language-reactor-landing-page.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-language-reactor-landing-page",
+  "date": "2026-05-30",
+  "type": "feature",
+  "title": "Language Reactor to Anki — turn your saved phrases, images, and audio into a deck"
+}


### PR DESCRIPTION
## What
Adds `/convert/language-reactor-to-anki` for the Wedge A "switch from X" lineup. One config entry in `convertLandingConfig.ts`, one sitemap entry, one changelog entry, count bumps in the two tests that assert on landing-page counts.

## Why
Closes #2725 (child of Wedge A #2719). Research spike picked Language Reactor over Anki→Notion reverse because the export shape (CSV bundled with media inside a ZIP) is handled day-one by the existing zip + CSV pipeline — no converter changes needed to land an honest page.

## How
- One landing config entry following the `zorbiToAnki` / `lingvistToAnki` shape (subhead, fidelity proof, four FAQs).
- Sitemap URL inserted after `pleco-to-anki` with `lastmod=2026-05-30`.
- Changelog entry as a feature.
- Count assertions in `ConvertLandingPage.test.tsx` (11 → 12) and `prerenderLandingPages.test.ts` (22 → 23) bumped.

The four FAQs cover the export flow, what comes across, the Anki-mobile thumbnail gotcha (honestly disclosed — `background-image:` URLs don't render on iOS/Android Anki), and the audio-pairing question.

Per the parent issue's "Honesty trumps SEO" principle, the thumbnail caveat is in the FAQ as pre-conversion expectation setting. The converter-side rewrite (turn `background-image:` into `<img>`) is a deliberate next-PR — not in scope here.

## Measuring success
Once the page is in the prerender output, the success signal is `/convert/language-reactor-to-anki` ranking in GSC and showing impressions on "language reactor anki" / "language reactor export anki" queries (4-6 week horizon). Sitemap inclusion + crawl pickup is the proximate check; signup conversion from this slug is the downstream check.

## Testing
- `pnpm --filter 2anki-web test -- --run` — 1357 passed (160 files)
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean (Biome, 1056 files)
- The slug renders through the existing `ConvertLandingPage` it.each suite (H1 + FAQs).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Visual parity with the other `/convert/*-to-anki` pages; the shared `<ConvertLandingPage>` component handles all rendering.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-30-language-reactor-landing-page.json` — "Language Reactor to Anki — turn your saved phrases, images, and audio into a deck"

## Risks
Low. New landing page, no shared infra changes. Touches two count-asserting tests (intentionally bumped). If the parallel Brainscape PR (#???) lands first, this branch will need a 3-line rebase on the same files — keep both entries, additive.

## Goal alignment
Wedge A → "switch from X" → Language Reactor sits in language-learning workflows. Honest landing for an export shape we already support → cheap acquisition surface for the 300K-user goal. Honest FAQ keeps trust intact even when the mobile-thumbnail caveat is real.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782727642&installation_id=132681956&pr_number=2903&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2903&signature=980abe547ae393ab4c33cbe7171290a21a64c4943ee119042cf77f73ae028bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->