### PR TITLE
feat: add chat regenerate endpoint for in-place template change

### DIFF
--- a/src/config/swagger.test.ts
+++ b/src/config/swagger.test.ts
@@ -249,6 +249,16 @@ describe('Swagger Documentation Coverage', () => {
       expect(ok.content).toHaveProperty('text/event-stream');
     });
 
+    it('documents /api/chat/conversations/{id}/regenerate as a Server-Sent Events stream', () => {
+      const op = spec.paths['/api/chat/conversations/{id}/regenerate']?.post;
+      expect(op).toBeDefined();
+      const ok = op.responses['200'];
+      expect(ok).toBeDefined();
+      expect(ok.content).toHaveProperty('text/event-stream');
+      const props = op.requestBody.content['application/json'].schema.properties;
+      expect(props.templateSlug).toBeDefined();
+    });
+
     it('documents templateSlug and multipart files for /api/chat/message', () => {
       const op = spec.paths['/api/chat/message']?.post;
       const jsonProps =

--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -29,13 +29,18 @@ function buildMocks(
   chatConsentAt: Date | null = new Date()
 ) {
   const execute = jest.fn();
-  const controller = new ChatController({ execute } as never);
+  const regenerate = jest.fn();
+  const controller = new ChatController({ execute, regenerate } as never);
   const res = buildRes(owner, patreon, subscriber, chatConsentAt);
-  return { execute, controller, res };
+  return { execute, regenerate, controller, res };
 }
 
 function buildReq(body: unknown, files?: Express.Multer.File[]): Request {
   return { body, files: files ?? [] } as unknown as Request;
+}
+
+function buildReqWithParams(body: unknown, params: Record<string, string>): Request {
+  return { body, params } as unknown as Request;
 }
 
 function makeFile(
@@ -334,5 +339,69 @@ describe('ChatController.sendMessage — multipart history parsing', () => {
         conversationHistory: [{ role: 'user', content: 'prior' }],
       })
     );
+  });
+});
+
+describe('ChatController.regenerateMessage', () => {
+  it('emits consent_required SSE error when chat_consent_at is null', async () => {
+    const { controller, res } = buildMocks(42, false, false, null);
+    await controller.regenerateMessage(buildReqWithParams({}, { id: '7' }), res);
+    const events = writtenEvents(res);
+    expect(events).toContainEqual({ event: 'error', data: { type: 'consent_required' } });
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it('returns 400 when the conversation id is not a positive integer', async () => {
+    const { regenerate, controller, res } = buildMocks();
+    await controller.regenerateMessage(buildReqWithParams({}, { id: 'abc' }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(regenerate).not.toHaveBeenCalled();
+  });
+
+  it('passes the conversation id and per-call templateSlug to the use case', async () => {
+    const { regenerate, controller, res } = buildMocks();
+    regenerate.mockResolvedValueOnce({ content: 'fresh', conversationId: 7 });
+
+    await controller.regenerateMessage(
+      buildReqWithParams({ templateSlug: 'cloze' }, { id: '7' }),
+      res
+    );
+
+    expect(regenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: 7,
+        templateSlug: 'cloze',
+        user: { owner: 42, patreon: false },
+      })
+    );
+  });
+
+  it('streams a done frame with the regenerated content', async () => {
+    const { regenerate, controller, res } = buildMocks();
+    regenerate.mockResolvedValueOnce({ content: 'fresh', conversationId: 7 });
+
+    await controller.regenerateMessage(
+      buildReqWithParams({ templateSlug: null }, { id: '7' }),
+      res
+    );
+
+    const events = writtenEvents(res);
+    expect(events).toContainEqual({
+      event: 'done',
+      data: { content: 'fresh', conversationId: 7 },
+    });
+  });
+
+  it('emits a conversation_not_found SSE error when the use case rejects', async () => {
+    const { regenerate, controller, res } = buildMocks();
+    regenerate.mockRejectedValueOnce(new ChatConversationNotFoundError());
+
+    await controller.regenerateMessage(buildReqWithParams({}, { id: '7' }), res);
+
+    const events = writtenEvents(res);
+    expect(events).toContainEqual({
+      event: 'error',
+      data: { type: 'conversation_not_found' },
+    });
   });
 });

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -186,6 +186,58 @@ class ChatController {
       res.end();
     }
   }
+
+  async regenerateMessage(req: Request, res: Response) {
+    if (!hasConsented(res.locals as Record<string, unknown>)) {
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.flushHeaders();
+      sseWrite(res, 'error', { type: 'consent_required' });
+      res.end();
+      return;
+    }
+
+    const conversationId = parseConversationId(req.params?.id);
+    if (conversationId == null) {
+      res.status(400).json({ error: 'conversationId is required' });
+      return;
+    }
+
+    const owner = res.locals.owner as number;
+    const patreon = (res.locals.patreon as boolean) ?? false;
+    const subscriber = (res.locals.subscriber as boolean) ?? false;
+    const isPremium = patreon || subscriber;
+
+    const rawTemplateSlug = req.body?.templateSlug;
+    const templateSlug = typeof rawTemplateSlug === 'string' ? rawTemplateSlug : null;
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    try {
+      const result = await this.chatUseCase.regenerate({
+        user: { owner, patreon: isPremium },
+        conversationId,
+        templateSlug,
+        onToken: (text) => sseWrite(res, 'token', text),
+      });
+
+      sseWrite(res, 'done', {
+        content: result.content,
+        conversationId: result.conversationId,
+        ...(result.cards != null ? { cards: result.cards } : {}),
+        ...(result.contentBefore != null ? { contentBefore: result.contentBefore } : {}),
+        ...(result.contentAfter != null ? { contentAfter: result.contentAfter } : {}),
+      });
+    } catch (err) {
+      emitChatError(res, err);
+    } finally {
+      res.end();
+    }
+  }
 }
 
 export default ChatController;

--- a/src/data_layer/ChatMessagesRepository.ts
+++ b/src/data_layer/ChatMessagesRepository.ts
@@ -28,6 +28,7 @@ export interface IChatMessagesRepository {
     messageId: number;
     content: string;
   }): Promise<boolean>;
+  deleteById(input: { userId: number; messageId: number }): Promise<boolean>;
 }
 
 export class ChatMessagesRepository implements IChatMessagesRepository {
@@ -82,6 +83,13 @@ export class ChatMessagesRepository implements IChatMessagesRepository {
       .where({ id: input.messageId, user_id: input.userId })
       .update({ content: input.content });
     return updated > 0;
+  }
+
+  async deleteById(input: { userId: number; messageId: number }): Promise<boolean> {
+    const deleted = await this.database(this.table)
+      .where({ id: input.messageId, user_id: input.userId })
+      .del();
+    return deleted > 0;
   }
 }
 
@@ -142,6 +150,15 @@ export class InMemoryChatMessagesRepository implements IChatMessagesRepository {
     );
     if (row == null) return false;
     row.content = input.content;
+    return true;
+  }
+
+  async deleteById(input: { userId: number; messageId: number }): Promise<boolean> {
+    const index = this.rows.findIndex(
+      (r) => r.id === input.messageId && r.user_id === input.userId
+    );
+    if (index === -1) return false;
+    this.rows.splice(index, 1);
     return true;
   }
 

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -501,6 +501,64 @@ const ChatRouter = () => {
     conversationsController.saveTemplate(req, res)
   );
 
+  /**
+   * @swagger
+   * /api/chat/conversations/{id}/regenerate:
+   *   post:
+   *     summary: Regenerate the last assistant turn in place (Server-Sent Events stream)
+   *     description: |
+   *       Deletes the most recent assistant message in the conversation and
+   *       re-runs the prior user prompt against Claude under the supplied
+   *       `templateSlug`, streaming the new turn back with the same SSE event
+   *       shape as `POST /api/chat/message` (`token` / `done` / `error`). The
+   *       prior user message is kept as-is, so the conversation does not grow a
+   *       duplicate turn on reload. The per-call `templateSlug` is independent
+   *       of the conversation's stored default template set via
+   *       `PATCH /api/chat/conversations/{id}/template`.
+   *     tags: [Chat]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema: { type: integer }
+   *     requestBody:
+   *       required: false
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               templateSlug:
+   *                 type: string
+   *                 nullable: true
+   *                 enum: [basic, basic-and-reversed, cloze, mcq]
+   *     responses:
+   *       200:
+   *         description: |
+   *           SSE stream of `token`, `done`, and `error` events, identical to
+   *           `POST /api/chat/message`.
+   *         content:
+   *           text/event-stream:
+   *             schema:
+   *               oneOf:
+   *                 - $ref: '#/components/schemas/ChatTokenFrame'
+   *                 - $ref: '#/components/schemas/ChatDoneFrame'
+   *                 - $ref: '#/components/schemas/ChatErrorFrame'
+   *       400:
+   *         description: Invalid conversation id
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   *       401:
+   *         description: Authentication required
+   */
+  router.post('/api/chat/conversations/:id/regenerate', RequireAuthentication, (req, res) =>
+    controller.regenerateMessage(req, res)
+  );
+
   return router;
 };
 

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -585,6 +585,87 @@ describe('ChatUseCase', () => {
     });
   });
 
+  describe('regenerate', () => {
+    async function seedConversation(
+      messagesRepo: InMemoryChatMessagesRepository,
+      conversationsRepo: InMemoryConversationsRepository,
+      userId: number
+    ) {
+      const conversationId = await conversationsRepo.create({ userId, title: 'Seeded' });
+      const turns: Array<{ role: 'user' | 'assistant'; content: string }> = [
+        { role: 'user', content: 'first prompt' },
+        { role: 'assistant', content: 'old assistant reply' },
+      ];
+      for (const turn of turns) {
+        await messagesRepo.insert({ userId, conversationId, role: turn.role, content: turn.content });
+        conversationsRepo.recordMessage({
+          userId,
+          conversationId,
+          role: turn.role,
+          content: turn.content,
+        });
+      }
+      return conversationId;
+    }
+
+    it('deletes the last assistant message and streams a fresh turn', async () => {
+      const { messagesRepo, conversationsRepo, useCase } = buildUseCase('new assistant reply');
+      const conversationId = await seedConversation(messagesRepo, conversationsRepo, PATREON_USER.owner);
+
+      const result = await useCase.regenerate({
+        user: PATREON_USER,
+        conversationId,
+        templateSlug: 'cloze',
+      });
+
+      expect(result.content).toBe('new assistant reply');
+      expect(result.conversationId).toBe(conversationId);
+
+      const remaining = messagesRepo.getAll().filter((r) => r.conversation_id === conversationId);
+      const assistantContents = remaining
+        .filter((r) => r.role === 'assistant')
+        .map((r) => r.content);
+      expect(assistantContents).toEqual(['new assistant reply']);
+    });
+
+    it('leaves the prior user message untouched', async () => {
+      const { messagesRepo, conversationsRepo, useCase } = buildUseCase('regenerated');
+      const conversationId = await seedConversation(messagesRepo, conversationsRepo, PATREON_USER.owner);
+
+      await useCase.regenerate({
+        user: PATREON_USER,
+        conversationId,
+        templateSlug: null,
+      });
+
+      const userMessages = messagesRepo
+        .getAll()
+        .filter((r) => r.conversation_id === conversationId && r.role === 'user');
+      expect(userMessages.map((r) => r.content)).toEqual(['first prompt']);
+    });
+
+    it('passes the regenerate templateSlug to the model prompt, not the stored default', async () => {
+      const { messagesRepo, conversationsRepo, anthropic, useCase } = buildUseCase('regenerated');
+      const conversationId = await seedConversation(messagesRepo, conversationsRepo, PATREON_USER.owner);
+
+      await useCase.regenerate({
+        user: PATREON_USER,
+        conversationId,
+        templateSlug: 'cloze',
+      });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(callArg.system[0].text).toMatch(/cloze deletion/i);
+    });
+
+    it('throws ChatConversationNotFoundError for an unknown conversation', async () => {
+      const { useCase } = buildUseCase('x');
+      await expect(
+        useCase.regenerate({ user: PATREON_USER, conversationId: 999, templateSlug: null })
+      ).rejects.toBeInstanceOf(ChatConversationNotFoundError);
+    });
+  });
+
   describe('ChatRateLimitError', () => {
     it('provides a resetDate as the first of next month', async () => {
       const { messagesRepo, useCase } = buildUseCase('');

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -294,10 +294,91 @@ export class ChatUseCase {
       });
     }
 
+    const recentHistory = conversationHistory.slice(-MAX_HISTORY_TURNS);
+    const attachmentBlocks = buildAttachmentBlocks(attachments);
+    const userContent: Anthropic.MessageParam['content'] =
+      attachmentBlocks.length > 0
+        ? [...attachmentBlocks, { type: 'text', text: content }]
+        : content;
+
+    await this.messagesRepo.insert({
+      userId: user.owner,
+      conversationId,
+      role: 'user',
+      content,
+    });
+
+    return this.streamAssistantTurn({
+      user,
+      conversationId,
+      templateSlug: input.templateSlug,
+      historyMessages: recentHistory.map((m) => ({ role: m.role, content: m.content })),
+      userContent,
+      onToken,
+    });
+  }
+
+  async regenerate(input: {
+    user: ChatUser;
+    conversationId: number;
+    templateSlug?: string | null;
+    onToken?: (text: string) => void;
+  }): Promise<SendMessageResult> {
+    const { user, onToken } = input;
+
+    const conversation = await this.conversationsRepo.findForUser({
+      userId: user.owner,
+      conversationId: input.conversationId,
+    });
+    if (conversation == null) {
+      throw new ChatConversationNotFoundError();
+    }
+
+    const latestAssistant = await this.messagesRepo.findLatestAssistantInConversation({
+      userId: user.owner,
+      conversationId: conversation.id,
+    });
+    if (latestAssistant != null) {
+      await this.messagesRepo.deleteById({
+        userId: user.owner,
+        messageId: latestAssistant.id,
+      });
+    }
+
+    const priorMessages = conversation.messages.filter(
+      (m) => m.id !== latestAssistant?.id
+    );
+    const lastUserIndex = priorMessages.map((m) => m.role).lastIndexOf('user');
+    const upToLastUser =
+      lastUserIndex >= 0 ? priorMessages.slice(0, lastUserIndex + 1) : priorMessages;
+    const recentHistory = upToLastUser.slice(-(MAX_HISTORY_TURNS + 1));
+    const historyHead = recentHistory.slice(0, -1);
+    const lastTurn = recentHistory[recentHistory.length - 1];
+
+    return this.streamAssistantTurn({
+      user,
+      conversationId: conversation.id,
+      templateSlug: input.templateSlug,
+      historyMessages: historyHead.map((m) => ({ role: m.role, content: m.content })),
+      userContent: lastTurn?.content ?? '',
+      onToken,
+    });
+  }
+
+  private async streamAssistantTurn(params: {
+    user: ChatUser;
+    conversationId: number;
+    templateSlug?: string | null;
+    historyMessages: Array<{ role: 'user' | 'assistant'; content: Anthropic.MessageParam['content'] }>;
+    userContent: Anthropic.MessageParam['content'];
+    onToken?: (text: string) => void;
+  }): Promise<SendMessageResult> {
+    const { user, conversationId, historyMessages, userContent, onToken } = params;
+
     const model = user.patreon ? PATREON_MODEL : FREE_MODEL;
 
-    const resolvedTemplate: ChatCardTemplate = isChatCardTemplate(input.templateSlug)
-      ? input.templateSlug
+    const resolvedTemplate: ChatCardTemplate = isChatCardTemplate(params.templateSlug)
+      ? params.templateSlug
       : 'basic';
     const mcqAllowed = user.patreon || resolvedTemplate === 'mcq';
 
@@ -309,23 +390,10 @@ export class ChatUseCase {
       ? `${baseSystemPrompt}\n\n${templateSuffix.trim()}`
       : baseSystemPrompt;
 
-    const recentHistory = conversationHistory.slice(-MAX_HISTORY_TURNS);
-    const attachmentBlocks = buildAttachmentBlocks(attachments);
-    const userContent: Anthropic.MessageParam['content'] =
-      attachmentBlocks.length > 0
-        ? [...attachmentBlocks, { type: 'text', text: content }]
-        : content;
     const messages: Anthropic.MessageParam[] = [
-      ...recentHistory.map((m) => ({ role: m.role, content: m.content })),
+      ...historyMessages.map((m) => ({ role: m.role, content: m.content })),
       { role: 'user', content: userContent },
     ];
-
-    await this.messagesRepo.insert({
-      userId: user.owner,
-      conversationId,
-      role: 'user',
-      content,
-    });
 
     const stream = this.anthropic.messages.stream({
       model,

--- a/src/usecases/chat/TagCardsUseCase.test.ts
+++ b/src/usecases/chat/TagCardsUseCase.test.ts
@@ -98,6 +98,7 @@ describe('TagCardsUseCase', () => {
         .fn()
         .mockResolvedValue({ id: 42, content: stored }),
       updateContent: jest.fn().mockResolvedValue(true),
+      deleteById: jest.fn().mockResolvedValue(true),
     };
     const useCase = new TagCardsUseCase(anthropic, repo);
     await useCase.execute({
@@ -129,6 +130,7 @@ describe('TagCardsUseCase', () => {
       countThisMonth: jest.fn(),
       findLatestAssistantInConversation: jest.fn(),
       updateContent: jest.fn(),
+      deleteById: jest.fn(),
     };
     const useCase = new TagCardsUseCase(anthropic, repo);
     await useCase.execute({

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-regenerate.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-regenerate.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-chat-regenerate",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Changing a chat card's template regenerates the turn in place instead of leaving duplicate messages"
+}


### PR DESCRIPTION
## What
Adds `POST /api/chat/conversations/:id/regenerate`. It deletes the most recent assistant message in the conversation and re-runs the prior user prompt against Claude under a per-call `templateSlug`, streaming the new turn back with the same `token` / `done` / `error` SSE shape as `POST /api/chat/message`. The prior user message is left untouched.

## Why
Closes #2956. The chat clients implement "change the template on the last assistant turn" by re-POSTing `/api/chat/message` with the prior prompt + new `templateSlug` + same `conversationId`. That persists a brand-new `(user, assistant)` pair, so reloading the conversation later shows duplicate turns. Regenerating in place fixes the duplicate.

## How
- New `regenerate` use-case method loads the conversation, deletes the last assistant message via a new `deleteById` repo method, rebuilds history up to and including the last user message, and re-runs the turn.
- Extracted a private `streamAssistantTurn` step shared by `execute` and `regenerate` so the Claude streaming/persist logic is not duplicated. Kept surgical — no change to the MCQ prompt logic or the multer filter.
- The per-call `templateSlug` is independent of the conversation's stored default (`PATCH .../template`).
- Controller parses the path id with the existing positive-integer validation (`== null` presence check), opens SSE, and maps errors to the existing `consent_required` / `conversation_not_found` / `server_error` frames.

## Measuring success
`logClaudeUsage('ChatUseCase', ...)` already fires for each regenerate turn. Behaviourally: reload a conversation after a template change in the native/web client — the turn count stays flat instead of growing.

## Testing
- Unit tests added: use-case (`deletes last assistant`, `prior user untouched`, `per-call slug drives prompt`, `not-found`), controller (`consent`, `400 on bad id`, `passes id + slug`, `done frame`, `not-found error frame`), and a swagger contract test for the new SSE path.
- `npx tsc -p . --noEmit` clean; chat-area Jest suites green (93 tests).

## Browser check
Browser check: not applicable — server endpoint + changelog only, no web UI change

## Changelog
`Changing a chat card's template regenerates the turn in place instead of leaving duplicate messages` (`web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-regenerate.json`)

## Coordination
Two sibling PRs touch the same chat backend files — #2953 (attachment file types, multer filter) and #2957 (MCQ prompt / card extraction) overlap on `src/routes/ChatRouter.ts` and `src/usecases/chat/ChatUseCase.ts`. This PR keeps changes localized (new route + new use-case method + a shared private step) and expects a rebase before merge.

## Follow-ups (not in this PR)
- Web UI swap to the new endpoint — deferred to avoid colliding with the in-flight chat-backend PRs; the issue's native-client follow-up (`ClaudeGenerateView.swift`) lives in the app repo.

## Risks
Touches Anthropic streaming. SONAR_TOKEN was not set locally, so `sonar-scanner` was not run — expect a possible Sonar bounce. `/security-review` is advisable before merge (external-API integration). Rollback is a plain revert; the new route is additive.

## Goal alignment
Removes a confusing duplicate-turn artifact from the chat-to-flashcards flow, keeping the core "notes → cards" experience clean as chat adoption grows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782810630&installation_id=132681956&pr_number=2965&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2965&signature=011c6298642f881b4d952d1767995de3d6ab77ea8f52b60caf10d2ce115e345a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->