### PR TITLE
fix: apply the code class to Notion code blocks

### DIFF
--- a/src/services/NotionService/blocks/BlockCode.test.tsx
+++ b/src/services/NotionService/blocks/BlockCode.test.tsx
@@ -74,4 +74,11 @@ describe('BlockCode — newline preservation', () => {
     expect(html).toMatch(/^<pre/);
     expect(html).toContain('<code>');
   });
+
+  it('applies the code class so the card template styles the block', () => {
+    const block = makeCodeBlock([{ plain_text: 'hello' }]);
+    const html = BlockCode(block, makeHandler());
+    expect(html).toContain('class="code"');
+    expect(html).not.toContain('code}');
+  });
 });

--- a/src/services/NotionService/blocks/BlockCode.tsx
+++ b/src/services/NotionService/blocks/BlockCode.tsx
@@ -16,7 +16,7 @@ const BlockCode = (block: CodeBlockObjectResponse, handler: BlockHandler) => {
   }
 
   return ReactDOMServer.renderToStaticMarkup(
-    <pre id={block.id} className={`code}`}>
+    <pre id={block.id} className="code">
       <code>
         {richText.map((t: RichTextItemResponse) => {
           const { annotations } = t;

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-code-block-styling.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-code-block-styling.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-code-block-styling",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Code blocks from Notion keep their monospace styling in converted cards"
+}


### PR DESCRIPTION
## What

`BlockCode.tsx` rendered every Notion code block with a malformed `className` template literal:

```tsx
<pre id={block.id} className={`code}`}>   // → <pre class="code}">
```

The stray brace meant the emitted class was `code}`, so the `.code` selector in the card template never matched. Code blocks lost their monospace box (background, padding) and rendered like inline code. Introduced by a 2022 refactor and unchanged since.

## Fix

One character: `className="code"`. Added a test asserting the rendered markup carries `class="code"` and no stray `code}`.

## Testing

- New failing test reproduced `class="code}"`, passes after the fix.
- `BlockCode.test.tsx`: 4 passed.
- `/check` green (server tsc, web typecheck, web vitest 1539 passed, web lint).
- Sonar: single-line literal fix — skipped per `.claude/rules/sonar.md` (and no `SONAR_TOKEN` configured locally).

## Scope note

This restores the code-block **styling** (the `.code` class). It does not change whitespace handling — `<pre>` already preserves newlines via its UA default — so it addresses the styling half of #1451 rather than the whitespace-collapse symptom. Linking as `Refs #1451`, not `Fixes`.

Browser check: not applicable — server-side render fix; the only `web/src/` change is a changelog JSON.

Refs #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782819843&installation_id=132681956&pr_number=2976&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2976&signature=2f3d2be8eb4854ce3933652b763486f23ae7aee34c8548590f19c6dede44ff7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->