### PR TITLE
feat: instrument signup and activation funnel events

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -45,6 +45,11 @@ export const KNOWN_EVENTS = new Set([
   'ai_conversion_completed',
   'feature_flag_changed',
   'account_created',
+  'signup_completed',
+  'upload_page_viewed',
+  'onboarding_shown',
+  'onboarding_skipped',
+  'onboarding_completed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/components/forms/RegisterForm.test.tsx
+++ b/web/src/components/forms/RegisterForm.test.tsx
@@ -18,6 +18,11 @@ vi.mock('../../lib/backend/get2ankiApi', () => ({
   }),
 }));
 
+const trackMock = vi.fn();
+vi.mock('../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
 function fillAndSubmit() {
   fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
     target: { value: 'taken@example.com' },
@@ -40,7 +45,59 @@ function renderForm(redirect?: string) {
 describe('RegisterForm', () => {
   beforeEach(() => {
     registerMock.mockReset();
+    trackMock.mockClear();
     localStorage.clear();
+    globalThis.sessionStorage.clear();
+  });
+
+  it('tracks signup_completed once with method email on a successful registration', async () => {
+    registerMock.mockResolvedValue({ status: 200 });
+
+    renderForm();
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(trackMock).toHaveBeenCalledWith('signup_completed', {
+        method: 'email',
+      });
+    });
+    expect(
+      trackMock.mock.calls.filter(([name]) => name === 'signup_completed')
+    ).toHaveLength(1);
+  });
+
+  it('sets the signup dedup flag so the upload page does not re-fire', async () => {
+    registerMock.mockResolvedValue({ status: 200 });
+
+    renderForm();
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(globalThis.sessionStorage.getItem('signup_completed_tracked')).toBe(
+        '1'
+      );
+    });
+  });
+
+  it('does not track signup_completed when the account already exists', async () => {
+    registerMock.mockResolvedValue({
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          message:
+            'An account with this email already exists. Try logging in instead.',
+        }),
+    });
+
+    renderForm();
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalled();
+    });
+    expect(trackMock).not.toHaveBeenCalledWith('signup_completed', {
+      method: 'email',
+    });
   });
 
   it('shows a recovery CTA with log in and reset password links when the account already exists', async () => {

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -9,6 +9,7 @@ import { WithAppleLink } from './WithAppleLink';
 import { WithMicrosoftLink } from './WithMicrosoftLink';
 import { getVisibleText } from '../../lib/text/getVisibleText';
 import { readSignupOrigin } from '../../lib/signupOrigin';
+import { track } from '../../lib/analytics/track';
 import styles from '../../styles/auth.module.css';
 
 interface Props {
@@ -17,6 +18,7 @@ interface Props {
 }
 
 const MIN_PASSWORD_LENGTH = 8;
+const SIGNUP_FLAG_KEY = 'signup_completed_tracked';
 
 function submitLabel(loading: boolean): string {
   if (loading) return 'Creating account…';
@@ -65,6 +67,8 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
     try {
       const res = await get2ankiApi().register('', email, password, signupOrigin);
       if (res.status === 200) {
+        track('signup_completed', { method: 'email' });
+        globalThis.sessionStorage?.setItem(SIGNUP_FLAG_KEY, '1');
         globalThis.sessionStorage?.setItem('email_verification_pending', 'true');
         try {
           globalThis.sessionStorage?.setItem('2anki_post_login', '1');

--- a/web/src/lib/analytics/events.activation.test.ts
+++ b/web/src/lib/analytics/events.activation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { KNOWN_EVENTS } from './events';
+
+const ACTIVATION_EVENTS = [
+  'signup_completed',
+  'upload_page_viewed',
+  'onboarding_shown',
+  'onboarding_skipped',
+  'onboarding_completed',
+] as const;
+
+describe('activation funnel events', () => {
+  it.each(ACTIVATION_EVENTS)('%s is in the web allowlist', (name) => {
+    expect(KNOWN_EVENTS.has(name)).toBe(true);
+  });
+
+  it.each(ACTIVATION_EVENTS)('%s is in the server allowlist', (name) => {
+    const serverSource = readFileSync(
+      join(__dirname, '../../../../src/types/AnalyticsEvents.ts'),
+      'utf8'
+    );
+    expect(serverSource).toContain(`'${name}'`);
+  });
+});

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -41,6 +41,11 @@ export const KNOWN_EVENTS = new Set([
   'transform_apkg_handoff_received',
   'transform_apkg_failed',
   'transform_apkg_over_cap',
+  'signup_completed',
+  'upload_page_viewed',
+  'onboarding_shown',
+  'onboarding_skipped',
+  'onboarding_completed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -15,6 +15,28 @@ vi.mock('./components/ExploreCard/ExploreCard', () => ({
   ExploreCard: () => <div data-testid="explore-card-stub" />,
 }));
 
+const trackMock = vi.fn();
+vi.mock('../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+type FakeUser = {
+  id?: number;
+  created_at?: string | null;
+  onboarded_at?: string | null;
+} | null;
+
+let fakeUser: FakeUser = null;
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => ({
+    data: fakeUser == null ? undefined : { user: fakeUser },
+    isLoading: false,
+    error: null,
+    isError: false,
+    refetch: () => {},
+  }),
+}));
+
 const renderPage = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -112,6 +134,76 @@ describe('UploadPage AI badge anon link', () => {
     renderPage();
     const link = screen.getByRole('link', { name: /sign in to turn it on/i });
     expect(link).toHaveAttribute('href', '/login?redirect=/card-options');
+  });
+});
+
+const SIGNUP_FLAG_KEY = 'signup_completed_tracked';
+
+const callsFor = (name: string) =>
+  trackMock.mock.calls.filter(([eventName]) => eventName === name);
+
+describe('UploadPage analytics', () => {
+  beforeEach(() => {
+    trackMock.mockClear();
+    fakeUser = null;
+    globalThis.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    fakeUser = null;
+    globalThis.sessionStorage.clear();
+  });
+
+  it('tracks upload_page_viewed once on mount', () => {
+    renderPage();
+    expect(callsFor('upload_page_viewed')).toHaveLength(1);
+  });
+
+  it('tracks signup_completed for a brand-new account that just signed up', () => {
+    fakeUser = {
+      id: 42,
+      created_at: new Date().toISOString(),
+      onboarded_at: null,
+    };
+    renderPage();
+    expect(callsFor('signup_completed')).toHaveLength(1);
+  });
+
+  it('does not track signup_completed for an already-onboarded user', () => {
+    fakeUser = {
+      id: 42,
+      created_at: new Date().toISOString(),
+      onboarded_at: new Date().toISOString(),
+    };
+    renderPage();
+    expect(callsFor('signup_completed')).toHaveLength(0);
+  });
+
+  it('does not track signup_completed for an account created long ago', () => {
+    fakeUser = {
+      id: 42,
+      created_at: '2024-01-01T00:00:00.000Z',
+      onboarded_at: null,
+    };
+    renderPage();
+    expect(callsFor('signup_completed')).toHaveLength(0);
+  });
+
+  it('does not double-fire signup_completed when the email path already tracked it', () => {
+    globalThis.sessionStorage.setItem(SIGNUP_FLAG_KEY, '1');
+    fakeUser = {
+      id: 42,
+      created_at: new Date().toISOString(),
+      onboarded_at: null,
+    };
+    renderPage();
+    expect(callsFor('signup_completed')).toHaveLength(0);
+  });
+
+  it('does not track signup_completed when there is no signed-in user', () => {
+    fakeUser = null;
+    renderPage();
+    expect(callsFor('signup_completed')).toHaveLength(0);
   });
 });
 

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
@@ -13,9 +13,22 @@ import UploadForm from './components/UploadForm/UploadForm';
 import pageStyles from './UploadPage.module.css';
 
 const REATTACH_KEY = 'upload_pending_filename';
+const SIGNUP_FLAG_KEY = 'signup_completed_tracked';
+const SIGNUP_RECENCY_MS = 10 * 60 * 1000;
 
 interface Props {
   setErrorMessage: ErrorHandlerType;
+}
+
+function isFreshSignup(
+  createdAt: string | null | undefined,
+  onboardedAt: string | null | undefined
+): boolean {
+  if (createdAt == null) return false;
+  if (onboardedAt != null) return false;
+  const createdMs = new Date(createdAt).getTime();
+  if (Number.isNaN(createdMs)) return false;
+  return Date.now() - createdMs <= SIGNUP_RECENCY_MS;
 }
 
 export function UploadPage({ setErrorMessage }: Readonly<Props>) {
@@ -28,6 +41,8 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
     return stored != null && stored.length > 0 ? stored : null;
   });
   const { data: userLocals } = useUserLocals();
+  const pageViewTracked = useRef(false);
+  const signupTracked = useRef(false);
 
   const isSignedIn = userLocals?.user?.id != null;
   const isAiOn = useMemo(() => {
@@ -44,6 +59,23 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
     else if (aiBadgeState === 'on') track('upload_ai_on_badge_viewed');
     else track('upload_ai_off_badge_viewed');
   }, [aiBadgeState]);
+
+  useEffect(() => {
+    if (pageViewTracked.current) return;
+    pageViewTracked.current = true;
+    track('upload_page_viewed');
+  }, []);
+
+  useEffect(() => {
+    if (signupTracked.current) return;
+    const user = userLocals?.user;
+    if (user?.id == null) return;
+    if (!isFreshSignup(user.created_at, user.onboarded_at)) return;
+    if (globalThis.sessionStorage?.getItem(SIGNUP_FLAG_KEY) != null) return;
+    signupTracked.current = true;
+    globalThis.sessionStorage?.setItem(SIGNUP_FLAG_KEY, '1');
+    track('signup_completed', { method: 'oauth' });
+  }, [userLocals]);
 
   useEffect(() => {
     if (searchParams.get('from') === 'pass') {

--- a/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.test.tsx
+++ b/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.test.tsx
@@ -8,6 +8,12 @@ vi.mock('../../../../lib/backend/markOnboarded', () => ({
   markOnboarded: () => markOnboardedMock(),
 }));
 
+const trackMock = vi.fn();
+
+vi.mock('../../../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
 import { OnboardingTour } from './OnboardingTour';
 
 const MIGRATION_DATE = '2026-06-08T00:00:00.000Z';
@@ -17,6 +23,7 @@ const BEFORE_MIGRATION = '2026-06-07T12:00:00.000Z';
 describe('OnboardingTour', () => {
   beforeEach(() => {
     markOnboardedMock.mockClear();
+    trackMock.mockClear();
   });
 
   it('renders the tour for a new user with no onboarded_at', () => {
@@ -178,5 +185,59 @@ describe('OnboardingTour', () => {
       ).not.toBeInTheDocument()
     );
     expect(markOnboardedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks onboarding_shown once when the tour first renders', () => {
+    render(
+      <OnboardingTour
+        createdAt={AFTER_MIGRATION}
+        onboardedAt={null}
+        migrationDate={MIGRATION_DATE}
+      />
+    );
+    const shownCalls = trackMock.mock.calls.filter(
+      ([name]) => name === 'onboarding_shown'
+    );
+    expect(shownCalls).toHaveLength(1);
+  });
+
+  it('does not track onboarding_shown when the tour is hidden', () => {
+    render(
+      <OnboardingTour
+        createdAt={AFTER_MIGRATION}
+        onboardedAt="2026-06-09T13:00:00.000Z"
+        migrationDate={MIGRATION_DATE}
+      />
+    );
+    expect(trackMock).not.toHaveBeenCalledWith('onboarding_shown');
+  });
+
+  it('tracks onboarding_skipped when Skip is pressed before the last step', () => {
+    render(
+      <OnboardingTour
+        createdAt={AFTER_MIGRATION}
+        onboardedAt={null}
+        migrationDate={MIGRATION_DATE}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(trackMock).toHaveBeenCalledWith('onboarding_skipped');
+    expect(trackMock).not.toHaveBeenCalledWith('onboarding_completed');
+  });
+
+  it('tracks onboarding_completed when Skip is pressed on the last step', () => {
+    render(
+      <OnboardingTour
+        createdAt={AFTER_MIGRATION}
+        onboardedAt={null}
+        migrationDate={MIGRATION_DATE}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(trackMock).toHaveBeenCalledWith('onboarding_completed');
+    expect(trackMock).not.toHaveBeenCalledWith('onboarding_skipped');
   });
 });

--- a/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.tsx
+++ b/web/src/pages/UploadPage/components/OnboardingTour/OnboardingTour.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { track } from '../../../../lib/analytics/track';
 import { markOnboarded } from '../../../../lib/backend/markOnboarded';
 import styles from './OnboardingTour.module.css';
 
@@ -51,9 +52,17 @@ export function OnboardingTour({
 }: Readonly<OnboardingTourProps>) {
   const [step, setStep] = useState(0);
   const [dismissed, setDismissed] = useState(false);
+  const shownTracked = useRef(false);
 
   const visible =
     !dismissed && shouldShowTour(createdAt, onboardedAt, migrationDate);
+
+  useEffect(() => {
+    if (visible && !shownTracked.current) {
+      shownTracked.current = true;
+      track('onboarding_shown');
+    }
+  }, [visible]);
 
   if (!visible) return null;
 
@@ -62,6 +71,7 @@ export function OnboardingTour({
   const isLast = step === STEPS.length - 1;
 
   const handleSkip = () => {
+    track(isLast ? 'onboarding_completed' : 'onboarding_skipped');
     setDismissed(true);
     void markOnboarded();
   };


### PR DESCRIPTION
## What
Adds activation-funnel analytics. Five new events, no UI or behavior change: `signup_completed`, `upload_page_viewed`, `onboarding_shown`, `onboarding_skipped`, `onboarding_completed`. Each name is added to BOTH allowlist sets — server `src/types/AnalyticsEvents.ts` and the web mirror `web/src/lib/analytics/events.ts` — so neither side drops them.

## Why
Stage 1 of fixing the signup -> first-upload leak. We were blind: the post-signup OnboardingTour fired zero events and there was no client-side signup event, so we couldn't see where new accounts drop off between creation and first upload.

## How
- **`signup_completed`** fires on both signup paths:
  - Email: `RegisterForm` on a 200 response, `{ method: 'email' }`, before the redirect.
  - OAuth (Notion/Google/Microsoft/Apple): the server OAuth callback redirects new accounts to `/upload` (via `landingForUser`, which returns `/upload` unless the user has Notion data or an explicit redirect). `RegisterForm` is never in that path, so `UploadPage` fires it on mount, `{ method: 'oauth' }`, gated on a fresh-signup check — `onboarded_at == null` AND `created_at` within 10 minutes — using the durable `onboarded_at` signal, not localStorage.
  - **Dedup across paths:** the email path also sets a `signup_completed_tracked` sessionStorage flag, and `UploadPage` skips the emit if that flag is present. So an email user who later lands on `/upload` with `onboarded_at` still null does not double-fire. SessionStorage here is ephemeral per-session UI dedup state, not durable user data.
- **`upload_page_viewed`** fires once on `UploadPage` mount (ref guard).
- **`onboarding_shown` / `onboarding_skipped` / `onboarding_completed`** fire in `OnboardingTour`, reusing the existing `onboarded_at` / `markOnboarded` plumbing — no new column, no localStorage. `shown` fires once when the tour first renders (ref guard). The tour's only terminal control is Skip: pressing it on the last step is `completed`, before the last step is `skipped`.
- `== null` used for all absent checks. No PII in any payload (only a `method` discriminator).

### Why `/upload` mount is the OAuth emit point
It is the single place all OAuth providers converge for a brand-new account (the server redirect target), it already loads `userLocals` with the `onboarded_at` / `created_at` durable signals needed to recognize a fresh account, and it is exactly the funnel stage we are measuring (signup -> upload). Firing in each provider callback would mean four scattered emit points; firing here is one.

## Measuring success
In the events sink, segment by `name`:
- `signup_completed` count (split by `props.method` = email vs oauth) per day vs. `account_created` (existing server email-only event) as a sanity cross-check.
- Funnel query: `signup_completed` -> `upload_page_viewed` -> `onboarding_shown` -> (`onboarding_completed` | `onboarding_skipped`) -> `upload_started`. The drop between `signup_completed` and `upload_started` is the leak this stage instruments.

## Testing
- Unit tests added (outside-in, track boundary mocked, asserting call args):
  - `events.activation.test.ts` — all five names present in BOTH the web set and the server source.
  - `RegisterForm.test.tsx` — fires `signup_completed { method: 'email' }` once on 200, sets the dedup flag, does not fire when the account already exists.
  - `UploadPage.test.tsx` — `upload_page_viewed` once on mount; `signup_completed { method: 'oauth' }` for a fresh account; suppressed for already-onboarded, old, flag-present, and anonymous cases.
  - `OnboardingTour.test.tsx` — `onboarding_shown` once when visible (not when hidden); `onboarding_skipped` before last step; `onboarding_completed` on last step.
- `pnpm --filter 2anki-web typecheck` green, `biome lint` green on changed files, server `tsc -p . --noEmit` green.
- Full web vitest suite: 175 files / 1507 tests pass.
- sonar-scanner: not run — `SONAR_TOKEN` is not set in this environment. Expect a possible Sonar bounce; the change is small (two effects, one pure helper, one ternary track call).

Browser check: not applicable — adds analytics event emission only (track() calls), no rendered output or behavior change


## Changelog
No changelog — internal instrumentation, no user-visible change.

## Risks
Low. Events-only; the track call is fire-and-forget and swallows failures, so analytics never breaks the user flow. The OAuth-path emit relies on `/upload` being the OAuth landing for new accounts (true today via `landingForUser`); if that landing changes, the OAuth `signup_completed` would move with it. The 10-minute recency window is a guard against re-firing for returning users whose tour is still pending — generous enough for the redirect to complete, tight enough to exclude established accounts.

## Goal alignment
Directly serves the 300K-user goal: it makes the signup -> first-upload funnel measurable, which is the prerequisite for fixing the activation leak that caps how many signups become active converters.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809754&installation_id=132681956&pr_number=2962&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2962&signature=24d9d54b98a5127a5cf1b6adedce9d2ea6d5f314c1154837e8f5e6c66eab802c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
