### PR TITLE
fix: frame Notion database preview as a 10-row sample

### DIFF
--- a/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.module.css
+++ b/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.module.css
@@ -110,11 +110,20 @@
   font-style: italic;
 }
 
+.sampleFraming {
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  margin: 0 0 0.5rem;
+}
+
 .rowCapFooter {
+  background: var(--color-bg-secondary);
+  border-top: 1px solid var(--color-border);
   color: var(--color-text-secondary);
   font-size: var(--text-sm);
-  margin: 0.75rem 0 0;
-  padding-top: 0.5rem;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
 }
 
 .empty {

--- a/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.test.tsx
+++ b/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.test.tsx
@@ -77,7 +77,7 @@ describe('DatabasePreviewPage', () => {
     expect(screen.getByText('Reading your database')).toBeInTheDocument();
   });
 
-  it('renders the table, stats line, dot badges and row-cap footer', async () => {
+  it('renders the table, stats line, dot badges and sample framing', async () => {
     mockGetDatabasePreview.mockResolvedValue(baseResponse);
     renderPage();
 
@@ -93,13 +93,31 @@ describe('DatabasePreviewPage', () => {
     expect(screen.getByText('Movement of water across a membrane')).toBeInTheDocument();
 
     expect(
-      screen.getByText('Showing the first 2 rows. Convert to see all of them.')
+      screen.getByText(
+        'Preview of the first 2 rows. Converting to Anki includes every row in this database.'
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        'Showing 2 rows here. Every row in this database is included when you convert.'
+      )
     ).toBeInTheDocument();
 
     const wordHeader = screen.getByRole('columnheader', { name: /Word/ });
     expect(wordHeader.textContent).toContain('●');
 
     expect(mockTrack).toHaveBeenCalledWith('database_preview_viewed', expect.any(Object));
+  });
+
+  it('omits the sample framing when every row already fits in the preview', async () => {
+    mockGetDatabasePreview.mockResolvedValue({ ...baseResponse, hasMore: false });
+    renderPage();
+
+    await screen.findByRole('heading', { name: 'Vocabulary' });
+
+    expect(screen.queryByText(/Preview of the first/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Every row in this database/i)).not.toBeInTheDocument();
   });
 
   it('shows the ambiguous-mapping warning when inference fails', async () => {

--- a/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.tsx
+++ b/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.tsx
@@ -46,6 +46,14 @@ function StatsLine({ data }: Readonly<{ data: DatabasePreviewResponse }>) {
   );
 }
 
+function SampleFraming({ count }: Readonly<{ count: number }>) {
+  return (
+    <p className={styles.sampleFraming} aria-live="polite">
+      Preview of the first {count} {count === 1 ? 'row' : 'rows'}. Converting to Anki includes every row in this database.
+    </p>
+  );
+}
+
 function PreviewTable({ data }: Readonly<{ data: DatabasePreviewResponse }>) {
   const { columns, samples, mapping } = data;
   return (
@@ -205,7 +213,7 @@ export default function DatabasePreviewPage({ setError }: Readonly<DatabasePrevi
       });
   };
 
-  const showRowCapFooter = data.rowCount > 0 && data.hasMore;
+  const showSampleFraming = data.rowCount > 0 && data.hasMore;
 
   return (
     <div className={sharedStyles.pageWide}>
@@ -249,10 +257,11 @@ export default function DatabasePreviewPage({ setError }: Readonly<DatabasePrevi
           <p className={styles.empty}>This database has no rows yet.</p>
         ) : (
           <>
+            {showSampleFraming && <SampleFraming count={data.rowCount} />}
             <PreviewTable data={data} />
-            {showRowCapFooter && (
+            {showSampleFraming && (
               <p className={styles.rowCapFooter}>
-                Showing the first {data.rowCount} rows. Convert to see all of them.
+                Showing {data.rowCount} {data.rowCount === 1 ? 'row' : 'rows'} here. Every row in this database is included when you convert.
               </p>
             )}
           </>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-database-preview-clarity.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-database-preview-clarity.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-database-preview-clarity",
+  "date": "2026-05-30",
+  "type": "fix",
+  "title": "Notion database preview labels the sample so it's clear all rows convert, not just the visible ones"
+}


### PR DESCRIPTION
## What
The Notion database preview at `/preview/database/:id` now labels its sample table so users can't mistake the 10 visible rows for the whole database. A new framing line sits above the table — \"Preview of the first N rows. Converting to Anki includes every row in this database.\" — and the existing footer below the table is rewritten as a muted strip repeating the same bridge.

## Why
Users were converting databases with many rows, seeing only 10 in the preview, and reading it as a regression — convinced we were silently dropping the rest of their pages. The 10-row cap is intentional (it's a preview, not the converter), and the conversion does include every row. The bug was framing: nothing on screen tied \"what I see in this table\" to \"what I get when I press Convert to Anki.\"

## How
- New `SampleFraming` component renders above the table when `hasMore` is true.
- Footer copy under the table moves to a backgrounded strip that visually attaches to the bottom of the table (`background: var(--color-bg-secondary)`, top border) and repeats the bridge in slightly different words so a user who scrolls past the header still sees it.
- Both lines only render when `data.hasMore` is true. Small databases that fit entirely in the preview see neither — there's nothing to clarify.
- Single rename: `showRowCapFooter` → `showSampleFraming` (now gates both header and footer).
- The Notion data-source query doesn't return a total-row count (see `src/services/NotionService/FEATURE.md`), so the copy honestly says \"every row\" without naming a number we don't have.

No backend changes. No new API surface. Contract preserved exactly.

## Measuring success
`database_preview_viewed` analytics event already fires on page load; if the reframing works, support emails about \"can't see all rows in a database\" should fall to zero. We don't currently log a separate \"user re-clicked Convert after the framing\" event — the bridge is read-only.

## Testing
- Updated existing Vitest case to assert both the new header and footer copy at `rowCount=2, hasMore=true`.
- New Vitest case confirms neither line renders when `hasMore=false`.
- All 1418 web vitest tests pass; `pnpm typecheck` and `pnpm lint` clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: I did not start the dev server (the workflow leaves that to the user). Please open `/preview/database/:id` on a database with more than 10 rows and confirm the framing reads correctly above the table and the muted strip sits cleanly below it.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-30-database-preview-clarity.json` — \"Notion database preview labels the sample so it's clear all rows convert, not just the visible ones\"

## Risks
Pure copy + presentation change on a single page. No data layer, no API, no migrations. Rollback is a single revert.

## Goal alignment
Trust dies the moment we look broken. Users bouncing at the preview because they think we're dropping rows is a conversion leak right before the \"Convert to Anki\" button — the highest-intent moment in the funnel. Clarifying the sample framing keeps high-intent Notion users moving toward a download, which is the path to the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782762564&installation_id=132681956&pr_number=2922&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2922&signature=1e9aa7589425f902e6f0b5255416876c45958756b1ac9c32fbd5cddb77d59fd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->