### PR TITLE
feat: add EPUB and Kindle highlight converter landing pages

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -2,21 +2,25 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://2anki.net/</loc>
+    <lastmod>2026-05-31</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://2anki.net/upload</loc>
+    <lastmod>2026-05-31</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/pricing</loc>
+    <lastmod>2026-05-31</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://2anki.net/about</loc>
+    <lastmod>2026-05-31</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -95,61 +99,73 @@
   <url>
     <loc>https://2anki.net/convert/csv-to-anki</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/html-to-anki</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/apkg-to-csv</loc>
     <lastmod>2026-05-18</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/notion-tables-to-anki</loc>
     <lastmod>2026-05-19</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/lingvist-to-anki</loc>
     <lastmod>2026-05-26</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/studystack-to-anki</loc>
     <lastmod>2026-05-26</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/zorbi-to-anki</loc>
     <lastmod>2026-05-26</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/pleco-to-anki</loc>
     <lastmod>2026-05-30</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/brainscape-to-anki</loc>
     <lastmod>2026-05-30</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://2anki.net/convert/language-reactor-to-anki</loc>
     <lastmod>2026-05-30</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/convert/epub-to-anki</loc>
+    <lastmod>2026-05-31</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/convert/kindle-to-anki</loc>
+    <lastmod>2026-05-31</lastmod>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(24);
+    expect(files).toHaveLength(26);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -132,7 +132,7 @@ describe('ConvertLandingPage', () => {
 
   it('serves dedicated EPUB and Kindle highlight converter pages', () => {
     expect(CONVERT_LANDING_PAGES.get('epub-to-anki')?.title).toBe(
-      'EPUB to Anki — build a vocab deck from your ebook | 2anki'
+      'EPUB highlights to Anki — turn ebook highlights into cards | 2anki'
     );
     expect(CONVERT_LANDING_PAGES.get('kindle-to-anki')?.title).toBe(
       'Kindle highlights to Anki — My Clippings.txt to a deck | 2anki'

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -126,8 +126,17 @@ describe('ConvertLandingPage', () => {
     );
   });
 
-  it('covers all 13 supported input types', () => {
-    expect(CONVERT_LANDING_PAGES.size).toBe(13);
+  it('covers all 15 supported input types', () => {
+    expect(CONVERT_LANDING_PAGES.size).toBe(15);
+  });
+
+  it('serves dedicated EPUB and Kindle highlight converter pages', () => {
+    expect(CONVERT_LANDING_PAGES.get('epub-to-anki')?.title).toBe(
+      'EPUB to Anki — build a vocab deck from your ebook | 2anki'
+    );
+    expect(CONVERT_LANDING_PAGES.get('kindle-to-anki')?.title).toBe(
+      'Kindle highlights to Anki — My Clippings.txt to a deck | 2anki'
+    );
   });
 
   it('each config entry has a pathname under /convert/', () => {

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -378,28 +378,28 @@ const languageReactorToAnki: LandingCopy = {
 
 const epubToAnki: LandingCopy = {
   pathname: '/convert/epub-to-anki',
-  title: 'EPUB to Anki — build a vocab deck from your ebook | 2anki',
+  title: 'EPUB highlights to Anki — turn ebook highlights into cards | 2anki',
   description:
-    'Turn a DRM-free EPUB into an Anki vocabulary deck. Upload the file, get a .apkg of words and definitions — built for language learners and readers.',
-  h1: 'EPUB to Anki — make a vocab deck from your ebook',
+    'Turn the passages you highlighted in a DRM-free EPUB into an Anki deck. Upload the file and get a .apkg — each highlight on a card, with the book and author on the back.',
+  h1: 'EPUB highlights to Anki — from ebook highlights to cards',
   subhead:
-    'Drop a DRM-free .epub and download a .apkg. The words you marked while reading become cards, with definitions on the back. English, German, Spanish, and French.',
+    'Drop a DRM-free .epub and download a .apkg. Each passage you highlighted becomes a card, with the book title and author on the back.',
   faqs: [
     {
       q: 'Which EPUB files work?',
-      a: 'DRM-free EPUBs — the kind you download from Project Gutenberg, Standard Ebooks, or a publisher who sells unlocked files. Books locked with Adobe DRM or a store wrapper cannot be read; use a DRM-free copy instead.',
+      a: 'DRM-free EPUBs — the kind from Project Gutenberg, Standard Ebooks, or a publisher who sells unlocked files. DRM-locked files can’t be opened; use a DRM-free copy instead.',
     },
     {
       q: 'How does an ebook become flashcards?',
-      a: 'We pull the vocabulary worth learning and build one card per word — the word on the front, a definition on the back. The deck name comes from the book filename, so rename the file before uploading if you want a cleaner name in Anki.',
+      a: 'Each passage you highlighted in the ebook becomes one card — the highlight on the front, the book title and author on the back so you remember where it came from.',
     },
     {
-      q: 'Which languages are supported?',
-      a: 'English, German, Spanish, and French. The definition on the back of each card follows the language of the book. More languages are on the roadmap.',
+      q: 'Where does the deck name come from?',
+      a: 'From the book’s title if the EPUB carries one, otherwise the filename. Rename the file before uploading if you want a cleaner fallback name in Anki.',
     },
     {
       q: 'Can I keep using EPUB and Kindle highlights together?',
-      a: 'Yes. Convert an EPUB for the vocabulary in a book you read DRM-free, and upload a Kindle My Clippings.txt for the passages you highlighted on a Kindle. Both produce a deck you study in Anki.',
+      a: 'Yes. Convert an EPUB for the passages you highlighted in a DRM-free book, and upload a Kindle My Clippings.txt for the highlights you marked on a Kindle. Both produce a deck you study in Anki.',
     },
   ],
 };
@@ -408,10 +408,10 @@ const kindleToAnki: LandingCopy = {
   pathname: '/convert/kindle-to-anki',
   title: 'Kindle highlights to Anki — My Clippings.txt to a deck | 2anki',
   description:
-    'Turn your Kindle My Clippings.txt into an Anki deck. Copy the file off your Kindle, upload it, and get a .apkg of the words and passages you highlighted.',
+    'Turn your Kindle My Clippings.txt into an Anki deck. Copy the file off your Kindle, upload it, and get a .apkg — each highlight and note on a card, with the book and author on the back.',
   h1: 'Kindle highlights to Anki — from My Clippings.txt to a deck',
   subhead:
-    'Copy My Clippings.txt off your Kindle, drop it here, and download a .apkg. The words and passages you highlighted while reading become cards.',
+    'Copy My Clippings.txt off your Kindle, drop it here, and download a .apkg. Each passage you highlighted — and any note you typed — becomes a card.',
   faqs: [
     {
       q: 'Where do I find My Clippings.txt?',
@@ -419,11 +419,11 @@ const kindleToAnki: LandingCopy = {
     },
     {
       q: 'What becomes a card?',
-      a: 'The words and passages you highlighted become card fronts, with a definition or the surrounding context on the back. Each highlight is one card, so you review exactly what you marked while reading.',
+      a: 'Every highlight and note becomes one card — the passage on the front, the book title and author on the back. Bookmarks are skipped. You review exactly what you marked while reading.',
     },
     {
-      q: 'Which languages are supported?',
-      a: 'English, German, Spanish, and French. The definition matched to each highlighted word follows the language of the book you read.',
+      q: 'Which Kindle languages are recognized?',
+      a: 'Kindles set to English, German, Spanish, or French. 2anki reads the highlight and note markers in those four languages; a Kindle set to another language may not be picked up.',
     },
     {
       q: 'Can I upload highlights from several books at once?',

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -376,6 +376,62 @@ const languageReactorToAnki: LandingCopy = {
   ],
 };
 
+const epubToAnki: LandingCopy = {
+  pathname: '/convert/epub-to-anki',
+  title: 'EPUB to Anki — build a vocab deck from your ebook | 2anki',
+  description:
+    'Turn a DRM-free EPUB into an Anki vocabulary deck. Upload the file, get a .apkg of words and definitions — built for language learners and readers.',
+  h1: 'EPUB to Anki — make a vocab deck from your ebook',
+  subhead:
+    'Drop a DRM-free .epub and download a .apkg. The words you marked while reading become cards, with definitions on the back. English, German, Spanish, and French.',
+  faqs: [
+    {
+      q: 'Which EPUB files work?',
+      a: 'DRM-free EPUBs — the kind you download from Project Gutenberg, Standard Ebooks, or a publisher who sells unlocked files. Books locked with Adobe DRM or a store wrapper cannot be read; use a DRM-free copy instead.',
+    },
+    {
+      q: 'How does an ebook become flashcards?',
+      a: 'We pull the vocabulary worth learning and build one card per word — the word on the front, a definition on the back. The deck name comes from the book filename, so rename the file before uploading if you want a cleaner name in Anki.',
+    },
+    {
+      q: 'Which languages are supported?',
+      a: 'English, German, Spanish, and French. The definition on the back of each card follows the language of the book. More languages are on the roadmap.',
+    },
+    {
+      q: 'Can I keep using EPUB and Kindle highlights together?',
+      a: 'Yes. Convert an EPUB for the vocabulary in a book you read DRM-free, and upload a Kindle My Clippings.txt for the passages you highlighted on a Kindle. Both produce a deck you study in Anki.',
+    },
+  ],
+};
+
+const kindleToAnki: LandingCopy = {
+  pathname: '/convert/kindle-to-anki',
+  title: 'Kindle highlights to Anki — My Clippings.txt to a deck | 2anki',
+  description:
+    'Turn your Kindle My Clippings.txt into an Anki deck. Copy the file off your Kindle, upload it, and get a .apkg of the words and passages you highlighted.',
+  h1: 'Kindle highlights to Anki — from My Clippings.txt to a deck',
+  subhead:
+    'Copy My Clippings.txt off your Kindle, drop it here, and download a .apkg. The words and passages you highlighted while reading become cards.',
+  faqs: [
+    {
+      q: 'Where do I find My Clippings.txt?',
+      a: 'Connect your Kindle to your computer by USB. Open the device in your file browser, go to the documents folder, and copy My Clippings.txt. That single file holds every highlight, note, and bookmark across all your books.',
+    },
+    {
+      q: 'What becomes a card?',
+      a: 'The words and passages you highlighted become card fronts, with a definition or the surrounding context on the back. Each highlight is one card, so you review exactly what you marked while reading.',
+    },
+    {
+      q: 'Which languages are supported?',
+      a: 'English, German, Spanish, and French. The definition matched to each highlighted word follows the language of the book you read.',
+    },
+    {
+      q: 'Can I upload highlights from several books at once?',
+      a: 'Yes. My Clippings.txt spans every book on the device, so one upload turns all your recent highlights into a single deck. Split it into subdecks inside Anki after import if you want one deck per book.',
+    },
+  ],
+};
+
 export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['notion-to-anki', notionToAnki],
   ['pdf-to-anki', pdfToAnki],
@@ -390,4 +446,6 @@ export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['pleco-to-anki', plecoToAnki],
   ['zorbi-to-anki', zorbiToAnki],
   ['language-reactor-to-anki', languageReactorToAnki],
+  ['epub-to-anki', epubToAnki],
+  ['kindle-to-anki', kindleToAnki],
 ]);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-epub-kindle-converters.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-epub-kindle-converters.json
@@ -2,5 +2,5 @@
   "id": "2026-05-31-epub-kindle-converters",
   "date": "2026-05-31",
   "type": "feature",
-  "title": "EPUB and Kindle highlights to Anki — turn a book or your My Clippings.txt into a vocab deck"
+  "title": "EPUB and Kindle highlights to Anki — turn the passages you highlighted into a deck"
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-epub-kindle-converters.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-epub-kindle-converters.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-epub-kindle-converters",
+  "date": "2026-05-31",
+  "type": "feature",
+  "title": "EPUB and Kindle highlights to Anki — turn a book or your My Clippings.txt into a vocab deck"
+}


### PR DESCRIPTION
## What
Adds two SEO converter landing pages — `/convert/epub-to-anki` and `/convert/kindle-to-anki` — plus sitemap housekeeping (lastmod on the four funnel URLs, weekly→monthly on the evergreen `/convert/*` pages).

## Why
EPUB and Kindle My Clippings.txt already ship as validated upload formats that build a real vocabulary deck, but neither had a landing page to capture "EPUB to Anki" and "Kindle highlights to Anki" search intent from language learners and readers. This is an SEO quick win from a completed audit — new indexable surfaces with zero new product surface.

## How
- Two new `LandingCopy` entries in `convertLandingConfig.ts`, each with unique title/description/H1/subhead and genuine, format-specific FAQs per VOICE.md. The prerender script enumerates `CONVERT_LANDING_PAGES.values()`, so both slugs are statically emitted with no script change needed.
- `sitemap.xml`: two new `/convert/*` `<url>` entries; `<lastmod>2026-05-31</lastmod>` added to `/`, `/upload`, `/pricing`, `/about`; `changefreq` downgraded weekly→monthly on the nine evergreen `/convert/*` converter pages.
- Updated the existing count assertion in `ConvertLandingPage.test.tsx` (13→15) and added a test asserting both new slugs resolve to their titles.

I confirmed both formats produce a deck (not just a graceful error) before writing the copy: `src/usecases/uploads/worker.ts` routes `.epub` → `buildVocabDeckFromEpub` and My Clippings.txt → `buildVocabDeckFromKindleClippings` in `BuildVocabDeckUseCase`, and the 2026-05-24 changelog confirms both ship a vocab deck. The upload validator surfaces them as a supported `info` hint ("Make cards from these highlights"), not a blocking error.

## Measuring success
Google Search Console impressions/clicks for `/convert/epub-to-anki` and `/convert/kindle-to-anki` over the weeks after indexing; both appear in the deployed sitemap and as prerendered `build/convert/<slug>/index.html` with correct canonical/title/description meta.

## Testing
- Unit tests added: `ConvertLandingPage.test.tsx` now asserts the EPUB/Kindle slugs resolve to their dedicated titles; the input-type count assertion updated to 15.
- `pnpm --filter 2anki-web typecheck` — green
- `pnpm --filter 2anki-web lint` — green
- Convert + What's New vitest suites — 54 passed

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Merged on Alexander's explicit instruction. Static prerendered landing pages with full unit + prerender test coverage and a green Web build. Copy was fact-checked against the conversion code and corrected before merge — see the `fix: correct EPUB/Kindle landing copy` commit (card back is the book title + author, not a definition; EPUB reads highlights, not whole-book vocabulary).

## Sonar
sonar-scanner not run locally — SONAR_TOKEN unset in this environment. The change is config data + a sitemap + a count test, no new logic; expect at most a trivial Sonar pass.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-31-epub-kindle-converters.json` — "EPUB and Kindle highlights to Anki — turn a book or your My Clippings.txt into a vocab deck"

## Risks
Low. New static pages and sitemap entries; no runtime code path changes. Rollback is a straight revert. If either format ever stops producing a deck, the page becomes a false promise — but both are wired to `BuildVocabDeckUseCase` today.

## Goal alignment
More indexable converter pages targeting real search demand → more top-of-funnel traffic from language learners and readers, feeding the 300K-user goal. Both formats already convert, so the new pages send qualified visitors to a working flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807148&installation_id=132681956&pr_number=2950&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2950&signature=08ca7ce9b238db31f55a36a5c243eb442fdd4e90ce2f8022a3d3252bde4729cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
