### PR TITLE
feat: extend upload funnel through paid stage

### DIFF
--- a/src/data_layer/EventsRepository.test.ts
+++ b/src/data_layer/EventsRepository.test.ts
@@ -186,4 +186,15 @@ describe('EventsRepository SQL generation', () => {
     expect(sql).toContain('group by "name"');
     expect(sql).not.toContain('anonymous_id) as distinct_identities)');
   });
+
+  it('groupUploadFunnel includes the paid funnel tail stages', async () => {
+    const { db, getSql } = captureGeneratedSql();
+    const repo = new EventsRepository(db);
+
+    await repo.groupUploadFunnel(new Date('2026-05-01'));
+
+    const sql = getSql();
+    expect(sql).toContain("'paywall_shown'");
+    expect(sql).toContain("'checkout_completed'");
+  });
 });

--- a/src/data_layer/EventsRepository.ts
+++ b/src/data_layer/EventsRepository.ts
@@ -33,6 +33,8 @@ const UPLOAD_FUNNEL_STAGES = [
   'conversion_succeeded',
   'conversion_failed',
   'deck_downloaded',
+  'paywall_shown',
+  'checkout_completed',
 ];
 
 export interface IEventsRepository {

--- a/src/services/ops/UploadFunnelService.test.ts
+++ b/src/services/ops/UploadFunnelService.test.ts
@@ -35,8 +35,49 @@ describe('UploadFunnelService', () => {
       conversion_succeeded: 72,
       conversion_failed: 20,
       deck_downloaded: 60,
+      paywall_shown: 0,
+      paid: 0,
     });
     expect(result.since).toBe(since.toISOString());
+  });
+
+  it('carries the paywall_shown and paid stages through to the response', async () => {
+    const repo = makeRepo([
+      { stage: 'upload_started', distinct_identities: 100 },
+      { stage: 'deck_downloaded', distinct_identities: 60 },
+      { stage: 'paywall_shown', distinct_identities: 30 },
+      { stage: 'checkout_completed', distinct_identities: 12 },
+    ]);
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.stages?.paywall_shown).toBe(30);
+    expect(result.stages?.paid).toBe(12);
+  });
+
+  it('computes the download to paid conversion rate', async () => {
+    const repo = makeRepo([
+      { stage: 'deck_downloaded', distinct_identities: 80 },
+      { stage: 'checkout_completed', distinct_identities: 20 },
+    ]);
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.download_to_paid_rate_pct).toBe(25);
+  });
+
+  it('reports a zero paid rate when no decks were downloaded', async () => {
+    const repo = makeRepo([
+      { stage: 'checkout_completed', distinct_identities: 5 },
+    ]);
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.stages?.deck_downloaded).toBe(0);
+    expect(result.download_to_paid_rate_pct).toBe(0);
   });
 
   it('computes the true upload to download success rate', async () => {

--- a/src/services/ops/UploadFunnelService.ts
+++ b/src/services/ops/UploadFunnelService.ts
@@ -8,11 +8,14 @@ export interface UploadFunnelStages {
   conversion_succeeded: number;
   conversion_failed: number;
   deck_downloaded: number;
+  paywall_shown: number;
+  paid: number;
 }
 
 export interface UploadFunnelResponse {
   stages: UploadFunnelStages | null;
   upload_to_download_rate_pct: number;
+  download_to_paid_rate_pct: number;
   since: string;
   as_of: string;
   error?: string;
@@ -40,6 +43,7 @@ export class UploadFunnelService {
       return {
         stages: null,
         upload_to_download_rate_pct: 0,
+        download_to_paid_rate_pct: 0,
         since: sinceStr,
         as_of,
         error: err instanceof Error ? err.message : String(err),
@@ -51,8 +55,18 @@ export class UploadFunnelService {
       stages.upload_started > 0
         ? (stages.deck_downloaded / stages.upload_started) * 100
         : 0;
+    const download_to_paid_rate_pct =
+      stages.deck_downloaded > 0
+        ? (stages.paid / stages.deck_downloaded) * 100
+        : 0;
 
-    return { stages, upload_to_download_rate_pct, since: sinceStr, as_of };
+    return {
+      stages,
+      upload_to_download_rate_pct,
+      download_to_paid_rate_pct,
+      since: sinceStr,
+      as_of,
+    };
   }
 
   private toStages(rows: UploadFunnelStageRow[]): UploadFunnelStages {
@@ -65,6 +79,8 @@ export class UploadFunnelService {
       conversion_succeeded: byStage.get('conversion_succeeded') ?? 0,
       conversion_failed: byStage.get('conversion_failed') ?? 0,
       deck_downloaded: byStage.get('deck_downloaded') ?? 0,
+      paywall_shown: byStage.get('paywall_shown') ?? 0,
+      paid: byStage.get('checkout_completed') ?? 0,
     };
   }
 }


### PR DESCRIPTION
## What
Extends the W22 upload funnel so it stitches from `deck_downloaded` through to PAID. Adds a `paid` stage and a `paywall_shown` intermediate stage to the funnel aggregation, plus a `download_to_paid_rate_pct` rate. All existing response fields are preserved.

## Why
The upload funnel stopped at `deck_downloaded`, so there was no single upload → preview → download → paid view — the biggest W22 funnel gap. This closes it using events that already exist; no new event types added.

## How
- `EventsRepository.groupUploadFunnel` now also groups `paywall_shown` and `checkout_completed` (added to `UPLOAD_FUNNEL_STAGES`, so the same single grouped query covers them — no extra round-trips).
- `UploadFunnelService` maps `checkout_completed` → `paid` and surfaces `paywall_shown`, then computes `download_to_paid_rate_pct` with the same zero-denominator guard as the upload→download rate (no downloads → 0, not NaN/Infinity).
- The use case and controller pass the response through unchanged; the contract is additive and backward-compatible.

**Why `checkout_completed`, not `purchase`:** `checkout_completed` is emitted via `track()` from the Stripe `checkout.session.completed` webhook into the events table — it marks money received. `purchase` is sent only to Google Analytics (GA4Service), never recorded in our events table, so a `purchase`-based stage would always read zero. Documented choice.

## Measuring success
Query `/api/ops/upload-funnel?window=30d` — the response now carries `stages.paid`, `stages.paywall_shown`, and `download_to_paid_rate_pct`. Confirm `stages.paid` is non-zero in any window with at least one completed checkout.

## Testing
- Unit tests added:
  - `EventsRepository.test.ts` — generated-SQL assertion that `groupUploadFunnel` includes `'paywall_shown'` and `'checkout_completed'` (real PG-dialect knex, no connection, per the raw-SQL testing rule — a mocked-repo test would let invalid PG SQL ship green).
  - `UploadFunnelService.test.ts` — the `paid` and `paywall_shown` stages map through, the `download_to_paid_rate_pct` is computed (80 downloads / 20 paid → 25), and the zero-denominator guard returns 0 (not NaN/Infinity) when no decks were downloaded.
- TDD: tests written failing first, confirmed failing for the right reason, then implemented to green.
- `pnpm test src/services/ops/UploadFunnelService.test.ts src/data_layer/EventsRepository.test.ts` — 15 passed. `OpsRouter.test.ts` (route-level) — 14 passed, additive fields don't break the `objectContaining` assertion.

## Browser check
Browser check: not applicable — backend-only, no `web/src/` files touched.

## Changelog
No entry — internal ops metric, no user-visible behavior change.

## Status
- Server `tsc --noEmit`: exit 0, no new errors. The known pre-existing `CreateJobWorkSpaceUseCase.test.ts` failure on origin/main is unrelated and untouched.
- `sonar-scanner`: not run — `SONAR_TOKEN` not set in this environment. Change is small and additive (two list entries, two mapped fields, one guarded rate calc); low Sonar risk. Expect no new findings; flagging in case of a bounce.

## Risks
Low. Purely additive to an internal ops endpoint. If `checkout_completed` volume is low in a given window the `paid` stage reads low/zero, which is the true signal, not a bug. Rollback is a straight revert with no data migration.

## Goal alignment
Closes the W22 funnel gap #1 by giving the trio a single upload → preview → download → paid view, so the biggest paid-conversion drop-off is measurable. Better funnel visibility directs prioritization toward the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782808448&installation_id=132681956&pr_number=2955&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2955&signature=8edf26638d154fee7afbe3a39e025355fcf3881ae49b4e7cf9fcf7d37827fe67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->