### PR TITLE
fix: landing-page honesty pass — CSV/XLSX parser truth + softened source-app paths

### DIFF
--- a/src/infrastracture/adapters/fileConversion/__tests__/convertXLSXToHTML.test.ts
+++ b/src/infrastracture/adapters/fileConversion/__tests__/convertXLSXToHTML.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'fs';
 import Workspace from '../../../../lib/parser/WorkSpace';
-import { convertXLSXToHTML } from '../convertXLSXToHTML';
+import { convertXLSXToHTML, looksLikeHeaderRow } from '../convertXLSXToHTML';
 import { join } from 'path';
+import * as XLSX from 'xlsx';
 
 describe('convertXLSXToHTML', () => {
   beforeAll(() => {
@@ -22,5 +23,64 @@ describe('convertXLSXToHTML', () => {
 
   afterAll(() => {
     delete process.env.WORKSPACE_BASE;
+  });
+});
+
+function buildXlsxBuffer(rows: unknown[][]): Buffer {
+  const worksheet = XLSX.utils.aoa_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');
+  return XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+}
+
+describe('looksLikeHeaderRow', () => {
+  it('treats a row of short non-numeric strings as a header', () => {
+    expect(looksLikeHeaderRow(['Term', 'Definition'] as never)).toBe(true);
+  });
+
+  it('treats a row with a numeric cell as data, not a header', () => {
+    expect(looksLikeHeaderRow(['Term', 42] as never)).toBe(false);
+  });
+
+  it('keeps a row with leading short labels but a long-form back cell as data', () => {
+    const longBack =
+      'A really long answer that runs well past the heuristic length cap used to spot label-shaped rows';
+    expect(looksLikeHeaderRow(['hello', longBack] as never)).toBe(false);
+  });
+});
+
+describe('convertXLSXToHTML header detection', () => {
+  it('skips a header row when row 0 looks like labels', () => {
+    const buffer = buildXlsxBuffer([
+      ['Term', 'Definition'],
+      ['hola', 'hello'],
+      ['adiós', 'goodbye'],
+    ]);
+    const html = convertXLSXToHTML(buffer, 'deck.html');
+    expect(html).not.toContain('<summary>Term</summary>');
+    expect(html).toContain('<summary>hola</summary>');
+    expect(html).toContain('<summary>adiós</summary>');
+  });
+
+  it('keeps row 0 when it contains a numeric cell', () => {
+    const buffer = buildXlsxBuffer([
+      ['question 1', 2024],
+      ['question 2', 2025],
+    ]);
+    const html = convertXLSXToHTML(buffer, 'deck.html');
+    expect(html).toContain('<summary>question 1</summary>');
+    expect(html).toContain('<summary>question 2</summary>');
+  });
+
+  it('keeps row 0 when a cell is too long to be a label', () => {
+    const longBack =
+      'A really long answer that runs well past the heuristic length cap used to spot label-shaped rows';
+    const buffer = buildXlsxBuffer([
+      ['hola', longBack],
+      ['adiós', 'goodbye'],
+    ]);
+    const html = convertXLSXToHTML(buffer, 'deck.html');
+    expect(html).toContain('<summary>hola</summary>');
+    expect(html).toContain('<summary>adiós</summary>');
   });
 });

--- a/src/infrastracture/adapters/fileConversion/convertXLSXToHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/convertXLSXToHTML.ts
@@ -2,6 +2,25 @@ import * as XLSX from 'xlsx';
 
 type XLSXRow = [string | undefined, string | undefined, ...unknown[]];
 
+const HEADER_CELL_MAX_LENGTH = 40;
+
+function cellLooksLikeHeader(cell: unknown): boolean {
+  if (cell == null) return true;
+  if (typeof cell === 'string') {
+    const trimmed = cell.trim();
+    if (trimmed.length === 0) return true;
+    if (trimmed.length > HEADER_CELL_MAX_LENGTH) return false;
+    return Number.isNaN(Number(trimmed));
+  }
+  return false;
+}
+
+export function looksLikeHeaderRow(row: XLSXRow): boolean {
+  const cells = row.filter((cell) => cell != null && String(cell).trim() !== '');
+  if (cells.length === 0) return false;
+  return cells.every(cellLooksLikeHeader);
+}
+
 export function convertXLSXToHTML(buffer: Buffer, title: string): string {
   const workbook = XLSX.read(buffer, { type: 'buffer' });
   const sheetName = workbook.SheetNames[0];
@@ -10,11 +29,16 @@ export function convertXLSXToHTML(buffer: Buffer, title: string): string {
     header: 1,
   }) as XLSXRow[];
 
+  const rows =
+    jsonData.length > 0 && looksLikeHeaderRow(jsonData[0])
+      ? jsonData.slice(1)
+      : jsonData;
+
   return `<!DOCTYPE html>
 <html>
 <head><title>${title}</title></head>
 <body>
-  ${jsonData
+  ${rows
     .map((row: XLSXRow) => {
       const front = row[0] || '';
       const back = row[1] || '';

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -243,7 +243,7 @@ const lingvistToAnki: LandingCopy = {
   faqs: [
     {
       q: 'How do I export from Lingvist?',
-      a: 'Go to your Lingvist account settings and look for the vocabulary export option. It downloads a CSV with your words and translations.',
+      a: 'Lingvist offers an account-data download — search Lingvist\'s help center at help.lingvist.com for "data export" to find the current path. The download includes a CSV of your vocabulary that you can upload here.',
     },
     {
       q: 'Which columns does Lingvist export?',
@@ -272,7 +272,7 @@ const studystackToAnki: LandingCopy = {
   faqs: [
     {
       q: 'How do I export from StudyStack?',
-      a: 'Open your stack, go to the stack settings or export menu, and choose CSV or text export. The file will have your terms and definitions.',
+      a: 'Open your stack on studystack.com and look for the export or download option in the stack\'s menu. The exported file should contain your terms and definitions, ready to upload here.',
     },
     {
       q: 'What format does the exported file use?',
@@ -284,7 +284,7 @@ const studystackToAnki: LandingCopy = {
     },
     {
       q: 'How many cards can I import?',
-      a: 'Free accounts convert up to 100 cards per month. Unlimited and Auto Sync plans remove the cap — see the pricing page.',
+      a: 'Free 2anki accounts convert up to 100 cards per month — this is the 2anki limit, not a StudyStack restriction. Unlimited and Auto Sync plans remove the cap — see the pricing page.',
     },
   ],
 };
@@ -330,7 +330,7 @@ const zorbiToAnki: LandingCopy = {
   faqs: [
     {
       q: 'How do I export from Zorbi?',
-      a: 'In Zorbi, open your deck and use the export option to download a CSV. The file contains your card fronts and backs.',
+      a: 'Open your deck on zorbi.com and look for the export option in the deck menu. Download the CSV and upload it here. If you can\'t find the export option, check Zorbi\'s help docs for the current path.',
     },
     {
       q: 'Do cloze deletions transfer?',

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -92,27 +92,27 @@ const csvToAnki: LandingCopy = {
   pathname: '/convert/csv-to-anki',
   title: 'CSV to Anki — spreadsheets to clean Anki decks | 2anki',
   description:
-    'Import a CSV or Excel sheet as an Anki deck that opens clean — correct fields, tags applied, one row per card.',
+    'Import a CSV or Excel sheet as an Anki deck that opens clean — correct fields, one row per card.',
   h1: 'CSV to Anki — import spreadsheets as flashcard decks',
   subhead:
-    'Drop a .csv file and get a .apkg deck. Column A becomes the front, column B becomes the back. Works with Excel exports too.',
+    'Drop a .csv file and get a .apkg deck. Column A becomes the front, everything after A joins into the back. Works with Excel exports too.',
   whatComesAcross: ankiFidelityProof,
   faqs: [
     {
       q: 'What format does the CSV need to be in?',
-      a: 'Two columns minimum: front in column A, back in column B. A header row is detected and skipped automatically. UTF-8 encoding works best for accented characters and CJK text.',
+      a: 'Column A is the front. Everything after A is joined into the back with spaces. Use a 2-column file for the cleanest result. A header row is detected and skipped automatically. UTF-8 encoding works best for accented characters and CJK text.',
     },
     {
       q: 'Can I import an Excel .xlsx file directly?',
-      a: 'Yes — upload the .xlsx file and we convert it. If the spreadsheet has multiple sheets, the first sheet is used.',
+      a: 'Yes — upload the .xlsx file and we convert it. If the spreadsheet has multiple sheets, the first sheet is used. A header row that looks like labels (short non-numeric text in every column) is detected and skipped.',
     },
     {
       q: 'How do I name the deck?',
       a: 'The deck name comes from the filename — rename the file before uploading and the deck will match. You can also rename the deck inside Anki after importing.',
     },
     {
-      q: 'Can I add tags from the spreadsheet?',
-      a: 'Add a third column with a tag or comma-separated tags and they attach to every card from that row. Leave the column empty to skip tagging.',
+      q: 'Where do tags come from?',
+      a: "v1 doesn't add tags from CSV columns. To tag cards, edit them in Anki after import, or paste the deck through Notion where strikethrough text becomes a tag on every card.",
     },
   ],
 };

--- a/web/src/pages/LandingPage/copy/quizlet.ts
+++ b/web/src/pages/LandingPage/copy/quizlet.ts
@@ -13,7 +13,7 @@ const quizletCopy: LandingCopy = {
   faqs: [
     {
       q: 'How do I get my set out of Quizlet?',
-      a: "Open the set, click the three dots, choose Export, and copy the text into a .txt file. Drop that file here and we'll make the deck.",
+      a: 'Quizlet\'s export flow has moved several times. Search help.quizlet.com for "export your set" to find the current path. Once you have the text, save it as a .txt file and drop it here.',
     },
     {
       q: 'Do my starred or learned cards come across?',

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-landing-page-honesty.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-landing-page-honesty.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-landing-page-honesty",
+  "date": "2026-05-30",
+  "type": "fix",
+  "title": "CSV and Excel landing pages describe the actual conversion shape, including header-row detection on .xlsx"
+}


### PR DESCRIPTION
## What
Three commits in one PR aligning landing-page FAQs with what the conversion pipeline (and the source apps) actually do today.

Commit 1 — CSV/XLSX false claims:
- Rewrote the csv-to-anki FAQ to describe real parser behavior: column A is the front, columns A+1..N are joined into the back with spaces, and tags do not come from CSV columns (the `@2anki/csv-to-apkg` library hardcodes `tags: []`).
- Taught `convertXLSXToHTML` to skip row 0 when it looks header-shaped (every non-empty cell is a short non-numeric string). Before, xlsx users silently saw their header row as the first card.

Commit 2 — softened 4 unverified click-paths:
- Lingvist, StudyStack, Zorbi (kept — zorbi.com responds 200), and the legacy Quizlet landing page now point at the source app's help search instead of naming a specific menu path that may have moved.
- StudyStack FAQ rephrases the "100 cards / month" line to make clear it's 2anki's limit, not a StudyStack restriction.

Commit 3 — changelog entry for the user-visible parts.

## Why
A read-only fact-check (run earlier today, separate research run — not a PR) compared every X→Anki landing page against the codebase and against each source app's help center. Three CSV/XLSX claims disagreed with the parser; four source-app click-paths could not be verified externally. The CSV/XLSX claims are the most damaging — users with 3+ column files were silently seeing column C/D/E in the back of every card, and xlsx users were getting their header row as the first card.

## How
- The xlsx header heuristic lives in `src/infrastracture/adapters/fileConversion/convertXLSXToHTML.ts` (the active path; `src/lib/parser/xlsx/convertXLSXToHTML.ts` is unreachable dead code and was left untouched to keep this PR scoped). `cellLooksLikeHeader` treats a cell as header-shaped when it is empty, or a string ≤ 40 chars that is not a parseable number. `looksLikeHeaderRow` requires every non-empty cell to pass.
- 3 new unit tests cover the heuristic (label row skipped, numeric row kept, mixed row with a long back cell kept).
- Zorbi was kept because `curl -sIL https://zorbi.com` returns 200 and serves a real Gatsby marketing page (no redirect to a defunct destination).

## Measuring success
This is a copy + small parser change. The relevant signal is that we stop receiving support replies from xlsx users about "my header row became a card" and from CSV users who put a tag in column C and saw it in the back. No new log line — the change is observable in the deck output.

## Testing
- Unit tests added: 3 in `src/infrastracture/adapters/fileConversion/__tests__/convertXLSXToHTML.test.ts` for the header-row heuristic, plus 1 for `looksLikeHeaderRow` covering a mixed row.
- `pnpm test src/infrastracture/adapters/fileConversion/` — 6 suites, 41 tests, all green.
- `pnpm --filter 2anki-web test` — 161 files, 1372 tests, all green (including the 37-test `ConvertLandingPage` suite).
- `pnpm tsc --noEmit` clean; `pnpm --filter 2anki-web typecheck` clean; `pnpm --filter 2anki-web lint` clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Visual check on `/convert/csv-to-anki`, `/convert/lingvist-to-anki`, `/convert/studystack-to-anki`, `/convert/zorbi-to-anki`, and `/quizlet-to-anki` — all FAQ text renders as written; no console noise. The xlsx parser change is server-side only and verified by the new unit tests.

## Changelog
`2026-05-30-landing-page-honesty.json` — type `fix`, title: "CSV and Excel landing pages describe the actual conversion shape, including header-row detection on .xlsx"

## Risks
- The xlsx header heuristic is intentionally conservative: a header row that contains a numeric label (e.g. "2024 totals") will be treated as data and become a card. Acceptable — the alternative is silently dropping a row of real data. The FAQ wording calls out the heuristic.
- Zorbi's site is alive today but could shut down later; the softened wording ("look for the export option in the deck menu") degrades gracefully if it does.

## Goal alignment
A learner who lands on `/convert/csv-to-anki` from search and follows the instructions either gets a clean deck or doesn't — copy that promises what the parser doesn't deliver erodes trust at the entry point of the funnel. The xlsx header fix turns a silent-error path (your first card is "Term / Definition") into the expected result. Both move us closer to the 300K-user goal by removing landing-page friction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782733218&installation_id=132681956&pr_number=2909&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2909&signature=d4b61212687ac8edb498b81a6f0c92e257562c4fc0db7e2f2b1c9adaa2aff35c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->