### PR TITLE
fix: paginate embedded Notion databases past 200 rows

### DIFF
--- a/src/services/NotionService/BlockHandler/BlockHandler.handleChildDatabase.test.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.handleChildDatabase.test.ts
@@ -1,0 +1,79 @@
+import BlockHandler from './BlockHandler';
+import CardOption from '../../../lib/parser/Settings/CardOption';
+import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
+import ParserRules from '../../../lib/parser/ParserRules';
+import Workspace from '../../../lib/parser/WorkSpace';
+import Deck from '../../../lib/parser/Deck';
+import NotionAPIWrapper from '../NotionAPIWrapper';
+import { setupTests } from '../../../test/configure-jest';
+
+beforeEach(() => setupTests());
+
+interface FakeApiOpts {
+  rowCount: number;
+}
+
+function makeApi(opts: FakeApiOpts): NotionAPIWrapper {
+  const results = Array.from({ length: opts.rowCount }, (_, i) => ({
+    id: `row-${i}`,
+    object: 'page',
+    created_time: '2024-01-01T00:00:00.000Z',
+    last_edited_time: '2024-01-01T00:00:00.000Z',
+    properties: {},
+  }));
+
+  return {
+    queryDatabase: jest.fn().mockResolvedValue({ results }),
+    getDatabase: jest.fn().mockResolvedValue({ id: 'embedded-db' }),
+    getDatabaseTitle: jest.fn().mockResolvedValue('Embedded DB'),
+    getPage: jest.fn().mockResolvedValue({
+      id: 'page',
+      object: 'page',
+      created_time: '2024-01-01T00:00:00.000Z',
+      last_edited_time: '2024-01-01T00:00:00.000Z',
+      properties: {},
+    }),
+    getPageTitle: jest.fn().mockResolvedValue('Row'),
+    getTopLevelTags: jest.fn().mockResolvedValue([]),
+    getBlocks: jest.fn().mockResolvedValue({ results: [] }),
+  } as unknown as NotionAPIWrapper;
+}
+
+function makeHandler(api: NotionAPIWrapper): BlockHandler {
+  const settings = new CardOption({});
+  const exporter = new CustomExporter('', new Workspace(true, 'fs').location);
+  return new BlockHandler(exporter, api, settings);
+}
+
+type WithPrivateHandleChildDatabase = {
+  handleChildDatabase: (
+    sd: { id: string },
+    rules: ParserRules
+  ) => Promise<Deck[]>;
+};
+
+describe('BlockHandler.handleChildDatabase', () => {
+  it('passes all=true to queryDatabase so embedded databases paginate fully', async () => {
+    const api = makeApi({ rowCount: 1 });
+    const handler = makeHandler(api);
+
+    await (handler as unknown as WithPrivateHandleChildDatabase).handleChildDatabase(
+      { id: 'embedded-db' },
+      new ParserRules()
+    );
+
+    expect(api.queryDatabase).toHaveBeenCalledWith('embedded-db', true);
+  });
+
+  it('processes every row returned, not just the first page', async () => {
+    const api = makeApi({ rowCount: 250 });
+    const handler = makeHandler(api);
+
+    const decks = await (
+      handler as unknown as WithPrivateHandleChildDatabase
+    ).handleChildDatabase({ id: 'embedded-db' }, new ParserRules());
+
+    expect(api.getPage).toHaveBeenCalledTimes(250);
+    expect(decks.length).toBeGreaterThanOrEqual(250);
+  });
+});

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -613,7 +613,7 @@ class BlockHandler {
     sd: BlockObjectResponse,
     rules: ParserRules
   ): Promise<Deck[]> {
-    const dbResult = await this.api.queryDatabase(sd.id);
+    const dbResult = await this.api.queryDatabase(sd.id, true);
     const database = await this.api.getDatabase(sd.id);
     const dbName = await this.api.getDatabaseTitle(database, this.settings);
     let dbDecks: Deck[] = [];

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-child-database-rows.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-child-database-rows.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-child-database-rows",
+  "date": "2026-05-30",
+  "type": "fix",
+  "title": "Notion pages with embedded databases convert every row, not just the first 200"
+}


### PR DESCRIPTION
## What
`BlockHandler.handleChildDatabase` called `this.api.queryDatabase(sd.id)` without `all: true`, so any Notion page containing an embedded database silently dropped rows past the first `DEFAULT_PAGE_SIZE_LIMIT` (200). Top-level database conversion (`findFlashcardsFromDatabaseRows`) already passes `all: true` and was unaffected.

## Why
A user converting a Notion page that contains an embedded database with more than 200 rows would get a partial deck with no warning. The fix aligns the embedded path with the working top-level path.

## How
One-line fix in `handleChildDatabase`: pass `true` as the second argument to `queryDatabase`. `NotionAPIWrapper.queryDatabase` already handles cursor-based pagination internally when `all=true`.

## Measuring success
Conversions of pages with embedded databases over 200 rows return decks whose card count matches the database row count. Spot-check via `pm2 logs` for `queryDatabase:<id>true` timer labels following a child-database conversion (the timer label encodes the `all` flag).

## Testing
- Unit tests added: `BlockHandler.handleChildDatabase.test.ts` — asserts `queryDatabase` is called with `(id, true)` and that 250 returned rows produce 250 traversed pages. Verified the test fails for the right reason without the fix.
- All 8 existing `BlockHandler/` test suites still pass.

## Browser check
Browser check: not applicable — server-only conversion logic, no rendered output. Changelog JSON is the only `web/src/` change.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-30-child-database-rows.json` — "Notion pages with embedded databases convert every row, not just the first 200"

## Risks
Low. The change matches the behavior of the top-level database path, which has been paginating with `all: true` in production. Embedded databases over 200 rows now cost more Notion API calls (additional paginated requests), but the conversion already paginates page blocks the same way; the rate-limit shape doesn't change. Rollback: revert this one-line change.

## Goal alignment
Removes a silent correctness failure on a hot-path conversion. Trust in correct conversions is foundational for the 300K-user goal — a user who hits "convert" and gets 200 of 600 expected cards back doesn't return.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782762221&installation_id=132681956&pr_number=2919&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2919&signature=6f17f515d99772462e0a5bf657bf32a3534716d84ac4d9bd3b7f7b4ace9a341f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->