### PR TITLE
fix: render chat MCQ cards from their shape and export with options

### DIFF
--- a/create_deck/tests/test_mcq.py
+++ b/create_deck/tests/test_mcq.py
@@ -1,8 +1,10 @@
 import importlib.util
 import json
 import os
+import sqlite3
 import sys
 import tempfile
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -74,6 +76,41 @@ class TestMCQDeckBuild:
                 assert result is not None
                 assert result.endswith(".apkg")
                 assert os.path.exists(result)
+            finally:
+                os.chdir(old_cwd)
+
+    def test_mcq_apkg_carries_options_and_correct_answer(self):
+        options = ["Lipase", "Amylase", "Protease", "Lactase"]
+        data = _mcq_deck_info(
+            "Which enzyme hydrolyses starch?",
+            options,
+            1,
+            "Amylase breaks down starch.",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_cwd = os.getcwd()
+            os.chdir(tmpdir)
+            try:
+                info_path = _write_deck_info(tmpdir, data)
+                result = build_one_deck(info_path, TEMPLATE_DIR)
+                extract_dir = os.path.join(tmpdir, "unpacked")
+                with zipfile.ZipFile(result) as archive:
+                    archive.extractall(extract_dir)
+                conn = sqlite3.connect(
+                    os.path.join(extract_dir, "collection.anki2")
+                )
+                try:
+                    flds = conn.execute("select flds from notes").fetchone()[0]
+                    models = json.loads(
+                        conn.execute("select models from col").fetchone()[0]
+                    )
+                finally:
+                    conn.close()
+                field_values = flds.split("\x1f")
+                assert "Lipase<br>Amylase<br>Protease<br>Lactase" in field_values
+                assert "Amylase" in field_values
+                model_names = [m["name"] for m in models.values()]
+                assert model_names == ["n2a-mcq"]
             finally:
                 os.chdir(old_cwd)
 

--- a/web/src/pages/Chat/CardPreview.test.tsx
+++ b/web/src/pages/Chat/CardPreview.test.tsx
@@ -182,4 +182,48 @@ describe('CardPreview', () => {
       expect(onSave).toHaveBeenCalledWith('My-Deck-Name');
     });
   });
+
+  describe('MCQ rendering off card shape', () => {
+    const mcqCard = {
+      front: 'Which enzyme hydrolyses starch?',
+      back: '',
+      options: ['Lipase', 'Amylase', 'Protease', 'Lactase'],
+      correctIndex: 1,
+      rationale: 'Amylase breaks down starch.',
+    };
+
+    it('renders options and marks the correct one without a template prop', () => {
+      render(<CardPreview cards={[mcqCard]} onSave={vi.fn()} />);
+      expect(
+        screen.getByText('Which enzyme hydrolyses starch?')
+      ).toBeInTheDocument();
+      for (const opt of mcqCard.options) {
+        expect(screen.getByText(opt)).toBeInTheDocument();
+      }
+      expect(
+        screen.getByLabelText('Correct answer').closest('li')
+      ).toHaveTextContent('Amylase');
+    });
+
+    it('renders MCQ options even when template is not mcq', () => {
+      render(
+        <CardPreview cards={[mcqCard]} onSave={vi.fn()} template="basic" />
+      );
+      for (const opt of mcqCard.options) {
+        expect(screen.getByText(opt)).toBeInTheDocument();
+      }
+      expect(screen.getByLabelText('Correct answer')).toBeInTheDocument();
+    });
+
+    it('keeps basic cards as front/back rows even when an MCQ card is also present', () => {
+      render(
+        <CardPreview
+          cards={[mcqCard, { front: 'Capital of France?', back: 'Paris' }]}
+          onSave={vi.fn()}
+        />
+      );
+      expect(screen.getByText('Capital of France?')).toBeInTheDocument();
+      expect(screen.getByText('Paris')).toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -141,9 +141,10 @@ export default function CardPreview({
     }
   }, [saveState]);
 
-  const isMcqTemplate = template === 'mcq';
   const displayCards =
     template === 'basic-and-reversed' ? expandForReversed(cards) : cards;
+  const allCardsAreMcq =
+    displayCards.length > 0 && displayCards.every(isMcqCard);
   const visibleCards = expanded
     ? displayCards
     : displayCards.slice(0, VISIBLE_COUNT);
@@ -278,7 +279,7 @@ export default function CardPreview({
         )}
       </div>
 
-      {!isMcqTemplate && (
+      {!allCardsAreMcq && (
         <div
           className={`${styles.cardPreviewColumnLabels} ${hideBackColumn && !hasTags ? styles.cardPreviewColumnLabelsSingle : ''} ${!hideBackColumn && hasTags ? styles.cardPreviewColumnLabelsThree : ''}`}
         >
@@ -315,7 +316,7 @@ export default function CardPreview({
         <>
           <div className={styles.cardPreviewList}>
             {visibleCards.map((card, i) =>
-              isMcqTemplate && isMcqCard(card) ? (
+              isMcqCard(card) ? (
                 <McqRow key={i} card={card} />
               ) : (
                 <div

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-mcq-cards.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-mcq-cards.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-chat-mcq-cards",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Multiple-choice cards from chat show all options and export with the correct answer"
+}


### PR DESCRIPTION
## What
Chat multiple-choice cards now show all four options and mark the correct one in the card preview, regardless of which template the preview was rendered with. The deck export path (already correct on current main) is locked behind a new read-back test.

## Why
URGENT prod report: users picked "Multiple choice" in chat, got cards that showed only the question — no options, no answer — and the exported deck was useless. Root cause for the visible symptom is the preview: `CardPreview` gated MCQ rendering on `template === 'mcq'`, and `ChatPanel` only threads the `template` prop to the most recent card message. Any earlier MCQ message — and the active one when template state didn't match — fell through to the basic front/back layout, hiding the options.

## How
- `CardPreview.tsx`: render MCQ off each card's own shape via `isMcqCard(card)` instead of `isMcqTemplate && isMcqCard(card)`. The Front/Back column header is suppressed only when every displayed card is MCQ, so mixed decks stay readable. No change needed in `ChatPanel` — keying off card shape removes the dependence on the thread-only-last-message prop.
- Export path was verified already-correct on current main: `ChatDeckController.asMcqShape` parses options/correctIndex, `ChatDeckUseCase` writes `mcq:true / options / correctIndices` into `deck_info.json`, and `create_deck.py` maps those onto the canonical `n2a-mcq` note type (fields: Question, Multiple Choice, Correct Answer, Extra). I chose to **reuse the existing n2a-mcq note type** (already wired into create_deck.py) rather than fold options into a Back field — it produces a genuinely answerable card and required no mapping change. The `china china china.apkg` (n2a-basic, empty Back, no options) was saved before this export code and before #2966, so its cards had no options at generation time and correctly fell to basic.
- Added a `create_deck` read-back test that unzips the produced `.apkg` and asserts the saved note carries the joined options HTML + correct answer under the `n2a-mcq` model — a regression guard against the old n2a-basic/empty-back collapse.

## Measuring success
After deploy: a chat MCQ deck downloaded from the app opens in Anki with four answerable choices and the correct answer marked. In the preview, every MCQ card shows its options immediately (not just the last message). No `n2a-basic`/empty-Back MCQ notes in newly exported decks.

## Testing
- Web (Vitest): 3 new `CardPreview` tests — options render + correct one marked without a `template` prop, render when `template="basic"`, and basic cards stay front/back when an MCQ card is also present. Full web suite green (1524).
- Server (Jest): existing `ChatDeckUseCase` / `ChatDeckController` MCQ tests green (33).
- Python (pytest): new read-back test asserting the apkg note fields carry options + correct answer under `n2a-mcq`; full create_deck suite green (98).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Merged on Alexander's explicit "deploy everything so I can test in prod" instruction — he will verify MCQ rendering in prod after deploy. Full coverage: 3 new CardPreview tests + a create_deck apkg read-back regression test; web suite green.

## Sonar
SONAR_TOKEN not set in this environment — scanner not run. Change is a guard flip plus one computed boolean; no new HTTP/HTML/zip sinks. Expect a clean scan; flagging in case of a maintainability bounce.

## Risks
Low. The Front/Back header now hides only when all displayed cards are MCQ; mixed and non-MCQ decks are unchanged. Rollback is reverting `CardPreview.tsx`.

## Goal alignment
Chat is a core conversion surface. A broken MCQ export means users who reached "download" got an unusable deck — a hard drop at the most valuable funnel step. Fixing it protects activation and trust as chat scales toward the 300K goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782811731&installation_id=132681956&pr_number=2968&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2968&signature=8b23cac9334a5998162b95ac1b8744c7089fb7da3efacb1657bf94001f3c2a5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
