### PR TITLE
fix: add loadIfExists to settings repo mock in job workspace test

### DIFF
--- a/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
+++ b/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
@@ -18,6 +18,9 @@ describe('CreateJobWorkSpaceUseCase', () => {
     load: jest
       .fn()
       .mockResolvedValue(new CardOption(CardOption.LoadDefaultOptions())),
+    loadIfExists: jest
+      .fn()
+      .mockResolvedValue(new CardOption(CardOption.LoadDefaultOptions())),
   };
 
   const parserRulesRepository: IParserRulesRepository = {


### PR DESCRIPTION
## What
The prod deploy is failing on `main` — `tsc -p .` errors:

```
src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts(17,9): error TS2741:
Property 'loadIfExists' is missing in type '{ load: jest.Mock }' but required in type 'ISettingsRepository'.
```

## Root cause
`7a7a76bf` (fix: load per-page Notion settings for each child page on convert) added `loadIfExists` to `ISettingsRepository` but didn't update this test's mock. `tsc -p .` typechecks test files, so the server build has been red on `main` since that merge; the latest deploy surfaced it.

## Fix
Add `loadIfExists` to the mock, returning default options (mirrors `load`). One-line type fix, no behavior change.

`npx tsc -p . --noEmit` → exit 0 locally.

Browser check: not applicable — server test mock, no rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807625&installation_id=132681956&pr_number=2952&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2952&signature=be9471bf8e5d4d6a1c6f08b60e1d9c752e5820289a7390c324370ee3fb7710e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->