### PR TITLE
feat: expose signups and total users in business metrics

### DIFF
--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -250,6 +250,48 @@ describe('UsersRepository.deleteUser', () => {
   });
 });
 
+describe('UsersRepository.countTotalUsers', () => {
+  it('counts every row in the users table and coerces the string count to a number', async () => {
+    const firstSpy = jest.fn().mockResolvedValue({ count: '19389' });
+    const countSpy = jest.fn().mockReturnValue({ first: firstSpy });
+    const knex = jest.fn().mockReturnValue({ count: countSpy }) as unknown as jest.Mock;
+    const repo = new UsersRepository(knex as any);
+
+    const total = await repo.countTotalUsers();
+
+    expect(countSpy).toHaveBeenCalledWith('* as count');
+    expect(total).toBe(19389);
+  });
+
+  it('returns 0 when the count row is missing', async () => {
+    const firstSpy = jest.fn().mockResolvedValue(undefined);
+    const countSpy = jest.fn().mockReturnValue({ first: firstSpy });
+    const knex = jest.fn().mockReturnValue({ count: countSpy }) as unknown as jest.Mock;
+    const repo = new UsersRepository(knex as any);
+
+    const total = await repo.countTotalUsers();
+
+    expect(total).toBe(0);
+  });
+});
+
+describe('UsersRepository.countSignupsSince', () => {
+  it('binds the cutoff date against created_at and coerces the count', async () => {
+    const firstSpy = jest.fn().mockResolvedValue({ count: '42' });
+    const countSpy = jest.fn().mockReturnValue({ first: firstSpy });
+    const whereSpy = jest.fn().mockReturnValue({ count: countSpy });
+    const knex = jest.fn().mockReturnValue({ where: whereSpy }) as unknown as jest.Mock;
+    const repo = new UsersRepository(knex as any);
+
+    const since = new Date('2026-05-30T14:32:07.000Z');
+    const count = await repo.countSignupsSince(since);
+
+    expect(whereSpy).toHaveBeenCalledWith('created_at', '>=', since);
+    expect(countSpy).toHaveBeenCalledWith('* as count');
+    expect(count).toBe(42);
+  });
+});
+
 const RUN_INTEGRATION = process.env.DATABASE_URL != null;
 
 (RUN_INTEGRATION ? describe : describe.skip)(

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -18,6 +18,11 @@ export interface ISignupCountryRepository {
   ): Promise<SignupCountryCount[]>;
 }
 
+export interface IUserSignupCountsRepository {
+  countTotalUsers(): Promise<number>;
+  countSignupsSince(since: Date): Promise<number>;
+}
+
 class UsersRepository {
   table: string;
   private deletedUserUsage: DeletedUserUsageRepository;
@@ -414,6 +419,45 @@ class UsersRepository {
       .select('stripe_customer_id')
       .first()
       .then((row: { stripe_customer_id: string | null } | undefined) => row?.stripe_customer_id ?? null);
+  }
+
+  async countTotalUsers(): Promise<number> {
+    const row = (await this.database(this.table)
+      .count<{ count: string | number }>('* as count')
+      .first()) as { count: string | number } | undefined;
+    return Number(row?.count ?? 0);
+  }
+
+  async countSignupsSince(since: Date): Promise<number> {
+    const row = (await this.database(this.table)
+      .where('created_at', '>=', since)
+      .count<{ count: string | number }>('* as count')
+      .first()) as { count: string | number } | undefined;
+    return Number(row?.count ?? 0);
+  }
+}
+
+export class InMemoryUserSignupCountsRepository
+  implements IUserSignupCountsRepository
+{
+  private totalUsers = 0;
+
+  private readonly signupDates: Date[] = [];
+
+  setTotalUsers(total: number): void {
+    this.totalUsers = total;
+  }
+
+  addSignup(createdAt: Date): void {
+    this.signupDates.push(createdAt);
+  }
+
+  async countTotalUsers(): Promise<number> {
+    return this.totalUsers;
+  }
+
+  async countSignupsSince(since: Date): Promise<number> {
+    return this.signupDates.filter((date) => date >= since).length;
   }
 }
 

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -63,6 +63,7 @@ const OpsRouter = () => {
     emojiFeedbackRepository: new EmojiFeedbackRepository(database),
     reengagementRepository: new ReEngagementFeedbackRepository(database),
     signupCountryRepository: new UsersRepository(database),
+    signupCountsRepository: new UsersRepository(database),
   });
 
   const conversionMetricsService = new ConversionMetricsService(

--- a/src/services/ops/BusinessMetricsService.test.ts
+++ b/src/services/ops/BusinessMetricsService.test.ts
@@ -8,6 +8,10 @@ import {
 } from './BusinessMetricsService';
 import { InMemoryBusinessMetricsCacheRepository } from '../../data_layer/BusinessMetricsCacheRepository';
 import { InMemoryCancellationFeedbackRepository } from '../../data_layer/CancellationFeedbackRepository';
+import {
+  InMemoryUserSignupCountsRepository,
+  IUserSignupCountsRepository,
+} from '../../data_layer/UsersRepository';
 
 interface FakeSubscriptionItem {
   price: {
@@ -675,6 +679,89 @@ describe('BusinessMetricsService', () => {
           }),
         ])
       );
+    });
+  });
+
+  describe('signup counts', () => {
+    it('returns total users plus 24h and 7d signup windows from the repo', async () => {
+      const stripe = buildFakeStripe({});
+      const signupCountsRepo = new InMemoryUserSignupCountsRepository();
+      signupCountsRepo.setTotalUsers(19389);
+      signupCountsRepo.addSignup(new Date(NOW_MS - 1 * SECONDS_PER_DAY * 1000 + 1000));
+      signupCountsRepo.addSignup(new Date(NOW_MS - 3 * SECONDS_PER_DAY * 1000));
+      signupCountsRepo.addSignup(new Date(NOW_MS - 6 * SECONDS_PER_DAY * 1000));
+      signupCountsRepo.addSignup(new Date(NOW_MS - 10 * SECONDS_PER_DAY * 1000));
+
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+        signupCountsRepository: signupCountsRepo,
+      });
+
+      const result = await service.getMetrics();
+
+      expect(result.total_users).toBe(19389);
+      expect(result.signups_24h).toBe(1);
+      expect(result.signups_7d).toBe(3);
+    });
+
+    it('caches signup counts within the TTL', async () => {
+      const stripe = buildFakeStripe({});
+      const signupCountsRepo = new InMemoryUserSignupCountsRepository();
+      signupCountsRepo.setTotalUsers(5);
+      const totalSpy = jest.spyOn(signupCountsRepo, 'countTotalUsers');
+      const sinceSpy = jest.spyOn(signupCountsRepo, 'countSignupsSince');
+
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+        signupCountsRepository: signupCountsRepo,
+      });
+
+      await service.getMetrics();
+      jest.advanceTimersByTime(10 * 60 * 1000);
+      await service.getMetrics();
+
+      expect(totalSpy).toHaveBeenCalledTimes(1);
+      expect(sinceSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports a per-metric error and nulls the windows when total count throws', async () => {
+      const stripe = buildFakeStripe({});
+      const signupCountsRepo: IUserSignupCountsRepository =
+        new InMemoryUserSignupCountsRepository();
+      jest
+        .spyOn(signupCountsRepo, 'countTotalUsers')
+        .mockRejectedValueOnce(new Error('counts down'));
+
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+        signupCountsRepository: signupCountsRepo,
+      });
+
+      const result = await service.getMetrics();
+
+      expect(result.total_users).toBeNull();
+      expect(result.mrr_usd).toBeCloseTo(0, 5);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            metric: 'total_users',
+            message: 'counts down',
+          }),
+        ])
+      );
+    });
+
+    it('omits the signup metrics when no counts repo is wired', async () => {
+      const stripe = buildFakeStripe({});
+      const service = new BusinessMetricsService({
+        stripeFactory: () => stripe as never,
+      });
+
+      const result = await service.getMetrics();
+
+      expect(result.total_users).toBeNull();
+      expect(result.signups_24h).toBeNull();
+      expect(result.signups_7d).toBeNull();
     });
   });
 });

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -28,6 +28,7 @@ import {
 } from '../../data_layer/ReEngagementFeedbackRepository';
 import {
   ISignupCountryRepository,
+  IUserSignupCountsRepository,
   SignupCountryCount,
 } from '../../data_layer/UsersRepository';
 
@@ -48,7 +49,10 @@ export type BusinessMetricKey =
   | 'emoji_feedback_comments'
   | 'reengagement_reasons_top'
   | 'reengagement_comments_recent'
-  | 'signup_countries_90d';
+  | 'signup_countries_90d'
+  | 'total_users'
+  | 'signups_24h'
+  | 'signups_7d';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -94,6 +98,9 @@ export interface BusinessMetricsResponse {
   reengagement_reasons_top: ReEngagementReasonCount[] | null;
   reengagement_comments_recent: ReEngagementCommentEntry[] | null;
   signup_countries_90d: SignupCountryCount[] | null;
+  total_users: number | null;
+  signups_24h: number | null;
+  signups_7d: number | null;
   as_of: string;
   cache_age_seconds: number;
   errors?: BusinessMetricError[];
@@ -108,6 +115,8 @@ export const REENGAGEMENT_REASONS_LOOKBACK_DAYS = 90;
 export const REENGAGEMENT_COMMENTS_LIMIT = 20;
 export const SIGNUP_COUNTRIES_LOOKBACK_DAYS = 90;
 export const SIGNUP_COUNTRIES_LIMIT = 10;
+export const SIGNUPS_24H_LOOKBACK_DAYS = 1;
+export const SIGNUPS_7D_LOOKBACK_DAYS = 7;
 
 interface BusinessMetricsServiceDeps {
   stripeFactory?: () => Stripe;
@@ -117,6 +126,7 @@ interface BusinessMetricsServiceDeps {
   emojiFeedbackRepository?: IEmojiFeedbackRepository;
   reengagementRepository?: IReEngagementFeedbackRepository;
   signupCountryRepository?: ISignupCountryRepository;
+  signupCountsRepository?: IUserSignupCountsRepository;
 }
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
@@ -197,6 +207,8 @@ export class BusinessMetricsService {
 
   private readonly signupCountryRepository: ISignupCountryRepository | null;
 
+  private readonly signupCountsRepository: IUserSignupCountsRepository | null;
+
   private inflightSourceRefresh: Promise<SourceRefreshResult> | null = null;
 
   constructor(deps: BusinessMetricsServiceDeps = {}) {
@@ -214,6 +226,7 @@ export class BusinessMetricsService {
       deps.reengagementRepository ??
       new InMemoryReEngagementFeedbackRepository();
     this.signupCountryRepository = deps.signupCountryRepository ?? null;
+    this.signupCountsRepository = deps.signupCountsRepository ?? null;
   }
 
   async getMetrics(): Promise<BusinessMetricsResponse> {
@@ -305,6 +318,15 @@ export class BusinessMetricsService {
       ) as ReEngagementCommentEntry[] | null,
       signup_countries_90d: dbValueByKey.has('signup_countries_90d')
         ? (dbValueByKey.get('signup_countries_90d') as SignupCountryCount[] | null)
+        : null,
+      total_users: dbValueByKey.has('total_users')
+        ? (dbValueByKey.get('total_users') as number | null)
+        : null,
+      signups_24h: dbValueByKey.has('signups_24h')
+        ? (dbValueByKey.get('signups_24h') as number | null)
+        : null,
+      signups_7d: dbValueByKey.has('signups_7d')
+        ? (dbValueByKey.get('signups_7d') as number | null)
         : null,
       as_of: now.toISOString(),
       cache_age_seconds: cacheAgeSeconds,
@@ -413,6 +435,36 @@ export class BusinessMetricsService {
             SIGNUP_COUNTRIES_LIMIT
           ),
       });
+    }
+
+    if (this.signupCountsRepository != null) {
+      const repo = this.signupCountsRepository;
+      tasks.push(
+        {
+          key: 'total_users',
+          fetch: () => repo.countTotalUsers(),
+        },
+        {
+          key: 'signups_24h',
+          fetch: () =>
+            repo.countSignupsSince(
+              new Date(
+                now.getTime() -
+                  SIGNUPS_24H_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
+              )
+            ),
+        },
+        {
+          key: 'signups_7d',
+          fetch: () =>
+            repo.countSignupsSince(
+              new Date(
+                now.getTime() -
+                  SIGNUPS_7D_LOOKBACK_DAYS * SECONDS_PER_DAY * 1000
+              )
+            ),
+        }
+      );
     }
 
     return tasks;

--- a/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
+++ b/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
@@ -24,6 +24,9 @@ describe('GetBusinessMetricsUseCase', () => {
       reengagement_reasons_top: [],
       reengagement_comments_recent: [],
       signup_countries_90d: [],
+      total_users: 19389,
+      signups_24h: 31,
+      signups_7d: 214,
       as_of: '2026-05-09T14:32:07.000Z',
       cache_age_seconds: 412,
     };


### PR DESCRIPTION
## What
Adds three aggregate metrics — `total_users`, `signups_24h`, `signups_7d` — to the owner-only `/api/ops/business/metrics` response.

## Why
Closes the W22 "signups not exposed" gap. The 300K-user trajectory was only computable by SSHing to prod for a manual `SELECT count(*)`. These counts now ride alongside the existing revenue/feedback metrics so the number is one request away.

## How
- `UsersRepository` gains `IUserSignupCountsRepository` with `countTotalUsers()` and `countSignupsSince(date)`, both via the knex query builder with a bound date (no string interpolation, CWE-89), plus an in-memory double matching the repo's existing test-double style.
- `BusinessMetricsService` adds the three keys to `BusinessMetricKey`, `BusinessMetricsResponse`, the parallel DB-task orchestration, and the typed response mapping. Each metric uses the same per-metric error handling (resolves to a `BusinessMetricError` on failure without breaking the rest) and the same 15-min cache. The 24h/7d cutoffs are derived from the single `now` the service already establishes per request — no wall-clock reads inside the metric path.
- Mapped to the explicit typed response shape (no raw rows, CWE-209). Existing fields untouched; the change is additive and backward-compatible.

## Measuring success
After deploy, `GET /api/ops/business/metrics` (owner-only) returns `total_users`, `signups_24h`, and `signups_7d`. Confirm `total_users` is in the expected range (~19 389 at time of writing) and the two windows are non-null with no entries in the `errors` array for those keys.

## Testing
- Unit tests added:
  - `UsersRepository.test.ts` — `countTotalUsers` (count + missing-row → 0) and `countSignupsSince` (binds `created_at >=` cutoff, coerces string count).
  - `BusinessMetricsService.test.ts` — three new metrics returned from a faked counts repo; counts cached within the TTL; a throwing counts repo yields a `total_users` `BusinessMetricError` while the rest of the response survives; metrics are null when no counts repo is wired.
  - `GetBusinessMetricsUseCase.test.ts` — response-shape fixture extended with the three fields.
- Repo methods use the plain query builder (`.count('* as count').where('created_at', '>=', since)`), not raw SQL, so the in-memory-double + builder-arg assertions cover the contract; no PG-dialect generated-SQL test required.

## Browser check
Not applicable — backend-only change, no `web/src/` files touched.

## Changelog
No entry — internal ops metric, no user-visible behavior change.

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` is not configured in this environment. The change adds plain query-builder methods and additive response fields; expect a clean scan, but flagging in case of a bounce.

## Risks
Low. Additive only — no existing field changed. A failure in the counts repo is isolated to the three new keys via the existing per-metric error path and cannot break the rest of the response. No migration (uses the existing `users.created_at` column).

## Goal alignment
Directly serves the 300K-user goal: makes the signup trajectory observable without manual prod access, so growth can be tracked and prioritized against the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809098&installation_id=132681956&pr_number=2959&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2959&signature=bf2689ccf06f7bb0e557f3ef3ce4d70418059bdb1f1f3fc5f9263c587f3a7b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->