### PR TITLE
fix: make /ops usable on mobile

### DIFF
--- a/web/src/pages/OpsPage/ErrorsTab.tsx
+++ b/web/src/pages/OpsPage/ErrorsTab.tsx
@@ -70,11 +70,14 @@ function CopyButton({ group }: Readonly<CopyButtonProps>) {
 
   const handleCopy = useCallback(() => {
     const artifact = buildCopyArtifact(group);
-    navigator.clipboard.writeText(artifact).then(() => {
-      setCopied(true);
-      if (timerRef.current != null) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setCopied(false), 1500);
-    }).catch(() => {});
+    navigator.clipboard
+      .writeText(artifact)
+      .then(() => {
+        setCopied(true);
+        if (timerRef.current != null) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {});
   }, [group]);
 
   useEffect(() => {
@@ -100,7 +103,11 @@ interface DetailPanelProps {
   onResolutionChange: () => void;
 }
 
-function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPanelProps>) {
+function DetailPanel({
+  group,
+  onClose,
+  onResolutionChange,
+}: Readonly<DetailPanelProps>) {
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
@@ -118,13 +125,17 @@ function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPane
     const action = group.resolved ? reopenErrorGroup : resolveErrorGroup;
     action(group.message_hash)
       .then(() => onResolutionChange())
-      .catch((e: unknown) => setActionError(e instanceof Error ? e.message : 'Action failed'))
+      .catch((e: unknown) =>
+        setActionError(e instanceof Error ? e.message : 'Action failed')
+      )
       .finally(() => setBusy(false));
   };
 
-  const release = group.release == null ? '(unknown)' : group.release.slice(0, 8);
+  const release =
+    group.release == null ? '(unknown)' : group.release.slice(0, 8);
   const userId = group.user_id == null ? 'anonymous' : String(group.user_id);
-  const browser = group.source === 'web' ? parseUserAgent(group.user_agent) : null;
+  const browser =
+    group.source === 'web' ? parseUserAgent(group.user_agent) : null;
 
   return (
     <aside
@@ -139,8 +150,20 @@ function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPane
         gap: '0.75rem',
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-        <h3 style={{ margin: 0, fontSize: 'var(--text-sm)', fontWeight: 'var(--font-semibold)' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+        }}
+      >
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 'var(--text-sm)',
+            fontWeight: 'var(--font-semibold)',
+          }}
+        >
           Error detail
         </h3>
         <button
@@ -153,19 +176,37 @@ function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPane
         </button>
       </div>
 
-      <p style={{ margin: 0, fontSize: 'var(--text-sm)', wordBreak: 'break-word' }}>
+      <p
+        style={{
+          margin: 0,
+          fontSize: 'var(--text-sm)',
+          wordBreak: 'break-word',
+        }}
+      >
         {group.message}
       </p>
 
-      <dl style={{ margin: 0, display: 'grid', gridTemplateColumns: '7rem 1fr', gap: '0.3rem 0.5rem', fontSize: 'var(--text-xs)' }}>
+      <dl
+        style={{
+          margin: 0,
+          display: 'grid',
+          gridTemplateColumns: '7rem 1fr',
+          gap: '0.3rem 0.5rem',
+          fontSize: 'var(--text-xs)',
+        }}
+      >
         <dt style={{ color: 'var(--color-text-tertiary)' }}>Source</dt>
         <dd style={{ margin: 0 }}>{group.source}</dd>
 
         <dt style={{ color: 'var(--color-text-tertiary)' }}>Occurrences</dt>
-        <dd style={{ margin: 0, fontVariantNumeric: 'tabular-nums' }}>{group.occurrences}</dd>
+        <dd style={{ margin: 0, fontVariantNumeric: 'tabular-nums' }}>
+          {group.occurrences}
+        </dd>
 
         <dt style={{ color: 'var(--color-text-tertiary)' }}>First seen</dt>
-        <dd style={{ margin: 0 }}>{new Date(group.first_seen).toUTCString()}</dd>
+        <dd style={{ margin: 0 }}>
+          {new Date(group.first_seen).toUTCString()}
+        </dd>
 
         <dt style={{ color: 'var(--color-text-tertiary)' }}>Last seen</dt>
         <dd style={{ margin: 0 }}>{new Date(group.last_seen).toUTCString()}</dd>
@@ -173,15 +214,21 @@ function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPane
         {group.resolved && group.resolved_at != null && (
           <>
             <dt style={{ color: 'var(--color-text-tertiary)' }}>Resolved</dt>
-            <dd style={{ margin: 0 }}>{new Date(group.resolved_at).toUTCString()}</dd>
+            <dd style={{ margin: 0 }}>
+              {new Date(group.resolved_at).toUTCString()}
+            </dd>
           </>
         )}
 
         <dt style={{ color: 'var(--color-text-tertiary)' }}>URL</dt>
-        <dd style={{ margin: 0, wordBreak: 'break-all' }}>{group.url ?? '(none)'}</dd>
+        <dd style={{ margin: 0, wordBreak: 'break-all' }}>
+          {group.url ?? '(none)'}
+        </dd>
 
         <dt style={{ color: 'var(--color-text-tertiary)' }}>Release</dt>
-        <dd style={{ margin: 0, fontFamily: 'ui-monospace, monospace' }}>{release}</dd>
+        <dd style={{ margin: 0, fontFamily: 'ui-monospace, monospace' }}>
+          {release}
+        </dd>
 
         <dt style={{ color: 'var(--color-text-tertiary)' }}>User</dt>
         <dd style={{ margin: 0 }}>{userId}</dd>
@@ -196,28 +243,47 @@ function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPane
 
       {group.stack != null && (
         <div>
-          <p style={{ margin: '0 0 0.25rem', fontSize: 'var(--text-xs)', color: 'var(--color-text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          <p
+            style={{
+              margin: '0 0 0.25rem',
+              fontSize: 'var(--text-xs)',
+              color: 'var(--color-text-tertiary)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+            }}
+          >
             Stack
           </p>
-          <pre style={{
-            margin: 0,
-            fontSize: '0.7rem',
-            fontFamily: 'ui-monospace, monospace',
-            color: 'var(--color-text-secondary)',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            background: 'var(--color-bg-secondary)',
-            borderRadius: 'var(--radius-sm)',
-            padding: '0.5rem',
-            maxHeight: '240px',
-            overflowY: 'auto',
-          }}>
+          <pre
+            style={{
+              margin: 0,
+              fontSize: '0.7rem',
+              fontFamily: 'ui-monospace, monospace',
+              color: 'var(--color-text-secondary)',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+              background: 'var(--color-bg-secondary)',
+              borderRadius: 'var(--radius-sm)',
+              padding: '0.5rem',
+              maxHeight: '240px',
+              overflowY: 'auto',
+            }}
+          >
             {group.stack}
           </pre>
         </div>
       )}
 
-      <div style={{ marginTop: 'auto', paddingTop: '0.5rem', display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+      <div
+        style={{
+          marginTop: 'auto',
+          paddingTop: '0.5rem',
+          display: 'flex',
+          gap: '0.5rem',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
         <CopyButton group={group} />
         <button
           type="button"
@@ -228,7 +294,9 @@ function DetailPanel({ group, onClose, onResolutionChange }: Readonly<DetailPane
           {group.resolved ? 'Reopen' : 'Resolve'}
         </button>
         {actionError != null && (
-          <span style={{ fontSize: 'var(--text-xs)', color: '#dc2626' }}>{actionError}</span>
+          <span style={{ fontSize: 'var(--text-xs)', color: '#dc2626' }}>
+            {actionError}
+          </span>
         )}
       </div>
     </aside>
@@ -242,19 +310,25 @@ export default function ErrorsTab() {
   const source: ErrorSource =
     rawSource === 'web' || rawSource === 'server' ? rawSource : 'all';
   const rawSort = searchParams.get('sort');
-  const sort: ErrorSort = rawSort === 'occurrences' ? 'occurrences' : 'last_seen';
+  const sort: ErrorSort =
+    rawSort === 'occurrences' ? 'occurrences' : 'last_seen';
   const rawStatus = searchParams.get('status');
   const status: ErrorStatus =
     rawStatus === 'resolved' || rawStatus === 'all' ? rawStatus : 'unresolved';
   const selectedHash = searchParams.get('id');
 
-  const { data, isLoading, error, refetch } = useErrorGroups({ source, sort, status });
+  const { data, isLoading, error, refetch } = useErrorGroups({
+    source,
+    sort,
+    status,
+  });
 
-  const selectedGroup = data?.groups.find((g) => g.message_hash === selectedHash) ?? null;
+  const selectedGroup =
+    data?.groups.find((g) => g.message_hash === selectedHash) ?? null;
 
   const updateParam = (key: string, value: string | null) => {
     const params = new URLSearchParams(searchParams);
-    if (value == null || value === '' ) {
+    if (value == null || value === '') {
       params.delete(key);
     } else {
       params.set(key, value);
@@ -263,9 +337,12 @@ export default function ErrorsTab() {
   };
 
   const selectGroup = (hash: string | null) => updateParam('id', hash);
-  const setSource = (s: ErrorSource) => updateParam('source', s === 'all' ? null : s);
-  const setStatus = (s: ErrorStatus) => updateParam('status', s === 'unresolved' ? null : s);
-  const toggleSort = () => updateParam('sort', sort === 'last_seen' ? 'occurrences' : 'last_seen');
+  const setSource = (s: ErrorSource) =>
+    updateParam('source', s === 'all' ? null : s);
+  const setStatus = (s: ErrorStatus) =>
+    updateParam('status', s === 'unresolved' ? null : s);
+  const toggleSort = () =>
+    updateParam('sort', sort === 'last_seen' ? 'occurrences' : 'last_seen');
 
   const countLabel = status === 'all' ? 'total' : status;
 
@@ -275,8 +352,12 @@ export default function ErrorsTab() {
         className={styles.tabHeader}
         style={{ justifyContent: 'space-between', alignItems: 'flex-start' }}
       >
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
-          <div style={{ display: 'flex', gap: '0.375rem', alignItems: 'center' }}>
+        <div
+          style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}
+        >
+          <div
+            style={{ display: 'flex', gap: '0.375rem', alignItems: 'center' }}
+          >
             <span style={filterLabelStyle}>Status</span>
             {STATUS_OPTIONS.map((opt) => (
               <button
@@ -287,14 +368,20 @@ export default function ErrorsTab() {
                     ? `${sharedStyles.btnSmallPill} ${sharedStyles.btnSmallPillActive ?? ''}`
                     : sharedStyles.btnSmallPill
                 }
-                style={status === opt.value ? { background: 'var(--color-primary)', color: '#fff' } : {}}
+                style={
+                  status === opt.value
+                    ? { background: 'var(--color-primary)', color: '#fff' }
+                    : {}
+                }
                 onClick={() => setStatus(opt.value)}
               >
                 {opt.label}
               </button>
             ))}
           </div>
-          <div style={{ display: 'flex', gap: '0.375rem', alignItems: 'center' }}>
+          <div
+            style={{ display: 'flex', gap: '0.375rem', alignItems: 'center' }}
+          >
             <span style={filterLabelStyle}>Source</span>
             {SOURCE_OPTIONS.map((opt) => (
               <button
@@ -305,7 +392,11 @@ export default function ErrorsTab() {
                     ? `${sharedStyles.btnSmallPill} ${sharedStyles.btnSmallPillActive ?? ''}`
                     : sharedStyles.btnSmallPill
                 }
-                style={source === opt.value ? { background: 'var(--color-primary)', color: '#fff' } : {}}
+                style={
+                  source === opt.value
+                    ? { background: 'var(--color-primary)', color: '#fff' }
+                    : {}
+                }
                 onClick={() => setSource(opt.value)}
               >
                 {opt.label}
@@ -338,10 +429,21 @@ export default function ErrorsTab() {
         </div>
       )}
 
-      <div style={{ display: 'flex', gap: 0, border: '1px solid var(--color-border)', borderRadius: 'var(--radius-md)', overflow: 'hidden', minHeight: '300px' }}>
+      <div
+        style={{
+          display: 'flex',
+          gap: 0,
+          border: '1px solid var(--color-border)',
+          borderRadius: 'var(--radius-md)',
+          overflow: 'hidden',
+          minHeight: '300px',
+        }}
+      >
         <div style={{ flex: 1, overflowY: 'auto' }}>
           {isLoading && data == null && (
-            <p className={styles.emptyHint} style={{ padding: '1.5rem' }}>Loading…</p>
+            <p className={styles.emptyHint} style={{ padding: '1.5rem' }}>
+              Loading…
+            </p>
           )}
 
           {!isLoading && data?.groups.length === 0 && (
@@ -353,94 +455,103 @@ export default function ErrorsTab() {
           )}
 
           {data != null && data.groups.length > 0 && (
-            <table className={styles.table} style={{ tableLayout: 'fixed' }}>
-              <colgroup>
-                <col style={{ width: '1.25rem' }} />
-                <col />
-                <col style={{ width: '10rem' }} />
-                <col style={{ width: '6rem' }} />
-                <col style={{ width: '5rem' }} />
-              </colgroup>
-              <thead>
-                <tr>
-                  <th aria-label="Source" />
-                  <th>Message</th>
-                  <th>URL</th>
-                  <th>Last seen</th>
-                  <th className={styles.numeric}>Count</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.groups.map((group) => {
-                  const isSelected = group.message_hash === selectedHash;
-                  return (
-                    <tr
-                      key={group.message_hash}
-                      style={{
-                        cursor: 'pointer',
-                        background: isSelected ? 'var(--color-bg-secondary)' : undefined,
-                        opacity: group.resolved ? 0.55 : undefined,
-                      }}
-                      onClick={() => selectGroup(isSelected ? null : group.message_hash)}
-                    >
-                      <td>
-                        <SourceDot source={group.source} />
-                      </td>
-                      <td
+            <div className={styles.tableScroll}>
+              <table
+                className={styles.table}
+                style={{ tableLayout: 'fixed', minWidth: '40rem' }}
+              >
+                <colgroup>
+                  <col style={{ width: '1.25rem' }} />
+                  <col />
+                  <col style={{ width: '10rem' }} />
+                  <col style={{ width: '6rem' }} />
+                  <col style={{ width: '5rem' }} />
+                </colgroup>
+                <thead>
+                  <tr>
+                    <th aria-label="Source" />
+                    <th>Message</th>
+                    <th>URL</th>
+                    <th>Last seen</th>
+                    <th className={styles.numeric}>Count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.groups.map((group) => {
+                    const isSelected = group.message_hash === selectedHash;
+                    return (
+                      <tr
+                        key={group.message_hash}
                         style={{
-                          fontFamily: 'ui-monospace, monospace',
-                          fontSize: 'var(--text-xs)',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
+                          cursor: 'pointer',
+                          background: isSelected
+                            ? 'var(--color-bg-secondary)'
+                            : undefined,
+                          opacity: group.resolved ? 0.55 : undefined,
                         }}
-                        title={group.message}
+                        onClick={() =>
+                          selectGroup(isSelected ? null : group.message_hash)
+                        }
                       >
-                        {group.resolved && (
-                          <span
-                            style={{
-                              fontFamily: 'inherit',
-                              fontSize: '0.65rem',
-                              fontWeight: 'var(--font-semibold)',
-                              color: 'var(--color-text-tertiary)',
-                              border: '1px solid var(--color-border)',
-                              borderRadius: 'var(--radius-sm)',
-                              padding: '0 0.3rem',
-                              marginRight: '0.4rem',
-                            }}
-                          >
-                            Resolved
-                          </span>
-                        )}
-                        {truncate(group.message, 80)}
-                      </td>
-                      <td
-                        style={{
-                          fontSize: 'var(--text-xs)',
-                          color: 'var(--color-text-secondary)',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                        }}
-                        title={group.url ?? undefined}
-                      >
-                        {group.url == null ? '—' : truncate(group.url, 40)}
-                      </td>
-                      <td
-                        style={{
-                          fontSize: 'var(--text-xs)',
-                          color: 'var(--color-text-secondary)',
-                          fontVariantNumeric: 'tabular-nums',
-                        }}
-                      >
-                        {relative(group.last_seen)}
-                      </td>
-                      <td className={styles.numeric}>{group.occurrences}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
+                        <td>
+                          <SourceDot source={group.source} />
+                        </td>
+                        <td
+                          style={{
+                            fontFamily: 'ui-monospace, monospace',
+                            fontSize: 'var(--text-xs)',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                          title={group.message}
+                        >
+                          {group.resolved && (
+                            <span
+                              style={{
+                                fontFamily: 'inherit',
+                                fontSize: '0.65rem',
+                                fontWeight: 'var(--font-semibold)',
+                                color: 'var(--color-text-tertiary)',
+                                border: '1px solid var(--color-border)',
+                                borderRadius: 'var(--radius-sm)',
+                                padding: '0 0.3rem',
+                                marginRight: '0.4rem',
+                              }}
+                            >
+                              Resolved
+                            </span>
+                          )}
+                          {truncate(group.message, 80)}
+                        </td>
+                        <td
+                          style={{
+                            fontSize: 'var(--text-xs)',
+                            color: 'var(--color-text-secondary)',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                          title={group.url ?? undefined}
+                        >
+                          {group.url == null ? '—' : truncate(group.url, 40)}
+                        </td>
+                        <td
+                          style={{
+                            fontSize: 'var(--text-xs)',
+                            color: 'var(--color-text-secondary)',
+                            fontVariantNumeric: 'tabular-nums',
+                          }}
+                        >
+                          {relative(group.last_seen)}
+                        </td>
+                        <td className={styles.numeric}>{group.occurrences}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
           )}
         </div>
 
@@ -462,7 +573,8 @@ export default function ErrorsTab() {
             fontVariantNumeric: 'tabular-nums',
           }}
         >
-          {data.totalGroups} {countLabel} group{data.totalGroups === 1 ? '' : 's'}
+          {data.totalGroups} {countLabel} group
+          {data.totalGroups === 1 ? '' : 's'}
         </p>
       )}
     </div>

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -9,12 +9,18 @@
 
 .tabs {
   display: flex;
+  flex-wrap: nowrap;
   gap: 0.25rem;
   border-bottom: 1px solid var(--color-border);
   margin: 0.25rem 0 1rem;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
 }
 
 .tab {
+  flex-shrink: 0;
+  white-space: nowrap;
   padding: 0.5rem 0.875rem;
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
@@ -843,6 +849,12 @@
 }
 
 /* ── Performance tab ────────────────────────────────────────────── */
+
+.tableScroll {
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
 
 .table {
   width: 100%;

--- a/web/src/pages/OpsPage/PerformanceTab.tsx
+++ b/web/src/pages/OpsPage/PerformanceTab.tsx
@@ -64,28 +64,30 @@ const STATUS_COLORS: Record<string, string> = {
 const COUNTRY_BAR_COLOR = '#3b82f6';
 
 const renderDurationsTable = (rows: JobDurationPercentiles[]) => (
-  <table className={styles.table}>
-    <thead>
-      <tr>
-        <th>Window</th>
-        <th>p50</th>
-        <th>p95</th>
-        <th>p99</th>
-        <th>Completed jobs</th>
-      </tr>
-    </thead>
-    <tbody>
-      {rows.map((row) => (
-        <tr key={row.window}>
-          <td>{row.window === '24h' ? 'Last 24h' : 'Last 7d'}</td>
-          <td className={styles.numeric}>{formatMs(row.p50_ms)}</td>
-          <td className={styles.numeric}>{formatMs(row.p95_ms)}</td>
-          <td className={styles.numeric}>{formatMs(row.p99_ms)}</td>
-          <td className={styles.numeric}>{formatCount(row.count)}</td>
+  <div className={styles.tableScroll}>
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>Window</th>
+          <th>p50</th>
+          <th>p95</th>
+          <th>p99</th>
+          <th>Completed jobs</th>
         </tr>
-      ))}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.window}>
+            <td>{row.window === '24h' ? 'Last 24h' : 'Last 7d'}</td>
+            <td className={styles.numeric}>{formatMs(row.p50_ms)}</td>
+            <td className={styles.numeric}>{formatMs(row.p95_ms)}</td>
+            <td className={styles.numeric}>{formatMs(row.p99_ms)}</td>
+            <td className={styles.numeric}>{formatCount(row.count)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
 );
 
 const renderStatusBreakdown = (
@@ -94,7 +96,9 @@ const renderStatusBreakdown = (
   const total = rows.reduce((sum, row) => sum + row.count, 0);
   if (total === 0) {
     return (
-      <p className={styles.emptyHint}>No terminal-status jobs in the last 24h.</p>
+      <p className={styles.emptyHint}>
+        No terminal-status jobs in the last 24h.
+      </p>
     );
   }
   return (
@@ -134,37 +138,41 @@ const renderSlowestJobs = (
   rows: PerformanceMetricsResponse['slowest_jobs_24h']
 ) => {
   if (rows.length === 0) {
-    return <p className={styles.emptyHint}>No completed jobs in the last 24h.</p>;
+    return (
+      <p className={styles.emptyHint}>No completed jobs in the last 24h.</p>
+    );
   }
   return (
-    <table className={styles.table}>
-      <thead>
-        <tr>
-          <th>Job</th>
-          <th>Type</th>
-          <th>Duration</th>
-          <th>Cards</th>
-          <th>Completed</th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row) => (
-          <tr key={row.id}>
-            <td className={styles.numericMuted}>
-              <JobIdCell id={row.id} />
-            </td>
-            <td>{row.type ?? '—'}</td>
-            <td className={styles.numeric}>{formatMs(row.duration_ms)}</td>
-            <td className={styles.numeric}>
-              {row.card_count == null ? '—' : formatCount(row.card_count)}
-            </td>
-            <td className={styles.numericMuted}>
-              {new Date(row.completed_at).toLocaleString()}
-            </td>
+    <div className={styles.tableScroll}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Job</th>
+            <th>Type</th>
+            <th>Duration</th>
+            <th>Cards</th>
+            <th>Completed</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.id}>
+              <td className={styles.numericMuted}>
+                <JobIdCell id={row.id} />
+              </td>
+              <td>{row.type ?? '—'}</td>
+              <td className={styles.numeric}>{formatMs(row.duration_ms)}</td>
+              <td className={styles.numeric}>
+                {row.card_count == null ? '—' : formatCount(row.card_count)}
+              </td>
+              <td className={styles.numericMuted}>
+                {new Date(row.completed_at).toLocaleString()}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/web/src/pages/OpsPage/PricingAbFunnelTab.tsx
+++ b/web/src/pages/OpsPage/PricingAbFunnelTab.tsx
@@ -79,40 +79,42 @@ export default function PricingAbFunnelTab() {
             <h2 className={styles.sectionTitle}>Variant funnel</h2>
           </div>
           <div className={sharedStyles.surface}>
-            <table className={styles.table}>
-              <thead>
-                <tr>
-                  <th>Variant</th>
-                  <th className={styles.numeric}>Users shown</th>
-                  <th className={styles.numeric}>Upgrade clicks</th>
-                  <th className={styles.numeric}>Click rate</th>
-                  <th className={styles.numeric}>Paid conversions</th>
-                  <th className={styles.numeric}>Revenue</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.variants.map((row) => (
-                  <tr key={row.variant}>
-                    <td>
-                      <code>{row.variant}</code>
-                    </td>
-                    <td className={styles.numeric}>{fmt(row.users_shown)}</td>
-                    <td className={styles.numeric}>
-                      {fmt(row.upgrade_clicks)}
-                    </td>
-                    <td className={styles.numeric}>
-                      {fmtPct(row.upgrade_click_rate_pct)}
-                    </td>
-                    <td className={styles.numeric}>
-                      {fmt(row.paid_conversions)}
-                    </td>
-                    <td className={styles.numeric}>
-                      {fmtRevenue(row.revenue_cents)}
-                    </td>
+            <div className={styles.tableScroll}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Variant</th>
+                    <th className={styles.numeric}>Users shown</th>
+                    <th className={styles.numeric}>Upgrade clicks</th>
+                    <th className={styles.numeric}>Click rate</th>
+                    <th className={styles.numeric}>Paid conversions</th>
+                    <th className={styles.numeric}>Revenue</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {data.variants.map((row) => (
+                    <tr key={row.variant}>
+                      <td>
+                        <code>{row.variant}</code>
+                      </td>
+                      <td className={styles.numeric}>{fmt(row.users_shown)}</td>
+                      <td className={styles.numeric}>
+                        {fmt(row.upgrade_clicks)}
+                      </td>
+                      <td className={styles.numeric}>
+                        {fmtPct(row.upgrade_click_rate_pct)}
+                      </td>
+                      <td className={styles.numeric}>
+                        {fmt(row.paid_conversions)}
+                      </td>
+                      <td className={styles.numeric}>
+                        {fmtRevenue(row.revenue_cents)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
       )}
@@ -127,26 +129,28 @@ export default function PricingAbFunnelTab() {
             </p>
           </div>
           <div className={sharedStyles.surface}>
-            <table className={styles.table}>
-              <thead>
-                <tr>
-                  <th>Surface</th>
-                  <th className={styles.numeric}>Distinct users</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.surface_breakdown.map((row) => (
-                  <tr key={row.surface}>
-                    <td>
-                      <code>{row.surface}</code>
-                    </td>
-                    <td className={styles.numeric}>
-                      {fmt(row.distinct_users)}
-                    </td>
+            <div className={styles.tableScroll}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Surface</th>
+                    <th className={styles.numeric}>Distinct users</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {data.surface_breakdown.map((row) => (
+                    <tr key={row.surface}>
+                      <td>
+                        <code>{row.surface}</code>
+                      </td>
+                      <td className={styles.numeric}>
+                        {fmt(row.distinct_users)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </div>
         </section>
       )}


### PR DESCRIPTION
## What

The `/ops` admin dashboard was unusable on a phone. Two breakers, both fixed:

1. **Tab bar** — the 11-tab nav (`Engineering … Pricing A/B`) was a non-wrapping flex row with no `overflow-x`, so the strip ran past the viewport and forced the *whole page* to scroll sideways. The later tabs were effectively unreachable. It's now a self-contained horizontally-scrollable strip (`overflow-x: auto`, tabs `flex-shrink: 0` + `white-space: nowrap`).
2. **Tables** — the Performance, Pricing A/B, and Errors tables weren't wrapped in any scroll container, so wide numeric tables blew out page width. Each is now wrapped in an `overflow-x: auto` container (new `.tableScroll`). The fixed-layout Errors table also gets `min-width: 40rem` so it scrolls instead of crushing the Message column.

No logic changes — wrapper `<div>`s + CSS only. The large line counts in the TSX files are Biome re-indenting the wrapped JSX.

## Known follow-up (not in this PR)

The Errors tab's **detail panel** is an inline-styled `flex: 0 0 400px` side panel that appears after selecting an error row — it'll still be cramped on a narrow screen. Fixing it means moving the inline flex row to a media-query class so it stacks on mobile. Out of scope here (conditional, secondary); happy to do it as a follow-up if it bites.

## Verification asked of reviewer

I can't browser-verify this myself. Please open `pnpm dev` → `/ops` at **375px** (DevTools device toolbar) and confirm:
- The tab strip scrolls horizontally and every tab is reachable (no whole-page sideways scroll).
- Performance / Pricing A/B / Errors tables scroll within their card instead of widening the page.

Then tick the boxes below.

- No changelog entry — `/ops` is admin-only internal tooling; no user-visible change.
- Sonar not run locally — CSS + JSX-wrapping change with no new logic or security surface.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes:

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782767881&installation_id=132681956&pr_number=2934&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2934&signature=fa12ec446be88e3a8efa28efe4fc824c4211d34efa59fe518b146eea92f54963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->