### PR TITLE
fix: route bookmark metadata fetch through SSRF guard

### DIFF
--- a/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.test.ts
+++ b/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.test.ts
@@ -1,0 +1,95 @@
+import axios from 'axios';
+import dns from 'dns';
+
+import useMetadata from './useMetadata';
+
+jest.mock('axios', () => {
+  const actual = jest.requireActual('axios');
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      isAxiosError: actual.isAxiosError,
+    },
+  };
+});
+
+jest.mock('dns', () => ({
+  __esModule: true,
+  default: { promises: { lookup: jest.fn() } },
+  promises: { lookup: jest.fn() },
+}));
+
+const scrape = jest.fn();
+jest.mock('metascraper', () => () => (...args: unknown[]) => scrape(...args));
+jest.mock('metascraper-description', () => ({}), { virtual: true });
+jest.mock('metascraper-image', () => ({}), { virtual: true });
+jest.mock('metascraper-logo-favicon', () => ({}), { virtual: true });
+jest.mock('metascraper-title', () => ({}), { virtual: true });
+jest.mock('metascraper-url', () => ({}), { virtual: true });
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedLookup = dns.promises.lookup as jest.Mock;
+
+describe('useMetadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedLookup.mockResolvedValue([{ address: '13.224.0.1', family: 4 }]);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('scrapes metadata for a normal public bookmark URL', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data: '<html></html>' });
+    scrape.mockResolvedValueOnce({
+      title: 'Spaced repetition',
+      description: 'A learning technique',
+      logo: 'https://example.com/logo.png',
+      image: 'https://example.com/og.png',
+    });
+
+    const result = await useMetadata('https://example.com/article');
+
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'https://example.com/article',
+      expect.objectContaining({ lookup: expect.any(Function) })
+    );
+    expect(result.title).toBe('Spaced repetition');
+  });
+
+  it('refuses a loopback bookmark URL without making an outbound request', async () => {
+    const result = await useMetadata('https://127.0.0.1/admin');
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(scrape).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      description: '',
+      title: '127.0.0.1',
+      logo: '',
+      image: '',
+    });
+  });
+
+  it('refuses a cloud-metadata bookmark URL without making an outbound request', async () => {
+    const result = await useMetadata('https://169.254.169.254/latest/meta-data');
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(scrape).not.toHaveBeenCalled();
+    expect(result.title).toBe('169.254.169.254');
+  });
+
+  it('refuses a DNS-rebinding host that resolves to a private IP', async () => {
+    mockedLookup.mockResolvedValueOnce([
+      { address: '169.254.169.254', family: 4 },
+    ]);
+
+    const result = await useMetadata('https://imds.attacker.example/meta');
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+    expect(scrape).not.toHaveBeenCalled();
+    expect(result.title).toBe('imds.attacker.example');
+  });
+});

--- a/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.ts
+++ b/src/services/NotionService/blocks/media/BlockBookmark/hooks/useMetadata.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import instrumentedAxios from '../../../../../observability/instrumentedAxios';
 
 const metascraper = require('metascraper')([
   require('metascraper-description'),
@@ -17,7 +17,7 @@ export interface Metadata {
 
 export default async function useMetadata(url: string): Promise<Metadata> {
   try {
-    const response = await axios.get(url);
+    const response = await instrumentedAxios.get('notion', url);
     return metascraper({ html: response.data, url });
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## What
The Notion bookmark metadata hook (`useMetadata`) fetched a user-controlled bookmark URL with raw `axios.get`, bypassing the repo SSRF guard. This routes it through `instrumentedAxios.get('notion', url)`.

## Why
Confirmed via an external security report. Flow: `blockToStaticMarkup.ts` (case `bookmark`) → `BlockBookmark` → `useMetadata(bookmark.url)` → raw `axios.get(url)`. The URL comes straight from a Notion bookmark block, which the user controls. It was a **non-blind SSRF** — metascraper parsed the response and the scraped title/description/image rendered into the card, so an attacker could probe internal services (RFC1918, loopback, `169.254.169.254` cloud metadata) and read a slice of the response back through the rendered card.

## How
Swapped the raw `axios` import for the `instrumentedAxios` default export and call `instrumentedAxios.get('notion', url)`. The `notion` channel has a null host allowlist (any public host, which bookmarks need) but still: rejects private/loopback/link-local addresses, rejects IPv4-mapped IPv6, pins DNS to defeat rebinding, and requires `https`. `response.data` access is unchanged (same `AxiosResponse` shape). The existing `try/catch` fallback (hostname-only `Metadata` placeholder) is preserved — a refused URL degrades to the same safe placeholder a network error already produced. Matches the established pattern in `downloadMediaOrSkip.ts`.

## Measuring success
The guard records every outbound `notion` call via the observability sink (`recordOutboundCall`). After deploy, refused bookmark URLs no longer produce an outbound call row for a private host, and the `notion`-service outbound log shows only public-host fetches. A bookmark pointing at a private/loopback host now renders the hostname-only placeholder instead of scraped internal content.

## Testing
- Unit tests added in `useMetadata.test.ts` (4 cases). Mocks only the external edge (the guard's `axios` + `dns` boundary) and the `metascraper` HTML parser; the real `instrumentedAxios` and real `useMetadata` run:
  - scrapes metadata for a normal public bookmark URL (and pins DNS via the `lookup` option)
  - refuses a loopback URL (`https://127.0.0.1/...`) — no outbound request, returns the hostname placeholder
  - refuses a cloud-metadata URL (`https://169.254.169.254/...`) — no outbound request
  - refuses a DNS-rebinding host that resolves to a private IP — no outbound request
- Verified the tests fail for the right reason against the unmodified source (raw `axios.get` was still called for every private/loopback URL), then pass after the swap.
- Server `tsc -p . --noEmit` clean. `instrumentedAxios` suite (20 tests) still green.

## Browser check
Browser check: not applicable — no `web/src/` files; server-side conversion path only.

## Changelog
No entry — internal security fix with no behavior change for legitimate users. Public bookmarks scrape exactly as before; only private/internal-host URLs (which a legit user would never bookmark to convert) are now refused.

## Sonar
`SONAR_TOKEN` was not set locally, so `sonar-scanner` was not run. Change is a two-line import + call swap that **removes** a security hotspot (raw axios on a user URL) rather than adding one, so a Sonar bounce is unlikely.

## Risks
A bookmark whose host genuinely resolves only to a private IP, or that is `http://` only, will now render the hostname-only placeholder instead of scraped metadata. That is the intended security trade-off and matches the existing network-error fallback. Rollback is a one-commit revert.

## Security review
This touches external-API integration (SSRF guard) — please run `/security-review` before merge. Do not merge without it.

## Goal alignment
Protects the conversion path's integrity and the box's internal network as we scale toward 300K users — a public, abusable SSRF on a hot path is a liability that grows with traffic.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782825848&installation_id=132681956&pr_number=2977&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2977&signature=974e9ae78acee0e78d4f4a7a41d6265663fed5671329028860ebcff0cb0b77ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->