### PR TITLE
fix: render Notion block equations as display math

### DIFF
--- a/src/lib/notion-render/renderBlocks.test.ts
+++ b/src/lib/notion-render/renderBlocks.test.ts
@@ -114,7 +114,24 @@ describe('renderNotionBlocks — text blocks', () => {
     expect(out.html).toContain(
       '<pre><code class="language-javascript">console.log(&quot;hi&quot;)</code></pre>'
     );
-    expect(out.html).toContain('\\(a + b\\)');
+    expect(out.html).toContain('\\[a + b\\]');
+  });
+
+  it('renders inline equations in rich text with inline delimiters', async () => {
+    const blocks: NotionRenderableBlock[] = [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            { plain_text: 'where ' },
+            { type: 'equation', equation: { expression: 'x^2' } },
+          ],
+        },
+      },
+    ];
+    const out = await renderNotionBlocks(blocks, noChildren);
+    expect(out.html).toContain('\\(x^2\\)');
+    expect(out.html).not.toContain('\\[x^2\\]');
   });
 });
 

--- a/src/lib/notion-render/renderBlocks.ts
+++ b/src/lib/notion-render/renderBlocks.ts
@@ -259,7 +259,7 @@ const renderCode = (block: NotionRenderableBlock): string => {
 const renderEquation = (block: NotionRenderableBlock): string => {
   const expr = block.equation?.expression;
   if (expr == null || expr === '') return '';
-  return `\\(${escapeHtml(expr)}\\)`;
+  return `\\[${escapeHtml(expr)}\\]`;
 };
 
 const renderChildPageTitle = (block: NotionRenderableBlock): string => {

--- a/src/services/NotionService/blocks/BlockEquation.test.ts
+++ b/src/services/NotionService/blocks/BlockEquation.test.ts
@@ -1,31 +1,40 @@
-import BlockEquation from './BlockEquation';
+import BlockEquation, { renderDisplayEquation } from './BlockEquation';
 import { EquationBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+
+function makeEquationBlock(expression: string): EquationBlockObjectResponse {
+  return {
+    object: 'block',
+    id: 'be5503f9-7544-460d-a500-fdc3c04431e8',
+    parent: {
+      type: 'block_id',
+      block_id: '0d75beab-5fbe-46b3-aeaa-bc64e765bb41',
+    },
+    created_time: '2022-12-25T19:32:00.000Z',
+    last_edited_time: '2022-12-25T19:32:00.000Z',
+    created_by: {
+      object: 'user',
+      id: 'aa',
+    },
+    last_edited_by: {
+      object: 'user',
+      id: 'aa',
+    },
+    has_children: false,
+    archived: false,
+    type: 'equation',
+    equation: { expression },
+  } as EquationBlockObjectResponse;
+}
 
 describe('BlockEquation', () => {
   test('MathJax transform', () => {
     const expected = '\\(\\sqrt{x}\\)';
-    const input = {
-      object: 'block',
-      id: 'be5503f9-7544-460d-a500-fdc3c04431e8',
-      parent: {
-        type: 'block_id',
-        block_id: '0d75beab-5fbe-46b3-aeaa-bc64e765bb41',
-      },
-      created_time: '2022-12-25T19:32:00.000Z',
-      last_edited_time: '2022-12-25T19:32:00.000Z',
-      created_by: {
-        object: 'user',
-        id: 'aa',
-      },
-      last_edited_by: {
-        object: 'user',
-        id: 'aa',
-      },
-      has_children: false,
-      archived: false,
-      type: 'equation',
-      equation: { expression: '\\sqrt{x}' },
-    } as EquationBlockObjectResponse;
-    expect(BlockEquation(input)).toBe(expected);
+    expect(BlockEquation(makeEquationBlock('\\sqrt{x}'))).toBe(expected);
+  });
+
+  test('renderDisplayEquation wraps in display delimiters', () => {
+    expect(renderDisplayEquation(makeEquationBlock('\\sqrt{x}'))).toBe(
+      '\\[\\sqrt{x}\\]'
+    );
   });
 });

--- a/src/services/NotionService/blocks/BlockEquation.ts
+++ b/src/services/NotionService/blocks/BlockEquation.ts
@@ -3,10 +3,18 @@ import {
   EquationRichTextItemResponse,
 } from '@notionhq/client/build/src/api-endpoints';
 
-export default function BlockEquation(
-  block: EquationBlockObjectResponse | EquationRichTextItemResponse
-) {
-  const { equation } = block;
-  const { expression } = equation;
+type EquationBlock =
+  | EquationBlockObjectResponse
+  | EquationRichTextItemResponse;
+
+export function renderInlineEquation(block: EquationBlock): string {
+  const { expression } = block.equation;
   return `\\(${expression}\\)`;
 }
+
+export function renderDisplayEquation(block: EquationBlock): string {
+  const { expression } = block.equation;
+  return `\\[${expression}\\]`;
+}
+
+export default renderInlineEquation;

--- a/src/services/NotionService/helpers/blockToStaticMarkup.test.ts
+++ b/src/services/NotionService/helpers/blockToStaticMarkup.test.ts
@@ -86,6 +86,28 @@ describe('blockToStaticMarkup', () => {
     expect(result).not.toContain('synced_block');
   });
 
+  it('renders a standalone equation block as display math', async () => {
+    const handler = makeHandler();
+    const equation = {
+      object: 'block',
+      id: 'equation-1',
+      type: 'equation',
+      equation: { expression: '\\sqrt{x}' },
+      parent: { type: 'page_id', page_id: 'page-1' },
+      created_time: '2026-05-21T07:46:00.000Z',
+      last_edited_time: '2026-05-21T07:46:00.000Z',
+      created_by: { object: 'user', id: 'user-1' },
+      last_edited_by: { object: 'user', id: 'user-1' },
+      has_children: false,
+      archived: false,
+      in_trash: false,
+    } as unknown as BlockObjectResponse;
+
+    const result = await blockToStaticMarkup(handler, equation);
+
+    expect(result).toBe('\\[\\sqrt{x}\\]');
+  });
+
   it('still emits the unsupported placeholder for genuinely unknown block types', async () => {
     const handler = makeHandler();
     const unknownBlock = {

--- a/src/services/NotionService/helpers/blockToStaticMarkup.ts
+++ b/src/services/NotionService/helpers/blockToStaticMarkup.ts
@@ -8,7 +8,7 @@ import { BlockCallout } from '../blocks/BlockCallout';
 import { BlockChildPage } from '../blocks/BlockChildPage';
 import BlockCode from '../blocks/BlockCode';
 import { BlockDivider } from '../blocks/BlockDivider';
-import BlockEquation from '../blocks/BlockEquation';
+import { renderDisplayEquation } from '../blocks/BlockEquation';
 import { BlockHeading } from '../blocks/BlockHeadings';
 import BlockParagraph from '../blocks/BlockParagraph';
 import { BlockQuote } from '../blocks/BlockQuote';
@@ -94,7 +94,7 @@ export const blockToStaticMarkup = async (
       back += await BlockColumnList(c, handler);
       break;
     case 'equation':
-      back += BlockEquation(c as EquationBlockObjectResponse);
+      back += renderDisplayEquation(c as EquationBlockObjectResponse);
       break;
     case 'link_to_page':
       back += await LinkToPage(c, handler);

--- a/src/services/NotionService/helpers/renderTextChildren.tsx
+++ b/src/services/NotionService/helpers/renderTextChildren.tsx
@@ -5,7 +5,7 @@ import {
 import ReactDOMServer from 'react-dom/server';
 import CardOption from '../../../lib/parser/Settings';
 
-import BlockEquation from '../blocks/BlockEquation';
+import { renderInlineEquation } from '../blocks/BlockEquation';
 import HandleBlockAnnotations from '../blocks/HandleBlockAnnotations';
 import isEquation from './isEquation';
 import isMention from './isMention';
@@ -22,7 +22,7 @@ export default function renderTextChildren(
   const content = text
     .map((t: RichTextItemResponse) => {
       if (isEquation(t)) {
-        return BlockEquation(t as EquationRichTextItemResponse);
+        return renderInlineEquation(t as EquationRichTextItemResponse);
       }
 
       if (isText(t) || isMention(t)) {

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-block-equation-display.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-block-equation-display.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-block-equation-display",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Block equations from Notion render as centered display math"
+}


### PR DESCRIPTION
## What
Standalone block equations from Notion now render as MathJax display math `\[...\]` (centered, larger) instead of inline `\(...\)`. Inline equations inside rich text stay inline `\(...\)`.

## Why
Refs #208. Block equations were emitting inline delimiters in both render paths, so they rendered small and inline rather than as centered display math the way Notion shows them.

## How
Two live render paths, fixed in both:
1. **Main conversion path** — `BlockEquation.ts` now exports `renderInlineEquation` (default) and `renderDisplayEquation`. The standalone-block call site (`helpers/blockToStaticMarkup.ts`, `case 'equation'`) uses `renderDisplayEquation`; the inline call site (`helpers/renderTextChildren.tsx`) uses `renderInlineEquation`. Two named functions, no boolean flag.
2. **Ankify auto-sync path** — `lib/notion-render/renderBlocks.ts` block-equation helper now emits `\[escapeHtml(expr)\]` (display); existing escaping unchanged. Inline `lib/notion-render/richText.ts` stays `\(...\)`.

## Measuring success
After deploy, a Notion page with a standalone block equation produces deck HTML containing `\[...\]`; spot-check a converted deck in Anki — the block equation renders centered/larger. No log line added (pure render change).

## Testing
- Unit tests added:
  - `BlockEquation.test.ts` — `renderDisplayEquation` → `\[\sqrt{x}\]`; inline test unchanged.
  - `blockToStaticMarkup.test.ts` — standalone equation block → `\[\sqrt{x}\]`.
  - `notion-render/renderBlocks.test.ts` — block equation → `\[...\]`; inline rich-text equation stays `\(...\)`.
  - `notion-render/richText.test.ts` inline assertion unchanged.
- All four suites green (34 server tests). Server tsc + web typecheck + web changelog-loader test green.

## Browser check
Browser check: not applicable — the only `web/src/` change is a changelog JSON entry; the code change is server-only.

## Changelog
`Block equations from Notion render as centered display math` (`web/src/pages/WhatsNewPage/changelog/2026-05-31-block-equation-display.json`).

## Sonar
`SONAR_TOKEN` unset locally — scanner not run. Change is a delimiter swap plus two small named functions with no new control flow, so Sonar risk is minimal; expect a clean gate.

## Risks
Low. If a downstream consumer relied on block equations being inline `\(...\)`, they now see display math — that is the intended fix. Rollback = revert the commit.

## Goal alignment
Cleaner, more faithful Notion → Anki conversion (equations render the way the source page shows them) supports the "simplest, fastest, most beautiful" mission and reduces a conversion-quality friction point.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782833380&installation_id=132681956&pr_number=2987&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2987&signature=98691fa00b34a3a4ea379f6cb0e4ae6c498767a19ebf99e2dbda5d96012a14b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->