### PR TITLE
chore: add /drive-acquisition issue-to-PR command

### DIFF
--- a/.claude/commands/drive-acquisition.md
+++ b/.claude/commands/drive-acquisition.md
@@ -1,0 +1,71 @@
+---
+description: Work GitHub issues that drive acquisition — verify relevance, close stale ones, fan out at most two engineer agents to open review-ready PRs
+argument-hint: optional — issue numbers to prioritize, or an acquisition sub-area (landing, signup, onboarding)
+---
+
+Work through 2anki/server GitHub issues to drive ACQUISITION — getting a
+first-time visitor to a finished deck, signed up, and converted. That is the
+binding constraint from the latest weekly retro (new paid conversions collapsed
+from ~28/wk to ~3/wk; signups ~7.6/day). Everything you touch must plausibly
+reduce friction somewhere on: landing page → first upload → preview → download →
+signup → paid. Work autonomously; do not wait on me between issues.
+
+If arguments were given ($ARGUMENTS), treat them as the seed: specific issue
+numbers to prioritize, or an acquisition sub-area to focus on. Otherwise triage
+the whole open-issue list through the acquisition filter below.
+
+ACQUISITION FILTER — only pick issues that move the top of the funnel:
+  IN SCOPE: landing/SEO pages, the convert path for logged-out/new users,
+  upload → preview → download friction, signup/registration flow, onboarding,
+  first-deck activation, the /limit and paywall screens, shareability, broken
+  conversions that make a first-timer bounce.
+  OUT OF SCOPE: power-user/settings features for existing paid users, internal
+  refactors, deep Notion edge cases that only long-tail users hit. If an issue
+  doesn't credibly affect a NEW user's path to a deck, skip it — leave it open.
+
+STEP 0 — VERIFY RELEVANCE before any code. For each candidate issue:
+  - Reproduce against current origin/main (pull first). An issue is NOT RELEVANT
+    if (a) already fixed — write a failing test and it passes; (b) the surface
+    no longer exists; (c) it's a duplicate of another open/closed issue; (d) it's
+    spam/junk.
+  - If NOT RELEVANT: close it with a short, specific, VOICE.md-compliant comment
+    stating the concrete evidence ("This was fixed in <area>; converting X now
+    produces Y" / "duplicate of #N" / "the <surface> referenced here was removed").
+    Use `gh issue comment` then `gh issue close`. NEVER close on a hunch — only
+    with reproduced evidence. NEVER name the reporter or quote their content.
+  - If RELEVANT and in acquisition scope: queue it for a fix.
+
+FAN OUT — at most TWO engineer agents running concurrently (never more). Each
+agent works in its own git worktree (isolation: "worktree"), on ONE issue, off a
+FRESH origin/main (never stack branches). When one finishes, start the next from
+the queue. Brief each agent to `pwd`-verify its worktree and HALT rather than
+commit into the main checkout.
+
+PER-ISSUE WORKFLOW (each agent):
+  1. git checkout main && pull; branch fix/<slug> or feat/<slug>.
+  2. TDD: failing test that reproduces the issue → confirm it fails for the right
+     reason → smallest fix → green.
+  3. Changelog JSON entry only if a real user would notice (web/src/pages/
+     WhatsNewPage/changelog/), per the rules; otherwise state "no entry" in the PR.
+  4. Run /check. Run sonar-scanner if a token is configured; if not, say so in
+     the PR body.
+  5. If the diff touches web/src/, add the ## Browser check attestation.
+  6. Conventional commit, subject ≤72 chars, "Fixes #<n>", Co-Authored-By line.
+  7. git push -u origin <branch>; open the PR READY for review (not draft).
+
+ABSOLUTE SAFETY RULES (non-negotiable):
+  - NEVER merge a PR. NEVER run `gh pr merge`. Leave every PR ready for my review.
+  - NEVER push to main. NEVER `git push` without `-u origin <branch>`.
+  - NEVER deploy, SSH to prod, or touch production data.
+  - One PR per issue, off fresh origin/main. Never stack branches.
+  - NEVER put a reporter's name, email, Notion workspace, or deck title in a
+    commit, PR, branch, or issue comment — use the numeric user ID or a role.
+  - When blocked or unsure an issue is safe/in-scope, SKIP it and leave it open.
+    Prefer doing nothing over shipping something wrong.
+
+LOG one line per issue as you go: issue # → verified relevant / closed (reason) /
+fixed (PR #) / skipped (reason). Stop when the acquisition-relevant queue is
+empty, you hit a tool/rate limit, or two agents can't make safe progress.
+
+Start now: pull main, pull the open issues, triage by the acquisition filter,
+and begin.


### PR DESCRIPTION
## Why

The latest weekly retro (W22) lands on one finding: **acquisition is the binding constraint** — new paid conversions collapsed from ~28/wk to ~3/wk and have held there for a month, while churn is steady and price isn't the objection. Signups run ~7.6/day. The leverage is the top of the funnel: landing → first upload → preview → download → signup → paid.

This adds a reusable `/drive-acquisition` command that points the issue-to-PR loop at exactly that.

## What

`.claude/commands/drive-acquisition.md`:
- **Acquisition filter** — only picks issues that move a first-time visitor toward a finished deck (landing/SEO, logged-out convert path, upload→preview→download friction, signup/onboarding, the `/limit` + paywall screens). Explicitly skips power-user/settings work and internal refactors.
- **Verify-first** — reproduces each candidate against current `origin/main`; closes the stale ones (already fixed / surface gone / duplicate / spam) with a short, VOICE-compliant comment backed by concrete evidence. Never closes on a hunch, never names a reporter.
- **Bounded fan-out** — at most **two** engineer agents concurrently, each in its own worktree, one issue per fresh `main`, never stacking branches.
- Same safety rails as `/overnight-prs`: never merge, never push to `main`, never deploy or touch prod, leaves every PR ready for review.

No changelog entry — internal tooling, no user-visible behavior change.

Browser check: not applicable — no `web/src/` files; command/doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782806274&installation_id=132681956&pr_number=2947&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2947&signature=15d0332cad1ba98b850dac814770a8d7911a7dd9faaac4a0953d310f50a6e8df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->