### PR TITLE
feat: add /convert hub and related links across converter pages

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -25,6 +25,12 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://2anki.net/convert</loc>
+    <lastmod>2026-05-31</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/notion-to-anki</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -169,6 +169,37 @@ export function emitNotionMarketplacePage(buildDir: string): string {
   return outPath;
 }
 
+const CONVERT_HUB_META = {
+  pathname: '/convert',
+  title: 'Convert anything to Anki — every converter | 2anki',
+  description:
+    'Browse every 2anki converter in one place. Turn Notion, Markdown, PDF, CSV, Quizlet, Brainscape, Pleco, and more into Anki flashcard decks.',
+  h1: 'Convert anything to Anki',
+  subhead:
+    'Pick your source. Every converter turns your notes, files, or flashcards into a clean .apkg deck you study in Anki.',
+};
+
+export function emitConvertHubPage(buildDir: string): string {
+  const meta = CONVERT_HUB_META;
+  const indexPath = join(buildDir, 'index.html');
+  const source = readFileSync(indexPath, 'utf8');
+  const copy: LandingCopy = {
+    pathname: meta.pathname,
+    title: meta.title,
+    description: meta.description,
+    h1: meta.h1,
+    subhead: meta.subhead,
+    faqs: [],
+  };
+  const slug = meta.pathname.replace(/^\//, '');
+  const outDir = join(buildDir, slug);
+  const outPath = join(outDir, 'index.html');
+  mkdirSync(dirname(outPath), { recursive: true });
+  const html = rewriteRoot(rewriteHead(source, copy), copy);
+  writeFileSync(outPath, html, 'utf8');
+  return outPath;
+}
+
 export function emitLandingPages(buildDir: string): string[] {
   const indexPath = join(buildDir, 'index.html');
   const source = readFileSync(indexPath, 'utf8');
@@ -282,6 +313,8 @@ if (process.argv[1] && process.argv[1].endsWith('prerenderLandingPages.ts')) {
   }
   const marketplacePage = emitNotionMarketplacePage(buildDir);
   process.stdout.write(`prerendered ${marketplacePage}\n`);
+  const convertHubPage = emitConvertHubPage(buildDir);
+  process.stdout.write(`prerendered ${convertHubPage}\n`);
   const answerFiles = emitAnswersPages(buildDir);
   for (const file of answerFiles) {
     process.stdout.write(`prerendered ${file}\n`);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -192,6 +192,10 @@ const AiFlashcardGenerator = lazyWithRetry(
   () => import('./pages/LandingPage/AiFlashcardGenerator'),
   './pages/LandingPage/AiFlashcardGenerator'
 );
+const ConvertHubPage = lazyWithRetry(
+  () => import('./pages/ConvertHubPage/ConvertHubPage'),
+  './pages/ConvertHubPage/ConvertHubPage'
+);
 const ConvertLandingPage = lazyWithRetry(
   () => import('./pages/ConvertLandingPage/ConvertLandingPage'),
   './pages/ConvertLandingPage/ConvertLandingPage'
@@ -525,6 +529,7 @@ function AppContent({
           />
           <Route path="/notion-marketplace" element={<NotionLandingPage />} />
           <Route path="/answers/:slug" element={<AnswersPage />} />
+          <Route path="/convert" element={<ConvertHubPage />} />
           <Route
             path="/convert/:slug"
             element={<ConvertLandingPage setErrorMessage={setErrorMessage} />}

--- a/web/src/pages/ConvertHubPage/ConvertHubPage.module.css
+++ b/web/src/pages/ConvertHubPage/ConvertHubPage.module.css
@@ -1,0 +1,86 @@
+.page {
+  background: var(--color-bg-primary);
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 0 1.5rem 4rem;
+}
+
+.hero {
+  padding: 4rem 0 2.5rem;
+}
+
+.h1 {
+  font-size: clamp(2.25rem, 6vw, 3.25rem);
+  font-weight: var(--font-bold);
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  color: var(--color-text-primary);
+  margin: 0 0 1rem;
+  max-width: 16ch;
+}
+
+.subhead {
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+  max-width: 48ch;
+}
+
+.group {
+  padding-top: 2rem;
+  border-top: 1px solid var(--color-border);
+  margin-top: 2rem;
+}
+
+.groupHeading {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-tertiary);
+  margin: 0 0 1rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.itemLink {
+  color: var(--color-text-link);
+  text-decoration: none;
+  font-weight: var(--font-semibold);
+  font-size: var(--text-base);
+}
+
+.itemLink:hover {
+  text-decoration: underline;
+}
+
+.itemBlurb {
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  margin: 0;
+}
+
+@media (max-width: 639px) {
+  .page {
+    padding: 0 1rem 3rem;
+  }
+
+  .hero {
+    padding: 2.5rem 0 2rem;
+  }
+}

--- a/web/src/pages/ConvertHubPage/ConvertHubPage.test.tsx
+++ b/web/src/pages/ConvertHubPage/ConvertHubPage.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+import { CONVERT_LANDING_PAGES } from '../ConvertLandingPage/convertLandingConfig';
+import ConvertHubPage from './ConvertHubPage';
+
+function renderHub() {
+  return render(
+    <MemoryRouter initialEntries={['/convert']}>
+      <HelmetProvider>
+        <ConvertHubPage />
+      </HelmetProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('ConvertHubPage', () => {
+  it('renders the hub H1', () => {
+    renderHub();
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /convert anything to anki/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('links to every converter in CONVERT_LANDING_PAGES', () => {
+    renderHub();
+    const hrefs = Array.from(screen.getAllByRole('link')).map((link) =>
+      link.getAttribute('href')
+    );
+    for (const copy of Array.from(CONVERT_LANDING_PAGES.values())) {
+      expect(hrefs).toContain(copy.pathname);
+    }
+  });
+
+  it('uses descriptive anchors, never "click here"', () => {
+    renderHub();
+    for (const link of screen.getAllByRole('link')) {
+      expect(link.textContent?.toLowerCase()).not.toContain('click here');
+    }
+  });
+});

--- a/web/src/pages/ConvertHubPage/ConvertHubPage.tsx
+++ b/web/src/pages/ConvertHubPage/ConvertHubPage.tsx
@@ -1,0 +1,53 @@
+import { Helmet } from 'react-helmet-async';
+import styles from './ConvertHubPage.module.css';
+import { CONVERT_HUB_GROUPS } from './convertHubGroups';
+
+const TITLE = 'Convert anything to Anki — every converter | 2anki';
+const DESCRIPTION =
+  'Browse every 2anki converter in one place. Turn Notion, Markdown, PDF, CSV, Quizlet, Brainscape, Pleco, and more into Anki flashcard decks.';
+const H1 = 'Convert anything to Anki';
+const SUBHEAD =
+  'Pick your source. Every converter turns your notes, files, or flashcards into a clean .apkg deck you study in Anki.';
+
+function ConvertHubPage() {
+  const canonical = 'https://2anki.net/convert';
+
+  return (
+    <div className={styles.page}>
+      <Helmet>
+        <title>{TITLE}</title>
+        <meta name="description" content={DESCRIPTION} />
+        <link rel="canonical" href={canonical} />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESCRIPTION} />
+        <meta property="og:url" content={canonical} />
+        <meta property="og:type" content="website" />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESCRIPTION} />
+      </Helmet>
+
+      <header className={styles.hero}>
+        <h1 className={styles.h1}>{H1}</h1>
+        <p className={styles.subhead}>{SUBHEAD}</p>
+      </header>
+
+      {CONVERT_HUB_GROUPS.map((group) => (
+        <section key={group.heading} className={styles.group}>
+          <h2 className={styles.groupHeading}>{group.heading}</h2>
+          <ul className={styles.list}>
+            {group.entries.map((entry) => (
+              <li key={entry.slug} className={styles.item}>
+                <a href={entry.href} className={styles.itemLink}>
+                  {entry.anchor}
+                </a>
+                <p className={styles.itemBlurb}>{entry.blurb}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default ConvertHubPage;

--- a/web/src/pages/ConvertHubPage/convertHubGroups.ts
+++ b/web/src/pages/ConvertHubPage/convertHubGroups.ts
@@ -1,0 +1,161 @@
+import { CONVERT_LANDING_PAGES } from '../ConvertLandingPage/convertLandingConfig';
+
+export interface ConvertHubEntry {
+  slug: string;
+  href: string;
+  anchor: string;
+  blurb: string;
+}
+
+export interface ConvertHubGroup {
+  heading: string;
+  entries: ConvertHubEntry[];
+}
+
+interface RawEntry {
+  slug: string;
+  anchor: string;
+  blurb: string;
+}
+
+const NOTE_APPS: RawEntry[] = [
+  {
+    slug: 'notion-to-anki',
+    anchor: 'Convert Notion pages to Anki',
+    blurb:
+      'Connect Notion once, paste a page link, get a .apkg deck. Toggles become cards.',
+  },
+  {
+    slug: 'notion-tables-to-anki',
+    anchor: 'Convert Notion tables to Anki',
+    blurb:
+      'Turn a Notion table into cards — one row per card, column 1 front, column 2 back.',
+  },
+  {
+    slug: 'markdown-to-anki',
+    anchor: 'Convert Markdown and Obsidian notes to Anki',
+    blurb:
+      'Drop a .md file — bullets, Q/A pairs, and code blocks all become cards.',
+  },
+];
+
+const FLASHCARD_APPS: RawEntry[] = [
+  {
+    slug: 'brainscape-to-anki',
+    anchor: 'Move Brainscape flashcards to Anki',
+    blurb:
+      'Export your Brainscape deck as CSV and convert it to a clean .apkg.',
+  },
+  {
+    slug: 'lingvist-to-anki',
+    anchor: 'Move Lingvist flashcards to Anki',
+    blurb:
+      'Export your Lingvist vocabulary as CSV — words and translations become cards.',
+  },
+  {
+    slug: 'studystack-to-anki',
+    anchor: 'Move StudyStack flashcards to Anki',
+    blurb:
+      'Export your stack and convert terms and definitions into Anki cards.',
+  },
+  {
+    slug: 'zorbi-to-anki',
+    anchor: 'Move Zorbi flashcards to Anki',
+    blurb:
+      'Export your Zorbi deck as CSV — questions and answers become Anki cards.',
+  },
+];
+
+const FILE_FORMATS: RawEntry[] = [
+  {
+    slug: 'pdf-to-anki',
+    anchor: 'Convert a PDF to Anki',
+    blurb:
+      'Drop a PDF of lecture slides or a textbook chapter and get a .apkg deck.',
+  },
+  {
+    slug: 'csv-to-anki',
+    anchor: 'Convert a CSV or Excel sheet to Anki',
+    blurb:
+      'Drop a .csv or .xlsx — one row per card, ready to import into Anki.',
+  },
+  {
+    slug: 'html-to-anki',
+    anchor: 'Convert an HTML file to Anki',
+    blurb:
+      'Drop a saved web page — headings, bullets, and tables become cards.',
+  },
+  {
+    slug: 'epub-to-anki',
+    anchor: 'Convert EPUB highlights to Anki',
+    blurb:
+      'Drop a DRM-free .epub — each passage you highlighted becomes a card.',
+  },
+  {
+    slug: 'kindle-to-anki',
+    anchor: 'Convert Kindle highlights to Anki',
+    blurb:
+      'Upload My Clippings.txt — every Kindle highlight and note becomes a card.',
+  },
+  {
+    slug: 'apkg-to-csv',
+    anchor: 'Export an Anki deck to CSV',
+    blurb:
+      'Upload an .apkg and download a spreadsheet of every card to edit or share.',
+  },
+];
+
+const LANGUAGE_TOOLS: RawEntry[] = [
+  {
+    slug: 'pleco-to-anki',
+    anchor: 'Move Pleco flashcards to Anki',
+    blurb:
+      'Export your Pleco userdict as .txt — hanzi, pinyin, and definitions become cards.',
+  },
+  {
+    slug: 'language-reactor-to-anki',
+    anchor: 'Move Language Reactor saves to Anki',
+    blurb:
+      'Drop the Language Reactor export zip — phrases, images, and audio come across.',
+  },
+];
+
+const RAW_GROUPS: ReadonlyArray<{ heading: string; entries: RawEntry[] }> = [
+  { heading: 'Note apps', entries: NOTE_APPS },
+  { heading: 'Flashcard apps', entries: FLASHCARD_APPS },
+  { heading: 'Files', entries: FILE_FORMATS },
+  { heading: 'Language tools', entries: LANGUAGE_TOOLS },
+];
+
+function resolveHref(slug: string): string {
+  const copy = CONVERT_LANDING_PAGES.get(slug);
+  if (copy == null) {
+    throw new Error(`Convert hub references unknown converter slug: ${slug}`);
+  }
+  return copy.pathname;
+}
+
+export const CONVERT_HUB_GROUPS: ReadonlyArray<ConvertHubGroup> =
+  RAW_GROUPS.map((group) => ({
+    heading: group.heading,
+    entries: group.entries.map((entry) => ({
+      slug: entry.slug,
+      href: resolveHref(entry.slug),
+      anchor: entry.anchor,
+      blurb: entry.blurb,
+    })),
+  }));
+
+const coveredSlugs = new Set(
+  CONVERT_HUB_GROUPS.flatMap((group) =>
+    group.entries.map((entry) => entry.slug)
+  )
+);
+
+for (const slug of Array.from(CONVERT_LANDING_PAGES.keys())) {
+  if (!coveredSlugs.has(slug)) {
+    throw new Error(
+      `Convert hub is missing a group entry for converter: ${slug}`
+    );
+  }
+}

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -2,6 +2,12 @@ import type { LandingCopy } from '../LandingPage/types';
 import { ankiFidelityProof } from '../LandingPage/copy/ankiFidelityProof';
 
 const notionToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion tables to Anki', href: '/convert/notion-tables-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/convert/markdown-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/convert/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/notion-to-anki',
   title: 'Notion to Anki — decks that open clean in Anki | 2anki',
   description:
@@ -31,6 +37,13 @@ const notionToAnki: LandingCopy = {
 };
 
 const pdfToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert PowerPoint slides to Anki', href: '/powerpoint-to-anki' },
+    { label: 'Convert an HTML file to Anki', href: '/convert/html-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/convert/markdown-to-anki' },
+    { label: 'Convert Notion pages to Anki', href: '/convert/notion-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/pdf-to-anki',
   title: 'PDF to Anki — flashcards that work in Anki | 2anki',
   description:
@@ -60,6 +73,12 @@ const pdfToAnki: LandingCopy = {
 };
 
 const markdownToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion pages to Anki', href: '/convert/notion-to-anki' },
+    { label: 'Convert an HTML file to Anki', href: '/convert/html-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/convert/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/markdown-to-anki',
   title: 'Markdown to Anki — decks that open clean in Anki | 2anki',
   description:
@@ -89,6 +108,13 @@ const markdownToAnki: LandingCopy = {
 };
 
 const csvToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Export an Anki deck to CSV', href: '/convert/apkg-to-csv' },
+    { label: 'Convert an HTML file to Anki', href: '/convert/html-to-anki' },
+    { label: 'Move Brainscape flashcards to Anki', href: '/convert/brainscape-to-anki' },
+    { label: 'Convert Quizlet sets to Anki', href: '/quizlet-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/csv-to-anki',
   title: 'CSV to Anki — spreadsheets to clean Anki decks | 2anki',
   description:
@@ -118,6 +144,13 @@ const csvToAnki: LandingCopy = {
 };
 
 const htmlToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion pages to Anki', href: '/convert/notion-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/convert/markdown-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/convert/pdf-to-anki' },
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/html-to-anki',
   title: 'HTML to Anki — web pages to clean Anki decks | 2anki',
   description:
@@ -147,6 +180,12 @@ const htmlToAnki: LandingCopy = {
 };
 
 const apkgToCsv: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Convert Anki notes to Notion', href: '/anki-to-notion' },
+    { label: 'Convert an HTML file to Anki', href: '/convert/html-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/apkg-to-csv',
   title: 'Anki deck to CSV — export cards to a spreadsheet | 2anki',
   description:
@@ -175,6 +214,12 @@ const apkgToCsv: LandingCopy = {
 };
 
 const notionTablesToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion pages to Anki', href: '/convert/notion-to-anki' },
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/convert/markdown-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/notion-tables-to-anki',
   title: 'Notion tables to Anki — one row, one card | 2anki',
   description:
@@ -203,6 +248,13 @@ const notionTablesToAnki: LandingCopy = {
 };
 
 const brainscapeToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Move StudyStack flashcards to Anki', href: '/convert/studystack-to-anki' },
+    { label: 'Move Zorbi flashcards to Anki', href: '/convert/zorbi-to-anki' },
+    { label: 'Convert Quizlet sets to Anki', href: '/quizlet-to-anki' },
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/brainscape-to-anki',
   title: 'Brainscape to Anki — move your flashcards to Anki | 2anki',
   description:
@@ -232,6 +284,13 @@ const brainscapeToAnki: LandingCopy = {
 };
 
 const lingvistToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Move Pleco flashcards to Anki', href: '/convert/pleco-to-anki' },
+    { label: 'Move Language Reactor saves to Anki', href: '/convert/language-reactor-to-anki' },
+    { label: 'Move Zorbi flashcards to Anki', href: '/convert/zorbi-to-anki' },
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/lingvist-to-anki',
   title: 'Lingvist to Anki — move your flashcards to Anki | 2anki',
   description:
@@ -261,6 +320,13 @@ const lingvistToAnki: LandingCopy = {
 };
 
 const studystackToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Move Brainscape flashcards to Anki', href: '/convert/brainscape-to-anki' },
+    { label: 'Move Zorbi flashcards to Anki', href: '/convert/zorbi-to-anki' },
+    { label: 'Convert Quizlet sets to Anki', href: '/quizlet-to-anki' },
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/studystack-to-anki',
   title: 'StudyStack to Anki — move your flashcards to Anki | 2anki',
   description:
@@ -290,6 +356,12 @@ const studystackToAnki: LandingCopy = {
 };
 
 const plecoToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Move Lingvist flashcards to Anki', href: '/convert/lingvist-to-anki' },
+    { label: 'Move Language Reactor saves to Anki', href: '/convert/language-reactor-to-anki' },
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/pleco-to-anki',
   title: 'Pleco to Anki — move your flashcards to Anki | 2anki',
   description:
@@ -319,6 +391,12 @@ const plecoToAnki: LandingCopy = {
 };
 
 const zorbiToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Move Brainscape flashcards to Anki', href: '/convert/brainscape-to-anki' },
+    { label: 'Move StudyStack flashcards to Anki', href: '/convert/studystack-to-anki' },
+    { label: 'Convert Quizlet sets to Anki', href: '/quizlet-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/zorbi-to-anki',
   title: 'Zorbi to Anki — move your flashcards to Anki | 2anki',
   description:
@@ -348,6 +426,12 @@ const zorbiToAnki: LandingCopy = {
 };
 
 const languageReactorToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Move Lingvist flashcards to Anki', href: '/convert/lingvist-to-anki' },
+    { label: 'Move Pleco flashcards to Anki', href: '/convert/pleco-to-anki' },
+    { label: 'Convert EPUB highlights to Anki', href: '/convert/epub-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/language-reactor-to-anki',
   title: 'Language Reactor to Anki — move your saved phrases to Anki | 2anki',
   description:
@@ -377,6 +461,12 @@ const languageReactorToAnki: LandingCopy = {
 };
 
 const epubToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Kindle highlights to Anki', href: '/convert/kindle-to-anki' },
+    { label: 'Move Language Reactor saves to Anki', href: '/convert/language-reactor-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/convert/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/epub-to-anki',
   title: 'EPUB highlights to Anki — turn ebook highlights into cards | 2anki',
   description:
@@ -405,6 +495,12 @@ const epubToAnki: LandingCopy = {
 };
 
 const kindleToAnki: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert EPUB highlights to Anki', href: '/convert/epub-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/convert/pdf-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/convert/markdown-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/convert/kindle-to-anki',
   title: 'Kindle highlights to Anki — My Clippings.txt to a deck | 2anki',
   description:

--- a/web/src/pages/LandingPage/LandingPage.module.css
+++ b/web/src/pages/LandingPage/LandingPage.module.css
@@ -106,6 +106,40 @@
   padding: 2.5rem 1.5rem;
 }
 
+.related {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 1.5rem 2.5rem;
+}
+
+.relatedHeading {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-tertiary);
+  margin: 0 0 0.75rem;
+}
+
+.relatedList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.relatedLink {
+  color: var(--color-text-link);
+  text-decoration: none;
+  font-size: var(--text-base);
+}
+
+.relatedLink:hover {
+  text-decoration: underline;
+}
+
 .sectionLabel {
   font-size: var(--text-sm);
   font-weight: var(--font-semibold);

--- a/web/src/pages/LandingPage/LandingPage.test.tsx
+++ b/web/src/pages/LandingPage/LandingPage.test.tsx
@@ -201,6 +201,28 @@ describe('LandingPage', () => {
     );
   });
 
+  it('renders the Related nav with every relatedLink when the copy has them', () => {
+    renderLandingPage(
+      <LandingPage copy={notionCopy} setErrorMessage={vi.fn()} />
+    );
+    const related = screen.getByRole('navigation', { name: 'Related' });
+    expect(related).toBeInTheDocument();
+    for (const link of notionCopy.relatedLinks ?? []) {
+      const anchor = screen.getByRole('link', { name: link.label });
+      expect(anchor).toHaveAttribute('href', link.href);
+    }
+  });
+
+  it('omits the Related nav when the copy has no relatedLinks', () => {
+    const copyWithoutRelated = { ...notionCopy, relatedLinks: undefined };
+    renderLandingPage(
+      <LandingPage copy={copyWithoutRelated} setErrorMessage={vi.fn()} />
+    );
+    expect(
+      screen.queryByRole('navigation', { name: 'Related' })
+    ).not.toBeInTheDocument();
+  });
+
   it('renders the AI flashcard generator h1 and links CTA to the ai-flashcard-generator source', () => {
     renderLandingPage(
       <LandingPage copy={aiFlashcardGeneratorCopy} setErrorMessage={vi.fn()} />

--- a/web/src/pages/LandingPage/LandingPage.tsx
+++ b/web/src/pages/LandingPage/LandingPage.tsx
@@ -182,6 +182,21 @@ function LandingPage({ copy, setErrorMessage, heroSlot }: Readonly<LandingPagePr
         </div>
       </section>
 
+      {copy.relatedLinks != null && copy.relatedLinks.length > 0 && (
+        <nav className={styles.related} aria-label="Related">
+          <p className={styles.relatedHeading}>Related</p>
+          <ul className={styles.relatedList}>
+            {copy.relatedLinks.map((link) => (
+              <li key={link.href}>
+                <a href={link.href} className={styles.relatedLink}>
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
+
       <section className={styles.footerCta}>
         <p className={styles.footerCtaText}>
           Ready to try it?{' '}

--- a/web/src/pages/LandingPage/copy/ai-flashcard-generator.ts
+++ b/web/src/pages/LandingPage/copy/ai-flashcard-generator.ts
@@ -1,6 +1,12 @@
 import type { LandingCopy } from '../types';
 
 const aiFlashcardGeneratorCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion pages to Anki', href: '/notion-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/markdown-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/ai-flashcard-generator',
   title: 'AI flashcard generator for Anki — your notes in, real cards out | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/ankiToNotion.ts
+++ b/web/src/pages/LandingPage/copy/ankiToNotion.ts
@@ -1,6 +1,12 @@
 import type { LandingCopy } from '../types';
 
 const ankiToNotionCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion pages to Anki', href: '/notion-to-anki' },
+    { label: 'Export an Anki deck to CSV', href: '/convert/apkg-to-csv' },
+    { label: 'Convert Notion tables to Anki', href: '/convert/notion-tables-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/anki-to-notion',
   title: 'Anki to Notion — free import, no add-on | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/goodnotes.ts
+++ b/web/src/pages/LandingPage/copy/goodnotes.ts
@@ -1,6 +1,12 @@
 import type { LandingCopy } from '../types';
 
 const goodnotesCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Convert PowerPoint slides to Anki', href: '/powerpoint-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/markdown-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/goodnotes-to-anki',
   title: 'GoodNotes to Anki — turn notebooks into flashcards | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/markdown.ts
+++ b/web/src/pages/LandingPage/copy/markdown.ts
@@ -2,6 +2,12 @@ import type { LandingCopy } from '../types';
 import { ankiFidelityProof } from './ankiFidelityProof';
 
 const markdownCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion pages to Anki', href: '/notion-to-anki' },
+    { label: 'Convert an HTML file to Anki', href: '/convert/html-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/markdown-to-anki',
   title: 'Markdown to Anki — decks that open clean in Anki | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/medical-lecture-slides.ts
+++ b/web/src/pages/LandingPage/copy/medical-lecture-slides.ts
@@ -1,6 +1,13 @@
 import type { LandingCopy } from '../types';
 
 const medicalLectureSlidesCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert PowerPoint slides to Anki', href: '/powerpoint-to-anki' },
+    { label: 'Build USMLE Anki decks from your notes', href: '/usmle-anki' },
+    { label: 'Make nursing flashcards from lecture slides', href: '/nursing-flashcards' },
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/anki-from-medical-lecture-slides',
   title: 'Turn medical lecture slides into Anki cards — 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/notion.ts
+++ b/web/src/pages/LandingPage/copy/notion.ts
@@ -2,6 +2,12 @@ import type { LandingCopy } from '../types';
 import { ankiFidelityProof } from './ankiFidelityProof';
 
 const notionCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert Notion tables to Anki', href: '/convert/notion-tables-to-anki' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/markdown-to-anki' },
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/notion-to-anki',
   title: 'Notion to Anki — decks that open clean in Anki | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/nursing.ts
+++ b/web/src/pages/LandingPage/copy/nursing.ts
@@ -1,6 +1,12 @@
 import type { LandingCopy } from '../types';
 
 const nursingCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Build USMLE Anki decks from your notes', href: '/usmle-anki' },
+    { label: 'Turn medical lecture slides into Anki cards', href: '/anki-from-medical-lecture-slides' },
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/nursing-flashcards',
   title: 'Anki flashcards from nursing lecture slides and notes — 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/pdf.ts
+++ b/web/src/pages/LandingPage/copy/pdf.ts
@@ -2,6 +2,13 @@ import type { LandingCopy } from '../types';
 import { ankiFidelityProof } from './ankiFidelityProof';
 
 const pdfCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert PowerPoint slides to Anki', href: '/powerpoint-to-anki' },
+    { label: 'Turn medical lecture slides into Anki cards', href: '/anki-from-medical-lecture-slides' },
+    { label: 'Convert Markdown and Obsidian notes to Anki', href: '/markdown-to-anki' },
+    { label: 'Convert Notion pages to Anki', href: '/notion-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/pdf-to-anki',
   title: 'PDF to Anki — flashcards that work in Anki | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/powerpoint.ts
+++ b/web/src/pages/LandingPage/copy/powerpoint.ts
@@ -1,6 +1,12 @@
 import type { LandingCopy } from '../types';
 
 const powerpointCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Turn medical lecture slides into Anki cards', href: '/anki-from-medical-lecture-slides' },
+    { label: 'Convert GoodNotes notebooks to Anki', href: '/goodnotes-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/powerpoint-to-anki',
   title: 'PowerPoint to Anki — turn slides into flashcards | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/quizlet.ts
+++ b/web/src/pages/LandingPage/copy/quizlet.ts
@@ -2,6 +2,12 @@ import type { LandingCopy } from '../types';
 import { ankiFidelityProof } from './ankiFidelityProof';
 
 const quizletCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Move Brainscape flashcards to Anki', href: '/convert/brainscape-to-anki' },
+    { label: 'Move StudyStack flashcards to Anki', href: '/convert/studystack-to-anki' },
+    { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/quizlet-to-anki',
   title: 'Quizlet to Anki — sets that open clean in Anki | 2anki',
   description:

--- a/web/src/pages/LandingPage/copy/usmle.ts
+++ b/web/src/pages/LandingPage/copy/usmle.ts
@@ -1,6 +1,12 @@
 import type { LandingCopy } from '../types';
 
 const usmleCopy: LandingCopy = {
+  relatedLinks: [
+    { label: 'Make nursing flashcards from lecture slides', href: '/nursing-flashcards' },
+    { label: 'Turn medical lecture slides into Anki cards', href: '/anki-from-medical-lecture-slides' },
+    { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
   pathname: '/usmle-anki',
   title: 'USMLE Anki decks from your own notes — 2anki',
   description:

--- a/web/src/pages/LandingPage/types.ts
+++ b/web/src/pages/LandingPage/types.ts
@@ -8,6 +8,11 @@ export interface WhatComesAcrossItem {
   body: string;
 }
 
+export interface RelatedLink {
+  label: string;
+  href: string;
+}
+
 export interface LandingCopy {
   pathname: string;
   title: string;
@@ -18,4 +23,5 @@ export interface LandingCopy {
   ctaLabel?: string;
   ctaHref?: string;
   whatComesAcross?: WhatComesAcrossItem[];
+  relatedLinks?: ReadonlyArray<RelatedLink>;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-converter-hub.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-converter-hub.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-converter-hub",
+  "date": "2026-05-31",
+  "type": "feature",
+  "title": "Convert hub at /convert lists every converter, grouped by note apps, flashcard apps, files, and language tools"
+}


### PR DESCRIPTION
## What
Builds the converter internal-link graph in two parts. (H1) Every landing and convert page now renders a "Related" nav after its FAQ, with 3-5 descriptive-anchor links to topically related converters plus the new hub. (M3) A new `/convert` hub/pillar page lists every converter grouped by source type (note apps, flashcard apps, files, language tools), each with a one-line description and a real descriptive anchor.

## Why
From a completed SEO audit: the converter landing cluster was orphaned — 24 high-priority pages emitted zero internal links, so crawlers had no path between siblings and no pillar to consolidate topical authority. Internal linking is a direct lever on organic discovery, which feeds the top of the signup funnel.

## How
- Added an optional `relatedLinks` field to `LandingCopy`, mirroring `AnswerConfig.relatedLinks`; `LandingPage` renders it as a `<nav aria-label="Related">` after the FAQ using the same markup AnswersPage uses.
- Populated relatedLinks across 26 pages (15 in `convertLandingConfig.ts` + 11 standalone copy files).
- The hub builds its converter list from the existing `CONVERT_LANDING_PAGES` map, so it stays in sync automatically. A module-level guard throws if a converter is missing from the hub groups — a new converter can't silently drop off the pillar.
- Registered `/convert` in `App.tsx` (lazy-loaded, before `/convert/:slug`), added a prerender emit so it's statically emitted, and a sitemap `<url>` at priority 0.8.

## Measuring success
Google Search Console: rising impressions/clicks on the `/convert/*` cluster and the new `/convert` URL over the following weeks, plus a drop in "Discovered – currently not indexed" for converter pages as internal links give crawlers a path. The hub appears in the sitemap and prerendered build output (`build/convert/index.html`).

## Testing
- Unit tests added: hub renders a link to every entry in `CONVERT_LANDING_PAGES`; hub anchors are descriptive (never "click here"); landing pages with relatedLinks render the Related nav with every link; landing pages without relatedLinks omit the nav.
- Full web vitest suite green (1489 passed). Typecheck + biome lint clean.
- Verified the prerender `emitConvertHubPage` emits the hub HTML with the correct h1 and canonical via a throwaway colocated test (removed after).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Merged on Alexander's standing instruction. New /convert hub is auto-generated from CONVERT_LANDING_PAGES with an import-time guard against missing converters; full web suite green (1489 tests) incl. hub + related-nav render tests; prerender emit verified. Alexander to spot-check /convert visually post-merge — revertable as a clean additive diff (636 insertions, 0 deletions) if anything looks off.

## Changelog
"Convert hub at /convert lists every converter, grouped by note apps, flashcard apps, files, and language tools"

## Risks
Low. Additive only (636 insertions, 0 deletions). Worst case is a mistyped href; the hub guard and tests catch missing/unknown converter slugs at import time. SonarCloud was not run locally (SONAR_TOKEN unset) — expect a possible Sonar bounce, though the changes are simple presentational components and data.

## Goal alignment
Internal linking across the orphaned converter cluster is a direct organic-discovery lever. More indexed, interlinked converter pages → more search entries → more top-of-funnel signups, which moves us toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782810246&installation_id=132681956&pr_number=2963&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2963&signature=768dd7287c98aa4249e1dd2b89aefd65796aa28805c5c2bee6646a4d9668cd07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
