### PR TITLE
feat: emit account_created event on signup

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -23,6 +23,8 @@ jest.mock('../lib/misc/hashToken', () => ({
   default: jest.fn().mockReturnValue('hashed-token'),
 }));
 
+jest.mock('../services/events/track', () => ({ track: jest.fn() }));
+
 const mockGetById = jest.fn().mockResolvedValue({ patreon: false });
 
 jest.mock('../data_layer/UsersRepository', () => {
@@ -43,6 +45,9 @@ import SubscriptionService from '../services/SubscriptionService';
 import OauthIdentitiesRepository from '../data_layer/OauthIdentitiesRepository';
 import NotionRepository from '../data_layer/NotionRespository';
 import { SESSION_MAX_AGE_MS } from '../shared/session';
+import { track } from '../services/events/track';
+
+const trackMock = track as jest.Mock;
 
 const SAMPLE_PW = '12345678';
 
@@ -89,6 +94,67 @@ const buildController = (overrides?: {
 };
 
 describe('UsersController.register', () => {
+  beforeEach(() => {
+    trackMock.mockClear();
+  });
+
+  it('emits account_created keyed to the new user id and the request anonymous id on success', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const { controller } = buildController({ register });
+    const req = {
+      body: { email: 'jane.doe@example.com', password: SAMPLE_PW, source: '/notion-to-anki' },
+      query: {},
+      cookies: { anon_id: 'anon-abc-123' },
+    } as unknown as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(trackMock).toHaveBeenCalledWith('account_created', {
+      userId: 1,
+      anonymousId: 'anon-abc-123',
+      props: { signup_origin: '/notion-to-anki' },
+    });
+  });
+
+  it('emits account_created with a null anonymous id when no anon_id cookie is present', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const { controller } = buildController({ register });
+    const req = {
+      body: { email: 'jane.doe@example.com', password: SAMPLE_PW },
+      query: {},
+      cookies: {},
+    } as unknown as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'account_created',
+      expect.objectContaining({ userId: 1, anonymousId: null })
+    );
+  });
+
+  it('does not emit account_created when the email is already registered', async () => {
+    const getUserFrom = jest
+      .fn()
+      .mockResolvedValue({ id: 1, email: 'taken@example.com' });
+    const register = jest.fn();
+    const { controller } = buildController({ getUserFrom, register });
+    const req = {
+      body: { email: 'taken@example.com', password: SAMPLE_PW },
+      cookies: { anon_id: 'anon-abc-123' },
+    } as unknown as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.register(req, res, next);
+
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
   it('rejects requests missing both email and password with 400', async () => {
     const { controller } = buildController();
     const req = { body: {} } as express.Request;

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -22,6 +22,7 @@ import NotionRepository from '../data_layer/NotionRespository';
 import hashToken from '../lib/misc/hashToken';
 import { extractCountryFromRequest } from '../lib/http/extractCountryFromRequest';
 import { RecordUserVisibleErrorUseCase } from '../usecases/observability/RecordUserVisibleErrorUseCase';
+import { track } from '../services/events/track';
 
 class UsersController {
   constructor(
@@ -179,6 +180,14 @@ class UsersController {
       );
       const newUser = await this.userService.getUserFrom(email);
       if (newUser) {
+        const cookies = req.cookies as Record<string, unknown> | undefined;
+        const anonId = cookies?.anon_id;
+        track('account_created', {
+          userId: Number(newUser.id),
+          anonymousId:
+            typeof anonId === 'string' && anonId.length > 0 ? anonId : null,
+          props: signupOrigin == null ? {} : { signup_origin: signupOrigin },
+        });
         try {
           const country = extractCountryFromRequest(req);
           if (country != null) {

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -44,6 +44,7 @@ export const KNOWN_EVENTS = new Set([
   'pdf_print_options_used',
   'ai_conversion_completed',
   'feature_flag_changed',
+  'account_created',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;


### PR DESCRIPTION
## What
Adds a durable `account_created` analytics event emitted on successful user registration. The event is keyed to **both** the new `user_id` and the request's `anonymous_id` (read from the `anon_id` cookie, same source as `UploadService.resolveAnonId`).

## Why
Closes the W22 funnel gap: there was no durable signup event, so the funnel could not trace `anonymous_id → registered → paid`. The whole point of this event is the `anonymous_id ↔ user_id` link it records — that link is what makes the anonymous-cap → register → paid path traceable end to end.

## How
- Added `'account_created'` to `KNOWN_EVENTS` in `src/types/AnalyticsEvents.ts`.
- In `UsersController.register`, on confirmed account creation (after the new user is fetched), call `track('account_created', { userId, anonymousId, props })`. `userId` is the numeric new-user id; `anonymousId` is the `anon_id` cookie or `null`; `props` carries `signup_origin` when present (already computed via `parseSignupOrigin`).
- Emits only on genuine success. The email-already-exists path returns earlier and does not fire. No PII (email/password/token) in props.
- Purely additive instrumentation — no change to registration behavior, responses, or status codes.

## Measuring success
Query the `events` table: `select count(*) from events where name = 'account_created'` should climb with new signups, and rows should carry both `user_id` and (when the visitor had an `anon_id` cookie) `anonymous_id`. The funnel can then join `account_created.anonymous_id` back to earlier anonymous events and forward to `purchase`/`checkout_completed` on the same `user_id`.

## Testing
- Unit tests added in `src/controllers/UsersControllers.test.ts`:
  - successful registration emits `account_created` with the new user id, the request anonymous id, and `signup_origin`
  - emits with `anonymousId: null` when no `anon_id` cookie is present
  - email-already-exists path does NOT emit
- `pnpm test src/controllers/UsersControllers.test.ts` → 82 passing.
- `npx tsc --noEmit` → exit 0, no new errors.

## Browser check
Not applicable — backend-only change; no files under `web/src/` touched.

## Changelog
No entry — internal analytics, no user-visible behavior change.

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` not configured in this environment. Change is small and additive (one event-name constant + a 9-line emit block); expect a clean Sonar pass but flagging in case of a bounce.

## Risks
Low. The `track` call is fire-and-forget (synchronous, swallows nothing user-facing) and sits inside the existing success branch. If analytics misbehaved it could not affect the registration response. Rollback: revert the commit.

## Goal alignment
Instrumentation that makes the anonymous → registered → paid funnel traceable directly supports the 300K-user goal — we can't optimize the signup→paid conversion we can't measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782808338&installation_id=132681956&pr_number=2954&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2954&signature=cc08244f56ecf4d6507429245523d3bf0d3a03cc5284b85c9c32ce528deb6ff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->