### PR TITLE
fix: stop showing logged-in users the anonymous limit page

### DIFF
--- a/web/src/pages/LimitPage/LimitPage.module.css
+++ b/web/src/pages/LimitPage/LimitPage.module.css
@@ -9,6 +9,13 @@
   margin-bottom: 3rem;
 }
 
+.statusLine {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-warning);
+  margin: 0 0 var(--space-2);
+}
+
 .heading {
   font-size: clamp(1.5rem, 4vw, 2.25rem);
   font-weight: var(--font-bold);

--- a/web/src/pages/LimitPage/LimitPage.test.tsx
+++ b/web/src/pages/LimitPage/LimitPage.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HelmetProvider } from 'react-helmet-async';
 import { LimitPage } from './LimitPage';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
 
 vi.mock('../../lib/analytics/track', () => ({
   track: vi.fn(),
@@ -19,13 +20,31 @@ vi.mock('../../lib/backend/get2ankiApi', () => ({
 }));
 
 vi.mock('../../lib/hooks/useUserLocals', () => ({
-  useUserLocals: vi.fn(() => ({
-    data: {
-      user: { id: 1, email: 'test@example.com' },
-    },
-    isLoading: false,
-  })),
+  useUserLocals: vi.fn(),
 }));
+
+const mockedUseUserLocals = vi.mocked(useUserLocals);
+
+function asLoggedIn() {
+  mockedUseUserLocals.mockReturnValue({
+    data: { user: { id: 1, email: 'test@example.com' } },
+    isLoading: false,
+  } as ReturnType<typeof useUserLocals>);
+}
+
+function asAnonymous() {
+  mockedUseUserLocals.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+  } as ReturnType<typeof useUserLocals>);
+}
+
+function asLoading() {
+  mockedUseUserLocals.mockReturnValue({
+    data: undefined,
+    isLoading: true,
+  } as ReturnType<typeof useUserLocals>);
+}
 
 function renderPage(initialEntries: string[] = ['/limit']) {
   const queryClient = new QueryClient({
@@ -46,6 +65,7 @@ function renderPage(initialEntries: string[] = ['/limit']) {
 describe('LimitPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    asLoggedIn();
   });
 
   it('shows the monthly limit message', () => {
@@ -102,33 +122,72 @@ describe('LimitPage', () => {
       expect(globalThis.location.href).toBe('https://checkout.stripe.com/pass');
     });
   });
+
+  it('shows the logged-in upgrade view even when the URL says kind=anonymous', () => {
+    asLoggedIn();
+    renderPage(['/limit?kind=anonymous']);
+    expect(screen.getByText('You reached 100 cards this month')).toBeTruthy();
+    expect(screen.getByText('Get Auto Sync')).toBeTruthy();
+    expect(screen.queryByText('Sign up free')).toBeNull();
+    expect(screen.queryByText('Sign up free and finish converting')).toBeNull();
+  });
 });
 
 describe('LimitPage — anonymous variant', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    asAnonymous();
   });
 
-  it('shows the sign-up heading for kind=anonymous', () => {
-    renderPage(['/limit?kind=anonymous']);
-    expect(screen.getByText('Sign up free to keep converting')).toBeTruthy();
+  it('shows the status line explaining the conversion stopped', () => {
+    renderPage();
+    expect(
+      screen.getByText('Conversion stopped — you reached the 21-card limit')
+    ).toBeTruthy();
   });
 
-  it('shows a "Sign up free" CTA pointing at /register', () => {
-    renderPage(['/limit?kind=anonymous']);
-    const cta = screen.getByText('Sign up free');
+  it('shows the no-account heading', () => {
+    renderPage();
+    expect(
+      screen.getByText('You hit the limit for converting without an account')
+    ).toBeTruthy();
+  });
+
+  it('shows a "Sign up free and finish converting" CTA pointing at /register', () => {
+    renderPage();
+    const cta = screen.getByText('Sign up free and finish converting');
     expect(cta.closest('a')?.getAttribute('href')).toBe('/register?redirect=/upload');
   });
 
+  it('lists the cap-fix benefit first', () => {
+    renderPage();
+    expect(screen.getByText('Convert up to 100 cards a month')).toBeTruthy();
+  });
+
   it('keeps a secondary Sign in link', () => {
-    renderPage(['/limit?kind=anonymous']);
+    renderPage();
     const signIn = screen.getByText('Sign in');
     expect(signIn.closest('a')?.getAttribute('href')).toBe('/login?redirect=/upload');
   });
 
   it('does not show the monthly-limit upgrade UI for anonymous users', () => {
-    renderPage(['/limit?kind=anonymous']);
+    renderPage();
     expect(screen.queryByText('You reached 100 cards this month')).toBeNull();
     expect(screen.queryByText('Get Auto Sync')).toBeNull();
+  });
+});
+
+describe('LimitPage — loading state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asLoading();
+  });
+
+  it('does not show the anonymous variant while user locals are loading', () => {
+    renderPage(['/limit?kind=anonymous']);
+    expect(screen.queryByText('Sign up free and finish converting')).toBeNull();
+    expect(
+      screen.queryByText('You hit the limit for converting without an account')
+    ).toBeNull();
   });
 });

--- a/web/src/pages/LimitPage/LimitPage.tsx
+++ b/web/src/pages/LimitPage/LimitPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { track } from '../../lib/analytics/track';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
@@ -14,6 +14,9 @@ import {
 import styles from './LimitPage.module.css';
 
 const REF = 'limit-wall';
+
+const ANONYMOUS_CARD_CAP = 21;
+const FREE_MONTHLY_CARDS = 100;
 
 const UNLIMITED_BENEFITS = [
   'Unlimited flashcards',
@@ -37,14 +40,20 @@ function AnonymousLimit() {
   return (
     <div className={styles.page}>
       <Helmet>
-        <title>Sign up free to keep converting | 2anki</title>
+        <title>You reached the conversion limit | 2anki</title>
       </Helmet>
 
       <header className={styles.header}>
-        <h1 className={styles.heading}>Sign up free to keep converting</h1>
+        <p className={styles.statusLine}>
+          Conversion stopped — you reached the {ANONYMOUS_CARD_CAP}-card limit
+        </p>
+        <h1 className={styles.heading}>
+          You hit the limit for converting without an account
+        </h1>
         <p className={styles.subheading}>
-          A free account converts up to 100 cards a month. Without an account,
-          conversions are capped at 21 cards.
+          Without an account, conversions stop at {ANONYMOUS_CARD_CAP} cards. A
+          free account raises that to {FREE_MONTHLY_CARDS} cards a month — same
+          conversion, no cap to worry about.
         </p>
       </header>
 
@@ -52,7 +61,9 @@ function AnonymousLimit() {
         <div className={`${styles.planCard} ${styles.planCardFeatured}`}>
           <p className={styles.planTitle}>Free account</p>
           <ul className={styles.planBenefits}>
-            <li className={styles.planBenefit}>Up to 100 cards a month</li>
+            <li className={styles.planBenefit}>
+              Convert up to {FREE_MONTHLY_CARDS} cards a month
+            </li>
             <li className={styles.planBenefit}>Save and re-download your decks</li>
             <li className={styles.planBenefit}>Connect Notion, Dropbox, and Google Drive</li>
           </ul>
@@ -66,7 +77,7 @@ function AnonymousLimit() {
               })
             }
           >
-            Sign up free
+            Sign up free and finish converting
           </Link>
         </div>
       </div>
@@ -79,8 +90,7 @@ function AnonymousLimit() {
 }
 
 export function LimitPage() {
-  const [searchParams] = useSearchParams();
-  const { data: userLocals } = useUserLocals();
+  const { data: userLocals, isLoading } = useUserLocals();
   const email = userLocals?.user?.email;
   const isLoggedIn = userLocals?.user?.id != null;
   const [autoSyncPending, setAutoSyncPending] = useState(false);
@@ -89,13 +99,16 @@ export function LimitPage() {
   const [weekPassPending, setWeekPassPending] = useState(false);
   const [passError, setPassError] = useState<string | null>(null);
 
-  const kind = searchParams.get('kind');
-  const showAnonymous = kind === 'anonymous' || !isLoggedIn;
+  const showAnonymous = !isLoggedIn;
 
   useEffect(() => {
-    if (showAnonymous) return;
+    if (isLoading || showAnonymous) return;
     track('paywall_shown', { surface: REF });
-  }, [showAnonymous]);
+  }, [isLoading, showAnonymous]);
+
+  if (isLoading) {
+    return <div className={styles.page} aria-busy="true" />;
+  }
 
   if (showAnonymous) {
     return <AnonymousLimit />;

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-limit-page-clarity.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-limit-page-clarity.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-limit-page-clarity",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Hitting the free limit now explains what happened and shows the right options whether or not you're signed in"
+}


### PR DESCRIPTION
## What
Fixes the limit page picking the anonymous "Sign up free" variant for signed-in users, and rewrites the anonymous variant so a user who hit the no-account cap understands what happened and what to do next.

## Why
A Hotjar recording showed a logged-in user landing on `/limit?kind=anonymous` and getting a sign-up wall — useless to someone who already has an account. The server emits `?kind=anonymous` on an ownerless Notion retry, and variant selection was OR-ing the param with auth state (`kind === 'anonymous' || !isLoggedIn`), so the param won. Separately, anonymous users hitting the cap didn't realize they'd hit a limit and retry-looped.

## How
- Variant selection now keys off real auth state only: `const showAnonymous = !isLoggedIn;`. The `?kind=anonymous` param no longer overrides a logged-in session (`useSearchParams`/`kind` dropped — unused).
- `useUserLocals` exposes `isLoading`. While loading, `isLoggedIn` is false, so a logged-in user would briefly flash the anonymous wall. The page now renders a neutral loading state (`aria-busy`) until locals resolve, then commits to a variant.
- Anonymous variant copy (designer-approved): warning status line above the heading, a heading naming the no-account cause, a subheading + benefits + CTA pointing at the fix, updated Helmet title. The `21`-card cap and `100`-card free allowance are pulled into single named constants (`ANONYMOUS_CARD_CAP`, `FREE_MONTHLY_CARDS`) referenced in the status line, subheading, and card so they can't drift.
- New `.statusLine` CSS class uses the existing `--color-warning` (amber) token and `--space-2` — amber, not danger red, because the state is recoverable.

The Auto Sync / Unlimited / pass card block was left untouched (separate PR owns it).

## Measuring success
`paywall_shown` with `variant: 'anonymous'` should drop relative to total `paywall_shown` once logged-in users stop being routed into the anonymous wall, and `paywall_upgrade_clicked { plan: 'free_signup' }` from already-authenticated sessions should fall to ~zero. The anonymous variant's status-line copy should lift the `free_signup` click-through among genuinely-anonymous sessions.

## Testing
Unit tests added/updated in `LimitPage.test.tsx`:
- New: **shows the logged-in upgrade view even when the URL says kind=anonymous** — the regression test for the bug. Mocks `useUserLocals` as logged-in, renders `/limit?kind=anonymous`, asserts the upgrade UI is present and neither "Sign up free" nor "Sign up free and finish converting" renders. Verified it fails against the old `kind === 'anonymous' || !isLoggedIn` line before the fix.
- New: anonymous-variant tests assert the status line, no-account heading, cap-fix-first benefit, and new CTA.
- New: loading-state test asserts the anonymous wall does not render while locals load.
- `useUserLocals` is now mocked per-test (logged-in / anonymous / loading).

All 16 LimitPage tests pass; full web suite green (1543 passed). Typecheck + Biome lint clean.

Sonar: not run locally — `SONAR_TOKEN` unset on this box. Change is a single localized component with no new HTTP/HTML-render/zip/path surface; expect CI Sonar to be clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified via the test suite and reading the rendered DOM (logged-in upgrade view, anonymous variant copy, loading state). The amber status line uses an existing theme token.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-05-31-limit-page-clarity.json` — "Hitting the free limit now explains what happened and shows the right options whether or not you're signed in"

## Risks
Low — UI-only, scoped to one page. Rollback is reverting this PR. The server-side root cause (logged-in Notion retries hitting the ownerless `AnonymousCardCapError` path in `UploadService.ts`, which is what emits `?kind=anonymous`) is a **separate follow-up, not fixed here** — this PR makes the client robust to that param regardless.

## Goal alignment
Conversion-funnel fix: stops sending signed-in users to a dead-end sign-up wall, and makes the genuine-anonymous wall explain the limit so users sign up and finish converting instead of retry-looping — both feed the upload → download → signup funnel toward the 300K goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782828846&installation_id=132681956&pr_number=2980&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2980&signature=a9ffe213046985baf07f39e8caf5a3afb6b8a78b83f8d8ca49710320dcdcb9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->