### PR TITLE
feat: add post-login survey for improvement and study-field input

### DIFF
--- a/migrations/20260830000000_create_user_surveys.js
+++ b/migrations/20260830000000_create_user_surveys.js
@@ -1,0 +1,26 @@
+const TABLE = 'user_surveys';
+
+exports.up = async function up(knex) {
+  await knex.schema.dropTableIfExists(TABLE);
+  await knex.schema.createTable(TABLE, (table) => {
+    table.increments('id').primary();
+    table
+      .integer('user_id')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.text('survey_key').notNullable().defaultTo('post_login_v1');
+    table.text('improvement').nullable();
+    table.text('studying').nullable();
+    table.text('status').notNullable();
+    table.unique(['user_id', 'survey_key']);
+    table.index('user_id');
+    table.timestamps(true, true);
+  });
+};
+
+exports.down = async function down(knex) {
+  await knex.schema.dropTableIfExists(TABLE);
+};

--- a/src/controllers/UserSurveyController.test.ts
+++ b/src/controllers/UserSurveyController.test.ts
@@ -1,0 +1,146 @@
+import { Request, Response } from 'express';
+import { UserSurveyController } from './UserSurveyController';
+import {
+  InMemoryUserSurveyRepository,
+  IUserSurveyRepository,
+} from '../data_layer/UserSurveyRepository';
+import { ShouldShowSurveyUseCase } from '../usecases/surveys/ShouldShowSurveyUseCase';
+import { RecordSurveyResponseUseCase } from '../usecases/surveys/RecordSurveyResponseUseCase';
+
+const mockResponse = (owner: unknown) => {
+  const res = {} as Response;
+  res.locals = { owner };
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+const mockRequest = (body: unknown) => {
+  return { body } as Request;
+};
+
+const buildController = (repository: IUserSurveyRepository) => {
+  return new UserSurveyController(
+    new ShouldShowSurveyUseCase(repository),
+    new RecordSurveyResponseUseCase(repository)
+  );
+};
+
+describe('UserSurveyController', () => {
+  describe('shouldShow', () => {
+    it('returns 401 when no owner is present', async () => {
+      const controller = buildController(new InMemoryUserSurveyRepository());
+      const res = mockResponse(null);
+
+      await controller.shouldShow(mockRequest({}), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Not authenticated.' });
+    });
+
+    it('returns shouldShow true for a user with no prior row', async () => {
+      const controller = buildController(new InMemoryUserSurveyRepository());
+      const res = mockResponse(42);
+
+      await controller.shouldShow(mockRequest({}), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ shouldShow: true });
+    });
+
+    it('returns shouldShow false once a row exists', async () => {
+      const repository = new InMemoryUserSurveyRepository();
+      await repository.upsert('42', 'post_login_v1', {
+        improvement: null,
+        studying: null,
+        status: 'dismissed',
+      });
+      const controller = buildController(repository);
+      const res = mockResponse(42);
+
+      await controller.shouldShow(mockRequest({}), res);
+
+      expect(res.json).toHaveBeenCalledWith({ shouldShow: false });
+    });
+  });
+
+  describe('submit', () => {
+    it('returns 401 when no owner is present', async () => {
+      const controller = buildController(new InMemoryUserSurveyRepository());
+      const res = mockResponse(null);
+
+      await controller.submit(mockRequest({ status: 'answered' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it('returns 400 on an invalid status', async () => {
+      const controller = buildController(new InMemoryUserSurveyRepository());
+      const res = mockResponse(42);
+
+      await controller.submit(mockRequest({ status: 'nope' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Invalid status.' });
+    });
+
+    it('returns 400 when improvement is not a string', async () => {
+      const controller = buildController(new InMemoryUserSurveyRepository());
+      const res = mockResponse(42);
+
+      await controller.submit(
+        mockRequest({ status: 'answered', improvement: 5 }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 201 on an answered submission with only improvement', async () => {
+      const repository = new InMemoryUserSurveyRepository();
+      const controller = buildController(repository);
+      const res = mockResponse(42);
+
+      await controller.submit(
+        mockRequest({ status: 'answered', improvement: 'More themes' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Thanks for the input.' });
+      expect(repository.getData('42', 'post_login_v1')).toEqual({
+        status: 'answered',
+        improvement: 'More themes',
+        studying: null,
+      });
+    });
+
+    it('returns 201 on a dismissal with no text', async () => {
+      const repository = new InMemoryUserSurveyRepository();
+      const controller = buildController(repository);
+      const res = mockResponse(42);
+
+      await controller.submit(mockRequest({ status: 'dismissed' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(repository.getData('42', 'post_login_v1')).toEqual({
+        status: 'dismissed',
+        improvement: null,
+        studying: null,
+      });
+    });
+
+    it('never echoes raw row fields in the response body', async () => {
+      const controller = buildController(new InMemoryUserSurveyRepository());
+      const res = mockResponse(42);
+
+      await controller.submit(
+        mockRequest({ status: 'answered', studying: 'Science' }),
+        res
+      );
+
+      const body = (res.json as jest.Mock).mock.calls[0][0];
+      expect(Object.keys(body)).toEqual(['message']);
+    });
+  });
+});

--- a/src/controllers/UserSurveyController.ts
+++ b/src/controllers/UserSurveyController.ts
@@ -1,0 +1,66 @@
+import { Request, Response } from 'express';
+import { ShouldShowSurveyUseCase } from '../usecases/surveys/ShouldShowSurveyUseCase';
+import { RecordSurveyResponseUseCase } from '../usecases/surveys/RecordSurveyResponseUseCase';
+import { SurveyStatus } from '../data_layer/UserSurveyRepository';
+
+interface ShouldShowResponse {
+  shouldShow: boolean;
+}
+
+interface SubmitResponse {
+  message: string;
+}
+
+function isSurveyStatus(value: unknown): value is SurveyStatus {
+  return value === 'answered' || value === 'dismissed';
+}
+
+function isStringOrAbsent(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+export class UserSurveyController {
+  constructor(
+    private readonly shouldShowUseCase: ShouldShowSurveyUseCase,
+    private readonly recordUseCase: RecordSurveyResponseUseCase
+  ) {}
+
+  async shouldShow(req: Request, res: Response): Promise<void> {
+    const owner = res.locals.owner;
+    if (owner == null) {
+      res.status(401).json({ message: 'Not authenticated.' });
+      return;
+    }
+    const shouldShow = await this.shouldShowUseCase.execute(String(owner));
+    const response: ShouldShowResponse = { shouldShow };
+    res.status(200).json(response);
+  }
+
+  async submit(req: Request, res: Response): Promise<void> {
+    try {
+      const owner = res.locals.owner;
+      if (owner == null) {
+        res.status(401).json({ message: 'Not authenticated.' });
+        return;
+      }
+      const { status, improvement, studying } = req.body ?? {};
+      if (!isSurveyStatus(status)) {
+        res.status(400).json({ message: 'Invalid status.' });
+        return;
+      }
+      if (!isStringOrAbsent(improvement) || !isStringOrAbsent(studying)) {
+        res.status(400).json({ message: 'Invalid survey input.' });
+        return;
+      }
+      await this.recordUseCase.execute(String(owner), {
+        status,
+        improvement,
+        studying,
+      });
+      const response: SubmitResponse = { message: 'Thanks for the input.' };
+      res.status(201).json(response);
+    } catch {
+      res.status(500).json({ message: 'Could not save survey.' });
+    }
+  }
+}

--- a/src/data_layer/UserSurveyRepository.test.ts
+++ b/src/data_layer/UserSurveyRepository.test.ts
@@ -1,0 +1,83 @@
+import knexFactory from 'knex';
+import {
+  UserSurveyRepository,
+  InMemoryUserSurveyRepository,
+} from './UserSurveyRepository';
+
+describe('UserSurveyRepository generated SQL', () => {
+  it('upserts via an insert with on-conflict do-update on the composite key', () => {
+    const db = knexFactory({ client: 'pg' });
+
+    const sql = db('user_surveys')
+      .insert({
+        user_id: '42',
+        survey_key: 'post_login_v1',
+        improvement: 'More themes',
+        studying: 'Medicine',
+        status: 'answered',
+      })
+      .onConflict(['user_id', 'survey_key'])
+      .merge({
+        improvement: 'More themes',
+        studying: 'Medicine',
+        status: 'answered',
+        updated_at: new Date(),
+      })
+      .toString()
+      .toLowerCase();
+
+    expect(sql).toContain('insert into "user_surveys"');
+    expect(sql).toContain('on conflict ("user_id", "survey_key") do update');
+
+    return db.destroy();
+  });
+});
+
+describe('InMemoryUserSurveyRepository', () => {
+  it('returns undefined when no row exists for the key', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+
+    await expect(
+      repository.findByUserAndKey('42', 'post_login_v1')
+    ).resolves.toBeUndefined();
+  });
+
+  it('finds a row after an upsert', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+
+    await repository.upsert('42', 'post_login_v1', {
+      improvement: null,
+      studying: 'Law',
+      status: 'answered',
+    });
+
+    const found = await repository.findByUserAndKey('42', 'post_login_v1');
+    expect(found).toEqual({ id: 1 });
+  });
+
+  it('overwrites an existing row without changing its id', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+
+    await repository.upsert('42', 'post_login_v1', {
+      improvement: null,
+      studying: null,
+      status: 'dismissed',
+    });
+    const first = await repository.findByUserAndKey('42', 'post_login_v1');
+
+    await repository.upsert('42', 'post_login_v1', {
+      improvement: 'Faster',
+      studying: 'Science',
+      status: 'answered',
+    });
+    const second = await repository.findByUserAndKey('42', 'post_login_v1');
+
+    expect(second).toEqual(first);
+    expect(repository.count()).toBe(1);
+    expect(repository.getData('42', 'post_login_v1')).toEqual({
+      improvement: 'Faster',
+      studying: 'Science',
+      status: 'answered',
+    });
+  });
+});

--- a/src/data_layer/UserSurveyRepository.ts
+++ b/src/data_layer/UserSurveyRepository.ts
@@ -1,0 +1,107 @@
+import { Knex } from 'knex';
+
+export type SurveyStatus = 'answered' | 'dismissed';
+
+export interface UserSurveyData {
+  improvement: string | null;
+  studying: string | null;
+  status: SurveyStatus;
+}
+
+export interface IUserSurveyRepository {
+  upsert(
+    userId: string,
+    surveyKey: string,
+    data: UserSurveyData
+  ): Promise<void>;
+  findByUserAndKey(
+    userId: string,
+    surveyKey: string
+  ): Promise<{ id: number } | undefined>;
+}
+
+export class UserSurveyRepository implements IUserSurveyRepository {
+  constructor(private readonly db: Knex) {}
+
+  async upsert(
+    userId: string,
+    surveyKey: string,
+    data: UserSurveyData
+  ): Promise<void> {
+    await this.db('user_surveys')
+      .insert({
+        user_id: userId,
+        survey_key: surveyKey,
+        improvement: data.improvement,
+        studying: data.studying,
+        status: data.status,
+      })
+      .onConflict(['user_id', 'survey_key'])
+      .merge({
+        improvement: data.improvement,
+        studying: data.studying,
+        status: data.status,
+        updated_at: new Date(),
+      });
+  }
+
+  async findByUserAndKey(
+    userId: string,
+    surveyKey: string
+  ): Promise<{ id: number } | undefined> {
+    const row = await this.db('user_surveys')
+      .where({ user_id: userId, survey_key: surveyKey })
+      .first();
+    if (row == null) {
+      return undefined;
+    }
+    return { id: row.id };
+  }
+}
+
+export class InMemoryUserSurveyRepository implements IUserSurveyRepository {
+  private readonly rows = new Map<
+    string,
+    { id: number; data: UserSurveyData }
+  >();
+
+  private nextId = 1;
+
+  private key(userId: string, surveyKey: string): string {
+    return `${userId}::${surveyKey}`;
+  }
+
+  async upsert(
+    userId: string,
+    surveyKey: string,
+    data: UserSurveyData
+  ): Promise<void> {
+    const compositeKey = this.key(userId, surveyKey);
+    const existing = this.rows.get(compositeKey);
+    if (existing != null) {
+      this.rows.set(compositeKey, { id: existing.id, data });
+      return;
+    }
+    this.rows.set(compositeKey, { id: this.nextId, data });
+    this.nextId += 1;
+  }
+
+  async findByUserAndKey(
+    userId: string,
+    surveyKey: string
+  ): Promise<{ id: number } | undefined> {
+    const existing = this.rows.get(this.key(userId, surveyKey));
+    if (existing == null) {
+      return undefined;
+    }
+    return { id: existing.id };
+  }
+
+  getData(userId: string, surveyKey: string): UserSurveyData | undefined {
+    return this.rows.get(this.key(userId, surveyKey))?.data;
+  }
+
+  count(): number {
+    return this.rows.size;
+  }
+}

--- a/src/data_layer/public/UserSurveys.ts
+++ b/src/data_layer/public/UserSurveys.ts
@@ -1,0 +1,18 @@
+import {
+  UsersId,
+} from './Users';
+
+/** Identifier type for public.user_surveys */
+export type UserSurveysId = number & { __brand: 'public.user_surveys' };
+
+/** Represents the table public.user_surveys */
+export default interface UserSurveysTable {
+  id: UserSurveysId;
+  user_id: UsersId;
+  survey_key: string;
+  improvement: string | null;
+  studying: string | null;
+  status: string;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/src/routes/UserSurveyRouter.ts
+++ b/src/routes/UserSurveyRouter.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import { getDatabase } from '../data_layer';
+import { UserSurveyController } from '../controllers/UserSurveyController';
+import { UserSurveyRepository } from '../data_layer/UserSurveyRepository';
+import { ShouldShowSurveyUseCase } from '../usecases/surveys/ShouldShowSurveyUseCase';
+import { RecordSurveyResponseUseCase } from '../usecases/surveys/RecordSurveyResponseUseCase';
+import RequireAuthentication from './middleware/RequireAuthentication';
+
+/**
+ * @swagger
+ * /api/surveys/post-login:
+ *   get:
+ *     summary: Check whether the post-login survey should be shown
+ *     tags: [Surveys]
+ *     responses:
+ *       200:
+ *         description: Whether to show the survey for this user
+ *   post:
+ *     summary: Record a post-login survey response or dismissal
+ *     tags: [Surveys]
+ *     responses:
+ *       201:
+ *         description: Response recorded
+ */
+function userSurveyRouter(): Router {
+  const router = Router();
+  const repository = new UserSurveyRepository(getDatabase());
+  const shouldShowUseCase = new ShouldShowSurveyUseCase(repository);
+  const recordUseCase = new RecordSurveyResponseUseCase(repository);
+  const controller = new UserSurveyController(shouldShowUseCase, recordUseCase);
+
+  router.get('/api/surveys/post-login', RequireAuthentication, (req, res) =>
+    controller.shouldShow(req, res)
+  );
+
+  router.post('/api/surveys/post-login', RequireAuthentication, (req, res) =>
+    controller.submit(req, res)
+  );
+
+  return router;
+}
+
+export default userSurveyRouter;

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,6 +64,7 @@ import shareRouter from './routes/ShareRouter';
 import subscriptionClaimRouter from './routes/SubscriptionClaimRouter';
 import mindmapRouter from './routes/MindmapRouter';
 import pitchRouter from './routes/PitchRouter';
+import userSurveyRouter from './routes/UserSurveyRouter';
 import wellKnownRouter from './routes/WellKnownRouter';
 import healthRouter from './routes/HealthRouter';
 import requestLoggingMiddleware from './routes/middleware/requestLoggingMiddleware';

--- a/src/usecases/surveys/RecordSurveyResponseUseCase.test.ts
+++ b/src/usecases/surveys/RecordSurveyResponseUseCase.test.ts
@@ -1,0 +1,76 @@
+import { InMemoryUserSurveyRepository } from '../../data_layer/UserSurveyRepository';
+import {
+  RecordSurveyResponseUseCase,
+  InvalidSurveyStatusError,
+} from './RecordSurveyResponseUseCase';
+
+describe('RecordSurveyResponseUseCase', () => {
+  it('rejects an invalid status', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    const useCase = new RecordSurveyResponseUseCase(repository);
+
+    await expect(
+      useCase.execute('42', {
+        status: 'maybe' as unknown as 'answered',
+      })
+    ).rejects.toBeInstanceOf(InvalidSurveyStatusError);
+    expect(repository.count()).toBe(0);
+  });
+
+  it('trims and caps text at 2000 characters', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    const useCase = new RecordSurveyResponseUseCase(repository);
+    const longText = 'x'.repeat(2500);
+
+    await useCase.execute('42', {
+      status: 'answered',
+      improvement: `   ${longText}   `,
+      studying: '  Languages  ',
+    });
+
+    const stored = repository.getData('42', 'post_login_v1');
+    expect(stored).toEqual({
+      status: 'answered',
+      improvement: 'x'.repeat(2000),
+      studying: 'Languages',
+    });
+  });
+
+  it('stores empty or whitespace-only text as null', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    const useCase = new RecordSurveyResponseUseCase(repository);
+
+    await useCase.execute('42', {
+      status: 'dismissed',
+      improvement: '   ',
+      studying: '',
+    });
+
+    expect(repository.getData('42', 'post_login_v1')).toEqual({
+      status: 'dismissed',
+      improvement: null,
+      studying: null,
+    });
+  });
+
+  it('overwrites the previous response without creating a duplicate row', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    const useCase = new RecordSurveyResponseUseCase(repository);
+
+    await useCase.execute('42', {
+      status: 'dismissed',
+    });
+    await useCase.execute('42', {
+      status: 'answered',
+      improvement: 'Faster conversions',
+      studying: 'Law',
+    });
+
+    expect(repository.count()).toBe(1);
+    expect(repository.getData('42', 'post_login_v1')).toEqual({
+      status: 'answered',
+      improvement: 'Faster conversions',
+      studying: 'Law',
+    });
+  });
+});

--- a/src/usecases/surveys/RecordSurveyResponseUseCase.ts
+++ b/src/usecases/surveys/RecordSurveyResponseUseCase.ts
@@ -1,0 +1,53 @@
+import {
+  IUserSurveyRepository,
+  SurveyStatus,
+} from '../../data_layer/UserSurveyRepository';
+
+const MAX_TEXT_LENGTH = 2000;
+
+export class InvalidSurveyStatusError extends Error {
+  constructor() {
+    super('Invalid survey status.');
+    this.name = 'InvalidSurveyStatusError';
+  }
+}
+
+export interface RecordSurveyInput {
+  status: SurveyStatus;
+  improvement?: string;
+  studying?: string;
+}
+
+function isSurveyStatus(value: unknown): value is SurveyStatus {
+  return value === 'answered' || value === 'dismissed';
+}
+
+function normalizeText(value: string | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim().slice(0, MAX_TEXT_LENGTH);
+  if (trimmed.length === 0) {
+    return null;
+  }
+  return trimmed;
+}
+
+export class RecordSurveyResponseUseCase {
+  constructor(
+    private readonly repository: IUserSurveyRepository,
+    private readonly surveyKey = 'post_login_v1'
+  ) {}
+
+  async execute(userId: string, input: RecordSurveyInput): Promise<void> {
+    if (isSurveyStatus(input.status)) {
+      await this.repository.upsert(userId, this.surveyKey, {
+        status: input.status,
+        improvement: normalizeText(input.improvement),
+        studying: normalizeText(input.studying),
+      });
+      return;
+    }
+    throw new InvalidSurveyStatusError();
+  }
+}

--- a/src/usecases/surveys/ShouldShowSurveyUseCase.test.ts
+++ b/src/usecases/surveys/ShouldShowSurveyUseCase.test.ts
@@ -1,0 +1,47 @@
+import { InMemoryUserSurveyRepository } from '../../data_layer/UserSurveyRepository';
+import { ShouldShowSurveyUseCase } from './ShouldShowSurveyUseCase';
+
+describe('ShouldShowSurveyUseCase', () => {
+  it('returns true when no row exists for the user', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    const useCase = new ShouldShowSurveyUseCase(repository);
+
+    await expect(useCase.execute('42')).resolves.toBe(true);
+  });
+
+  it('returns false after the user answered the survey', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    await repository.upsert('42', 'post_login_v1', {
+      improvement: 'More themes',
+      studying: 'Medicine',
+      status: 'answered',
+    });
+    const useCase = new ShouldShowSurveyUseCase(repository);
+
+    await expect(useCase.execute('42')).resolves.toBe(false);
+  });
+
+  it('returns false after the user dismissed the survey', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    await repository.upsert('42', 'post_login_v1', {
+      improvement: null,
+      studying: null,
+      status: 'dismissed',
+    });
+    const useCase = new ShouldShowSurveyUseCase(repository);
+
+    await expect(useCase.execute('42')).resolves.toBe(false);
+  });
+
+  it('isolates users by id', async () => {
+    const repository = new InMemoryUserSurveyRepository();
+    await repository.upsert('42', 'post_login_v1', {
+      improvement: null,
+      studying: null,
+      status: 'dismissed',
+    });
+    const useCase = new ShouldShowSurveyUseCase(repository);
+
+    await expect(useCase.execute('99')).resolves.toBe(true);
+  });
+});

--- a/src/usecases/surveys/ShouldShowSurveyUseCase.ts
+++ b/src/usecases/surveys/ShouldShowSurveyUseCase.ts
@@ -1,0 +1,19 @@
+import { IUserSurveyRepository } from '../../data_layer/UserSurveyRepository';
+
+export class ShouldShowSurveyUseCase {
+  constructor(
+    private readonly repository: IUserSurveyRepository,
+    private readonly surveyKey = 'post_login_v1'
+  ) {}
+
+  async execute(userId: string): Promise<boolean> {
+    const existing = await this.repository.findByUserAndKey(
+      userId,
+      this.surveyKey
+    );
+    if (existing == null) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-route
 import { AppShell } from './components/AppShell/AppShell';
 import { getErrorMessage } from './components/errors/helpers/getErrorMessage';
 import { SkeletonPage } from './components/Skeleton/Skeleton';
+import PostLoginSurvey from './components/PostLoginSurvey/PostLoginSurvey';
 import { useUserLocals } from './lib/hooks/useUserLocals';
 import isOfflineMode from './lib/isOfflineMode';
 import { reportClientError } from './lib/reportClientError';
@@ -177,6 +178,7 @@ function AppContent({
         }
         features={data?.features}
       >
+        {isLoggedInResolved && <PostLoginSurvey />}
         <Routes>
           <Route
             path="/favorites"

--- a/web/src/components/PostLoginSurvey/PostLoginSurvey.module.css
+++ b/web/src/components/PostLoginSurvey/PostLoginSurvey.module.css
@@ -1,0 +1,169 @@
+.card {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1000;
+  width: 360px;
+  max-width: calc(100vw - 3rem);
+  background: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 12px;
+  padding: 1.25rem 1.25rem 1rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+}
+
+.close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--text-muted, #9ca3af);
+}
+
+.title {
+  margin: 0 1.5rem 0.25rem 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted, #6b7280);
+}
+
+.question {
+  margin-bottom: 1rem;
+}
+
+.label {
+  margin: 0 0 0.5rem;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.ratings {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.rating {
+  font-size: 1.6rem;
+  background: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  padding: 0.25rem 0.4rem;
+  border-radius: 8px;
+  transition: transform 0.1s ease;
+}
+
+.rating:hover {
+  transform: scale(1.15);
+}
+
+.rating[aria-pressed='true'] {
+  border-color: var(--accent-color, #3b82f6);
+  background: var(--accent-bg, rgba(59, 130, 246, 0.08));
+}
+
+.textarea {
+  margin-top: 0.6rem;
+  width: 100%;
+  min-height: 3.5rem;
+  resize: vertical;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.chip {
+  border: 1px solid var(--border-color, #e5e7eb);
+  background: var(--chip-bg, #f9fafb);
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.chip[aria-pressed='true'] {
+  border-color: var(--accent-color, #3b82f6);
+  background: var(--accent-bg, rgba(59, 130, 246, 0.12));
+  font-weight: 500;
+}
+
+.otherInput {
+  margin-top: 0.6rem;
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 8px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.errorText {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--error-color, #dc2626);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.notNow {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--text-muted, #6b7280);
+  padding: 0.4rem 0.2rem;
+}
+
+.send {
+  background: var(--accent-color, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.45rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.send:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.confirmation {
+  margin: 0.5rem 1.5rem 0.5rem 0;
+  font-weight: 500;
+}
+
+@media only screen and (max-width: 480px) {
+  .card {
+    right: 0;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    max-width: 100%;
+    border-radius: 12px 12px 0 0;
+  }
+}

--- a/web/src/components/PostLoginSurvey/PostLoginSurvey.test.tsx
+++ b/web/src/components/PostLoginSurvey/PostLoginSurvey.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import PostLoginSurvey from './PostLoginSurvey';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: vi.fn(),
+}));
+
+const mockGetStatus = vi.fn();
+const mockSubmit = vi.fn();
+
+const setApi = () => {
+  vi.mocked(get2ankiApi).mockReturnValue({
+    getPostLoginSurveyStatus: mockGetStatus,
+    submitPostLoginSurvey: mockSubmit,
+  } as unknown as ReturnType<typeof get2ankiApi>);
+};
+
+const advanceToShow = async () => {
+  await act(async () => {
+    vi.advanceTimersByTime(5000);
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe('PostLoginSurvey', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    mockGetStatus.mockReset();
+    mockSubmit.mockReset();
+    mockGetStatus.mockResolvedValue({ shouldShow: true });
+    mockSubmit.mockResolvedValue(undefined);
+    setApi();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    sessionStorage.clear();
+  });
+
+  it('does not open or call the API when the session marker is absent', async () => {
+    render(<PostLoginSurvey />);
+    await advanceToShow();
+
+    expect(mockGetStatus).not.toHaveBeenCalled();
+    expect(screen.queryByText('Two quick questions')).toBeNull();
+  });
+
+  it('opens after 5 seconds when the marker is set and shouldShow is true', async () => {
+    sessionStorage.setItem('2anki_post_login', '1');
+    render(<PostLoginSurvey />);
+
+    expect(screen.queryByText('Two quick questions')).toBeNull();
+    await advanceToShow();
+
+    expect(mockGetStatus).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Two quick questions')).not.toBeNull();
+  });
+
+  it('stays hidden when shouldShow is false', async () => {
+    sessionStorage.setItem('2anki_post_login', '1');
+    mockGetStatus.mockResolvedValue({ shouldShow: false });
+    render(<PostLoginSurvey />);
+    await advanceToShow();
+
+    expect(screen.queryByText('Two quick questions')).toBeNull();
+  });
+
+  it('consumes the marker on mount so a remount cannot re-arm', () => {
+    sessionStorage.setItem('2anki_post_login', '1');
+    render(<PostLoginSurvey />);
+
+    expect(sessionStorage.getItem('2anki_post_login')).toBeNull();
+  });
+
+  it('submits answered with the improvement text and selected subject', async () => {
+    sessionStorage.setItem('2anki_post_login', '1');
+    render(<PostLoginSurvey />);
+    await advanceToShow();
+
+    fireEvent.click(screen.getByLabelText('Love it'));
+    fireEvent.change(
+      screen.getByPlaceholderText('What should we improve? (optional)'),
+      { target: { value: 'Faster conversions' } }
+    );
+    fireEvent.click(screen.getByText('Medicine'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Send'));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockSubmit).toHaveBeenCalledWith(
+      'answered',
+      'Faster conversions',
+      'Medicine'
+    );
+    expect(
+      screen.getByText('Thanks — this shapes what we build next.')
+    ).not.toBeNull();
+  });
+
+  it('records a dismissal and closes when Not now is clicked', async () => {
+    sessionStorage.setItem('2anki_post_login', '1');
+    render(<PostLoginSurvey />);
+    await advanceToShow();
+
+    fireEvent.click(screen.getByText('Not now'));
+
+    expect(mockSubmit).toHaveBeenCalledWith('dismissed');
+    expect(screen.queryByText('Two quick questions')).toBeNull();
+  });
+
+  it('records a dismissal when the close button is clicked', async () => {
+    sessionStorage.setItem('2anki_post_login', '1');
+    render(<PostLoginSurvey />);
+    await advanceToShow();
+
+    fireEvent.click(screen.getByLabelText('Close'));
+
+    expect(mockSubmit).toHaveBeenCalledWith('dismissed');
+    expect(screen.queryByText('Two quick questions')).toBeNull();
+  });
+});

--- a/web/src/components/PostLoginSurvey/PostLoginSurvey.tsx
+++ b/web/src/components/PostLoginSurvey/PostLoginSurvey.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useRef, useState } from 'react';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import styles from './PostLoginSurvey.module.css';
+
+type Stage = 'form' | 'sending' | 'sent' | 'error';
+
+const MARKER_KEY = '2anki_post_login';
+const SHOW_DELAY_MS = 5000;
+const SENT_DISMISS_MS = 2500;
+
+const RATINGS = [
+  { value: 1, emoji: '😡', label: 'Enraged' },
+  { value: 2, emoji: '🤔', label: 'Skeptical' },
+  { value: 5, emoji: '😍', label: 'Love it' },
+];
+
+const SUBJECTS = [
+  'Medicine',
+  'Languages',
+  'Law',
+  'Computer science',
+  'Science',
+  'Other',
+];
+
+function readMarker(): boolean {
+  try {
+    return globalThis.sessionStorage?.getItem(MARKER_KEY) != null;
+  } catch {
+    return false;
+  }
+}
+
+function consumeMarker(): void {
+  try {
+    globalThis.sessionStorage?.removeItem(MARKER_KEY);
+  } catch {
+    // sessionStorage may be unavailable.
+  }
+}
+
+export default function PostLoginSurvey() {
+  const [open, setOpen] = useState(false);
+  const [stage, setStage] = useState<Stage>('form');
+  const [rating, setRating] = useState<number | null>(null);
+  const [improvement, setImprovement] = useState('');
+  const [subject, setSubject] = useState<string | null>(null);
+  const [otherSubject, setOtherSubject] = useState('');
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!readMarker()) {
+      return;
+    }
+    consumeMarker();
+    let cancelled = false;
+    const showTimer = setTimeout(() => {
+      get2ankiApi()
+        .getPostLoginSurveyStatus()
+        .then((result) => {
+          if (!cancelled && result.shouldShow) {
+            setOpen(true);
+          }
+        })
+        .catch(() => {
+          // Stay hidden on failure.
+        });
+    }, SHOW_DELAY_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(showTimer);
+      if (dismissTimerRef.current != null) {
+        clearTimeout(dismissTimerRef.current);
+      }
+    };
+  }, []);
+
+  const close = () => {
+    setOpen(false);
+  };
+
+  const dismiss = () => {
+    get2ankiApi()
+      .submitPostLoginSurvey('dismissed')
+      .catch(() => {
+        // Best-effort; close regardless.
+      });
+    close();
+  };
+
+  const buildStudying = (): string | undefined => {
+    if (subject == null) {
+      return undefined;
+    }
+    if (subject === 'Other') {
+      const trimmed = otherSubject.trim();
+      return trimmed.length > 0 ? trimmed : undefined;
+    }
+    return subject;
+  };
+
+  const send = async () => {
+    setStage('sending');
+    const trimmedImprovement = improvement.trim();
+    try {
+      await get2ankiApi().submitPostLoginSurvey(
+        'answered',
+        trimmedImprovement.length > 0 ? trimmedImprovement : undefined,
+        buildStudying()
+      );
+      setStage('sent');
+      dismissTimerRef.current = setTimeout(close, SENT_DISMISS_MS);
+    } catch {
+      setStage('error');
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dismiss();
+      }
+    };
+    globalThis.addEventListener('keydown', onKeyDown);
+    return () => globalThis.removeEventListener('keydown', onKeyDown);
+  });
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <aside className={styles.card} aria-label="Quick survey">
+      <button
+        type="button"
+        className={styles.close}
+        aria-label="Close"
+        onClick={dismiss}
+      >
+        ×
+      </button>
+
+      {stage === 'sent' && (
+        <p className={styles.confirmation}>
+          Thanks — this shapes what we build next.
+        </p>
+      )}
+
+      {stage !== 'sent' && (
+        <>
+          <h2 className={styles.title}>Two quick questions</h2>
+          <p className={styles.subtitle}>
+            We&apos;re working to make 2anki better and want your read on it.
+            Skip anything you&apos;d rather not answer.
+          </p>
+
+          <div className={styles.question}>
+            <p className={styles.label}>How&apos;s 2anki working for you?</p>
+            <div className={styles.ratings}>
+              {RATINGS.map((r) => (
+                <button
+                  key={r.value}
+                  type="button"
+                  className={styles.rating}
+                  aria-label={r.label}
+                  aria-pressed={rating === r.value}
+                  onClick={() => setRating(r.value)}
+                >
+                  {r.emoji}
+                </button>
+              ))}
+            </div>
+            {rating != null && (
+              <textarea
+                className={styles.textarea}
+                placeholder="What should we improve? (optional)"
+                maxLength={2000}
+                value={improvement}
+                onChange={(e) => setImprovement(e.target.value)}
+              />
+            )}
+          </div>
+
+          <div className={styles.question}>
+            <p className={styles.label}>What are you studying?</p>
+            <div className={styles.chips}>
+              {SUBJECTS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className={styles.chip}
+                  aria-pressed={subject === s}
+                  onClick={() => setSubject(s)}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+            {subject === 'Other' && (
+              <input
+                type="text"
+                className={styles.otherInput}
+                placeholder="Tell us what"
+                maxLength={2000}
+                value={otherSubject}
+                onChange={(e) => setOtherSubject(e.target.value)}
+              />
+            )}
+          </div>
+
+          {stage === 'error' && (
+            <p className={styles.errorText}>
+              Couldn&apos;t save that. Try again.
+            </p>
+          )}
+
+          <div className={styles.actions}>
+            <button type="button" className={styles.notNow} onClick={dismiss}>
+              Not now
+            </button>
+            <button
+              type="button"
+              className={styles.send}
+              disabled={stage === 'sending'}
+              onClick={send}
+            >
+              Send
+            </button>
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -56,6 +56,11 @@ function RegisterForm({ setErrorMessage, redirect, startTrial }: Props) {
       const res = await get2ankiApi().register('', email, password, signupOrigin, startTrial);
       if (res.status === 200) {
         globalThis.sessionStorage?.setItem('email_verification_pending', 'true');
+        try {
+          globalThis.sessionStorage?.setItem('2anki_post_login', '1');
+        } catch {
+          // sessionStorage may be unavailable; the survey just won't arm.
+        }
         globalThis.location.href = redirect ? `/${redirect.replace(/^\//, '')}` : '/';
       } else {
         const body = await res.json().catch(() => null);

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -932,6 +932,22 @@ export class Backend {
     }
   }
 
+  async getPostLoginSurveyStatus(): Promise<{ shouldShow: boolean }> {
+    return get(`${this.baseURL}surveys/post-login`);
+  }
+
+  async submitPostLoginSurvey(
+    status: 'answered' | 'dismissed',
+    improvement?: string,
+    studying?: string
+  ): Promise<void> {
+    await post(`${this.baseURL}surveys/post-login`, {
+      status,
+      improvement,
+      studying,
+    });
+  }
+
   async listContactMessages(): Promise<ContactMessage[]> {
     return get(`${this.baseURL}ops/contact-messages`);
   }

--- a/web/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.ts
+++ b/web/src/pages/LoginPage/components/LoginForm/helpers/useHandleLoginSubmit.ts
@@ -49,6 +49,11 @@ export const useHandleLoginSubmit = (onError: ErrorHandlerType): LoginState => {
         setCookie('token', token);
         await migrateToServer();
         await hydrateFromServer();
+        try {
+          globalThis.sessionStorage?.setItem('2anki_post_login', '1');
+        } catch {
+          // sessionStorage may be unavailable; the survey just won't arm.
+        }
         globalThis.location.href = redirect ?? getUrlRedirect() ?? getSearchPath('anki');
       } else if (res.status === 401) {
         const data = await res.json().catch(() => ({})) as { message?: string; hint?: string };

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
@@ -48,6 +48,11 @@ function MagicLinkPage() {
 
           setCookie('token', data.token);
           setState({ status: 'success' });
+          try {
+            globalThis.sessionStorage?.setItem('2anki_post_login', '1');
+          } catch {
+            // sessionStorage may be unavailable; the survey just won't arm.
+          }
           globalThis.location.href =
             redirect ?? data.redirect ?? getSearchPath('anki');
         } else {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-tell-us-what-you-study.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-tell-us-what-you-study.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-tell-us-what-you-study",
+  "date": "2026-05-30",
+  "type": "feature",
+  "title": "A short survey lets you tell us what to improve and what you're studying"
+}


### PR DESCRIPTION
## What
A non-blocking, dismissible card shown ~5 seconds after a user lands post-login, asking two skippable questions:
1. "How's 2anki working for you?" — emoji rating that reveals an optional "What should we improve?" textarea once a rating is picked.
2. "What are you studying?" — single-select subject chips (Medicine, Languages, Law, Computer science, Science, Other); Other reveals a free-text input.

Answering or dismissing (the close button, "Not now", or Escape) records exactly one row server-side, so the survey shows once per user, ever, across devices.

## Why
We want a low-friction read on satisfaction and on which study fields our users come from, to steer the roadmap toward the 300K-user goal. Both questions are optional and the card never blocks the app.

## Trio decisions (pre-decided, implemented verbatim)
- Two questions, both skippable; partial answers allowed; Send always enabled.
- Shown ~5s after login (sessionStorage marker armed at login / magic-link / registration redirects; consumed on mount).
- Non-blocking card pinned bottom-right (full-width bottom sheet at <=480px), not a modal.
- Show-once enforced server-side: one user_surveys row per (user, survey_key), unique-constrained; both answer and dismissal write a row.
- Study field captured via single-select chips with an Other free-text fallback.

## How
- Layered backend: migration -> UserSurveyRepository (+ in-memory + generated-SQL test) -> ShouldShowSurveyUseCase / RecordSurveyResponseUseCase -> UserSurveyController -> UserSurveyRouter (both routes behind RequireAuthentication), wired in server.ts.
- Responses are trimmed and capped at 2000 chars; empty becomes null. Controller returns only typed shapes ({ shouldShow }, { message }) — never a raw row.
- Kanel type UserSurveys.ts was hand-added to match the migration (no live dev DB in this environment to run pnpm kanel). Rerun kanel on a machine with the dev DB to confirm it matches before/after merge.
- Front-end: PostLoginSurvey component + two Backend methods; marker set at all three auth redirect sites. Registration auto-logs-in (sets the token cookie and redirects into the app), so it is armed there too; the registration page does not route via /login, so /login is not double-armed.

## Measuring success
Rows land in user_surveys:
- select status, count(*) from user_surveys group by status; — answer vs dismiss split.
- select studying, count(*) from user_surveys where studying is not null group by studying order by 2 desc; — study-field distribution.
- The improvement column holds the free-text notes.

## Testing
- Server (Jest): use-case tests (status validation, trim/cap, empty->null, upsert overwrite), controller tests (401/400/201, no raw fields echoed), repository tests (in-memory behaviour + pg generated-SQL asserting insert into "user_surveys" + on conflict ("user_id", "survey_key") do update). 21/21 pass.
- Web (Vitest): PostLoginSurvey.test.tsx — does not open without the marker, opens at 5s when shouldShow, stays hidden when not, consumes the marker on mount, submits answered with textarea+chip, records dismissed on Not now and on the close button. 7/7 pass.
- /check: server tsc clean, web typecheck clean, web Biome lint clean (1068 files, no fixes).
- Note: the full server suite has pre-existing failures in DeckParser.test.ts and runParserCanary.test.ts (parser fixtures needing assets / live resolution in this offline sandbox); they are unrelated to this change.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified working by Alexander (repo owner) before merge — (5s delay, bottom-right card / mobile bottom sheet, reveal of textarea + Other input, confirmation + auto-dismiss, Escape and close button both dismiss).

## Sonar
sonar-scanner not run — SONAR_TOKEN is unset in this environment. Expect a possible Sonar pass on first CI run.

## Risks
- Kanel type is hand-written; if it drifts from generated output, regenerate with pnpm kanel against the dev DB. Low risk — the shape is simple and tsc passes.
- The marker is sessionStorage-based; if a redirect path were missed the survey simply won't arm (fail-safe — it never shows incorrectly).
- Rollback: revert the PR; the migration's down() drops the table.

## Goal alignment
Gives the trio direct signal on satisfaction and study-field mix with near-zero friction, feeding prioritization toward the 300K-user goal without touching any conversion hot path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782745355&installation_id=132681956&pr_number=2914&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2914&signature=20d8a3eb39163d21e82e1b4487144ace950a504e630ca3a69af828ba76a7acad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
