### PR TITLE
feat: accept zip, docx, md, txt as chat attachments

### DIFF
--- a/src/config/swagger.test.ts
+++ b/src/config/swagger.test.ts
@@ -269,6 +269,19 @@ describe('Swagger Documentation Coverage', () => {
       expect(multipart.schema.properties.files).toBeDefined();
     });
 
+    it('documents the expanded attachment MIME types for /api/chat/message', () => {
+      const op = spec.paths['/api/chat/message']?.post;
+      const filesDescription =
+        op.requestBody.content['multipart/form-data'].schema.properties.files
+          .description;
+      expect(filesDescription).toContain('application/zip');
+      expect(filesDescription).toContain(
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      );
+      expect(filesDescription).toContain('text/markdown');
+      expect(filesDescription).toContain('text/plain');
+    });
+
     it('exposes ChatBasicCard, ChatMcqCard, and the three SSE frame schemas', () => {
       const schemas = spec.components.schemas;
       expect(schemas.ChatBasicCard).toBeDefined();

--- a/src/controllers/ChatController.test.ts
+++ b/src/controllers/ChatController.test.ts
@@ -290,6 +290,102 @@ describe('ChatController.sendMessage — file attachments', () => {
   });
 });
 
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+const DOCX_MIME =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+describe('ChatController.sendMessage — expanded attachment types', () => {
+  it('accepts a Notion .zip whose bytes start with the zip signature', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+    const file = makeFile({
+      mimetype: 'application/zip',
+      originalname: 'export.zip',
+      buffer: Buffer.concat([ZIP_MAGIC, Buffer.alloc(40)]),
+    });
+    await controller.sendMessage(buildReq({ content: 'Cards' }, [file]), res);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({ mimeType: 'application/zip', fileName: 'export.zip' }),
+        ],
+      })
+    );
+  });
+
+  it('accepts a .docx whose bytes start with the zip signature', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+    const file = makeFile({
+      mimetype: DOCX_MIME,
+      originalname: 'essay.docx',
+      buffer: Buffer.concat([ZIP_MAGIC, Buffer.alloc(40)]),
+    });
+    await controller.sendMessage(buildReq({ content: 'Summarize' }, [file]), res);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [expect.objectContaining({ mimeType: DOCX_MIME })],
+      })
+    );
+  });
+
+  it('accepts a .md attachment of UTF-8 text', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+    const file = makeFile({
+      mimetype: 'text/markdown',
+      originalname: 'notes.md',
+      buffer: Buffer.from('# Heading\n\nbody', 'utf8'),
+    });
+    await controller.sendMessage(buildReq({ content: 'Make cards' }, [file]), res);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({ mimeType: 'text/markdown', fileName: 'notes.md' }),
+        ],
+      })
+    );
+  });
+
+  it('accepts a .txt attachment of UTF-8 text', async () => {
+    const { execute, controller, res } = buildMocks();
+    execute.mockResolvedValueOnce({ content: 'ok', conversationId: 1 });
+    const file = makeFile({
+      mimetype: 'text/plain',
+      originalname: 'scratch.txt',
+      buffer: Buffer.from('plain notes', 'utf8'),
+    });
+    await controller.sendMessage(buildReq({ content: 'Summarize' }, [file]), res);
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [expect.objectContaining({ mimeType: 'text/plain' })],
+      })
+    );
+  });
+
+  it('rejects a declared .zip whose bytes are not a real zip', async () => {
+    const { controller, res } = buildMocks();
+    const file = makeFile({
+      mimetype: 'application/zip',
+      originalname: 'fake.zip',
+      buffer: Buffer.from('not really a zip', 'utf8'),
+    });
+    await controller.sendMessage(buildReq({ content: 'Hi' }, [file]), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a declared .txt that contains binary NUL bytes', async () => {
+    const { controller, res } = buildMocks();
+    const file = makeFile({
+      mimetype: 'text/plain',
+      originalname: 'binary.txt',
+      buffer: Buffer.from([0x68, 0x69, 0x00, 0xff, 0xfe]),
+    });
+    await controller.sendMessage(buildReq({ content: 'Hi' }, [file]), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
 describe('ChatController.sendMessage — multipart history parsing', () => {
   it('parses history when serialized as a JSON string by multer (multipart/form-data)', async () => {
     const { execute, controller, res } = buildMocks();

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -13,13 +13,58 @@ const MAX_CONTENT_LENGTH = 100_000;
 const MAX_FILE_COUNT = 5;
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const MAX_TOTAL_SIZE = 25 * 1024 * 1024;
-const ALLOWED_MIMES = new Set([
+
+const ZIP_MIME = 'application/zip';
+const DOCX_MIME =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const MARKDOWN_MIME = 'text/markdown';
+const PLAIN_TEXT_MIME = 'text/plain';
+
+const BINARY_VERIFIED_MIMES = new Set([
   'application/pdf',
   'image/png',
   'image/jpeg',
   'image/gif',
   'image/webp',
 ]);
+
+const ZIP_BASED_MIMES = new Set([ZIP_MIME, DOCX_MIME]);
+const TEXT_MIMES = new Set([MARKDOWN_MIME, PLAIN_TEXT_MIME]);
+
+const ALLOWED_MIMES = new Set([
+  ...BINARY_VERIFIED_MIMES,
+  ...ZIP_BASED_MIMES,
+  ...TEXT_MIMES,
+]);
+
+const ZIP_SIGNATURE = [0x50, 0x4b, 0x03, 0x04];
+
+function hasZipSignature(buffer: Buffer): boolean {
+  if (buffer.length < ZIP_SIGNATURE.length) return false;
+  return ZIP_SIGNATURE.every((byte, i) => buffer[i] === byte);
+}
+
+function looksLikeUtf8Text(buffer: Buffer): boolean {
+  if (buffer.includes(0x00)) return false;
+  const sample = buffer.subarray(0, 8192).toString('utf8');
+  return !sample.includes('�');
+}
+
+function contentMatchesMime(buffer: Buffer, mimeType: string): boolean {
+  if (BINARY_VERIFIED_MIMES.has(mimeType)) {
+    return detectFileMime(buffer) === mimeType;
+  }
+  if (ZIP_BASED_MIMES.has(mimeType)) {
+    return hasZipSignature(buffer);
+  }
+  if (TEXT_MIMES.has(mimeType)) {
+    return looksLikeUtf8Text(buffer);
+  }
+  return false;
+}
+
+const ATTACH_REJECTED_MESSAGE =
+  'Files work here as PDF, image, .zip, .docx, .md, or .txt.';
 
 function sseWrite(res: Response, event: string, data: unknown): void {
   res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
@@ -51,7 +96,7 @@ function validateAttachments(rawFiles: Express.Multer.File[]): AttachmentValidat
       return { ok: false, error: `${safeName} is ${sizeMB} MB. The per-file limit is 10 MB.` };
     }
     if (!ALLOWED_MIMES.has(file.mimetype)) {
-      return { ok: false, error: `Can't attach ${safeName}. Only PDF and image files work here.` };
+      return { ok: false, error: `Can't attach ${safeName}. ${ATTACH_REJECTED_MESSAGE}` };
     }
   }
 
@@ -66,11 +111,11 @@ function validateAttachments(rawFiles: Express.Multer.File[]): AttachmentValidat
 
   const attachments: ChatAttachment[] = [];
   for (const file of rawFiles) {
-    if (detectFileMime(file.buffer) !== file.mimetype) {
-      const safeName = getSafeFilename(file.originalname);
-      return { ok: false, error: `Can't attach ${safeName}. Only PDF and image files work here.` };
+    const safeName = getSafeFilename(file.originalname);
+    if (!contentMatchesMime(file.buffer, file.mimetype)) {
+      return { ok: false, error: `Can't attach ${safeName}. ${ATTACH_REJECTED_MESSAGE}` };
     }
-    attachments.push({ mimeType: file.mimetype, data: file.buffer });
+    attachments.push({ mimeType: file.mimetype, data: file.buffer, fileName: safeName });
   }
 
   return { ok: true, attachments };

--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -84,7 +84,10 @@ const ChatRouter = () => {
    *       are the frame separator.
    *
    *       The request accepts `multipart/form-data` so the caller can attach
-   *       up to 5 files (PDF or image) totalling 25 MB.
+   *       up to 5 files totalling 25 MB. PDFs and images are sent to the
+   *       model as native blocks; `.zip` (Notion export), `.docx`, `.md`, and
+   *       `.txt` are parsed to text on the server and injected into the model
+   *       context as `<file name="…">…</file>` blocks before the prompt runs.
    *
    *       Card-shape footgun: when the caller is a Patreon (lifetime/paid)
    *       user, the assistant may emit MCQ-shape cards even if
@@ -149,10 +152,14 @@ const ChatRouter = () => {
    *                 type: array
    *                 maxItems: 5
    *                 description: |
-   *                   PDF or image attachments. Per-file limit 10 MB,
+   *                   Study-material attachments. Per-file limit 10 MB,
    *                   combined limit 25 MB. Accepted MIME types:
    *                   `application/pdf`, `image/png`, `image/jpeg`,
-   *                   `image/gif`, `image/webp`.
+   *                   `image/gif`, `image/webp`, `application/zip`,
+   *                   `application/vnd.openxmlformats-officedocument.wordprocessingml.document`,
+   *                   `text/markdown`, `text/plain`. The zip, docx, markdown,
+   *                   and plain-text types are parsed to text server-side and
+   *                   injected into the model context before the prompt runs.
    *                 items:
    *                   type: string
    *                   format: binary

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -1,3 +1,4 @@
+import { zipSync, strToU8 } from 'fflate';
 import {
   ChatUseCase,
   ChatRateLimitError,
@@ -6,6 +7,41 @@ import {
 } from './ChatUseCase';
 import { InMemoryChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
 import { InMemoryConversationsRepository } from '../../data_layer/ConversationsRepository';
+
+jest.mock(
+  '../../infrastracture/adapters/fileConversion/convertDocxToHTML',
+  () => ({
+    convertDocxToHTML: jest.fn(),
+  })
+);
+
+import { convertDocxToHTML } from '../../infrastracture/adapters/fileConversion/convertDocxToHTML';
+
+const mockedConvertDocx = convertDocxToHTML as jest.MockedFunction<typeof convertDocxToHTML>;
+
+const ZIP_MIME = 'application/zip';
+const DOCX_MIME =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+const MARKDOWN_MIME = 'text/markdown';
+const PLAIN_TEXT_MIME = 'text/plain';
+
+function notionZip(files: Record<string, string>): Buffer {
+  const entries: Record<string, Uint8Array> = {};
+  for (const [name, contents] of Object.entries(files)) {
+    entries[name] = strToU8(contents);
+  }
+  return Buffer.from(zipSync(entries));
+}
+
+function lastUserText(stream: jest.Mock): string {
+  const callArg = stream.mock.calls[0][0];
+  const lastMessage = callArg.messages[callArg.messages.length - 1];
+  if (typeof lastMessage.content === 'string') return lastMessage.content;
+  const textBlock = lastMessage.content.find(
+    (block: { type: string }) => block.type === 'text'
+  );
+  return textBlock?.text ?? '';
+}
 
 const FREE_USER = { owner: 1, patreon: false } as const;
 const PATREON_USER = { owner: 2, patreon: true } as const;
@@ -434,6 +470,125 @@ describe('ChatUseCase', () => {
       const all = messagesRepo.getAll();
       const userMsg = all.find((m) => m.role === 'user');
       expect(userMsg?.content).toBe('Summarize this PDF');
+    });
+  });
+
+  describe('text-extractable attachments', () => {
+    beforeEach(() => {
+      mockedConvertDocx.mockReset();
+    });
+
+    it('injects markdown attachment text into the prompt', async () => {
+      const { anthropic, useCase } = buildUseCase('answer');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards from this',
+        conversationHistory: [],
+        attachments: [
+          {
+            mimeType: MARKDOWN_MIME,
+            data: Buffer.from('# Photosynthesis\n\nConverts light to energy.', 'utf8'),
+            fileName: 'bio.md',
+          },
+        ],
+      });
+
+      const prompt = lastUserText(anthropic.messages.stream);
+      expect(prompt).toContain('<file name="bio.md">');
+      expect(prompt).toContain('Converts light to energy.');
+      expect(prompt).toContain('Make cards from this');
+    });
+
+    it('injects plain text attachment text into the prompt', async () => {
+      const { anthropic, useCase } = buildUseCase('answer');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'Summarize',
+        conversationHistory: [],
+        attachments: [
+          {
+            mimeType: PLAIN_TEXT_MIME,
+            data: Buffer.from('Mitosis has four phases.', 'utf8'),
+            fileName: 'lecture.txt',
+          },
+        ],
+      });
+
+      const prompt = lastUserText(anthropic.messages.stream);
+      expect(prompt).toContain('<file name="lecture.txt">');
+      expect(prompt).toContain('Mitosis has four phases.');
+    });
+
+    it('injects Notion .zip export text into the prompt', async () => {
+      const { anthropic, useCase } = buildUseCase('answer');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'Cards please',
+        conversationHistory: [],
+        attachments: [
+          {
+            mimeType: ZIP_MIME,
+            data: notionZip({
+              'Cell Biology.html':
+                '<html><body><h1>Ribosomes</h1><p>Synthesize proteins.</p></body></html>',
+            }),
+            fileName: 'notion-export.zip',
+          },
+        ],
+      });
+
+      const prompt = lastUserText(anthropic.messages.stream);
+      expect(prompt).toContain('<file name="notion-export.zip">');
+      expect(prompt).toContain('Ribosomes');
+      expect(prompt).toContain('Synthesize proteins.');
+    });
+
+    it('injects .docx attachment text into the prompt', async () => {
+      mockedConvertDocx.mockResolvedValue('<h1>Kinetics</h1><p>Rate of reaction.</p>');
+      const { anthropic, useCase } = buildUseCase('answer');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'Explain',
+        conversationHistory: [],
+        attachments: [
+          {
+            mimeType: DOCX_MIME,
+            data: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+            fileName: 'chem.docx',
+          },
+        ],
+      });
+
+      const prompt = lastUserText(anthropic.messages.stream);
+      expect(prompt).toContain('<file name="chem.docx">');
+      expect(prompt).toContain('Rate of reaction.');
+    });
+
+    it('keeps a PDF as a native block while injecting a sibling .md as text', async () => {
+      const { anthropic, useCase } = buildUseCase('answer');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'Combine these',
+        conversationHistory: [],
+        attachments: [
+          { mimeType: 'application/pdf', data: Buffer.from([0x25, 0x50, 0x44, 0x46]), fileName: 'slides.pdf' },
+          { mimeType: MARKDOWN_MIME, data: Buffer.from('extra md notes', 'utf8'), fileName: 'notes.md' },
+        ],
+      });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      const lastMessage = callArg.messages[callArg.messages.length - 1];
+      const docBlock = lastMessage.content.find(
+        (block: { type: string }) => block.type === 'document'
+      );
+      expect(docBlock).toBeDefined();
+      const prompt = lastUserText(anthropic.messages.stream);
+      expect(prompt).toContain('extra md notes');
     });
   });
 

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -3,6 +3,7 @@ import type { IChatMessagesRepository } from '../../data_layer/ChatMessagesRepos
 import type { IConversationsRepository } from '../../data_layer/ConversationsRepository';
 import { logClaudeUsage } from '../../lib/claude/logClaudeUsage';
 import { buildAttachmentBlocks, type ChatAttachment } from './buildAttachmentBlocks';
+import { extractAttachmentText, buildAttachmentTextBlock } from './extractAttachmentText';
 import { isChatCardTemplate, templatePromptSuffix, type ChatCardTemplate } from './chatTemplates';
 
 const REQUIRED_MCQ_OPTION_COUNT = 4;
@@ -366,10 +367,14 @@ export class ChatUseCase {
 
     const recentHistory = conversationHistory.slice(-MAX_HISTORY_TURNS);
     const attachmentBlocks = buildAttachmentBlocks(attachments);
+    const extractedText = await extractAttachmentText(attachments);
+    const attachmentTextBlock = buildAttachmentTextBlock(extractedText);
+    const promptText =
+      attachmentTextBlock.length > 0 ? `${attachmentTextBlock}\n\n${content}` : content;
     const userContent: Anthropic.MessageParam['content'] =
       attachmentBlocks.length > 0
-        ? [...attachmentBlocks, { type: 'text', text: content }]
-        : content;
+        ? [...attachmentBlocks, { type: 'text', text: promptText }]
+        : promptText;
 
     await this.messagesRepo.insert({
       userId: user.owner,

--- a/src/usecases/chat/buildAttachmentBlocks.ts
+++ b/src/usecases/chat/buildAttachmentBlocks.ts
@@ -3,6 +3,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 export interface ChatAttachment {
   mimeType: string;
   data: Buffer;
+  fileName?: string;
 }
 
 type ImageMediaType = 'image/jpeg' | 'image/png' | 'image/gif' | 'image/webp';
@@ -13,32 +14,26 @@ function isImageMime(mime: string): mime is ImageMediaType {
   return IMAGE_MIMES.has(mime);
 }
 
+const PDF_MIME = 'application/pdf';
+
 export function buildAttachmentBlocks(
   attachments: ChatAttachment[]
 ): Anthropic.ContentBlockParam[] {
-  return attachments.map((attachment): Anthropic.ContentBlockParam => {
+  const blocks: Anthropic.ContentBlockParam[] = [];
+  for (const attachment of attachments) {
     const data = attachment.data.toString('base64');
 
     if (isImageMime(attachment.mimeType)) {
-      const block: Anthropic.ImageBlockParam = {
+      blocks.push({
         type: 'image',
-        source: {
-          type: 'base64',
-          media_type: attachment.mimeType,
-          data,
-        },
-      };
-      return block;
+        source: { type: 'base64', media_type: attachment.mimeType, data },
+      });
+    } else if (attachment.mimeType === PDF_MIME) {
+      blocks.push({
+        type: 'document',
+        source: { type: 'base64', media_type: PDF_MIME, data },
+      });
     }
-
-    const block: Anthropic.DocumentBlockParam = {
-      type: 'document',
-      source: {
-        type: 'base64',
-        media_type: 'application/pdf',
-        data,
-      },
-    };
-    return block;
-  });
+  }
+  return blocks;
 }

--- a/src/usecases/chat/extractAttachmentText.test.ts
+++ b/src/usecases/chat/extractAttachmentText.test.ts
@@ -1,0 +1,199 @@
+import { zipSync, strToU8 } from 'fflate';
+
+import {
+  extractAttachmentText,
+  buildAttachmentTextBlock,
+  isTextExtractableMime,
+  ZIP_MIME,
+  DOCX_MIME,
+  MARKDOWN_MIME,
+  PLAIN_TEXT_MIME,
+  MAX_TEXT_PER_FILE,
+} from './extractAttachmentText';
+import type { ChatAttachment } from './buildAttachmentBlocks';
+
+jest.mock(
+  '../../infrastracture/adapters/fileConversion/convertDocxToHTML',
+  () => ({
+    convertDocxToHTML: jest.fn(),
+  })
+);
+
+import { convertDocxToHTML } from '../../infrastracture/adapters/fileConversion/convertDocxToHTML';
+
+const mockedConvertDocx = convertDocxToHTML as jest.MockedFunction<typeof convertDocxToHTML>;
+
+function notionZip(files: Record<string, string>): Buffer {
+  const entries: Record<string, Uint8Array> = {};
+  for (const [name, contents] of Object.entries(files)) {
+    entries[name] = strToU8(contents);
+  }
+  return Buffer.from(zipSync(entries));
+}
+
+describe('isTextExtractableMime', () => {
+  it.each([ZIP_MIME, DOCX_MIME, MARKDOWN_MIME, PLAIN_TEXT_MIME])(
+    'returns true for %s',
+    (mime) => {
+      expect(isTextExtractableMime(mime)).toBe(true);
+    }
+  );
+
+  it.each(['application/pdf', 'image/png', 'image/jpeg'])(
+    'returns false for %s',
+    (mime) => {
+      expect(isTextExtractableMime(mime)).toBe(false);
+    }
+  );
+});
+
+describe('extractAttachmentText', () => {
+  beforeEach(() => {
+    mockedConvertDocx.mockReset();
+  });
+
+  it('reads markdown attachments as UTF-8', async () => {
+    const attachment: ChatAttachment = {
+      mimeType: MARKDOWN_MIME,
+      data: Buffer.from('# Title\n\nSome **markdown** body.', 'utf8'),
+      fileName: 'notes.md',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result).toEqual([
+      { fileName: 'notes.md', text: '# Title\n\nSome **markdown** body.' },
+    ]);
+  });
+
+  it('reads plain text attachments as UTF-8', async () => {
+    const attachment: ChatAttachment = {
+      mimeType: PLAIN_TEXT_MIME,
+      data: Buffer.from('plain notes here', 'utf8'),
+      fileName: 'scratch.txt',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result).toEqual([{ fileName: 'scratch.txt', text: 'plain notes here' }]);
+  });
+
+  it('extracts text from a Notion .zip export, stripping HTML tags', async () => {
+    const attachment: ChatAttachment = {
+      mimeType: ZIP_MIME,
+      data: notionZip({
+        'Page abc.html':
+          '<html><body><h1>Mitochondria</h1><p>Powerhouse of the cell.</p></body></html>',
+      }),
+      fileName: 'export.zip',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].fileName).toBe('export.zip');
+    expect(result[0].text).toContain('Mitochondria');
+    expect(result[0].text).toContain('Powerhouse of the cell.');
+    expect(result[0].text).not.toContain('<h1>');
+  });
+
+  it('ignores hidden and __MACOSX entries in a zip', async () => {
+    const attachment: ChatAttachment = {
+      mimeType: ZIP_MIME,
+      data: notionZip({
+        '__MACOSX/._Page.html': '<html><body>junk</body></html>',
+        'Real.html': '<html><body><p>Real content</p></body></html>',
+      }),
+      fileName: 'export.zip',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result[0].text).toContain('Real content');
+    expect(result[0].text).not.toContain('junk');
+  });
+
+  it('does not extract a zip entry whose name escapes via ..', async () => {
+    const attachment: ChatAttachment = {
+      mimeType: ZIP_MIME,
+      data: notionZip({
+        '../escape.html': '<html><body><p>escaped</p></body></html>',
+        'safe.html': '<html><body><p>safe content</p></body></html>',
+      }),
+      fileName: 'export.zip',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result[0].text).toContain('safe content');
+    expect(result[0].text).not.toContain('escaped');
+  });
+
+  it('extracts text from a .docx via the conversion adapter', async () => {
+    mockedConvertDocx.mockResolvedValue('<h2>Heading</h2><p>Docx body text</p>');
+    const attachment: ChatAttachment = {
+      mimeType: DOCX_MIME,
+      data: Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+      fileName: 'essay.docx',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result[0].fileName).toBe('essay.docx');
+    expect(result[0].text).toContain('Heading');
+    expect(result[0].text).toContain('Docx body text');
+  });
+
+  it('skips image and pdf attachments', async () => {
+    const attachments: ChatAttachment[] = [
+      { mimeType: 'image/png', data: Buffer.from([0x89, 0x50]), fileName: 'a.png' },
+      { mimeType: 'application/pdf', data: Buffer.from([0x25, 0x50]), fileName: 'b.pdf' },
+    ];
+
+    const result = await extractAttachmentText(attachments);
+
+    expect(result).toEqual([]);
+  });
+
+  it('truncates a single file over the per-file cap with a marker', async () => {
+    const big = 'x'.repeat(MAX_TEXT_PER_FILE + 5_000);
+    const attachment: ChatAttachment = {
+      mimeType: PLAIN_TEXT_MIME,
+      data: Buffer.from(big, 'utf8'),
+      fileName: 'big.txt',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result[0].text.length).toBeLessThanOrEqual(MAX_TEXT_PER_FILE + 20);
+    expect(result[0].text).toContain('truncated');
+  });
+
+  it('drops empty extractions', async () => {
+    const attachment: ChatAttachment = {
+      mimeType: PLAIN_TEXT_MIME,
+      data: Buffer.from('   \n  ', 'utf8'),
+      fileName: 'blank.txt',
+    };
+
+    const result = await extractAttachmentText([attachment]);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('buildAttachmentTextBlock', () => {
+  it('wraps each file in a named file block', () => {
+    const block = buildAttachmentTextBlock([
+      { fileName: 'a.md', text: 'first' },
+      { fileName: 'b.txt', text: 'second' },
+    ]);
+
+    expect(block).toContain('<file name="a.md">\nfirst\n</file>');
+    expect(block).toContain('<file name="b.txt">\nsecond\n</file>');
+  });
+
+  it('returns empty string for no extracted files', () => {
+    expect(buildAttachmentTextBlock([])).toBe('');
+  });
+});

--- a/src/usecases/chat/extractAttachmentText.ts
+++ b/src/usecases/chat/extractAttachmentText.ts
@@ -1,0 +1,122 @@
+import { strFromU8, unzipSync } from 'fflate';
+import * as cheerio from 'cheerio';
+
+import type { ChatAttachment } from './buildAttachmentBlocks';
+import { convertDocxToHTML } from '../../infrastracture/adapters/fileConversion/convertDocxToHTML';
+import { isHiddenFileOrDirectory, isHTMLFile, isMarkdownFile } from '../../lib/storage/checks';
+
+export const ZIP_MIME = 'application/zip';
+export const DOCX_MIME =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+export const MARKDOWN_MIME = 'text/markdown';
+export const PLAIN_TEXT_MIME = 'text/plain';
+
+export const TEXT_EXTRACTABLE_MIMES = new Set<string>([
+  ZIP_MIME,
+  DOCX_MIME,
+  MARKDOWN_MIME,
+  PLAIN_TEXT_MIME,
+]);
+
+export const MAX_TEXT_PER_FILE = 50_000;
+export const MAX_TEXT_TOTAL = 200_000;
+const TRUNCATION_MARKER = '\n[…truncated]';
+
+export interface ExtractedAttachmentText {
+  fileName: string;
+  text: string;
+}
+
+export function isTextExtractableMime(mimeType: string): boolean {
+  return TEXT_EXTRACTABLE_MIMES.has(mimeType);
+}
+
+function isUnsafeZipEntryName(name: string): boolean {
+  if (name.startsWith('/') || name.startsWith('\\')) return true;
+  if (/^[A-Za-z]:[\\/]/.test(name)) return true;
+  const segments = name.split(/[\\/]/);
+  return segments.includes('..');
+}
+
+function htmlToText(html: string): string {
+  const $ = cheerio.load(html);
+  $('script, style').remove();
+  return $.root().text().replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+function readZipEntryText(name: string, bytes: Uint8Array): string | null {
+  if (isHTMLFile(name)) return htmlToText(strFromU8(bytes));
+  if (isMarkdownFile(name)) return strFromU8(bytes);
+  return null;
+}
+
+function extractZipText(data: Buffer): string {
+  const loadedZip = unzipSync(new Uint8Array(data), {
+    filter: (file) =>
+      !isHiddenFileOrDirectory(file.name) && !isUnsafeZipEntryName(file.name),
+  });
+
+  const parts: string[] = [];
+  let collected = 0;
+  for (const name of Object.keys(loadedZip)) {
+    if (collected >= MAX_TEXT_PER_FILE) break;
+    if (isUnsafeZipEntryName(name) || name.includes('__MACOSX/')) continue;
+    const text = readZipEntryText(name, loadedZip[name]);
+    if (text == null) continue;
+    parts.push(text);
+    collected += text.length;
+  }
+  return parts.join('\n\n').trim();
+}
+
+async function extractOne(attachment: ChatAttachment): Promise<string> {
+  switch (attachment.mimeType) {
+    case ZIP_MIME:
+      return extractZipText(attachment.data);
+    case DOCX_MIME:
+      return htmlToText(await convertDocxToHTML(attachment.data));
+    case MARKDOWN_MIME:
+    case PLAIN_TEXT_MIME:
+      return attachment.data.toString('utf8');
+    default:
+      return '';
+  }
+}
+
+function capText(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + TRUNCATION_MARKER;
+}
+
+export async function extractAttachmentText(
+  attachments: ChatAttachment[]
+): Promise<ExtractedAttachmentText[]> {
+  const out: ExtractedAttachmentText[] = [];
+  let totalBudget = MAX_TEXT_TOTAL;
+
+  for (const attachment of attachments) {
+    if (!isTextExtractableMime(attachment.mimeType)) continue;
+    if (totalBudget <= 0) break;
+
+    const raw = (await extractOne(attachment)).trim();
+    if (raw.length === 0) continue;
+
+    const perFileCap = Math.min(MAX_TEXT_PER_FILE, totalBudget);
+    const text = capText(raw, perFileCap);
+    totalBudget -= text.length;
+
+    out.push({
+      fileName: attachment.fileName ?? 'attachment',
+      text,
+    });
+  }
+
+  return out;
+}
+
+export function buildAttachmentTextBlock(extracted: ExtractedAttachmentText[]): string {
+  if (extracted.length === 0) return '';
+  return extracted
+    .map((file) => `<file name="${file.fileName}">\n${file.text}\n</file>`)
+    .join('\n\n');
+}


### PR DESCRIPTION
## What
Expands the chat assistant's accepted attachment types. The server now extracts text from Notion `.zip` exports, `.docx`, `.md`, and `.txt` files and injects it into the model context as `<file name="…">…</file>` blocks before the prompt runs. PDFs and images keep going through as native Anthropic blocks. Limits are unchanged (5 files, 10 MB each, 25 MB total).

## Why
Closes the high-priority slice of #2953. The chat picker previously hid the same study-material file types the Create tab accepts first-class. The top ask is dropping a Notion `.zip` straight into chat for the model to reason about.

## How
- `ChatController` allowlist gains `application/zip`, the docx MIME, `text/markdown`, `text/plain`. Content is verified against the declared MIME (zip signature for zip/docx, UTF-8 sanity for md/txt) and the filename is regenerated via `getSafeFilename`, which is passed to the use case as the `<file>` name.
- New pure module `extractAttachmentText.ts` turns each text-extractable attachment into text, reusing `convertDocxToHTML` (mammoth) and `fflate` — no reimplemented parsing. `buildAttachmentBlocks` now only emits native blocks for image + PDF.
- Per-file extracted text capped at 50 000 chars, total at 200 000 chars, with a `[…truncated]` marker.

### Zip-safety approach
The Notion zip is unzipped **in memory** with `fflate.unzipSync` — nothing is written to disk, so zip-slip is structurally impossible. As defense in depth the entry filter and the read loop both reject any entry name containing `..`, an absolute path, a drive prefix, or a hidden/`__MACOSX` entry. Only HTML (tags stripped via cheerio) and markdown entries are read; everything else is ignored.

## Measuring success
Look for chat turns whose user content carries a `<file name="…">` block in the `ChatUseCase` Claude call. In prod, `logClaudeUsage('ChatUseCase', …)` already logs token usage per turn — a rise in input tokens on chat turns with attachments confirms extracted text is reaching the model. Rejected attachments surface as 400s on `POST /api/chat/message`.

## Testing
- Unit tests added:
  - `extractAttachmentText.test.ts` — md/txt UTF-8 read, Notion zip text extraction, `__MACOSX`/hidden skip, `..` entry rejection, docx via adapter, image/PDF skip, per-file truncation, empty-drop, `<file>` block wrapping.
  - `ChatUseCase.test.ts` — integration: md, txt, Notion zip, and docx extracted text reaches the prompt payload (Anthropic boundary mocked); PDF stays a native block while a sibling `.md` injects as text.
  - `ChatController.test.ts` — accepts zip/docx/md/txt with correct content; rejects a fake `.zip` and a binary `.txt`.
  - `swagger.test.ts` — asserts the new MIME types are documented on `/api/chat/message`.
- `npx tsc -p . --noEmit` clean; chat + swagger + controller suites green (176 tests).
- Sonar: `SONAR_TOKEN` not set locally, so `sonar-scanner` was not run — expect a possible Sonar pass on CI. New code was kept low-nesting (extracted `readZipEntryText`, positive boolean returns).

## Browser check
Browser check: not applicable — server-side attachment parsing, no web UI change

## Changelog
No changelog entry — the web chat attach control is still hard-gated to PDF/image client-side, so there is no web-visible change. This PR enables the native client (per #2953, "native client wiring is ready the moment the server side lands"). A web-visible entry should land with the PR that expands the web picker.

## Scope: shipped vs deferred
- **Shipped (high priority):** Notion `.zip`, `.docx`, `.md`, `.txt`.
- **Deferred to a follow-up (medium/low):** `.html`, `.csv`/`.tsv`, `.xlsx`, `.opml`, `.apkg`, `.pptx`, `.epub`.
- Did **not** auto-close #2953 — only the high-priority types shipped.

## Coordination
Touches the shared chat backend. Two sibling PRs overlap here: **#2956** (regenerate endpoint — adds a route to `ChatRouter.ts`) and **#2957** (MCQ prompt — edits the prompt/extraction in `ChatUseCase.ts`). My changes are surgical: the controller allowlist + content checks, a new `extractAttachmentText.ts` module, and a `await extractAttachmentText(...)` call plus a prepended text block in `ChatUseCase.execute`. Expect a rebase against whichever sibling merges first; the `ChatUseCase.ts` message-building block and the `ChatRouter.ts` swagger comment are the likely conflict points.

## `/security-review` required before merge
This touches file upload + an external-API integration (Anthropic). Run `/security-review` before merging — pay particular attention to the zip path (in-memory `fflate.unzipSync`, entry-name screening, the 50k/200k caps that bound token cost).

## Risks
- A malformed zip/docx surfaces as a thrown error from `convertDocxToHTML`/`fflate`; it propagates to the SSE `error` frame rather than a clean per-file message. Acceptable for v1; a follow-up can map it to a friendlier attachment-level error.
- Rollback: revert the commit — no migration, no schema, no config change.

## Goal alignment
Removes a friction point in the chat surface (the fastest path from "I have study material" to cards), matching chat to the Create tab's accepted types. Notion `.zip`-into-chat is the named top request, and consistency across surfaces reduces the "why is this greyed out" confusion that costs activation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782810791&installation_id=132681956&pr_number=2967&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2967&signature=9c934f65e8a373050038e8c0c5047c00e4d4ff81d9cdb892a4d8e1773ebea6f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->