### PR TITLE
fix: correct /ops conversions tier join and normalize failure reasons

### DIFF
--- a/src/data_layer/JobsMetricsRepository.test.ts
+++ b/src/data_layer/JobsMetricsRepository.test.ts
@@ -119,6 +119,16 @@ describe('JobsMetricsRepository — counts cover the real Notion job types', () 
     expect(rate).toBeNull();
   });
 
+  it('counts paid conversions when owner is the numeric user id as a string', async () => {
+    await insertUser(db, '19848', 'cus_numeric');
+    await insertJob(db, { owner: '19848', object_id: 'n-1', type: 'page' });
+    await insertJob(db, { owner: '19848', object_id: 'n-2', type: 'database' });
+
+    const count = await repo.countPaidConversions7d(sevenDaysAgo);
+
+    expect(count).toBe(2);
+  });
+
   it('groups top failure reasons across Notion job types', async () => {
     await insertJob(db, {
       owner: 'free-user',
@@ -148,5 +158,66 @@ describe('JobsMetricsRepository — counts cover the real Notion job types', () 
       { reason: 'rate limit', count: 2 },
       { reason: 'timeout', count: 1 },
     ]);
+  });
+});
+
+interface CapturingRunner {
+  run(): Promise<unknown>;
+}
+
+interface CapturingClient {
+  runner(builder: { toQuery(): string }): CapturingRunner;
+}
+
+function captureCompiledSql(pg: Knex): () => string {
+  const client = pg.client as unknown as CapturingClient;
+  const originalRunner = client.runner.bind(client);
+  let captured = '';
+  client.runner = (builder: { toQuery(): string }) => {
+    const runner = originalRunner(builder);
+    runner.run = () => {
+      captured = builder.toQuery();
+      return Promise.reject(new Error('captured'));
+    };
+    return runner;
+  };
+  return () => captured;
+}
+
+describe('JobsMetricsRepository — tier join emits portable SQL on Postgres', () => {
+  let pg: Knex;
+
+  beforeEach(() => {
+    pg = knex({ client: 'pg' });
+  });
+
+  afterEach(async () => {
+    await pg.destroy();
+  });
+
+  it('casts users.id to text so it joins against the varchar jobs.owner', async () => {
+    const getSql = captureCompiledSql(pg);
+    const repo = new JobsMetricsRepository(pg);
+    const sevenDaysAgo = new Date('2026-05-01T00:00:00.000Z');
+
+    await repo.countPaidConversions7d(sevenDaysAgo).catch(() => undefined);
+
+    const sql = getSql();
+    expect(sql).toContain('CAST(users.id AS TEXT) = "jobs"."owner"');
+    expect(sql).toContain('"jobs"."type" in');
+    expect(sql).toContain(`"jobs"."status" = 'done'`);
+    expect(sql).toContain("users.stripe_customer_id IS NOT NULL");
+  });
+
+  it('emits the text cast for the free success-rate query too', async () => {
+    const getSql = captureCompiledSql(pg);
+    const repo = new JobsMetricsRepository(pg);
+    const sevenDaysAgo = new Date('2026-05-01T00:00:00.000Z');
+
+    await repo.computeFreeSuccessRate7d(sevenDaysAgo).catch(() => undefined);
+
+    const sql = getSql();
+    expect(sql).toContain('CAST(users.id AS TEXT) = "jobs"."owner"');
+    expect(sql).toContain("users.stripe_customer_id IS NULL");
   });
 });

--- a/src/data_layer/JobsMetricsRepository.ts
+++ b/src/data_layer/JobsMetricsRepository.ts
@@ -4,6 +4,7 @@ import type {
   ConversionErrorCount,
   FailedConversionsWeekPoint,
 } from '../services/ops/ConversionMetricsService';
+import { normalizeFailureReasons } from './normalizeFailureReasons';
 
 export interface IJobsMetricsRepository {
   countFreeConversions7d(sevenDaysAgo: Date): Promise<number>;
@@ -33,8 +34,13 @@ export class JobsMetricsRepository implements IJobsMetricsRepository {
     sevenDaysAgo: Date,
     tier: ConversionTier
   ): Knex.QueryBuilder {
+    const ownerJoin = this.database.raw(
+      'CAST(users.id AS TEXT) = "jobs"."owner"'
+    );
     return this.database('jobs')
-      .join('users', 'jobs.owner', '=', 'users.id')
+      .join('users', function joinOnUserId() {
+        this.on(ownerJoin);
+      })
       .where('jobs.created_at', '>=', sevenDaysAgo)
       .whereIn('jobs.type', NOTION_CONVERSION_TYPES)
       .whereRaw(tier === 'paid' ? PAID_CUSTOMER_FILTER : FREE_CUSTOMER_FILTER);
@@ -97,16 +103,16 @@ export class JobsMetricsRepository implements IJobsMetricsRepository {
       .whereNotNull('jobs.job_reason_failure')
       .select('jobs.job_reason_failure as reason')
       .count('jobs.id as count')
-      .groupBy('jobs.job_reason_failure')
-      .orderBy('count', 'desc')
-      .limit(10);
+      .groupBy('jobs.job_reason_failure');
 
-    return (
+    const rawRows = (
       results as Array<{ reason: string; count: number | string }>
     ).map((row) => ({
       reason: row.reason || 'Unknown',
       count: Number(row.count),
     }));
+
+    return normalizeFailureReasons(rawRows);
   }
 
   async failedConversionsWeekly(

--- a/src/data_layer/normalizeFailureReasons.test.ts
+++ b/src/data_layer/normalizeFailureReasons.test.ts
@@ -1,0 +1,84 @@
+import { normalizeFailureReasons } from './normalizeFailureReasons';
+
+describe('normalizeFailureReasons', () => {
+  it('excludes monthly_limit quota blocks entirely', () => {
+    const result = normalizeFailureReasons([
+      {
+        reason: JSON.stringify({
+          code: 'monthly_limit',
+          cards_used: 91,
+          limit: 100,
+        }),
+        count: 5,
+      },
+    ]);
+
+    expect(result).toEqual([]);
+  });
+
+  it('uses the code field from a JSON blob with a code', () => {
+    const result = normalizeFailureReasons([
+      { reason: JSON.stringify({ code: 'timeout' }), count: 3 },
+    ]);
+
+    expect(result).toEqual([{ reason: 'timeout', count: 3 }]);
+  });
+
+  it('buckets the empty-deck prose message to empty_deck', () => {
+    const result = normalizeFailureReasons([
+      {
+        reason:
+          "No cards in this deck yet. 2anki turns Notion toggle blocks into flashcards — the toggle title becomes the question, what's inside is the answer. Wrap your key terms in toggles in Notion, then convert again.",
+        count: 4,
+      },
+    ]);
+
+    expect(result).toEqual([{ reason: 'empty_deck', count: 4 }]);
+  });
+
+  it('passes a short plain string through unchanged', () => {
+    const result = normalizeFailureReasons([
+      { reason: 'notion_token_expired', count: 2 },
+    ]);
+
+    expect(result).toEqual([{ reason: 'notion_token_expired', count: 2 }]);
+  });
+
+  it('re-aggregates counts across rows that normalize to the same code', () => {
+    const result = normalizeFailureReasons([
+      { reason: JSON.stringify({ code: 'timeout', detail: 'a' }), count: 2 },
+      { reason: JSON.stringify({ code: 'timeout', detail: 'b' }), count: 3 },
+    ]);
+
+    expect(result).toEqual([{ reason: 'timeout', count: 5 }]);
+  });
+
+  it('sorts by count descending and limits to 10 reasons', () => {
+    const rows = Array.from({ length: 12 }, (_, i) => ({
+      reason: `reason_${i}`,
+      count: i + 1,
+    }));
+
+    const result = normalizeFailureReasons(rows);
+
+    expect(result).toHaveLength(10);
+    expect(result[0]).toEqual({ reason: 'reason_11', count: 12 });
+    expect(result.map((r) => r.reason)).not.toContain('reason_0');
+  });
+
+  it('buckets long prose to a stable stem so variants merge', () => {
+    const longProse =
+      'Something went wrong on our end converting this file. Job ID 123. Check status at 2anki.net/status.';
+    const longProseOther =
+      'Something went wrong on our end converting this file. Job ID 456. Check status at 2anki.net/status.';
+
+    const result = normalizeFailureReasons([
+      { reason: longProse, count: 2 },
+      { reason: longProseOther, count: 3 },
+    ]);
+
+    expect(result).toEqual([
+      { reason: 'Something went wrong on our end converti…', count: 5 },
+    ]);
+  });
+});

--- a/src/data_layer/normalizeFailureReasons.ts
+++ b/src/data_layer/normalizeFailureReasons.ts
@@ -1,0 +1,62 @@
+import type { ConversionErrorCount } from '../services/ops/ConversionMetricsService';
+
+const EXCLUDED_CODES = new Set(['monthly_limit']);
+
+const STEM_LENGTH = 40;
+const PROSE_THRESHOLD = STEM_LENGTH;
+
+const KNOWN_PROSE_BUCKETS: Array<{ prefix: string; code: string }> = [
+  { prefix: 'No cards in this deck yet.', code: 'empty_deck' },
+];
+
+interface RawFailureRow {
+  reason: string;
+  count: number;
+}
+
+function codeFromJsonBlob(reason: string): string | null {
+  if (!reason.trimStart().startsWith('{')) return null;
+  try {
+    const parsed = JSON.parse(reason) as { code?: unknown };
+    if (typeof parsed.code === 'string' && parsed.code.length > 0) {
+      return parsed.code;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function bucketProse(reason: string): string {
+  const known = KNOWN_PROSE_BUCKETS.find((bucket) =>
+    reason.startsWith(bucket.prefix)
+  );
+  if (known) return known.code;
+  if (reason.length > PROSE_THRESHOLD) {
+    return `${reason.slice(0, STEM_LENGTH).trimEnd()}…`;
+  }
+  return reason;
+}
+
+function normalizeReason(reason: string): string {
+  const code = codeFromJsonBlob(reason);
+  if (code != null) return code;
+  return bucketProse(reason);
+}
+
+export function normalizeFailureReasons(
+  rows: RawFailureRow[]
+): ConversionErrorCount[] {
+  const totals = new Map<string, number>();
+
+  for (const row of rows) {
+    const normalized = normalizeReason(row.reason);
+    if (EXCLUDED_CODES.has(normalized)) continue;
+    totals.set(normalized, (totals.get(normalized) ?? 0) + Number(row.count));
+  }
+
+  return Array.from(totals.entries())
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+}


### PR DESCRIPTION
## What
Fixes the `/ops/conversions` admin page, which showed `—` for every free/paid tier count and success rate, and listed raw JSON blobs and full prose strings as distinct "top failure reasons".

## Why
Internal admin metrics page was unusable. Two confirmed bugs in `src/data_layer/JobsMetricsRepository.ts`:

1. **Broken tier JOIN.** `conversionsForTier` joined `jobs.owner` (varchar) to `users.id` (integer). Postgres has no `varchar = integer` operator, so the four tier queries (`countFreeConversions7d`, `countPaidConversions7d`, `computeFreeSuccessRate7d`, `computePaidSuccessRate7d`) errored/returned nothing → frontend `formatNumberOrDash` rendered `—`. The failure-reasons and weekly-chart queries don't join `users`, which is why only the tier metrics broke.
2. **Unparsed failure reasons.** `topFailureReasons7d` grouped on the raw `job_reason_failure` text column, which holds mixed content — clean codes, full user-facing prose, and JSON blobs like `{"code":"monthly_limit",...}`. Each distinct blob became its own row instead of bucketing by a normalized code.

## How
1. Join now casts with portable `CAST(users.id AS TEXT)` (works on both Postgres prod and better-sqlite3 local), emitted via a single raw `on`-clause so knex's types stay happy.
2. New pure helper `src/data_layer/normalizeFailureReasons.ts`: for each raw row it parses JSON and uses `.code` when present, buckets the known empty-deck prose to `empty_deck`, buckets other long prose to a stable 40-char stem (so per-job-ID variants merge), passes short plain strings through, **excludes `monthly_limit`** (a quota/paywall block, not a conversion failure), re-aggregates by normalized reason, sorts desc, limits to 10. The repository fetches all distinct reasons in the window (no SQL `limit`) before bucketing, so excluding `monthly_limit` can't leave the top-10 short.

## Measuring success
After deploy, the `/ops/conversions` page renders real numbers for Free/Paid conversions and success rates instead of `—`, and the "Top failure reasons" panel shows short normalized codes (`empty_deck`, `timeout`, `notion_token_expired`, …) with no `monthly_limit` row.

## Metrics SQL verification
SQL was verified against the Postgres dialect via a generated-SQL test (`JobsMetricsRepository — tier join emits portable SQL on Postgres`) built on a real `knex({ client: 'pg' })` with no connection — it asserts the join compiles to `CAST(users.id AS TEXT) = "jobs"."owner"` plus the tier/type/status filters. A sqlite integration test (`counts paid conversions when owner is the numeric user id as a string`) proves the join returns rows for a seeded numeric-owner job.

## Testing
- Unit tests added: `normalizeFailureReasons.test.ts` — monthly_limit excluded, `{"code":"timeout"}` → `timeout`, empty-deck prose → `empty_deck`, plain string passthrough, re-aggregation sums across same-code rows, sort+limit-10, long-prose stem merge.
- Repository tests added: PG-dialect generated-SQL test for the join (count + success-rate queries), sqlite integration test for numeric-owner join.
- `/check`: server tsc clean; `pnpm test` for `src/data_layer/JobsMetricsRepository.test.ts`, `src/data_layer/normalizeFailureReasons.test.ts`, and `src/services/ops` all green (88 tests).

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files in the diff.

## Sonar
`sonar-scanner` is installed but `SONAR_TOKEN` is unset in this environment, so the rule engine was not run locally — expect the CI Sonar analysis to be the first pass. The change is small (one repository method + one pure helper) with no nested ternaries or new HTTP/HTML sinks.

## Changelog
No entry — internal admin page (`/ops/conversions`), no end-user-visible change.

## Risks
Low. The cast is portable across both dialects (verified by the generated-SQL test and the sqlite integration test). If a `jobs.owner` value is ever non-numeric it simply won't match a user row — same behavior as today, no crash. Rollback is a revert.

## Goal alignment
Restores the conversion-funnel visibility (free vs paid success rates, what's actually breaking) that the trio needs to prioritize work toward the 300K-user goal — the page is the instrument, this makes it read true.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782830589&installation_id=132681956&pr_number=2983&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2983&signature=8663241d96dbe6df2a73fb07695511d5776722b359a0a4d496d34ece15225667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->