### PR TITLE
fix: offer log in or reset on register email-exists

### DIFF
--- a/web/src/components/forms/RegisterForm.test.tsx
+++ b/web/src/components/forms/RegisterForm.test.tsx
@@ -1,0 +1,89 @@
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import RegisterForm from './RegisterForm';
+
+const registerMock = vi.fn();
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    register: registerMock,
+  }),
+}));
+
+function fillAndSubmit() {
+  fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+    target: { value: 'taken@example.com' },
+  });
+  fireEvent.change(screen.getByLabelText('Password'), {
+    target: { value: 'supersecret' },
+  });
+  fireEvent.click(screen.getByRole('checkbox'));
+  fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+}
+
+function renderForm(redirect?: string) {
+  return render(
+    <MemoryRouter initialEntries={['/register']}>
+      <RegisterForm setErrorMessage={vi.fn()} redirect={redirect ?? null} />
+    </MemoryRouter>
+  );
+}
+
+describe('RegisterForm', () => {
+  beforeEach(() => {
+    registerMock.mockReset();
+    localStorage.clear();
+  });
+
+  it('shows a recovery CTA with log in and reset password links when the account already exists', async () => {
+    registerMock.mockResolvedValue({
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          message:
+            'An account with this email already exists. Try logging in instead.',
+        }),
+    });
+
+    renderForm('/pricing');
+    fillAndSubmit();
+
+    const recovery = await screen.findByRole('alert');
+    const logIn = within(recovery).getByRole('link', { name: 'Log in' });
+    expect(logIn).toHaveAttribute('href', '/login?redirect=%2Fpricing');
+
+    const reset = within(recovery).getByRole('link', {
+      name: 'Reset password',
+    });
+    expect(reset).toHaveAttribute('href', '/forgot');
+  });
+
+  it('does not show the recovery CTA on a generic failure', async () => {
+    registerMock.mockResolvedValue({
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          message: 'Invalid user data. Required email and password!',
+        }),
+    });
+
+    renderForm();
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Reset password' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -1,4 +1,5 @@
 import { SyntheticEvent, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import TopMessage from '../TopMessage/TopMessage';
 import { ErrorHandlerType } from '../errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
@@ -22,11 +23,21 @@ function submitLabel(loading: boolean): string {
   return 'Create account';
 }
 
+function isAccountExistsFailure(message: unknown): boolean {
+  return typeof message === 'string' && message.includes('already exists');
+}
+
+function loginHref(redirect?: string | null): string {
+  if (redirect == null) return '/login';
+  return `/login?redirect=${encodeURIComponent(redirect)}`;
+}
+
 function RegisterForm({ setErrorMessage, redirect }: Props) {
   const [email, setEmail] = useState(localStorage.getItem('email') || '');
   const [tos, setTos] = useState(false);
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [accountExists, setAccountExists] = useState(false);
   const signupOrigin = useMemo(
     () =>
       readSignupOrigin(
@@ -49,6 +60,7 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
   const handleSubmit = async (event: SyntheticEvent) => {
     event.preventDefault();
     setLoading(true);
+    setAccountExists(false);
 
     try {
       const res = await get2ankiApi().register('', email, password, signupOrigin);
@@ -63,6 +75,14 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
       } else {
         const body = await res.json().catch(() => null);
         const backendMessage = body?.message;
+        if (isAccountExistsFailure(backendMessage)) {
+          if (email.includes('@')) {
+            localStorage.setItem('email', email);
+          }
+          setAccountExists(true);
+          setLoading(false);
+          return;
+        }
         setErrorMessage(
           backendMessage ??
             'Something went wrong on our end. Try again, or email support@2anki.net if it keeps happening.'
@@ -96,6 +116,15 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
     <div className={styles.formPage}>
       <div className={styles.formCard}>
         <TopMessage />
+        {accountExists && (
+          <div className={styles.recovery} role="alert">
+            <p>This email already has an account — log in or reset your password.</p>
+            <div className={styles.recoveryActions}>
+              <Link to={loginHref(redirect)}>Log in</Link>
+              <Link to="/forgot">Reset password</Link>
+            </div>
+          </div>
+        )}
         <h1 className={styles.formTitle}>
           {getVisibleText('navigation.register.title')}
         </h1>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-register-account-exists-recovery.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-register-account-exists-recovery.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-register-account-exists-recovery",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Signing up with an email that already has an account now links straight to log in or password reset"
+}

--- a/web/src/styles/auth.module.css
+++ b/web/src/styles/auth.module.css
@@ -293,6 +293,30 @@
   margin-top: 0.375rem;
 }
 
+.recovery {
+  background: var(--color-danger-light);
+  border: 1px solid var(--color-danger-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.recovery p {
+  font-size: var(--text-sm);
+  color: var(--color-danger-text);
+  margin: 0 0 0.5rem;
+}
+
+.recoveryActions {
+  display: flex;
+  gap: 1rem;
+}
+
+.recoveryActions a {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+}
+
 .footerText {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);


### PR DESCRIPTION
## What
When email registration fails because an account already exists, the form now renders an inline recovery block with a **Log in** link (carrying the typed email through `localStorage` and the `redirect` query param) and a **Reset password** link. Previously the user hit a dead-end plain-text error and the only login affordance was the generic footer link.

## Why
Fixes #942. A user who forgot they already have an account (and likely forgot the password) stalled at the register form with no contextual recovery path. This gives them a one-click way out toward log in or password reset, recovering would-be-lost signups.

## How
- `handleSubmit` inspects the backend failure body. Both the invalid-data path and the account-exists path return HTTP 400, so status alone is not a stable signal — detection keys off the backend's stable message via a tolerant `includes('already exists')` check rather than brittle full-string equality.
- On that specific failure: persist the typed email to `localStorage` (the same key `LoginForm` reads to prefill), set an `accountExists` flag, and render an `alertDanger`-styled `role="alert"` block with two React Router `<Link>`s. All other failures keep the existing plain-error rendering.
- Login href carries `redirect` (`/login?redirect=…`); reset goes to the existing `/forgot` route. `== null` used for the redirect presence check.
- No new component — stayed within `RegisterForm` plus a small style addition in `auth.module.css`. Did not touch the post-signup notice area (owned separately for #375).

## Measuring success
Funnel: register → login/forgot transitions from the register surface should rise where the prior step was a 400 account-exists response. Watch for a drop in repeat failed `register` 400s from the same email within a session and a corresponding bump in `/login` and `/forgot` arrivals carrying a `redirect` param.

## Testing
- Unit tests added (`RegisterForm.test.tsx`):
  - Account-exists 400 -> recovery `alert` renders with a Log in link (`/login?redirect=%2Fpricing`) and a Reset password link (`/forgot`).
  - Generic 400 -> no recovery `alert`, no Reset password link; plain error path preserved.
- `/check`: web typecheck clean, web lint clean (Biome, 1103 files), full web vitest green (1475 tests). Server `tsc` shows one pre-existing failure in `src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts` unrelated to this PR (no server files touched).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: On `/register`, submitting an email that already has an account swaps the dead-end error for the inline recovery block — Log in (prefilled email, redirect preserved) and Reset password both route correctly. At 375px the recovery block wraps cleanly above the title with no overflow and no console errors. Generic validation failures still show the plain error with no recovery CTA.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-31-register-account-exists-recovery.json` — "Signing up with an email that already has an account now links straight to log in or password reset"

## Sonar
`SONAR_TOKEN` unset locally — `sonar-scanner` not run. Change is a small component edit (one new conditional branch, two pure helpers); expect it to pass but flagging in case of a Sonar bounce.

## Risks
Detection relies on the backend's `"already exists"` substring. If that message text changes, the recovery block silently stops appearing and the user falls back to the existing plain-error path — degraded, not broken. No status-code signal distinguishes the two 400s today; documented as the chosen tradeoff. Rollback is a clean revert of one component file plus the style and changelog additions.

## Goal alignment
Recovers signups that previously dead-ended at the register form, directly supporting the 300K-user growth goal by removing a friction point in the acquisition funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807059&installation_id=132681956&pr_number=2949&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2949&signature=a6fed9d517a420824cf0eda75618e48884418225b97f9a5e1da7299ab321cb58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->