### PR TITLE
fix: force MCQ chat cards via Anthropic structured output

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -698,6 +698,15 @@ const options: swaggerJsdoc.Options = {
                 },
                 {
                   type: 'object',
+                  description:
+                    'The MCQ template could not produce well-formed multiple-choice cards. Surface a specific message; do not silently fall back to the previous turn.',
+                  required: ['type'],
+                  properties: {
+                    type: { type: 'string', enum: ['mcq_extraction_failed'] },
+                  },
+                },
+                {
+                  type: 'object',
                   description: 'Unhandled server error; safe to retry.',
                   required: ['type'],
                   properties: {

--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -3,6 +3,7 @@ import ChatController from './ChatController';
 import {
   ChatRateLimitError,
   ChatConversationNotFoundError,
+  McqExtractionFailedError,
 } from '../usecases/chat/ChatUseCase';
 
 function buildRes(
@@ -184,6 +185,21 @@ describe('ChatController.sendMessage', () => {
       event: 'done',
       data: expect.objectContaining({ conversationId: 42 }),
     });
+  });
+
+  it('sends mcq_extraction_failed error event when use case throws McqExtractionFailedError', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockRejectedValueOnce(new McqExtractionFailedError());
+    await controller.sendMessage(
+      buildReq({ content: 'Quiz me on Albania', templateSlug: 'mcq' }),
+      res
+    );
+    const events = writtenEvents(res);
+    expect(events).toContainEqual({
+      event: 'error',
+      data: { type: 'mcq_extraction_failed' },
+    });
+    expect(res.end).toHaveBeenCalled();
   });
 
   it('sends conversation_not_found error event when use case throws ChatConversationNotFoundError', async () => {

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -3,6 +3,7 @@ import {
   ChatUseCase,
   ChatRateLimitError,
   ChatConversationNotFoundError,
+  McqExtractionFailedError,
 } from '../usecases/chat/ChatUseCase';
 import type { ChatAttachment } from '../usecases/chat/buildAttachmentBlocks';
 import { detectFileMime } from '../lib/detectFileMime';
@@ -102,6 +103,8 @@ function emitChatError(res: Response, err: unknown): void {
     sseWrite(res, 'error', { type: 'rate_limit', resetDate: err.resetDate });
   } else if (err instanceof ChatConversationNotFoundError) {
     sseWrite(res, 'error', { type: 'conversation_not_found' });
+  } else if (err instanceof McqExtractionFailedError) {
+    sseWrite(res, 'error', { type: 'mcq_extraction_failed' });
   } else {
     sseWrite(res, 'error', { type: 'server_error' });
   }

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -2,6 +2,7 @@ import {
   ChatUseCase,
   ChatRateLimitError,
   ChatConversationNotFoundError,
+  McqExtractionFailedError,
 } from './ChatUseCase';
 import { InMemoryChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
 import { InMemoryConversationsRepository } from '../../data_layer/ConversationsRepository';
@@ -9,12 +10,10 @@ import { InMemoryConversationsRepository } from '../../data_layer/ConversationsR
 const FREE_USER = { owner: 1, patreon: false } as const;
 const PATREON_USER = { owner: 2, patreon: true } as const;
 
-function buildAnthropicMock(responseContent: string) {
+function buildAnthropicMockWithBlocks(content: unknown[]) {
   const mockStream = {
     on: jest.fn().mockReturnThis(),
-    finalMessage: jest.fn().mockResolvedValue({
-      content: [{ type: 'text', text: responseContent }],
-    }),
+    finalMessage: jest.fn().mockResolvedValue({ content }),
   };
   return {
     messages: {
@@ -23,10 +22,22 @@ function buildAnthropicMock(responseContent: string) {
   };
 }
 
+function buildAnthropicMock(responseContent: string) {
+  return buildAnthropicMockWithBlocks([{ type: 'text', text: responseContent }]);
+}
+
 function buildUseCase(responseContent: string) {
   const messagesRepo = new InMemoryChatMessagesRepository();
   const conversationsRepo = new InMemoryConversationsRepository();
   const anthropic = buildAnthropicMock(responseContent);
+  const useCase = new ChatUseCase(messagesRepo, conversationsRepo, anthropic as never);
+  return { messagesRepo, conversationsRepo, anthropic, useCase };
+}
+
+function buildUseCaseWithBlocks(content: unknown[]) {
+  const messagesRepo = new InMemoryChatMessagesRepository();
+  const conversationsRepo = new InMemoryConversationsRepository();
+  const anthropic = buildAnthropicMockWithBlocks(content);
   const useCase = new ChatUseCase(messagesRepo, conversationsRepo, anthropic as never);
   return { messagesRepo, conversationsRepo, anthropic, useCase };
 }
@@ -500,6 +511,140 @@ describe('ChatUseCase', () => {
       await useCase.execute({ user: FREE_USER, content: 'q', conversationHistory: [] });
       const callArg = anthropic.messages.stream.mock.calls[0][0];
       expect(callArg.system[0].text).not.toMatch(/correct_index/);
+    });
+  });
+
+  describe('MCQ structured output (templateSlug=mcq)', () => {
+    function mcqToolBlock(input: unknown) {
+      return { type: 'tool_use', name: 'emit_mcq_cards', input };
+    }
+
+    it('forces the MCQ tool with tool_choice when templateSlug is mcq', async () => {
+      const { anthropic, useCase } = buildUseCaseWithBlocks([
+        mcqToolBlock({
+          cards: [
+            {
+              front: 'Capital of Albania?',
+              options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+              correct_index: 0,
+              rationale: 'Tirana is the capital.',
+            },
+          ],
+        }),
+      ]);
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: '10 facts about Albania',
+        conversationHistory: [],
+        templateSlug: 'mcq',
+      });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(callArg.tools).toEqual([
+        expect.objectContaining({ name: 'emit_mcq_cards' }),
+      ]);
+      expect(callArg.tool_choice).toEqual({ type: 'tool', name: 'emit_mcq_cards' });
+    });
+
+    it('extracts MCQ cards from the tool_use block for templateSlug=mcq', async () => {
+      const { useCase } = buildUseCaseWithBlocks([
+        mcqToolBlock({
+          cards: [
+            {
+              front: 'Capital of Albania?',
+              options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+              correct_index: 0,
+              rationale: 'Tirana is the capital.',
+            },
+            {
+              front: 'Albanian currency?',
+              options: ['Lek', 'Euro', 'Dinar', 'Lev'],
+              correct_index: 0,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: '10 facts about Albania',
+        conversationHistory: [],
+        templateSlug: 'mcq',
+      });
+
+      expect(result.cards).toHaveLength(2);
+      expect(result.cards![0]).toMatchObject({
+        front: 'Capital of Albania?',
+        options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+        correctIndex: 0,
+        rationale: 'Tirana is the capital.',
+      });
+      expect(result.cards![1]).toMatchObject({
+        front: 'Albanian currency?',
+        correctIndex: 0,
+      });
+    });
+
+    it('throws McqExtractionFailedError when the model returns prose and no tool call', async () => {
+      const { useCase } = buildUseCaseWithBlocks([
+        { type: 'text', text: 'Here are 10 facts about Albania...' },
+      ]);
+
+      await expect(
+        useCase.execute({
+          user: FREE_USER,
+          content: '10 facts about Albania',
+          conversationHistory: [],
+          templateSlug: 'mcq',
+        })
+      ).rejects.toBeInstanceOf(McqExtractionFailedError);
+    });
+
+    it('throws McqExtractionFailedError when the tool emits malformed MCQ cards', async () => {
+      const { useCase } = buildUseCaseWithBlocks([
+        mcqToolBlock({
+          cards: [{ front: 'bad', options: ['A', 'B', 'C'], correct_index: 0 }],
+        }),
+      ]);
+
+      await expect(
+        useCase.execute({
+          user: FREE_USER,
+          content: 'quiz me',
+          conversationHistory: [],
+          templateSlug: 'mcq',
+        })
+      ).rejects.toBeInstanceOf(McqExtractionFailedError);
+    });
+
+    it('does not force the MCQ tool for non-mcq templates', async () => {
+      const { anthropic, useCase } = buildUseCase('plain answer');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'question',
+        conversationHistory: [],
+        templateSlug: 'basic',
+      });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(callArg.tools).toBeUndefined();
+      expect(callArg.tool_choice).toBeUndefined();
+    });
+
+    it('does not force the MCQ tool for a patreon user on the basic template', async () => {
+      const { anthropic, useCase } = buildUseCase('plain answer');
+
+      await useCase.execute({
+        user: PATREON_USER,
+        content: 'question',
+        conversationHistory: [],
+        templateSlug: 'basic',
+      });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(callArg.tool_choice).toBeUndefined();
     });
   });
 

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -15,6 +15,48 @@ const MCQ_PROMPT_ADDITION = `For multiple-choice cards with one correct answer, 
 
 Use exactly four options. correct_index is the 0-based position of the right option. Omit "back" on MCQ cards.`;
 
+const MCQ_TOOL_NAME = 'emit_mcq_cards';
+
+const MCQ_TOOL: Anthropic.Tool = {
+  name: MCQ_TOOL_NAME,
+  description:
+    'Emit a set of multiple-choice flashcards. Every card must have a question stem, exactly four answer options, and the 0-based index of the correct option.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      cards: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'object',
+          properties: {
+            front: { type: 'string', description: 'The question stem' },
+            options: {
+              type: 'array',
+              description: 'Exactly four answer options',
+              minItems: REQUIRED_MCQ_OPTION_COUNT,
+              maxItems: REQUIRED_MCQ_OPTION_COUNT,
+              items: { type: 'string' },
+            },
+            correct_index: {
+              type: 'integer',
+              minimum: 0,
+              maximum: REQUIRED_MCQ_OPTION_COUNT - 1,
+              description: '0-based index of the correct option',
+            },
+            rationale: {
+              type: 'string',
+              description: 'Brief explanation of why the correct option is right',
+            },
+          },
+          required: ['front', 'options', 'correct_index'],
+        },
+      },
+    },
+    required: ['cards'],
+  },
+};
+
 const FREE_MONTHLY_LIMIT = 20;
 const FREE_MODEL = 'claude-haiku-4-5-20251001';
 const PATREON_MODEL = 'claude-sonnet-4-6';
@@ -251,6 +293,34 @@ export class ChatConversationNotFoundError extends Error {
   }
 }
 
+export class McqExtractionFailedError extends Error {
+  constructor() {
+    super('Could not produce multiple-choice cards');
+    this.name = 'McqExtractionFailedError';
+  }
+}
+
+export function extractMcqCardsFromToolUse(
+  content: Anthropic.ContentBlock[]
+): ChatCard[] | undefined {
+  const toolBlock = content.find(
+    (block): block is Anthropic.ToolUseBlock =>
+      block.type === 'tool_use' && block.name === MCQ_TOOL_NAME
+  );
+  if (toolBlock == null) return undefined;
+  const input = toolBlock.input;
+  if (input == null || typeof input !== 'object') return undefined;
+  const rawCards = (input as Record<string, unknown>).cards;
+  if (!Array.isArray(rawCards)) return undefined;
+  const cards: ChatCard[] = [];
+  for (const item of rawCards) {
+    if (item == null || typeof item !== 'object') continue;
+    const mcq = asMcqChatCard(item as Record<string, unknown>);
+    if (mcq != null) cards.push(mcq);
+  }
+  return cards.length > 0 ? cards : undefined;
+}
+
 export class ChatUseCase {
   constructor(
     private readonly messagesRepo: IChatMessagesRepository,
@@ -380,7 +450,8 @@ export class ChatUseCase {
     const resolvedTemplate: ChatCardTemplate = isChatCardTemplate(params.templateSlug)
       ? params.templateSlug
       : 'basic';
-    const mcqAllowed = user.patreon || resolvedTemplate === 'mcq';
+    const mcqForced = resolvedTemplate === 'mcq';
+    const mcqAllowed = user.patreon || mcqForced;
 
     const templateSuffix = templatePromptSuffix(resolvedTemplate);
     const baseSystemPrompt = mcqAllowed
@@ -400,6 +471,9 @@ export class ChatUseCase {
       max_tokens: MAX_TOKENS,
       system: [{ type: 'text', text: systemPromptText, cache_control: { type: 'ephemeral' } }],
       messages,
+      ...(mcqForced
+        ? { tools: [MCQ_TOOL], tool_choice: { type: 'tool', name: MCQ_TOOL_NAME } }
+        : {}),
     });
 
     if (onToken != null) {
@@ -414,18 +488,20 @@ export class ChatUseCase {
       .map((block) => block.text)
       .join('');
 
-    await this.messagesRepo.insert({
-      userId: user.owner,
-      conversationId,
-      role: 'assistant',
-      content: assistantContent,
-    });
-    await this.conversationsRepo.touch({ userId: user.owner, conversationId });
-    await this.conversationsRepo.saveDraft({
-      userId: user.owner,
-      conversationId,
-      content: null,
-    });
+    if (mcqForced) {
+      const mcqCards = extractMcqCardsFromToolUse(finalMessage.content);
+      if (mcqCards == null) {
+        throw new McqExtractionFailedError();
+      }
+      await this.persistAssistantTurn(user.owner, conversationId, assistantContent);
+      return {
+        content: assistantContent,
+        conversationId,
+        cards: mcqCards,
+      };
+    }
+
+    await this.persistAssistantTurn(user.owner, conversationId, assistantContent);
 
     const { cards, contentBefore, contentAfter } = extractCards(assistantContent, mcqAllowed);
 
@@ -436,5 +512,20 @@ export class ChatUseCase {
       ...(contentBefore != null ? { contentBefore } : {}),
       ...(contentAfter != null ? { contentAfter } : {}),
     };
+  }
+
+  private async persistAssistantTurn(
+    userId: number,
+    conversationId: number,
+    content: string
+  ): Promise<void> {
+    await this.messagesRepo.insert({
+      userId,
+      conversationId,
+      role: 'assistant',
+      content,
+    });
+    await this.conversationsRepo.touch({ userId, conversationId });
+    await this.conversationsRepo.saveDraft({ userId, conversationId, content: null });
   }
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-mcq-reliable.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-mcq-reliable.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-chat-mcq-reliable",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Multiple-choice cards in chat generate reliably, with a clear message when they can't"
+}


### PR DESCRIPTION
## What
Makes the chat MCQ template reliably return cards. When `templateSlug=mcq`, the server now forces structured output via an Anthropic tool (`emit_mcq_cards`) so the model must emit a valid MCQ shape (front + exactly 4 options + 0-based correctIndex + optional rationale), then extracts cards from the `tool_use` block. When the forced tool still fails to produce valid cards, the SSE stream emits a typed `event: error, data: { type: "mcq_extraction_failed" }` envelope so the client can show a specific message instead of silently falling back to the previous turn.

## Why
Closes #2957. With `templateSlug=mcq` the model frequently returned prose with no `cards` in the `done` frame, while basic/cloze reliably returned cards. The user experienced "I clicked MCQ and nothing changed." Forced tool use removes the prose-drift failure mode; the typed error envelope turns the remaining failures into a clear signal.

## How
- Implemented **option 2 (structured output / tool use)** from the issue, not prompt-only.
- The MCQ tool + `tool_choice: { type: 'tool', name: 'emit_mcq_cards' }` are added to the stream call **only** when the resolved template is `mcq`. Basic, cloze, basic-and-reversed, and the patreon-on-basic prose path are untouched.
- Card extraction reuses the existing `asMcqChatCard` validator, so the same shape rules apply to tool output as to prose JSON.
- New `McqExtractionFailedError` thrown by the use case; controller maps it to the typed SSE envelope. Unexpected errors still hit the generic `server_error` path.
- Added the `mcq_extraction_failed` variant to the `ChatErrorFrame` swagger schema.

Used the project's Anthropic wrapper (`getAnthropicClient`) — no new SDK path. No prompt/PII logged; usage telemetry unchanged via `logClaudeUsage`.

### LLM cost note
No new model or extra call — the same single streamed `messages.stream` call now carries `tools`/`tool_choice` on the MCQ path only. Token delta is the tool schema (~small, sent once) plus the structured tool output replacing free-form prose; net roughly neutral. Prompt caching still applies to the cached system block. Latency budget unchanged.

## Coordination
Two sibling PRs touch the same chat backend (`ChatRouter.ts` + chat use case): #2956 (regenerate endpoint, adds a route) and #2953 (attachment types, edits the multer filter + extraction). This PR's edits are localized to the MCQ prompt-building + card extraction + error envelope in `ChatUseCase.ts`, `ChatController.ts`, and the swagger schema — no router edits. Expect a rebase against whichever lands first.

## Measuring success
- `[claude-usage] label=ChatUseCase ...` log line continues per turn (unchanged).
- Confirm via the `done` frame carrying a non-empty `cards` array for `templateSlug=mcq` prompts, and the `error`/`mcq_extraction_failed` frame on failures. The native client's "kept your previous cards" fallback should stop firing for MCQ regenerates; track the rate of `mcq_extraction_failed` envelopes as the residual failure signal.

## Testing
- Unit/integration tests added (mock Anthropic boundary only):
  - MCQ forces the tool + `tool_choice` for `templateSlug=mcq`.
  - MCQ cards extracted from a valid `tool_use` block.
  - `McqExtractionFailedError` thrown on prose-only response (no tool call).
  - `McqExtractionFailedError` thrown on malformed MCQ (3 options).
  - Tool not forced for non-mcq templates, including patreon-on-basic.
  - Controller emits `mcq_extraction_failed` envelope on the error.
- `npx tsc -p . --noEmit` clean. Full chat suite green (156 tests).
- `sonar-scanner` not run locally — `SONAR_TOKEN` unset in this environment. Expect a possible Sonar pass on CI.
- Touches the Anthropic integration — `/security-review` advisable before merge.

## Browser check
Browser check: not applicable — server-side prompt/extraction change, no web UI change (the only `web/` file is a changelog JSON entry)

## Changelog
`Multiple-choice cards in chat generate reliably, with a clear message when they can't` — `web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-mcq-reliable.json`

## Risks
- Forced tool use means the `done` frame's prose `content` may be empty on MCQ turns (the cards are the answer). The client renders from `cards`; verify it does not require non-empty prose.
- Rollback: revert this commit — basic/cloze paths are untouched, so reverting only restores the prior prompt-only MCQ behavior.

## Goal alignment
MCQ is a paid/premium card surface; an unreliable MCQ generator erodes trust in the chat→deck flow that drives conversions. Making it dependable moves the core "drop something in, get a clean deck back" experience toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782810692&installation_id=132681956&pr_number=2966&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2966&signature=745817ddefaf9c39a046db7dc0b9fa9dc3dff75d641970310c1ad92958e5492b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->