### PR TITLE
feat: add signup stage to upload funnel

### DIFF
--- a/src/data_layer/EventsRepository.test.ts
+++ b/src/data_layer/EventsRepository.test.ts
@@ -197,4 +197,14 @@ describe('EventsRepository SQL generation', () => {
     expect(sql).toContain("'paywall_shown'");
     expect(sql).toContain("'checkout_completed'");
   });
+
+  it('groupUploadFunnel includes the account_created signup stage', async () => {
+    const { db, getSql } = captureGeneratedSql();
+    const repo = new EventsRepository(db);
+
+    await repo.groupUploadFunnel(new Date('2026-05-01'));
+
+    const sql = getSql();
+    expect(sql).toContain("'account_created'");
+  });
 });

--- a/src/data_layer/EventsRepository.ts
+++ b/src/data_layer/EventsRepository.ts
@@ -34,6 +34,7 @@ const UPLOAD_FUNNEL_STAGES = [
   'conversion_failed',
   'deck_downloaded',
   'paywall_shown',
+  'account_created',
   'checkout_completed',
 ];
 

--- a/src/services/ops/UploadFunnelService.test.ts
+++ b/src/services/ops/UploadFunnelService.test.ts
@@ -36,9 +36,46 @@ describe('UploadFunnelService', () => {
       conversion_failed: 20,
       deck_downloaded: 60,
       paywall_shown: 0,
+      signup: 0,
       paid: 0,
     });
     expect(result.since).toBe(since.toISOString());
+  });
+
+  it('carries the account_created count through to the signup stage', async () => {
+    const repo = makeRepo([
+      { stage: 'deck_downloaded', distinct_identities: 60 },
+      { stage: 'account_created', distinct_identities: 18 },
+    ]);
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.stages?.signup).toBe(18);
+  });
+
+  it('computes the download to signup conversion rate', async () => {
+    const repo = makeRepo([
+      { stage: 'deck_downloaded', distinct_identities: 80 },
+      { stage: 'account_created', distinct_identities: 20 },
+    ]);
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.download_to_signup_rate_pct).toBe(25);
+  });
+
+  it('reports a zero signup rate when no decks were downloaded', async () => {
+    const repo = makeRepo([
+      { stage: 'account_created', distinct_identities: 5 },
+    ]);
+    const service = new UploadFunnelService({ eventsRepo: repo });
+
+    const result = await service.getMetrics(since);
+
+    expect(result.stages?.deck_downloaded).toBe(0);
+    expect(result.download_to_signup_rate_pct).toBe(0);
   });
 
   it('carries the paywall_shown and paid stages through to the response', async () => {

--- a/src/services/ops/UploadFunnelService.ts
+++ b/src/services/ops/UploadFunnelService.ts
@@ -9,12 +9,14 @@ export interface UploadFunnelStages {
   conversion_failed: number;
   deck_downloaded: number;
   paywall_shown: number;
+  signup: number;
   paid: number;
 }
 
 export interface UploadFunnelResponse {
   stages: UploadFunnelStages | null;
   upload_to_download_rate_pct: number;
+  download_to_signup_rate_pct: number;
   download_to_paid_rate_pct: number;
   since: string;
   as_of: string;
@@ -43,6 +45,7 @@ export class UploadFunnelService {
       return {
         stages: null,
         upload_to_download_rate_pct: 0,
+        download_to_signup_rate_pct: 0,
         download_to_paid_rate_pct: 0,
         since: sinceStr,
         as_of,
@@ -55,6 +58,10 @@ export class UploadFunnelService {
       stages.upload_started > 0
         ? (stages.deck_downloaded / stages.upload_started) * 100
         : 0;
+    const download_to_signup_rate_pct =
+      stages.deck_downloaded > 0
+        ? (stages.signup / stages.deck_downloaded) * 100
+        : 0;
     const download_to_paid_rate_pct =
       stages.deck_downloaded > 0
         ? (stages.paid / stages.deck_downloaded) * 100
@@ -63,6 +70,7 @@ export class UploadFunnelService {
     return {
       stages,
       upload_to_download_rate_pct,
+      download_to_signup_rate_pct,
       download_to_paid_rate_pct,
       since: sinceStr,
       as_of,
@@ -80,6 +88,7 @@ export class UploadFunnelService {
       conversion_failed: byStage.get('conversion_failed') ?? 0,
       deck_downloaded: byStage.get('deck_downloaded') ?? 0,
       paywall_shown: byStage.get('paywall_shown') ?? 0,
+      signup: byStage.get('account_created') ?? 0,
       paid: byStage.get('checkout_completed') ?? 0,
     };
   }


### PR DESCRIPTION
## What
Adds a SIGNUP stage to the ops upload funnel so it reads end-to-end: upload → conversion → download → signup → paid. The funnel now surfaces how many registered accounts a download cohort produces, plus a `download_to_signup_rate_pct`.

## Why
The funnel previously jumped straight from download to paid, hiding the signup step where a large share of the drop-off lives. The `account_created` event (merged in #2954) already carries both `user_id` and `anonymous_id`; this wires it into the funnel view so we can see the download → signup conversion before prioritizing funnel work toward the 300K-user goal.

## How
- `EventsRepository`: add `'account_created'` to `UPLOAD_FUNNEL_STAGES`. The existing single grouped query counts `count(distinct COALESCE(user_id::text, anonymous_id))` per stage — adding the name is all it needs; no extra round-trips, no new event types, no cohort joins.
- `UploadFunnelService`: map `account_created → signup` in `toStages` (mirroring `checkout_completed → paid`), and add `download_to_signup_rate_pct` (signup / deck_downloaded × 100) with the same `> 0` zero-denominator guard as the paid rate, including in the empty-path return so the response contract stays consistent. All existing fields are kept; the use case and controller stay unchanged pass-throughs.

## Measuring success
`GET /api/ops/upload-funnel` (ops-owner only) now returns `stages.signup` and `download_to_signup_rate_pct`. Confirm in production by hitting that endpoint and checking `stages.signup > 0` and a plausible `download_to_signup_rate_pct` over a recent window.

## Testing
- `EventsRepository.test.ts`: generated-SQL test (real PG-dialect knex, no connection) asserts the funnel SQL now includes `'account_created'`.
- `UploadFunnelService.test.ts`: `signup` maps through, `download_to_signup_rate_pct` computes (20 / 80 → 25), and the zero-downloads guard returns 0 (not NaN/undefined).
- `OpsRouter.test.ts` passes unchanged — the additive fields don't break its `objectContaining` assertions.

## Browser check
Browser check: not applicable — backend-only change, no `web/src/` files touched.

## Changelog
No entry — internal ops metric, no user-visible behavior change.

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` not set in this environment. The change is small and additive (one array element, one interface field, one map lookup, one guarded ratio mirroring the existing paid-rate line); no new functions or branching complexity. Expect a clean Sonar pass.

## Risks
Low. The query shape is unchanged beyond one extra value in the `whereIn` list; all new response fields are additive. Rollback is a straight revert of this PR.

## Goal alignment
Makes the signup drop-off visible in the funnel the trio uses to prioritize, which is upstream of any work that moves us toward 300K users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809022&installation_id=132681956&pr_number=2958&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2958&signature=fea11b01c70860b71762d5886c2931b75f920d7dafead1d3c1e757dea26584a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->