### PR TITLE
feat: turn the Ops sidebar entry into an expandable folder

### DIFF
--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -240,6 +240,35 @@
   gap: 0.125rem;
 }
 
+.sidebarFolderHeader {
+  width: 100%;
+  background: none;
+  border: none;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.sidebarFolderChevron {
+  flex-shrink: 0;
+  color: var(--color-text-tertiary);
+  transition: transform var(--transition-fast);
+}
+
+.sidebarFolderChevronOpen {
+  transform: rotate(90deg);
+}
+
+.sidebarFolderItems {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.sidebarFolderItems .sidebarRow {
+  padding-left: 44px;
+}
+
 .sidebarSpacer {
   flex: 1 1 auto;
 }

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -211,12 +211,90 @@ describe('Sidebar admin group', () => {
     );
   });
 
-  it('shows Ops when ops is on', () => {
-    renderSidebar({ ops: true });
+  it('shows Ops as an expandable folder when ops is on', () => {
+    renderSidebar({ ops: true, pathname: '/upload' });
+    expect(
+      screen.getByRole('button', { name: 'Ops' })
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+describe('Sidebar Ops folder', () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('keeps the folder collapsed and its tabs hidden off /ops', () => {
+    renderSidebar({ ops: true, pathname: '/upload' });
+    expect(
+      screen.queryByRole('link', { name: 'Errors' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('expands the folder and reveals tabs when the header is clicked', () => {
+    renderSidebar({ ops: true, pathname: '/upload' });
+    fireEvent.click(screen.getByRole('button', { name: 'Ops' }));
+    expect(screen.getByRole('button', { name: 'Ops' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByRole('link', { name: 'Errors' })).toHaveAttribute(
+      'href',
+      '/ops/errors'
+    );
+  });
+
+  it('auto-expands and lists every ops tab when on an /ops route', () => {
+    renderSidebar({ ops: true, pathname: '/ops/errors' });
+    expect(screen.getByRole('button', { name: 'Ops' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    expect(screen.getByRole('link', { name: 'Engineering' })).toHaveAttribute(
+      'href',
+      '/ops'
+    );
+    expect(screen.getByRole('link', { name: 'Pricing A/B' })).toHaveAttribute(
+      'href',
+      '/ops/pricing-ab'
+    );
+  });
+
+  it('marks exactly the current tab active, not the Engineering index', () => {
+    renderSidebar({ ops: true, pathname: '/ops/errors' });
+    expect(screen.getByRole('link', { name: 'Errors' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    expect(
+      screen.getByRole('link', { name: 'Engineering' })
+    ).not.toHaveAttribute('aria-current', 'page');
+  });
+
+  it('marks Engineering active only on the /ops index', () => {
+    renderSidebar({ ops: true, pathname: '/ops' });
+    expect(screen.getByRole('link', { name: 'Engineering' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    expect(screen.getByRole('link', { name: 'Errors' })).not.toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+  });
+
+  it('falls back to a single Ops link when the sidebar is collapsed', () => {
+    localStorage.setItem('sidebar.collapsed', 'true');
+    renderSidebar({ ops: true, pathname: '/ops/errors' });
     expect(screen.getByRole('link', { name: 'Ops' })).toHaveAttribute(
       'href',
       '/ops'
     );
+    expect(
+      screen.queryByRole('button', { name: 'Ops' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Errors' })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -15,6 +15,7 @@ import CameraIcon from '../icons/CameraIcon';
 import RectangleGroupIcon from '../icons/RectangleGroupIcon';
 import SwatchIcon from '../icons/SwatchIcon';
 import LayersIcon from '../icons/LayersIcon';
+import ChevronRightIcon from '../icons/ChevronRightIcon';
 import CommandLineIcon from '../icons/CommandLineIcon';
 import CreditCardIcon from '../icons/CreditCardIcon';
 import PrinterIcon from '../icons/PrinterIcon';
@@ -25,6 +26,7 @@ import UserCircleIcon from '../icons/UserCircleIcon';
 import SettingsIcon from '../icons/SettingsIcon';
 import WrenchIcon from '../icons/WrenchIcon';
 import ShareIcon from '../icons/ShareIcon';
+import { OPS_TABS } from '../../pages/OpsPage/opsTabs';
 import { ThemeSwitcher } from '../ThemeSwitcher/ThemeSwitcher';
 import { ThemeToggle } from '../ThemeSwitcher/ThemeToggle';
 import styles from './AppShell.module.css';
@@ -149,6 +151,78 @@ function SidebarRow({
       {Icon && <Icon width={20} height={20} />}
       <span className={styles.sidebarRowLabel}>{children}</span>
     </Link>
+  );
+}
+
+interface OpsSidebarFolderProps {
+  pathname: string;
+  collapsed: boolean;
+  onNavigate: React.MouseEventHandler<HTMLAnchorElement>;
+}
+
+function OpsSidebarFolder({
+  pathname,
+  collapsed,
+  onNavigate,
+}: Readonly<OpsSidebarFolderProps>) {
+  const opsActive = pathname === '/ops' || pathname.startsWith('/ops/');
+  const [open, setOpen] = useState(opsActive);
+  const expanded = open || opsActive;
+
+  if (collapsed) {
+    return (
+      <SidebarRow
+        href="/ops"
+        pathname={pathname}
+        matchPrefix
+        onClick={onNavigate}
+        icon={WrenchIcon}
+      >
+        Ops
+      </SidebarRow>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`${styles.sidebarRow} ${styles.sidebarFolderHeader}`}
+        aria-expanded={expanded}
+        aria-controls="ops-folder-items"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <WrenchIcon width={20} height={20} />
+        <span className={styles.sidebarRowLabel}>Ops</span>
+        <ChevronRightIcon
+          width={16}
+          height={16}
+          className={`${styles.sidebarFolderChevron} ${
+            expanded ? styles.sidebarFolderChevronOpen : ''
+          }`}
+        />
+      </button>
+      {expanded && (
+        <div
+          id="ops-folder-items"
+          role="group"
+          aria-label="Ops"
+          className={styles.sidebarFolderItems}
+        >
+          {OPS_TABS.map((tab) => (
+            <SidebarRow
+              key={tab.to}
+              href={tab.to}
+              pathname={pathname}
+              matchPrefix={tab.to !== '/ops'}
+              onClick={onNavigate}
+            >
+              {tab.label}
+            </SidebarRow>
+          ))}
+        </div>
+      )}
+    </>
   );
 }
 
@@ -404,14 +478,11 @@ export function Sidebar({
               </SidebarRow>
             )}
             {showOps && (
-              <SidebarRow
-                href="/ops"
+              <OpsSidebarFolder
                 pathname={pathname}
-                onClick={handleNavClick()}
-                icon={WrenchIcon}
-              >
-                Ops
-              </SidebarRow>
+                collapsed={collapsed}
+                onNavigate={handleNavClick()}
+              />
             )}
           </div>
         )}

--- a/web/src/components/icons/ChevronRightIcon.tsx
+++ b/web/src/components/icons/ChevronRightIcon.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export default function ChevronRightIcon({
+  width = 20,
+  height = 20,
+  className,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      stroke="currentColor"
+      width={width}
+      height={height}
+      className={className}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="m9 5 7 7-7 7" />
+    </svg>
+  );
+}

--- a/web/src/pages/OpsPage/OpsLayout.test.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, expect, test } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -21,39 +21,31 @@ const renderAt = (path: string) =>
   );
 
 describe('OpsLayout', () => {
-  test('renders both tab links', () => {
+  test('renders the Ops heading and the active section breadcrumb', () => {
     renderAt('/ops');
-    expect(screen.getByRole('link', { name: 'Engineering' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Business' })).toBeInTheDocument();
-  });
-
-  test('marks Engineering active on /ops', () => {
-    renderAt('/ops');
-    const engineering = screen.getByRole('link', { name: 'Engineering' });
-    const business = screen.getByRole('link', { name: 'Business' });
-    expect(engineering).toHaveAttribute('aria-current', 'page');
-    expect(business).not.toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('heading', { name: 'Ops' })).toBeInTheDocument();
+    const section = screen.getByText('Engineering');
+    expect(section).toHaveAttribute('aria-current', 'page');
     expect(screen.getByTestId('engineering')).toBeInTheDocument();
   });
 
-  test('marks Business active on /ops/business', () => {
+  test('shows the Business section name on /ops/business', () => {
     renderAt('/ops/business');
-    const engineering = screen.getByRole('link', { name: 'Engineering' });
-    const business = screen.getByRole('link', { name: 'Business' });
-    expect(business).toHaveAttribute('aria-current', 'page');
-    expect(engineering).not.toHaveAttribute('aria-current', 'page');
+    expect(screen.getByText('Business')).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
+    expect(screen.queryByText('Engineering')).not.toBeInTheDocument();
     expect(screen.getByTestId('business')).toBeInTheDocument();
   });
 
-  test('clicking the Business tab updates the URL and renders BusinessTab', () => {
+  test('no longer renders an in-page tab bar', () => {
     renderAt('/ops');
-    expect(screen.getByTestId('engineering')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('link', { name: 'Business' }));
-
-    expect(screen.getByTestId('business')).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'Business' })
-    ).toHaveAttribute('aria-current', 'page');
+      screen.queryByRole('link', { name: 'Business' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('navigation', { name: 'Ops sections' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/OpsPage/OpsLayout.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.tsx
@@ -1,73 +1,11 @@
 import { useEffect } from 'react';
-import { Link, Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
+import { OPS_TABS } from './opsTabs';
 
 const PAGE_TITLE = 'Ops · 2anki';
-
-const TABS = [
-  {
-    to: '/ops',
-    label: 'Engineering',
-    match: (path: string) => path === '/ops' || path.startsWith('/ops?'),
-  },
-  {
-    to: '/ops/errors',
-    label: 'Errors',
-    match: (path: string) => path.startsWith('/ops/errors'),
-  },
-  {
-    to: '/ops/performance',
-    label: 'Performance',
-    match: (path: string) => path.startsWith('/ops/performance'),
-  },
-  {
-    to: '/ops/conversions',
-    label: 'Conversions',
-    match: (path: string) => path.startsWith('/ops/conversions'),
-  },
-  {
-    to: '/ops/upload-funnel',
-    label: 'Upload funnel',
-    match: (path: string) => path.startsWith('/ops/upload-funnel'),
-  },
-  {
-    to: '/ops/business',
-    label: 'Business',
-    match: (path: string) => path.startsWith('/ops/business'),
-  },
-  {
-    to: '/ops/showcase',
-    label: 'Showcase',
-    match: (path: string) => path.startsWith('/ops/showcase'),
-  },
-  {
-    to: '/ops/interviews',
-    label: 'Interviews',
-    match: (path: string) => path.startsWith('/ops/interviews'),
-  },
-  {
-    to: '/ops/messages',
-    label: 'Messages',
-    match: (path: string) => path.startsWith('/ops/messages'),
-  },
-  {
-    to: '/ops/commands',
-    label: 'Commands',
-    match: (path: string) => path.startsWith('/ops/commands'),
-  },
-  {
-    to: '/ops/flags',
-    label: 'Flags',
-    match: (path: string) => path.startsWith('/ops/flags'),
-  },
-  {
-    to: '/ops/pricing-ab',
-    label: 'Pricing A/B',
-    match: (path: string) => path.startsWith('/ops/pricing-ab'),
-  },
-];
 
 export default function OpsLayout() {
   const location = useLocation();
@@ -76,26 +14,17 @@ export default function OpsLayout() {
   }, []);
 
   const fullPath = `${location.pathname}${location.search}`;
+  const activeTab = OPS_TABS.find((tab) => tab.match(fullPath));
 
   return (
     <main className={sharedStyles.pageWide} data-hj-suppress>
-      <h1 className={sharedStyles.title}>Ops</h1>
-      <nav aria-label="Ops sections" className={styles.tabs}>
-        {TABS.map((tab) => {
-          const isActive = tab.match(fullPath);
-          return (
-            <Link
-              key={tab.to}
-              to={tab.to}
-              className={
-                isActive ? `${styles.tab} ${styles.tabActive}` : styles.tab
-              }
-              aria-current={isActive ? 'page' : undefined}
-            >
-              {tab.label}
-            </Link>
-          );
-        })}
+      <nav aria-label="Breadcrumb" className={styles.breadcrumb}>
+        <h1 className={sharedStyles.title}>Ops</h1>
+        {activeTab && (
+          <span className={styles.breadcrumbSection} aria-current="page">
+            {activeTab.label}
+          </span>
+        )}
       </nav>
       <Outlet />
     </main>

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -7,37 +7,24 @@
   margin-bottom: 0.25rem;
 }
 
-.tabs {
+.breadcrumb {
   display: flex;
-  flex-wrap: nowrap;
-  gap: 0.25rem;
-  border-bottom: 1px solid var(--color-border);
+  align-items: center;
+  gap: 0.5rem;
   margin: 0.25rem 0 1rem;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
 }
 
-.tab {
-  flex-shrink: 0;
-  white-space: nowrap;
-  padding: 0.5rem 0.875rem;
-  font-size: var(--text-sm);
+.breadcrumbSection {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: var(--text-lg);
   color: var(--color-text-secondary);
-  text-decoration: none;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  transition: color 120ms ease;
 }
 
-.tab:hover {
-  color: var(--color-text-primary);
-}
-
-.tabActive {
-  color: var(--color-text-primary);
-  border-bottom-color: var(--color-primary);
-  font-weight: var(--font-semibold);
+.breadcrumbSection::before {
+  content: '›';
+  color: var(--color-text-tertiary);
 }
 
 .tabHeader {

--- a/web/src/pages/OpsPage/opsTabs.test.ts
+++ b/web/src/pages/OpsPage/opsTabs.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { OPS_TABS } from './opsTabs';
+
+describe('OPS_TABS', () => {
+  it('lists all 12 ops tabs with the Engineering index first', () => {
+    expect(OPS_TABS).toHaveLength(12);
+    expect(OPS_TABS[0]).toMatchObject({ to: '/ops', label: 'Engineering' });
+  });
+
+  it('has a unique route for every tab', () => {
+    const paths = OPS_TABS.map((tab) => tab.to);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it('matches the index only on /ops, not on child routes', () => {
+    const index = OPS_TABS[0];
+    expect(index.match('/ops')).toBe(true);
+    expect(index.match('/ops?window=24h')).toBe(true);
+    expect(index.match('/ops/errors')).toBe(false);
+  });
+
+  it('matches a child tab on its own route', () => {
+    const errors = OPS_TABS.find((tab) => tab.to === '/ops/errors');
+    expect(errors?.match('/ops/errors')).toBe(true);
+    expect(errors?.match('/ops')).toBe(false);
+  });
+});

--- a/web/src/pages/OpsPage/opsTabs.ts
+++ b/web/src/pages/OpsPage/opsTabs.ts
@@ -1,0 +1,68 @@
+export interface OpsTab {
+  to: string;
+  label: string;
+  match: (path: string) => boolean;
+}
+
+export const OPS_TABS: OpsTab[] = [
+  {
+    to: '/ops',
+    label: 'Engineering',
+    match: (path) => path === '/ops' || path.startsWith('/ops?'),
+  },
+  {
+    to: '/ops/errors',
+    label: 'Errors',
+    match: (path) => path.startsWith('/ops/errors'),
+  },
+  {
+    to: '/ops/performance',
+    label: 'Performance',
+    match: (path) => path.startsWith('/ops/performance'),
+  },
+  {
+    to: '/ops/conversions',
+    label: 'Conversions',
+    match: (path) => path.startsWith('/ops/conversions'),
+  },
+  {
+    to: '/ops/upload-funnel',
+    label: 'Upload funnel',
+    match: (path) => path.startsWith('/ops/upload-funnel'),
+  },
+  {
+    to: '/ops/business',
+    label: 'Business',
+    match: (path) => path.startsWith('/ops/business'),
+  },
+  {
+    to: '/ops/showcase',
+    label: 'Showcase',
+    match: (path) => path.startsWith('/ops/showcase'),
+  },
+  {
+    to: '/ops/interviews',
+    label: 'Interviews',
+    match: (path) => path.startsWith('/ops/interviews'),
+  },
+  {
+    to: '/ops/messages',
+    label: 'Messages',
+    match: (path) => path.startsWith('/ops/messages'),
+  },
+  {
+    to: '/ops/commands',
+    label: 'Commands',
+    match: (path) => path.startsWith('/ops/commands'),
+  },
+  {
+    to: '/ops/flags',
+    label: 'Flags',
+    match: (path) => path.startsWith('/ops/flags'),
+  },
+  {
+    to: '/ops/pricing-ab',
+    label: 'Pricing A/B',
+    match: (path) => path.startsWith('/ops/pricing-ab'),
+  },
+];


### PR DESCRIPTION
## What

The `/ops` admin page had 12 tabs in a cramped horizontal bar. This replaces that nav model:

- The sidebar **Ops** entry is now an expandable **folder** listing all 12 tabs (Engineering, Errors, Performance, Conversions, Upload funnel, Business, Showcase, Interviews, Messages, Commands, Flags, Pricing A/B).
- It **auto-expands** whenever you're on any `/ops` route; otherwise it's a disclosure you toggle.
- The **in-page horizontal tab bar is removed** — `OpsLayout` now shows an `Ops › Section` breadcrumb. (Decided with the user: the auto-expanded sidebar folder covers fast switching, so the cramped bar is redundant.)
- The 12 tab definitions move to a shared `web/src/pages/OpsPage/opsTabs.ts` — single source of truth for both the folder and the breadcrumb.

## Details

- Folder header is a `<button aria-expanded aria-controls>` (toggles, never navigates); children are exact-matched so the `/ops` index doesn't mark every tab active; the mobile drawer only closes on child-link clicks, not on the toggle.
- When the **whole sidebar is collapsed** to icons (64px), the Ops entry falls back to a single icon link to `/ops` (no inline tree, no flyout).
- New `ChevronRightIcon` rotates 90° on expand.

## Trio
pm + designer + engineer reviewed. Resolved two conflicts: grouping → **flat 12** (not Engineering/Business sub-clusters — those are tabs, and it matches the user's list); tab bar → **removed** (user confirmed via prompt).

## Tests
Full web suite green (1460). New: `opsTabs.test.ts` (list shape + match semantics), Sidebar folder tests (auto-expand on `/ops`, toggle off-route, exactly-one active child, collapsed-sidebar fallback link), rewritten `OpsLayout.test.tsx` for the breadcrumb (asserts the old tab bar is gone).

No changelog — admin-only surface (gated by `features.ops`).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Admin-only (`features.ops`). Verify locally: folder auto-expands on /ops, tabs navigate + highlight correctly, breadcrumb shows the section, collapsed sidebar shows a single Ops link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782769838&installation_id=132681956&pr_number=2935&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2935&signature=7b076a88b633f9c69dfd3822cb64ece7234b7ba3e7318f2bb314f046a10528e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->