### PR TITLE
feat: Stripe-style sidebar — usage-ranked links, section labels, collapse rail

### DIFF
--- a/src/KnexConfig.test.ts
+++ b/src/KnexConfig.test.ts
@@ -1,0 +1,35 @@
+type MigrationsConfig = { disableMigrationsListValidation?: boolean };
+
+function loadConfigWith(localDev: string | undefined) {
+  jest.resetModules();
+  const original = process.env.LOCAL_DEV;
+  if (localDev === undefined) {
+    delete process.env.LOCAL_DEV;
+  } else {
+    process.env.LOCAL_DEV = localDev;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const config = require('./KnexConfig').default;
+  if (original === undefined) {
+    delete process.env.LOCAL_DEV;
+  } else {
+    process.env.LOCAL_DEV = original;
+  }
+  return config.migrations as MigrationsConfig;
+}
+
+describe('KnexConfig migrations validation', () => {
+  it('disables migration-list validation in local dev', () => {
+    expect(loadConfigWith('true').disableMigrationsListValidation).toBe(true);
+  });
+
+  it('keeps strict validation when LOCAL_DEV is unset (prod/CI)', () => {
+    expect(loadConfigWith(undefined).disableMigrationsListValidation).toBe(
+      false
+    );
+  });
+
+  it('keeps strict validation when LOCAL_DEV is not exactly "true"', () => {
+    expect(loadConfigWith('false').disableMigrationsListValidation).toBe(false);
+  });
+});

--- a/src/KnexConfig.ts
+++ b/src/KnexConfig.ts
@@ -11,6 +11,11 @@ const KnexConfig: Knex.Config = {
   migrations: {
     tableName: 'knex_migrations',
     directory: process.env.MIGRATIONS_DIR || 'migrations',
+    // Local dev DBs accumulate knex_migrations rows for files that were later
+    // renamed on main, which makes migrate.latest() crash the boot with
+    // "migration directory is corrupt". Skip that check in local dev only;
+    // prod and CI keep strict validation.
+    disableMigrationsListValidation: process.env.LOCAL_DEV === 'true',
   },
 };
 

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -130,14 +130,15 @@
   top: 50%;
   transform: translateY(-50%);
   white-space: nowrap;
-  padding: 2px 8px;
-  border: 1px solid var(--color-border);
+  padding: 4px 10px;
   border-radius: var(--radius-sm);
-  background: var(--color-bg-secondary);
-  box-shadow: var(--shadow-sm);
+  /* Tooltip is intentionally theme-independent, like Stripe's: always a
+     dark slate pill so the label reads on light and dark backgrounds. */
+  background: #1f2937;
+  box-shadow: var(--shadow-md);
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
-  color: var(--color-text-primary);
+  color: #f9fafb;
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--transition-fast);

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -182,7 +182,9 @@
 
   .sidebar.sidebarCollapsed .sidebarTheme {
     display: flex;
-    justify-content: center;
+    align-items: center;
+    padding-left: 0;
+    padding-right: 0;
   }
 
   .sidebar.sidebarCollapsed .sidebarGroupLabel {

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -46,24 +46,85 @@
   padding: 0;
 }
 
-.sidebarCollapseToggle {
+.sidebarGroupLabel {
+  margin: 0 0 var(--space-1);
+  padding: 0 0.75rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.collapseRail {
+  position: fixed;
+  top: 50%;
+  left: 228px;
+  transform: translateY(-50%);
+  z-index: 45;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: var(--radius-sm);
+  width: 24px;
+  height: 48px;
+  margin: 0;
+  padding: 0;
   border: none;
   background: none;
-  color: var(--color-text-tertiary);
   cursor: pointer;
-  flex-shrink: 0;
-  padding: 0;
+  -webkit-tap-highlight-color: transparent;
 }
 
-.sidebarCollapseToggle:hover {
+.collapseRailIndicator {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2px;
+  height: 32px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: var(--color-border);
+  color: var(--color-text-tertiary);
+  opacity: 0.6;
+  transition:
+    width var(--transition-fast),
+    height var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    opacity var(--transition-fast);
+}
+
+.collapseRailIndicator svg {
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.collapseRail:hover .collapseRailIndicator,
+.collapseRail:focus-visible .collapseRailIndicator {
+  width: 24px;
+  height: 24px;
+  border-color: var(--color-border);
+  background: var(--color-bg-secondary);
+  box-shadow: var(--shadow-sm);
   color: var(--color-text-primary);
-  background: var(--color-bg-tertiary);
+  opacity: 1;
+}
+
+.collapseRail:hover .collapseRailIndicator svg,
+.collapseRail:focus-visible .collapseRailIndicator svg {
+  opacity: 1;
+}
+
+.collapseRail:focus-visible {
+  outline: 2px solid var(--color-text-primary);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.collapseRail:focus:not(:focus-visible) {
+  outline: none;
 }
 
 @media (min-width: 1024px) {
@@ -101,6 +162,14 @@
     display: flex;
     justify-content: center;
   }
+
+  .sidebar.sidebarCollapsed .sidebarGroupLabel {
+    display: none;
+  }
+
+  .sidebar.sidebarCollapsed .collapseRail {
+    left: 52px;
+  }
 }
 
 @media (max-width: 1023px) {
@@ -108,7 +177,7 @@
     width: 240px;
   }
 
-  .sidebarCollapseToggle {
+  .collapseRail {
     display: none;
   }
 }

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -132,13 +132,11 @@
   white-space: nowrap;
   padding: 4px 10px;
   border-radius: var(--radius-sm);
-  /* Tooltip is intentionally theme-independent, like Stripe's: always a
-     dark slate pill so the label reads on light and dark backgrounds. */
-  background: #1f2937;
+  background: var(--color-text-primary);
   box-shadow: var(--shadow-md);
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
-  color: #f9fafb;
+  color: var(--color-bg-primary);
   opacity: 0;
   pointer-events: none;
   transition: opacity var(--transition-fast);

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -104,12 +104,12 @@
   align-items: center;
   justify-content: center;
   width: 2px;
-  height: 32px;
+  height: 20px;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  background: var(--color-border);
+  background: var(--color-text-tertiary);
   color: var(--color-text-tertiary);
-  opacity: 0.6;
+  opacity: 1;
   transition:
     width var(--transition-fast),
     height var(--transition-fast),
@@ -122,6 +122,30 @@
 .collapseRailIndicator svg {
   opacity: 0;
   transition: opacity var(--transition-fast);
+}
+
+.collapseRailLabel {
+  position: absolute;
+  left: calc(50% + 20px);
+  top: 50%;
+  transform: translateY(-50%);
+  white-space: nowrap;
+  padding: 2px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-secondary);
+  box-shadow: var(--shadow-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast);
+}
+
+.collapseRail:hover .collapseRailLabel,
+.collapseRail:focus-visible .collapseRailLabel {
+  opacity: 1;
 }
 
 .collapseRail:hover .collapseRailIndicator,

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -27,6 +27,29 @@
   background: var(--color-bg-secondary);
   padding: 1.25rem 0.75rem;
   transition: width var(--transition-fast);
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.sidebar:hover {
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.sidebar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.sidebar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sidebar::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 4px;
+}
+
+.sidebar:hover::-webkit-scrollbar-thumb {
+  background: var(--color-border);
 }
 
 .sidebarRowLabel {

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -82,91 +82,67 @@
 .collapseRail {
   position: fixed;
   top: 50%;
-  left: 228px;
+  left: 232px;
   transform: translateY(-50%);
   z-index: 45;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 48px;
+  gap: 6px;
+  height: 30px;
   margin: 0;
-  padding: 0;
+  padding: 0 8px;
   border: none;
-  background: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-tertiary);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
-.collapseRailIndicator {
-  box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.collapseRailCollapsed {
+  left: 56px;
+}
+
+.collapseRailLine {
   width: 3px;
   height: 24px;
-  border: 1px solid transparent;
   border-radius: 999px;
-  background: var(--color-text-tertiary);
-  color: var(--color-text-tertiary);
-  opacity: 1;
-  transition:
-    width var(--transition-fast),
-    height var(--transition-fast),
-    background-color var(--transition-fast),
-    border-color var(--transition-fast),
-    box-shadow var(--transition-fast),
-    opacity var(--transition-fast);
+  background: currentColor;
 }
 
-.collapseRailIndicator svg {
-  opacity: 0;
-  transition: opacity var(--transition-fast);
-}
-
-.collapseRailLabel {
-  position: absolute;
-  left: calc(50% + 20px);
-  top: 50%;
-  transform: translateY(-50%);
+.collapseRailContent {
+  display: none;
+  align-items: center;
+  gap: 6px;
   white-space: nowrap;
-  padding: 4px 10px;
-  border-radius: var(--radius-sm);
-  background: var(--color-text-primary);
-  box-shadow: var(--shadow-md);
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
+}
+
+.collapseRail:hover,
+.collapseRail:focus-visible {
+  background: var(--color-text-primary);
   color: var(--color-bg-primary);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity var(--transition-fast);
+  box-shadow: var(--shadow-md);
 }
 
-.collapseRail:hover .collapseRailLabel,
-.collapseRail:focus-visible .collapseRailLabel {
-  opacity: 1;
+.collapseRail:hover .collapseRailLine,
+.collapseRail:focus-visible .collapseRailLine {
+  display: none;
 }
 
-.collapseRail:hover .collapseRailIndicator,
-.collapseRail:focus-visible .collapseRailIndicator {
-  width: 24px;
-  height: 24px;
-  border-color: var(--color-border);
-  background: var(--color-bg-secondary);
-  box-shadow: var(--shadow-sm);
-  color: var(--color-text-primary);
-  opacity: 1;
-}
-
-.collapseRail:hover .collapseRailIndicator svg,
-.collapseRail:focus-visible .collapseRailIndicator svg {
-  opacity: 1;
+.collapseRail:hover .collapseRailContent,
+.collapseRail:focus-visible .collapseRailContent {
+  display: inline-flex;
 }
 
 .collapseRail:focus-visible {
   outline: 2px solid var(--color-text-primary);
   outline-offset: 2px;
-  border-radius: var(--radius-sm);
 }
 
 .collapseRail:focus:not(:focus-visible) {
@@ -211,10 +187,6 @@
 
   .sidebar.sidebarCollapsed .sidebarGroupLabel {
     display: none;
-  }
-
-  .sidebar.sidebarCollapsed .collapseRail {
-    left: 52px;
   }
 }
 

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -103,10 +103,10 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2px;
-  height: 20px;
+  width: 3px;
+  height: 24px;
   border: 1px solid transparent;
-  border-radius: var(--radius-sm);
+  border-radius: 999px;
   background: var(--color-text-tertiary);
   color: var(--color-text-tertiary);
   opacity: 1;

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -279,10 +279,26 @@ describe('Sidebar active state', () => {
 });
 
 describe('Sidebar group hierarchy', () => {
-  it('does not render group labels', () => {
+  it('labels the Library and Resources groups', () => {
     renderSidebar();
-    expect(screen.queryByText('Make')).not.toBeInTheDocument();
-    expect(screen.queryByText('Learn')).not.toBeInTheDocument();
+    expect(screen.getByText('Library')).toBeInTheDocument();
+    expect(screen.getByText('Resources')).toBeInTheDocument();
+  });
+
+  it('orders the top feature group by visit frequency (Upload, Notion, Note types first)', () => {
+    renderSidebar();
+    const nav = screen.getByRole('navigation');
+    const hrefs = Array.from(nav.querySelectorAll('a')).map((a) =>
+      a.getAttribute('href')
+    );
+    const upload = hrefs.indexOf('/upload');
+    const notion = hrefs.indexOf('/notion');
+    const templates = hrefs.indexOf('/templates');
+    const importRoute = hrefs.indexOf('/import');
+    expect(upload).toBeGreaterThanOrEqual(0);
+    expect(upload).toBeLessThan(notion);
+    expect(notion).toBeLessThan(templates);
+    expect(templates).toBeLessThan(importRoute);
   });
 
   it('omits the Admin group label when no admin flags are on', () => {

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -361,6 +361,16 @@ describe('Sidebar collapse toggle', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the rail label, flipping between Collapse and Expand', () => {
+    renderSidebar();
+    const toggle = screen.getByRole('button', { name: 'Collapse sidebar' });
+    expect(toggle).toHaveTextContent('Collapse');
+    fireEvent.click(toggle);
+    expect(
+      screen.getByRole('button', { name: 'Expand sidebar' })
+    ).toHaveTextContent('Expand');
+  });
+
   it('persists the collapsed state to localStorage', () => {
     renderSidebar();
     fireEvent.click(screen.getByRole('button', { name: 'Collapse sidebar' }));

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -361,6 +361,13 @@ describe('Sidebar collapse toggle', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the collapse rail outside the sidebar aside element', () => {
+    renderSidebar();
+    const aside = screen.getByRole('complementary', { name: 'primary' });
+    const rail = screen.getByRole('button', { name: 'Collapse sidebar' });
+    expect(aside.contains(rail)).toBe(false);
+  });
+
   it('renders the rail label, flipping between Collapse and Expand', () => {
     renderSidebar();
     const toggle = screen.getByRole('button', { name: 'Collapse sidebar' });

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -219,7 +219,6 @@ export function Sidebar({
         className={styles.collapseRail}
         aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
         aria-expanded={!collapsed}
-        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
       >
         <span className={styles.collapseRailIndicator} aria-hidden="true">
           {collapsed ? (

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -228,6 +228,9 @@ export function Sidebar({
             <ArrowLeftIcon width={16} height={16} />
           )}
         </span>
+        <span className={styles.collapseRailLabel} aria-hidden="true">
+          {collapsed ? 'Expand' : 'Collapse'}
+        </span>
       </button>
       <nav className={styles.sidebarNav}>
         <div className={styles.sidebarGroup}>

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../../lib/hooks/useTheme';
 import { useCardUsage } from '../../lib/hooks/useCardUsage';
@@ -213,24 +214,29 @@ export function Sidebar({
           <img src={logoSrc} alt="" />
         </Link>
       </div>
-      <button
-        type="button"
-        onClick={onToggleClick}
-        className={styles.collapseRail}
-        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        aria-expanded={!collapsed}
-      >
-        <span className={styles.collapseRailIndicator} aria-hidden="true">
-          {collapsed ? (
-            <ArrowRightIcon width={16} height={16} />
-          ) : (
-            <ArrowLeftIcon width={16} height={16} />
-          )}
-        </span>
-        <span className={styles.collapseRailLabel} aria-hidden="true">
-          {collapsed ? 'Expand' : 'Collapse'}
-        </span>
-      </button>
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <button
+            type="button"
+            onClick={onToggleClick}
+            className={`${styles.collapseRail} ${
+              collapsed ? styles.collapseRailCollapsed : ''
+            }`}
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            aria-expanded={!collapsed}
+          >
+            <span className={styles.collapseRailLine} aria-hidden="true" />
+            <span className={styles.collapseRailContent} aria-hidden="true">
+              {collapsed ? (
+                <ArrowRightIcon width={16} height={16} />
+              ) : (
+                <ArrowLeftIcon width={16} height={16} />
+              )}
+              {collapsed ? 'Expand' : 'Collapse'}
+            </span>
+          </button>,
+          document.body
+        )}
       <nav className={styles.sidebarNav}>
         <div className={styles.sidebarGroup}>
           <SidebarRow

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -212,17 +212,23 @@ export function Sidebar({
         >
           <img src={logoSrc} alt="" />
         </Link>
-        <button
-          type="button"
-          onClick={onToggleClick}
-          className={styles.sidebarCollapseToggle}
-          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          aria-pressed={collapsed}
-          title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        >
-          {collapsed ? <ArrowRightIcon width={16} height={16} /> : <ArrowLeftIcon width={16} height={16} />}
-        </button>
       </div>
+      <button
+        type="button"
+        onClick={onToggleClick}
+        className={styles.collapseRail}
+        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        aria-expanded={!collapsed}
+        title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      >
+        <span className={styles.collapseRailIndicator} aria-hidden="true">
+          {collapsed ? (
+            <ArrowRightIcon width={16} height={16} />
+          ) : (
+            <ArrowLeftIcon width={16} height={16} />
+          )}
+        </span>
+      </button>
       <nav className={styles.sidebarNav}>
         <div className={styles.sidebarGroup}>
           <SidebarRow
@@ -243,13 +249,39 @@ export function Sidebar({
             Notion to Anki
           </SidebarRow>
           <SidebarRow
-            href="/import"
+            href="/templates"
             pathname={pathname}
             matchPrefix={false}
             onClick={handleNavClick()}
-            icon={ArrowLeftIcon}
+            icon={SwatchIcon}
           >
-            Anki to Notion
+            Note types
+          </SidebarRow>
+          <SidebarRow
+            href="/print"
+            pathname={pathname}
+            matchPrefix={false}
+            onClick={handleNavClick()}
+            icon={PrinterIcon}
+          >
+            {getVisibleText('navigation.print')}
+          </SidebarRow>
+          <SidebarRow
+            href="/chat"
+            pathname={pathname}
+            matchPrefix={false}
+            onClick={handleNavClick()}
+            icon={ChatBubbleIcon}
+          >
+            Chat
+          </SidebarRow>
+          <SidebarRow
+            href="/mindmaps"
+            pathname={pathname}
+            onClick={handleNavClick()}
+            icon={ShareIcon}
+          >
+            Mind maps
           </SidebarRow>
           <SidebarRow
             href="/image-occlusion"
@@ -270,39 +302,13 @@ export function Sidebar({
             Photo to deck
           </SidebarRow>
           <SidebarRow
-            href="/mindmaps"
-            pathname={pathname}
-            onClick={handleNavClick()}
-            icon={ShareIcon}
-          >
-            Mind maps
-          </SidebarRow>
-          <SidebarRow
-            href="/templates"
+            href="/import"
             pathname={pathname}
             matchPrefix={false}
             onClick={handleNavClick()}
-            icon={SwatchIcon}
+            icon={ArrowLeftIcon}
           >
-            Note types
-          </SidebarRow>
-          <SidebarRow
-            href="/chat"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={ChatBubbleIcon}
-          >
-            Chat
-          </SidebarRow>
-          <SidebarRow
-            href="/print"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={PrinterIcon}
-          >
-            {getVisibleText('navigation.print')}
+            Anki to Notion
           </SidebarRow>
           <SidebarRow
             href="/transform"
@@ -325,6 +331,7 @@ export function Sidebar({
           )}
         </div>
         <div className={styles.sidebarGroup}>
+          <p className={styles.sidebarGroupLabel}>Library</p>
           <SidebarRow
             href="/downloads"
             pathname={pathname}
@@ -355,6 +362,7 @@ export function Sidebar({
           </SidebarRow>
         </div>
         <div className={styles.sidebarGroup}>
+          <p className={styles.sidebarGroupLabel}>Resources</p>
           <SidebarRow
             href="/documentation"
             pathname={pathname}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-30-sidebar-stripe-polish.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-30-sidebar-stripe-polish.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-30-sidebar-stripe-polish",
+  "date": "2026-05-30",
+  "type": "style",
+  "title": "Sidebar puts your most-used tools first, with grouped sections and a hover rail to collapse it"
+}


### PR DESCRIPTION
## What

Polishes the app sidebar, taking inspiration from Stripe's dashboard, plus a local-dev resilience fix.

### 1. Links ranked by real usage
Reordered the primary feature group by actual prod visit frequency (direct page-load GETs from server access logs), most-visited on top:

| Rank | Link | Route | Hits |
|---|---|---|---|
| 1 | Upload | /upload | 1703 |
| 2 | Notion to Anki | /notion | 263 |
| 3 | Note types | /templates | 185 |
| 4 | Print | /print | 109 |
| 5 | Chat | /chat | 84 |
| 6 | Mind maps | /mindmaps | 33 |
| 7 | Image Occlusion | /image-occlusion | 22 |
| 8 | Photo to deck | /photo-to-deck | 19 |
| 9 | Anki to Notion | /import | 6 |
| 10 | Transform | /transform | 0 |

**Caveat:** server logs capture only direct loads / refreshes / bookmarks, not in-app SPA navigation, so the ranking favours externally-linked pages. /documentation (1069) and /pricing (222) rank high but stay in the Resources group rather than jumping into the feature list; Library (My decks, Settings) is unchanged.

### 2. Stripe-style section labels
Added muted uppercase labels to the **Library** and **Resources** groups. Admin (KI/Ops) stays unlabelled by existing convention (there's a test asserting this).

### 3. Collapse rail
Replaced the in-header collapse button with a Stripe-style gutter rail: a thin vertical line at the sidebar's right edge, vertically centred, that morphs into a chevron button on hover/focus and toggles collapse. `position: fixed` so it escapes the sidebar's `overflow:auto` clip; desktop-only (hidden where the sidebar becomes a mobile drawer). Same `aria-label`s + `aria-expanded`, wide hit area, `focus-visible` outline.

### 4. Thin auto-hiding scrollbar
The sidebar scrollbar (always-on track under macOS "Show scroll bars: Always") now hides by default and reveals a thin bar on hover.

### 5. Local-dev boot crash fix (`fix:` commit)
Local dev DBs accumulate `knex_migrations` rows for files later renamed on main, which crashes boot with *"migration directory is corrupt"*. Set `disableMigrationsListValidation` **in local dev only** (`LOCAL_DEV=true`); prod and CI keep strict validation. Regression-tested across both env branches.

## Trio
pm + designer + engineer reviewed the rail before code (parallel). PM: ship, remove the duplicate header toggle, keep auto-minimize analytics. Designer: line→circle morph spec, chevron direction, focus treatment. Engineer: caught that `overflow:auto` clips an absolutely-positioned rail → use `position:fixed`, and that lifting the collapse hook would break the in-isolation Sidebar tests → kept the hook in Sidebar. No visual disagreement, so no preview route.

## Tests
- Sidebar: existing collapse/auto-minimize tests still pass (rail keeps the same aria-labels); new tests for the Library/Resources labels and the usage-driven order. Full web suite: 1436 passing.
- `KnexConfig.test.ts`: asserts validation is disabled only when `LOCAL_DEV=true`.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified on localhost across iterations — collapse rail (hover label, theme-aware), usage-ranked nav, section labels, collapsed theme-toggle alignment. Rail is desktop-only; the unchanged mobile drawer at 375px shows no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782767207&installation_id=132681956&pr_number=2932&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2932&signature=a73827c467c0153a8b50f1cc6f797f433e7bfb52d92684fb6ba5d10e4b985f93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
