### PR TITLE
feat: show verify-email notice after signup

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { ChunkReloadOverlay } from './components/ChunkReloadOverlay/ChunkReloadO
 import { getErrorMessage } from './components/errors/helpers/getErrorMessage';
 import { SkeletonPage } from './components/Skeleton/Skeleton';
 import PostLoginSurvey from './components/PostLoginSurvey/PostLoginSurvey';
+import { VerifyEmailNotice } from './components/VerifyEmailNotice/VerifyEmailNotice';
 import {
   clearReloadingFlag,
   isReloadingForFreshChunks,
@@ -308,6 +309,7 @@ function AppContent({
         features={data?.features}
       >
         {isLoggedInResolved && <PostLoginSurvey />}
+        <VerifyEmailNotice emailVerified={data?.user?.email_verified} />
         <Routes>
           <Route
             path="/favorites"

--- a/web/src/components/VerifyEmailNotice/VerifyEmailNotice.module.css
+++ b/web/src/components/VerifyEmailNotice/VerifyEmailNotice.module.css
@@ -1,0 +1,31 @@
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  background: var(--color-primary-light);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.message {
+  font-weight: var(--font-medium);
+}
+
+.dismiss {
+  padding: 0.25rem 0.625rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.dismiss:hover {
+  color: var(--color-text-primary);
+}

--- a/web/src/components/VerifyEmailNotice/VerifyEmailNotice.test.tsx
+++ b/web/src/components/VerifyEmailNotice/VerifyEmailNotice.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { VerifyEmailNotice } from './VerifyEmailNotice';
+
+const FLAG_KEY = 'email_verification_pending';
+
+describe('VerifyEmailNotice', () => {
+  beforeEach(() => {
+    globalThis.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    globalThis.sessionStorage.clear();
+  });
+
+  it('renders the verify copy when the pending flag is set', () => {
+    globalThis.sessionStorage.setItem(FLAG_KEY, 'true');
+
+    render(<VerifyEmailNotice />);
+
+    expect(
+      screen.getByText(/confirm your email to secure your account/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when the pending flag is absent', () => {
+    const { container } = render(<VerifyEmailNotice />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the email is already verified', () => {
+    globalThis.sessionStorage.setItem(FLAG_KEY, 'true');
+
+    const { container } = render(<VerifyEmailNotice emailVerified />);
+
+    expect(container.firstChild).toBeNull();
+    expect(globalThis.sessionStorage.getItem(FLAG_KEY)).toBeNull();
+  });
+
+  it('clears the flag and hides when dismissed', () => {
+    globalThis.sessionStorage.setItem(FLAG_KEY, 'true');
+
+    const { container } = render(<VerifyEmailNotice />);
+
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    expect(globalThis.sessionStorage.getItem(FLAG_KEY)).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/components/VerifyEmailNotice/VerifyEmailNotice.tsx
+++ b/web/src/components/VerifyEmailNotice/VerifyEmailNotice.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import styles from './VerifyEmailNotice.module.css';
+
+const FLAG_KEY = 'email_verification_pending';
+
+function readPending(): boolean {
+  try {
+    return globalThis.sessionStorage?.getItem(FLAG_KEY) != null;
+  } catch {
+    return false;
+  }
+}
+
+function clearPending(): void {
+  try {
+    globalThis.sessionStorage?.removeItem(FLAG_KEY);
+  } catch {
+    // sessionStorage may be unavailable; nothing to clear.
+  }
+}
+
+interface VerifyEmailNoticeProps {
+  emailVerified?: boolean;
+}
+
+export function VerifyEmailNotice({
+  emailVerified,
+}: Readonly<VerifyEmailNoticeProps>) {
+  const [pending, setPending] = useState(() => readPending());
+
+  useEffect(() => {
+    if (emailVerified === true && pending) {
+      clearPending();
+      setPending(false);
+    }
+  }, [emailVerified, pending]);
+
+  if (emailVerified === true || !pending) return null;
+
+  const dismiss = () => {
+    clearPending();
+    setPending(false);
+  };
+
+  return (
+    <output className={styles.banner}>
+      <span className={styles.message}>
+        Check your inbox — confirm your email to secure your account.
+      </span>
+      <button
+        type="button"
+        className={styles.dismiss}
+        aria-label="Dismiss"
+        onClick={dismiss}
+      >
+        Dismiss
+      </button>
+    </output>
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-verify-email-after-signup.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-verify-email-after-signup.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-verify-email-after-signup",
+  "date": "2026-05-31",
+  "type": "feature",
+  "title": "After signing up, a reminder to confirm your email keeps your account secure"
+}


### PR DESCRIPTION
## What
Adds a dismissible, accessible "verify your email" notice that appears after a new email signup. It reads the existing `email_verification_pending` sessionStorage flag (already set by the register flow) and prompts the user to confirm their email. The notice clears the flag when dismissed, or automatically once the account is verified, so it shows once rather than forever.

## Why
Fixes #375. A newly-registered user currently lands post-signup with no indication their account needs verifying. This closes an activation gap: the flag was already being set but nothing consumed it.

## How
- New `VerifyEmailNotice` component under `web/src/components/VerifyEmailNotice/`. Self-gates on the sessionStorage flag and an optional `emailVerified` prop; renders nothing when the flag is absent or the email is already verified.
- Mounted once in `App.tsx` as a sibling of `<Routes>` (next to `PostLoginSurvey`), so it shows on whatever landing the post-signup redirect targets, in either the logged-in or logged-out shell.
- `RegisterForm.tsx` is untouched — the flag setter already lives there and is owned by a concurrent PR.
- Styling reuses the existing `AccessBanner` token pattern (`--color-primary-light`, `--color-border`, `--text-sm`).

## Measuring success
Activation funnel: share of new email signups whose accounts reach `email_verified = true` within 24h should rise. The notice has no analytics event of its own; the signal is the downstream verification rate on the existing user record.

## Testing
- Unit tests added (Vitest, `VerifyEmailNotice.test.tsx`): notice renders with the verify copy when the flag is set; renders nothing when the flag is absent; renders nothing and clears the flag when already verified; dismiss clears the flag and hides the notice. Failing-first confirmed (module-not-found), then green — 4/4 passing.
- Changelog loader uniqueness test passes with the new entry.
- `pnpm --filter 2anki-web typecheck` and `lint` (Biome) clean.
- Note: server `tsc` surfaces one pre-existing failure in `src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts` (`loadIfExists` missing on a test mock) that exists on `origin/main` and is unrelated to this web-only change.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: I could not run a browser in this environment, so the boxes are intentionally left unticked for a human pass before merge. Verified instead via Vitest + jsdom against the real sessionStorage flag. The notice mounts in both shells (logged-in sidebar and logged-out top-bar) and uses the same banner tokens as `AccessBanner`, which renders correctly at 375px today.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-31-verify-email-after-signup.json` — "After signing up, a reminder to confirm your email keeps your account secure"

## Sonar
sonar-scanner not run — `SONAR_TOKEN` is not set in this environment. Expect CI to run the rule engine; the change is a single small presentational component plus one mount line.

## Risks
Low. Purely additive presentational component gated on a sessionStorage flag. If unwanted, deleting the component dir and the one `App.tsx` line reverts it cleanly. No data, auth, or payment surface touched.

## Goal alignment
Activation lever toward the 300K-user goal: closes the post-signup gap where users never learned they had to verify, improving the share of registrations that become usable, verified accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782806943&installation_id=132681956&pr_number=2948&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2948&signature=71c90f2ed16b92ff9251439f77102d6ff169d7feb780ab174f9853f62d65b0de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->