### PR TITLE
fix: route ankify media fetch through SSRF guard

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -344,7 +344,7 @@ const AnkifyRouter = () => {
     ankiConnectFactory,
     notionBlockChildrenFetcherFactory,
     buildNotionPageMetaFetcher,
-    fetch,
+    undefined,
     new ErrorEventRepository(db),
     (owner: number) =>
       new MarkNotionTokenInvalidUseCase(

--- a/src/routes/AnkifyWebhookRouter.ts
+++ b/src/routes/AnkifyWebhookRouter.ts
@@ -39,7 +39,7 @@ const AnkifyWebhookRouter = () => {
     ankiConnectFactory,
     notionBlockChildrenFetcherFactory,
     undefined,
-    fetch,
+    undefined,
     new ErrorEventRepository(db),
     (owner: number) =>
       new MarkNotionTokenInvalidUseCase(

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -17,7 +17,18 @@ jest.mock('../../services/ankify/notionPageWalker', () => ({
   walkNotionPageForFlashcards: jest.fn(),
 }));
 
+jest.mock('axios');
+
+jest.mock('node:dns', () => ({
+  promises: { lookup: jest.fn() },
+}));
+
+import axios from 'axios';
+import dns from 'node:dns';
 import { walkNotionPageForFlashcards } from '../../services/ankify/notionPageWalker';
+
+const mockAxiosGet = axios.get as jest.Mock;
+const mockDnsLookup = dns.promises.lookup as jest.Mock;
 
 const sampleClient = (): AnkifyClient => ({
   id: 1,
@@ -450,13 +461,10 @@ describe('SyncNotionPageToRacUseCase', () => {
   });
 
   test('downloads Notion file images and pushes them to media before addNote', async () => {
-    const sampleFetcher = jest.fn(async (url: string) => ({
-      ok: true,
-      arrayBuffer: async () => {
-        expect(url).toBe('https://prod-files.notion.so/img.png?signed=1');
-        return new TextEncoder().encode('PNGDATA').buffer as ArrayBuffer;
-      },
-    })) as unknown as typeof fetch;
+    const sampleFetcher = jest.fn(async (url: string) => {
+      expect(url).toBe('https://prod-files.notion.so/img.png?signed=1');
+      return { status: 200, data: Buffer.from('PNGDATA') };
+    });
 
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
       cards: [
@@ -561,7 +569,7 @@ describe('SyncNotionPageToRacUseCase', () => {
   test('records sync_logs error but does not fail when image download fails', async () => {
     const failingFetch = jest.fn(async () => {
       throw new Error('network down');
-    }) as unknown as typeof fetch;
+    });
 
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
       cards: [
@@ -861,7 +869,7 @@ describe('SyncNotionPageToRacUseCase', () => {
         () => ac,
         () => async () => [],
         undefined,
-        fetch,
+        undefined,
         errorEventRepo
       );
 
@@ -901,7 +909,7 @@ describe('SyncNotionPageToRacUseCase', () => {
         () => ac,
         () => async () => [],
         undefined,
-        fetch,
+        undefined,
         errorEventRepo
       );
 
@@ -933,7 +941,7 @@ describe('SyncNotionPageToRacUseCase', () => {
         () => ac,
         () => async () => [],
         undefined,
-        fetch,
+        undefined,
         errorEventRepo
       );
 
@@ -996,5 +1004,113 @@ describe('SyncNotionPageToRacUseCase', () => {
 
     expect(repos.notionRepo.markTokenInvalid).toHaveBeenCalledWith(42);
     expect(repos.subscriptions.setEnabled).toHaveBeenCalledWith(1, false);
+  });
+
+  describe('default media fetcher routes through the SSRF guard', () => {
+    const fileMediaCard = (url: string) =>
+      sampleCard({
+        back: 'See <img src="ankify-img-1.png">',
+        media: [
+          {
+            block_id: 'img-1',
+            kind: 'image',
+            source: 'file',
+            url,
+            filename: 'ankify-img-1.png',
+          },
+        ],
+      });
+
+    beforeEach(() => {
+      mockAxiosGet.mockReset();
+      mockDnsLookup.mockReset();
+    });
+
+    const buildUseCase = (
+      repos: ReturnType<typeof makeRepos>,
+      ac: AnkiConnectClient
+    ) =>
+      new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+    it('refuses a loopback media URL and stores no media', async () => {
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [fileMediaCard('http://127.0.0.1/secret.png')],
+        diagnostic: { blocks_scanned: 1, blocks_matched: 1, pattern_hits: { toggle: 1 } },
+      });
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+
+      const result = await buildUseCase(repos, ac).execute({
+        owner: 42,
+        notionPageId: 'page-id',
+        trigger: 'manual',
+      });
+
+      expect(mockAxiosGet).not.toHaveBeenCalled();
+      expect(ac.storeMediaFile).not.toHaveBeenCalled();
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toMatch(/img-1/);
+      expect(ac.addNote).toHaveBeenCalled();
+    });
+
+    it('refuses a link-local metadata media URL and stores no media', async () => {
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [fileMediaCard('http://169.254.169.254/latest/meta-data/')],
+        diagnostic: { blocks_scanned: 1, blocks_matched: 1, pattern_hits: { toggle: 1 } },
+      });
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+
+      const result = await buildUseCase(repos, ac).execute({
+        owner: 42,
+        notionPageId: 'page-id',
+        trigger: 'manual',
+      });
+
+      expect(mockAxiosGet).not.toHaveBeenCalled();
+      expect(ac.storeMediaFile).not.toHaveBeenCalled();
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('fetches a public media URL through the guard and stores the bytes', async () => {
+      mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+      mockAxiosGet.mockResolvedValue({
+        status: 200,
+        data: Buffer.from('PNGDATA'),
+      });
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [fileMediaCard('https://prod-files.notion.so/img.png?signed=1')],
+        diagnostic: { blocks_scanned: 1, blocks_matched: 1, pattern_hits: { toggle: 1 } },
+      });
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+
+      const result = await buildUseCase(repos, ac).execute({
+        owner: 42,
+        notionPageId: 'page-id',
+        trigger: 'manual',
+      });
+
+      expect(mockAxiosGet).toHaveBeenCalledWith(
+        'https://prod-files.notion.so/img.png?signed=1',
+        expect.objectContaining({ responseType: 'arraybuffer' })
+      );
+      expect(ac.storeMediaFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filename: 'ankify-img-1.png',
+          data: Buffer.from('PNGDATA').toString('base64'),
+        })
+      );
+      expect(result.errors).toEqual([]);
+    });
   });
 });

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import instrumentedAxios from '../../services/observability/instrumentedAxios';
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
 import { AnkifySyncMappingsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncMappingsRepository';
 import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncConflictsRepository';
@@ -80,7 +81,19 @@ const BACK_FIELD_BASIC = 'Back';
 const DECK_PARENT = 'Notion Sync';
 const DECK_TITLE_FALLBACK = 'Untitled';
 
-export type AnkifyMediaFetcher = typeof fetch;
+export interface AnkifyMediaResponse {
+  status: number;
+  data: Buffer;
+}
+
+export type AnkifyMediaFetcher = (url: string) => Promise<AnkifyMediaResponse>;
+
+const guardedMediaFetcher: AnkifyMediaFetcher = async (url) => {
+  const response = await instrumentedAxios.get<Buffer>('notion', url, {
+    responseType: 'arraybuffer',
+  });
+  return { status: response.status, data: Buffer.from(response.data) };
+};
 
 export type AnkifyZeroReasonCode =
   | 'empty_page'
@@ -122,9 +135,6 @@ const summarizeCardErrors = (errors: string[]): string | null => {
   return `${errors.length} ${noun} failed: ${errors[0]}`;
 };
 
-const arrayBufferToBase64 = (buffer: ArrayBuffer): string =>
-  Buffer.from(buffer).toString('base64');
-
 function isNotionNotFoundError(error: unknown): boolean {
   return (
     error != null &&
@@ -156,7 +166,7 @@ export class SyncNotionPageToRacUseCase {
     private readonly ankiConnect: AnkiConnectFactory,
     private readonly notionFetcher: NotionFetcherFactory,
     private readonly notionPageMeta?: NotionPageMetaFetcher,
-    private readonly mediaFetcher: AnkifyMediaFetcher = fetch,
+    private readonly mediaFetcher: AnkifyMediaFetcher = guardedMediaFetcher,
     private readonly errorEvents?: IErrorEventRepository,
     private readonly onTokenInvalid?: OnTokenInvalidFn
   ) {}
@@ -371,13 +381,12 @@ export class SyncNotionPageToRacUseCase {
     }
     try {
       const response = await this.mediaFetcher(ref.url);
-      if (!response.ok) {
+      if (response.status < 200 || response.status >= 300) {
         throw new Error(`HTTP ${response.status}`);
       }
-      const buffer = await response.arrayBuffer();
       await ac.storeMediaFile({
         filename: ref.filename,
-        data: arrayBufferToBase64(buffer),
+        data: response.data.toString('base64'),
       });
     } catch (error) {
       result.errors.push(


### PR DESCRIPTION
## What
The Ankify Notion-page sync fetched card media with raw \`fetch\`, with no SSRF protection. This routes the media fetch through \`instrumentedAxios\` on the \`notion\` channel so private IPs are blocked and DNS is pinned.

## Why
An external security report flagged a confirmed SSRF in \`SyncNotionPageToRacUseCase.uploadSingleMediaRef\`. The media URL is derived from a Notion external image/video/audio/file block (\`external.url\`), which is user-controlled. An authenticated Ankify user could point it at an internal/private destination (e.g. link-local metadata endpoints, loopback, RFC1918); the server would fetch and store the response. Reachable during manual, polling, and webhook-triggered Ankify sync.

This is distinct from the bookmark-metadata SSRF (separate PR in flight); no shared files touched.

## How
- New \`guardedMediaFetcher\` default routes through \`instrumentedAxios.get('notion', url, { responseType: 'arraybuffer' })\` — same pattern as \`downloadMediaOrSkip\`. The \`notion\` channel allows any public host but rejects private/loopback/link-local addresses and pins DNS to the resolved address, exactly right for arbitrary external media.
- \`AnkifyMediaFetcher\` type and \`uploadSingleMediaRef\` adapted to the axios response shape (\`.status\`, Buffer \`.data\`) instead of the fetch \`Response\` shape (\`.ok\`, \`.arrayBuffer()\`). Existing try/catch logging path preserved.
- The injectable \`mediaFetcher\` seam is kept so tests can substitute a fake.
- Two route call sites that explicitly passed raw \`fetch\` (\`AnkifyRouter\`, \`AnkifyWebhookRouter\`) now fall back to the guarded default. The polling path in \`data_layer/index.ts\` already used the default.

## Measuring success
The guard records each blocked attempt via the observability sink (\`recordOutboundCall\` on the \`notion\` service with the rejected endpoint) and the refusal surfaces as a per-card error in the sync log payload (\`errors[]\`). A private-host media URL now produces a \`HTTP\`/observability rejection error in \`ankify_sync_logs\` instead of a stored file; legitimate \`prod-files.notion.so\` media still stores.

## Testing
- Unit tests added (colocated, \`SyncNotionPageToRacUseCase.test.ts\`), under \`describe('default media fetcher routes through the SSRF guard')\`:
  - refuses a loopback media URL (\`http://127.0.0.1/...\`) — no axios call, no media stored, error recorded
  - refuses a link-local metadata URL (\`http://169.254.169.254/...\`) — no media stored
  - fetches a public media URL through the guard (DNS mocked to a public IP, axios mocked) and stores the bytes base64-encoded
- Mocks only the external edge (\`axios\`, \`node:dns\`); the real \`instrumentedAxios\` guard runs in the loop.
- All 25 tests in the file pass; ankify route + usecase suites (64 tests) green; server \`tsc -p .\` clean.

## Browser check
Browser check: not applicable — no \`web/src\` changes (server-only SSRF fix).

## Changelog
No entry — internal security fix, no user-visible behavior change.

## Sonar
\`sonar-scanner\` not run locally — \`SONAR_TOKEN\` unset in this environment. Change is a small, scoped use-case edit; expect the analysis to run on CI.

## Risks
Legitimate Notion media on public hosts is unaffected (the \`notion\` channel has a null host allowlist — any public host passes). The only behavior change is that private/loopback/link-local media URLs are now refused, which is the intended fix. Rollback: revert the commit; the previous default was raw \`fetch\`.

\`/security-review\` should run before merge.

## Goal alignment
Closes an SSRF hole on an authenticated paid surface. Trust and safety on paid features protects the path to 300K users; a server-side request forgery on the box is a credibility and infrastructure risk that scales badly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782826416&installation_id=132681956&pr_number=2978&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2978&signature=4186d97ba5198c803341304b40ccd77a0477ccc8a6395c82e3e50910c327ab71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->