### PR TITLE
fix: persist chat MCQ cards so they survive a reload

### DIFF
--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -4,7 +4,9 @@ import {
   ChatRateLimitError,
   ChatConversationNotFoundError,
   McqExtractionFailedError,
+  extractCards,
 } from './ChatUseCase';
+import { ConversationsUseCase } from './ConversationsUseCase';
 import { InMemoryChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
 import { InMemoryConversationsRepository } from '../../data_layer/ConversationsRepository';
 
@@ -739,6 +741,94 @@ describe('ChatUseCase', () => {
         front: 'Albanian currency?',
         correctIndex: 0,
       });
+    });
+
+    it('persists MCQ cards as a JSON code block that extractCards recovers on reload', async () => {
+      const { messagesRepo, useCase } = buildUseCaseWithBlocks([
+        { type: 'text', text: 'Here are your quiz cards:' },
+        mcqToolBlock({
+          cards: [
+            {
+              front: 'Capital of Albania?',
+              options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+              correct_index: 0,
+              rationale: 'Tirana is the capital.',
+            },
+          ],
+        }),
+      ]);
+
+      const { conversationId } = await useCase.execute({
+        user: FREE_USER,
+        content: 'quiz me on Albania',
+        conversationHistory: [],
+        templateSlug: 'mcq',
+      });
+
+      const persisted = await messagesRepo.findLatestAssistantInConversation({
+        userId: FREE_USER.owner,
+        conversationId,
+      });
+      const recovered = extractCards(persisted!.content, true);
+      expect(recovered.cards).toEqual([
+        {
+          front: 'Capital of Albania?',
+          back: '',
+          options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+          correctIndex: 0,
+          rationale: 'Tirana is the capital.',
+        },
+      ]);
+    });
+
+    it('round-trips MCQ cards through persistence and conversation hydration', async () => {
+      const conversationsRepo = new InMemoryConversationsRepository();
+      const messagesRepo = new InMemoryChatMessagesRepository();
+      const anthropic = buildAnthropicMockWithBlocks([
+        mcqToolBlock({
+          cards: [
+            {
+              front: 'Albanian currency?',
+              options: ['Lek', 'Euro', 'Dinar', 'Lev'],
+              correct_index: 0,
+            },
+          ],
+        }),
+      ]);
+      const chatUseCase = new ChatUseCase(
+        messagesRepo,
+        conversationsRepo,
+        anthropic as never
+      );
+
+      const { conversationId, content } = await chatUseCase.execute({
+        user: FREE_USER,
+        content: 'quiz me',
+        conversationHistory: [],
+        templateSlug: 'mcq',
+      });
+
+      conversationsRepo.recordMessage({
+        userId: FREE_USER.owner,
+        conversationId,
+        role: 'assistant',
+        content,
+      });
+
+      const conversationsUseCase = new ConversationsUseCase(conversationsRepo);
+      const view = await conversationsUseCase.get({
+        userId: FREE_USER.owner,
+        conversationId,
+      });
+      const assistant = view?.messages.find((m) => m.role === 'assistant');
+      expect(assistant?.cards).toEqual([
+        {
+          front: 'Albanian currency?',
+          back: '',
+          options: ['Lek', 'Euro', 'Dinar', 'Lev'],
+          correctIndex: 0,
+        },
+      ]);
     });
 
     it('throws McqExtractionFailedError when the model returns prose and no tool call', async () => {

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -301,6 +301,25 @@ export class McqExtractionFailedError extends Error {
   }
 }
 
+function mcqCardToWireShape(card: ChatCard): Record<string, unknown> {
+  return {
+    front: card.front,
+    options: card.options ?? [],
+    correct_index: card.correctIndex ?? 0,
+    ...(card.rationale != null && card.rationale.length > 0
+      ? { rationale: card.rationale }
+      : {}),
+    ...(card.tags != null && card.tags.length > 0 ? { tags: card.tags } : {}),
+  };
+}
+
+export function embedMcqCardsAsJsonBlock(prose: string, cards: ChatCard[]): string {
+  const jsonArray = JSON.stringify(cards.map(mcqCardToWireShape));
+  const block = `\`\`\`json\n${jsonArray}\n\`\`\``;
+  const trimmedProse = prose.trim();
+  return trimmedProse.length > 0 ? `${trimmedProse}\n\n${block}` : block;
+}
+
 export function extractMcqCardsFromToolUse(
   content: Anthropic.ContentBlock[]
 ): ChatCard[] | undefined {
@@ -498,9 +517,10 @@ export class ChatUseCase {
       if (mcqCards == null) {
         throw new McqExtractionFailedError();
       }
-      await this.persistAssistantTurn(user.owner, conversationId, assistantContent);
+      const persistedContent = embedMcqCardsAsJsonBlock(assistantContent, mcqCards);
+      await this.persistAssistantTurn(user.owner, conversationId, persistedContent);
       return {
-        content: assistantContent,
+        content: persistedContent,
         conversationId,
         cards: mcqCards,
       };

--- a/src/usecases/chat/ConversationsUseCase.test.ts
+++ b/src/usecases/chat/ConversationsUseCase.test.ts
@@ -85,6 +85,32 @@ describe('ConversationsUseCase', () => {
       expect(assistant?.contentAfter).toBe('Hope that helps!');
     });
 
+    it('hydrates MCQ cards from a persisted JSON code block on reload', async () => {
+      const repo = new InMemoryConversationsRepository();
+      const useCase = new ConversationsUseCase(repo);
+      const id = await repo.create({ userId: USER_A, title: 'MCQ' });
+      const assistantContent =
+        'Here are your quiz cards:\n\n```json\n[{"front":"Capital of Albania?","options":["Tirana","Durrës","Vlorë","Shkodër"],"correct_index":0,"rationale":"Tirana is the capital."}]\n```';
+      repo.recordMessage({
+        userId: USER_A,
+        conversationId: id,
+        role: 'assistant',
+        content: assistantContent,
+      });
+
+      const result = await useCase.get({ userId: USER_A, conversationId: id });
+      const assistant = result?.messages.find((m) => m.role === 'assistant');
+      expect(assistant?.cards).toEqual([
+        {
+          front: 'Capital of Albania?',
+          back: '',
+          options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+          correctIndex: 0,
+          rationale: 'Tirana is the capital.',
+        },
+      ]);
+    });
+
     it('does not attach cards to user messages even when their content has JSON', async () => {
       const repo = new InMemoryConversationsRepository();
       const useCase = new ConversationsUseCase(repo);

--- a/src/usecases/chat/ConversationsUseCase.ts
+++ b/src/usecases/chat/ConversationsUseCase.ts
@@ -58,7 +58,7 @@ function hydrateMessages(
     if (m.role !== 'assistant') {
       return m;
     }
-    const { cards, contentBefore, contentAfter } = extractCards(m.content);
+    const { cards, contentBefore, contentAfter } = extractCards(m.content, true);
     return {
       ...m,
       ...(cards != null ? { cards } : {}),

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-mcq-persist.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-mcq-persist.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-chat-mcq-persist",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Multiple-choice cards from chat stay put after a page reload"
+}


### PR DESCRIPTION
## What
MCQ cards generated in the chat assistant now survive a page reload. Previously they rendered live in-session but disappeared on refresh.

## Why
Confirmed bug: in the `mcqForced` branch of `ChatUseCase`, the persisted assistant content was built from only the model's text blocks (the prose intro). The actual cards came from the Anthropic tool-use block and were returned live to the client but never serialized. On reload, `ConversationsUseCase.hydrateMessages` found no card JSON in the prose and also called `extractCards` without `mcqAllowed`. Both gaps are fixed.

User-visible outcome: a chat conversation that produced multiple-choice cards shows those cards again when reopened.

## How
1. `embedMcqCardsAsJsonBlock(prose, cards)` serializes the extracted cards into the same fenced `json` code block basic/cloze cards already use. Field names are the wire shape `extractCards`/`parseCardItem` reads back: `front`, `options`, `correct_index`, optional `rationale`/`tags`. The combined prose + JSON block is what gets persisted; the live response still returns `cards: mcqCards`.
2. `ConversationsUseCase.hydrateMessages` now calls `extractCards(m.content, true)` so the MCQ shape is recognized on reload.

Basic/cloze are unaffected: those cards carry neither `options` nor `correct_index`, so the MCQ branch in `parseCardItem` never fires for them.

### Persisted-content format
For an MCQ turn with prose "Here are your quiz cards:" the stored content is:
```
Here are your quiz cards:

```json
[{"front":"Capital of Albania?","options":["Tirana","Durrës","Vlorë","Shkodër"],"correct_index":0,"rationale":"Tirana is the capital."}]
```
```
When prose is empty, only the fenced JSON block is stored.

## Measuring success
After deploy, a chat MCQ conversation reopened via the get/hydrate endpoint returns assistant messages with a populated `cards` array (`options` + `correctIndex`). No structured metric exists for chat card hydration today; the regression is covered by the round-trip test.

## Testing
- Unit tests added:
  - `ChatUseCase.test.ts` — persisted content for an MCQ turn, run through `extractCards(content, true)`, yields the MCQ cards (regression).
  - `ChatUseCase.test.ts` — full round-trip: generate an MCQ turn (mocked tool-use), replay the persisted content into the conversation, hydrate via `ConversationsUseCase.get`, assert cards return with `options` + `correctIndex`.
  - `ConversationsUseCase.test.ts` — hydration recovers MCQ shape from a persisted JSON block.
- Verified all 3 new tests fail without the source change and pass with it. Basic/cloze hydration tests still pass (74/74).
- `npx tsc -p . --noEmit` clean.
- Sonar: not run — `SONAR_TOKEN` unset in this environment. Change is small and adds no new HTTP/HTML sink; expect no security finding.

## Browser check
Browser check: not applicable — server-side persistence fix, web diff is changelog only

## Changelog
`Multiple-choice cards from chat stay put after a page reload`

## Risks
Low. The change only adds a JSON block to persisted MCQ content and widens hydration to recognize MCQ. Touches the Anthropic chat integration path, so `/security-review` is advisable before merge. No latency or token/cost impact — serialization is local; no extra LLM calls. Rollback = revert the commit.

## Goal alignment
Chat is a core conversion surface. Cards silently vanishing on reload is a trust-eroding bug that makes the MCQ feature feel broken; fixing it keeps generated work durable, supporting retention toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782813491&installation_id=132681956&pr_number=2972&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2972&signature=52293919c4cf615188734f95f025829c98c8e0333b5ac5816374ebcefbb80260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->