### PR TITLE
fix: regenerate chat turn in place on note-type change

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -54,10 +54,11 @@ vi.mock('../../lib/backend/api', () => ({
   del: vi.fn(),
 }));
 
-import { get, post } from '../../lib/backend/api';
+import { get, patch, post } from '../../lib/backend/api';
 
 const mockPost = post as ReturnType<typeof vi.fn>;
 const mockGet = get as ReturnType<typeof vi.fn>;
+const mockPatch = patch as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   mockUseUserLocals.mockReturnValue(consentedLocals);
@@ -645,6 +646,7 @@ describe('ChatPanel — template selector', () => {
   beforeEach(() => {
     mockPost.mockReset();
     mockGet.mockResolvedValue({ used: 0, limit: 20 });
+    mockPatch.mockResolvedValue({ ok: true, status: 204 });
   });
 
   it('renders "Template: Basic" pill alongside the cards', () => {
@@ -716,36 +718,95 @@ describe('ChatPanel — template selector', () => {
     });
   });
 
-  it('auto-regenerates the last turn when the template changes', async () => {
+  it('regenerates in place via the conversation endpoint when the template changes', async () => {
     mockPost.mockResolvedValueOnce(
       makeSseResponse([
         {
           event: 'done',
           data: {
             content: 'Reply',
-            conversationId: 1,
+            conversationId: 7,
             cards: [{ front: 'New', back: 'Card' }],
           },
         },
       ])
     );
-    renderChatPanel({ initialMessages: assistantWithCards });
+    renderChatPanel({
+      initialMessages: assistantWithCards,
+      initialConversationId: 7,
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
     fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith(
-        '/api/chat/message',
-        expect.objectContaining({
-          content: '20 cards about Norway',
-          templateSlug: 'cloze',
-        })
+        '/api/chat/conversations/7/regenerate',
+        { templateSlug: 'cloze' }
       );
     });
-    const regenerateCall = mockPost.mock.calls.find(
+  });
+
+  it('does not re-send the prior message as a new turn on template change', async () => {
+    mockPost.mockResolvedValueOnce(
+      makeSseResponse([
+        {
+          event: 'done',
+          data: {
+            content: 'Reply',
+            conversationId: 7,
+            cards: [{ front: 'New', back: 'Card' }],
+          },
+        },
+      ])
+    );
+    renderChatPanel({
+      initialMessages: assistantWithCards,
+      initialConversationId: 7,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/chat/conversations/7/regenerate',
+        { templateSlug: 'cloze' }
+      );
+    });
+    const messageCall = mockPost.mock.calls.find(
       (call) => call[0] === '/api/chat/message'
     );
-    expect(regenerateCall).toBeDefined();
-    expect(regenerateCall?.[1].history).toEqual([]);
+    expect(messageCall).toBeUndefined();
+  });
+
+  it('replaces the target assistant message in place without appending a new one', async () => {
+    mockPost.mockResolvedValueOnce(
+      makeSseResponse([
+        {
+          event: 'done',
+          data: {
+            content: 'Regenerated reply',
+            conversationId: 7,
+            cards: [{ front: 'Cloze front', back: 'Cloze back' }],
+          },
+        },
+      ])
+    );
+    renderChatPanel({
+      initialMessages: assistantWithCards,
+      initialConversationId: 7,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    await waitFor(() => {
+      expect(screen.getByText('Cloze front')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Capital?')).not.toBeInTheDocument();
+    expect(screen.getByText('20 cards about Norway')).toBeInTheDocument();
+  });
+
+  it('does not regenerate when there is no saved conversation', async () => {
+    renderChatPanel({ initialMessages: assistantWithCards });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    expect(mockPost).not.toHaveBeenCalled();
   });
 
   it('shows a skeleton while regenerating and hides the Download button', async () => {
@@ -757,7 +818,10 @@ describe('ChatPanel — template selector', () => {
     );
     mockPost.mockReturnValueOnce(sseResponse);
 
-    renderChatPanel({ initialMessages: assistantWithCards });
+    renderChatPanel({
+      initialMessages: assistantWithCards,
+      initialConversationId: 7,
+    });
     expect(
       screen.getByRole('button', { name: 'Download deck' })
     ).toBeInTheDocument();

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -115,13 +115,6 @@ function findLastAssistantWithCardsIdx(messages: Message[]): number {
   return -1;
 }
 
-function findUserIdxBefore(messages: Message[], beforeIdx: number): number {
-  for (let i = beforeIdx - 1; i >= 0; i--) {
-    if (messages[i].role === 'user') return i;
-  }
-  return -1;
-}
-
 export function parseSseEvent(
   rawEvent: string
 ): { eventType: string; data: string } | null {
@@ -924,9 +917,7 @@ export default function ChatPanel({
     newSlug: ChatCardTemplate,
     targetIdx: number
   ) {
-    const userIdx = findUserIdxBefore(messages, targetIdx);
-    if (userIdx === -1) return;
-    const userContent = messages[userIdx].content;
+    if (activeConversationId == null) return;
 
     setRegeneratingIdx(targetIdx);
     setIsLoading(true);
@@ -934,19 +925,12 @@ export default function ChatPanel({
     setStreamingText('');
     setUserScrolledAway(false);
 
-    const history = messages
-      .slice(0, userIdx)
-      .slice(-10)
-      .map((m) => ({ role: m.role, content: m.content }));
-
     let response: Response;
     try {
-      response = await post('/api/chat/message', {
-        content: userContent,
-        history,
-        conversationId: activeConversationId,
-        templateSlug: newSlug,
-      });
+      response = await post(
+        `/api/chat/conversations/${activeConversationId}/regenerate`,
+        { templateSlug: newSlug }
+      );
     } catch {
       setNetworkError("Couldn't rebuild your cards. Try again.");
       setIsLoading(false);

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-regenerate-in-place.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-chat-regenerate-in-place.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-chat-regenerate-in-place",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Changing a card's note type rebuilds it in place instead of duplicating the chat"
+}


### PR DESCRIPTION
## What

Changing a card's note type in chat now hits the in-place regenerate endpoint (`POST /api/chat/conversations/:id/regenerate`) — which deletes the last assistant message and re-streams it under the new template — instead of re-POSTing to `/api/chat/message`.

The old path treated each template switch as a brand-new turn, inserting a duplicate `(user, assistant)` pair every time. Confirmed against prod data: a single conversation had accumulated 16 messages from repeated template switches.

## Changes

- `web/src/components/ChatPanel/ChatPanel.tsx` — `regenerateLastTurn` rewired to the regenerate endpoint, guarded on `activeConversationId`, dropped the user-message/history reconstruction.
- `web/src/components/ChatPanel/ChatPanel.test.tsx` — asserts `/api/chat/message` is **not** called on template change; in-place replacement + no-op regression tests.
- Changelog entry.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Regeneration verified in prod by Alexander — only the last assistant turn updates on note-type change; no duplicate turns.

Sonar not run locally (`SONAR_TOKEN` unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
