### PR TITLE
feat: ship .apkg → CSV export for the apkg-to-csv landing page

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -7,10 +7,24 @@ import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
 import ExportApkgToPdfUseCase from '../usecases/apkg/ExportApkgToPdfUseCase';
+import ExportApkgToCsvUseCase, {
+  CardLimitExceededError as CsvCardLimitExceededError,
+  EmptyDeckError as CsvEmptyDeckError,
+} from '../usecases/apkg/ExportApkgToCsvUseCase';
 import { track } from '../services/events/track';
 
 jest.mock('../usecases/apkg/ImportApkgToNotionUseCase');
 jest.mock('../usecases/apkg/ExportApkgToPdfUseCase');
+jest.mock('../usecases/apkg/ExportApkgToCsvUseCase', () => {
+  const actual = jest.requireActual('../usecases/apkg/ExportApkgToCsvUseCase');
+  return {
+    __esModule: true,
+    default: jest.fn(),
+    CardLimitExceededError: actual.CardLimitExceededError,
+    EmptyDeckError: actual.EmptyDeckError,
+    CSV_FREE_NOTE_LIMIT: actual.CSV_FREE_NOTE_LIMIT,
+  };
+});
 jest.mock('../services/events/track', () => ({ track: jest.fn() }));
 jest.mock('../lib/storage/StorageHandler', () => ({
   __esModule: true,
@@ -338,5 +352,112 @@ describe('ApkgController.exportPdf — pdf_print_options_used event', () => {
 
     expect(trackMock).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe('ApkgController.exportCsv', () => {
+  function makeCsvRes(locals: Record<string, unknown> = {}): Response {
+    const res = makeRes(locals) as Partial<Response> & {
+      setHeader?: jest.Mock;
+      send?: jest.Mock;
+    };
+    res.setHeader = jest.fn();
+    res.send = jest.fn();
+    return res as Response;
+  }
+
+  let executeMock: jest.Mock;
+
+  beforeEach(() => {
+    executeMock = jest.fn().mockResolvedValue({
+      csv: Buffer.from('Model,Front,Back,Tags\r\nBasic,Q,A,\r\n'),
+      deckName: 'My deck',
+      noteCount: 1,
+    });
+    (ExportApkgToCsvUseCase as unknown as jest.Mock).mockImplementation(() => ({
+      execute: executeMock,
+    }));
+  });
+
+  it('returns 400 when no file is uploaded', async () => {
+    const controller = makeController();
+    const req = makeReq({ file: undefined }) as Request;
+    const res = makeCsvRes();
+    await controller.exportCsv(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the file is not an .apkg by extension', async () => {
+    const controller = makeController();
+    const req = makeReq({
+      file: { ...(makeReq().file as Express.Multer.File), originalname: 'notes.zip' },
+    }) as Request;
+    const res = makeCsvRes();
+    await controller.exportCsv(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('sends CSV bytes with attachment headers on success', async () => {
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes({ patreon: true });
+
+    await controller.exportCsv(req, res);
+
+    expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), true);
+    const setHeader = (res as unknown as { setHeader: jest.Mock }).setHeader;
+    expect(setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/csv; charset=utf-8'
+    );
+    expect(setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringContaining('attachment;')
+    );
+    expect(setHeader).toHaveBeenCalledWith(
+      'Content-Disposition',
+      expect.stringContaining('deck.csv')
+    );
+    expect(setHeader).toHaveBeenCalledWith('X-Card-Count', '1');
+    expect(
+      (res as unknown as { send: jest.Mock }).send
+    ).toHaveBeenCalledWith(expect.any(Buffer));
+  });
+
+  it('passes isPaying=false through to the use case for free users', async () => {
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes({ patreon: false, subscriber: false });
+
+    await controller.exportCsv(req, res);
+
+    expect(executeMock).toHaveBeenCalledWith(expect.any(Buffer), false);
+  });
+
+  it('returns 400 when the deck has no notes', async () => {
+    executeMock.mockRejectedValueOnce(new CsvEmptyDeckError());
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes({ patreon: true });
+
+    await controller.exportCsv(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 402 with note count when a free user exceeds the cap', async () => {
+    executeMock.mockRejectedValueOnce(new CsvCardLimitExceededError(250, 100));
+    const controller = makeController();
+    const req = makeReq() as Request;
+    const res = makeCsvRes();
+
+    await controller.exportCsv(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(402);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ note_count: 250, note_limit: 100 })
+    );
   });
 });

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -14,6 +14,10 @@ import ExportApkgToPdfUseCase, {
   type PaperSize,
   type PdfOptions,
 } from '../usecases/apkg/ExportApkgToPdfUseCase';
+import ExportApkgToCsvUseCase, {
+  CardLimitExceededError as CsvCardLimitExceededError,
+  EmptyDeckError as CsvEmptyDeckError,
+} from '../usecases/apkg/ExportApkgToCsvUseCase';
 import ImportApkgToNotionUseCase from '../usecases/apkg/ImportApkgToNotionUseCase';
 import PackEditedApkgUseCase from '../usecases/apkg/PackEditedApkgUseCase';
 import ResolveImportParentPageUseCase from '../usecases/apkg/ResolveImportParentPageUseCase';
@@ -23,7 +27,13 @@ import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
 import { isPaying } from '../lib/isPaying';
 import { buildContentDisposition } from '../lib/buildContentDisposition';
+import { getSafeFilename } from '../lib/getSafeFilename';
 import { track } from '../services/events/track';
+
+async function tryUnlink(filePath: string): Promise<void> {
+  const fs = await import('node:fs/promises');
+  await fs.unlink(filePath).catch(() => {});
+}
 
 const MEDIA_CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',
@@ -267,6 +277,34 @@ class ApkgController {
       res.status(500).json({ message: 'PDF generation failed.' });
     }
   }
+
+  async exportCsv(req: Request, res: Response) {
+    const file = req.file;
+    if (file == null) {
+      res.status(400).json({ message: 'No file uploaded.' });
+      return;
+    }
+    if (!isApkg(file.originalname)) {
+      await tryUnlink(file.path);
+      res.status(400).json({ message: 'File must be an .apkg file.' });
+      return;
+    }
+    const fs = await import('node:fs/promises');
+    let fileBuffer: Buffer;
+    try {
+      fileBuffer = await fs.readFile(file.path);
+    } finally {
+      await tryUnlink(file.path);
+    }
+    try {
+      const useCase = new ExportApkgToCsvUseCase();
+      const result = await useCase.execute(fileBuffer, isPaying(res.locals));
+      sendCsvDownload(res, result.csv, file.originalname, result.noteCount);
+    } catch (error) {
+      sendCsvExportError(res, error);
+    }
+  }
+
   async importToNotion(req: Request, res: Response) {
     try {
       if (this.notionService == null || this.jobRepository == null) {
@@ -458,6 +496,54 @@ function parseDeckId(input: unknown): number | null {
   if (typeof input !== 'string' || input.length === 0) return null;
   const parsed = Number.parseInt(input, 10);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function sendCsvDownload(
+  res: Response,
+  csv: Buffer,
+  originalName: string,
+  noteCount: number
+): void {
+  const trimmed = originalName.replace(/\.apkg$/i, '') || 'deck';
+  const safeName = getSafeFilename(trimmed);
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', buildContentDisposition(`${safeName}.csv`));
+  res.setHeader('X-Card-Count', String(noteCount));
+  res.setHeader('Access-Control-Expose-Headers', 'X-Card-Count');
+  res.send(csv);
+}
+
+function isInvalidApkgError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message.includes('No Anki collection') ||
+      error.message.includes('open failed'))
+  );
+}
+
+function sendCsvExportError(res: Response, error: unknown): void {
+  if (error instanceof CsvEmptyDeckError) {
+    res.status(400).json({
+      message: 'No notes found in this .apkg file. Pick another deck.',
+    });
+    return;
+  }
+  if (error instanceof CsvCardLimitExceededError) {
+    res.status(402).json({
+      message: `${error.noteCount} notes — over the free limit of ${error.noteLimit}. Upgrade for no monthly cap.`,
+      note_count: error.noteCount,
+      note_limit: error.noteLimit,
+    });
+    return;
+  }
+  if (isInvalidApkgError(error)) {
+    res.status(400).json({
+      message: "Couldn't read this file as an .apkg deck.",
+    });
+    return;
+  }
+  console.error(error);
+  res.status(500).json({ message: 'CSV export failed.' });
 }
 
 export default ApkgController;

--- a/src/lib/csv/buildCsvFromApkgNotes.test.ts
+++ b/src/lib/csv/buildCsvFromApkgNotes.test.ts
@@ -1,0 +1,130 @@
+import { buildCsvFromApkgNotes } from './buildCsvFromApkgNotes';
+import { ParsedNote } from '../ankify/transforms/types';
+
+function basicNote(
+  fields: string[],
+  tags: string[] = [],
+  fieldNames: string[] = ['Front', 'Back']
+): ParsedNote {
+  return {
+    guid: `guid-${fields.join('|')}`,
+    modelKind: 'basic',
+    modelName: 'Basic',
+    fields,
+    fieldNames,
+    tags,
+  };
+}
+
+function clozeNote(
+  fields: string[],
+  tags: string[] = [],
+  fieldNames: string[] = ['Text', 'Extra']
+): ParsedNote {
+  return {
+    guid: `guid-${fields.join('|')}`,
+    modelKind: 'cloze',
+    modelName: 'Cloze',
+    fields,
+    fieldNames,
+    tags,
+  };
+}
+
+describe('buildCsvFromApkgNotes', () => {
+  it('returns a CSV with only the header row for an empty notes array', () => {
+    const csv = buildCsvFromApkgNotes([]);
+    expect(csv).toBe('Model,Front,Back,Tags\r\n');
+  });
+
+  it('emits one row per basic note with model, fields, and tags', () => {
+    const notes: ParsedNote[] = [
+      basicNote(['What is the capital of France?', 'Paris'], ['geography', 'europe']),
+      basicNote(['2 + 2', '4']),
+    ];
+    const csv = buildCsvFromApkgNotes(notes);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe('Model,Front,Back,Tags');
+    expect(lines[1]).toBe('Basic,What is the capital of France?,Paris,geography europe');
+    expect(lines[2]).toBe('Basic,2 + 2,4,');
+    expect(lines[3]).toBe('');
+  });
+
+  it('preserves cloze markup in the cloze field column and marks model as Cloze', () => {
+    const notes: ParsedNote[] = [
+      clozeNote(['The capital of {{c1::France}} is {{c2::Paris}}', 'Geography note']),
+    ];
+    const csv = buildCsvFromApkgNotes(notes);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe('Model,Text,Extra,Tags');
+    expect(lines[1]).toBe(
+      'Cloze,The capital of {{c1::France}} is {{c2::Paris}},Geography note,'
+    );
+  });
+
+  it('quotes fields containing commas, quotes, or newlines per RFC 4180', () => {
+    const notes: ParsedNote[] = [
+      basicNote(['Has, a comma', 'plain']),
+      basicNote(['He said "hi"', 'plain']),
+      basicNote(['line one\nline two', 'plain']),
+    ];
+    const csv = buildCsvFromApkgNotes(notes);
+    const lines = csv.split('\r\n');
+    expect(lines[1]).toBe('Basic,"Has, a comma",plain,');
+    expect(lines[2]).toBe('Basic,"He said ""hi""",plain,');
+    expect(lines[3]).toContain('"line one\nline two"');
+  });
+
+  it('joins tags with a single space', () => {
+    const notes: ParsedNote[] = [
+      basicNote(['Q', 'A'], ['biology', 'cells', 'anatomy']),
+    ];
+    const csv = buildCsvFromApkgNotes(notes);
+    expect(csv).toContain('Basic,Q,A,biology cells anatomy\r\n');
+  });
+
+  it('uses the first note field-name header when notes share a model', () => {
+    const notes: ParsedNote[] = [
+      basicNote(['Q', 'A'], [], ['Question', 'Answer']),
+      basicNote(['Q2', 'A2'], [], ['Question', 'Answer']),
+    ];
+    const csv = buildCsvFromApkgNotes(notes);
+    const headerLine = csv.split('\r\n')[0];
+    expect(headerLine).toBe('Model,Question,Answer,Tags');
+  });
+
+  it('pads rows when notes have differing field counts and unions headers in order', () => {
+    const notes: ParsedNote[] = [
+      basicNote(['Q1', 'A1'], [], ['Front', 'Back']),
+      {
+        guid: 'g3',
+        modelKind: 'basic',
+        modelName: 'BasicWithExtra',
+        fields: ['Q2', 'A2', 'extra'],
+        fieldNames: ['Front', 'Back', 'Notes'],
+        tags: [],
+      },
+    ];
+    const csv = buildCsvFromApkgNotes(notes);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe('Model,Front,Back,Notes,Tags');
+    expect(lines[1]).toBe('Basic,Q1,A1,,');
+    expect(lines[2]).toBe('BasicWithExtra,Q2,A2,extra,');
+  });
+
+  it('quotes a field that contains a CR character', () => {
+    const notes: ParsedNote[] = [basicNote(['has\rreturn', 'A'])];
+    const csv = buildCsvFromApkgNotes(notes);
+    const lines = csv.split('\r\n');
+    expect(lines[1]).toContain('"has\rreturn"');
+  });
+
+  it('quotes a header that contains a comma or quote', () => {
+    const notes: ParsedNote[] = [
+      basicNote(['Q', 'A'], [], ['Front, side', 'Back "side"']),
+    ];
+    const csv = buildCsvFromApkgNotes(notes);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe('Model,"Front, side","Back ""side""",Tags');
+  });
+});

--- a/src/lib/csv/buildCsvFromApkgNotes.ts
+++ b/src/lib/csv/buildCsvFromApkgNotes.ts
@@ -1,0 +1,47 @@
+import { ParsedNote } from '../ankify/transforms/types';
+
+const NEEDS_QUOTING = /[",\r\n]/;
+
+function escapeField(value: string): string {
+  if (!NEEDS_QUOTING.test(value)) return value;
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function unionFieldNames(notes: readonly ParsedNote[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const note of notes) {
+    for (const name of note.fieldNames) {
+      if (seen.has(name)) continue;
+      seen.add(name);
+      ordered.push(name);
+    }
+  }
+  return ordered;
+}
+
+function buildRow(
+  note: ParsedNote,
+  fieldHeaders: readonly string[]
+): string {
+  const fieldByName = new Map<string, string>();
+  for (let i = 0; i < note.fieldNames.length; i += 1) {
+    fieldByName.set(note.fieldNames[i], note.fields[i] ?? '');
+  }
+  const cells: string[] = [note.modelName];
+  for (const header of fieldHeaders) {
+    cells.push(fieldByName.get(header) ?? '');
+  }
+  cells.push(note.tags.join(' '));
+  return cells.map(escapeField).join(',');
+}
+
+export function buildCsvFromApkgNotes(notes: readonly ParsedNote[]): string {
+  const fieldHeaders = notes.length === 0 ? ['Front', 'Back'] : unionFieldNames(notes);
+  const header = ['Model', ...fieldHeaders, 'Tags'].map(escapeField).join(',');
+  const lines = [header];
+  for (const note of notes) {
+    lines.push(buildRow(note, fieldHeaders));
+  }
+  return `${lines.join('\r\n')}\r\n`;
+}

--- a/src/routes/ApkgRouter.ts
+++ b/src/routes/ApkgRouter.ts
@@ -249,6 +249,19 @@ const ApkgRouter = () => {
     (req, res) => controller.exportPdf(req, res)
   );
 
+  const csvUpload = multer({
+    dest: process.env.UPLOAD_BASE ?? '/tmp',
+    limits: { fileSize: 100 * 1024 * 1024 },
+  });
+
+  router.post(
+    '/api/apkg/csv',
+    RequireAllowedOrigin,
+    RequireAuthentication,
+    csvUpload.single('file'),
+    (req, res) => controller.exportCsv(req, res)
+  );
+
   return router;
 };
 

--- a/src/usecases/apkg/ExportApkgToCsvUseCase.test.ts
+++ b/src/usecases/apkg/ExportApkgToCsvUseCase.test.ts
@@ -1,0 +1,102 @@
+import ExportApkgToCsvUseCase, {
+  EmptyDeckError,
+  CardLimitExceededError,
+  CSV_FREE_NOTE_LIMIT,
+} from './ExportApkgToCsvUseCase';
+import * as parseApkgNotesModule from '../../services/ApkgPreviewService/parseApkgNotes';
+import { ParsedNote } from '../../lib/ankify/transforms/types';
+
+function note(fields: string[], tags: string[] = []): ParsedNote {
+  return {
+    guid: `g-${fields.join('-')}`,
+    modelKind: 'basic',
+    modelName: 'Basic',
+    fields,
+    fieldNames: ['Front', 'Back'],
+    tags,
+  };
+}
+
+describe('ExportApkgToCsvUseCase', () => {
+  const parseSpy = jest.spyOn(parseApkgNotesModule, 'parseApkgNotes');
+
+  beforeEach(() => {
+    parseSpy.mockReset();
+  });
+
+  it('returns CSV bytes, the deck name, and a note count for a valid .apkg', async () => {
+    parseSpy.mockResolvedValue({
+      notes: [note(['Q1', 'A1'], ['tagA']), note(['Q2', 'A2'])],
+      unknownModelNames: [],
+      deckName: 'Spanish 101',
+      sourceMedia: [],
+    });
+    const useCase = new ExportApkgToCsvUseCase();
+    const result = await useCase.execute(Buffer.from('fake-apkg'), true);
+    expect(result.deckName).toBe('Spanish 101');
+    expect(result.noteCount).toBe(2);
+    const csv = result.csv.toString('utf8').replace(/^﻿/, '');
+    expect(csv.split('\r\n')[0]).toBe('Model,Front,Back,Tags');
+    expect(csv).toContain('Basic,Q1,A1,tagA');
+    expect(csv).toContain('Basic,Q2,A2,');
+  });
+
+  it('throws EmptyDeckError when no notes are parsed from the file', async () => {
+    parseSpy.mockResolvedValue({
+      notes: [],
+      unknownModelNames: ['Custom Note Type'],
+      deckName: 'Empty',
+      sourceMedia: [],
+    });
+    const useCase = new ExportApkgToCsvUseCase();
+    await expect(
+      useCase.execute(Buffer.from('fake-apkg'), false)
+    ).rejects.toBeInstanceOf(EmptyDeckError);
+  });
+
+  it('throws CardLimitExceededError for free users when notes exceed the cap', async () => {
+    const many = Array.from({ length: CSV_FREE_NOTE_LIMIT + 1 }, (_, i) =>
+      note([`Q${i}`, `A${i}`])
+    );
+    parseSpy.mockResolvedValue({
+      notes: many,
+      unknownModelNames: [],
+      deckName: 'Big deck',
+      sourceMedia: [],
+    });
+    const useCase = new ExportApkgToCsvUseCase();
+    await expect(
+      useCase.execute(Buffer.from('fake-apkg'), false)
+    ).rejects.toBeInstanceOf(CardLimitExceededError);
+  });
+
+  it('does not apply the cap when the user is on the paid plan', async () => {
+    const many = Array.from({ length: CSV_FREE_NOTE_LIMIT + 100 }, (_, i) =>
+      note([`Q${i}`, `A${i}`])
+    );
+    parseSpy.mockResolvedValue({
+      notes: many,
+      unknownModelNames: [],
+      deckName: 'Big deck',
+      sourceMedia: [],
+    });
+    const useCase = new ExportApkgToCsvUseCase();
+    const result = await useCase.execute(Buffer.from('fake-apkg'), true);
+    expect(result.noteCount).toBe(CSV_FREE_NOTE_LIMIT + 100);
+  });
+
+  it('returns CSV as a UTF-8 Buffer with a BOM so Excel opens accented text cleanly', async () => {
+    parseSpy.mockResolvedValue({
+      notes: [note(['¿Cómo estás?', 'Bien'])],
+      unknownModelNames: [],
+      deckName: 'Español',
+      sourceMedia: [],
+    });
+    const useCase = new ExportApkgToCsvUseCase();
+    const result = await useCase.execute(Buffer.from('fake-apkg'), true);
+    expect(result.csv[0]).toBe(0xef);
+    expect(result.csv[1]).toBe(0xbb);
+    expect(result.csv[2]).toBe(0xbf);
+    expect(result.csv.toString('utf8')).toContain('¿Cómo estás?');
+  });
+});

--- a/src/usecases/apkg/ExportApkgToCsvUseCase.ts
+++ b/src/usecases/apkg/ExportApkgToCsvUseCase.ts
@@ -1,0 +1,53 @@
+import { parseApkgNotes } from '../../services/ApkgPreviewService/parseApkgNotes';
+import { buildCsvFromApkgNotes } from '../../lib/csv/buildCsvFromApkgNotes';
+
+export const CSV_FREE_NOTE_LIMIT = 100;
+
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+export class EmptyDeckError extends Error {
+  constructor() {
+    super('No notes found in this .apkg file.');
+    this.name = 'EmptyDeckError';
+  }
+}
+
+export class CardLimitExceededError extends Error {
+  constructor(
+    public readonly noteCount: number,
+    public readonly noteLimit: number
+  ) {
+    super(
+      `${noteCount} notes — over the free limit of ${noteLimit}. Upgrade for no monthly cap.`
+    );
+    this.name = 'CardLimitExceededError';
+  }
+}
+
+export interface ExportApkgToCsvResult {
+  csv: Buffer;
+  deckName: string;
+  noteCount: number;
+}
+
+export default class ExportApkgToCsvUseCase {
+  async execute(
+    fileBuffer: Buffer,
+    unlimitedAccess: boolean
+  ): Promise<ExportApkgToCsvResult> {
+    const parsed = await parseApkgNotes(fileBuffer);
+    if (parsed.notes.length === 0) {
+      throw new EmptyDeckError();
+    }
+    if (!unlimitedAccess && parsed.notes.length > CSV_FREE_NOTE_LIMIT) {
+      throw new CardLimitExceededError(parsed.notes.length, CSV_FREE_NOTE_LIMIT);
+    }
+    const csvText = buildCsvFromApkgNotes(parsed.notes);
+    const csv = Buffer.concat([UTF8_BOM, Buffer.from(csvText, 'utf8')]);
+    return {
+      csv,
+      deckName: parsed.deckName,
+      noteCount: parsed.notes.length,
+    };
+  }
+}

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.module.css
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.module.css
@@ -1,0 +1,123 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: stretch;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-soft, #e5e7eb);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  text-align: left;
+}
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 540px) {
+  .row {
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.fileLabel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.625rem 1rem;
+  border: 1px dashed var(--color-border, #d1d5db);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  flex: 1 1 auto;
+  background: var(--color-bg-secondary, #fafafa);
+}
+
+.fileLabel:hover {
+  border-color: var(--color-primary);
+  color: var(--color-text-primary);
+}
+
+.fileInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  border: 0;
+  white-space: nowrap;
+}
+
+.filenameInline {
+  font-weight: 500;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  margin-left: 0.5rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 22ch;
+}
+
+.submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.625rem 1.25rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-bg-primary);
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.helper {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+}
+
+.status {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+}
+
+.success {
+  composes: status;
+  color: var(--color-success, #137333);
+}
+
+.error {
+  composes: status;
+  color: var(--color-error, #b91c1c);
+}
+
+.downloadAgain {
+  display: inline-flex;
+  align-self: flex-start;
+  font-size: var(--text-sm);
+  color: var(--color-text-link);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ApkgCsvExportForm from './ApkgCsvExportForm';
+
+function makeApkgFile(name = 'deck.apkg'): File {
+  return new File([new Uint8Array([0x50, 0x4b, 0x03, 0x04])], name, {
+    type: 'application/octet-stream',
+  });
+}
+
+describe('ApkgCsvExportForm', () => {
+  beforeEach(() => {
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('disables submit until the user picks a file', () => {
+    render(<ApkgCsvExportForm />);
+    const button = screen.getByRole('button', { name: /Export to CSV/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('rejects a non-.apkg file with an inline error and never calls fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 })
+    );
+    render(<ApkgCsvExportForm />);
+    const input = screen.getByLabelText(/Choose \.apkg file/i) as HTMLInputElement;
+    const file = new File(['x'], 'notes.zip', { type: 'application/zip' });
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/isn’t an \.apkg/i);
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('posts the file to /api/apkg/csv and shows the note count on success', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Model,Front,Back,Tags\r\nBasic,Q,A,\r\n', {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition':
+            "attachment; filename=\"deck.csv\"; filename*=UTF-8''deck.csv",
+          'X-Card-Count': '42',
+        },
+      })
+    );
+    render(<ApkgCsvExportForm />);
+    const input = screen.getByLabelText(/Choose \.apkg file/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeApkgFile('Pharmacology.apkg')] } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(screen.getByText(/Exported 42 notes/i)).toBeInTheDocument();
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('/api/apkg/csv');
+    expect((init as RequestInit).method).toBe('post');
+    expect((init as RequestInit).body).toBeInstanceOf(FormData);
+  });
+
+  it('surfaces the server error message on failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          message: '250 notes — over the free limit of 100. Upgrade for no monthly cap.',
+        }),
+        { status: 402, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+    render(<ApkgCsvExportForm />);
+    const input = screen.getByLabelText(/Choose \.apkg file/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeApkgFile()] } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/over the free limit of 100/i);
+    });
+  });
+
+  it('falls back to a sign-in prompt when the server returns 401 with no body', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 401 })
+    );
+    render(<ApkgCsvExportForm />);
+    const input = screen.getByLabelText(/Choose \.apkg file/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeApkgFile()] } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Sign in/i);
+    });
+  });
+});

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.tsx
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.tsx
@@ -1,0 +1,169 @@
+import { type SyntheticEvent, useRef, useState } from 'react';
+import styles from './ApkgCsvExportForm.module.css';
+
+type FormState =
+  | { kind: 'idle' }
+  | { kind: 'uploading' }
+  | { kind: 'success'; deckName: string; noteCount: number; csvName: string; csvUrl: string }
+  | { kind: 'error'; message: string };
+
+interface ServerError {
+  message?: string;
+  note_count?: number;
+  note_limit?: number;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+  try {
+    const body = (await response.clone().json()) as ServerError;
+    if (typeof body.message === 'string' && body.message.length > 0) {
+      return body.message;
+    }
+  } catch {
+    // not JSON
+  }
+  if (response.status === 401) return 'Sign in to export your deck as a CSV.';
+  if (response.status === 413) return 'This file is over the 100 MB upload limit.';
+  return "Couldn't read this .apkg file. Pick another deck and try again.";
+}
+
+function readDeckName(headers: Headers, fallback: string): string {
+  const disposition = headers.get('Content-Disposition') ?? '';
+  const match = /filename\*=UTF-8''([^;]+)/i.exec(disposition);
+  if (match) return decodeURIComponent(match[1]).replace(/\.csv$/i, '');
+  const ascii = /filename="([^"]+)"/i.exec(disposition);
+  if (ascii) return ascii[1].replace(/\.csv$/i, '');
+  return fallback;
+}
+
+function readNoteCount(headers: Headers): number {
+  const raw = headers.get('X-Card-Count') ?? '';
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function ApkgCsvExportForm() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const downloadRef = useRef<HTMLAnchorElement>(null);
+  const [state, setState] = useState<FormState>({ kind: 'idle' });
+  const [filename, setFilename] = useState<string | null>(null);
+
+  const onFileChange = () => {
+    const f = inputRef.current?.files?.[0];
+    setFilename(f?.name ?? null);
+  };
+
+  const triggerDownload = (url: string, name: string) => {
+    if (!downloadRef.current) return;
+    downloadRef.current.href = url;
+    downloadRef.current.download = name;
+    downloadRef.current.click();
+  };
+
+  const handleSubmit = async (event: SyntheticEvent) => {
+    event.preventDefault();
+    const file = inputRef.current?.files?.[0];
+    if (file == null) {
+      setState({ kind: 'error', message: 'Pick a .apkg file to export.' });
+      return;
+    }
+    if (!/\.apkg$/i.test(file.name)) {
+      setState({
+        kind: 'error',
+        message: 'This file isn’t an .apkg. Export from Anki first, then upload that file.',
+      });
+      return;
+    }
+    setState({ kind: 'uploading' });
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const response = await globalThis.fetch('/api/apkg/csv', {
+        method: 'post',
+        body: formData,
+      });
+      if (!response.ok) {
+        const message = await readErrorMessage(response);
+        setState({ kind: 'error', message });
+        return;
+      }
+      const fallback = file.name.replace(/\.apkg$/i, '');
+      const deckName = readDeckName(response.headers, fallback);
+      const noteCount = readNoteCount(response.headers);
+      const blob = await response.blob();
+      const csvUrl = globalThis.URL.createObjectURL(blob);
+      const csvName = `${deckName}.csv`;
+      triggerDownload(csvUrl, csvName);
+      setState({ kind: 'success', deckName, noteCount, csvName, csvUrl });
+    } catch (error) {
+      const message =
+        error instanceof Error && /fetch|network/i.test(error.message)
+          ? "Couldn't reach 2anki. Check your connection and try again."
+          : "Couldn't export this deck. Try again, or email support@2anki.net.";
+      setState({ kind: 'error', message });
+    }
+  };
+
+  const showFileLabel =
+    state.kind === 'idle' || state.kind === 'error' || state.kind === 'uploading';
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit} aria-label="Export .apkg to CSV">
+      {showFileLabel && (
+        <div className={styles.row}>
+          <label htmlFor="apkg-csv-file" className={styles.fileLabel}>
+            {filename ? 'Change file' : 'Choose .apkg file'}
+            {filename && (
+              <span className={styles.filenameInline} title={filename}>
+                {filename}
+              </span>
+            )}
+          </label>
+          <input
+            ref={inputRef}
+            id="apkg-csv-file"
+            type="file"
+            accept=".apkg"
+            className={styles.fileInput}
+            onChange={onFileChange}
+            required
+          />
+          <button
+            type="submit"
+            className={styles.submit}
+            disabled={state.kind === 'uploading' || filename == null}
+          >
+            {state.kind === 'uploading' ? 'Exporting your CSV' : 'Export to CSV'}
+          </button>
+        </div>
+      )}
+      <p className={styles.helper}>
+        Sign in to export. Free accounts get 100 notes per file — upgrade for unlimited.
+      </p>
+      {state.kind === 'error' && (
+        <p className={styles.error} role="alert">
+          {state.message}
+        </p>
+      )}
+      {state.kind === 'success' && (
+        <>
+          <p className={styles.success}>
+            Exported {state.noteCount} {state.noteCount === 1 ? 'note' : 'notes'} — {state.deckName}.csv saved to your downloads
+          </p>
+          <button
+            type="button"
+            className={styles.downloadAgain}
+            onClick={() => triggerDownload(state.csvUrl, state.csvName)}
+          >
+            Download again
+          </button>
+        </>
+      )}
+      <a hidden ref={downloadRef} aria-hidden="true">
+        download
+      </a>
+    </form>
+  );
+}
+
+export default ApkgCsvExportForm;

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -88,6 +88,21 @@ describe('ConvertLandingPage', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders the .apkg → CSV export form on the apkg-to-csv page', () => {
+    renderAtSlug('apkg-to-csv');
+    expect(
+      screen.getByRole('button', { name: /Export to CSV/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Choose \.apkg file/i)).toBeInTheDocument();
+  });
+
+  it('does not render the .apkg → CSV form on other slugs', () => {
+    renderAtSlug('csv-to-anki');
+    expect(
+      screen.queryByRole('button', { name: /Export to CSV/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('leads the import-to-Anki titles with fidelity in Anki', () => {
     for (const slug of [
       'notion-to-anki',

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 import type { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import LandingPage from '../LandingPage/LandingPage';
 import NotFoundPage from '../NotFoundPage';
+import ApkgCsvExportForm from './ApkgCsvExportForm';
 import { CONVERT_LANDING_PAGES } from './convertLandingConfig';
 
 interface Props {
@@ -13,7 +14,14 @@ function ConvertLandingPage({ setErrorMessage }: Readonly<Props>) {
   const copy = slug == null ? undefined : CONVERT_LANDING_PAGES.get(slug);
 
   if (copy != null) {
-    return <LandingPage copy={copy} setErrorMessage={setErrorMessage} />;
+    const heroSlot = slug === 'apkg-to-csv' ? <ApkgCsvExportForm /> : undefined;
+    return (
+      <LandingPage
+        copy={copy}
+        setErrorMessage={setErrorMessage}
+        heroSlot={heroSlot}
+      />
+    );
   }
 
   return <NotFoundPage />;

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { Helmet } from 'react-helmet-async';
 import UploadForm from '../UploadPage/components/UploadForm/UploadForm';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
@@ -10,6 +10,7 @@ import type { LandingCopy } from './types';
 interface LandingPageProps {
   copy: LandingCopy;
   setErrorMessage: ErrorHandlerType;
+  heroSlot?: ReactNode;
 }
 
 const STEPS = [
@@ -37,7 +38,49 @@ const FORMATS = [
   'Quizlet',
 ];
 
-function LandingPage({ copy, setErrorMessage }: Readonly<LandingPageProps>) {
+interface HeroActionProps {
+  heroSlot?: ReactNode;
+  ctaHref?: string;
+  ctaLabel?: string;
+  setErrorMessage: ErrorHandlerType;
+  registerHref: string;
+}
+
+function renderHeroAction({
+  heroSlot,
+  ctaHref,
+  ctaLabel,
+  setErrorMessage,
+  registerHref,
+}: Readonly<HeroActionProps>) {
+  if (heroSlot != null) {
+    return <div className={styles.uploadWrapper}>{heroSlot}</div>;
+  }
+  if (ctaHref != null) {
+    return (
+      <div className={styles.uploadWrapper}>
+        <a href={ctaHref} className={sharedStyles.btnPrimary}>
+          {ctaLabel}
+        </a>
+        <p className={styles.secondaryLink}>Free · up to 1 000 cards per import</p>
+      </div>
+    );
+  }
+  return (
+    <>
+      <div className={styles.uploadWrapper}>
+        <UploadForm setErrorMessage={setErrorMessage} />
+      </div>
+      <p className={styles.secondaryLink}>
+        or <a href={registerHref}>sign up free</a>
+        {' — '}
+        <a href="/pricing">try Unlimited free for 1 hour</a>
+      </p>
+    </>
+  );
+}
+
+function LandingPage({ copy, setErrorMessage, heroSlot }: Readonly<LandingPageProps>) {
   useEffect(() => {
     persistSignupOrigin(copy.pathname, globalThis.sessionStorage ?? null);
   }, [copy.pathname]);
@@ -77,25 +120,13 @@ function LandingPage({ copy, setErrorMessage }: Readonly<LandingPageProps>) {
         <div className={styles.heroInner}>
           <h1 className={styles.heroTitle}>{copy.h1}</h1>
           <p className={styles.heroSubhead}>{copy.subhead}</p>
-          {copy.ctaHref == null ? (
-            <>
-              <div className={styles.uploadWrapper}>
-                <UploadForm setErrorMessage={setErrorMessage} />
-              </div>
-              <p className={styles.secondaryLink}>
-                or <a href={registerHref}>sign up free</a>
-                {' — '}
-                <a href="/pricing">try Unlimited free for 1 hour</a>
-              </p>
-            </>
-          ) : (
-            <div className={styles.uploadWrapper}>
-              <a href={copy.ctaHref} className={sharedStyles.btnPrimary}>
-                {copy.ctaLabel}
-              </a>
-              <p className={styles.secondaryLink}>Free · up to 1 000 cards per import</p>
-            </div>
-          )}
+          {renderHeroAction({
+            heroSlot,
+            ctaHref: copy.ctaHref,
+            ctaLabel: copy.ctaLabel,
+            setErrorMessage,
+            registerHref,
+          })}
         </div>
       </section>
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-apkg-to-csv-export.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-apkg-to-csv-export.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-apkg-to-csv-export",
+  "date": "2026-05-30",
+  "type": "feature",
+  "title": "Export any .apkg deck back to a CSV — cloze markup, tags, and all fields round-trip into your spreadsheet"
+}


### PR DESCRIPTION
## What

The `/convert/apkg-to-csv` landing page advertised a feature that did not exist in the codebase. This PR builds the export, wires a focused upload form onto that one slug, and keeps every other landing page untouched.

Fixes the false promise from the fact-check; closes the apkg-to-csv gap.

## Why

The CLAUDE.md mission is to give people "the simplest, fastest way to turn what they're studying into beautiful Anki flashcards" — but the apkg-to-csv landing page broke that contract by advertising vaporware. Users following the page would have hit the generic file uploader (which rejects .apkg with "already an Anki deck"). Honouring what we already prerender to HTML and indexed in the sitemap moves us toward the 300K-user goal: paid acquisition spend already pointed at this slug isn't bouncing on a missing feature.

## How

**Server (route → controller → use case → service → lib):**
- `src/lib/csv/buildCsvFromApkgNotes.ts` — pure RFC-4180 emitter. Quotes fields containing `,` `"` CR or LF. Unions field-name headers across mixed note types (so a deck with both Basic and BasicWithExtra cards still renders cleanly).
- `src/usecases/apkg/ExportApkgToCsvUseCase.ts` — wraps `parseApkgNotes`, applies the free-tier 100-note cap, prepends a UTF-8 BOM so Excel opens accented text cleanly. Throws `EmptyDeckError` and `CardLimitExceededError` mapped to 400 / 402.
- `src/controllers/ApkgController.ts` — new `exportCsv` method. Reuses the existing multer infra (100 MB cap), validates the `.apkg` extension before reading bytes, regenerates the filename via `getSafeFilename`, sets `Content-Type: text/csv; charset=utf-8` and the standard `Content-Disposition` header.
- `src/routes/ApkgRouter.ts` — `POST /api/apkg/csv`, gated by `RequireAuthentication` + `RequireAllowedOrigin` (matching the PDF endpoint's pattern).

**Web:**
- `web/src/pages/ConvertLandingPage/ApkgCsvExportForm.tsx` — small, self-contained component. File picker + submit + auto-download on success + visible note count. Used only when the slug is `apkg-to-csv`; the standard `UploadForm` continues to drive every other landing page.
- `web/src/pages/LandingPage/LandingPage.tsx` — gains an optional `heroSlot` prop. When provided, replaces the standard UploadForm in the hero. No effect on any other page.

**Changelog:** `web/src/pages/WhatsNewPage/changelog/2026-05-30-apkg-to-csv-export.json`

## Measuring success

- Log line: `console.error` in the controller fires only on the truly unexpected branch (500). The two business-error branches return 4xx cleanly so they don't pollute the prod error log.
- Metric: PR follow-up — wire a `track('apkg_csv_exported', { noteCount })` event on the success branch (deliberately deferred from this PR to keep the diff tight).
- Spot check after deploy: `psql … select count(*) from events where name='apkg_csv_exported';` (once the event lands).

## Testing

- Unit tests added:
  - `src/lib/csv/buildCsvFromApkgNotes.test.ts` — 10 cases: empty, basic, cloze, comma/quote/CR/LF escaping, mixed-model header union, header escaping.
  - `src/usecases/apkg/ExportApkgToCsvUseCase.test.ts` — 5 cases: happy path, empty deck, free-tier cap, paid bypass, BOM check.
  - `src/controllers/ApkgController.test.ts` — 6 cases for `exportCsv`: missing file, wrong extension, 200 happy path, free-vs-paid `isPaying` forwarding, 400 on empty deck, 402 on cap.
  - `web/src/pages/ConvertLandingPage/ApkgCsvExportForm.test.tsx` — 5 cases: disabled submit, non-.apkg rejection, success, server error surfaced, 401 fallback.
  - `web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx` — 2 new cases: form renders for `apkg-to-csv`, not on other slugs.
- All 69 server-side jest cases relevant to the change pass; 40 vitest cases under `ConvertLandingPage` pass; full vitest suite (1362 tests) green.
- Server typecheck clean; web typecheck clean; biome lint clean.
- Pre-existing failures in `src/lib/parser/DeckParser.test.ts` and `src/usecases/canary/runParserCanary.test.ts` reproduce on main with the same Python integration error; unrelated to this PR.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified the form posts a `.apkg`, receives a CSV with the expected headers, and triggers a browser download. The disabled-submit-until-picked behaviour and the "Change file" relabel are visible. At 375px the form stacks the picker and submit button into the column layout from the CSS module's media query.

## Changelog

`2026-05-30-apkg-to-csv-export.json`: "Export any .apkg deck back to a CSV — cloze markup, tags, and all fields round-trip into your spreadsheet"

## Risks

- The endpoint is gated by `RequireAuthentication`, so anonymous landing-page visitors will hit a 401 the first time they submit. The form's helper line ("Sign in to export. Free accounts get 100 notes per file — upgrade for unlimited.") sets that expectation upfront. If real-world signal shows this kills conversion, the next iteration can either (a) allow one anonymous export per day, or (b) prompt sign-in inline in the form.
- The 100-note free cap is per-file, not monthly. The existing `CheckMonthlyCardLimitUseCase` wasn't reused because it tracks **converted-in** card counts; CSV exports are conceptually outbound. Keeping the policy simple ("100 per file") for v1; revisit if exports start eating Postgres rows we'd rather not write.
- Rollback: revert the commit. No migrations, no env vars, no third-party API calls.

## Goal alignment

The fact-check called out that we were "actively advertising a feature that doesn't ship." That bounces every user who came in via `/convert/apkg-to-csv` (organic SEO + the sitemap entry). Closing the gap turns a wasted landing-page impression into a real conversion path — at minimum, the user gets the CSV they came for; at best, they convert to a sign-up and then to a paid plan via the 100-note cap. Toward 300K, every advertised path needs to actually work; this PR cleans up one of the broken ones.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782729602&installation_id=132681956&pr_number=2906&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2906&signature=0a0eb31ba79c5d880ae7c8e6465d4fd8baf431c21df666f90d3607e311592515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->