### PR TITLE
fix: link the photo-to-deck MCQ upgrade hint to pricing

### DIFF
--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.module.css
@@ -185,6 +185,18 @@
   line-height: var(--leading-normal);
 }
 
+.densityHintLink {
+  font-size: inherit;
+  font-weight: var(--font-medium);
+  color: var(--color-text-link);
+  text-decoration: none;
+}
+
+.densityHintLink:hover {
+  color: var(--color-text-link-hover);
+  text-decoration: underline;
+}
+
 .cameraButtonContainer {
   display: flex;
   flex-direction: column;

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { PhotoToFlashcardsPage } from './PhotoToFlashcardsPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PhotoToFlashcardsPage />
+    </MemoryRouter>
+  );
+}
 
 const mockTrack = vi.fn();
 vi.mock('../../lib/analytics/track', () => ({
@@ -91,7 +100,7 @@ describe('PhotoToFlashcardsPage', () => {
   });
 
   it('renders the title and audience hint', () => {
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     expect(screen.getByText('Photo to deck')).toBeTruthy();
     expect(screen.getByText(/Turn a photo of your notes, slides, or textbook/)).toBeTruthy();
     expect(screen.getByText(/Free plan: 5 photos per month/)).toBeTruthy();
@@ -99,13 +108,30 @@ describe('PhotoToFlashcardsPage', () => {
 
   it('omits the free-plan notice for paying users', () => {
     setLocals({ paying: true });
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     expect(screen.queryByText(/Free plan: 5 photos per month/)).toBeNull();
+  });
+
+  it('links the multiple-choice upgrade hint to pricing for free users', () => {
+    setLocals({ paying: false });
+    renderPage();
+    const upgrade = screen.getByRole('link', { name: 'Upgrade' });
+    expect(upgrade.getAttribute('href')).toBe('/pricing?from=photo-mcq');
+    expect(screen.getByText(/for multiple-choice cards/)).toBeTruthy();
+  });
+
+  it('describes multiple-choice cards without an upgrade link for paying users', () => {
+    setLocals({ paying: true });
+    renderPage();
+    expect(screen.queryByRole('link', { name: 'Upgrade' })).toBeNull();
+    expect(
+      screen.getByText(/the AI writes options A–D/)
+    ).toBeTruthy();
   });
 
   it('rejects unsupported file types', () => {
     setLocals({ paying: true });
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
     fireEvent.change(input, { target: { files: [pdf] } });
@@ -114,7 +140,7 @@ describe('PhotoToFlashcardsPage', () => {
 
   it('rejects photos over 10 MB', () => {
     setLocals({ paying: true });
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     const oversized = makePhoto('big.jpg', 'image/jpeg', 11 * 1024 * 1024);
     fireEvent.change(input, { target: { files: [oversized] } });
@@ -126,7 +152,7 @@ describe('PhotoToFlashcardsPage', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto()] } });
     fireEvent.click(screen.getByText('Get cards'));
@@ -141,7 +167,7 @@ describe('PhotoToFlashcardsPage', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto()] } });
     fireEvent.click(screen.getByText('Get cards'));
@@ -163,7 +189,7 @@ describe('PhotoToFlashcardsPage', () => {
       );
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto()] } });
     fireEvent.click(screen.getByText('Get cards'));
@@ -180,7 +206,7 @@ describe('PhotoToFlashcardsPage', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 413 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto()] } });
     fireEvent.click(screen.getByText('Get cards'));
@@ -203,7 +229,7 @@ describe('PhotoToFlashcardsPage', () => {
     const clickSpy = vi.fn();
     HTMLAnchorElement.prototype.click = clickSpy;
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto('biology.jpg')] } });
     fireEvent.click(screen.getByText('Get cards'));
@@ -215,7 +241,7 @@ describe('PhotoToFlashcardsPage', () => {
   });
 
   it('renders the "Take a photo" button', () => {
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     expect(screen.getByRole('button', { name: 'Take a photo' })).toBeTruthy();
   });
 
@@ -224,7 +250,7 @@ describe('PhotoToFlashcardsPage', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto()] } });
     fireEvent.click(screen.getByRole('button', { name: 'Get cards' }));
@@ -239,7 +265,7 @@ describe('PhotoToFlashcardsPage', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const cameraInput = document.getElementById('photo-camera-input') as HTMLInputElement;
     fireEvent.change(cameraInput, { target: { files: [makePhoto()] } });
     fireEvent.click(screen.getByRole('button', { name: 'Get cards' }));
@@ -250,7 +276,7 @@ describe('PhotoToFlashcardsPage', () => {
   });
 
   it('renders the card-count input with 10 as the default', () => {
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = screen.getByLabelText('How many cards?') as HTMLInputElement;
     expect(input.type).toBe('number');
     expect(input.value).toBe('10');
@@ -266,7 +292,7 @@ describe('PhotoToFlashcardsPage', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     fireEvent.change(screen.getByLabelText('How many cards?'), { target: { value: '16' } });
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto()] } });
@@ -284,7 +310,7 @@ describe('PhotoToFlashcardsPage', () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     fireEvent.change(screen.getByLabelText('How many cards?'), { target: { value: '3' } });
     const photoInput = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(photoInput, { target: { files: [makePhoto()] } });
@@ -296,19 +322,19 @@ describe('PhotoToFlashcardsPage', () => {
   });
 
   it('persists the chosen card count to localStorage', () => {
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     fireEvent.change(screen.getByLabelText('How many cards?'), { target: { value: '4' } });
     expect(window.localStorage.getItem('photoToFlashcards.cardCount')).toBe('4');
   });
 
   it('restores the previously chosen card count from localStorage', () => {
     window.localStorage.setItem('photoToFlashcards.cardCount', '17');
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     expect((screen.getByLabelText('How many cards?') as HTMLInputElement).value).toBe('17');
   });
 
   it('clamps card count to the 1..20 range', () => {
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = screen.getByLabelText('How many cards?') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '99' } });
     expect(input.value).toBe('20');
@@ -328,7 +354,7 @@ describe('PhotoToFlashcardsPage', () => {
       );
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<PhotoToFlashcardsPage />);
+    renderPage();
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makePhoto()] } });
     fireEvent.click(screen.getByText('Get cards'));
@@ -343,7 +369,7 @@ describe('PhotoToFlashcardsPage', () => {
 
   describe('mode toggle', () => {
     it('renders the mode radiogroup with Generate selected by default', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const group = screen.getByRole('radiogroup', { name: 'Conversion mode' });
       expect(group).toBeTruthy();
       expect(
@@ -355,7 +381,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('selecting Copy existing questions unchecks Generate cards', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       fireEvent.click(screen.getByRole('radio', { name: 'Copy existing questions' }));
       expect(
         screen.getByRole('radio', { name: 'Generate cards' })
@@ -366,13 +392,13 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('hides the card-count control when verbatim is selected', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       fireEvent.click(screen.getByRole('radio', { name: 'Copy existing questions' }));
       expect(screen.queryByLabelText('How many cards?')).toBeNull();
     });
 
     it('shows the card-count control when generative is selected', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       expect(screen.getByLabelText('How many cards?')).toBeTruthy();
     });
 
@@ -381,7 +407,7 @@ describe('PhotoToFlashcardsPage', () => {
       const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
       vi.stubGlobal('fetch', fetchMock);
 
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       fireEvent.click(screen.getByRole('radio', { name: 'Copy existing questions' }));
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto()] } });
@@ -397,7 +423,7 @@ describe('PhotoToFlashcardsPage', () => {
       const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
       vi.stubGlobal('fetch', fetchMock);
 
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto()] } });
       fireEvent.click(screen.getByRole('button', { name: 'Get cards' }));
@@ -408,7 +434,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('shows both mode helpers regardless of selection', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       expect(screen.getByText(/AI writes the questions/)).toBeTruthy();
       expect(screen.getByText(/Cards are copied exactly as written/)).toBeTruthy();
     });
@@ -424,7 +450,7 @@ describe('PhotoToFlashcardsPage', () => {
       vi.stubGlobal('fetch', fetchMock);
       HTMLAnchorElement.prototype.click = vi.fn();
 
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       fireEvent.click(screen.getByRole('radio', { name: 'Copy existing questions' }));
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto()] } });
@@ -447,7 +473,7 @@ describe('PhotoToFlashcardsPage', () => {
       vi.stubGlobal('fetch', fetchMock);
       HTMLAnchorElement.prototype.click = vi.fn();
 
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       fireEvent.click(screen.getByRole('radio', { name: 'Copy existing questions' }));
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto()] } });
@@ -468,13 +494,13 @@ describe('PhotoToFlashcardsPage', () => {
 
   describe('section cards layout', () => {
     it('renders four section cards in generative mode', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const cards = document.querySelectorAll('[data-section-card]');
       expect(cards).toHaveLength(4);
     });
 
     it('renders three section cards in verbatim mode', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       fireEvent.click(screen.getByRole('radio', { name: 'Copy existing questions' }));
       const cards = document.querySelectorAll('[data-section-card]');
       expect(cards).toHaveLength(3);
@@ -483,7 +509,7 @@ describe('PhotoToFlashcardsPage', () => {
 
   describe('source image toggle', () => {
     it('renders the source image toggle on by default', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const toggle = screen.getByRole('switch', {
         name: /Show source image on the back of each card/,
       }) as HTMLInputElement;
@@ -495,7 +521,7 @@ describe('PhotoToFlashcardsPage', () => {
       const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
       vi.stubGlobal('fetch', fetchMock);
 
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto()] } });
       fireEvent.click(screen.getByRole('button', { name: 'Get cards' }));
@@ -512,7 +538,7 @@ describe('PhotoToFlashcardsPage', () => {
       const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
       vi.stubGlobal('fetch', fetchMock);
 
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const checkbox = screen.getByRole('switch', {
         name: /Show source image on the back of each card/,
       });
@@ -538,7 +564,7 @@ describe('PhotoToFlashcardsPage', () => {
     }
 
     it('appends a second picker selection instead of replacing the first', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto('first.jpg')] } });
       fireEvent.change(input, { target: { files: [makePhoto('second.jpg')] } });
@@ -548,7 +574,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('accepts multiple photos in a single picker invocation', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, {
         target: { files: [makePhoto('a.jpg'), makePhoto('b.jpg'), makePhoto('c.jpg')] },
@@ -557,7 +583,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('appends drag-and-drop additions to the existing set', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto('one.jpg')] } });
 
@@ -569,7 +595,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('appends clipboard-pasted images to the existing set', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto('one.jpg')] } });
 
@@ -582,7 +608,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('removes the targeted photo when its × button is clicked and leaves the rest', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, {
         target: { files: [makePhoto('keep1.jpg'), makePhoto('drop.jpg'), makePhoto('keep2.jpg')] },
@@ -595,7 +621,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('returns to the empty state after removing the last thumbnail', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto('only.jpg')] } });
       expect(getThumbnails()).toHaveLength(1);
@@ -605,7 +631,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('keeps duplicate filenames in the same batch (one is allowed)', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, {
         target: { files: [makePhoto('same.jpg'), makePhoto('same.jpg')] },
@@ -614,7 +640,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('the Convert CTA reflects the photo count after each addition', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, { target: { files: [makePhoto('a.jpg')] } });
       expect(screen.getByRole('button', { name: 'Get cards' })).toBeTruthy();
@@ -625,7 +651,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('rejects an invalid file in a mixed batch but keeps the valid ones', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
       fireEvent.change(input, { target: { files: [makePhoto('ok.jpg'), pdf] } });
@@ -634,7 +660,7 @@ describe('PhotoToFlashcardsPage', () => {
     });
 
     it('exposes a multiple-file input so picker allows in-batch multi-select', () => {
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       expect(input.multiple).toBe(true);
     });
@@ -653,7 +679,7 @@ describe('PhotoToFlashcardsPage', () => {
       vi.stubGlobal('fetch', fetchMock);
       HTMLAnchorElement.prototype.click = vi.fn();
 
-      render(<PhotoToFlashcardsPage />);
+      renderPage();
       const input = document.getElementById('photo-file-input') as HTMLInputElement;
       fireEvent.change(input, {
         target: { files: [makePhoto('a.jpg'), makePhoto('b.jpg')] },

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabel';
@@ -546,9 +547,20 @@ export function PhotoToFlashcardsPage() {
           Include multiple-choice questions
         </label>
         <p className={pageStyles.densityHint}>
-          {isPaying
-            ? 'When the source looks like a quiz, the AI writes options A–D.'
-            : 'Upgrade for multiple-choice cards.'}
+          {isPaying ? (
+            'When the source looks like a quiz, the AI writes options A–D.'
+          ) : (
+            <>
+              <Link
+                to="/pricing?from=photo-mcq"
+                className={pageStyles.densityHintLink}
+              >
+                Upgrade
+              </Link>{' '}
+              for multiple-choice cards — A–D options when the source looks like
+              a quiz.
+            </>
+          )}
         </p>
       </div>
 


### PR DESCRIPTION
## What

On the Photo to deck page, free users saw **"Upgrade for multiple-choice cards."** as plain text below the disabled multiple-choice toggle. Every other upgrade prompt in the app links to `/pricing` (Sidebar, Import, Image Occlusion) — this one was a dead end with no click target.

This wires the word **"Upgrade"** to `/pricing?from=photo-mcq` and enriches the free-tier copy to describe the feature, matching the paid string's specificity:

- Free: _**Upgrade** for multiple-choice cards — A–D options when the source looks like a quiz._
- Paid (unchanged): _When the source looks like a quiz, the AI writes options A–D._

The link is styled to inherit the hint's size and use the link token, so it reads as a link without shouting inside the tertiary helper text.

## Why `?from=photo-mcq`

Distinct attribution from the Sidebar's `?from=limit` (the usage-limit nudge) so paid conversions from this specific paywall are separable.

## Trio

pm + designer + engineer reviewed before code. Both agreed: link only "Upgrade", use `?from=photo-mcq`. Designer added the copy enrichment + hint-scoped link styling.

## Tests

Two new cases in `PhotoToFlashcardsPage.test.tsx`: free users get an `Upgrade` link pointing at `/pricing?from=photo-mcq`; paying users get the descriptive text with no link. Adding `<Link>` required wrapping the page renders in `MemoryRouter` (new `renderPage` helper). 46/46 pass.

No changelog entry — this wires an existing string to the established upgrade pattern; the user-facing surface is a paywall hint, not a new capability.

Sonar not run locally (no `SONAR_TOKEN` configured); change is a small JSX/CSS CTA wiring with no new complexity or security sink — flagging in case of a Sonar bounce.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Boxes left unticked — needs a local browser verify (free account: confirm "Upgrade" navigates to /pricing?from=photo-mcq; paid account: confirm descriptive text, no link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782765856&installation_id=132681956&pr_number=2928&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2928&signature=c8e0890cbe5deeaf4357147ed58d5c5f7d9964402a3651dd411d2a06623a49ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->