### PR TITLE
fix: show the current showcase on the ops showcase tab

### DIFF
--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -1,3 +1,27 @@
+.showcaseCurrent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.showcaseCurrentTitle {
+  font-size: var(--text-base);
+  font-weight: 500;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.showcaseStats {
+  display: flex;
+  gap: 2rem;
+}
+
+.showcaseStat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
 .header {
   display: flex;
   align-items: flex-start;

--- a/web/src/pages/OpsPage/ShowcaseTab.test.tsx
+++ b/web/src/pages/OpsPage/ShowcaseTab.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { getShowcase, ShowcaseData } from '../../lib/backend/getShowcase';
+import ShowcaseTab from './ShowcaseTab';
+
+vi.mock('../../lib/backend/getShowcase', () => ({
+  getShowcase: vi.fn(),
+}));
+
+vi.mock('../PreviewApkgPage/CardFrame', () => ({
+  CardFrame: ({ card }: { card: { templateName: string } }) => (
+    <div data-testid="card-frame">{card.templateName}</div>
+  ),
+}));
+
+const buildShowcase = (
+  overrides: Partial<ShowcaseData> = {}
+): ShowcaseData => ({
+  pageTitle: 'Organic Chemistry Ch. 4',
+  notionBlocks: [
+    {
+      id: 'b1',
+      type: 'paragraph',
+      hasChildren: false,
+      canExpand: false,
+      html: '<p>a</p>',
+    },
+    {
+      id: 'b2',
+      type: 'toggle',
+      hasChildren: true,
+      canExpand: true,
+      html: '',
+      summaryHtml: '<p>q</p>',
+    },
+  ],
+  ankiCards: [
+    {
+      id: 1,
+      ord: 0,
+      templateName: 'Card 1',
+      deckName: 'Chemistry',
+      deckPath: ['Chemistry'],
+      noteTypeName: 'Basic',
+      css: '',
+      front: 'Q',
+      back: 'A',
+    },
+  ],
+  populatedAt: '2026-05-30T10:00:00.000Z',
+  ...overrides,
+});
+
+describe('ShowcaseTab', () => {
+  beforeEach(() => {
+    vi.mocked(getShowcase).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('shows the current showcase fetched on mount', async () => {
+    vi.mocked(getShowcase).mockResolvedValue(buildShowcase());
+
+    render(<ShowcaseTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Organic Chemistry Ch. 4')).toBeInTheDocument()
+    );
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByTestId('card-frame')).toHaveTextContent('Card 1');
+  });
+
+  test('shows the empty state when no showcase is configured', async () => {
+    vi.mocked(getShowcase).mockResolvedValue(null);
+
+    render(<ShowcaseTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/No showcase configured/i)).toBeInTheDocument()
+    );
+  });
+});

--- a/web/src/pages/OpsPage/ShowcaseTab.tsx
+++ b/web/src/pages/OpsPage/ShowcaseTab.tsx
@@ -1,9 +1,18 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
+import { getShowcase, ShowcaseData } from '../../lib/backend/getShowcase';
 import sharedStyles from '../../styles/shared.module.css';
+import { CardFrame } from '../PreviewApkgPage/CardFrame';
 import styles from './OpsPage.module.css';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
+type CurrentStatus = 'loading' | 'loaded' | 'empty';
+
+function formatPopulatedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
 
 async function callOpsShowcase(
   method: 'POST' | 'DELETE',
@@ -23,7 +32,9 @@ async function callOpsShowcase(
   );
   if (!response.ok) {
     const data = await response.json().catch(() => ({}));
-    throw new Error(data.message ?? `${response.status} ${response.statusText}`);
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
   }
   return response.json();
 }
@@ -33,6 +44,21 @@ export default function ShowcaseTab() {
   const [apkgKey, setApkgKey] = useState('');
   const [status, setStatus] = useState<Status>('idle');
   const [message, setMessage] = useState('');
+  const [current, setCurrent] = useState<ShowcaseData | null>(null);
+  const [currentStatus, setCurrentStatus] = useState<CurrentStatus>('loading');
+  const [cardIndex, setCardIndex] = useState(0);
+
+  const loadCurrent = useCallback(async () => {
+    setCurrentStatus('loading');
+    const data = await getShowcase();
+    setCurrent(data);
+    setCardIndex(0);
+    setCurrentStatus(data == null ? 'empty' : 'loaded');
+  }, []);
+
+  useEffect(() => {
+    loadCurrent();
+  }, [loadCurrent]);
 
   const handlePopulate = async () => {
     if (pageId.trim().length === 0 || apkgKey.trim().length === 0) return;
@@ -45,6 +71,7 @@ export default function ShowcaseTab() {
       });
       setStatus('success');
       setMessage(result.message);
+      await loadCurrent();
     } catch (error) {
       setStatus('error');
       setMessage(error instanceof Error ? error.message : 'Unknown error');
@@ -60,6 +87,7 @@ export default function ShowcaseTab() {
       setMessage(result.message);
       setPageId('');
       setApkgKey('');
+      await loadCurrent();
     } catch (error) {
       setStatus('error');
       setMessage(error instanceof Error ? error.message : 'Unknown error');
@@ -73,6 +101,67 @@ export default function ShowcaseTab() {
         Populate the &ldquo;See it in action&rdquo; section on the homepage with
         a real Notion page and its converted Anki cards.
       </p>
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Current showcase</h2>
+        {currentStatus === 'loading' && (
+          <p className={styles.emptyHint}>Reading the current showcase</p>
+        )}
+        {currentStatus === 'empty' && (
+          <p className={styles.emptyHint}>
+            No showcase configured. Populate one below to show it on the
+            homepage.
+          </p>
+        )}
+        {currentStatus === 'loaded' && current && (
+          <div className={styles.showcaseCurrent}>
+            <p className={styles.showcaseCurrentTitle}>{current.pageTitle}</p>
+            <div className={styles.showcaseStats}>
+              <div className={styles.showcaseStat}>
+                <span className={styles.cardValue}>
+                  {current.notionBlocks.length}
+                </span>
+                <span className={styles.controlsLabel}>Notion blocks</span>
+              </div>
+              <div className={styles.showcaseStat}>
+                <span className={styles.cardValue}>
+                  {current.ankiCards.length}
+                </span>
+                <span className={styles.controlsLabel}>Anki cards</span>
+              </div>
+            </div>
+            <p className={styles.cardFootnote}>
+              Populated {formatPopulatedAt(current.populatedAt)}
+            </p>
+            {current.ankiCards[cardIndex] && (
+              <CardFrame card={current.ankiCards[cardIndex]} />
+            )}
+            {current.ankiCards.length > 1 && (
+              <div className={styles.controls}>
+                <button
+                  type="button"
+                  className={sharedStyles.btnSmall}
+                  onClick={() => setCardIndex((i) => i - 1)}
+                  disabled={cardIndex === 0}
+                >
+                  Previous card
+                </button>
+                <span className={styles.controlsLabel}>
+                  {cardIndex + 1} / {current.ankiCards.length}
+                </span>
+                <button
+                  type="button"
+                  className={sharedStyles.btnSmall}
+                  onClick={() => setCardIndex((i) => i + 1)}
+                  disabled={cardIndex === current.ankiCards.length - 1}
+                >
+                  Next card
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
 
       <section className={`${sharedStyles.surface} ${styles.card}`}>
         <h2 className={styles.cardTitle}>Populate</h2>


### PR DESCRIPTION
## What
The `/ops` Showcase tab rendered only the populate/purge form, so an admin could not see which Notion page and Anki cards were currently live on the homepage. This adds a "Current showcase" panel that fetches and displays the live showcase.

## Why
Internal admin gap: the tab is a write-only control with no read-back. An admin had no way to confirm what's configured without leaving the page and loading the homepage.

## How
Reused the existing public `GET /api/showcase` endpoint (no backend change). The shared typed client `getShowcase()` already returns `ShowcaseData | null` (page title, Notion blocks, Anki cards, populated time) and `null` on the 404 empty case. ShowcaseTab fetches on mount and re-fetches after a successful populate or purge, renders the page title, block/card counts, populated timestamp, and a card preview via the existing `CardFrame` component, with a carousel when more than one card. Shows an empty state when none is configured. No raw DB rows reach the client — the endpoint already maps to an explicit response shape.

## Measuring success
Open `/ops` → Showcase: the "Current showcase" panel shows the live page title and counts, or "No showcase configured" when empty. After populate/purge the panel reflects the new state without a reload. Confirms against the same `GET /api/showcase` the homepage uses.

## Testing
- Unit tests added: ShowcaseTab renders the fetched current showcase (title, counts, card preview) and shows the empty state when `getShowcase` returns null, mocking the API at the module edge.
- Full web suite: 1543 passed; web typecheck and Biome lint clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `/ops` admin tab; verified panel renders with a configured showcase, empty state with none, and refresh after populate/purge.

## Changelog
No entry — internal admin page (`/ops`), no user-visible change.

## Risks
Low. No backend or schema change; reuses the existing public read endpoint and the existing CardFrame renderer. If the showcase is empty the endpoint 404s and the client maps it to the empty state. Sonar was not run locally (no token/scanner configured) — expect a possible Sonar pass on CI.

## Goal alignment
Internal tooling. Lets the admin verify the homepage "See it in action" showcase, which is part of the landing-page conversion surface that feeds the 300K-user goal — keeping that section correct and current is easier when the admin can see what's live.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782831644&installation_id=132681956&pr_number=2985&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2985&signature=90346d1e808313bebde336d04e31835d3700f7c44f5c6dcdd5460a354d1edcea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->