### PR TITLE
fix: render full upload funnel stages on the ops tab

### DIFF
--- a/web/src/pages/OpsPage/UploadFunnelTab.test.tsx
+++ b/web/src/pages/OpsPage/UploadFunnelTab.test.tsx
@@ -58,8 +58,13 @@ describe('UploadFunnelTab', () => {
         conversion_succeeded: 11200,
         conversion_failed: 320,
         deck_downloaded: 10300,
+        paywall_shown: 4200,
+        signup: 3100,
+        paid: 620,
       },
       upload_to_download_rate_pct: 57.83,
+      download_to_signup_rate_pct: 30.1,
+      download_to_paid_rate_pct: 6.02,
       since: '2026-05-01T00:00:00.000Z',
       as_of: '2026-05-30T00:00:00.000Z',
     });
@@ -78,8 +83,25 @@ describe('UploadFunnelTab', () => {
     expect(
       screen.getByText('10 300', { normalizer: spaceNormalizer })
     ).toBeInTheDocument();
-    expect(screen.getByText('57.8%')).toBeInTheDocument();
+    expect(
+      screen.getByText('4200', { normalizer: spaceNormalizer })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('3100', { normalizer: spaceNormalizer })
+    ).toBeInTheDocument();
+    expect(screen.getByText('620')).toBeInTheDocument();
+
+    expect(screen.getByText('Paywall shown')).toBeInTheDocument();
+    expect(screen.getByText('Signup')).toBeInTheDocument();
+    expect(screen.getByText('Paid')).toBeInTheDocument();
     expect(screen.getByText('Conversion failed')).toBeInTheDocument();
+
+    expect(screen.getByText('Upload to download')).toBeInTheDocument();
+    expect(screen.getByText('57.8%')).toBeInTheDocument();
+    expect(screen.getByText('Download to signup')).toBeInTheDocument();
+    expect(screen.getByText('30.1%')).toBeInTheDocument();
+    expect(screen.getByText('Download to paid')).toBeInTheDocument();
+    expect(screen.getByText('6.0%')).toBeInTheDocument();
   });
 
   test('shows the zero state and an honest 0% rate when there are no uploads', async () => {
@@ -89,8 +111,13 @@ describe('UploadFunnelTab', () => {
         conversion_succeeded: 0,
         conversion_failed: 0,
         deck_downloaded: 0,
+        paywall_shown: 0,
+        signup: 0,
+        paid: 0,
       },
       upload_to_download_rate_pct: 0,
+      download_to_signup_rate_pct: 0,
+      download_to_paid_rate_pct: 0,
       since: '2026-05-01T00:00:00.000Z',
       as_of: '2026-05-30T00:00:00.000Z',
     });
@@ -100,13 +127,16 @@ describe('UploadFunnelTab', () => {
     await waitFor(() =>
       expect(screen.getByText('No uploads in this window')).toBeInTheDocument()
     );
-    expect(screen.getByText('0.0%')).toBeInTheDocument();
+    expect(screen.getAllByText('No downloads in this window')).toHaveLength(2);
+    expect(screen.getAllByText('0.0%')).toHaveLength(3);
   });
 
   test('renders the server error message in the danger banner', async () => {
     mockFetch({
       stages: null,
       upload_to_download_rate_pct: 0,
+      download_to_signup_rate_pct: 0,
+      download_to_paid_rate_pct: 0,
       since: '2026-05-01T00:00:00.000Z',
       as_of: '2026-05-30T00:00:00.000Z',
       error: 'relation "events" does not exist',

--- a/web/src/pages/OpsPage/UploadFunnelTab.tsx
+++ b/web/src/pages/OpsPage/UploadFunnelTab.tsx
@@ -26,21 +26,63 @@ const COUNT_TILES: CountTile[] = [
   { key: 'upload_started', label: 'Upload started', muted: false },
   { key: 'conversion_succeeded', label: 'Conversion succeeded', muted: false },
   { key: 'deck_downloaded', label: 'Deck downloaded', muted: false },
+  { key: 'paywall_shown', label: 'Paywall shown', muted: false },
+  { key: 'signup', label: 'Signup', muted: false },
+  { key: 'paid', label: 'Paid', muted: false },
   { key: 'conversion_failed', label: 'Conversion failed', muted: true },
 ];
+
+interface RateHero {
+  label: string;
+  rate: number;
+  numerator: keyof UploadFunnelStages;
+  denominator: keyof UploadFunnelStages;
+  numeratorNoun: string;
+  denominatorNoun: string;
+  emptyFootnote: string;
+}
 
 export default function UploadFunnelTab() {
   const { data, loading, error, window, setWindow, refresh } =
     useUploadFunnel();
 
   const stages = data?.stages ?? null;
-  const hasUploads = stages != null && stages.upload_started > 0;
+
+  const rateHeroes: RateHero[] = [
+    {
+      label: 'Upload to download',
+      rate: data?.upload_to_download_rate_pct ?? 0,
+      numerator: 'deck_downloaded',
+      denominator: 'upload_started',
+      numeratorNoun: 'a download',
+      denominatorNoun: 'uploads',
+      emptyFootnote: 'No uploads in this window',
+    },
+    {
+      label: 'Download to signup',
+      rate: data?.download_to_signup_rate_pct ?? 0,
+      numerator: 'signup',
+      denominator: 'deck_downloaded',
+      numeratorNoun: 'signup',
+      denominatorNoun: 'downloads',
+      emptyFootnote: 'No downloads in this window',
+    },
+    {
+      label: 'Download to paid',
+      rate: data?.download_to_paid_rate_pct ?? 0,
+      numerator: 'paid',
+      denominator: 'deck_downloaded',
+      numeratorNoun: 'a paid plan',
+      denominatorNoun: 'downloads',
+      emptyFootnote: 'No downloads in this window',
+    },
+  ];
 
   return (
     <>
       <p className={styles.panelTitle}>Upload funnel</p>
       <p className={styles.panelSubtitle}>
-        Distinct-identity counts per stage and the true upload-to-download rate.
+        Distinct-identity counts per stage, from upload through signup to paid.
       </p>
 
       <div className={styles.tabHeader}>
@@ -94,17 +136,24 @@ export default function UploadFunnelTab() {
 
       {stages != null && (
         <>
-          <div className={`${sharedStyles.surface} ${styles.rateHero}`}>
-            <p className={styles.rateHeroLabel}>Upload to download</p>
-            <p className={styles.rateHeroValue}>
-              {formatRate(data?.upload_to_download_rate_pct ?? 0)}
-            </p>
-            <p className={styles.rateHeroFootnote}>
-              {hasUploads
-                ? `${formatCount(stages.deck_downloaded)} of ${formatCount(stages.upload_started)} uploads reached a download`
-                : 'No uploads in this window'}
-            </p>
-          </div>
+          {rateHeroes.map((hero) => {
+            const denominatorCount = stages[hero.denominator];
+            const numeratorCount = stages[hero.numerator];
+            return (
+              <div
+                key={hero.label}
+                className={`${sharedStyles.surface} ${styles.rateHero}`}
+              >
+                <p className={styles.rateHeroLabel}>{hero.label}</p>
+                <p className={styles.rateHeroValue}>{formatRate(hero.rate)}</p>
+                <p className={styles.rateHeroFootnote}>
+                  {denominatorCount > 0
+                    ? `${formatCount(numeratorCount)} of ${formatCount(denominatorCount)} ${hero.denominatorNoun} reached ${hero.numeratorNoun}`
+                    : hero.emptyFootnote}
+                </p>
+              </div>
+            );
+          })}
 
           <div className={styles.cardGrid}>
             {COUNT_TILES.map((tile) => (

--- a/web/src/pages/OpsPage/uploadFunnelTypes.ts
+++ b/web/src/pages/OpsPage/uploadFunnelTypes.ts
@@ -3,11 +3,16 @@ export interface UploadFunnelStages {
   conversion_succeeded: number;
   conversion_failed: number;
   deck_downloaded: number;
+  paywall_shown: number;
+  signup: number;
+  paid: number;
 }
 
 export interface UploadFunnelResponse {
   stages: UploadFunnelStages | null;
   upload_to_download_rate_pct: number;
+  download_to_signup_rate_pct: number;
+  download_to_paid_rate_pct: number;
   since: string;
   as_of: string;
   error?: string;

--- a/web/src/pages/OpsPage/useUploadFunnel.test.ts
+++ b/web/src/pages/OpsPage/useUploadFunnel.test.ts
@@ -29,8 +29,13 @@ describe('useUploadFunnel', () => {
         conversion_succeeded: 80,
         conversion_failed: 20,
         deck_downloaded: 60,
+        paywall_shown: 40,
+        signup: 30,
+        paid: 6,
       },
       upload_to_download_rate_pct: 60,
+      download_to_signup_rate_pct: 50,
+      download_to_paid_rate_pct: 10,
       since: '2026-05-01T00:00:00.000Z',
       as_of: '2026-05-30T00:00:00.000Z',
     };
@@ -42,6 +47,9 @@ describe('useUploadFunnel', () => {
 
     await waitFor(() => expect(result.current.data).toEqual(payload));
 
+    expect(result.current.data?.stages?.paid).toBe(6);
+    expect(result.current.data?.download_to_signup_rate_pct).toBe(50);
+    expect(result.current.data?.download_to_paid_rate_pct).toBe(10);
     expect(result.current.window).toBe('30d');
     expect(globalThis.fetch).toHaveBeenCalledWith(
       '/api/ops/upload-funnel?window=30d',
@@ -57,8 +65,13 @@ describe('useUploadFunnel', () => {
           conversion_succeeded: 0,
           conversion_failed: 0,
           deck_downloaded: 0,
+          paywall_shown: 0,
+          signup: 0,
+          paid: 0,
         },
         upload_to_download_rate_pct: 0,
+        download_to_signup_rate_pct: 0,
+        download_to_paid_rate_pct: 0,
         since: '2026-05-01T00:00:00.000Z',
         as_of: '2026-05-30T00:00:00.000Z',
       })


### PR DESCRIPTION
## What
The `/ops` Upload funnel tab now renders the full funnel the backend computes: upload started → conversion succeeded → deck downloaded → paywall shown → signup → paid (plus the muted conversion-failed tile), and three conversion-rate heroes (upload→download, download→signup, download→paid).

## Why
The backend `/api/ops/upload-funnel` (`UploadFunnelService` / `EventsRepository.groupUploadFunnel`) returns the complete funnel, but the frontend types and tab were stale — only the original four stages and the single upload-to-download rate rendered. The new paid-conversion stages and rates were silently dropped.

## How
- `uploadFunnelTypes.ts` — added `paywall_shown`, `signup`, `paid` to `UploadFunnelStages` and `download_to_signup_rate_pct`, `download_to_paid_rate_pct` to `UploadFunnelResponse`, matching the server interfaces field-for-field.
- `UploadFunnelTab.tsx` — added the three stage tiles in funnel order and drove the rate heroes off a small data list so all three rates render with the existing `rateHero` surface (no new chart style).
- Updated both test files to mock the complete payload and assert the new stage counts and the two new rate values.

### Backend fields wired up
From `src/services/ops/UploadFunnelService.ts` (`UploadFunnelStages` / `UploadFunnelResponse`):
- Stages: `paywall_shown`, `signup` (from `account_created`), `paid` (from `checkout_completed`)
- Rates: `download_to_signup_rate_pct`, `download_to_paid_rate_pct`

## Measuring success
Open `/ops` → Upload funnel tab in prod: the Paywall shown / Signup / Paid tiles and the Download to signup / Download to paid rate heroes are populated from the live endpoint instead of being absent.

## Testing
- Unit tests updated: `UploadFunnelTab.test.tsx` (full-payload render asserts the new stages + all three rate labels/values; zero-state asserts 3×`0.0%` and 2×"No downloads in this window") and `useUploadFunnel.test.ts` (asserts `stages.paid`, `download_to_signup_rate_pct`, `download_to_paid_rate_pct`).
- `pnpm --filter 2anki-web typecheck`, the two funnel vitest files (9 tests), full web vitest suite (1541 tests), and Biome lint all green.
- sonar-scanner not run — `SONAR_TOKEN` unset in this environment. Change is a small data-driven render in one component; expect no new security findings.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Internal admin tab; verified the funnel tiles and rate heroes render for populated, zero, and error states.

## Changelog
No entry — internal admin page (`/ops`), not user-visible.

## Risks
Low. Type-and-render only; no backend or data change. If a field name ever drifts on the server the tile would show 0, not crash.

## Goal alignment
Indirect — the ops funnel tab is the instrument the team uses to find the biggest drop-off between upload, signup, and paid. Surfacing the paid-conversion stages is what makes those drop-offs visible, which is upstream of the 300K-user work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782831376&installation_id=132681956&pr_number=2984&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2984&signature=0027828ddf7c63c7eb8d300fb1dbd47d9af2f7ed1fb06381c7daaf7ce008dc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->