### PR TITLE
feat: track paywall_shown on upload card-limit redirects

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -434,6 +434,13 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     expect(redirectedTo()).toBe('/limit?kind=card_count');
     expect(capturedSend()).toBeNull();
     expect(incrementSpy).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      'paywall_shown',
+      expect.objectContaining({
+        userId: 42,
+        props: expect.objectContaining({ kind: 'card_count', source: 'upload' }),
+      })
+    );
   });
 
   it('sends the deck and increments card usage for a logged-in free user under the limit', async () => {
@@ -479,6 +486,14 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     expect(redirectedTo()).toBe('/limit?kind=anonymous');
     expect(capturedSend()).toBeNull();
     expect(incrementSpy).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      'paywall_shown',
+      expect.objectContaining({
+        userId: null,
+        anonymousId: null,
+        props: expect.objectContaining({ kind: 'anonymous', source: 'upload' }),
+      })
+    );
   });
 
   it('sends the deck for an anonymous conversion at or under 21 cards without incrementing usage', async () => {

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -233,8 +233,20 @@ class UploadService {
       return await this.handleSyncUpload(req, res, settings, ws, paying);
     } catch (err) {
       if (err instanceof MonthlyLimitError) {
+        const owner = getOwner(res);
+        track('paywall_shown', {
+          userId: owner != null ? Number(owner) : null,
+          anonymousId: this.resolveAnonId(req),
+          props: { source: this.resolveUploadSource(req), kind: 'card_count' },
+        });
         return res.redirect('/limit?kind=card_count');
       } else if (err instanceof AnonymousCardCapError) {
+        const owner = getOwner(res);
+        track('paywall_shown', {
+          userId: owner != null ? Number(owner) : null,
+          anonymousId: this.resolveAnonId(req),
+          props: { source: this.resolveUploadSource(req), kind: 'anonymous' },
+        });
         return res.redirect('/limit?kind=anonymous');
       } else if (isLimitError(err as Error)) {
         handleUploadLimitError(req, res);


### PR DESCRIPTION
## What
Emit a durable `paywall_shown` analytics event immediately before each of the two upload card-limit redirects in `UploadService.handleUpload`'s catch block — the `MonthlyLimitError` → `/limit?kind=card_count` path and the `AnonymousCardCapError` → `/limit?kind=anonymous` path.

## Why
W22 retro flagged an observability gap: when a free or anonymous user hits the upload paywall, we recorded no durable event, so we could not measure whether the newly-enforced limits convert or bounce users. Both redirects previously fired bare with no tracking. This closes that gap so the funnel from limit-hit → upgrade is measurable.

## How
`paywall_shown` is already a `KnownEvent`; no new event type. Each branch calls the existing `track` helper with the same `userId`/`anonymousId` shape as the `upload_started` event in this file, plus `props.kind` (`card_count` vs `anonymous`) and the upload `source`. `owner` is re-derived via `getOwner(res)` inside the catch because the try-block binding is block-scoped and out of scope there.

## Measuring success
Query the analytics events table for `name = 'paywall_shown'` grouped by `props.kind`. Both `card_count` and `anonymous` rows should begin appearing after deploy; their volume against `upload_started` gives the limit-hit rate, and downstream `checkout_started` / paid events for the same `anonymousId`/`userId` give the conversion-vs-bounce split.

## Testing
- Unit tests added: extended the two existing card-limit redirect tests in `UploadService.test.ts` to assert `track` is called with `'paywall_shown'` and `props.kind === 'card_count'` (logged-in free) / `'anonymous'` (anonymous). Written failing-first, confirmed they failed because the event was not emitted, then implemented and confirmed green (16/16 pass).

## Changelog
No changelog entry — internal instrumentation, no user-visible behavior change.

## Risks
Low. Two added `track` calls on already-terminal error paths; `track` PII-strips props and drops oversized payloads, and a tracking failure cannot affect the redirect. Rollback is a straight revert.

## Notes
- Backend-only; no `web/src/` files touched, so no Browser check section.
- `sonar-scanner` was not run locally — no `SONAR_TOKEN` configured in this environment. The change is two near-identical `track` calls inside an existing catch block (no new functions or branches), so a Sonar bounce is unlikely; flagging here per the sonar rule rather than going silent.

## Goal alignment
Moves us toward the 300K-user goal by making the upload paywall measurable. Without `paywall_shown`, we can't tell whether the enforced limits drive upgrades or just lose users — this instrumentation is the prerequisite for tuning the limit and the paywall copy against real conversion data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782805177&installation_id=132681956&pr_number=2945&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2945&signature=ec9c1bb74706ad5987eb0c9aa431cca3c57f21d65990a58763757c34d15d02ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->