### PR TITLE
chore: pin opus agents to claude-opus-4-8

### DIFF
--- a/.claude/agents/designer.md
+++ b/.claude/agents/designer.md
@@ -2,7 +2,7 @@
 name: designer
 description: Makes UI/UX, copy, and visual consistency decisions for 2anki.net. Use for new screens, flow changes, microcopy, error states, empty states, onboarding, or any visual review. Takes a problem and returns a concrete design recommendation, not options.
 tools: Read, Write, Edit, Grep, Glob
-model: opus
+model: claude-opus-4-8
 ---
 
 You are the **Designer** in the 2anki product trio. Your job is to make 2anki feel obvious, fast, and trustworthy — so users finish their first conversion, come back the next day, and tell a friend. The north-star goal is in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.

--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -2,7 +2,7 @@
 name: engineer
 description: Implements features and bug fixes for 2anki/server. Use for turning specs into code, writing tests, reviewing PRs, debugging production issues, refactoring, and any change that touches the codebase. Takes a spec or issue, produces working code with tests, opens a PR.
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: opus
+model: claude-opus-4-8
 ---
 
 You are the **Engineer** in the 2anki product trio. Your job is to ship working code that moves us toward the 300K-user goal in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -2,7 +2,7 @@
 name: pm
 description: Acts as Product Manager for 2anki/server. Use to synthesize user feedback, prioritize features, write specs, run weekly retros, and translate raw customer signal into clear engineering work. Trigger on phrases like "what should I build next", "here's some feedback", "write a spec for X", or any time raw customer data is pasted.
 tools: Read, Write, Edit, Grep, Glob, WebFetch
-model: opus
+model: claude-opus-4-8
 ---
 
 You are the **Product Manager** in the 2anki product trio. Your job is to make sure we're building the right things, in the right order, to reach the 300K-user goal in `CLAUDE.md`. Read `.claude/agents/_trio.md` for shared working protocol — follow it in every substantive response.

--- a/.claude/agents/prod-incident-responder.md
+++ b/.claude/agents/prod-incident-responder.md
@@ -2,7 +2,7 @@
 name: prod-incident-responder
 description: Reads recent prod logs, picks the highest-impact recurring error, drafts a minimal fix PR with a regression test. Use when prod logs show a recurring crash that has not been addressed (e.g. the GeneratePackagesUseCase name crash pattern).
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: opus
+model: claude-opus-4-8
 isolation: worktree
 ---
 

--- a/.claude/agents/seo-content.md
+++ b/.claude/agents/seo-content.md
@@ -2,7 +2,7 @@
 name: seo-content
 description: Owns landing-page content quality, topical authority, and internal linking on 2anki.net. Use for landing-page copy reviews, new landing-page proposals, content gaps against search intent, and sitemap audits.
 tools: Read, Write, Edit, Grep, Glob, WebFetch
-model: opus
+model: claude-opus-4-8
 ---
 
 You are the **SEO Content** specialist. Your job is to drive organic acquisition toward the 300K-user goal in `CLAUDE.md` by making 2anki the best answer to "how do I turn X into Anki cards."

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -2,7 +2,7 @@
 name: test-writer
 description: Writes Jest tests for a given source file in an isolated worktree. Reads the file, designs colocated tests against the public surface, runs them, and returns the diff. Does not touch source code.
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: opus
+model: claude-opus-4-8
 isolation: worktree
 ---
 


### PR DESCRIPTION
Switches the six opus-tier subagents — pm, engineer, designer, seo-content, prod-incident-responder, test-writer — from the floating `opus` alias to the explicit `claude-opus-4-8` model id. The sonnet and haiku agents are unchanged.

No changelog entry — internal tooling, no user-visible behavior change.

Browser check: not applicable — edits `.claude/agents/` frontmatter, no web/src/ change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782762280&installation_id=132681956&pr_number=2921&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2921&signature=9b6cf36a43816a178595c3149500d51f16887e2788b6c2732ae88717ee444982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->