### PR TITLE
fix: stop surfacing transient job-poll errors as a raw banner

### DIFF
--- a/web/src/lib/backend/api.test.ts
+++ b/web/src/lib/backend/api.test.ts
@@ -26,20 +26,27 @@ describe('api.get error tagging', () => {
     );
   });
 
-  it('attaches url and method as properties on the thrown error', async () => {
+  it('attaches url, method, and status as properties on the thrown error', async () => {
     fetchSpy.mockResolvedValueOnce(
-      new Response(JSON.stringify({ message: 'boom' }), { status: 500 })
+      new Response(JSON.stringify({ message: 'boom' }), { status: 503 })
     );
 
-    let caught: (Error & { url?: string; method?: string }) | undefined;
+    let caught:
+      | (Error & { url?: string; method?: string; status?: number })
+      | undefined;
     try {
       await get('http://localhost/api/uploads');
     } catch (e) {
-      caught = e as Error & { url?: string; method?: string };
+      caught = e as Error & {
+        url?: string;
+        method?: string;
+        status?: number;
+      };
     }
 
     expect(caught?.url).toBe('/api/uploads');
     expect(caught?.method).toBe('GET');
+    expect(caught?.status).toBe(503);
   });
 
   it('tags network failures with the URL', async () => {

--- a/web/src/lib/backend/api.ts
+++ b/web/src/lib/backend/api.ts
@@ -83,7 +83,8 @@ export const get = async (
     throw taggedHttpError(
       `Network error on GET ${pathOf(url)}: ${cause instanceof Error ? cause.message : String(cause)}`,
       'GET',
-      url
+      url,
+      0
     );
   }
 
@@ -100,7 +101,8 @@ export const get = async (
       throw taggedHttpError(
         `Resource not found: ${response.status} ${response.statusText}`,
         'GET',
-        url
+        url,
+        response.status
       );
     }
     const errorData = await response
@@ -112,7 +114,8 @@ export const get = async (
     throw taggedHttpError(
       `HTTP error! GET ${pathOf(url)} status: ${response.status}, message: ${errorData.message}`,
       'GET',
-      url
+      url,
+      response.status
     );
   }
 
@@ -127,10 +130,20 @@ function pathOf(url: string): string {
   }
 }
 
-function taggedHttpError(message: string, method: string, url: string): Error {
-  const err = new Error(message) as Error & { url?: string; method?: string };
+function taggedHttpError(
+  message: string,
+  method: string,
+  url: string,
+  status: number
+): Error {
+  const err = new Error(message) as Error & {
+    url?: string;
+    method?: string;
+    status?: number;
+  };
   err.url = pathOf(url);
   err.method = method;
+  err.status = status;
   return err;
 }
 

--- a/web/src/pages/DownloadsPage/hooks/useJobs.test.tsx
+++ b/web/src/pages/DownloadsPage/hooks/useJobs.test.tsx
@@ -5,6 +5,7 @@ import useJobs from './useJobs';
 import Backend from '../../../lib/backend';
 import { UserNotice } from '../../../lib/errors/UserNotice';
 import { JobsId } from '../../../schemas/public/Jobs';
+import JobResponse from '../../../schemas/public/JobResponse';
 
 function makeMockBackend(): Backend {
   return {
@@ -64,6 +65,98 @@ describe('useJobs warmup window', () => {
     expect(notice.message).toBe(
       'This job is still running. Wait for it to finish.'
     );
+  });
+
+  it('keeps the last jobs and stays silent when a poll hits a transient 503', async () => {
+    const backend = makeMockBackend();
+    const job = { id: 7, status: 'done' } as unknown as JobResponse;
+    const transient = new Error(
+      'HTTP error! GET /upload/jobs status: 503, message: Service Unavailable'
+    ) as Error & { status?: number };
+    transient.status = 503;
+    (backend.getJobs as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([job])
+      .mockRejectedValueOnce(transient);
+    const setError = vi.fn();
+
+    const { result } = renderHook(() => useJobs(backend, setError));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.refreshJobs();
+    });
+
+    expect(setError).not.toHaveBeenCalled();
+    expect(result.current.jobs).toEqual([job]);
+  });
+
+  it('stays silent on a network/fetch poll failure and keeps the last jobs', async () => {
+    const backend = makeMockBackend();
+    const job = { id: 9, status: 'done' } as unknown as JobResponse;
+    const networkError = new Error(
+      'Network error on GET /upload/jobs: Failed to fetch'
+    ) as Error & { status?: number };
+    networkError.status = 0;
+    (backend.getJobs as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([job])
+      .mockRejectedValueOnce(networkError);
+    const setError = vi.fn();
+
+    const { result } = renderHook(() => useJobs(backend, setError));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await result.current.refreshJobs();
+    });
+
+    expect(setError).not.toHaveBeenCalled();
+    expect(result.current.jobs).toEqual([job]);
+  });
+
+  it('propagates an auth failure from a poll so the redirect path fires', async () => {
+    const backend = makeMockBackend();
+    const unauthorized = new UserNotice('Unauthorized') as UserNotice & {
+      status?: number;
+    };
+    unauthorized.status = 401;
+    (backend.getJobs as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      unauthorized
+    );
+    const setError = vi.fn();
+
+    renderHook(() => useJobs(backend, setError));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(setError).toHaveBeenCalledWith(unauthorized);
+  });
+
+  it('propagates a 403 forbidden poll failure instead of swallowing it', async () => {
+    const backend = makeMockBackend();
+    const forbidden = new Error(
+      'HTTP error! GET /upload/jobs status: 403, message: Forbidden'
+    ) as Error & { status?: number };
+    forbidden.status = 403;
+    (backend.getJobs as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      forbidden
+    );
+    const setError = vi.fn();
+
+    renderHook(() => useJobs(backend, setError));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(setError).toHaveBeenCalledWith(forbidden);
   });
 
   it('switches to 10000ms after warmup expires with no active jobs', async () => {

--- a/web/src/pages/DownloadsPage/hooks/useJobs.tsx
+++ b/web/src/pages/DownloadsPage/hooks/useJobs.tsx
@@ -14,6 +14,20 @@ interface UseJobsResult {
   lastFetchedAt: Date | null;
 }
 
+function statusOf(error: unknown): number | undefined {
+  if (error != null && typeof error === 'object' && 'status' in error) {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === 'number') return status;
+  }
+  return undefined;
+}
+
+function isTransientPollError(error: unknown): boolean {
+  const status = statusOf(error);
+  if (status == null) return false;
+  return status === 0 || status >= 500;
+}
+
 export default function useJobs(
   backend: Backend,
   setError: ErrorHandlerType
@@ -33,6 +47,7 @@ export default function useJobs(
       setJobs(active);
       setLastFetchedAt(new Date());
     } catch (error) {
+      if (isTransientPollError(error)) return;
       setError(error);
     }
   }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-downloads-poll-resilience.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-downloads-poll-resilience.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-downloads-poll-resilience",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Your decks list stays put when a refresh briefly fails instead of flashing a technical error"
+}


### PR DESCRIPTION
## What
The `/downloads` page polls `GET /api/upload/jobs` every few seconds. On any poll failure, the hook surfaced the raw thrown message in a prominent dismissible banner — a transient 503 during a deploy/drain window showed `HTTP error! GET /api/upload/jobs status: 503, message: Service Unavailable` to the user, then recovered on the next poll anyway. This stops that: a background poll that hits a transient failure now keeps showing the last successful jobs list and recovers silently.

## Why
A user screenshot showed the raw `HTTP error!` string in a top banner on `/downloads`. Root cause: `useJobs(backend, setError)` calls the page-level `setError` on every poll failure, and `classifyError` falls through to printing the stripped raw message. The 503 was transient (server restart). A routine background-poll hiccup must not slam a raw technical error in the user's face — it's also a mild info leak (CWE-209).

## How
- `useJobs.fetchJobs` now branches on the failure: transient errors (network/fetch or 5xx, identified by status `0` or `>= 500`) are swallowed — the last jobs stay rendered, the next poll recovers. Non-transient errors (401/403 and anything else) still propagate to `setError`, preserving the redirect-to-login path.
- To branch without string-matching the message, `taggedHttpError` in `api.ts` now carries the numeric HTTP `status` (`0` for network errors). It previously carried only `url` and `method`. `useJobs` reads it via a small `isTransientPollError` helper.
- Scope is tight to the jobs-poll path. `deleteJob` / `restartJob` (user-initiated) and the `useUploads` path are untouched.

## Measuring success
After deploy, the next deploy/drain window should no longer produce user reports of a raw `HTTP error! GET /api/upload/jobs status: 503` banner on `/downloads`. The jobs table stays populated through a brief 503; auth failures still bounce to `/login`.

## Testing
- Unit tests added (`useJobs.test.tsx`): a transient 503 poll stays silent and keeps the last jobs; a network/fetch poll failure stays silent and keeps the last jobs; a 401 propagates to `setError` (redirect path); a 403 propagates to `setError`.
- `api.test.ts`: the thrown error now carries `status` alongside `url`/`method`.
- Full web suite green: 1543 passed. Typecheck + Biome lint clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified `/downloads` renders the jobs list and the poll degrades gracefully; transient-failure path covered by unit tests.

## Changelog
`Your decks list stays put when a refresh briefly fails instead of flashing a technical error`

## Risks
Low. If a real, persistent jobs-endpoint outage (5xx) occurs, the page now shows a stale-but-last jobs list instead of an error — acceptable, and the page already displays `lastFetchedAt`. Auth (401/403) handling is preserved. Rollback: revert the single commit.

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` unset in this environment. Change is small (one helper + a status field); expect a clean scan, flag if it bounces.

## Goal alignment
Removes a scary raw-error banner from the core post-conversion surface (`/downloads`), where users land to grab their decks. A deploy-window hiccup no longer reads as "the product is broken" — directly supports the simpler/more-trustworthy experience behind the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782829428&installation_id=132681956&pr_number=2982&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2982&signature=21b9afede74b1fe3eef91685db9cf2ebd0fff983085bf74121f656422d862e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->