### PR TITLE
refactor: extract SSE event loop from ChatPanel sendMessage

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import ChatPanel from './ChatPanel';
+import ChatPanel, { consumeSseEvents } from './ChatPanel';
 
 window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
@@ -740,5 +740,48 @@ describe('ChatPanel — template selector', () => {
         })
       ).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('consumeSseEvents', () => {
+  function streamFromStrings(parts: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+      start(controller) {
+        for (const part of parts) controller.enqueue(encoder.encode(part));
+        controller.close();
+      },
+    });
+  }
+
+  it('dispatches each complete SSE event in arrival order', async () => {
+    const stream = streamFromStrings([
+      'event: token\ndata: "Hi"\n\n',
+      'event: done\ndata: {"content":"Hi","conversationId":1}\n\n',
+    ]);
+    const received: Array<[string, string]> = [];
+
+    await consumeSseEvents(stream, (eventType, data) => {
+      received.push([eventType, data]);
+    });
+
+    expect(received).toEqual([
+      ['token', '"Hi"'],
+      ['done', '{"content":"Hi","conversationId":1}'],
+    ]);
+  });
+
+  it('reassembles an event split across two stream chunks', async () => {
+    const stream = streamFromStrings([
+      'event: tok',
+      'en\ndata: "split"\n\n',
+    ]);
+    const received: Array<[string, string]> = [];
+
+    await consumeSseEvents(stream, (eventType, data) => {
+      received.push([eventType, data]);
+    });
+
+    expect(received).toEqual([['token', '"split"']]);
   });
 });

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -138,6 +138,29 @@ export function parseSseEvent(
   return { eventType, data };
 }
 
+export async function consumeSseEvents(
+  body: ReadableStream<Uint8Array>,
+  onEvent: (eventType: string, data: string) => void
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const events = buffer.split('\n\n');
+    buffer = events.pop() ?? '';
+
+    for (const rawEvent of events) {
+      const parsed = parseSseEvent(rawEvent);
+      if (parsed != null) onEvent(parsed.eventType, parsed.data);
+    }
+  }
+}
+
 async function downloadDeck(
   cards: ChatCard[],
   deckName: string,
@@ -818,24 +841,8 @@ export default function ChatPanel({
       if (eventType === 'error') return handleSseError(data);
     };
 
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
-
     try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, { stream: true });
-        const events = buffer.split('\n\n');
-        buffer = events.pop() ?? '';
-
-        for (const rawEvent of events) {
-          const parsed = parseSseEvent(rawEvent);
-          if (parsed != null) dispatchSseEvent(parsed.eventType, parsed.data);
-        }
-      }
+      await consumeSseEvents(response.body, dispatchSseEvent);
     } catch {
       setNetworkError("Couldn't send this message. Try again.");
     } finally {
@@ -950,60 +957,61 @@ export default function ChatPanel({
       return;
     }
 
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = '';
+    const handleRegenToken = (data: string) => {
+      const text = JSON.parse(data) as string;
+      setStreamingText((prev) => prev + text);
+    };
+
+    const handleRegenDone = (data: string) => {
+      const result = JSON.parse(data) as ApiDonePayload;
+      setMessages((prev) =>
+        prev.map((m, i) =>
+          i === targetIdx
+            ? {
+                role: 'assistant',
+                content: result.content,
+                contentBefore: result.contentBefore,
+                contentAfter: result.contentAfter,
+                cards: result.cards,
+              }
+            : m
+        )
+      );
+      setMessagesUsedThisMonth((n) => n + 1);
+      setActiveConversationId(result.conversationId);
+      if (result.cards != null && result.cards.length > 0) {
+        onCardsGenerated?.(result.cards);
+      }
+    };
+
+    const handleRegenError = (data: string) => {
+      const err = JSON.parse(data) as ApiErrorPayload;
+      if (err.type === 'rate_limit') {
+        setLimitReached(true);
+        if (err.resetDate != null) setResetDate(err.resetDate);
+        return;
+      }
+      if (err.type === 'conversation_not_found') {
+        setNetworkError('This conversation is gone. Start a new one.');
+        setActiveConversationId(null);
+        onConversationNotFound?.();
+        return;
+      }
+      if (err.type === 'consent_required') {
+        setShowConsentModal(true);
+        return;
+      }
+      setNetworkError("Couldn't rebuild your cards. Try again.");
+    };
+
+    const dispatchRegenEvent = (eventType: string, data: string) => {
+      if (eventType === 'token') return handleRegenToken(data);
+      if (eventType === 'done') return handleRegenDone(data);
+      if (eventType === 'error') return handleRegenError(data);
+    };
 
     try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const events = buffer.split('\n\n');
-        buffer = events.pop() ?? '';
-        for (const rawEvent of events) {
-          const parsed = parseSseEvent(rawEvent);
-          if (parsed == null) continue;
-          if (parsed.eventType === 'token') {
-            const text = JSON.parse(parsed.data) as string;
-            setStreamingText((prev) => prev + text);
-          } else if (parsed.eventType === 'done') {
-            const result = JSON.parse(parsed.data) as ApiDonePayload;
-            setMessages((prev) =>
-              prev.map((m, i) =>
-                i === targetIdx
-                  ? {
-                      role: 'assistant',
-                      content: result.content,
-                      contentBefore: result.contentBefore,
-                      contentAfter: result.contentAfter,
-                      cards: result.cards,
-                    }
-                  : m
-              )
-            );
-            setMessagesUsedThisMonth((n) => n + 1);
-            setActiveConversationId(result.conversationId);
-            if (result.cards != null && result.cards.length > 0) {
-              onCardsGenerated?.(result.cards);
-            }
-          } else if (parsed.eventType === 'error') {
-            const err = JSON.parse(parsed.data) as ApiErrorPayload;
-            if (err.type === 'rate_limit') {
-              setLimitReached(true);
-              if (err.resetDate != null) setResetDate(err.resetDate);
-            } else if (err.type === 'conversation_not_found') {
-              setNetworkError('This conversation is gone. Start a new one.');
-              setActiveConversationId(null);
-              onConversationNotFound?.();
-            } else if (err.type === 'consent_required') {
-              setShowConsentModal(true);
-            } else {
-              setNetworkError("Couldn't rebuild your cards. Try again.");
-            }
-          }
-        }
-      }
+      await consumeSseEvents(response.body, dispatchRegenEvent);
     } catch {
       setNetworkError("Couldn't rebuild your cards. Try again.");
     } finally {


### PR DESCRIPTION
## What
Extracts the SSE read/buffer/split/dispatch loop out of `ChatPanel`'s `sendMessage` into a named `consumeSseEvents(body, onEvent)` helper. `regenerateLastTurn` shared a byte-identical loop, so it now reuses the same helper with its own dispatch closure instead of carrying a third copy.

## Why
Closes #2509. `sendMessage` (~133 LOC, ~18-20 branches) was over Sonar's cognitive-complexity threshold; any future chat-area PR that added a branch would bounce on a code smell. Pay the refactor once. No user-visible outcome — this is an internal restructuring.

## How
The streaming mechanics (getReader, TextDecoder, the `while` loop, `\n\n` buffer split, per-event `parseSseEvent`) move into the module-level `consumeSseEvents`. The component keeps its per-event handling as flat named closures (`handleSseToken`/`handleSseDone`/`handleSseError` → `dispatchSseEvent`), passed in as the `onEvent` callback. The `try/catch/finally` error and cleanup path stays in the caller, unchanged. `regenerateLastTurn`'s inline if/else-if dispatch is lifted to matching named closures so it can share the helper.

## Measuring success
Not a runtime-observable change. Confirmation is the Sonar analysis on this PR reporting `sendMessage` below the cognitive-complexity threshold, and the next chat-area PR not bouncing on that smell.

## Testing
- Full web vitest suite green: 176 files, 1516 tests.
- ChatPanel suite (35 tests) covers the streaming path outside-in: token, done, error (rate_limit / consent_required), and regenerate.
- Added a focused unit test driving `consumeSseEvents` through a fake stream, including an event split across two chunks — buffer reassembly the prior tests never isolated.
- Sonar: `sonar-scanner` not run locally (no `SONAR_TOKEN` configured in this environment). Expect the CI Sonar analysis to confirm the complexity drop.

## Browser check
Browser check: not applicable — pure refactor, no behavior or rendered-output change

## Changelog
No entry — internal refactor, no user-visible behavior change.

## Risks
Low. Pure extraction with identical event order, handlers, and error paths; covered by the existing streaming tests plus the new chunk-split test. Rollback is a single revert.

## Goal alignment
Keeps the chat surface (a conversion entry point toward the 300K-user goal) cheap to iterate on — the next chat PR ships without a Sonar detour.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782810528&installation_id=132681956&pr_number=2964&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2964&signature=17f608e2fb5d9ac79e6df95198215563a610fbedb61b89a97c85a4b719f25bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->