### PR TITLE
fix: auto-recover lazy-loaded chunks after a deploy

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,18 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { lazy, ReactElement, useState } from 'react';
+import { lazy, ReactElement, useEffect, useState } from 'react';
 import { CookiesProvider, useCookies } from 'react-cookie';
 import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { AppShell } from './components/AppShell/AppShell';
+import { ChunkReloadOverlay } from './components/ChunkReloadOverlay/ChunkReloadOverlay';
 import { getErrorMessage } from './components/errors/helpers/getErrorMessage';
 import { SkeletonPage } from './components/Skeleton/Skeleton';
 import PostLoginSurvey from './components/PostLoginSurvey/PostLoginSurvey';
+import {
+  clearReloadingFlag,
+  isReloadingForFreshChunks,
+  lazyWithRetry,
+} from './lib/chunkReload';
 import { useUserLocals } from './lib/hooks/useUserLocals';
 import isOfflineMode from './lib/isOfflineMode';
 import { reportClientError } from './lib/reportClientError';
@@ -19,106 +25,222 @@ import HomePage from './pages/HomePage';
 import NotFoundPage from './pages/NotFoundPage';
 import UploadPage from './pages/UploadPage';
 
-const RegisterPage = lazy(() => import('./pages/RegisterPage'));
-const SearchPage = lazy(() => import('./pages/SearchPage'));
-const LoginPage = lazy(() => import('./pages/LoginPage'));
-const NewPasswordPage = lazy(() => import('./pages/NewPasswordPage'));
-const DownloadsPage = lazy(() => import('./pages/DownloadsPage'));
-const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
-const PricingPage = lazy(() => import('./pages/PricingPage'));
-const AccountPage = lazy(() => import('./pages/AccountPage/AccountPage'));
-const AccountClaimPage = lazy(() => import('./pages/AccountClaimPage/AccountClaimPage'));
+const RegisterPage = lazyWithRetry(() => import('./pages/RegisterPage'), './pages/RegisterPage');
+const SearchPage = lazyWithRetry(() => import('./pages/SearchPage'), './pages/SearchPage');
+const LoginPage = lazyWithRetry(() => import('./pages/LoginPage'), './pages/LoginPage');
+const NewPasswordPage = lazyWithRetry(
+  () => import('./pages/NewPasswordPage'),
+  './pages/NewPasswordPage'
+);
+const DownloadsPage = lazyWithRetry(
+  () => import('./pages/DownloadsPage'),
+  './pages/DownloadsPage'
+);
+const ForgotPasswordPage = lazyWithRetry(
+  () => import('./pages/ForgotPasswordPage'),
+  './pages/ForgotPasswordPage'
+);
+const PricingPage = lazyWithRetry(() => import('./pages/PricingPage'), './pages/PricingPage');
+const AccountPage = lazyWithRetry(
+  () => import('./pages/AccountPage/AccountPage'),
+  './pages/AccountPage/AccountPage'
+);
+const AccountClaimPage = lazyWithRetry(
+  () => import('./pages/AccountClaimPage/AccountClaimPage'),
+  './pages/AccountClaimPage/AccountClaimPage'
+);
 const AccountPreviewPage = import.meta.env.DEV
   ? lazy(() => import('./pages/AccountPreviewPage/AccountPreviewPage'))
   : null;
 const NotionPreviewPage = import.meta.env.DEV
   ? lazy(() => import('./pages/NotionPreviewPage/NotionPreviewPage'))
   : null;
-const SuccessfulCheckoutPage = lazy(
-  () => import('./pages/SuccessfulCheckout/SuccessfulCheckout')
+const SuccessfulCheckoutPage = lazyWithRetry(
+  () => import('./pages/SuccessfulCheckout/SuccessfulCheckout'),
+  './pages/SuccessfulCheckout/SuccessfulCheckout'
 );
-const DocsPage = lazy(() => import('./pages/DocsPage/DocsPage'));
-const CardOptionsPage = lazy(() => import('./pages/CardOptionsPage'));
-const TemplatesPage = lazy(() => import('./pages/TemplatesPage'));
-const TemplatesEditorPage = lazy(
-  () => import('./pages/TemplatesPage/EditorPage')
+const DocsPage = lazyWithRetry(() => import('./pages/DocsPage/DocsPage'), './pages/DocsPage/DocsPage');
+const CardOptionsPage = lazyWithRetry(
+  () => import('./pages/CardOptionsPage'),
+  './pages/CardOptionsPage'
 );
-const RulesPage = lazy(() => import('./pages/RulesPage'));
-const PreviewPage = lazy(() => import('./pages/PreviewPage'));
-const DatabasePreviewPage = lazy(() => import('./pages/DatabasePreviewPage'));
-const PreviewApkgPage = lazy(() => import('./pages/PreviewApkgPage'));
-const AnkifyPage = lazy(() => import('./pages/AnkifyPage'));
-const AnkifySetupPage = lazy(
-  () => import('./pages/AnkifyPage/AnkifySetupPage')
+const TemplatesPage = lazyWithRetry(
+  () => import('./pages/TemplatesPage'),
+  './pages/TemplatesPage'
 );
-const AnkifyHistoryPage = lazy(
-  () => import('./pages/AnkifyPage/AnkifyHistoryPage')
+const TemplatesEditorPage = lazyWithRetry(
+  () => import('./pages/TemplatesPage/EditorPage'),
+  './pages/TemplatesPage/EditorPage'
 );
-const OpsLayout = lazy(() => import('./pages/OpsPage/OpsLayout'));
-const EngineeringTab = lazy(() => import('./pages/OpsPage/EngineeringTab'));
-const ErrorsTab = lazy(() => import('./pages/OpsPage/ErrorsTab'));
-const PerformanceTab = lazy(() => import('./pages/OpsPage/PerformanceTab'));
-const ConversionsTab = lazy(() => import('./pages/OpsPage/ConversionsTab'));
-const BusinessTab = lazy(() => import('./pages/OpsPage/BusinessTab'));
-const ShowcaseTab = lazy(() => import('./pages/OpsPage/ShowcaseTab'));
-const InterviewsTab = lazy(() => import('./pages/OpsPage/InterviewsTab'));
-const ContactMessagesTab = lazy(
-  () => import('./pages/OpsPage/ContactMessagesTab')
+const RulesPage = lazyWithRetry(() => import('./pages/RulesPage'), './pages/RulesPage');
+const PreviewPage = lazyWithRetry(() => import('./pages/PreviewPage'), './pages/PreviewPage');
+const DatabasePreviewPage = lazyWithRetry(
+  () => import('./pages/DatabasePreviewPage'),
+  './pages/DatabasePreviewPage'
 );
-const CommandsTab = lazy(() => import('./pages/OpsPage/CommandsTab'));
-const PricingAbFunnelTab = lazy(
-  () => import('./pages/OpsPage/PricingAbFunnelTab')
+const PreviewApkgPage = lazyWithRetry(
+  () => import('./pages/PreviewApkgPage'),
+  './pages/PreviewApkgPage'
 );
-const FeedbackPage = lazy(() => import('./pages/FeedbackPage/FeedbackPage'));
-const NotionToAnki = lazy(() => import('./pages/LandingPage/NotionToAnki'));
-const AnkiToNotion = lazy(() => import('./pages/LandingPage/AnkiToNotion'));
-const QuizletToAnki = lazy(() => import('./pages/LandingPage/QuizletToAnki'));
-const MarkdownToAnki = lazy(() => import('./pages/LandingPage/MarkdownToAnki'));
-const PdfToAnki = lazy(() => import('./pages/LandingPage/PdfToAnki'));
-const UsmleAnki = lazy(() => import('./pages/LandingPage/UsmleAnki'));
-const NursingFlashcards = lazy(
-  () => import('./pages/LandingPage/NursingFlashcards')
+const AnkifyPage = lazyWithRetry(() => import('./pages/AnkifyPage'), './pages/AnkifyPage');
+const AnkifySetupPage = lazyWithRetry(
+  () => import('./pages/AnkifyPage/AnkifySetupPage'),
+  './pages/AnkifyPage/AnkifySetupPage'
 );
-const AnkiFromMedicalLectureSlides = lazy(
-  () => import('./pages/LandingPage/AnkiFromMedicalLectureSlides')
+const AnkifyHistoryPage = lazyWithRetry(
+  () => import('./pages/AnkifyPage/AnkifyHistoryPage'),
+  './pages/AnkifyPage/AnkifyHistoryPage'
 );
-const PowerpointToAnki = lazy(
-  () => import('./pages/LandingPage/PowerpointToAnki')
+const OpsLayout = lazyWithRetry(
+  () => import('./pages/OpsPage/OpsLayout'),
+  './pages/OpsPage/OpsLayout'
 );
-const GoodnotesToAnki = lazy(
-  () => import('./pages/LandingPage/GoodnotesToAnki')
+const EngineeringTab = lazyWithRetry(
+  () => import('./pages/OpsPage/EngineeringTab'),
+  './pages/OpsPage/EngineeringTab'
 );
-const AiFlashcardGenerator = lazy(
-  () => import('./pages/LandingPage/AiFlashcardGenerator')
+const ErrorsTab = lazyWithRetry(
+  () => import('./pages/OpsPage/ErrorsTab'),
+  './pages/OpsPage/ErrorsTab'
 );
-const ConvertLandingPage = lazy(
-  () => import('./pages/ConvertLandingPage/ConvertLandingPage')
+const PerformanceTab = lazyWithRetry(
+  () => import('./pages/OpsPage/PerformanceTab'),
+  './pages/OpsPage/PerformanceTab'
 );
-const MagicLinkPage = lazy(() => import('./pages/MagicLinkPage'));
-const PrintPage = lazy(() => import('./pages/PrintPage'));
-const WhatsNewPage = lazy(() => import('./pages/WhatsNewPage/WhatsNewPage'));
-const ImportPage = lazy(() => import('./pages/ImportPage'));
-const ImageOcclusionPage = lazy(() =>
-  import('./pages/ImageOcclusionPage').then((m) => ({
-    default: m.ImageOcclusionPage,
-  }))
+const ConversionsTab = lazyWithRetry(
+  () => import('./pages/OpsPage/ConversionsTab'),
+  './pages/OpsPage/ConversionsTab'
 );
-const PhotoToFlashcardsPage = lazy(() =>
-  import('./pages/PhotoToFlashcardsPage').then((m) => ({
-    default: m.PhotoToFlashcardsPage,
-  }))
+const BusinessTab = lazyWithRetry(
+  () => import('./pages/OpsPage/BusinessTab'),
+  './pages/OpsPage/BusinessTab'
 );
-const ChatPage = lazy(() => import('./pages/Chat/ChatPage'));
-const NotionLandingPage = lazy(
-  () => import('./pages/NotionLandingPage/NotionLandingPage')
+const ShowcaseTab = lazyWithRetry(
+  () => import('./pages/OpsPage/ShowcaseTab'),
+  './pages/OpsPage/ShowcaseTab'
 );
-const AnswersPage = lazy(() => import('./pages/AnswersPage/AnswersPage'));
-const LimitPage = lazy(() => import('./pages/LimitPage/LimitPage'));
-const SharedDeckPage = lazy(() => import('./pages/SharedDeckPage'));
-const MindmapsPage = lazy(() => import('./pages/MindmapsPage'));
-const SecurityPage = lazy(() => import('./pages/SecurityPage/SecurityPage'));
-const StatusPage = lazy(() => import('./pages/StatusPage/StatusPage'));
-const TransformPage = lazy(() => import('./pages/TransformPage'));
+const InterviewsTab = lazyWithRetry(
+  () => import('./pages/OpsPage/InterviewsTab'),
+  './pages/OpsPage/InterviewsTab'
+);
+const ContactMessagesTab = lazyWithRetry(
+  () => import('./pages/OpsPage/ContactMessagesTab'),
+  './pages/OpsPage/ContactMessagesTab'
+);
+const CommandsTab = lazyWithRetry(
+  () => import('./pages/OpsPage/CommandsTab'),
+  './pages/OpsPage/CommandsTab'
+);
+const PricingAbFunnelTab = lazyWithRetry(
+  () => import('./pages/OpsPage/PricingAbFunnelTab'),
+  './pages/OpsPage/PricingAbFunnelTab'
+);
+const FeedbackPage = lazyWithRetry(
+  () => import('./pages/FeedbackPage/FeedbackPage'),
+  './pages/FeedbackPage/FeedbackPage'
+);
+const NotionToAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/NotionToAnki'),
+  './pages/LandingPage/NotionToAnki'
+);
+const AnkiToNotion = lazyWithRetry(
+  () => import('./pages/LandingPage/AnkiToNotion'),
+  './pages/LandingPage/AnkiToNotion'
+);
+const QuizletToAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/QuizletToAnki'),
+  './pages/LandingPage/QuizletToAnki'
+);
+const MarkdownToAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/MarkdownToAnki'),
+  './pages/LandingPage/MarkdownToAnki'
+);
+const PdfToAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/PdfToAnki'),
+  './pages/LandingPage/PdfToAnki'
+);
+const UsmleAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/UsmleAnki'),
+  './pages/LandingPage/UsmleAnki'
+);
+const NursingFlashcards = lazyWithRetry(
+  () => import('./pages/LandingPage/NursingFlashcards'),
+  './pages/LandingPage/NursingFlashcards'
+);
+const AnkiFromMedicalLectureSlides = lazyWithRetry(
+  () => import('./pages/LandingPage/AnkiFromMedicalLectureSlides'),
+  './pages/LandingPage/AnkiFromMedicalLectureSlides'
+);
+const PowerpointToAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/PowerpointToAnki'),
+  './pages/LandingPage/PowerpointToAnki'
+);
+const GoodnotesToAnki = lazyWithRetry(
+  () => import('./pages/LandingPage/GoodnotesToAnki'),
+  './pages/LandingPage/GoodnotesToAnki'
+);
+const AiFlashcardGenerator = lazyWithRetry(
+  () => import('./pages/LandingPage/AiFlashcardGenerator'),
+  './pages/LandingPage/AiFlashcardGenerator'
+);
+const ConvertLandingPage = lazyWithRetry(
+  () => import('./pages/ConvertLandingPage/ConvertLandingPage'),
+  './pages/ConvertLandingPage/ConvertLandingPage'
+);
+const MagicLinkPage = lazyWithRetry(
+  () => import('./pages/MagicLinkPage'),
+  './pages/MagicLinkPage'
+);
+const PrintPage = lazyWithRetry(() => import('./pages/PrintPage'), './pages/PrintPage');
+const WhatsNewPage = lazyWithRetry(
+  () => import('./pages/WhatsNewPage/WhatsNewPage'),
+  './pages/WhatsNewPage/WhatsNewPage'
+);
+const ImportPage = lazyWithRetry(() => import('./pages/ImportPage'), './pages/ImportPage');
+const ImageOcclusionPage = lazyWithRetry(
+  () =>
+    import('./pages/ImageOcclusionPage').then((m) => ({
+      default: m.ImageOcclusionPage,
+    })),
+  './pages/ImageOcclusionPage'
+);
+const PhotoToFlashcardsPage = lazyWithRetry(
+  () =>
+    import('./pages/PhotoToFlashcardsPage').then((m) => ({
+      default: m.PhotoToFlashcardsPage,
+    })),
+  './pages/PhotoToFlashcardsPage'
+);
+const ChatPage = lazyWithRetry(() => import('./pages/Chat/ChatPage'), './pages/Chat/ChatPage');
+const NotionLandingPage = lazyWithRetry(
+  () => import('./pages/NotionLandingPage/NotionLandingPage'),
+  './pages/NotionLandingPage/NotionLandingPage'
+);
+const AnswersPage = lazyWithRetry(
+  () => import('./pages/AnswersPage/AnswersPage'),
+  './pages/AnswersPage/AnswersPage'
+);
+const LimitPage = lazyWithRetry(
+  () => import('./pages/LimitPage/LimitPage'),
+  './pages/LimitPage/LimitPage'
+);
+const SharedDeckPage = lazyWithRetry(
+  () => import('./pages/SharedDeckPage'),
+  './pages/SharedDeckPage'
+);
+const MindmapsPage = lazyWithRetry(() => import('./pages/MindmapsPage'), './pages/MindmapsPage');
+const SecurityPage = lazyWithRetry(
+  () => import('./pages/SecurityPage/SecurityPage'),
+  './pages/SecurityPage/SecurityPage'
+);
+const StatusPage = lazyWithRetry(
+  () => import('./pages/StatusPage/StatusPage'),
+  './pages/StatusPage/StatusPage'
+);
+const TransformPage = lazyWithRetry(
+  () => import('./pages/TransformPage'),
+  './pages/TransformPage'
+);
 
 const queryClient = new QueryClient();
 
@@ -410,6 +532,18 @@ function AppContent({
 
 function AppWithCookies() {
   const [cookies, setCookie] = useCookies(['token']);
+  const [showReloadOverlay, setShowReloadOverlay] = useState<boolean>(() =>
+    isReloadingForFreshChunks()
+  );
+
+  useEffect(() => {
+    if (!showReloadOverlay) {
+      return;
+    }
+    clearReloadingFlag();
+    const id = window.setTimeout(() => setShowReloadOverlay(false), 600);
+    return () => window.clearTimeout(id);
+  }, [showReloadOverlay]);
 
   if (isOfflineMode() && !cookies.token) {
     setCookie('token', '?');
@@ -428,6 +562,7 @@ function AppWithCookies() {
 
   return (
     <QueryClientProvider client={queryClient}>
+      {showReloadOverlay && <ChunkReloadOverlay />}
       <AppContent
         error={apiError as Error | null}
         setErrorMessage={handledError}

--- a/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.module.css
+++ b/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.module.css
@@ -1,0 +1,23 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+}
+
+.logo {
+  width: 96px;
+  height: auto;
+  opacity: 0.85;
+}
+
+.message {
+  margin: 0;
+}

--- a/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.test.tsx
+++ b/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ChunkReloadOverlay } from './ChunkReloadOverlay';
+
+describe('ChunkReloadOverlay', () => {
+  it('renders the live region with the update message', () => {
+    render(<ChunkReloadOverlay />);
+    const overlay = screen.getByTestId('chunk-reload-overlay');
+    expect(overlay).toBeInTheDocument();
+    expect(overlay.getAttribute('role')).toBe('status');
+    expect(overlay.getAttribute('aria-live')).toBe('polite');
+    expect(screen.getByText('Updating to the latest version.')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.tsx
+++ b/web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.tsx
@@ -1,0 +1,19 @@
+import styles from './ChunkReloadOverlay.module.css';
+
+export function ChunkReloadOverlay() {
+  return (
+    <div
+      className={styles.overlay}
+      role="status"
+      aria-live="polite"
+      data-testid="chunk-reload-overlay"
+    >
+      <img
+        className={styles.logo}
+        src="https://2anki.net/mascot/navbar-logo.png"
+        alt=""
+      />
+      <p className={styles.message}>Updating to the latest version.</p>
+    </div>
+  );
+}

--- a/web/src/lib/chunkReload.test.ts
+++ b/web/src/lib/chunkReload.test.ts
@@ -1,8 +1,66 @@
+import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isChunkLoadError, recoverFromChunkError, withinChunkReloadCooldown } from './chunkReload';
+import {
+  clearReloadingFlag,
+  isChunkLoadError,
+  isReloadingForFreshChunks,
+  lazyWithRetry,
+  recoverFromChunkError,
+  withinChunkReloadCooldown,
+} from './chunkReload';
 
 const STORAGE_KEY = '2anki:chunkReload:lastAt';
+const RELOADING_FLAG_KEY = '2anki:chunkReload:reloading';
+const PER_CHUNK_KEY_PREFIX = '2anki:chunkReload:chunk:';
+
+function makeChunkError(): Error {
+  return new TypeError(
+    'Failed to fetch dynamically imported module: https://2anki.net/assets/A.js'
+  );
+}
+
+function makeCssPreloadError(): Error {
+  return new Error(
+    'Unable to preload CSS for https://2anki.net/assets/A-XYZ.css'
+  );
+}
+
+function makeModuleScriptError(): Error {
+  return new TypeError('Importing a module script failed.');
+}
+
+function setVisibility(state: 'visible' | 'hidden'): void {
+  Object.defineProperty(document, 'visibilityState', {
+    value: state,
+    configurable: true,
+  });
+}
+
+async function readLazyFactory<T>(
+  Component: React.LazyExoticComponent<React.ComponentType<T>>
+): Promise<unknown> {
+  type LazyInternal = { _init: (payload: unknown) => unknown; _payload: unknown };
+  const internal = Component as unknown as LazyInternal;
+  try {
+    const result = internal._init(internal._payload);
+    if (
+      result != null &&
+      typeof (result as { then?: unknown }).then === 'function'
+    ) {
+      return await (result as Promise<unknown>);
+    }
+    return result;
+  } catch (e) {
+    if (
+      e != null &&
+      typeof (e as { then?: unknown }).then === 'function'
+    ) {
+      return await (e as Promise<unknown>);
+    }
+    throw e;
+  }
+}
 
 describe('isChunkLoadError', () => {
   it('returns true for a ChunkLoadError by name', () => {
@@ -113,6 +171,131 @@ describe('recoverFromChunkError', () => {
 
     expect(result).toBe(true);
     expect(reloadMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('isChunkLoadError — new patterns', () => {
+  it('returns true for "Unable to preload CSS" Error', () => {
+    expect(isChunkLoadError(makeCssPreloadError())).toBe(true);
+  });
+
+  it('returns true for "Importing a module script failed" TypeError', () => {
+    expect(isChunkLoadError(makeModuleScriptError())).toBe(true);
+  });
+});
+
+describe('lazyWithRetry', () => {
+  let reloadMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    reloadMock = vi.fn();
+    vi.stubGlobal('location', { reload: reloadMock });
+    setVisibility('visible');
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the imported module when the factory succeeds', async () => {
+    const factory = vi.fn(async () => ({
+      default: (() => null) as unknown as React.ComponentType<unknown>,
+    }));
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    const result = (await readLazyFactory(Component)) as { default: unknown };
+
+    expect(factory).toHaveBeenCalledOnce();
+    expect(typeof result.default).toBe('function');
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects once → reloads the page', async () => {
+    const factory = vi.fn(() => Promise.reject(makeChunkError()));
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    void readLazyFactory(Component);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(reloadMock).toHaveBeenCalledOnce();
+    expect(sessionStorage.getItem(`${PER_CHUNK_KEY_PREFIX}./pages/Foo`)).not.toBeNull();
+    expect(sessionStorage.getItem(RELOADING_FLAG_KEY)).toBe('1');
+  });
+
+  it('rejects twice on the same key in the same session → throws without reloading', async () => {
+    sessionStorage.setItem(`${PER_CHUNK_KEY_PREFIX}./pages/Foo`, String(Date.now()));
+
+    const error = makeChunkError();
+    const factory = vi.fn(() => Promise.reject(error));
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    await expect(readLazyFactory(Component)).rejects.toBe(error);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('does not reload when document is hidden', async () => {
+    setVisibility('hidden');
+
+    const error = makeChunkError();
+    const factory = vi.fn(() => Promise.reject(error));
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    await expect(readLazyFactory(Component)).rejects.toBe(error);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('rethrows non-chunk errors without reloading', async () => {
+    const error = new Error('boom');
+    const factory = vi.fn(() => Promise.reject(error));
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    await expect(readLazyFactory(Component)).rejects.toBe(error);
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(`${PER_CHUNK_KEY_PREFIX}./pages/Foo`)).toBeNull();
+  });
+
+  it('reloads independently for a different chunk key on the same session', async () => {
+    sessionStorage.setItem(`${PER_CHUNK_KEY_PREFIX}./pages/Foo`, String(Date.now()));
+
+    const factory = vi.fn(() => Promise.reject(makeChunkError()));
+    const Component = lazyWithRetry(factory, './pages/Bar');
+
+    void readLazyFactory(Component);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(reloadMock).toHaveBeenCalledOnce();
+    expect(sessionStorage.getItem(`${PER_CHUNK_KEY_PREFIX}./pages/Bar`)).not.toBeNull();
+  });
+});
+
+describe('reloading flag', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('isReloadingForFreshChunks returns false by default', () => {
+    expect(isReloadingForFreshChunks()).toBe(false);
+  });
+
+  it('isReloadingForFreshChunks returns true after recoverFromChunkError fires', () => {
+    vi.stubGlobal('location', { reload: vi.fn() });
+    recoverFromChunkError(makeChunkError());
+    expect(isReloadingForFreshChunks()).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('clearReloadingFlag removes the flag', () => {
+    sessionStorage.setItem(RELOADING_FLAG_KEY, '1');
+    clearReloadingFlag();
+    expect(isReloadingForFreshChunks()).toBe(false);
   });
 });
 

--- a/web/src/lib/chunkReload.ts
+++ b/web/src/lib/chunkReload.ts
@@ -1,9 +1,15 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+
 const STORAGE_KEY = '2anki:chunkReload:lastAt';
+const PER_CHUNK_KEY_PREFIX = '2anki:chunkReload:chunk:';
 const COOLDOWN_MS = 30_000;
+const RELOADING_FLAG_KEY = '2anki:chunkReload:reloading';
 
 const CHUNK_ERROR_MESSAGES = [
   'Failed to fetch dynamically imported module',
   'error loading dynamically imported module',
+  'Unable to preload CSS',
+  'Importing a module script failed',
 ];
 
 export function isChunkLoadError(error: unknown): boolean {
@@ -35,7 +41,62 @@ export function recoverFromChunkError(error: unknown): boolean {
     return false;
   }
 
+  markReloading();
   sessionStorage.setItem(STORAGE_KEY, String(Date.now()));
   location.reload();
   return true;
+}
+
+function markReloading(): void {
+  try {
+    sessionStorage.setItem(RELOADING_FLAG_KEY, '1');
+  } catch {
+    // sessionStorage may be disabled; overlay simply won't render.
+  }
+}
+
+export function clearReloadingFlag(): void {
+  try {
+    sessionStorage.removeItem(RELOADING_FLAG_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function isReloadingForFreshChunks(): boolean {
+  try {
+    return sessionStorage.getItem(RELOADING_FLAG_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- React.lazy's generic requires ComponentType<any> to preserve route component prop shapes.
+export function lazyWithRetry<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+  chunkKey: string
+): LazyExoticComponent<T> {
+  return lazy<T>(async () => {
+    try {
+      return await factory();
+    } catch (error) {
+      if (!isChunkLoadError(error)) {
+        throw error;
+      }
+      const perChunkKey = `${PER_CHUNK_KEY_PREFIX}${chunkKey}`;
+      if (sessionStorage.getItem(perChunkKey) != null) {
+        throw error;
+      }
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState !== 'visible'
+      ) {
+        throw error;
+      }
+      sessionStorage.setItem(perChunkKey, String(Date.now()));
+      markReloading();
+      location.reload();
+      return new Promise<{ default: T }>(() => {});
+    }
+  });
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-stale-chunk-reload.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-stale-chunk-reload.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-stale-chunk-reload",
+  "date": "2026-05-30",
+  "type": "fix",
+  "title": "Open tabs left over from before a deploy reload themselves instead of going blank"
+}


### PR DESCRIPTION
## What
Wraps every `lazy()` route in `web/src/App.tsx` with a new `lazyWithRetry` helper. When a hashed chunk URL stops resolving — typically because the user's cached `index.html` survived a deploy and points at chunks that no longer live on the CDN — the wrapper triggers `location.reload()` once per chunk and shows a quiet full-page overlay while the fresh boot loads. A second failure on the same chunk re-throws so the existing `RootErrorBoundary` catches it instead of looping.

## Why
Production users are hitting `Error: Unable to preload CSS for ...` and `Importing a module script failed.` whenever they have a tab open across a deploy. The `lazy()` factory rejects, no boundary catches it inside `<Suspense>`, and the page goes blank. The pre-existing `recoverFromChunkError` listener and `RootErrorBoundary` are a backstop but they fire late and show a "this page was updated" card the user has to click through. Catching at the wrapper recovers automatically.

## How
- `web/src/lib/chunkReload.ts`: adds `lazyWithRetry(factory, chunkKey)`. Per-chunk session key, so a *later* deploy that breaks a *different* chunk still gets one reload. Also adds two CDN error patterns (`Unable to preload CSS`, `Importing a module script failed`) to `isChunkLoadError` and a `reloading` flag the App reads on the post-reload boot.
- `web/src/components/ChunkReloadOverlay/`: full-viewport overlay with the mascot and "Updating to the latest version." Uses existing color tokens; no new design surface. Renders for ~600 ms after the reload boot then hides.
- `web/src/App.tsx`: every production-routed `lazy(() => import('./pages/X'))` is now `lazyWithRetry(..., './pages/X')`. The two dev-only `/dev/*` preview pages stay on bare `lazy` since they're never deployed.
- Existing `index.tsx` `window.addEventListener('error' | 'unhandledrejection')` listeners and `RootErrorBoundary` stay in place as a backstop for chunks that miss the wrapper.

## Measuring success
Two leading indicators in Sentry:
1. Drop in `Unable to preload CSS for ...` and `Importing a module script failed.` events from logged-in sessions after a deploy.
2. Rise in `recoverFromChunkError` invocations vs. baseline — the wrapper writes the reloading flag and reloads, so the post-boot path is observable via the new `2anki:chunkReload:chunk:*` sessionStorage keys if we ever want to instrument client-side.

## Testing
- `web/src/lib/chunkReload.test.ts`: 26 cases. New ones cover `lazyWithRetry` (success path, reject-once-then-reload, reject-twice-no-reload-on-same-key, hidden-tab-no-reload, non-chunk-error rethrow, distinct chunk keys reload independently), and the reload flag round-trip. Two new CDN error patterns covered.
- `web/src/components/ChunkReloadOverlay/ChunkReloadOverlay.test.tsx`: renders the live region with the message.
- Full web vitest suite: 1397 passed.
- `pnpm typecheck`, `pnpm lint`, server `tsc` all clean.
- Sonar locally: scanner is installed but `SONAR_TOKEN` is unset in this env — expect Sonar to post results on CI. The new code is a single helper with one branch, an overlay component, and a wide mechanical wrap of `lazy(() => import(...))` — low complexity, no taint surface.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Smoke-tested the App boot path locally. Forcing a chunk-load reject path through DevTools (block `*.js` on a route navigation) reloads the page once and shows the overlay briefly during the post-reload boot. Hidden-tab path verified via the unit test.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-30-stale-chunk-reload.json` — "Open tabs left over from before a deploy reload themselves instead of going blank"

## Risks
- The overlay flashes on the post-reload boot for ~600 ms. If `App` is slow to render initially (cold CDN cache for the new chunks), the user sees the overlay for slightly longer. Worst case: same as today's blank page, except with mascot.
- A reload loop is bounded by per-chunk sessionStorage keys and the existing 30s global cooldown. If both somehow fail, `RootErrorBoundary` catches the throw and renders the "this page was updated" card. No infinite loops.
- Rollback: revert this commit; the pre-existing global listeners and error boundary continue to handle stale chunks the way they do today.

## Goal alignment
Conversion path. A user who lands on a blank page after a deploy isn't downloading a deck. Quietly self-healing across deploys protects every funnel step from upload through download, which is where the 300K-user story lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782761740&installation_id=132681956&pr_number=2917&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2917&signature=4d63d521f127e3bbb0a4a469eb11d3296a2d5fc37b0aec45914657e840ca3b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->