### PR TITLE
fix: confirm tag add in chat with a count

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.module.css
+++ b/web/src/components/ChatPanel/ChatPanel.module.css
@@ -262,6 +262,12 @@
   margin: 0;
 }
 
+.successMessage {
+  font-size: var(--text-xs);
+  color: var(--color-success);
+  margin: 0;
+}
+
 .composerPill {
   position: relative;
   display: flex;

--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -263,6 +263,65 @@ describe('ChatPanel — CardPreview integration', () => {
   });
 });
 
+describe('ChatPanel — add tags feedback', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+  });
+
+  const taggableMessages = [
+    {
+      role: 'assistant' as const,
+      content: '',
+      cards: [
+        { front: 'Q1', back: 'A1' },
+        { front: 'Q2', back: 'A2' },
+      ],
+    },
+  ];
+
+  it('shows "Tags added to N cards" after a successful tag add', async () => {
+    mockPost.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ tags: [['anatomy'], ['anatomy']] }),
+    });
+    renderChatPanel({ initialMessages: taggableMessages });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add tags' }));
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/chat/tag-cards',
+        expect.objectContaining({
+          cards: [
+            { front: 'Q1', back: 'A1' },
+            { front: 'Q2', back: 'A2' },
+          ],
+        })
+      );
+    });
+    expect(
+      await screen.findByText('Tags added to 2 cards')
+    ).toBeInTheDocument();
+  });
+
+  it('does not show the success message when the tag add fails', async () => {
+    mockPost.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+    renderChatPanel({ initialMessages: taggableMessages });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add tags' }));
+
+    expect(
+      await screen.findByText("Couldn't add tags. Try again.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Tags added to/)).not.toBeInTheDocument();
+  });
+});
+
 describe('ChatPanel — aria-live', () => {
   it('message list container has aria-live="polite"', async () => {
     mockPost.mockResolvedValueOnce(

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -85,6 +85,7 @@ const MAX_TOTAL_BYTES = 25 * 1024 * 1024;
 const MAX_FILE_COUNT = 5;
 
 const FREE_MONTHLY_LIMIT = 20;
+const TAG_SUCCESS_DISMISS_MS = 3000;
 
 function formatResetDate(iso: string): string {
   try {
@@ -584,6 +585,7 @@ export default function ChatPanel({
   const [regeneratingIdx, setRegeneratingIdx] = useState<number | null>(null);
   const [taggingIdx, setTaggingIdx] = useState<number | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [limitReached, setLimitReached] = useState(false);
   const [resetDate, setResetDate] = useState<string | null>(null);
   const [messagesUsedThisMonth, setMessagesUsedThisMonth] = useState(0);
@@ -865,6 +867,7 @@ export default function ChatPanel({
     const cardsToTag = target.cards;
     setTaggingIdx(messageIdx);
     setNetworkError(null);
+    setSuccessMessage(null);
     try {
       const response = await post('/api/chat/tag-cards', {
         cards: cardsToTag.map((c) => ({ front: c.front, back: c.back })),
@@ -891,6 +894,10 @@ export default function ChatPanel({
           };
         })
       );
+      const taggedCount = cardsToTag.length;
+      const cardWord = taggedCount === 1 ? 'card' : 'cards';
+      setSuccessMessage(`Tags added to ${taggedCount} ${cardWord}`);
+      window.setTimeout(() => setSuccessMessage(null), TAG_SUCCESS_DISMISS_MS);
     } catch {
       setNetworkError("Couldn't add tags. Try again.");
     } finally {
@@ -1220,6 +1227,11 @@ export default function ChatPanel({
               )}
               {networkError != null && (
                 <p className={styles.networkError}>{networkError}</p>
+              )}
+              {successMessage != null && (
+                <p className={styles.successMessage} role="status">
+                  {successMessage}
+                </p>
               )}
             </div>
           </>

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -347,7 +347,7 @@ export default function CardPreview({
                         <span
                           className={styles.cardPreviewTagSkeleton}
                           role="status"
-                          aria-label="Generating tags"
+                          aria-label="Adding tags"
                         />
                       ) : (
                         <TagChips tags={card.tags ?? []} />

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-tags-feedback.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-tags-feedback.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-chat-tags-feedback",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Chat cards confirm when tags are added, with a count of the cards tagged"
+}


### PR DESCRIPTION
## What
The chat "Add tags" flow gains an inline success confirmation. After tags are added, a brief **Tags added to N cards** message appears near the composer (auto-cleared after 3s), and the in-flight skeleton label changes from "Generating tags" to "Adding tags" so the loading state isn't mistaken for AI generation.

## Why
User report: clicking Add tags hid the button and the cards updated silently — with no confirmation, the action felt broken and users refreshed to check. The flow already had an error path (`Couldn't add tags. Try again.`) but no success path.

## How
- New `successMessage` state in `ChatPanel`, set after the returned tags are merged into the cards, cleared on a 3s timeout and reset at the start of each add.
- Rendered with a new `.successMessage` CSS rule mirroring `.networkError`, using the existing `--color-success` token — no new component, no toast library.
- `CardPreview` tag-skeleton `aria-label` changed `Generating tags` → `Adding tags`.

Surgical and localized to the tagging flow.

## Measuring success
The success element renders with `role="status"` and the exact string `Tags added to N cards`. In QA / browser, the message appears immediately after a successful add. Drop-off on the tagging step (users who add tags but then refresh) should fall.

## Testing
- Unit tests added in `ChatPanel.test.tsx`: success message renders as `Tags added to 2 cards` after a successful `/api/chat/tag-cards` call; does **not** render on a failed call (error message shows instead). Mocked only at the HTTP edge (`post`). Verified the success test fails for the right reason when the source line is removed.
- Full web vitest green (177 files, 1526 tests). Web typecheck green. `biome lint` clean on changed files.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Merged on Alexander's standing deploy-to-test instruction. Adds an inline success confirmation; full web suite green, rebased cleanly on the cloze-label fix.

## Changelog
`Chat cards confirm when tags are added, with a count of the cards tagged` (`web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-tags-feedback.json`).

## Risks
Low. Additive UI state; existing in-flight (button hidden + skeleton) and error behavior unchanged. Rollback is a revert.

## Coordination
Touches the same two files as the in-flight `fix/chat-template-card-kind-mismatch` (`CardPreview.tsx`, `ChatPanel.tsx`). Edits here are localized to the tagging flow (success state + skeleton label) and do not touch the note-type label/picker or card rendering. Expect a rebase against whichever merges first.

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` unset in this environment. Change is small (additive state + one label + one CSS rule); expect no new complexity smells, but reviewers should watch for a Sonar bounce.

## Goal alignment
The chat→deck path is a core conversion flow. Silent success made a working feature feel broken, eroding trust and pushing users to refresh. Clear confirmation keeps users moving toward a downloaded deck — directly supporting the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782812535&installation_id=132681956&pr_number=2970&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2970&signature=4388150dd430713c0197c45b8f7c4199df12a106bbbb551dbd314d5986ecdcdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
