### PR TITLE
fix: photo to deck appends new selections instead of replacing

### DIFF
--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
@@ -74,6 +74,60 @@
   border-radius: var(--radius-sm);
 }
 
+.thumbnailStrip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin: var(--space-4) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.thumbnail {
+  position: relative;
+  width: 96px;
+  height: 96px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+}
+
+.thumbnailImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbnailRemove {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.thumbnailRemove:hover {
+  background: rgba(0, 0, 0, 0.85);
+}
+
+.thumbnailRemove:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .footer {
   display: flex;
   justify-content: flex-end;

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
@@ -257,7 +257,7 @@ describe('PhotoToFlashcardsPage', () => {
     expect(input.min).toBe('1');
     expect(input.max).toBe('20');
     expect(
-      screen.getByText('3–5 for a quick pass, 6–10 for typical study, 11–20 for a dense page.')
+      screen.getByText(/3–5 for a quick pass, 6–10 for typical study, 11–20 for a dense page/)
     ).toBeTruthy();
   });
 
@@ -527,6 +527,143 @@ describe('PhotoToFlashcardsPage', () => {
         (fetchMock.mock.calls[0][1] as RequestInit).body as string
       ) as { includeSourceImage: boolean };
       expect(body.includeSourceImage).toBe(false);
+    });
+  });
+
+  describe('multi-photo append behaviour', () => {
+    function getThumbnails(): HTMLElement[] {
+      return Array.from(
+        document.querySelectorAll('[aria-label^="Remove "]')
+      ) as HTMLElement[];
+    }
+
+    it('appends a second picker selection instead of replacing the first', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [makePhoto('first.jpg')] } });
+      fireEvent.change(input, { target: { files: [makePhoto('second.jpg')] } });
+      expect(getThumbnails()).toHaveLength(2);
+      expect(screen.getByRole('button', { name: 'Remove first.jpg' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Remove second.jpg' })).toBeTruthy();
+    });
+
+    it('accepts multiple photos in a single picker invocation', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, {
+        target: { files: [makePhoto('a.jpg'), makePhoto('b.jpg'), makePhoto('c.jpg')] },
+      });
+      expect(getThumbnails()).toHaveLength(3);
+    });
+
+    it('appends drag-and-drop additions to the existing set', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [makePhoto('one.jpg')] } });
+
+      const dropzone = document.querySelector('label[for="photo-file-input"]') as HTMLElement;
+      fireEvent.drop(dropzone, {
+        dataTransfer: { files: [makePhoto('two.jpg'), makePhoto('three.jpg')] },
+      });
+      expect(getThumbnails()).toHaveLength(3);
+    });
+
+    it('appends clipboard-pasted images to the existing set', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [makePhoto('one.jpg')] } });
+
+      const dropzone = document.querySelector('label[for="photo-file-input"]') as HTMLElement;
+      fireEvent.paste(dropzone, {
+        clipboardData: { files: [makePhoto('pasted.jpg')] },
+      });
+      expect(getThumbnails()).toHaveLength(2);
+      expect(screen.getByRole('button', { name: 'Remove pasted.jpg' })).toBeTruthy();
+    });
+
+    it('removes the targeted photo when its × button is clicked and leaves the rest', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, {
+        target: { files: [makePhoto('keep1.jpg'), makePhoto('drop.jpg'), makePhoto('keep2.jpg')] },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Remove drop.jpg' }));
+      expect(getThumbnails()).toHaveLength(2);
+      expect(screen.getByRole('button', { name: 'Remove keep1.jpg' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Remove keep2.jpg' })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: 'Remove drop.jpg' })).toBeNull();
+    });
+
+    it('returns to the empty state after removing the last thumbnail', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [makePhoto('only.jpg')] } });
+      expect(getThumbnails()).toHaveLength(1);
+      fireEvent.click(screen.getByRole('button', { name: 'Remove only.jpg' }));
+      expect(getThumbnails()).toHaveLength(0);
+      expect(screen.getByText('Drop photos, paste, or click to add')).toBeTruthy();
+    });
+
+    it('keeps duplicate filenames in the same batch (one is allowed)', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, {
+        target: { files: [makePhoto('same.jpg'), makePhoto('same.jpg')] },
+      });
+      expect(getThumbnails()).toHaveLength(2);
+    });
+
+    it('the Convert CTA reflects the photo count after each addition', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, { target: { files: [makePhoto('a.jpg')] } });
+      expect(screen.getByRole('button', { name: 'Get cards' })).toBeTruthy();
+      fireEvent.change(input, { target: { files: [makePhoto('b.jpg')] } });
+      expect(screen.getByRole('button', { name: 'Get cards from 2 photos' })).toBeTruthy();
+      fireEvent.change(input, { target: { files: [makePhoto('c.jpg')] } });
+      expect(screen.getByRole('button', { name: 'Get cards from 3 photos' })).toBeTruthy();
+    });
+
+    it('rejects an invalid file in a mixed batch but keeps the valid ones', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+      fireEvent.change(input, { target: { files: [makePhoto('ok.jpg'), pdf] } });
+      expect(getThumbnails()).toHaveLength(1);
+      expect(screen.getByText('Use JPEG, PNG, WebP, or GIF.')).toBeTruthy();
+    });
+
+    it('exposes a multiple-file input so picker allows in-batch multi-select', () => {
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      expect(input.multiple).toBe(true);
+    });
+
+    it('uploads each photo sequentially when converting a multi-photo set', async () => {
+      setLocals({ paying: true });
+      const makeOkResponse = () =>
+        new Response('fake-apkg-bytes', {
+          status: 200,
+          headers: {
+            'X-Card-Count': '5',
+            'Content-Type': 'application/octet-stream',
+          },
+        });
+      const fetchMock = vi.fn().mockImplementation(async () => makeOkResponse());
+      vi.stubGlobal('fetch', fetchMock);
+      HTMLAnchorElement.prototype.click = vi.fn();
+
+      render(<PhotoToFlashcardsPage />);
+      const input = document.getElementById('photo-file-input') as HTMLInputElement;
+      fireEvent.change(input, {
+        target: { files: [makePhoto('a.jpg'), makePhoto('b.jpg')] },
+      });
+      fireEvent.click(screen.getByRole('button', { name: 'Get cards from 2 photos' }));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      await waitFor(() => {
+        expect(screen.getByText(/10 cards from 2 photos\. Decks downloaded\./)).toBeTruthy();
+      });
     });
   });
 });

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -15,6 +15,12 @@ type UploadSource = 'camera' | 'library';
 type Density = 'sparse' | 'balanced' | 'dense';
 type PhotoMode = 'generative' | 'verbatim';
 
+interface SelectedPhoto {
+  id: string;
+  file: File;
+  previewUrl: string;
+}
+
 const MIN_CARDS = 1;
 const MAX_CARDS = 20;
 const DEFAULT_CARDS = 10;
@@ -53,13 +59,32 @@ function downloadBlob(blob: Blob, filename: string): void {
   URL.revokeObjectURL(url);
 }
 
+function makePhotoId(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+  return `photo-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+}
+
+function validatePhoto(file: File): string | null {
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return 'Use JPEG, PNG, WebP, or GIF.';
+  }
+  if (file.size > MAX_SIZE_BYTES) {
+    return 'Photo is over the 10 MB limit. Try a smaller image.';
+  }
+  return null;
+}
+
 export function PhotoToFlashcardsPage() {
   const { data } = useUserLocals();
   const isPaying = isPayingUser(data?.locals);
 
   const [deckName, setDeckName] = useState('');
-  const [file, setFile] = useState<File | null>(null);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [photos, setPhotos] = useState<SelectedPhoto[]>([]);
   const [status, setStatus] = useState<Status>('idle');
   const [cardCount, setCardCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -75,40 +100,65 @@ export function PhotoToFlashcardsPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
 
+  const photoCount = photos.length;
+
+  const resetInputs = () => {
+    if (fileInputRef.current != null) fileInputRef.current.value = '';
+    if (cameraInputRef.current != null) cameraInputRef.current.value = '';
+  };
+
   const reset = () => {
-    setFile(null);
-    setPreviewUrl(null);
+    photos.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+    setPhotos([]);
     setStatus('idle');
     setCardCount(0);
     setError(null);
     setVerbatimEmptyState(false);
+    resetInputs();
   };
 
-  const handleFile = (next: File, source: UploadSource) => {
+  const appendPhotos = (incoming: File[], source: UploadSource) => {
+    if (incoming.length === 0) return;
     setError(null);
-    if (!ALLOWED_TYPES.includes(next.type)) {
-      setError('Use JPEG, PNG, WebP, or GIF.');
+
+    const accepted: SelectedPhoto[] = [];
+    let rejection: string | null = null;
+    for (const file of incoming) {
+      const issue = validatePhoto(file);
+      if (issue != null) {
+        rejection = issue;
+        continue;
+      }
+      accepted.push({
+        id: makePhotoId(),
+        file,
+        previewUrl: URL.createObjectURL(file),
+      });
+    }
+
+    if (accepted.length === 0) {
+      if (rejection != null) setError(rejection);
+      resetInputs();
       return;
     }
-    if (next.size > MAX_SIZE_BYTES) {
-      setError('Photo is over the 10 MB limit. Try a smaller image.');
-      return;
-    }
+
+    if (rejection != null) setError(rejection);
     setUploadSource(source);
-    setFile(next);
-    setPreviewUrl(URL.createObjectURL(next));
+    setPhotos((current) => [...current, ...accepted]);
     setStatus('idle');
     setCardCount(0);
+    setVerbatimEmptyState(false);
+    resetInputs();
   };
 
   const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const next = e.target.files?.[0];
-    if (next != null) handleFile(next, 'library');
+    const next = Array.from(e.target.files ?? []);
+    appendPhotos(next, 'library');
   };
 
   const handleCameraInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const next = e.target.files?.[0];
-    if (next != null) handleFile(next, 'camera');
+    const next = Array.from(e.target.files ?? []);
+    appendPhotos(next, 'camera');
   };
 
   const handleCardCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -123,8 +173,27 @@ export function PhotoToFlashcardsPage() {
 
   const handleDrop = (e: React.DragEvent<HTMLLabelElement>) => {
     e.preventDefault();
-    const next = e.dataTransfer.files[0];
-    if (next != null) handleFile(next, 'library');
+    const next = Array.from(e.dataTransfer.files ?? []);
+    appendPhotos(next, 'library');
+  };
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLLabelElement>) => {
+    const items = Array.from(e.clipboardData?.files ?? []);
+    if (items.length === 0) return;
+    e.preventDefault();
+    appendPhotos(items, 'library');
+  };
+
+  const removePhoto = (id: string) => {
+    setPhotos((current) => {
+      const removed = current.find((p) => p.id === id);
+      if (removed != null) URL.revokeObjectURL(removed.previewUrl);
+      return current.filter((p) => p.id !== id);
+    });
+    setStatus('idle');
+    setCardCount(0);
+    setVerbatimEmptyState(false);
+    setError(null);
   };
 
   const switchToGenerative = () => {
@@ -133,9 +202,79 @@ export function PhotoToFlashcardsPage() {
     card1Ref.current?.scrollIntoView?.({ behavior: 'smooth', block: 'start' });
   };
 
+  const convertOnePhoto = async (
+    photo: SelectedPhoto,
+    name: string
+  ): Promise<{ cardCount: number } | { error: string }> => {
+    const prepared = await prepareImageForVision(photo.file);
+
+    const res = await fetch('/api/image-occlusion/photo-to-deck', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        imageBase64: prepared.base64,
+        mediaType: prepared.mediaType,
+        deckName: name,
+        width: prepared.width,
+        height: prepared.height,
+        includeSourceImage,
+        density,
+        mode,
+        mcqEnabled: includeMcq && isPaying,
+      }),
+    });
+
+    if (res.status === 404) {
+      return { error: "Photo to deck isn't available yet." };
+    }
+    if (res.status === 401 || res.status === 403) {
+      return { error: 'Sign in to use photo to deck.' };
+    }
+    if (res.status === 413) {
+      return {
+        error: 'Photo is too large. Try a smaller or lower-resolution image.',
+      };
+    }
+    if (res.status === 429) {
+      const body = (await res.json().catch(() => ({}))) as {
+        used?: number;
+        limit?: number;
+      };
+      const limit = body.limit ?? 5;
+      const used = body.used ?? limit;
+      track('photo_quota_reached', { used, limit });
+      return {
+        error: `Free plan is ${limit} photos per month. Upgrade for unlimited.`,
+      };
+    }
+    if (!res.ok) {
+      const body = (await res
+        .json()
+        .catch(() => ({ message: res.statusText }))) as { message?: string };
+      return { error: body.message ?? "Couldn't read this photo. Try again." };
+    }
+
+    const count = Number(res.headers.get('X-Card-Count') ?? '0');
+    const blob = await res.blob();
+    downloadBlob(blob, `${name}.apkg`);
+    return { cardCount: count };
+  };
+
+  const buildDeckName = (
+    photo: SelectedPhoto,
+    index: number,
+    total: number
+  ): string => {
+    const trimmed = deckName.trim();
+    const fallback = photo.file.name.replace(/\.[^.]+$/, '') || 'Photo deck';
+    if (trimmed.length === 0) return fallback;
+    return total === 1 ? trimmed : `${trimmed} ${index + 1}`;
+  };
+
   const handleConvert = async () => {
-    if (file == null) {
-      setError('Select a photo first.');
+    if (photos.length === 0) {
+      setError('Add a photo first.');
       return;
     }
     setError(null);
@@ -143,84 +282,45 @@ export function PhotoToFlashcardsPage() {
     setStatus('reading');
     track('photo_upload_started', { source: uploadSource });
 
+    let totalCards = 0;
+
     try {
-      const prepared = await prepareImageForVision(file);
-
-      const baseName = file.name.replace(/\.[^.]+$/, '') || 'Photo deck';
-      const name = deckName.trim() || baseName;
-
-      const res = await fetch('/api/image-occlusion/photo-to-deck', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          imageBase64: prepared.base64,
-          mediaType: prepared.mediaType,
-          deckName: name,
-          width: prepared.width,
-          height: prepared.height,
-          includeSourceImage,
-          density,
-          mode,
-          mcqEnabled: includeMcq && isPaying,
-        }),
-      });
-
-      if (res.status === 404) {
-        setError("Photo to deck isn't available yet.");
-        setStatus('idle');
-        return;
-      }
-      if (res.status === 401 || res.status === 403) {
-        setError('Sign in to use photo to deck.');
-        setStatus('idle');
-        return;
-      }
-      if (res.status === 413) {
-        setError(
-          'Photo is too large. Try a smaller or lower-resolution image.'
-        );
-        setStatus('idle');
-        return;
-      }
-      if (res.status === 429) {
-        const body = (await res.json().catch(() => ({}))) as {
-          used?: number;
-          limit?: number;
-        };
-        const limit = body.limit ?? 5;
-        const used = body.used ?? limit;
-        track('photo_quota_reached', { used, limit });
-        setError(
-          `Free plan is ${limit} photos per month. Upgrade for unlimited.`
-        );
-        setStatus('idle');
-        return;
-      }
-      if (!res.ok) {
-        const body = (await res
-          .json()
-          .catch(() => ({ message: res.statusText }))) as {
-          message?: string;
-        };
-        setError(body.message ?? "Couldn't read this photo. Try again.");
-        setStatus('idle');
-        return;
+      for (let i = 0; i < photos.length; i += 1) {
+        const photo = photos[i];
+        const name = buildDeckName(photo, i, photos.length);
+        const result = await convertOnePhoto(photo, name);
+        if ('error' in result) {
+          setError(result.error);
+          setStatus('idle');
+          return;
+        }
+        totalCards += result.cardCount;
       }
 
-      const count = Number(res.headers.get('X-Card-Count') ?? '0');
-      const blob = await res.blob();
-      downloadBlob(blob, `${name}.apkg`);
-      setCardCount(count);
+      setCardCount(totalCards);
       setStatus('done');
-
-      if (mode === 'verbatim' && count === 0) {
+      if (mode === 'verbatim' && totalCards === 0) {
         setVerbatimEmptyState(true);
       }
     } catch {
       setError('Something broke on our end. Try again in a moment.');
       setStatus('idle');
     }
+  };
+
+  const renderConvertLabel = (): string => {
+    if (status === 'reading') {
+      return photoCount > 1 ? `Reading ${photoCount} photos` : 'Reading your photo';
+    }
+    return photoCount > 1 ? `Get cards from ${photoCount} photos` : 'Get cards';
+  };
+
+  const renderSuccessLabel = (): string => {
+    const cardWord = cardCount === 1 ? 'card' : 'cards';
+    if (photoCount > 1) {
+      return `${cardCount} ${cardWord} from ${photoCount} photos. Decks downloaded.`;
+    }
+    return `${cardCount} ${cardWord} from your photo. Deck downloaded.`;
   };
 
   return (
@@ -285,7 +385,9 @@ export function PhotoToFlashcardsPage() {
             value={deckName}
             onChange={(e) => setDeckName(e.target.value)}
             className={pageStyles.deckNameInput}
-            placeholder={file?.name.replace(/\.[^.]+$/, '') || 'Photo deck'}
+            placeholder={
+              photos[0]?.file.name.replace(/\.[^.]+$/, '') || 'Photo deck'
+            }
           />
         </div>
 
@@ -315,32 +417,65 @@ export function PhotoToFlashcardsPage() {
           htmlFor="photo-file-input"
           onDrop={handleDrop}
           onDragOver={(e) => e.preventDefault()}
+          onPaste={handlePaste}
         >
-          {previewUrl == null ? (
+          {photoCount === 0 ? (
             <>
               <span className={pageStyles.dropzoneTitle}>
-                Drop a photo or click to select
+                Drop photos, paste, or click to add
               </span>
               <span className={pageStyles.dropzoneHint}>
-                JPEG, PNG, WebP, GIF — up to 10 MB
+                JPEG, PNG, WebP, GIF — up to 10 MB each. Add as many as you need.
               </span>
             </>
           ) : (
-            <img
-              src={previewUrl}
-              alt="Selected photo"
-              className={pageStyles.preview}
-            />
+            <>
+              <span className={pageStyles.dropzoneTitle}>
+                Add more — drop, paste, or click
+              </span>
+              <span className={pageStyles.dropzoneHint}>
+                {photoCount} {photoCount === 1 ? 'photo' : 'photos'} ready
+              </span>
+            </>
           )}
           <input
             ref={fileInputRef}
             id="photo-file-input"
             type="file"
             accept={ALLOWED_TYPES.join(',')}
+            multiple
             onChange={handleFileInput}
             hidden
           />
         </label>
+
+        {photoCount > 0 && (
+          <ul
+            className={pageStyles.thumbnailStrip}
+            aria-label={`${photoCount} ${photoCount === 1 ? 'photo' : 'photos'} selected`}
+          >
+            {photos.map((photo) => (
+              <li key={photo.id} className={pageStyles.thumbnail}>
+                <img
+                  src={photo.previewUrl}
+                  alt={photo.file.name}
+                  className={pageStyles.thumbnailImage}
+                />
+                <button
+                  type="button"
+                  className={pageStyles.thumbnailRemove}
+                  aria-label={`Remove ${photo.file.name}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    removePhoto(photo.id);
+                  }}
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
 
       {mode === 'generative' && (
@@ -364,7 +499,7 @@ export function PhotoToFlashcardsPage() {
           </div>
           <p className={pageStyles.densityHint}>
             3–5 for a quick pass, 6–10 for typical study, 11–20 for a dense
-            page.
+            page. Applied to each photo.
           </p>
         </div>
       )}
@@ -420,10 +555,7 @@ export function PhotoToFlashcardsPage() {
       )}
 
       {status === 'done' && !verbatimEmptyState && (
-        <div className={styles.notificationSuccess}>
-          {cardCount} {cardCount === 1 ? 'card' : 'cards'} from your photo. Deck
-          downloaded.
-        </div>
+        <div className={styles.notificationSuccess}>{renderSuccessLabel()}</div>
       )}
 
       {verbatimEmptyState && (
@@ -445,7 +577,7 @@ export function PhotoToFlashcardsPage() {
           type="button"
           className={styles.btnSecondary}
           onClick={reset}
-          disabled={file == null && status === 'idle'}
+          disabled={photoCount === 0 && status === 'idle'}
         >
           Clear
         </button>
@@ -453,9 +585,9 @@ export function PhotoToFlashcardsPage() {
           type="button"
           className={styles.btnPrimary}
           onClick={handleConvert}
-          disabled={file == null || status === 'reading'}
+          disabled={photoCount === 0 || status === 'reading'}
         >
-          {status === 'reading' ? 'Reading your photo' : 'Get cards'}
+          {renderConvertLabel()}
         </button>
       </div>
     </section>

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -66,7 +66,9 @@ function makePhotoId(): string {
   ) {
     return crypto.randomUUID();
   }
-  return `photo-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+  const bytes = crypto.getRandomValues(new Uint8Array(8));
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `photo-${Date.now()}-${hex}`;
 }
 
 function validatePhoto(file: File): string | null {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-photo-upload-append.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-photo-upload-append.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-photo-upload-append",
+  "date": "2026-05-30",
+  "type": "fix",
+  "title": "Photo to deck keeps earlier photos when you add another one"
+}


### PR DESCRIPTION
## What
On the photo-to-deck page, selecting photos one at a time used to **replace** the previous selection — users who didn't multi-select in one OS file-picker invocation ended up with only the last photo. This change makes every new selection (file picker, drag-and-drop, clipboard paste) append to the existing set.

## Why
A user reported losing earlier photos when adding photos one at a time. The photo surface is an explicitly multi-image flow; the silent-replace behaviour quietly broke the simplest path to a deck.

## How
- `file: File | null` → `photos: SelectedPhoto[]` (id + file + previewUrl). New batches append; the file input now carries `multiple`.
- Drag-and-drop and a new clipboard-paste handler share one `appendPhotos` helper, so all three input paths behave identically.
- Each thumbnail renders with an inline × button (`aria-label="Remove <filename>"`); removing the last one returns the dropzone to its empty state.
- Convert iterates the set sequentially, downloading one `.apkg` per photo. When the user provided a deck name and selected ≥ 2 photos, decks are suffixed `Name 1`, `Name 2`, … to keep filenames unique on disk.
- Per-photo blob URLs are revoked on remove / Clear to avoid leaking them across long sessions.

## Measuring success
- Existing `photo_upload_started` event now fires once for the whole batch instead of per-photo; no telemetry shape change. The conversion success log on the server side stays one entry per photo (one fetch per photo).
- Watch the inbox for follow-ups citing "lost photos when I added another" — expected to stop after deploy.

## Testing
- Unit tests added (Vitest + RTL): picker × 2 separate selections both appear; multi-file picker batch appears; drag-drop appends to a picker selection; clipboard paste appends; remove × targets the right photo and leaves the rest; removing the last thumbnail returns to the empty state; duplicate filenames in one batch are allowed; mixed valid + invalid batch keeps the valid one and surfaces the validation error; the file input exposes `multiple`; Convert CTA label updates with the count; multi-photo Convert issues sequential fetches and the success banner names the total.
- All 1429 web tests pass; typecheck and lint clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Author did not run the dev server; please verify picker + drag-drop + paste + remove × in `pnpm dev` before merge.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-30-photo-upload-append.json` — "Photo to deck keeps earlier photos when you add another one".

## Risks
- Multi-photo conversion now triggers N sequential requests (each ~5–20s on Vision). The CTA label states the count up front and the in-flight label says "Reading N photos". If any photo fails, the loop halts and surfaces the error — partial decks already downloaded stay on the user's disk.
- Free-tier quota is per-photo on the server; a 5-photo batch from a user with 3 photos left will fail mid-loop on the 4th. The 429 error message surfaces as written.

## Goal alignment
Reduces unintended data loss in the primary multi-photo flow, restoring "drop something in, get a clean deck back" for the most common photo case (textbook spread, slide series). Reduces support-inbox volume on the photo surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782762988&installation_id=132681956&pr_number=2923&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2923&signature=68d23f0972735d91fc8bf1831542deb2e2d7b8efbaef51741f2b1d27db594a44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->