### PR TITLE
fix: align chat and notion OpenAPI annotations with controllers

### DIFF
--- a/src/config/swagger.test.ts
+++ b/src/config/swagger.test.ts
@@ -237,4 +237,85 @@ describe('Swagger Documentation Coverage', () => {
     expect(spec.components.securitySchemes.bearerAuth).toBeDefined();
     expect(spec.components.securitySchemes.cookieAuth).toBeDefined();
   });
+
+  describe('chat endpoint contract documentation', () => {
+    const spec = swaggerSpec as SwaggerSpec;
+
+    it('documents /api/chat/message as a Server-Sent Events stream', () => {
+      const op = spec.paths['/api/chat/message']?.post;
+      expect(op).toBeDefined();
+      const ok = op.responses['200'];
+      expect(ok).toBeDefined();
+      expect(ok.content).toHaveProperty('text/event-stream');
+    });
+
+    it('documents templateSlug and multipart files for /api/chat/message', () => {
+      const op = spec.paths['/api/chat/message']?.post;
+      const jsonProps =
+        op.requestBody.content['application/json'].schema.properties;
+      expect(jsonProps.templateSlug).toBeDefined();
+      const multipart = op.requestBody.content['multipart/form-data'];
+      expect(multipart).toBeDefined();
+      expect(multipart.schema.properties.files).toBeDefined();
+    });
+
+    it('exposes ChatBasicCard, ChatMcqCard, and the three SSE frame schemas', () => {
+      const schemas = spec.components.schemas;
+      expect(schemas.ChatBasicCard).toBeDefined();
+      expect(schemas.ChatMcqCard).toBeDefined();
+      expect(schemas.ChatTokenFrame).toBeDefined();
+      expect(schemas.ChatDoneFrame).toBeDefined();
+      expect(schemas.ChatErrorFrame).toBeDefined();
+    });
+
+    it('models the done-frame cards entry as a oneOf of basic and MCQ shapes', () => {
+      const doneFrame = spec.components.schemas.ChatDoneFrame;
+      const cards = doneFrame.properties.data.properties.cards;
+      expect(cards.items.oneOf).toBeDefined();
+      const refs = cards.items.oneOf.map((entry: { $ref: string }) => entry.$ref);
+      expect(refs).toContain('#/components/schemas/ChatBasicCard');
+      expect(refs).toContain('#/components/schemas/ChatMcqCard');
+    });
+
+    it('models /api/chat/deck cards as a oneOf of basic and MCQ shapes', () => {
+      const op = spec.paths['/api/chat/deck']?.post;
+      const cards =
+        op.requestBody.content['application/json'].schema.properties.cards;
+      expect(cards.items.oneOf).toBeDefined();
+      const refs = cards.items.oneOf.map((entry: { $ref: string }) => entry.$ref);
+      expect(refs).toContain('#/components/schemas/ChatBasicCard');
+      expect(refs).toContain('#/components/schemas/ChatMcqCard');
+    });
+
+    it('documents templateSlug on /api/chat/deck', () => {
+      const op = spec.paths['/api/chat/deck']?.post;
+      const props =
+        op.requestBody.content['application/json'].schema.properties;
+      expect(props.templateSlug).toBeDefined();
+    });
+
+    it('documents the four error-frame types for /api/chat/message', () => {
+      const errorFrame = spec.components.schemas.ChatErrorFrame;
+      const variants = errorFrame.properties.data.oneOf;
+      const types = variants.map(
+        (variant: { properties: { type: { enum: string[] } } }) =>
+          variant.properties.type.enum[0]
+      );
+      expect(types).toEqual(
+        expect.arrayContaining([
+          'rate_limit',
+          'consent_required',
+          'conversation_not_found',
+          'server_error',
+        ])
+      );
+    });
+
+    it('documents /api/notion/login as deprecated and points to get-notion-link', () => {
+      const op = spec.paths['/api/notion/login']?.get;
+      expect(op).toBeDefined();
+      expect(op.deprecated).toBe(true);
+      expect(op.description).toMatch(/get-notion-link/);
+    });
+  });
 });

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -551,6 +551,164 @@ const options: swaggerJsdoc.Options = {
             },
           },
         },
+        ChatBasicCard: {
+          type: 'object',
+          description:
+            'Basic two-sided flashcard. Front and back are both required strings.',
+          required: ['front', 'back'],
+          properties: {
+            front: { type: 'string' },
+            back: { type: 'string' },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 8,
+              description:
+                'Optional subject tags. Each tag is normalised server-side to lower-case kebab-case.',
+            },
+          },
+        },
+        ChatMcqCard: {
+          type: 'object',
+          description:
+            'Multiple-choice flashcard. On `/api/chat/deck` requests, `back` may be omitted — the server derives it from `options[correctIndex]`. On `/api/chat/message` `done` frames, `back` is emitted as an empty string.',
+          required: ['front', 'options', 'correctIndex'],
+          properties: {
+            front: { type: 'string' },
+            back: {
+              type: 'string',
+              description:
+                'Always emitted as an empty string in `done` frames. Optional in `/api/chat/deck` requests.',
+            },
+            options: {
+              type: 'array',
+              minItems: 4,
+              maxItems: 4,
+              items: { type: 'string' },
+              description: 'Exactly 4 non-empty option strings.',
+            },
+            correctIndex: {
+              type: 'integer',
+              minimum: 0,
+              maximum: 3,
+              description: 'Index into `options` of the correct answer.',
+            },
+            rationale: {
+              type: 'string',
+              description: 'Optional short explanation of the correct answer.',
+            },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              maxItems: 8,
+            },
+          },
+        },
+        ChatTokenFrame: {
+          type: 'object',
+          description:
+            'SSE frame emitted as `event: token`. `data` is a JSON string fragment of the assistant reply.',
+          properties: {
+            event: { type: 'string', enum: ['token'] },
+            data: {
+              type: 'string',
+              description: 'JSON-encoded string fragment.',
+            },
+          },
+          required: ['event', 'data'],
+        },
+        ChatDoneFrame: {
+          type: 'object',
+          description:
+            'SSE frame emitted as `event: done`. Terminal frame on success.',
+          properties: {
+            event: { type: 'string', enum: ['done'] },
+            data: {
+              type: 'object',
+              required: ['content', 'conversationId'],
+              properties: {
+                content: {
+                  type: 'string',
+                  description: 'Full assistant reply, also reconstructable by concatenating `token` frames.',
+                },
+                conversationId: {
+                  type: 'integer',
+                  description:
+                    'Conversation id the message was persisted under. Returned even for first-turn requests where the caller did not send one.',
+                },
+                cards: {
+                  type: 'array',
+                  description:
+                    'Generated flashcards, when the assistant produced them. Each entry is either a basic card or an MCQ card — clients must handle both shapes.',
+                  items: {
+                    oneOf: [
+                      { $ref: '#/components/schemas/ChatBasicCard' },
+                      { $ref: '#/components/schemas/ChatMcqCard' },
+                    ],
+                  },
+                },
+                contentBefore: {
+                  type: 'string',
+                  description: 'Prose that appeared before the cards block.',
+                },
+                contentAfter: {
+                  type: 'string',
+                  description: 'Prose that appeared after the cards block.',
+                },
+              },
+            },
+          },
+          required: ['event', 'data'],
+        },
+        ChatErrorFrame: {
+          type: 'object',
+          description:
+            'SSE frame emitted as `event: error`. Terminal frame on failure. HTTP status remains 200 — branch on `data.type`.',
+          properties: {
+            event: { type: 'string', enum: ['error'] },
+            data: {
+              oneOf: [
+                {
+                  type: 'object',
+                  description:
+                    'Monthly free-tier message budget reached. `resetDate` is when the budget refills.',
+                  required: ['type', 'resetDate'],
+                  properties: {
+                    type: { type: 'string', enum: ['rate_limit'] },
+                    resetDate: { type: 'string', format: 'date-time' },
+                  },
+                },
+                {
+                  type: 'object',
+                  description:
+                    'Caller has not yet recorded chat consent (POST /api/chat/consent).',
+                  required: ['type'],
+                  properties: {
+                    type: { type: 'string', enum: ['consent_required'] },
+                  },
+                },
+                {
+                  type: 'object',
+                  description:
+                    'The `conversationId` in the request does not belong to the caller or does not exist.',
+                  required: ['type'],
+                  properties: {
+                    type: { type: 'string', enum: ['conversation_not_found'] },
+                  },
+                },
+                {
+                  type: 'object',
+                  description: 'Unhandled server error; safe to retry.',
+                  required: ['type'],
+                  properties: {
+                    type: { type: 'string', enum: ['server_error'] },
+                  },
+                },
+              ],
+            },
+          },
+          required: ['event', 'data'],
+        },
       },
     },
     security: [

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -60,7 +60,37 @@ const ChatRouter = () => {
    * @swagger
    * /api/chat/message:
    *   post:
-   *     summary: Send a message to the study assistant
+   *     summary: Send a message to the study assistant (Server-Sent Events stream)
+   *     description: |
+   *       Streams the assistant's reply as Server-Sent Events (`text/event-stream`).
+   *       Three event names are emitted on the response, each carrying a JSON
+   *       payload in the `data:` line:
+   *
+   *       - `event: token` — incremental assistant text. `data` is a JSON
+   *         string fragment (e.g. `"Hello"`). Concatenate every `token`
+   *         payload to reconstruct the full reply.
+   *       - `event: done` — terminal frame for a successful turn. `data` is
+   *         a JSON object matching `ChatDoneFrame` (see schemas), carrying
+   *         the final assistant content, the conversation id, and, when the
+   *         assistant generated flashcards, a `cards` array plus the prose
+   *         that came before / after the cards.
+   *       - `event: error` — terminal frame for a failure. `data` is a JSON
+   *         object matching `ChatErrorFrame` (see schemas). The HTTP status
+   *         is still 200 because the stream has already opened; clients must
+   *         branch on the `error` frame's `type` field instead of HTTP code.
+   *
+   *       Each event ends with a blank line (`\n\n`). Clients that consume
+   *       SSE via a line-based reader must not discard empty lines — they
+   *       are the frame separator.
+   *
+   *       The request accepts `multipart/form-data` so the caller can attach
+   *       up to 5 files (PDF or image) totalling 25 MB.
+   *
+   *       Card-shape footgun: when the caller is a Patreon (lifetime/paid)
+   *       user, the assistant may emit MCQ-shape cards even if
+   *       `templateSlug=basic` is sent. `templateSlug` is a hint, not a
+   *       contract — clients must be ready for both card shapes on every
+   *       `done` frame. See the `ChatDoneFrame.cards` schema's `oneOf`.
    *     tags: [Chat]
    *     security:
    *       - bearerAuth: []
@@ -78,6 +108,13 @@ const ChatRouter = () => {
    *               conversationId:
    *                 type: integer
    *                 nullable: true
+   *               templateSlug:
+   *                 type: string
+   *                 nullable: true
+   *                 description: |
+   *                   Card template hint (`basic`, `basic-and-reversed`,
+   *                   `cloze`, `mcq`). Patreon users may still receive MCQ
+   *                   cards when this is `basic` — see endpoint description.
    *               history:
    *                 type: array
    *                 items:
@@ -89,13 +126,62 @@ const ChatRouter = () => {
    *                       enum: [user, assistant]
    *                     content:
    *                       type: string
+   *         multipart/form-data:
+   *           schema:
+   *             type: object
+   *             required: [content]
+   *             properties:
+   *               content:
+   *                 type: string
+   *                 maxLength: 100000
+   *               conversationId:
+   *                 type: integer
+   *                 nullable: true
+   *               templateSlug:
+   *                 type: string
+   *                 nullable: true
+   *               history:
+   *                 type: string
+   *                 description: |
+   *                   JSON-encoded array of `{ role, content }` history
+   *                   entries when sent over multipart.
+   *               files:
+   *                 type: array
+   *                 maxItems: 5
+   *                 description: |
+   *                   PDF or image attachments. Per-file limit 10 MB,
+   *                   combined limit 25 MB. Accepted MIME types:
+   *                   `application/pdf`, `image/png`, `image/jpeg`,
+   *                   `image/gif`, `image/webp`.
+   *                 items:
+   *                   type: string
+   *                   format: binary
    *     responses:
    *       200:
-   *         description: Assistant reply
+   *         description: |
+   *           SSE stream of `token`, `done`, and `error` events. Inspect the
+   *           terminal frame to determine success or failure — the HTTP
+   *           status is 200 for both outcomes once the stream is open.
+   *         content:
+   *           text/event-stream:
+   *             schema:
+   *               oneOf:
+   *                 - $ref: '#/components/schemas/ChatTokenFrame'
+   *                 - $ref: '#/components/schemas/ChatDoneFrame'
+   *                 - $ref: '#/components/schemas/ChatErrorFrame'
    *       400:
-   *         description: Invalid content
-   *       429:
-   *         description: Monthly message limit reached
+   *         description: |
+   *           Invalid request (missing `content`, content over the 100 000
+   *           character cap, too many files, file too large, total
+   *           attachment payload over 25 MB, or an attachment whose MIME
+   *           type is not allowed). Returned as `application/json` before
+   *           the SSE stream opens.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   *       401:
+   *         description: Authentication required
    */
   router.post(
     '/api/chat/message',
@@ -109,6 +195,13 @@ const ChatRouter = () => {
    * /api/chat/deck:
    *   post:
    *     summary: Generate an Anki deck from chat cards
+   *     description: |
+   *       Builds an `.apkg` from a client-supplied card list. Each card may
+   *       be either the basic shape (`front` + `back`) or the MCQ shape
+   *       (`front` + 4 `options` + `correctIndex`, with optional `rationale`
+   *       and `tags`); the two shapes can be mixed in a single request. Per
+   *       card, `tags` is an optional array of short subject tags
+   *       (lower-case, hyphenated, up to 8 per card).
    *     tags: [Chat]
    *     security:
    *       - bearerAuth: []
@@ -123,17 +216,21 @@ const ChatRouter = () => {
    *               deckName:
    *                 type: string
    *                 maxLength: 120
+   *               templateSlug:
+   *                 type: string
+   *                 nullable: true
+   *                 description: |
+   *                   Card template slug (`basic`, `basic-and-reversed`,
+   *                   `cloze`, `mcq`). The server still chooses the actual
+   *                   note model based on card shape — MCQ-shape cards
+   *                   render as MCQ regardless of this value.
    *               cards:
    *                 type: array
    *                 maxItems: 200
    *                 items:
-   *                   type: object
-   *                   required: [front, back]
-   *                   properties:
-   *                     front:
-   *                       type: string
-   *                     back:
-   *                       type: string
+   *                   oneOf:
+   *                     - $ref: '#/components/schemas/ChatBasicCard'
+   *                     - $ref: '#/components/schemas/ChatMcqCard'
    *     responses:
    *       200:
    *         description: Anki .apkg file
@@ -143,7 +240,22 @@ const ChatRouter = () => {
    *               type: string
    *               format: binary
    *       400:
-   *         description: Invalid input
+   *         description: |
+   *           Invalid input. `deckName` is required and must be 120
+   *           characters or fewer. `cards` must be a non-empty array of at
+   *           most 200 items. Each card must be either a basic card
+   *           (string `front` and string `back`) or a valid MCQ card (string
+   *           `front`, an `options` array of exactly 4 non-empty strings,
+   *           and an integer `correctIndex` in range `[0, 3]`). Cards that
+   *           match neither shape produce
+   *           `each card must have string front and back fields, or a
+   *           valid MCQ shape`.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   *       401:
+   *         description: Authentication required
    */
   router.post('/api/chat/deck', RequireAuthentication, (req, res) =>
     deckController.generate(req, res)

--- a/src/routes/NotionRouter.ts
+++ b/src/routes/NotionRouter.ts
@@ -115,15 +115,36 @@ const NotionRouter = () => {
 
   /**
    * @swagger
+   * /api/notion/login:
+   *   get:
+   *     deprecated: true
+   *     summary: Deprecated — use GET /api/notion/get-notion-link
+   *     description: |
+   *       There is no `/api/notion/login` endpoint. Integrators sometimes
+   *       guess this URL because OAuth flows are commonly called "login"
+   *       elsewhere; hitting it returns 404. The endpoint that returns the
+   *       Notion OAuth authorization URL is `GET /api/notion/get-notion-link`.
+   *     tags: [Notion]
+   *     responses:
+   *       404:
+   *         description: Not found. Call GET /api/notion/get-notion-link instead.
+   */
+
+  /**
+   * @swagger
    * /api/notion/get-notion-link:
    *   get:
-   *     summary: Get Notion connection link
+   *     summary: Get Notion connection link (Notion OAuth login URL)
    *     description: |
    *       Returns the OAuth link to connect to Notion. The link itself is
    *       public — anonymous and expired-session users still get back a
    *       working URL so the "Connect to Notion" button never goes inert.
    *       `isConnected` and `workspace` are only populated when the caller
    *       has a valid session.
+   *
+   *       Note: there is no `/api/notion/login` endpoint. Some integrators
+   *       guess that path because OAuth flows are commonly called "login";
+   *       this endpoint is the canonical one.
    *     tags: [Notion]
    *     responses:
    *       200:


### PR DESCRIPTION
## What
Brings `/api/docs/` in line with what the chat and Notion controllers actually accept and emit. JSDoc `@openapi` blocks only — no runtime behavior changes.

## Why
Closes #2905. A native-app integrator hit a chain of real bugs whose root cause was the same in every case: the Swagger annotations document a narrower surface than the controllers. Each undocumented gap mapped to a real bug they shipped (malformed SSE done-frame parsing, MCQ cards rendered as basic cards with empty backs, a 404 on the guessed `/api/notion/login` URL). Better integrator docs are how we keep native and third-party clients building on us instead of dropping the integration.

## How
**`/api/chat/message`**
- Document the SSE contract: `text/event-stream`, the `token` / `done` / `error` event names, and the JSON shape of each `data:` line.
- Add `templateSlug` to the request body.
- Add a `multipart/form-data` request body covering the `files[]` attachments (5 file max, 25 MB total, PDF + image MIMEs).
- Register `ChatTokenFrame`, `ChatDoneFrame`, `ChatErrorFrame` schemas in `components`. The done-frame `cards` entry is a `oneOf` of basic + MCQ shapes so the dual-shape reality is honest.
- `ChatErrorFrame.data` is a `oneOf` of the four real shapes (`rate_limit` with `resetDate`, `consent_required`, `conversation_not_found`, `server_error`).
- Endpoint description calls out the Patreon-user MCQ auto-promotion footgun so clients know `templateSlug` is a hint, not a contract.

**`/api/chat/deck`**
- Change `cards.items` from `required:[front,back]` to a `oneOf` of `ChatBasicCard` and `ChatMcqCard` — the current schema was wrong because `asMcqShape` accepts MCQ without `back`.
- Add `templateSlug` and per-card `tags` to the request schema.
- Replace vague "Invalid input" with the real dual-shape 400 message.

**`/api/notion/login` vs `/api/notion/get-notion-link`**
- Add a `deprecated: true` stub `@swagger` block at `/api/notion/login` whose only purpose is to point readers to `/api/notion/get-notion-link`. There's no route handler — only a doc entry — so Swagger UI surfaces it under the Notion tag for anyone searching "login".
- Extend the `get-notion-link` summary to include "Notion OAuth login URL" and add a paragraph noting that `/api/notion/login` is a common misguess.
- No redirect — adding a real route for a misguess would create a forever-maintenance contract. The doc-only solution is enough.

## Out of scope
- **CI lint that diffs accepted-vs-documented (suggestion #6 in the issue).** That's a substantive new tool, not a doc fix; file separately if worth doing.
- **Changing the Patreon→MCQ auto-promotion.** Product decision, not a doc fix.

## Measuring success
- Hit `/api/docs/` after deploy and confirm `/api/chat/message` shows the `text/event-stream` response and the three event schemas under "Components".
- Confirm `/api/chat/deck`'s `cards` items render as a "oneOf" picker in Swagger UI.
- Confirm `/api/notion/login` appears in the Notion tag, marked deprecated, with the cross-link in the description.
- The new `swagger.test.ts` cases lock the shape in: any future regression that drops the SSE content type, removes a `oneOf`, or breaks the four error-frame types fails CI.

## Testing
- Server unit tests: `pnpm test src/config/swagger.test.ts` (11 passed, 8 new) and `pnpm test src/controllers/ChatController src/controllers/ChatDeckController` (36 passed).
- `/check`: server tsc + web typecheck + web vitest (1375 passed) + web lint — all green.
- `sonar-scanner` not run locally — `SONAR_TOKEN` not configured on this machine. The diff is JSDoc + a test file; no new function complexity or branching to flag. Will react to any Sonar bounce on the PR.

## Changelog
No changelog entry — API contract documentation correction. The audience is API integrators, not end users of 2anki.net.

## Risks
- The new schemas in `components.schemas` (`ChatBasicCard`, `ChatMcqCard`, `ChatTokenFrame`, `ChatDoneFrame`, `ChatErrorFrame`) are additive and namespaced. No clash with existing schemas.
- The `/api/notion/login` stub has no route handler. `swagger.test.ts` enforces "every route is documented" but not the reverse, so a phantom doc entry is fine and intentional here.
- Rollback: revert the commit; the controllers were never touched.

## Goal alignment
A native-app integration team is currently source-diving our controllers to figure out the API. Each bug they shipped because the docs lied (malformed SSE parsing, empty-back MCQ decks, 404 on the connect button) translates into broken decks generated through our service. Healthy third-party integrations are a multiplier on the path to 300K — they bring users who never visit the web app directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782745151&installation_id=132681956&pr_number=2913&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2913&signature=c84bc6bc1ab8012d2af6dc367c1100f5abc51693be982bc468b2e04e4e062a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->