### PR TITLE
fix: delete per-conversion workspace dir after each job

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -26,6 +26,10 @@ jest.mock('../../../../usecases/users/CheckMonthlyCardLimitUseCase', () => {
 });
 jest.mock('../../../../services/events/track', () => ({ track: jest.fn() }));
 
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { APIResponseError, APIErrorCode } from '@notionhq/client';
 import performConversion from './performConversion';
 import NotionAPIWrapper from '../../../../services/NotionService/NotionAPIWrapper';
@@ -68,6 +72,25 @@ const baseRequest = {
   type: 'page',
   jobDbId: 42,
 };
+
+function makeRealWorkspace(): { location: string } {
+  const location = path.join(os.tmpdir(), `perform-conversion-test-${randomUUID()}`);
+  fs.mkdirSync(location, { recursive: true });
+  fs.writeFileSync(path.join(location, 'deck.apkg'), 'fake-bytes');
+  return { location };
+}
+
+function mockWorkspaceCreation(ws: { location: string }): void {
+  (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+    execute: jest.fn().mockResolvedValue({
+      ws,
+      exporter: {},
+      settings: {},
+      bl: {},
+      rules: {},
+    }),
+  }));
+}
 
 describe('performConversion — signature', () => {
   it('does not accept a res parameter (res is absent from ConversionRequest)', () => {
@@ -290,5 +313,65 @@ describe('performConversion — heavy pipeline', () => {
         props: expect.objectContaining({ reason: 'empty_deck' }),
       })
     );
+  });
+});
+
+describe('performConversion — workspace cleanup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    (SetJobFailedUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (NotionRepository as jest.Mock).mockImplementation(() => ({
+      markTokenInvalid: jest.fn().mockResolvedValue(undefined),
+      setReconnectEmailSent: jest.fn().mockResolvedValue(false),
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('removes the workspace directory after a successful conversion', async () => {
+    const ws = makeRealWorkspace();
+    mockWorkspaceCreation(ws);
+
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [{}, {}] }]),
+    }));
+    (CheckMonthlyCardLimitUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (BuildDeckForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest
+        .fn()
+        .mockResolvedValue({ size: 10, key: 'k', apkg: Buffer.from('x') }),
+    }));
+    (NotifyUserUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (CompleteJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(fs.existsSync(ws.location)).toBe(false);
+  });
+
+  it('removes the workspace directory when the conversion fails', async () => {
+    const ws = makeRealWorkspace();
+    mockWorkspaceCreation(ws);
+
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(new Error('deck build blew up')),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(fs.existsSync(ws.location)).toBe(false);
   });
 });

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import StorageHandler from '../../StorageHandler';
 import { Knex } from 'knex';
 import NotionAPIWrapper from '../../../../services/NotionService/NotionAPIWrapper';
@@ -73,6 +74,8 @@ export default async function performConversion(
   const settingsRepository = new SettingsRepository(database);
   const parserRulesRepository = new ParserRulesRepository(database);
 
+  let workspaceLocation: string | undefined;
+
   try {
     const createWorkSpace = new CreateJobWorkSpaceUseCase(
       jobRepository,
@@ -82,6 +85,7 @@ export default async function performConversion(
     const { ws, exporter, settings, bl, rules } = await createWorkSpace.execute(
       { api, id, owner, jobRepository, isPaying }
     );
+    workspaceLocation = ws.location;
 
     const createFlashcards = new CreateFlashcardsForJobUseCase(jobRepository);
     const decks = await createFlashcards.execute({
@@ -212,6 +216,18 @@ export default async function performConversion(
       });
     } else {
       console.error(error);
+    }
+  } finally {
+    if (workspaceLocation != null) {
+      try {
+        fs.rmSync(workspaceLocation, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.error('[conversion] workspace cleanup failed', {
+          jobId: id,
+          message:
+            cleanupError instanceof Error ? cleanupError.message : 'unknown',
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
## What
Per-conversion workspace directories under `WORKSPACE_BASE` are now removed at the end of every conversion job, on both the success and failure paths.

## Why
Closes #1337 (ENOSPC: no space left on device). Each conversion created a workspace directory but never deleted it — disk was only reclaimed by a periodic sweep. Under load the temp disk filled and every conversion failed with ENOSPC, the error users saw as "Error pops up" instead of a downloaded `.apkg`. The maintainer previously mitigated by restarting the server and adding a cron sweep, but the root cause (no per-job cleanup) was never fixed.

## How
Hoisted the workspace location out of the conversion `try` and added an outer `finally` that calls `fs.rmSync(workspaceLocation, { recursive: true, force: true })`. Cleanup runs only after the deck bytes are built, persisted, and the user notified — never while the `.apkg` is still being read. The `rmSync` is wrapped in its own try/catch so a cleanup failure logs and cannot crash the job. Mirrors the existing pattern in `ChatDeckUseCase` and `PhotoToFlashcardsUseCase`.

## Measuring success
Disk usage of `WORKSPACE_BASE` on the prod box should stay flat between sweeps instead of climbing; ENOSPC errors in `pm2 logs` should stop. A cleanup failure surfaces as the log line `[conversion] workspace cleanup failed` with the `jobId` — none expected under normal operation.

## Testing
- Unit tests added: workspace directory is removed after a successful conversion, and after a failed conversion (both assert `fs.existsSync(ws.location) === false`). Full file: 11 tests pass; `npx tsc --noEmit` clean.

## Browser check
Browser check: not applicable — server-side reliability fix, no rendered output.

## Changelog
No changelog entry — internal reliability fix, no user-visible behavior change. The symptom (occasional ENOSPC failures under load) was intermittent and not a named feature; a truthful, non-hedging What's New line per VOICE.md is not warranted.

## Sonar
sonar-scanner not run — `SONAR_TOKEN` unset in this environment (scanner is installed). The change is a single guarded `finally` block; low Sonar risk. Expect a clean scan or a trivial bounce.

## Risks
Cleanup runs in `finally` after all deck reads and persistence complete, so it cannot race the `.apkg` read. Worst case a cleanup error is caught and logged, leaving one stale directory the periodic sweep still collects. Rollback is reverting this single commit.

## Goal alignment
Directly serves the 300K-user goal: a full temp disk breaks conversions for every user at once, not just the one who filled it. Keeping the workspace clean keeps the core convert-and-download path reliable under scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782804475&installation_id=132681956&pr_number=2943&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2943&signature=07cc296711f68e97430e0acabe817cf818ce9a318fcb763a4a7151e079ba16f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->