### PR TITLE
fix: drop Auto Sync wording from mind map limit modal

### DIFF
--- a/web/src/pages/MindmapsPage/MindmapLimitModal.test.tsx
+++ b/web/src/pages/MindmapsPage/MindmapLimitModal.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MindmapLimitModal } from './MindmapLimitModal';
+
+function renderModal() {
+  return render(
+    <MemoryRouter>
+      <MindmapLimitModal onClose={() => {}} />
+    </MemoryRouter>,
+  );
+}
+
+describe('MindmapLimitModal', () => {
+  it('offers a generic upgrade line', () => {
+    renderModal();
+    expect(
+      screen.getByText(/Upgrade for unlimited mind maps\./),
+    ).toBeDefined();
+  });
+
+  it('does not mention Auto Sync', () => {
+    const { container } = renderModal();
+    expect(container.textContent).not.toMatch(/Auto[\s-]?Sync/i);
+  });
+});

--- a/web/src/pages/MindmapsPage/MindmapLimitModal.tsx
+++ b/web/src/pages/MindmapsPage/MindmapLimitModal.tsx
@@ -12,8 +12,8 @@ export function MindmapLimitModal({ onClose }: Readonly<MindmapLimitModalProps>)
       <div className={styles.header}>
         <h1 className={styles.heading}>You've used all 3 maps this month</h1>
         <p className={styles.subheading}>
-          Free accounts can have 3 mind maps at a time. Upgrade to Auto-Sync to
-          create as many as you need.
+          Free accounts can have 3 mind maps at a time. Upgrade for unlimited
+          mind maps.
         </p>
       </div>
       <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>


### PR DESCRIPTION
## What
The mind map limit modal told free users to "Upgrade to Auto-Sync to create as many as you need." This swaps that single line for a generic "Upgrade for unlimited mind maps." The Upgrade button and its `<Link to=\"/pricing\">` were already generic and are unchanged.

## Why
We're pulling Auto Sync from upsell copy. This is the copy-only slice; a separate larger PR handles the rest of the Auto Sync removal. No logic or link change.

## How
One-line copy edit in `MindmapLimitModal.tsx` plus a colocated Vitest test that asserts the new line renders and that no `Auto[\s-]?Sync` wording remains in the modal.

## Measuring success
The modal renders "Upgrade for unlimited mind maps." for free users at the 3-map cap; the new test guards against the Auto Sync string creeping back.

## Testing
- Unit tests added: `MindmapLimitModal.test.tsx` — asserts the generic upgrade line renders and the modal contains no Auto Sync wording.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Copy-only change inside the existing paywall modal; verified the modal renders the new line and the Upgrade link still points at /pricing.

## Changelog
No changelog — minor copy tweak inside a paywall modal; not worth a What's New entry.

## Risks
None beyond the single string. Rollback is a one-line revert.

## Goal alignment
Keeps upsell copy pointed at the plans we actually sell, so users hitting the mind map cap get a coherent path to upgrade — supporting conversion toward the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782828806&installation_id=132681956&pr_number=2979&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2979&signature=6f6c05c1b59224e20de2504b0ce9d8ddbcbede3601919e849d5490398d326712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->