### PR TITLE
fix: emit Article JSON-LD on Answers pages, not FAQPage

### DIFF
--- a/web/src/pages/AnswersPage/AnswersPage.test.tsx
+++ b/web/src/pages/AnswersPage/AnswersPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
-import AnswersPage from './AnswersPage';
+import AnswersPage, { buildArticleJsonLd } from './AnswersPage';
 import { ANSWERS_PAGES } from './answersConfig';
 
 function renderAtSlug(slug: string) {
@@ -62,5 +62,39 @@ describe('AnswersPage', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       config!.h1
     );
+  });
+
+  it('builds Article JSON-LD and never FAQPage or Question', () => {
+    const config = ANSWERS_PAGES.get('fsrs-explained')!;
+    const raw = buildArticleJsonLd(config);
+    const data = JSON.parse(raw);
+
+    expect(data['@type']).toBe('Article');
+    expect(data.headline).toBe(config.title);
+    expect(data.description).toBe(config.description);
+    expect(data.mainEntityOfPage['@id']).toBe(
+      `https://2anki.net/answers/${config.slug}`
+    );
+    expect(raw).not.toContain('FAQPage');
+    expect(raw).not.toContain('Question');
+  });
+
+  it('maps section headings to articleSection and bodies to articleBody', () => {
+    const config = ANSWERS_PAGES.get('convert-notion-to-anki')!;
+    const data = JSON.parse(buildArticleJsonLd(config));
+
+    expect(data.articleSection).toEqual(
+      config.sections.map((section) => section.heading)
+    );
+    for (const section of config.sections) {
+      expect(data.articleBody).toContain(section.body);
+    }
+  });
+
+  it('emits Article JSON-LD for every Answers page', () => {
+    for (const config of Array.from(ANSWERS_PAGES.values())) {
+      const data = JSON.parse(buildArticleJsonLd(config));
+      expect(data['@type']).toBe('Article');
+    }
   });
 });

--- a/web/src/pages/AnswersPage/AnswersPage.tsx
+++ b/web/src/pages/AnswersPage/AnswersPage.tsx
@@ -2,8 +2,23 @@ import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import NotFoundPage from '../NotFoundPage';
 import { AnswerFigure } from './AnswerFigures';
-import { ANSWERS_PAGES } from './answersConfig';
+import { AnswerConfig, ANSWERS_PAGES } from './answersConfig';
 import styles from './AnswersPage.module.css';
+
+export function buildArticleJsonLd(config: AnswerConfig): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: config.title,
+    description: config.description,
+    articleSection: config.sections.map((section) => section.heading),
+    articleBody: config.sections.map((section) => section.body).join('\n\n'),
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `https://2anki.net/answers/${config.slug}`,
+    },
+  });
+}
 
 function AnswersPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -15,18 +30,7 @@ function AnswersPage() {
 
   const canonical = `https://2anki.net/answers/${config.slug}`;
 
-  const faqJsonLd = JSON.stringify({
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: config.sections.map((section) => ({
-      '@type': 'Question',
-      name: section.heading,
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: section.body,
-      },
-    })),
-  });
+  const articleJsonLd = buildArticleJsonLd(config);
 
   return (
     <div className={styles.page}>
@@ -38,7 +42,7 @@ function AnswersPage() {
         <meta property="og:description" content={config.description} />
         <meta property="og:url" content={canonical} />
         <meta property="og:type" content="article" />
-        <script type="application/ld+json">{faqJsonLd}</script>
+        <script type="application/ld+json">{articleJsonLd}</script>
       </Helmet>
 
       <h1 className={styles.h1}>{config.h1}</h1>


### PR DESCRIPTION
## What
The Answers pages (`/answers/*`) were emitting `FAQPage` JSON-LD, mapping each H2 narrative section's heading to a `Question` and its body to an `acceptedAnswer`. This PR switches that structured data to `Article` schema.

## Why
SEO audit finding M1: the Answers sections are article prose (e.g. "What FSRS does", "Where 2anki fits in"), not questions. Declaring them as FAQ Q&A is a schema/content mismatch — Google can flag mismatched FAQ markup as spam and suppress the rich result. `Article` is the honest fit for narrative content.

## How
Extracted `buildArticleJsonLd(config)` in `AnswersPage.tsx` and used it in place of the inline FAQ builder. Mapping uses only real `AnswerConfig` fields: `title` → `headline`, `description` → `description`, section headings → `articleSection`, section bodies → `articleBody`, and `mainEntityOfPage` → the canonical URL. No author/publisher fabricated (the config has none). The builder is a pure exported function because react-helmet-async does not render `<script>` tags into `document.head` under jsdom, so the JSON-LD content is unit-testable directly.

`LandingPage.tsx`'s separate `FAQPage` JSON-LD is untouched — those are genuine Q&A and remain correct. No other files in the brief's do-not-touch list were modified.

## Measuring success
After deploy, fetch an Answers page and confirm `<script type="application/ld+json">` contains `"@type":"Article"` and no `FAQPage`/`Question`. Validate at https://search.google.com/test/rich-results against `https://2anki.net/answers/fsrs-explained` — it should report Article, not flag FAQ. Watch Search Console's Enhancements for the FAQ-mismatch warning to clear over the next crawl cycle.

## Testing
- Unit tests added (colocated `AnswersPage.test.tsx`): builder emits `@type: Article`, never `FAQPage`/`Question`; section headings map to `articleSection`; section bodies map to `articleBody`; every Answers page emits `Article`.
- Confirmed the new tests fail for the right reason against the old source (`buildArticleJsonLd is not a function`).
- Full web suite green: 174 files, 1487 tests. Web typecheck + Biome lint on changed files clean.

## Browser check
Browser check: not applicable — structured-data (JSON-LD) change only, no rendered output

## Changelog
No entry — internal SEO/structured-data change, not user-visible (JSON-LD lives in `<head>`).

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` unset in this environment. Change is a small pure-function extraction; expect CI Sonar to pass, flag if it bounces.

## Risks
Low. Pure structured-data swap; no rendered output changes. If `Article` markup somehow regressed a result, rollback is reverting this one commit. Search rich-result type for these pages was already effectively suppressible as FAQ-spam, so this is strictly a correctness improvement.

## Goal alignment
Answers pages are AI/search-driven acquisition surfaces. Honest, validated structured data keeps them eligible for rich results and avoids FAQ-spam suppression — protecting an organic top-of-funnel channel toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809534&installation_id=132681956&pr_number=2960&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2960&signature=9acfab0399aca6ea3d26acf6fe1b9189c4bf2f808c2c6c2ff8a52844d816df62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->