### PR TITLE
fix: restore focus rings, live regions, and heading semantics

### DIFF
--- a/web/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -45,7 +45,11 @@ export function FeedbackWidget({
 
   if (status === 'sent') {
     return (
-      <div className={compact ? styles.inlineThank : styles.thankYou}>
+      <div
+        role="status"
+        aria-live="polite"
+        className={compact ? styles.inlineThank : styles.thankYou}
+      >
         Thanks — feedback received.
       </div>
     );
@@ -95,9 +99,11 @@ export function FeedbackWidget({
           </button>
         </>
       )}
-      {status === 'error' && (
-        <p className={styles.errorText}>Something went wrong. Try again?</p>
-      )}
+      <div role="status" aria-live="polite">
+        {status === 'error' && (
+          <p className={styles.errorText}>Something went wrong. Try again?</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/forms/NewPasswordForm.tsx
+++ b/web/src/components/forms/NewPasswordForm.tsx
@@ -79,6 +79,7 @@ function NewPasswordForm({ setErrorMessage }: Readonly<Props>) {
                 autoComplete="new-password"
                 placeholder="New password"
                 required
+                aria-describedby="password-help"
               />
             </label>
             <p id="password-help" className={passwordHelpClass}>

--- a/web/src/pages/Chat/ConversationsSidebar.module.css
+++ b/web/src/pages/Chat/ConversationsSidebar.module.css
@@ -103,8 +103,12 @@
   border-radius: var(--radius-md);
   background: var(--color-bg-primary);
   color: var(--color-text-primary);
-  outline: none;
   min-width: 0;
+}
+
+.renameInput:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
 .menuWrapper {

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -226,7 +226,7 @@ export function HomePage({
 
       <section className={styles.stepsSection}>
         <div className={styles.stepsInner}>
-          <p className={styles.stepsHeading}>How it works</p>
+          <h2 className={styles.stepsHeading}>How it works</h2>
           <div className={styles.stepsGrid}>
             {STEPS.map((step) => (
               <div key={step.title} className={styles.step}>
@@ -244,7 +244,7 @@ export function HomePage({
       <ShowcaseSection />
 
       <section className={styles.featuresSection}>
-        <p className={styles.featuresHeading}>Other ways to use 2anki</p>
+        <h2 className={styles.featuresHeading}>Other ways to use 2anki</h2>
         <div className={styles.featuresGrid}>
           {FEATURES.map((feature) => (
             <Link key={feature.href} to={feature.href} className={styles.featureCard}>
@@ -261,7 +261,7 @@ export function HomePage({
       </section>
 
       <section id="walkthroughs" className={styles.bottomSection}>
-        <p className={styles.walkHeading}>Walkthroughs</p>
+        <h2 className={styles.walkHeading}>Walkthroughs</h2>
         <div className={styles.walkGrid}>
           {(showAll ? WALKTHROUGHS : WALKTHROUGHS.filter(([id]) => FEATURED_WALKTHROUGH_IDS.has(id))).map(([embedId, title]) => (
             <VideoCard

--- a/web/src/pages/MindmapsPage/MindmapList.module.css
+++ b/web/src/pages/MindmapsPage/MindmapList.module.css
@@ -69,5 +69,9 @@
 .deleteBtn:focus-visible {
   color: var(--color-danger);
   background: var(--color-danger-light);
+}
+
+.deleteBtn:focus-visible {
   outline: none;
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -298,14 +298,14 @@ export default function PricingPage({
 
   const passesSection = (
     <>
-      <p className={styles.sectionLabel}>Pay once — no subscription</p>
+      <h2 className={styles.sectionLabel}>Pay once — no subscription</h2>
       {passCards}
     </>
   );
 
   const monthlySection = (
     <>
-      <p className={styles.sectionLabel}>Monthly plans</p>
+      <h2 className={styles.sectionLabel}>Monthly plans</h2>
       {monthlyPlans}
     </>
   );
@@ -369,7 +369,7 @@ export default function PricingPage({
         </>
       )}
 
-      <p className={styles.sectionLabel}>One-time payment</p>
+      <h2 className={styles.sectionLabel}>One-time payment</h2>
       <div className={styles.grid}>
         <PricingCard
           badge="Pay once"

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-a11y-improvements.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-a11y-improvements.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-a11y-improvements",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Screen readers announce feedback confirmations, and keyboard focus stays visible across more controls"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -117,7 +117,7 @@
 [data-theme='dark'] {
   --color-text-primary: #f9fafb;
   --color-text-secondary: #9ca3af;
-  --color-text-tertiary: #6b7280;
+  --color-text-tertiary: #9ca3af;
   --color-text-danger: #f87171;
   --color-text-success: #34d399;
   --color-text-link: #60a5fa;

--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -795,7 +795,11 @@
 .infoButton:hover,
 .infoButton:focus-visible {
   color: var(--color-text-primary);
+}
+
+.infoButton:focus-visible {
   outline: none;
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
 }
 
 .infoPopover {


### PR DESCRIPTION
## What
Clears the blocker and serious findings from an accessibility audit of `web/src/`: missing form-hint association, silent feedback confirmations, removed focus rings, a failing dark-theme contrast token, and section titles that were styled `<p>` instead of headings.

## Why
Screen-reader and keyboard users were missing signals that sighted mouse users get. The password strength hint was unannounced, the feedback widget's "sent"/"error" messages were silent, several controls had `outline: none` with no replacement (invisible focus), the dark-theme tertiary text sat at ~3.4:1 (fails WCAG 4.5:1), and the HomePage/PricingPage section titles were not in the heading outline.

## How
- `NewPasswordForm` — `aria-describedby="password-help"` on the password input, mirroring `RegisterForm`.
- `FeedbackWidget` — both the sent and error messages render inside `role="status" aria-live="polite"`; the error region is always in the DOM (empty when idle) so the announcement fires on content change.
- Focus rings restored with the codebase's established `box-shadow: 0 0 0 2px var(--color-focus-ring)` pattern on `.infoButton`, `.deleteBtn`, and `.renameInput` (the static `outline: none` moved into a `:focus-visible` block with a visible replacement).
- Dark-theme `--color-text-tertiary` raised from `#6b7280` to `#9ca3af` (matches `--color-text-secondary`, which passes). Light theme untouched.
- HomePage and PricingPage section titles changed from `<p>` to `<h2>`, classNames preserved so the visuals are identical.

Skipped the audit's minor findings — this PR is blockers + serious only.

## Measuring success
Not a metric-instrumented change. Verifiable directly: VoiceOver/NVDA announces the feedback confirmation, Tab shows a focus ring on the three controls, an automated contrast check on the dark theme passes 4.5:1, and the heading outline (e.g. axe DevTools) lists the two pages' sections.

## Testing
- Full web Vitest suite green (1473 passed), including `NewPasswordForm.test.tsx`.
- `pnpm --filter 2anki-web typecheck` and `pnpm --filter 2anki-web lint` both clean.
- Sonar not run locally — `SONAR_TOKEN` is unset in this environment. Expect the CI Sonar pass; the diff is small CSS/JSX with no new functions, so low risk of new smells.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Boxes left unticked — Alexander to verify focus rings, headings, and dark-mode contrast in browser before merge.

## Changelog
`Screen readers announce feedback confirmations, and keyboard focus stays visible across more controls` (web/src/pages/WhatsNewPage/changelog/2026-05-31-a11y-improvements.json)

## Risks
Low. CSS additions and semantic tag swaps with classNames preserved — no layout or behavior change intended. The one visual change is the dark-theme tertiary text becoming slightly lighter (by design). Rollback is a plain revert.

## Goal alignment
Accessibility widens the addressable audience and reduces friction for keyboard and screen-reader users on the signup, pricing, and feedback surfaces — directly supporting the 300K-user growth goal by not silently excluding people.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807196&installation_id=132681956&pr_number=2951&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2951&signature=626aad9b9c03ff07a1748de739796bdc0cfc2429028329a4cc77a28cd846e5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->