### PR TITLE
fix: embed Loom recordings from Notion pages on cards

### DIFF
--- a/src/lib/notion-render/embedUrl.test.ts
+++ b/src/lib/notion-render/embedUrl.test.ts
@@ -57,6 +57,14 @@ describe('resolveEmbedUrl', () => {
     });
   });
 
+  it('rewrites a Loom share link to its embeddable form', () => {
+    const result = resolveEmbedUrl('https://www.loom.com/share/abc123');
+    expect(result).toEqual({
+      kind: 'iframe',
+      src: 'https://www.loom.com/embed/abc123',
+    });
+  });
+
   it('passes other URLs through as iframe src', () => {
     const result = resolveEmbedUrl('https://codepen.io/user/pen/abc');
     expect(result).toEqual({

--- a/src/lib/notion-render/embedUrl.ts
+++ b/src/lib/notion-render/embedUrl.ts
@@ -1,6 +1,8 @@
+import getLoomEmbedUrl from '../parser/helpers/getLoomEmbedUrl';
 import getYouTubeEmbedLink from '../parser/helpers/getYouTubeEmbedLink';
 import getYouTubeID from '../parser/helpers/getYouTubeID';
 import {
+  isLoomURL,
   isSoundCloudURL,
   isTwitterURL,
   isVimeoURL,
@@ -50,6 +52,9 @@ export const resolveEmbedUrl = (url: string): ResolvedEmbed => {
     if (id != null && id !== '') {
       return { kind: 'iframe', src: `https://player.vimeo.com/video/${id}` };
     }
+  }
+  if (isLoomURL(url) != null) {
+    return { kind: 'iframe', src: getLoomEmbedUrl(url) };
   }
   return { kind: 'iframe', src: url };
 };

--- a/src/lib/parser/helpers/getLoomEmbedUrl.test.ts
+++ b/src/lib/parser/helpers/getLoomEmbedUrl.test.ts
@@ -1,0 +1,21 @@
+import getLoomEmbedUrl from './getLoomEmbedUrl';
+
+describe('getLoomEmbedUrl', () => {
+  it('rewrites a Loom share link to the embed form', () => {
+    expect(
+      getLoomEmbedUrl('https://www.loom.com/share/abc123def456')
+    ).toBe('https://www.loom.com/embed/abc123def456');
+  });
+
+  it('preserves a trailing query string', () => {
+    expect(
+      getLoomEmbedUrl('https://www.loom.com/share/abc123?sid=xyz')
+    ).toBe('https://www.loom.com/embed/abc123?sid=xyz');
+  });
+
+  it('leaves an already-embed URL unchanged', () => {
+    expect(
+      getLoomEmbedUrl('https://www.loom.com/embed/abc123')
+    ).toBe('https://www.loom.com/embed/abc123');
+  });
+});

--- a/src/lib/parser/helpers/getLoomEmbedUrl.ts
+++ b/src/lib/parser/helpers/getLoomEmbedUrl.ts
@@ -1,0 +1,9 @@
+/**
+ * Loom share links (https://www.loom.com/share/<id>) refuse to render in an
+ * iframe — the embeddable form lives at https://www.loom.com/embed/<id>.
+ * Rewrites a share URL to its embed equivalent; any other Loom URL (already an
+ * embed, or an unexpected shape) is returned unchanged.
+ */
+export default function getLoomEmbedUrl(url: string): string {
+  return url.replace('/share/', '/embed/');
+}

--- a/src/lib/storage/checks.ts
+++ b/src/lib/storage/checks.ts
@@ -18,6 +18,8 @@ export const isTwitterURL = (url: string) => /twitter\.com/.exec(url);
 
 export const isVimeoURL = (url: string) => /vimeo\.com/.exec(url);
 
+export const isLoomURL = (url: string) => /loom\.com/.exec(url);
+
 export const isImageFileEmbedable = (url: string) => {
   const isLocalPath = !url.startsWith('http') && !url.startsWith('data:image');
   const hasTraversal = url.includes('../') || url.includes('..\\');

--- a/src/services/NotionService/blocks/media/BlockEmbed.test.tsx
+++ b/src/services/NotionService/blocks/media/BlockEmbed.test.tsx
@@ -1,0 +1,43 @@
+import { EmbedBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { BlockEmbed } from './BlockEmbed';
+import CardOption from '../../../../lib/parser/Settings/CardOption';
+import BlockHandler from '../../BlockHandler/BlockHandler';
+import CustomExporter from '../../../../lib/parser/exporters/CustomExporter';
+import Workspace from '../../../../lib/parser/WorkSpace';
+import MockNotionAPI from '../../_mock/MockNotionAPI';
+import { setupTests } from '../../../../test/configure-jest';
+
+beforeEach(() => setupTests());
+
+const makeHandler = () => {
+  const api = new MockNotionAPI('', '');
+  const exporter = new CustomExporter('', new Workspace(true, 'fs').location);
+  return new BlockHandler(exporter, api, new CardOption({}));
+};
+
+const makeEmbedBlock = (url: string) =>
+  ({
+    id: 'block-embed-test',
+    type: 'embed' as const,
+    object: 'block' as const,
+    parent: { type: 'page_id' as const, page_id: 'page-id' },
+    created_time: '',
+    last_edited_time: '',
+    created_by: { object: 'user' as const, id: 'user-id' },
+    last_edited_by: { object: 'user' as const, id: 'user-id' },
+    has_children: false,
+    archived: false,
+    in_trash: false,
+    embed: { url, caption: [] },
+  }) as EmbedBlockObjectResponse;
+
+describe('BlockEmbed — Loom', () => {
+  it('rewrites a Loom share link to the embeddable iframe src', () => {
+    const html = BlockEmbed(
+      makeEmbedBlock('https://www.loom.com/share/abc123'),
+      makeHandler()
+    );
+    expect(html).toContain('src="https://www.loom.com/embed/abc123"');
+    expect(html).not.toContain('/share/');
+  });
+});

--- a/src/services/NotionService/blocks/media/BlockEmbed.tsx
+++ b/src/services/NotionService/blocks/media/BlockEmbed.tsx
@@ -1,9 +1,14 @@
 import { EmbedBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { renderToStaticMarkup } from 'react-dom/server';
+import getLoomEmbedUrl from '../../../../lib/parser/helpers/getLoomEmbedUrl';
 import getYouTubeEmbedLink from '../../../../lib/parser/helpers/getYouTubeEmbedLink';
 import getYouTubeID from '../../../../lib/parser/helpers/getYouTubeID';
 import BlockHandler from '../../BlockHandler/BlockHandler';
-import { isSoundCloudURL, isTwitterURL } from '../../../../lib/storage/checks';
+import {
+  isLoomURL,
+  isSoundCloudURL,
+  isTwitterURL,
+} from '../../../../lib/storage/checks';
 
 export const BlockEmbed = (
   c: EmbedBlockObjectResponse,
@@ -23,6 +28,8 @@ export const BlockEmbed = (
           <a href={url}>{url}</a>
         </div>
       );
+    } else if (isLoomURL(url)) {
+      url = getLoomEmbedUrl(url);
     }
 
     const yt = getYouTubeID(url);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-loom-embeds.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-loom-embeds.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-loom-embeds",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Loom recordings embedded in Notion pages render on your cards"
+}


### PR DESCRIPTION
## What

Loom embeds in Notion never rendered on converted cards. A Loom embed block carries a share URL (`https://www.loom.com/share/<id>`), and both embed code paths wrapped that URL in an iframe unchanged. Loom refuses to render `/share/` URLs inside an iframe — the embeddable form is `/embed/<id>` — so the card showed a blank/blocked frame.

YouTube, Vimeo, and SoundCloud already get provider-specific URL rewrites; Loom was simply missing.

## Fix

- `isLoomURL` (`src/lib/storage/checks.ts`) + `getLoomEmbedUrl` (`src/lib/parser/helpers/getLoomEmbedUrl.ts`), a pure `/share/` → `/embed/` rewrite.
- Wired into the live Notion conversion path (`BlockEmbed.tsx`) and the Ankify render path (`resolveEmbedUrl` in `embedUrl.ts`), alongside the existing YouTube/Vimeo branches.

## Tests

- `getLoomEmbedUrl.test.ts` — share→embed rewrite, query-string preserved, already-embed left alone.
- `embedUrl.test.ts` — `resolveEmbedUrl` on a Loom share link returns the embed iframe (failed before the fix, passes after).
- `BlockEmbed.test.tsx` — the live path emits `src="…/embed/…"` and no longer contains `/share/`.

## Notes

- sonar-scanner not run locally (no token configured in this environment); changes are small and additive — one helper plus one branch per path.

Browser check: not applicable — server-side embed rewrite; the only `web/src/` change is a changelog entry.

Fixes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782778328&installation_id=132681956&pr_number=2941&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2941&signature=044cbfaa956e164f8f942463309fd6cf1cab8b3570e9d73a5633652786705fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->