### PR TITLE
fix: Notion purple highlights render purple, not red

### DIFF
--- a/src/services/NotionService/NotionColors.test.ts
+++ b/src/services/NotionService/NotionColors.test.ts
@@ -11,6 +11,29 @@ describe('color mappings', () => {
     expect(color).toBe('#E03E3E');
   });
 
+  test('purple background uses the purple hex, not the red one', () => {
+    expect(notionColorToHex('purple_background')).toBe('#6940A5');
+  });
+
+  test('each background color mirrors its text color', () => {
+    const names = [
+      'gray',
+      'brown',
+      'orange',
+      'yellow',
+      'green',
+      'blue',
+      'purple',
+      'pink',
+      'red',
+    ];
+    for (const name of names) {
+      expect(notionColorToHex(`${name}_background`)).toBe(
+        notionColorToHex(name)
+      );
+    }
+  });
+
   test('it is background', () => {
     expect(isNotionColorBackground('red_background')).toBe(true);
   });

--- a/src/services/NotionService/NotionColors.ts
+++ b/src/services/NotionService/NotionColors.ts
@@ -15,7 +15,7 @@ export const NOTION_COLORS = [
   { name: 'yellow_background', color: '#DFAB01' },
   { name: 'green_background', color: '#0F7B6C' },
   { name: 'blue_background', color: '#0B6E99' },
-  { name: 'purple_background', color: '#E03E3E' },
+  { name: 'purple_background', color: '#6940A5' },
   { name: 'pink_background', color: '#AD1A72' },
   { name: 'red_background', color: '#E03E3E' },
 ];

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-notion-purple-highlight.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-notion-purple-highlight.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-notion-purple-highlight",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Purple highlights from Notion keep their color on converted cards"
+}


### PR DESCRIPTION
## What

`NOTION_COLORS` mapped `purple_background` to `#E03E3E` — red's hex — so purple highlights coming through the Notion sync path (`HandleBlockAnnotations.tsx`, which sets an inline `backgroundColor` via `notionColorToHex`) rendered with a red background on converted cards.

Every other background color mirrors its text-color counterpart (e.g. `green_background` == `green`). Purple was the lone mismatch: its background value was a copy of red's hex. Fixed to `#6940A5` to match the purple text color.

## Test

Added two cases to `NotionColors.test.ts`:
- `purple_background` resolves to `#6940A5`, not the red hex
- each background color mirrors its text color (catches this class of copy-paste regression for all 9 colors)

Both failed before the fix (returned `#E03E3E`), pass after.

## Notes

- Found while auditing highlight-color coverage per #2225. This lands the concrete defect + a regression test for the mapping; the documentation sub-task in #2225 is left open, so this `Refs` rather than closes it.
- sonar-scanner not run — single-value data fix plus tests, no new code paths.

Browser check: not applicable — server-side color mapping; the only `web/src/` change is a changelog entry.

Refs #2225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782778028&installation_id=132681956&pr_number=2939&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2939&signature=3d746cfd0977370e4a9a0b2029f5b4868b3c758ef2f3e6250694a06c18d5bc45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->