### PR TITLE
fix: return 503 on transient storage errors during deck download

### DIFF
--- a/src/controllers/DownloadController.test.ts
+++ b/src/controllers/DownloadController.test.ts
@@ -343,3 +343,81 @@ describe('DownloadController.getDownloadPage view model', () => {
     expect(html).toContain('No decks found in your upload');
   });
 });
+
+describe('DownloadController.getFile storage error handling', () => {
+  function makeServiceThatThrows(error: unknown, overrides: Record<string, unknown> = {}) {
+    return makeService({
+      getFileBody: jest.fn().mockRejectedValue(error),
+      isMissingDownloadError: (e: unknown) =>
+        (e as { name?: string })?.name?.includes('NoSuchKey') === true,
+      isTransientStorageError: jest
+        .fn()
+        .mockImplementation((e: unknown) =>
+          (e as { transient?: boolean })?.transient === true
+        ),
+      deleteMissingFile: jest.fn(),
+      ...overrides,
+    });
+  }
+
+  it('redirects and drops the row when the object is gone (NoSuchKey)', async () => {
+    const error = Object.assign(new Error('not found'), { name: 'NoSuchKey' });
+    const service = makeServiceThatThrows(error);
+    const controller = new DownloadController(service as never);
+    const req = { params: { key: 'deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as never);
+
+    expect(service.deleteMissingFile).toHaveBeenCalledWith('test-owner', 'deck.apkg');
+    expect(res.redirect).toHaveBeenCalledWith('/downloads');
+  });
+
+  it('returns 503 with a retry message on a transient storage error', async () => {
+    const error = Object.assign(new Error('connection reset'), {
+      transient: true,
+    });
+    const service = makeServiceThatThrows(error);
+    const controller = new DownloadController(service as never);
+    const req = { params: { key: 'deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as never);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.send).toHaveBeenCalledWith(
+      'Storage is busy right now. Try the download again in a moment.'
+    );
+  });
+
+  it('does not leak raw storage error text on a transient failure', async () => {
+    const error = Object.assign(
+      new Error('S3 internal: bucket=2anki-prod endpoint leaked'),
+      { transient: true }
+    );
+    const service = makeServiceThatThrows(error);
+    const controller = new DownloadController(service as never);
+    const req = { params: { key: 'deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as never);
+
+    const sent = (res.send as jest.Mock).mock.calls.map((c) => String(c[0])).join('');
+    expect(sent).not.toContain('2anki-prod');
+    expect(sent).not.toContain('endpoint leaked');
+  });
+
+  it('falls back to the 404 expire page on an unknown error', async () => {
+    const error = new Error('weird internal detail user must not see');
+    const service = makeServiceThatThrows(error);
+    const controller = new DownloadController(service as never);
+    const req = { params: { key: 'deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as never);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    const sent = (res.send as jest.Mock).mock.calls.map((c) => String(c[0])).join('');
+    expect(sent).not.toContain('weird internal detail');
+  });
+});

--- a/src/controllers/DownloadController.ts
+++ b/src/controllers/DownloadController.ts
@@ -81,19 +81,30 @@ class DownloadController {
         throw new Error(`File not found: ${key}`);
       }
     } catch (error) {
-      console.error(error);
       if (this.service.isMissingDownloadError(error)) {
         this.service.deleteMissingFile(owner, key);
         res.redirect('/downloads');
-      } else {
-        console.info('Download failed');
-        console.error(error);
-        res
-          .status(404)
-          .send(
-            "Download link expire, try converting again <a href='/upload'>upload</a>"
-          );
+        return;
       }
+      if (this.service.isTransientStorageError(error)) {
+        console.info('Download storage transient error', {
+          owner,
+          name: (error as { name?: string })?.name,
+        });
+        res
+          .status(503)
+          .send(
+            'Storage is busy right now. Try the download again in a moment.'
+          );
+        return;
+      }
+      console.info('Download failed');
+      console.error(error);
+      res
+        .status(404)
+        .send(
+          "Download link expire, try converting again <a href='/upload'>upload</a>"
+        );
     }
   }
 

--- a/src/services/DownloadService.test.ts
+++ b/src/services/DownloadService.test.ts
@@ -1,0 +1,65 @@
+import DownloadService from './DownloadService';
+
+function makeService() {
+  return new DownloadService({} as never);
+}
+
+describe('DownloadService.isMissingDownloadError', () => {
+  it('matches a NoSuchKey error from the storage SDK', () => {
+    const service = makeService();
+    const error = Object.assign(new Error('not found'), { name: 'NoSuchKey' });
+    expect(service.isMissingDownloadError(error)).toBe(true);
+  });
+
+  it('does not match a generic error', () => {
+    const service = makeService();
+    expect(service.isMissingDownloadError(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('DownloadService.isTransientStorageError', () => {
+  it('matches a 5xx response from storage', () => {
+    const service = makeService();
+    const error = Object.assign(new Error('service unavailable'), {
+      name: 'ServiceUnavailable',
+      $metadata: { httpStatusCode: 503 },
+    });
+    expect(service.isTransientStorageError(error)).toBe(true);
+  });
+
+  it('matches a storage request timeout', () => {
+    const service = makeService();
+    const error = Object.assign(new Error('timed out'), {
+      name: 'TimeoutError',
+    });
+    expect(service.isTransientStorageError(error)).toBe(true);
+  });
+
+  it('matches a socket reset surfaced via error.code', () => {
+    const service = makeService();
+    const error = Object.assign(new Error('reset'), { code: 'ECONNRESET' });
+    expect(service.isTransientStorageError(error)).toBe(true);
+  });
+
+  it('matches a socket error nested under error.cause', () => {
+    const service = makeService();
+    const error = Object.assign(new Error('fetch failed'), {
+      cause: { code: 'ETIMEDOUT' },
+    });
+    expect(service.isTransientStorageError(error)).toBe(true);
+  });
+
+  it('does not match a NoSuchKey error', () => {
+    const service = makeService();
+    const error = Object.assign(new Error('not found'), {
+      name: 'NoSuchKey',
+      $metadata: { httpStatusCode: 404 },
+    });
+    expect(service.isTransientStorageError(error)).toBe(false);
+  });
+
+  it('does not match a generic error', () => {
+    const service = makeService();
+    expect(service.isTransientStorageError(new Error('boom'))).toBe(false);
+  });
+});

--- a/src/services/DownloadService.ts
+++ b/src/services/DownloadService.ts
@@ -1,6 +1,45 @@
 import StorageHandler from '../lib/storage/StorageHandler';
 import DownloadRepository from '../data_layer/DownloadRepository';
 
+const TRANSIENT_ERROR_NAMES = new Set([
+  'TimeoutError',
+  'RequestTimeout',
+  'RequestTimeoutException',
+  'ServiceUnavailable',
+  'SlowDown',
+  'InternalError',
+  'PriorRequestNotComplete',
+]);
+
+const TRANSIENT_SOCKET_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'EAI_AGAIN',
+  'EPIPE',
+  'ENETUNREACH',
+  'ENOTFOUND',
+]);
+
+function getErrorName(error: unknown): string | undefined {
+  return (error as { name?: string })?.name;
+}
+
+function getStorageStatusCode(error: unknown): number | undefined {
+  const metadata = (error as { $metadata?: { httpStatusCode?: number } })
+    ?.$metadata;
+  return typeof metadata?.httpStatusCode === 'number'
+    ? metadata.httpStatusCode
+    : undefined;
+}
+
+function getSocketCode(error: unknown): string | undefined {
+  const direct = (error as { code?: string })?.code;
+  if (typeof direct === 'string') return direct;
+  const nested = (error as { cause?: { code?: string } })?.cause?.code;
+  return typeof nested === 'string' ? nested : undefined;
+}
+
 class DownloadService {
   constructor(private downloadRepository: DownloadRepository) {}
 
@@ -26,8 +65,18 @@ class DownloadService {
   }
 
   isMissingDownloadError(error: unknown) {
-    const errorName = (error as { name?: string })?.name;
+    const errorName = getErrorName(error);
     return errorName != null && errorName.includes('NoSuchKey');
+  }
+
+  isTransientStorageError(error: unknown) {
+    if (this.isMissingDownloadError(error)) return false;
+    const statusCode = getStorageStatusCode(error);
+    if (statusCode != null && statusCode >= 500) return true;
+    const errorName = getErrorName(error);
+    if (errorName != null && TRANSIENT_ERROR_NAMES.has(errorName)) return true;
+    const socketCode = getSocketCode(error);
+    return socketCode != null && TRANSIENT_SOCKET_CODES.has(socketCode);
   }
 
   deleteMissingFile(owner: string, key: string) {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-download-retry.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-download-retry.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-download-retry",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Deck downloads that hit a busy storage server tell you to retry instead of failing silently"
+}


### PR DESCRIPTION
## What
Deck download (`GET /api/download/u/:key`) now distinguishes transient storage failures from permanent ones. A request timeout, socket reset, or 5xx from the S3-compatible storage backend returns 503 with a retry-friendly message. The missing-object case keeps its existing redirect; any other error keeps the existing 404 expire page.

## Why
Closes #1039. `DownloadController.getFile` only classified a `NoSuchKey` error. Every other storage error fell through to a generic catch that returned a 404 "Download link expired" page — even though a finished deck was still in storage and a retry would have worked. To the user this read as a "Failed to fetch" during download with no signal it was transient.

## How
- `DownloadService.isTransientStorageError` inspects the SDK error name (`TimeoutError`, `ServiceUnavailable`, `SlowDown`, …), the `$metadata.httpStatusCode` (≥ 500), and socket codes (`ECONNRESET`, `ETIMEDOUT`, …) including ones nested under `error.cause`. It returns `false` for `NoSuchKey` so the missing-object path is preserved. Classification lives in the service; HTTP shaping stays in the controller.
- `DownloadController.getFile` adds a 503 branch with "Storage is busy right now. Try the download again in a moment." plus an info log (`Download storage transient error`) carrying owner + SDK error name only.
- No raw storage error object, stack, or S3 text reaches the client (`.claude/rules/security.md`, CWE-209) — tests assert the response never contains bucket/endpoint detail on transient or unknown failures.

## Measuring success
Prod log line `Download storage transient error` (owner + SDK error name, no secrets) confirms the 503 branch fires; a drop in spurious 404 "expired" responses on `GET /api/download/u/:key` alongside these 503s shows transient blips are now classified correctly instead of looking like a dead link.

## Testing
- Unit tests added (run green: 24/24 across both files, 32/32 incl. neighbouring controllers; `tsc --noEmit` clean):
  - `src/services/DownloadService.test.ts` — `isTransientStorageError` matches 5xx, timeout, `ECONNRESET`, nested `error.cause` code; rejects `NoSuchKey` and generic errors; `isMissingDownloadError` regression cases.
  - `src/controllers/DownloadController.test.ts` — added a `getFile storage error handling` block: NoSuchKey → redirect + row cleanup; transient → 503 with retry message; no raw storage text leaks on transient or unknown failures; unknown → 404 expire page. All pre-existing DownloadController tests retained unchanged.

## Browser check
Browser check: not applicable — server-side error-handling change; the only `web/src` file is a changelog JSON, no rendered behavior change.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-31-download-retry.json` — "Deck downloads that hit a busy storage server tell you to retry instead of failing silently"

## Risks
Low. The new branch only triggers on errors that previously produced a 404 expire page; worst case a misclassified permanent error returns 503 instead of 404, which still tells the user to retry. Rollback is a clean revert of one commit.

## Goal alignment
Download is the last step before a user has their deck in Anki — a transient storage blip reading as an expired link makes a finished conversion look broken at the finish line. A clear, retryable message keeps users in the funnel, supporting the 300K-user goal.

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` is not configured in this environment. Change is a small, self-contained classifier plus one controller branch; expect a clean scan.
