### PR TITLE
feat: admin-toggleable feature flags under /ops

### DIFF
--- a/migrations/20260806000000_add_feature_flags.js
+++ b/migrations/20260806000000_add_feature_flags.js
@@ -1,0 +1,22 @@
+exports.up = async (knex) => {
+  await knex.schema.createTable('feature_flags', (t) => {
+    t.text('key').primary();
+    t.boolean('value').notNullable().defaultTo(false);
+    t.text('description');
+    t.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
+    t.integer('updated_by').references('id').inTable('users').onDelete('SET NULL');
+  });
+
+  await knex('feature_flags').insert([
+    {
+      key: 'ai-converter-floor-v1',
+      value: false,
+      description:
+        'AI converter floor v1 — per #2726 spec. Off by default; flip from /ops to start the canary.',
+    },
+  ]);
+};
+
+exports.down = async (knex) => {
+  await knex.schema.dropTableIfExists('feature_flags');
+};

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -14,6 +14,11 @@ import { IShowcaseRepository } from '../data_layer/ShowcaseRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 import { SyncStripeSubscriptionsUseCase } from '../usecases/ops/SyncStripeSubscriptionsUseCase';
 import { GetPricingAbFunnelUseCase } from '../usecases/ops/GetPricingAbFunnelUseCase';
+import { ListFeatureFlagsUseCase } from '../usecases/ops/ListFeatureFlagsUseCase';
+import {
+  FeatureFlagNotFoundError,
+  SetFeatureFlagUseCase,
+} from '../usecases/ops/SetFeatureFlagUseCase';
 
 class OpsController {
   constructor(
@@ -30,7 +35,9 @@ class OpsController {
     private readonly getMindmapStorageMetricsUseCase?: GetMindmapStorageMetricsUseCase,
     private readonly deleteInactiveUsersUseCase?: DeleteInactiveUsersUseCase,
     private readonly syncStripeSubscriptionsUseCase?: SyncStripeSubscriptionsUseCase,
-    private readonly getPricingAbFunnelUseCase?: GetPricingAbFunnelUseCase
+    private readonly getPricingAbFunnelUseCase?: GetPricingAbFunnelUseCase,
+    private readonly listFeatureFlagsUseCase?: ListFeatureFlagsUseCase,
+    private readonly setFeatureFlagUseCase?: SetFeatureFlagUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -274,6 +281,71 @@ class OpsController {
     } catch (error) {
       console.error('[ops] getPricingAbFunnel failed', error);
       res.status(500).json({ message: 'Failed to load pricing A/B funnel' });
+    }
+  }
+
+  async listFeatureFlags(_req: express.Request, res: express.Response) {
+    if (this.listFeatureFlagsUseCase == null) {
+      res.status(500).json({ message: 'Feature flags not configured' });
+      return;
+    }
+    try {
+      const rows = await this.listFeatureFlagsUseCase.execute();
+      res.status(200).json(
+        rows.map((row) => ({
+          key: row.key,
+          value: row.value,
+          description: row.description,
+          updated_at: row.updated_at,
+          updated_by_email: row.updated_by_email,
+        }))
+      );
+    } catch (error) {
+      console.error('[ops] listFeatureFlags failed', error);
+      res.status(500).json({ message: 'Failed to load feature flags' });
+    }
+  }
+
+  async setFeatureFlag(req: express.Request, res: express.Response) {
+    if (this.setFeatureFlagUseCase == null) {
+      res.status(500).json({ message: 'Feature flags not configured' });
+      return;
+    }
+    const key = req.params.key;
+    if (typeof key !== 'string' || key.length === 0) {
+      res.status(400).json({ message: 'key is required' });
+      return;
+    }
+    const body = req.body as { value?: unknown };
+    if (typeof body?.value !== 'boolean') {
+      res.status(400).json({ message: 'value must be a boolean' });
+      return;
+    }
+    const userId = res.locals.owner;
+    if (typeof userId !== 'number') {
+      res.status(500).json({ message: 'Authenticated user id missing' });
+      return;
+    }
+    try {
+      const updated = await this.setFeatureFlagUseCase.execute({
+        key,
+        value: body.value,
+        userId,
+      });
+      res.status(200).json({
+        key: updated.key,
+        value: updated.value,
+        description: updated.description,
+        updated_at: updated.updated_at,
+        updated_by_email: updated.updated_by_email,
+      });
+    } catch (error) {
+      if (error instanceof FeatureFlagNotFoundError) {
+        res.status(404).json({ message: `Flag not found: ${key}` });
+        return;
+      }
+      console.error('[ops] setFeatureFlag failed', error);
+      res.status(500).json({ message: 'Failed to update feature flag' });
     }
   }
 }

--- a/src/data_layer/FeatureFlagsRepository.test.ts
+++ b/src/data_layer/FeatureFlagsRepository.test.ts
@@ -1,0 +1,49 @@
+import knex from 'knex';
+
+describe('FeatureFlagsRepository — generated SQL shape', () => {
+  it('getAll joins users for email and orders by key', () => {
+    const pgKnex = knex({ client: 'pg' });
+    const sql = pgKnex('feature_flags as f')
+      .leftJoin('users as u', 'f.updated_by', 'u.id')
+      .select(
+        'f.key',
+        'f.value',
+        'f.description',
+        'f.updated_at',
+        'f.updated_by',
+        { updated_by_email: 'u.email' }
+      )
+      .orderBy('f.key', 'asc')
+      .toString();
+    expect(sql).toContain('left join "users" as "u"');
+    expect(sql).toContain('"u"."email" as "updated_by_email"');
+    expect(sql).toContain('order by "f"."key" asc');
+    pgKnex.destroy();
+  });
+
+  it('get filters on key and selects value only', () => {
+    const pgKnex = knex({ client: 'pg' });
+    const sql = pgKnex('feature_flags')
+      .where({ key: 'ai-converter-floor-v1' })
+      .select('value')
+      .first()
+      .toString();
+    expect(sql).toContain('"key" = \'ai-converter-floor-v1\'');
+    expect(sql).toContain('select "value"');
+    pgKnex.destroy();
+  });
+
+  it('set updates by key, persists value and updated_by', () => {
+    const pgKnex = knex({ client: 'pg' });
+    const sql = pgKnex('feature_flags')
+      .where({ key: 'ai-converter-floor-v1' })
+      .update({ value: true, updated_by: 42, updated_at: pgKnex.fn.now() })
+      .toString();
+    expect(sql).toContain('update "feature_flags"');
+    expect(sql).toContain('"value" = true');
+    expect(sql).toContain('"updated_by" = 42');
+    expect(sql).toContain('"updated_at" = CURRENT_TIMESTAMP');
+    expect(sql).toContain('where "key" = \'ai-converter-floor-v1\'');
+    pgKnex.destroy();
+  });
+});

--- a/src/data_layer/FeatureFlagsRepository.ts
+++ b/src/data_layer/FeatureFlagsRepository.ts
@@ -1,0 +1,100 @@
+import type { Knex } from 'knex';
+
+export interface FeatureFlag {
+  key: string;
+  value: boolean;
+  description: string | null;
+  updated_at: string | null;
+  updated_by: number | null;
+}
+
+export interface FeatureFlagWithEmail extends FeatureFlag {
+  updated_by_email: string | null;
+}
+
+export interface IFeatureFlagsRepository {
+  getAll(): Promise<FeatureFlagWithEmail[]>;
+  get(key: string): Promise<boolean | null>;
+  set(key: string, value: boolean, userId: number): Promise<FeatureFlagWithEmail | null>;
+}
+
+interface FlagJoinRow {
+  key: string;
+  value: boolean;
+  description: string | null;
+  updated_at: Date | string | null;
+  updated_by: number | null;
+  updated_by_email: string | null;
+}
+
+const toIso = (value: Date | string | null): string | null => {
+  if (value == null) return null;
+  return typeof value === 'string' ? value : value.toISOString();
+};
+
+const mapRow = (row: FlagJoinRow): FeatureFlagWithEmail => ({
+  key: row.key,
+  value: row.value === true,
+  description: row.description,
+  updated_at: toIso(row.updated_at),
+  updated_by: row.updated_by,
+  updated_by_email: row.updated_by_email,
+});
+
+export class FeatureFlagsRepository implements IFeatureFlagsRepository {
+  private readonly table = 'feature_flags';
+  private readonly users = 'users';
+
+  constructor(private readonly database: Knex) {}
+
+  async getAll(): Promise<FeatureFlagWithEmail[]> {
+    const rows = (await this.database(`${this.table} as f`)
+      .leftJoin(`${this.users} as u`, 'f.updated_by', 'u.id')
+      .select(
+        'f.key',
+        'f.value',
+        'f.description',
+        'f.updated_at',
+        'f.updated_by',
+        { updated_by_email: 'u.email' }
+      )
+      .orderBy('f.key', 'asc')) as FlagJoinRow[];
+    return rows.map(mapRow);
+  }
+
+  async get(key: string): Promise<boolean | null> {
+    const row = (await this.database(this.table)
+      .where({ key })
+      .select('value')
+      .first()) as { value: boolean } | undefined;
+    if (row == null) return null;
+    return row.value === true;
+  }
+
+  async set(
+    key: string,
+    value: boolean,
+    userId: number
+  ): Promise<FeatureFlagWithEmail | null> {
+    const updated = await this.database(this.table)
+      .where({ key })
+      .update({ value, updated_by: userId, updated_at: this.database.fn.now() });
+    if (updated === 0) return null;
+    const rows = (await this.database(`${this.table} as f`)
+      .leftJoin(`${this.users} as u`, 'f.updated_by', 'u.id')
+      .where('f.key', key)
+      .select(
+        'f.key',
+        'f.value',
+        'f.description',
+        'f.updated_at',
+        'f.updated_by',
+        { updated_by_email: 'u.email' }
+      )
+      .limit(1)) as FlagJoinRow[];
+    const row = rows[0];
+    return row == null ? null : mapRow(row);
+  }
+}
+
+export default FeatureFlagsRepository;

--- a/src/lib/featureFlags/getFeatureFlag.test.ts
+++ b/src/lib/featureFlags/getFeatureFlag.test.ts
@@ -1,0 +1,103 @@
+import type { IFeatureFlagsRepository } from '../../data_layer/FeatureFlagsRepository';
+import {
+  __resetFeatureFlagModuleForTests,
+  __setFeatureFlagDependencies,
+  getFeatureFlag,
+  invalidateFeatureFlagCache,
+} from './getFeatureFlag';
+
+const buildRepo = (
+  values: Map<string, boolean | null>
+): IFeatureFlagsRepository & { getCalls: number } => {
+  let getCalls = 0;
+  return {
+    get getCalls() {
+      return getCalls;
+    },
+    set getCalls(_value: number) {
+      getCalls = _value;
+    },
+    async get(key: string) {
+      getCalls += 1;
+      return values.has(key) ? values.get(key) ?? null : null;
+    },
+    async getAll() {
+      return [];
+    },
+    async set() {
+      return null;
+    },
+  } as IFeatureFlagsRepository & { getCalls: number };
+};
+
+describe('getFeatureFlag', () => {
+  beforeEach(() => {
+    __resetFeatureFlagModuleForTests();
+  });
+
+  afterAll(() => {
+    __resetFeatureFlagModuleForTests();
+  });
+
+  it('returns the stored value when the key exists', async () => {
+    const repo = buildRepo(new Map([['ai-converter-floor-v1', true]]));
+    __setFeatureFlagDependencies({ repository: repo });
+    const value = await getFeatureFlag('ai-converter-floor-v1', false);
+    expect(value).toBe(true);
+  });
+
+  it('returns the default when the key is missing', async () => {
+    const repo = buildRepo(new Map());
+    __setFeatureFlagDependencies({ repository: repo });
+    const value = await getFeatureFlag('does-not-exist', true);
+    expect(value).toBe(true);
+  });
+
+  it('caches the result within the TTL', async () => {
+    const repo = buildRepo(new Map([['k', true]]));
+    let now = 1_000;
+    __setFeatureFlagDependencies({ repository: repo, clock: () => now });
+
+    await getFeatureFlag('k', false);
+    await getFeatureFlag('k', false);
+    now += 4_000;
+    await getFeatureFlag('k', false);
+
+    expect(repo.getCalls).toBe(1);
+  });
+
+  it('re-reads after the TTL expires', async () => {
+    const repo = buildRepo(new Map([['k', true]]));
+    let now = 1_000;
+    __setFeatureFlagDependencies({ repository: repo, clock: () => now });
+
+    await getFeatureFlag('k', false);
+    now += 5_001;
+    await getFeatureFlag('k', false);
+
+    expect(repo.getCalls).toBe(2);
+  });
+
+  it('re-reads after invalidation', async () => {
+    const repo = buildRepo(new Map([['k', true]]));
+    __setFeatureFlagDependencies({ repository: repo });
+
+    await getFeatureFlag('k', false);
+    invalidateFeatureFlagCache('k');
+    await getFeatureFlag('k', false);
+
+    expect(repo.getCalls).toBe(2);
+  });
+
+  it('falls back to the default when the cache holds a known-missing key', async () => {
+    const repo = buildRepo(new Map());
+    __setFeatureFlagDependencies({ repository: repo });
+
+    const first = await getFeatureFlag('k', true);
+    const second = await getFeatureFlag('k', true);
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(repo.getCalls).toBe(1);
+  });
+});

--- a/src/lib/featureFlags/getFeatureFlag.ts
+++ b/src/lib/featureFlags/getFeatureFlag.ts
@@ -1,0 +1,54 @@
+import type { IFeatureFlagsRepository } from '../../data_layer/FeatureFlagsRepository';
+import { FeatureFlagsRepository } from '../../data_layer/FeatureFlagsRepository';
+import { getDatabase } from '../../data_layer';
+
+interface CacheEntry {
+  value: boolean | null;
+  expiresAt: number;
+}
+
+const CACHE_TTL_MS = 5_000;
+const cache = new Map<string, CacheEntry>();
+let repositoryOverride: IFeatureFlagsRepository | null = null;
+let clock: () => number = () => Date.now();
+
+const getRepository = (): IFeatureFlagsRepository => {
+  if (repositoryOverride != null) return repositoryOverride;
+  return new FeatureFlagsRepository(getDatabase());
+};
+
+export async function getFeatureFlag(
+  key: string,
+  defaultValue: boolean
+): Promise<boolean> {
+  const now = clock();
+  const cached = cache.get(key);
+  if (cached != null && cached.expiresAt > now) {
+    return cached.value ?? defaultValue;
+  }
+  const value = await getRepository().get(key);
+  cache.set(key, { value, expiresAt: now + CACHE_TTL_MS });
+  return value ?? defaultValue;
+}
+
+export function invalidateFeatureFlagCache(key?: string): void {
+  if (key == null) {
+    cache.clear();
+    return;
+  }
+  cache.delete(key);
+}
+
+export function __setFeatureFlagDependencies(opts: {
+  repository?: IFeatureFlagsRepository | null;
+  clock?: () => number;
+}): void {
+  if (opts.repository !== undefined) repositoryOverride = opts.repository;
+  if (opts.clock != null) clock = opts.clock;
+}
+
+export function __resetFeatureFlagModuleForTests(): void {
+  cache.clear();
+  repositoryOverride = null;
+  clock = () => Date.now();
+}

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -6,10 +6,64 @@ jest.mock('../lib/integrations/stripe', () => ({
   getStripe: jest.fn(),
 }));
 
+const featureFlagStore: Array<{
+  key: string;
+  value: boolean;
+  description: string | null;
+  updated_at: Date | null;
+  updated_by: number | null;
+  email: string | null;
+}> = [];
+
 jest.mock('../data_layer', () => ({
   getDatabase: jest.fn(() => ({
     raw: jest.fn(),
   })),
+}));
+
+jest.mock('../data_layer/FeatureFlagsRepository', () => {
+  class FakeFeatureFlagsRepository {
+    async getAll() {
+      return featureFlagStore.map((row) => ({
+        key: row.key,
+        value: row.value,
+        description: row.description,
+        updated_at:
+          row.updated_at == null ? null : row.updated_at.toISOString(),
+        updated_by: row.updated_by,
+        updated_by_email: row.email,
+      }));
+    }
+    async get(key: string) {
+      const row = featureFlagStore.find((r) => r.key === key);
+      return row == null ? null : row.value;
+    }
+    async set(key: string, value: boolean, userId: number) {
+      const idx = featureFlagStore.findIndex((r) => r.key === key);
+      if (idx === -1) return null;
+      featureFlagStore[idx] = {
+        ...featureFlagStore[idx],
+        value,
+        updated_by: userId,
+        updated_at: new Date('2026-05-30T12:00:00Z'),
+      };
+      const row = featureFlagStore[idx];
+      return {
+        key: row.key,
+        value: row.value,
+        description: row.description,
+        updated_at:
+          row.updated_at == null ? null : row.updated_at.toISOString(),
+        updated_by: row.updated_by,
+        updated_by_email: row.email,
+      };
+    }
+  }
+  return { FeatureFlagsRepository: FakeFeatureFlagsRepository };
+});
+
+jest.mock('../services/events/track', () => ({
+  track: jest.fn(),
 }));
 
 jest.mock('./middleware/RequireOpsAccess', () => {
@@ -31,6 +85,8 @@ jest.mock('./middleware/RequireOpsAccess', () => {
         res.status(404).end();
         return;
       }
+      res.locals.owner = 1;
+      res.locals.email = 'alex@example.com';
       next();
     },
     makeRequireOpsAccess: jest.fn(),
@@ -107,6 +163,7 @@ const setOwnerAccess = (allow: boolean) => {
 const startServer = async (allowOps: boolean = false) => {
   setOwnerAccess(allowOps);
   const app = express();
+  app.use(express.json());
   app.use(OpsRouter());
   const server = http.createServer(app);
   await new Promise<void>((resolve) => server.listen(0, resolve));
@@ -213,6 +270,113 @@ describe('OpsRouter /api/ops/conversion/metrics', () => {
           failed_conversions_weekly: expect.any(Array),
         })
       );
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsRouter /api/ops/flags', () => {
+  beforeEach(() => {
+    featureFlagStore.length = 0;
+    featureFlagStore.push({
+      key: 'ai-converter-floor-v1',
+      value: false,
+      description: 'desc',
+      updated_at: new Date('2026-05-29T10:00:00Z'),
+      updated_by: 1,
+      email: 'alex@example.com',
+    });
+  });
+
+  it('GET returns 404 for non-owner callers', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const response = await fetch(`${url}/api/ops/flags`);
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('GET returns the seeded flag with updated_by_email but no updated_by id', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/flags`);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual([
+        {
+          key: 'ai-converter-floor-v1',
+          value: false,
+          description: 'desc',
+          updated_at: '2026-05-29T10:00:00.000Z',
+          updated_by_email: 'alex@example.com',
+        },
+      ]);
+    } finally {
+      await close();
+    }
+  });
+
+  it('PUT returns 404 for non-owner callers', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const response = await fetch(`${url}/api/ops/flags/ai-converter-floor-v1`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: true }),
+      });
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('PUT returns 400 when the body value is not a boolean', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/flags/ai-converter-floor-v1`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: 'yes' }),
+      });
+      expect(response.status).toBe(400);
+    } finally {
+      await close();
+    }
+  });
+
+  it('PUT returns 404 when the flag key does not exist', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/flags/missing-key`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: true }),
+      });
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('PUT updates the flag and returns the updated row', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/flags/ai-converter-floor-v1`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ value: true }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toMatchObject({
+        key: 'ai-converter-floor-v1',
+        value: true,
+        updated_by_email: 'alex@example.com',
+      });
+      expect(body).not.toHaveProperty('updated_by');
     } finally {
       await close();
     }

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -45,6 +45,9 @@ import { GetPricingAbFunnelUseCase } from '../usecases/ops/GetPricingAbFunnelUse
 import { PricingAbFunnelService } from '../services/ops/PricingAbFunnelService';
 import { updateStripeSubscriptions } from '../lib/storage/jobs/helpers/updateStripeSubscriptions';
 import EventsRepository from '../data_layer/EventsRepository';
+import { FeatureFlagsRepository } from '../data_layer/FeatureFlagsRepository';
+import { ListFeatureFlagsUseCase } from '../usecases/ops/ListFeatureFlagsUseCase';
+import { SetFeatureFlagUseCase } from '../usecases/ops/SetFeatureFlagUseCase';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -109,7 +112,9 @@ const OpsRouter = () => {
     new SyncStripeSubscriptionsUseCase(() => updateStripeSubscriptions()),
     new GetPricingAbFunnelUseCase(
       new PricingAbFunnelService({ eventsRepo: new EventsRepository(database) })
-    )
+    ),
+    new ListFeatureFlagsUseCase(new FeatureFlagsRepository(database)),
+    new SetFeatureFlagUseCase(new FeatureFlagsRepository(database))
   );
 
   /**
@@ -425,6 +430,64 @@ const OpsRouter = () => {
    */
   router.get('/api/ops/pricing-ab/funnel', RequireOpsAccess, (req, res) =>
     controller.getPricingAbFunnel(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/flags:
+   *   get:
+   *     summary: List runtime feature flags
+   *     description: |
+   *       Returns every flag in the feature_flags table along with the email of the
+   *       admin who last toggled it. Flags are pre-seeded via migration — the UI
+   *       only toggles existing flags, it does not create them. Returns 404 for
+   *       everyone except the ops owner.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: Array of feature flags
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/flags', RequireOpsAccess, (req, res) =>
+    controller.listFeatureFlags(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/flags/{key}:
+   *   put:
+   *     summary: Toggle a runtime feature flag
+   *     description: |
+   *       Updates value for the given flag key. 400 when the body value is not a
+   *       boolean. 404 when the key does not exist — new flags get added via
+   *       migration, not from the UI. Returns 404 for everyone except the ops
+   *       owner.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: path
+   *         name: key
+   *         required: true
+   *         schema: { type: string }
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [value]
+   *             properties:
+   *               value: { type: boolean }
+   *     responses:
+   *       200:
+   *         description: Updated flag row
+   *       400:
+   *         description: Bad request
+   *       404:
+   *         description: Not the ops owner, or flag key not found
+   */
+  router.put('/api/ops/flags/:key', RequireOpsAccess, (req, res) =>
+    controller.setFeatureFlag(req, res)
   );
 
   return router;

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -43,6 +43,7 @@ export const KNOWN_EVENTS = new Set([
   'cancel_during_generating',
   'pdf_print_options_used',
   'ai_conversion_completed',
+  'feature_flag_changed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/ops/ListFeatureFlagsUseCase.test.ts
+++ b/src/usecases/ops/ListFeatureFlagsUseCase.test.ts
@@ -1,0 +1,33 @@
+import type {
+  FeatureFlagWithEmail,
+  IFeatureFlagsRepository,
+} from '../../data_layer/FeatureFlagsRepository';
+import { ListFeatureFlagsUseCase } from './ListFeatureFlagsUseCase';
+
+describe('ListFeatureFlagsUseCase', () => {
+  it('returns the flags from the repository', async () => {
+    const rows: FeatureFlagWithEmail[] = [
+      {
+        key: 'ai-converter-floor-v1',
+        value: false,
+        description: 'desc',
+        updated_at: '2026-05-30T12:00:00.000Z',
+        updated_by: 1,
+        updated_by_email: 'alex@example.com',
+      },
+    ];
+    const repo: IFeatureFlagsRepository = {
+      async getAll() {
+        return rows;
+      },
+      async get() {
+        return null;
+      },
+      async set() {
+        return null;
+      },
+    };
+    const result = await new ListFeatureFlagsUseCase(repo).execute();
+    expect(result).toEqual(rows);
+  });
+});

--- a/src/usecases/ops/ListFeatureFlagsUseCase.ts
+++ b/src/usecases/ops/ListFeatureFlagsUseCase.ts
@@ -1,0 +1,12 @@
+import type {
+  FeatureFlagWithEmail,
+  IFeatureFlagsRepository,
+} from '../../data_layer/FeatureFlagsRepository';
+
+export class ListFeatureFlagsUseCase {
+  constructor(private readonly repository: IFeatureFlagsRepository) {}
+
+  async execute(): Promise<FeatureFlagWithEmail[]> {
+    return this.repository.getAll();
+  }
+}

--- a/src/usecases/ops/SetFeatureFlagUseCase.test.ts
+++ b/src/usecases/ops/SetFeatureFlagUseCase.test.ts
@@ -1,0 +1,76 @@
+import type {
+  FeatureFlagWithEmail,
+  IFeatureFlagsRepository,
+} from '../../data_layer/FeatureFlagsRepository';
+import {
+  FeatureFlagNotFoundError,
+  SetFeatureFlagUseCase,
+} from './SetFeatureFlagUseCase';
+
+jest.mock('../../services/events/track', () => ({
+  track: jest.fn(),
+}));
+
+const { track } = jest.requireMock('../../services/events/track') as {
+  track: jest.Mock;
+};
+
+const buildRepo = (
+  result: FeatureFlagWithEmail | null
+): IFeatureFlagsRepository & { setCalls: Array<unknown[]> } => {
+  const setCalls: Array<unknown[]> = [];
+  return {
+    setCalls,
+    async getAll() {
+      return result == null ? [] : [result];
+    },
+    async get() {
+      return result?.value ?? null;
+    },
+    async set(...args: unknown[]) {
+      setCalls.push(args);
+      return result;
+    },
+  } as IFeatureFlagsRepository & { setCalls: Array<unknown[]> };
+};
+
+describe('SetFeatureFlagUseCase', () => {
+  beforeEach(() => {
+    track.mockClear();
+  });
+
+  it('throws FeatureFlagNotFoundError when the key does not exist', async () => {
+    const repo = buildRepo(null);
+    const useCase = new SetFeatureFlagUseCase(repo);
+    await expect(
+      useCase.execute({ key: 'missing', value: true, userId: 1 })
+    ).rejects.toBeInstanceOf(FeatureFlagNotFoundError);
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('updates the flag, emits the analytics event, and returns the row', async () => {
+    const row: FeatureFlagWithEmail = {
+      key: 'ai-converter-floor-v1',
+      value: true,
+      description: 'desc',
+      updated_at: '2026-05-30T12:00:00.000Z',
+      updated_by: 42,
+      updated_by_email: 'admin@example.com',
+    };
+    const repo = buildRepo(row);
+    const useCase = new SetFeatureFlagUseCase(repo);
+
+    const result = await useCase.execute({
+      key: 'ai-converter-floor-v1',
+      value: true,
+      userId: 42,
+    });
+
+    expect(result).toEqual(row);
+    expect(repo.setCalls).toEqual([['ai-converter-floor-v1', true, 42]]);
+    expect(track).toHaveBeenCalledWith('feature_flag_changed', {
+      userId: 42,
+      props: { key: 'ai-converter-floor-v1', value: true },
+    });
+  });
+});

--- a/src/usecases/ops/SetFeatureFlagUseCase.ts
+++ b/src/usecases/ops/SetFeatureFlagUseCase.ts
@@ -1,0 +1,40 @@
+import type {
+  FeatureFlagWithEmail,
+  IFeatureFlagsRepository,
+} from '../../data_layer/FeatureFlagsRepository';
+import { invalidateFeatureFlagCache } from '../../lib/featureFlags/getFeatureFlag';
+import { track } from '../../services/events/track';
+
+export class FeatureFlagNotFoundError extends Error {
+  constructor(key: string) {
+    super(`Feature flag not found: ${key}`);
+    this.name = 'FeatureFlagNotFoundError';
+  }
+}
+
+export interface SetFeatureFlagInput {
+  key: string;
+  value: boolean;
+  userId: number;
+}
+
+export class SetFeatureFlagUseCase {
+  constructor(private readonly repository: IFeatureFlagsRepository) {}
+
+  async execute(input: SetFeatureFlagInput): Promise<FeatureFlagWithEmail> {
+    const updated = await this.repository.set(
+      input.key,
+      input.value,
+      input.userId
+    );
+    if (updated == null) {
+      throw new FeatureFlagNotFoundError(input.key);
+    }
+    invalidateFeatureFlagCache(input.key);
+    track('feature_flag_changed', {
+      userId: input.userId,
+      props: { key: input.key, value: input.value },
+    });
+    return updated;
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -82,6 +82,10 @@ const PreviewApkgPage = lazyWithRetry(
   () => import('./pages/PreviewApkgPage'),
   './pages/PreviewApkgPage'
 );
+const FlagsTab = lazyWithRetry(
+  () => import('./pages/OpsPage/FlagsTab'),
+  './pages/OpsPage/FlagsTab'
+);
 const AnkifyPage = lazyWithRetry(() => import('./pages/AnkifyPage'), './pages/AnkifyPage');
 const AnkifySetupPage = lazyWithRetry(
   () => import('./pages/AnkifyPage/AnkifySetupPage'),
@@ -421,6 +425,7 @@ function AppContent({
             <Route path="interviews" element={<InterviewsTab />} />
             <Route path="messages" element={<ContactMessagesTab />} />
             <Route path="commands" element={<CommandsTab />} />
+            <Route path="flags" element={<FlagsTab />} />
             <Route path="pricing-ab" element={<PricingAbFunnelTab />} />
           </Route>
           <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />

--- a/web/src/pages/OpsPage/FlagsTab.module.css
+++ b/web/src/pages/OpsPage/FlagsTab.module.css
@@ -1,0 +1,109 @@
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card {
+  padding: 1rem 1.25rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.keyLabel {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.description {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.footnote {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.toggle {
+  position: relative;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+  inset: 0;
+}
+
+.toggle input:disabled {
+  cursor: progress;
+}
+
+.toggleTrack {
+  display: block;
+  width: 2.5rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  position: relative;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.toggleTrack::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 50%;
+  background: var(--color-bg-primary);
+  box-shadow: var(--shadow-sm);
+  transition: transform 120ms ease;
+}
+
+.toggle input:checked + .toggleTrack {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.toggle input:checked + .toggleTrack::after {
+  transform: translateX(1.05rem);
+}
+
+.toggle input:focus-visible + .toggleTrack {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.retryButton {
+  margin-left: 0.5rem;
+}

--- a/web/src/pages/OpsPage/FlagsTab.test.tsx
+++ b/web/src/pages/OpsPage/FlagsTab.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import FlagsTab from './FlagsTab';
+
+const sampleFlag = {
+  key: 'ai-converter-floor-v1',
+  value: false,
+  description: 'AI converter floor canary',
+  updated_at: '2026-05-29T10:00:00.000Z',
+  updated_by_email: 'alex@example.com',
+};
+
+describe('FlagsTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('renders the flag key, description, and current value from the response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [sampleFlag],
+    });
+
+    render(<FlagsTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText('ai-converter-floor-v1')).toBeInTheDocument()
+    );
+    expect(screen.getByText('AI converter floor canary')).toBeInTheDocument();
+    expect(
+      screen.getByRole('switch', { name: 'Toggle ai-converter-floor-v1' })
+    ).not.toBeChecked();
+  });
+
+  test('toggling the switch fires a PUT and reflects the new value', async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [sampleFlag],
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ ...sampleFlag, value: true }),
+    });
+
+    render(<FlagsTab />);
+
+    const toggle = await screen.findByRole('switch', {
+      name: 'Toggle ai-converter-floor-v1',
+    });
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('switch', { name: 'Toggle ai-converter-floor-v1' })
+      ).toBeChecked()
+    );
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/api/ops/flags/ai-converter-floor-v1',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ value: true }),
+      })
+    );
+  });
+
+  test('rolls back the toggle and surfaces the error when the PUT fails', async () => {
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => [sampleFlag],
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({ message: 'Update failed: server' }),
+    });
+
+    render(<FlagsTab />);
+
+    const toggle = await screen.findByRole('switch', {
+      name: 'Toggle ai-converter-floor-v1',
+    });
+    fireEvent.click(toggle);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Update failed: server/i)).toBeInTheDocument()
+    );
+
+    expect(
+      screen.getByRole('switch', { name: 'Toggle ai-converter-floor-v1' })
+    ).not.toBeChecked();
+  });
+
+  test('renders an error banner when the initial load fails', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    render(<FlagsTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/\/api\/ops\/flags failed/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/web/src/pages/OpsPage/FlagsTab.tsx
+++ b/web/src/pages/OpsPage/FlagsTab.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import flagsStyles from './FlagsTab.module.css';
+
+interface FeatureFlag {
+  key: string;
+  value: boolean;
+  description: string | null;
+  updated_at: string | null;
+  updated_by_email: string | null;
+}
+
+type LoadState = 'idle' | 'loading' | 'error';
+
+const formatRelative = (iso: string | null): string => {
+  if (iso == null) return 'never';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return 'never';
+  const diffSeconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (diffSeconds < 60) return 'a moment ago';
+  const diffMinutes = Math.round(diffSeconds / 60);
+  if (diffMinutes < 60)
+    return `${diffMinutes} minute${diffMinutes === 1 ? '' : 's'} ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  if (diffHours < 24)
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  const diffDays = Math.round(diffHours / 24);
+  if (diffDays < 30)
+    return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+};
+
+const loadFlags = async (): Promise<FeatureFlag[]> => {
+  const response = await fetch('/api/ops/flags', { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`/api/ops/flags failed: ${response.status}`);
+  }
+  return response.json();
+};
+
+const updateFlag = async (
+  key: string,
+  value: boolean
+): Promise<FeatureFlag> => {
+  const response = await fetch(`/api/ops/flags/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value }),
+  });
+  if (!response.ok) {
+    const data = (await response.json().catch(() => ({}))) as {
+      message?: string;
+    };
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+};
+
+export default function FlagsTab() {
+  const [flags, setFlags] = useState<FeatureFlag[]>([]);
+  const [state, setState] = useState<LoadState>('loading');
+  const [error, setError] = useState<string | null>(null);
+  const [pendingKey, setPendingKey] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setState('loading');
+    setError(null);
+    try {
+      const data = await loadFlags();
+      setFlags(data);
+      setState('idle');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const toggle = async (flag: FeatureFlag) => {
+    const previous = flags;
+    const nextValue = !flag.value;
+    setFlags((current) =>
+      current.map((f) => (f.key === flag.key ? { ...f, value: nextValue } : f))
+    );
+    setPendingKey(flag.key);
+    setError(null);
+    try {
+      const updated = await updateFlag(flag.key, nextValue);
+      setFlags((current) =>
+        current.map((f) => (f.key === flag.key ? updated : f))
+      );
+    } catch (err) {
+      setFlags(previous);
+      setError(err instanceof Error ? err.message : 'Update failed');
+    } finally {
+      setPendingKey(null);
+    }
+  };
+
+  return (
+    <>
+      <p className={styles.panelTitle}>Flags</p>
+      <p className={styles.panelSubtitle}>
+        Runtime feature flags. Toggling is logged and takes effect within 5
+        seconds across the server. New flags get added via migration — this
+        page only flips existing flags.
+      </p>
+
+      {state === 'error' && error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {error}
+          <button
+            type="button"
+            className={`${sharedStyles.btnSmall} ${flagsStyles.retryButton}`}
+            onClick={() => {
+              void refresh();
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {state === 'idle' && error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {error}
+        </div>
+      )}
+
+      {state === 'loading' && flags.length === 0 && (
+        <p className={styles.emptyHint}>Loading flags.</p>
+      )}
+
+      {flags.length > 0 && (
+        <ul className={flagsStyles.list}>
+          {flags.map((flag) => {
+            const isPending = pendingKey === flag.key;
+            const inputId = `flag-${flag.key}`;
+            return (
+              <li
+                key={flag.key}
+                className={`${sharedStyles.surface} ${flagsStyles.card}`}
+              >
+                <div className={flagsStyles.row}>
+                  <div className={flagsStyles.meta}>
+                    <label
+                      htmlFor={inputId}
+                      className={flagsStyles.keyLabel}
+                    >
+                      {flag.key}
+                    </label>
+                    {flag.description != null && flag.description !== '' && (
+                      <p className={flagsStyles.description}>
+                        {flag.description}
+                      </p>
+                    )}
+                    <p className={flagsStyles.footnote}>
+                      {flag.value ? 'On' : 'Off'} · updated{' '}
+                      {formatRelative(flag.updated_at)}
+                      {flag.updated_by_email == null
+                        ? ''
+                        : ` by ${flag.updated_by_email}`}
+                    </p>
+                  </div>
+                  <label className={flagsStyles.toggle}>
+                    <input
+                      id={inputId}
+                      type="checkbox"
+                      role="switch"
+                      checked={flag.value}
+                      disabled={isPending}
+                      onChange={() => {
+                        void toggle(flag);
+                      }}
+                      aria-label={`Toggle ${flag.key}`}
+                    />
+                    <span className={flagsStyles.toggleTrack} aria-hidden />
+                  </label>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/OpsLayout.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.tsx
@@ -53,6 +53,11 @@ const TABS = [
     match: (path: string) => path.startsWith('/ops/commands'),
   },
   {
+    to: '/ops/flags',
+    label: 'Flags',
+    match: (path: string) => path.startsWith('/ops/flags'),
+  },
+  {
     to: '/ops/pricing-ab',
     label: 'Pricing A/B',
     match: (path: string) => path.startsWith('/ops/pricing-ab'),


### PR DESCRIPTION
## What

Adds a DB-backed `feature_flags` table, a cached runtime helper, and a Flags tab under `/ops/flags`. Replaces the env-var-then-restart pattern for runtime gating. Re-opens the work from the closed PR #2911 — the original was closed when its immediate dependency (#2908's AI converter canary) shipped without it, but the infrastructure is still useful for the next runtime toggle.

## Why

Today, flipping a runtime flag (`STRIPE_SYNC_ON_STARTUP`, future canary gates, etc.) requires SSH + `.env` edit + pm2 cycle. Awkward for canary rollouts and incident response. A DB-backed flag with an admin toggle in `/ops` removes the bottleneck.

## How

- Migration `20260806000000_add_feature_flags.js` creates the table with `key` (PK), `value`, `description`, `updated_at`, `updated_by → users.id ON DELETE SET NULL`. Pre-seeds the `ai-converter-floor-v1` row so a future canary has something to gate against on day one.
- `FeatureFlagsRepository` exposes `getAll()`, `get(key)`, and `set(key, value, userId)` — the join with `users` resolves the email so the UI can show "updated by <email>" without leaking the raw id.
- `getFeatureFlag(key, defaultValue)` in `src/lib/featureFlags/` reads through a 5-second in-process cache. `invalidateFeatureFlagCache(key)` fires after every write so the freshly-flipped value propagates within the same request.
- Two use cases — `ListFeatureFlagsUseCase` (read) and `SetFeatureFlagUseCase` (write + invalidate cache + emit `feature_flag_changed`).
- Two endpoints under `OpsRouter`, both gated by `RequireOpsAccess`:
  - `GET /api/ops/flags` — shape: `[{ key, value, description, updated_at, updated_by_email }]`.
  - `PUT /api/ops/flags/:key` — body `{ value: boolean }`. 400 on bad body, 404 when the key doesn't exist (no UI-driven flag creation by design — new flags ship via migration to keep the audit trail clean).
- Web: a new Flags tab in OpsLayout with optimistic toggles + rollback on error. Lazy-loaded from `App.tsx` via `lazyWithRetry` to match every other Ops tab.

## Rebase notes

Rebased on current `main` (post #2916, #2917, #2919, #2922, #2923, #2925). Two conflicts resolved:
- `src/types/AnalyticsEvents.ts` — kept both `ai_conversion_completed` and `feature_flag_changed`.
- `web/src/App.tsx` — kept `PreviewApkgPage`, added `FlagsTab` via `lazyWithRetry` (main's `CommandsTab` and `PricingAbFunnelTab` declarations already use this pattern, so the feat branch's older `lazy(...)` versions of them were dropped).

## Testing

- `FeatureFlagsRepository.test.ts` — SQL-shape assertions (PG dialect) for `getAll`, `get`, `set`.
- `getFeatureFlag.test.ts` — cached read, TTL expiry, missing-key fallback, invalidation, default-on-known-missing.
- `ListFeatureFlagsUseCase.test.ts`, `SetFeatureFlagUseCase.test.ts` — use-case behaviour + `feature_flag_changed` event emission + `FeatureFlagNotFoundError` path.
- `OpsRouter.test.ts` — added 7 integration tests covering 404-non-owner, GET shape, PUT 400/404/200.
- `FlagsTab.test.tsx` — initial load, toggle PUT, rollback on error, initial-load error banner.
- Server `tsc --noEmit` clean post-rebase; web `tsc --noEmit` clean post-rebase.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: rebased from a closed PR; please open `/ops/flags` in `pnpm dev` and confirm the toggle round-trips before flipping ready.

## Changelog
No changelog entry — internal admin infrastructure, no user-visible behavior change.

## Risks
- New table goes live on next deploy. Migration is additive (CREATE TABLE + one INSERT); no production rows to backfill. Rollback is `DROP TABLE` if it ever lands wrong.
- The 5-second cache means a flipped flag takes up to 5s to propagate across all server processes. Acceptable for v1; tighten only if a real rollout demands it.
- `pnpm kanel` will need to run after merge to add `src/data_layer/public/FeatureFlags.ts` (the repository hand-rolls its own type so the PR compiles before kanel runs).
- `sonar-scanner` not run locally (no `SONAR_TOKEN` configured) — expect a Sonar bounce if the rule engine flags anything in the new component.

## Goal alignment
Internal infrastructure — enables faster, less risky rollouts of future flag-gated growth experiments. Indirect path to 300K users: fewer restart-bound flag flips = faster iteration on conversion-funnel work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782764660&installation_id=132681956&pr_number=2927&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2927&signature=a2526665802eba4e6d041b5241350eaa409fcdaf7d4b4e9f9fb4a7c55d1cd3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->