### PR TITLE
fix: label chat cards by their real kind, not the picker

### DIFF
--- a/src/usecases/chat/ChatDeckUseCase.test.ts
+++ b/src/usecases/chat/ChatDeckUseCase.test.ts
@@ -131,6 +131,31 @@ describe('ChatDeckUseCase.execute basic-and-reversed template', () => {
   });
 });
 
+describe('ChatDeckUseCase.execute cloze content under a basic template label', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (CustomExporter as unknown as jest.Mock).mockImplementation(() => ({
+      configure: jest.fn(),
+      save: jest.fn().mockResolvedValue(Buffer.from('apkg')),
+    }));
+  });
+
+  it('exports cloze:true from the front content even when templateSlug is basic', async () => {
+    const useCase = new ChatDeckUseCase();
+    await useCase.execute({
+      deckName: 'Mismatched',
+      templateSlug: 'basic',
+      cards: [{ front: 'The capital of France is {{c1::Paris}}.', back: '' }],
+    });
+    const Mock = CustomExporter as unknown as jest.Mock;
+    const configure = Mock.mock.results[0].value.configure as jest.Mock;
+    const deckInfo = configure.mock.calls[0][0] as Array<{
+      cards: Array<{ cloze: boolean }>;
+    }>;
+    expect(deckInfo[0].cards[0].cloze).toBe(true);
+  });
+});
+
 describe('looksLikeCloze', () => {
   it('returns true for a single cloze marker', () => {
     expect(looksLikeCloze('Paris is the capital of {{c1::France}}')).toBe(true);

--- a/web/src/lib/chat/templates.test.ts
+++ b/web/src/lib/chat/templates.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { effectiveTemplateForCards } from './templates';
+
+const basicCard = { front: 'Capital of France?', back: 'Paris' };
+const clozeCard = { front: 'The capital of France is {{c1::Paris}}.', back: '' };
+const mcqCard = {
+  front: 'Which enzyme hydrolyses starch?',
+  back: '',
+  options: ['Lipase', 'Amylase', 'Protease', 'Lactase'],
+  correctIndex: 1,
+};
+
+describe('effectiveTemplateForCards', () => {
+  it('returns the selected template when there are no cards', () => {
+    expect(effectiveTemplateForCards([], 'basic')).toBe('basic');
+  });
+
+  it('reports cloze when every card is a cloze deletion even if basic is selected', () => {
+    expect(effectiveTemplateForCards([clozeCard, clozeCard], 'basic')).toBe(
+      'cloze'
+    );
+  });
+
+  it('reports mcq when every card is multiple choice even if basic is selected', () => {
+    expect(effectiveTemplateForCards([mcqCard], 'basic')).toBe('mcq');
+  });
+
+  it('keeps the selected template for plain front/back cards', () => {
+    expect(effectiveTemplateForCards([basicCard], 'basic')).toBe('basic');
+  });
+
+  it('preserves basic-and-reversed for plain front/back cards', () => {
+    expect(effectiveTemplateForCards([basicCard], 'basic-and-reversed')).toBe(
+      'basic-and-reversed'
+    );
+  });
+
+  it('falls back to the selected template when card kinds are mixed', () => {
+    expect(effectiveTemplateForCards([clozeCard, basicCard], 'cloze')).toBe(
+      'cloze'
+    );
+  });
+});

--- a/web/src/lib/chat/templates.ts
+++ b/web/src/lib/chat/templates.ts
@@ -18,3 +18,30 @@ export const CHAT_TEMPLATE_OPTIONS: ChatTemplateOption[] = [
 ];
 
 export const DEFAULT_TEMPLATE: ChatCardTemplate = 'basic';
+
+interface ShapeCard {
+  front: string;
+  back: string;
+  options?: string[];
+  correctIndex?: number;
+}
+
+const CLOZE_MARKER = /\{\{c\d+::/;
+
+function isMcqShape(card: ShapeCard): boolean {
+  return Array.isArray(card.options) && typeof card.correctIndex === 'number';
+}
+
+function isClozeShape(card: ShapeCard): boolean {
+  return CLOZE_MARKER.test(card.front);
+}
+
+export function effectiveTemplateForCards(
+  cards: ShapeCard[],
+  selected: ChatCardTemplate
+): ChatCardTemplate {
+  if (cards.length === 0) return selected;
+  if (cards.every(isMcqShape)) return 'mcq';
+  if (cards.every(isClozeShape)) return 'cloze';
+  return selected;
+}

--- a/web/src/pages/Chat/CardPreview.test.tsx
+++ b/web/src/pages/Chat/CardPreview.test.tsx
@@ -215,6 +215,36 @@ describe('CardPreview', () => {
       expect(screen.getByLabelText('Correct answer')).toBeInTheDocument();
     });
 
+    it('labels the note type as Cloze when cards are cloze even if basic is selected', () => {
+      render(
+        <CardPreview
+          cards={[
+            { front: 'The capital of France is {{c1::Paris}}.', back: '' },
+          ]}
+          onSave={vi.fn()}
+          template="basic"
+          onTemplateChange={vi.fn()}
+        />
+      );
+      expect(
+        screen.getByRole('button', { name: 'Note type: Cloze' })
+      ).toBeInTheDocument();
+    });
+
+    it('labels the note type as Multiple choice when cards are MCQ even if basic is selected', () => {
+      render(
+        <CardPreview
+          cards={[mcqCard]}
+          onSave={vi.fn()}
+          template="basic"
+          onTemplateChange={vi.fn()}
+        />
+      );
+      expect(
+        screen.getByRole('button', { name: 'Note type: Multiple choice' })
+      ).toBeInTheDocument();
+    });
+
     it('keeps basic cards as front/back rows even when an MCQ card is also present', () => {
       render(
         <CardPreview

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import DownloadIcon from '../../components/icons/DownloadIcon';
 import { TemplateSelector } from '../../components/ChatPanel/TemplateSelector';
-import type { ChatCardTemplate } from '../../lib/chat/templates';
+import {
+  effectiveTemplateForCards,
+  type ChatCardTemplate,
+} from '../../lib/chat/templates';
 import styles from './CardPreview.module.css';
 
 interface ChatCard {
@@ -141,6 +144,8 @@ export default function CardPreview({
     }
   }, [saveState]);
 
+  const displayTemplate =
+    template == null ? template : effectiveTemplateForCards(cards, template);
   const displayCards =
     template === 'basic-and-reversed' ? expandForReversed(cards) : cards;
   const allCardsAreMcq =
@@ -150,7 +155,7 @@ export default function CardPreview({
     : displayCards.slice(0, VISIBLE_COUNT);
   const hasMore = displayCards.length > VISIBLE_COUNT;
   const hideBackColumn =
-    template === 'cloze' &&
+    displayTemplate === 'cloze' &&
     (isRegenerating === true ||
       (cards.length > 0 && cards.every((c) => c.back.trim().length === 0)));
   const hasTags =
@@ -197,9 +202,9 @@ export default function CardPreview({
           {cardLabel}
         </span>
 
-        {template != null && onTemplateChange != null && (
+        {displayTemplate != null && onTemplateChange != null && (
           <TemplateSelector
-            value={template}
+            value={displayTemplate}
             onChange={onTemplateChange}
             disabled={templateDisabled === true || isRegenerating === true}
           />

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-cloze-note-type.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-cloze-note-type.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-chat-cloze-note-type",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Chat cloze cards show as Cloze and download as the Cloze note type"
+}


### PR DESCRIPTION
## What
The chat card preview labeled cards by the picker's selected template instead of the cards' real kind. When the model emitted cloze cards while Basic was selected, the header read "Note Type: Basic" but the cards were clearly cloze (`{{c1::…}}` fronts, empty backs). This change derives the displayed note type from the cards themselves.

## Why
A real user reported choosing Basic but seeing cloze cards — the label disagreed with the content. The danger flagged was a broken download (cloze syntax exported as a Basic note type, leaving literal braces). I verified the export is already safe (see below); the bug was purely the deceptive label.

## How
New pure helper `effectiveTemplateForCards(cards, selected)` in `web/src/lib/chat/templates.ts`: all-MCQ cards report `mcq`, all-cloze report `cloze`, otherwise the selected template stands. `CardPreview` feeds this effective value to the note-type pill (label + menu highlight) and to the back-column hide logic, mirroring the MCQ render fix that keys off card shape. No prompt/generation change.

## Diagnosis (per-layer)
- **A) Generation ignores the selected template — TRUE (upstream cause).** `ChatUseCase.streamAssistantTurn` only hard-forces `mcq` (via `tool_choice`). For `basic`, `templatePromptSuffix` is `''` (`chatTemplates.ts`), so no override is sent and the base system prompt still teaches cloze syntax — the model is free to emit cloze under a Basic selection. **Open product question below; not changed here.**
- **B/C) Label conflated with the picker — TRUE (fixed).** `TemplateSelector` label was bound to `activeTemplate` (the picker), never the cards. Chat cards carry no explicit `modelKind`; kind is implicit in the front content. Fixed by deriving the label from card shape.
- **D) Export — SAFE, not broken.** `ChatDeckUseCase` sets `cloze: looksLikeCloze(c.front)` from the actual `{{c1::}}` content, not the `templateSlug`; `create_deck.py` picks `n2a-cloze` when `card['cloze']` and `{{c` is present. **A cloze-content deck already downloads as the Cloze note type and works in Anki today — never Basic-with-literal-braces.** Added a characterization test asserting `cloze:true` is exported even when `templateSlug` is `basic`.

## Measuring success
The note-type pill on a chat card set with `{{c1::}}` fronts now reads "Note type: Cloze" (or "Multiple choice" for MCQ) regardless of the selected template. No new log line — this is a render correctness fix verified by unit tests.

## Testing
- Unit tests added:
  - `web/src/lib/chat/templates.test.ts` — `effectiveTemplateForCards` (cloze/mcq/basic/mixed/empty).
  - `CardPreview.test.tsx` — label shows Cloze / Multiple choice when cards are cloze/MCQ even with `template="basic"`.
  - `ChatDeckUseCase.test.ts` — cloze content exports `cloze:true` under a `basic` templateSlug (proves export follows content, not label).
- Full web vitest (1532) and chat jest (193) green; server + web typecheck green; biome lint clean on changed files. sonar-scanner installed but `SONAR_TOKEN` unset locally — expect the CI Sonar pass to be the first rule-engine run; change is one small pure helper + label wiring, low risk.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Merged on Alexander's standing "deploy everything so I can test in prod" instruction — he is actively testing chat in prod. Label-only behavior change; export already verified safe (cloze content -> n2a-cloze). Full web suite (1532) + chat jest (193) green.

## Changelog
"Chat cloze cards show as Cloze and download as the Cloze note type"

## Risks
Low. The picker still drives regeneration on change. The only visible shift is the label now reflects the cards. If a card set is mixed-kind, the label falls back to the selected template (unchanged behavior).

## Open product question
Should the chat generator *honor* the selected note type — i.e. when Basic is selected, refuse to emit cloze? That's a prompt-contract change (only `mcq` is hard-forced today) and a separate product decision. This PR makes the label and export truthful — the safe, shippable fix — without silently rewriting what the model is allowed to emit. Your call on whether to also constrain generation.

## Goal alignment
Removes a trust-eroding contradiction on the chat surface (a core conversion path toward the 300K goal): the user no longer sees a note type that disagrees with their cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782812461&installation_id=132681956&pr_number=2969&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2969&signature=41db331f35e851a3e49dac0a5c4fb2740bfee449c70345e05a69e5c0cabdbc45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
