### PR TITLE
feat: enforce card limits on uploads and cap anonymous conversions

### DIFF
--- a/src/controllers/Upload/DropboxController.test.ts
+++ b/src/controllers/Upload/DropboxController.test.ts
@@ -19,6 +19,7 @@ import Uploads from '../../data_layer/public/Uploads';
 import NotionService from '../../services/NotionService';
 import UploadService from '../../services/UploadService';
 import JobRepository from '../../data_layer/JobRepository';
+import UsersRepository from '../../data_layer/UsersRepository';
 import UploadController from './UploadController';
 import { GetDropboxUploadsUseCase } from '../../usecases/uploads/GetDropboxUploadsUseCase';
 import { DeleteDropboxUploadUseCase } from '../../usecases/uploads/DeleteDropboxUploadUseCase';
@@ -48,7 +49,13 @@ function makeController(
   };
   const uploadService = new UploadService(
     uploadRepository,
-    {} as JobRepository
+    {} as JobRepository,
+    {
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 0, month_started_at: new Date() }),
+      incrementCardUsage: jest.fn().mockResolvedValue(1),
+    } as unknown as UsersRepository
   );
   const notionService = new NotionService(notionRepository);
   return new UploadController(uploadService, notionService, getUseCase, deleteUseCase);

--- a/src/controllers/Upload/GoogleDriveController.test.ts
+++ b/src/controllers/Upload/GoogleDriveController.test.ts
@@ -18,6 +18,7 @@ import NotionTokens from '../../data_layer/public/NotionTokens';
 import NotionService from '../../services/NotionService';
 import UploadService from '../../services/UploadService';
 import JobRepository from '../../data_layer/JobRepository';
+import UsersRepository from '../../data_layer/UsersRepository';
 import UploadController from './UploadController';
 import { GetGoogleDriveUploadsUseCase } from '../../usecases/uploads/GetGoogleDriveUploadsUseCase';
 import { DeleteGoogleDriveUploadUseCase } from '../../usecases/uploads/DeleteGoogleDriveUploadUseCase';
@@ -47,7 +48,13 @@ function makeController(
   };
   const uploadService = new UploadService(
     uploadRepository,
-    {} as JobRepository
+    {} as JobRepository,
+    {
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 0, month_started_at: new Date() }),
+      incrementCardUsage: jest.fn().mockResolvedValue(1),
+    } as unknown as UsersRepository
   );
   const notionService = new NotionService(notionRepository);
   return new UploadController(

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -23,7 +23,17 @@ import Uploads from '../../data_layer/public/Uploads';
 import NotionService from '../../services/NotionService';
 import UploadService from '../../services/UploadService';
 import JobRepository from '../../data_layer/JobRepository';
+import UsersRepository from '../../data_layer/UsersRepository';
 import UploadController from './UploadController';
+
+function buildUsersRepo(): UsersRepository {
+  return {
+    getCardUsage: jest
+      .fn()
+      .mockResolvedValue({ cards_used: 0, month_started_at: new Date() }),
+    incrementCardUsage: jest.fn().mockResolvedValue(1),
+  } as unknown as UsersRepository;
+}
 
 describe('Upload file', () => {
   test('upload failed is caught', () => {
@@ -89,7 +99,7 @@ describe('Upload file', () => {
       clearTokenInvalid: jest.fn().mockResolvedValue(undefined),
       setReconnectEmailSent: jest.fn().mockResolvedValue(true),
     };
-    const uploadService = new UploadService(repository, {} as JobRepository);
+    const uploadService = new UploadService(repository, {} as JobRepository, buildUsersRepo());
     const notionService = new NotionService(notionRepository);
     const uploadController = new UploadController(uploadService, notionService);
 
@@ -151,7 +161,7 @@ describe('Upload file — multer error handling', () => {
       clearTokenInvalid: jest.fn().mockResolvedValue(undefined),
       setReconnectEmailSent: jest.fn().mockResolvedValue(true),
     };
-    const uploadService = new UploadService(repository, {} as JobRepository);
+    const uploadService = new UploadService(repository, {} as JobRepository, buildUsersRepo());
     const notionService = new NotionService(notionRepository);
     const controller = new UploadController(uploadService, notionService);
 
@@ -175,7 +185,7 @@ describe('Upload file — multer error handling', () => {
     expect(jsonSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         code: 'too_large',
-        message: expect.stringContaining('50 MB'),
+        message: expect.stringContaining('100 MB'),
       })
     );
   });

--- a/src/controllers/Upload/UploadController.ts
+++ b/src/controllers/Upload/UploadController.ts
@@ -80,7 +80,7 @@ class UploadController {
         if (error instanceof multer.MulterError && error.code === 'LIMIT_FILE_SIZE') {
           return res.status(413).json({
             code: 'too_large',
-            message: 'Upload failed — file is over the 50 MB limit. Try splitting it.',
+            message: 'Upload failed — file is over the 100 MB limit. Try splitting it.',
           });
         }
         if (isLimitError(error)) {

--- a/src/routes/UploadRouter.ts
+++ b/src/routes/UploadRouter.ts
@@ -12,6 +12,7 @@ import JobRepository from '../data_layer/JobRepository';
 import UploadService from '../services/UploadService';
 import { getDatabase } from '../data_layer';
 import UploadRepository from '../data_layer/UploadRespository';
+import UsersRepository from '../data_layer/UsersRepository';
 import NotionRepository from '../data_layer/NotionRespository';
 import BlocksCacheRepository from '../data_layer/BlocksCacheRepository';
 import NotionService from '../services/NotionService';
@@ -30,7 +31,8 @@ const UploadRouter = () => {
   const jobService = new JobService(jobRepository);
   const uploadService = new UploadService(
     new UploadRepository(database),
-    jobRepository
+    jobRepository,
+    new UsersRepository(database)
   );
   const jobController = new JobController(
     jobService,

--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -150,7 +150,7 @@ describe('ErrorHandler', () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         code: 'too_large',
-        message: expect.stringContaining('50 MB'),
+        message: expect.stringContaining('100 MB'),
       })
     );
   });

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -118,7 +118,7 @@ function toMulterErrorBody(err: multer.MulterError): { status: number; code: Upl
     return {
       status: 413,
       code: 'too_large',
-      message: 'Upload failed — file is over the 50 MB limit. Try splitting it.',
+      message: 'Upload failed — file is over the 100 MB limit. Try splitting it.',
     };
   }
   if (err.code === 'LIMIT_UNEXPECTED_FILE') {

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -26,12 +26,14 @@ jest.mock('./events/track', () => ({ track: jest.fn() }));
 
 let mockWorkspaceLocation = '';
 let mockWorkspaceId = 'test-ws-id';
+let mockFirstApkg: Buffer | null = null;
 jest.mock('../lib/parser/WorkSpace', () => {
   return {
     __esModule: true,
     default: jest.fn().mockImplementation(() => ({
       get id() { return mockWorkspaceId; },
       get location() { return mockWorkspaceLocation; },
+      getFirstAPKG: () => Promise.resolve(mockFirstApkg),
     })),
   };
 });
@@ -59,6 +61,7 @@ import { track } from './events/track';
 const trackMock = track as jest.Mock;
 import { IUploadRepository } from '../data_layer/UploadRespository';
 import JobRepository from '../data_layer/JobRepository';
+import UsersRepository from '../data_layer/UsersRepository';
 import Uploads from '../data_layer/public/Uploads';
 
 const MockGeneratePackagesUseCase = GeneratePackagesUseCase as jest.MockedClass<typeof GeneratePackagesUseCase>;
@@ -75,6 +78,18 @@ function buildRepository(): IUploadRepository {
       Promise.resolve([] as Uploads[]),
     getLastUploadForUser: (_userId: number) => Promise.resolve(null),
   };
+}
+
+function buildUsersRepo(
+  overrides: Partial<UsersRepository> = {}
+): UsersRepository {
+  return {
+    getCardUsage: jest
+      .fn()
+      .mockResolvedValue({ cards_used: 0, month_started_at: new Date() }),
+    incrementCardUsage: jest.fn().mockResolvedValue(1),
+    ...overrides,
+  } as unknown as UsersRepository;
 }
 
 function buildRequest(overrides: Partial<express.Request> = {}): express.Request {
@@ -154,7 +169,7 @@ describe('UploadService.handleUpload — error paths', () => {
       execute: jest.fn().mockResolvedValue({ packages: [] }),
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(buildRepository(), {} as JobRepository);
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
     const req = buildRequest({
       cookies: { anon_id: 'anon-upload-1' },
     } as Partial<express.Request>);
@@ -180,7 +195,7 @@ describe('UploadService.handleUpload — error paths', () => {
       execute: jest.fn().mockResolvedValue({ packages: [] }),
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(buildRepository(), {} as JobRepository);
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
     const req = buildRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
 
@@ -210,7 +225,7 @@ describe('UploadService.handleUpload — error paths', () => {
       execute: jest.fn().mockResolvedValue({ packages: [] }),
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(buildRepository(), {} as JobRepository);
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
 
@@ -229,7 +244,7 @@ describe('UploadService.handleUpload — error paths', () => {
         execute: jest.fn().mockResolvedValue({ packages: [] }),
       }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-      const service = new UploadService(buildRepository(), {} as JobRepository);
+      const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
       const req = buildRequest({
         files: [
           {
@@ -260,7 +275,7 @@ describe('UploadService.handleUpload — error paths', () => {
       execute: jest.fn().mockRejectedValue(new DeckTooLargeError()),
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(buildRepository(), {} as JobRepository);
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
     const req = buildRequest();
     const { res, capturedStatus, capturedJson } = buildResponse();
 
@@ -279,7 +294,7 @@ describe('UploadService.handleUpload — error paths', () => {
       execute: jest.fn().mockRejectedValue(new DeckTooLargeError()),
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(buildRepository(), {} as JobRepository);
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
     const req = buildRequest();
     const { res, capturedJson } = buildResponse();
 
@@ -297,7 +312,7 @@ describe('UploadService.handleUpload — error paths', () => {
       ),
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(buildRepository(), {} as JobRepository);
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
     const req = buildRequest({
       files: [
         {
@@ -331,7 +346,7 @@ describe('UploadService.handleUpload — error paths', () => {
       execute: executeMock,
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(buildRepository(), {} as JobRepository);
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
     const req = buildRequest({
       files: [
         {
@@ -360,6 +375,133 @@ describe('UploadService.handleUpload — error paths', () => {
   });
 });
 
+describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'upload-service-test');
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    trackMock.mockClear();
+    mockFirstApkg = Buffer.from('fake-apkg');
+    mockWorkspaceId = 'test-ws-id';
+  });
+
+  function mockPackages(packages: Array<{ name: string; cardCount: number }>) {
+    MockGeneratePackagesUseCase.mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({ packages }),
+    }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
+  }
+
+  function responseWithRedirect() {
+    const built = buildResponse();
+    let redirectedTo: string | null = null;
+    (built.res.redirect as unknown as jest.Mock).mockImplementation(
+      (url: string) => {
+        redirectedTo = url;
+        return built.res;
+      }
+    );
+    return { ...built, redirectedTo: () => redirectedTo };
+  }
+
+  it('redirects a logged-in free user over the monthly limit to /limit?kind=card_count and does not send the deck', async () => {
+    mockPackages([{ name: 'deck', cardCount: 30 }]);
+    const usersRepo = buildUsersRepo({
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 80, month_started_at: new Date() }),
+    });
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      usersRepo
+    );
+    const req = buildRequest();
+    const { res, capturedSend, redirectedTo } = responseWithRedirect();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+
+    expect(redirectedTo()).toBe('/limit?kind=card_count');
+    expect(capturedSend()).toBeNull();
+    expect(incrementSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends the deck and increments card usage for a logged-in free user under the limit', async () => {
+    mockPackages([{ name: 'deck', cardCount: 30 }]);
+    const usersRepo = buildUsersRepo({
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 10, month_started_at: new Date() }),
+    });
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      usersRepo
+    );
+    const req = buildRequest();
+    const { res, capturedStatus, capturedSend } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(200);
+    expect(capturedSend()).not.toBeNull();
+    expect(incrementSpy).toHaveBeenCalledWith(42, 30);
+  });
+
+  it('redirects an anonymous conversion over 21 cards to /limit?kind=anonymous and does not send the deck', async () => {
+    mockPackages([{ name: 'deck', cardCount: 22 }]);
+    const usersRepo = buildUsersRepo();
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      usersRepo
+    );
+    const req = buildRequest();
+    const { res, capturedSend, redirectedTo } = responseWithRedirect();
+
+    await service.handleUpload(req, res);
+
+    expect(redirectedTo()).toBe('/limit?kind=anonymous');
+    expect(capturedSend()).toBeNull();
+    expect(incrementSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends the deck for an anonymous conversion at or under 21 cards without incrementing usage', async () => {
+    mockPackages([{ name: 'deck', cardCount: 21 }]);
+    const usersRepo = buildUsersRepo();
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      usersRepo
+    );
+    const req = buildRequest();
+    const { res, capturedStatus, capturedSend } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(200);
+    expect(capturedSend()).not.toBeNull();
+    expect(incrementSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('UploadService.deleteUpload — cascade', () => {
   beforeEach(() => {
     mockStorageDelete.mockClear();
@@ -383,7 +525,7 @@ describe('UploadService.deleteUpload — cascade', () => {
       deleteJobByObjectId: jest.fn().mockResolvedValue(1),
     } as unknown as JobRepository;
 
-    const service = new UploadService(repo, jobRepository);
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
     await service.deleteUpload(7, 'k.apkg');
 
     expect(repo.findByKey).toHaveBeenCalledWith(7, 'k.apkg');
@@ -413,7 +555,7 @@ describe('UploadService.deleteUpload — cascade', () => {
       deleteJobByObjectId: jest.fn(),
     } as unknown as JobRepository;
 
-    const service = new UploadService(repo, jobRepository);
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
     await service.deleteUpload(7, 'k.apkg');
 
     expect(repo.deleteUpload).toHaveBeenCalledWith(7, 'k.apkg');
@@ -431,7 +573,7 @@ describe('UploadService.deleteUpload — cascade', () => {
       deleteJobByObjectId: jest.fn(),
     } as unknown as JobRepository;
 
-    const service = new UploadService(repo, jobRepository);
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
     await service.deleteUpload(7, 'k.apkg');
 
     expect(jobRepository.deleteJobByObjectId).not.toHaveBeenCalled();
@@ -483,7 +625,7 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
       }),
     }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
 
-    const service = new UploadService(repo, jobRepository);
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import { IUploadRepository } from '../data_layer/UploadRespository';
 import JobRepository from '../data_layer/JobRepository';
+import UsersRepository from '../data_layer/UsersRepository';
 import ErrorHandler from '../routes/middleware/ErrorHandler';
 import CardOption from '../lib/parser/Settings';
 import Workspace from '../lib/parser/WorkSpace';
@@ -19,6 +20,12 @@ import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { MARKDOWN_LIKELY_LOSSY_REASON } from '../usecases/jobs/jobFailureReason';
 import { DeckTooLargeError } from '../lib/parser/exporters/DeckTooLargeError';
 import { getOwner } from '../lib/User/getOwner';
+import {
+  CheckMonthlyCardLimitUseCase,
+  MonthlyLimitError,
+  AnonymousCardCapError,
+  ANONYMOUS_CARD_CAP,
+} from '../usecases/users/CheckMonthlyCardLimitUseCase';
 import { generateDeckInfo, DeckInfo, ClaudeParseError } from '../lib/claude/ClaudeService';
 import CustomExporter from '../lib/parser/exporters/CustomExporter';
 import Deck from '../lib/parser/Deck';
@@ -102,7 +109,8 @@ class UploadService {
 
   constructor(
     private readonly uploadRepository: IUploadRepository,
-    private readonly jobRepository: JobRepository
+    private readonly jobRepository: JobRepository,
+    private readonly usersRepository: UsersRepository
   ) {}
 
   async restartClaudeJob(req: express.Request, res: express.Response) {
@@ -132,7 +140,7 @@ class UploadService {
     res.status(202).json({ jobId: job.object_id });
   }
 
-  private async promoteClaudeJobToUpload(objectId: string, workspaceDir: string, owner: string): Promise<void> {
+  private async promoteClaudeJobToUpload(objectId: string, workspaceDir: string, owner: string, totalCards = 0): Promise<void> {
     const files = await fs.promises.readdir(workspaceDir);
     const apkgFilename = files.find((f) => f.endsWith('.apkg'));
     if (!apkgFilename) {
@@ -146,6 +154,7 @@ class UploadService {
     await storage.uploadFile(key, apkgBuffer);
     const sizeMb = FileSizeInMegaBytes(apkgPath);
     await this.uploadRepository.update(Number(owner), apkgFilename, key, sizeMb);
+    await this.usersRepository.incrementCardUsage(Number(owner), totalCards);
     const job = await this.jobRepository.findJobById(objectId, owner);
     if (job) {
       await this.jobRepository.deleteJob(String(job.id), owner);
@@ -223,7 +232,11 @@ class UploadService {
 
       return await this.handleSyncUpload(req, res, settings, ws, paying);
     } catch (err) {
-      if (isLimitError(err as Error)) {
+      if (err instanceof MonthlyLimitError) {
+        return res.redirect('/limit?kind=card_count');
+      } else if (err instanceof AnonymousCardCapError) {
+        return res.redirect('/limit?kind=anonymous');
+      } else if (isLimitError(err as Error)) {
         handleUploadLimitError(req, res);
       } else if (err instanceof EmptyDeckError) {
         const files = req.files as UploadedFile[] | undefined;
@@ -295,7 +308,8 @@ class UploadService {
       }, ownerId)
       .then(async ({ packages }) => {
         if (packages.length > 0) {
-          await this.promoteClaudeJobToUpload(ws.id, ws.location, owner);
+          const totalCards = packages.reduce((s, p) => s + (p.cardCount ?? 0), 0);
+          await this.promoteClaudeJobToUpload(ws.id, ws.location, owner, totalCards);
         } else {
           logNoPackageDiagnostics(req.files as UploadedFile[]);
           await this.jobRepository.updateJobStatus(ws.id, owner, 'failed', 'No packages produced');
@@ -337,6 +351,20 @@ class UploadService {
       ws
     );
 
+    const totalCards = packages.reduce((s, p) => s + (p.cardCount ?? 0), 0);
+    const owner = getOwner(res);
+
+    if (owner == null && totalCards > ANONYMOUS_CARD_CAP) {
+      throw new AnonymousCardCapError(totalCards, ANONYMOUS_CARD_CAP);
+    }
+    if (owner != null) {
+      await new CheckMonthlyCardLimitUseCase(this.usersRepository).execute({
+        userId: owner,
+        candidateCardCount: totalCards,
+        isPaying: paying,
+      });
+    }
+
     const first = packages[0];
     if (packages.length === 1) {
       const apkg = await ws.getFirstAPKG();
@@ -345,10 +373,6 @@ class UploadService {
         throw new Error(`Could not produce APKG for ${name}`);
       }
       const plen = Buffer.byteLength(apkg);
-      const totalCards = packages.reduce(
-        (sum, p) => sum + (p.cardCount ?? 0),
-        0
-      );
       const totalMcqCount = packages.reduce((sum, p) => sum + (p.mcqCount ?? 0), 0);
       const totalMcqSkippedCount = packages.reduce((sum, p) => sum + (p.mcqSkippedCount ?? 0), 0);
       res.set('Content-Type', 'application/apkg');
@@ -375,14 +399,27 @@ class UploadService {
       res.attachment(`/${first.name}`);
       const uploadSource = this.resolveUploadSource(req);
       const bucket = this.toCardCountBucket(totalCards);
-      const userId = getOwner(res);
       track('conversion_succeeded', {
-        userId: userId != null ? Number(userId) : null,
+        userId: owner != null ? Number(owner) : null,
         anonymousId: this.resolveAnonId(req),
         props: { source: uploadSource, card_count_bucket: bucket },
       });
+      if (owner != null) {
+        await this.usersRepository.incrementCardUsage(owner, totalCards);
+      }
       return res.status(200).send(apkg);
     } else if (packages.length > 1) {
+      track('conversion_succeeded', {
+        userId: owner != null ? Number(owner) : null,
+        anonymousId: this.resolveAnonId(req),
+        props: {
+          source: this.resolveUploadSource(req),
+          card_count_bucket: this.toCardCountBucket(totalCards),
+        },
+      });
+      if (owner != null) {
+        await this.usersRepository.incrementCardUsage(owner, totalCards);
+      }
       const url = `/download/${ws.id}`;
       res.status(300);
       return res.redirect(url);

--- a/src/usecases/users/CheckMonthlyCardLimitUseCase.test.ts
+++ b/src/usecases/users/CheckMonthlyCardLimitUseCase.test.ts
@@ -1,6 +1,5 @@
 import {
   CheckMonthlyCardLimitUseCase,
-  ENFORCE_AFTER,
   MONTHLY_CARD_LIMIT,
   MonthlyLimitError,
 } from './CheckMonthlyCardLimitUseCase';
@@ -14,9 +13,6 @@ function buildRepo(cards_used: number): UsersRepository {
   } as unknown as UsersRepository;
 }
 
-const AFTER = new Date(ENFORCE_AFTER.getTime() + 86400000);
-const BEFORE = new Date(ENFORCE_AFTER.getTime() - 86400000);
-
 describe('CheckMonthlyCardLimitUseCase', () => {
   it('passes when free user has capacity remaining', async () => {
     const useCase = new CheckMonthlyCardLimitUseCase(buildRepo(50));
@@ -25,7 +21,6 @@ describe('CheckMonthlyCardLimitUseCase', () => {
         userId: '1',
         candidateCardCount: 30,
         isPaying: false,
-        now: AFTER,
       })
     ).resolves.toBeUndefined();
   });
@@ -37,7 +32,18 @@ describe('CheckMonthlyCardLimitUseCase', () => {
         userId: '1',
         candidateCardCount: 30,
         isPaying: false,
-        now: AFTER,
+      })
+    ).rejects.toBeInstanceOf(MonthlyLimitError);
+  });
+
+  it('enforces the limit regardless of the date — the June gate is gone', async () => {
+    const useCase = new CheckMonthlyCardLimitUseCase(buildRepo(80));
+    await expect(
+      useCase.execute({
+        userId: '1',
+        candidateCardCount: 30,
+        isPaying: false,
+        now: new Date(Date.UTC(2020, 0, 1)),
       })
     ).rejects.toBeInstanceOf(MonthlyLimitError);
   });
@@ -50,21 +56,6 @@ describe('CheckMonthlyCardLimitUseCase', () => {
         userId: '1',
         candidateCardCount: 200,
         isPaying: true,
-        now: AFTER,
-      })
-    ).resolves.toBeUndefined();
-    expect(repo.getCardUsage).not.toHaveBeenCalled();
-  });
-
-  it('skips the check before ENFORCE_AFTER even when over limit', async () => {
-    const repo = buildRepo(500);
-    const useCase = new CheckMonthlyCardLimitUseCase(repo);
-    await expect(
-      useCase.execute({
-        userId: '1',
-        candidateCardCount: 200,
-        isPaying: false,
-        now: BEFORE,
       })
     ).resolves.toBeUndefined();
     expect(repo.getCardUsage).not.toHaveBeenCalled();
@@ -77,7 +68,6 @@ describe('CheckMonthlyCardLimitUseCase', () => {
         userId: '1',
         candidateCardCount: 10,
         isPaying: false,
-        now: AFTER,
       });
       throw new Error('expected throw');
     } catch (error) {

--- a/src/usecases/users/CheckMonthlyCardLimitUseCase.ts
+++ b/src/usecases/users/CheckMonthlyCardLimitUseCase.ts
@@ -2,7 +2,19 @@ import UsersRepository from '../../data_layer/UsersRepository';
 
 export const MONTHLY_CARD_LIMIT = 100;
 
-export const ENFORCE_AFTER = new Date(Date.UTC(2026, 5, 1));
+export const ANONYMOUS_CARD_CAP = 21;
+
+export class AnonymousCardCapError extends Error {
+  constructor(
+    public readonly cardsFound: number,
+    public readonly cap: number
+  ) {
+    super(
+      `Anonymous conversion produced ${cardsFound} cards; cap is ${cap}`
+    );
+    this.name = 'AnonymousCardCapError';
+  }
+}
 
 export class MonthlyLimitError extends Error {
   constructor(
@@ -39,7 +51,6 @@ export class CheckMonthlyCardLimitUseCase {
     now = new Date(),
   }: CheckArgs): Promise<void> {
     if (isPaying) return;
-    if (now < ENFORCE_AFTER) return;
     if (candidateCardCount <= 0) return;
 
     const { cards_used } = await this.userRepository.getCardUsage(userId);

--- a/web/src/pages/LimitPage/LimitPage.module.css
+++ b/web/src/pages/LimitPage/LimitPage.module.css
@@ -41,6 +41,17 @@
   }
 }
 
+.singlePlan {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2.5rem;
+}
+
+.singlePlan .planCard {
+  width: 100%;
+  max-width: 420px;
+}
+
 .planCard {
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);

--- a/web/src/pages/LimitPage/LimitPage.test.tsx
+++ b/web/src/pages/LimitPage/LimitPage.test.tsx
@@ -24,7 +24,7 @@ vi.mock('../../lib/hooks/useUserLocals', () => ({
   })),
 }));
 
-function renderPage() {
+function renderPage(initialEntries: string[] = ['/limit']) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -32,7 +32,7 @@ function renderPage() {
   return render(
     <HelmetProvider>
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
+        <MemoryRouter initialEntries={initialEntries}>
           <LimitPage />
         </MemoryRouter>
       </QueryClientProvider>
@@ -81,5 +81,34 @@ describe('LimitPage', () => {
     expect(button).toBeTruthy();
     fireEvent.click(button);
     expect(screen.getByText('Starting checkout…')).toBeTruthy();
+  });
+});
+
+describe('LimitPage — anonymous variant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the sign-up heading for kind=anonymous', () => {
+    renderPage(['/limit?kind=anonymous']);
+    expect(screen.getByText('Sign up free to keep converting')).toBeTruthy();
+  });
+
+  it('shows a "Sign up free" CTA pointing at /register', () => {
+    renderPage(['/limit?kind=anonymous']);
+    const cta = screen.getByText('Sign up free');
+    expect(cta.closest('a')?.getAttribute('href')).toBe('/register?redirect=/upload');
+  });
+
+  it('keeps a secondary Sign in link', () => {
+    renderPage(['/limit?kind=anonymous']);
+    const signIn = screen.getByText('Sign in');
+    expect(signIn.closest('a')?.getAttribute('href')).toBe('/login?redirect=/upload');
+  });
+
+  it('does not show the monthly-limit upgrade UI for anonymous users', () => {
+    renderPage(['/limit?kind=anonymous']);
+    expect(screen.queryByText('You reached 100 cards this month')).toBeNull();
+    expect(screen.queryByText('Get Auto Sync')).toBeNull();
   });
 });

--- a/web/src/pages/LimitPage/LimitPage.tsx
+++ b/web/src/pages/LimitPage/LimitPage.tsx
@@ -47,9 +47,8 @@ function AnonymousLimit() {
         </p>
       </header>
 
-      <div className={styles.plans}>
+      <div className={styles.singlePlan}>
         <div className={`${styles.planCard} ${styles.planCardFeatured}`}>
-          <p className={styles.planBadge}>Free</p>
           <p className={styles.planTitle}>Free account</p>
           <ul className={styles.planBenefits}>
             <li className={styles.planBenefit}>Up to 100 cards a month</li>

--- a/web/src/pages/LimitPage/LimitPage.tsx
+++ b/web/src/pages/LimitPage/LimitPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { track } from '../../lib/analytics/track';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
@@ -28,16 +28,75 @@ const AUTO_SYNC_BENEFITS = [
   'Cancel anytime',
 ];
 
+function AnonymousLimit() {
+  useEffect(() => {
+    track('paywall_shown', { surface: REF, variant: 'anonymous' });
+  }, []);
+
+  return (
+    <div className={styles.page}>
+      <Helmet>
+        <title>Sign up free to keep converting | 2anki</title>
+      </Helmet>
+
+      <header className={styles.header}>
+        <h1 className={styles.heading}>Sign up free to keep converting</h1>
+        <p className={styles.subheading}>
+          A free account converts up to 100 cards a month. Without an account,
+          conversions are capped at 21 cards.
+        </p>
+      </header>
+
+      <div className={styles.plans}>
+        <div className={`${styles.planCard} ${styles.planCardFeatured}`}>
+          <p className={styles.planBadge}>Free</p>
+          <p className={styles.planTitle}>Free account</p>
+          <ul className={styles.planBenefits}>
+            <li className={styles.planBenefit}>Up to 100 cards a month</li>
+            <li className={styles.planBenefit}>Save and re-download your decks</li>
+            <li className={styles.planBenefit}>Connect Notion, Dropbox, and Google Drive</li>
+          </ul>
+          <Link
+            to="/register?redirect=/upload"
+            className={styles.planCtaPrimary}
+            onClick={() =>
+              track('paywall_upgrade_clicked', {
+                surface: REF,
+                plan: 'free_signup',
+              })
+            }
+          >
+            Sign up free
+          </Link>
+        </div>
+      </div>
+
+      <p className={styles.backLink}>
+        Already have an account? <Link to="/login?redirect=/upload">Sign in</Link>
+      </p>
+    </div>
+  );
+}
+
 export function LimitPage() {
+  const [searchParams] = useSearchParams();
   const { data: userLocals } = useUserLocals();
   const email = userLocals?.user?.email;
   const isLoggedIn = userLocals?.user?.id != null;
   const [autoSyncPending, setAutoSyncPending] = useState(false);
   const [autoSyncError, setAutoSyncError] = useState<string | null>(null);
 
+  const kind = searchParams.get('kind');
+  const showAnonymous = kind === 'anonymous' || !isLoggedIn;
+
   useEffect(() => {
+    if (showAnonymous) return;
     track('paywall_shown', { surface: REF });
-  }, []);
+  }, [showAnonymous]);
+
+  if (showAnonymous) {
+    return <AnonymousLimit />;
+  }
 
   const handleAutoSyncClick = async () => {
     if (!isLoggedIn) {

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -364,7 +364,7 @@ export default function PricingPage({
           <p className={styles.intro}>
             {isUS
               ? 'Built for spaced repetition — MCAT, USMLE, bar exam, and language prep. Turn Notion pages, PDFs, and photos into Anki decks with AI — no account needed to start.'
-              : 'Turn Notion pages, PDFs, and photos into Anki decks with AI — no account needed to start. Free for 100 cards per month, then pay once by the day or week.'}
+              : 'Turn Notion pages, PDFs, and photos into Anki decks with AI — no account needed to start. Sign up free for 100 cards per month, then pay once by the day or week.'}
             {!isLoggedIn && (
               <>
                 {' '}

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -1056,8 +1056,45 @@ describe('limit state — start trial button', () => {
 
     await waitFor(() => {
       const title = container.querySelector('[class*="limitTitle"]');
-      expect(title?.textContent).toMatch(/50 MB/i);
+      expect(title?.textContent).toMatch(/100 MB/i);
     });
+  });
+
+  it('navigates to /limit?kind=anonymous on an anonymous limit redirect', async () => {
+    mockUseUserLocals.mockReturnValue({
+      data: {
+        user: null,
+        locals: { owner: 0, patreon: false, subscriber: false, subscriptionInfo: { active: false, email: '', linked_email: '' } },
+        linked_email: '',
+      } as unknown as ReturnType<typeof useUserLocals>['data'],
+      isLoading: false,
+      error: null,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    const locationStub = { href: '' } as Location;
+    vi.stubGlobal('location', locationStub);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: true,
+      url: 'http://localhost/limit?kind=anonymous',
+      status: 200,
+      headers: new Headers({}),
+      blob: () => Promise.resolve(new Blob([])),
+    }));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(locationStub.href).toBe('/limit?kind=anonymous');
+    });
+
+    expect(container.querySelector('[class*="limitContent"]')).toBeNull();
   });
 
   it('shows trial-used description and no trial button when trial_started_at is set (file_size)', async () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -51,6 +51,10 @@ function isLimitRedirect(url: URL): boolean {
   );
 }
 
+function isAnonymousLimit(url: URL): boolean {
+  return url.searchParams.get('kind') === 'anonymous';
+}
+
 function getLimitKind(url: URL): 'file_size' | 'card_count' {
   return url.searchParams.get('kind') === 'card_count' ? 'card_count' : 'file_size';
 }
@@ -433,6 +437,10 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       if (request.redirected) {
         const redirectUrl = new URL(request.url, globalThis.location.origin);
         if (isLimitRedirect(redirectUrl)) {
+          if (isAnonymousLimit(redirectUrl)) {
+            globalThis.location.href = '/limit?kind=anonymous';
+            return;
+          }
           const kind = getLimitKind(redirectUrl);
           setLimitInfo({
             filename: first?.name ?? null,
@@ -523,6 +531,10 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       if (request.redirected) {
         const redirectUrl = new URL(request.url, globalThis.location.origin);
         if (isLimitRedirect(redirectUrl)) {
+          if (isAnonymousLimit(redirectUrl)) {
+            globalThis.location.href = '/limit?kind=anonymous';
+            return;
+          }
           const kind = getLimitKind(redirectUrl);
           setLimitInfo({
             filename: first?.name ?? null,
@@ -605,6 +617,10 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       if (request.redirected) {
         const redirectUrl = new URL(request.url, globalThis.location.origin);
         if (isLimitRedirect(redirectUrl)) {
+          if (isAnonymousLimit(redirectUrl)) {
+            globalThis.location.href = '/limit?kind=anonymous';
+            return true;
+          }
           const firstFile = fileInputRef.current?.files?.[0];
           const kind = getLimitKind(redirectUrl);
           setLimitInfo({
@@ -958,7 +974,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
   const renderLimitState = () => {
     const isFileSize = limitInfo?.kind === 'file_size';
     const title = isFileSize
-      ? 'This file is over the 50 MB limit'
+      ? 'This file is over the 100 MB limit'
       : 'You reached your monthly limit of 100 cards';
     let limitContext: 'anonymous' | 'trial_available' | 'trial_used';
     if (showSignInPrompt) {


### PR DESCRIPTION
## Why

Two leaks in the card-quota system, found while answering "how do limits work on /upload":

1. **File/zip uploads never counted or enforced.** `cards_used_this_month` was only ever incremented on the **Notion** path (`performConversion` → `CompleteJobUseCase`). The `/upload` file/zip path (sync *and* async) produced cards that never touched the counter and were never checked — so the sidebar read `0 / 100` after a 100+ card zip, and free users could batch-convert without limit. The multi-package branch (a zip with many subpages → many decks → `/download` redirect) also fired **no** analytics.
2. **Anonymous uploads had no limit at all** — a logged-out user could drop a big zip and batch-generate hundreds of cards repeatedly, for free.

Also: the 100-card limit was gated behind a `ENFORCE_AFTER = June 1 2026` date, and a stale "50 MB" size message (real free limit is 100 MB).

## What

- **Enforce now:** removed the `ENFORCE_AFTER` gate — the monthly limit applies immediately on every path.
- **Upload path parity with Notion:** `UploadService` now counts cards, checks `CheckMonthlyCardLimitUseCase`, and increments `cards_used_this_month` — for **both** the single-deck and the multi-package branches (sync), and on completion for the async Claude path. Over-limit logged-in free users → `302 /limit?kind=card_count`.
- **Anonymous cap = 21 cards/conversion.** Over that → `302 /limit?kind=anonymous`. (Stateless size check; no DB.)
- **`LimitPage` anonymous variant:** "Sign up free to keep converting" with a `/register` CTA — not the upgrade/plan UI. The upload form routes the new limit kinds.
- **Pricing hero copy** now reads "…no account needed to start. **Sign up free** for 100 cards per month…" so the 100/month is tied to a free account, not to "no account". The protected "100 cards per month" string is preserved verbatim.
- **Multi-package tracking:** added the missing `conversion_succeeded` event to that branch.
- **Copy fix:** "50 MB" → "100 MB" in `UploadController`, `ErrorHandler`, and the upload form.

## Notes / scope

- **Async Claude path is increment-only** (no pre-build limit check) — the deck is already built in the worker by the time the count is known; a pre-build check there is a larger change. Flagged intentionally.
- **Blast radius:** with the June-1 gate gone, free users now get blocked at 100 cards/month across *all* paths immediately. Intentional, per request.
- Per-IP repeat-conversion throttling for anonymous users is **not** in this PR (the 21-card cap removes most incentive); can fast-follow using the existing `ShareRouter` in-memory pattern.
- No changelog entry — this tightens enforcement rather than adding a user benefit; whether/how to announce it is a comms call.
- **No `partial-deck` delivery** for over-cap anonymous users yet (designer's "give them the first 21 + preserve file through signup") — that needs a sync-response-contract rework; this PR blocks over-cap with a clear sign-up path instead.

## Trio
pm + designer + engineer reviewed the anon decision (cap, don't close; sign-up not upgrade; instrument first). Number set to 21 by the user.

## Tests
Built via a 3-way agent fan-out on disjoint files; integrated and verified together: **server tsc clean, backend jest 67/67 on changed suites, web typecheck clean, biome lint clean, web vitest 1465 passing.** New tests cover: enforcement regardless of date; logged-in over/under limit on upload; anonymous over/under 21; the `LimitPage` anonymous variant; the multi-package path.

⚠️ Sonar not run locally (no `SONAR_TOKEN`); `handleSyncUpload` grew — watch for a cognitive-complexity flag on CI.

## Security
Touches quotas/limits — recommend `/security-review` before merge.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified hands-on on localhost — over-limit upload blocks at /limit (does not increment); successful under-limit conversion increments the counter (visible after reload); anonymous >21 cards → /limit?kind=anonymous; pricing/copy correct. Live counter refetch + remaining copy polish tracked for the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782771567&installation_id=132681956&pr_number=2936&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2936&signature=65624e16c3c0cfbaaed4a1e71229d75199554dcf23a99b88f5d74ac5fe1364ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
