### PR TITLE
Fix: suppress Hotjar user text on notion and upload

### DIFF
--- a/web/src/pages/SearchPage/SearchPage.test.tsx
+++ b/web/src/pages/SearchPage/SearchPage.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SearchPage } from './SearchPage';
+
+const mockUseNotionData = vi.fn();
+
+vi.mock('./helpers/useNotionData', () => ({
+  default: () => mockUseNotionData(),
+}));
+
+vi.mock('./components/SearchContainer', () => ({
+  default: () => <div data-testid="search-container" />,
+}));
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({}),
+}));
+
+describe('SearchPage Hotjar suppression', () => {
+  beforeEach(() => {
+    mockUseNotionData.mockReturnValue({
+      connected: true,
+      connectionLink: '/api/notion/connect',
+      error: null,
+      loading: false,
+      refetch: vi.fn(),
+      workSpace: 'Pristine’s Notion',
+    });
+  });
+
+  it('suppresses the connected workspace name from Hotjar recordings', () => {
+    render(<SearchPage setError={vi.fn()} />);
+
+    expect(screen.getByText('Pristine’s Notion')).toHaveAttribute(
+      'data-hj-suppress'
+    );
+  });
+});

--- a/web/src/pages/SearchPage/SearchPage.tsx
+++ b/web/src/pages/SearchPage/SearchPage.tsx
@@ -52,7 +52,7 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
       {notionData.connected && notionData.workSpace && (
         <div className={searchStyles.workspaceLine}>
           <span className={searchStyles.workspaceDot} />
-          <span className={searchStyles.workspaceName}>
+          <span className={searchStyles.workspaceName} data-hj-suppress>
             {notionData.workSpace}
           </span>
           <a

--- a/web/src/pages/SearchPage/components/ListSearchResults.test.tsx
+++ b/web/src/pages/SearchPage/components/ListSearchResults.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import ListSearchResults from './ListSearchResults';
+
+describe('ListSearchResults Hotjar suppression', () => {
+  it('suppresses the empty-state headline when it includes a workspace name', () => {
+    render(
+      <ListSearchResults
+        results={[]}
+        setFavorites={vi.fn()}
+        setError={vi.fn()}
+        workSpace="Pristine’s Notion"
+      />
+    );
+
+    expect(screen.getByText('No pages found in “Pristine’s Notion”')).toHaveAttribute(
+      'data-hj-suppress'
+    );
+  });
+});

--- a/web/src/pages/SearchPage/components/ListSearchResults.tsx
+++ b/web/src/pages/SearchPage/components/ListSearchResults.tsx
@@ -56,7 +56,7 @@ export default function ListSearchResults(
       : `No pages found ${scope}`;
     return (
       <div className={styles.emptyState}>
-        <p>{headline}</p>
+        <p data-hj-suppress>{headline}</p>
         <p className={styles.secondaryText}>
           Try a different search term, or make sure the page is shared with
           the 2anki integration — see{' '}

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -833,6 +833,30 @@ describe('UploadForm analytics events', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('suppresses the uploaded filename in success copy from Hotjar recordings', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'File-Name': encodeURIComponent('private-notes.apkg'),
+        'X-Card-Count': '5',
+      }),
+      blob: () => Promise.resolve(new Blob(['fake'])),
+    }));
+
+    renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = document.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    const successCopy = await screen.findByText(
+      'private-notes.apkg was saved to your downloads'
+    );
+    expect(successCopy).toHaveAttribute('data-hj-suppress');
+  });
+
 });
 
 describe('limit state — start trial button', () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -833,7 +833,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
           {mcqDrawerOpen && renderMcqDrawer()}
         </>
       )}
-      <p className={formStyles.successSecondary}>
+      <p className={formStyles.successSecondary} data-hj-suppress>
         {deckName} was saved to your downloads
       </p>
       {warningMessage && (


### PR DESCRIPTION
Closes #982 

## Summary

- Add `data-hj-suppress` to the connected Notion workspace name on `/notion`
- Add `data-hj-suppress` to the Notion search empty-state headline when it includes workspace/search text
- Add `data-hj-suppress` to the upload success filename copy
- Add focused Vitest coverage for the suppressed user-data text

## Notes

AI-assisted tooling was used locally, and the final changes were reviewed and tested before submission.

**No changelog entry** - this changes analytics/privacy attributes only, with no rendered user-facing flow change.

**Browser check:** not applicable - analytics privacy attributes only; no rendered output change.

Sonar was not run locally because `SONAR_TOKEN` is not configured in this environment for this project.

## Testing

- `pnpm build`
- `pnpm --filter 2anki-web typecheck`
- `pnpm --filter 2anki-web lint`
- `pnpm --filter 2anki-web test:run src/pages/SearchPage/SearchPage.test.tsx src/pages/SearchPage/components/ListSearchResults.test.tsx src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782745016&installation_id=132681956&pr_number=2912&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2912&signature=535033c89550b2e074199581328894f262b1794e8603c7155ead5a2370873233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->