### PR TITLE
style: lead the upload page with the deck you'll get

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -78,10 +78,13 @@ describe('UploadPage header', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the page subtitle', () => {
+  it('renders the page subtitle naming the deck quality and formats', () => {
     renderPage();
     expect(
-      screen.getByText(/Drop a file and get a clean Anki deck in seconds/i)
+      screen.getByText(/Drop a file and get a deck you don't have to fix/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Notion, PDF, Markdown, HTML, Word, and CSV too\./i)
     ).toBeInTheDocument();
   });
 });
@@ -134,6 +137,30 @@ describe('UploadPage AI badge anon link', () => {
     renderPage();
     const link = screen.getByRole('link', { name: /sign in to turn it on/i });
     expect(link).toHaveAttribute('href', '/login?redirect=/card-options');
+  });
+});
+
+describe('UploadPage AI badge placement', () => {
+  beforeEach(() => {
+    globalThis.sessionStorage.clear();
+  });
+
+  it('renders the AI badge after the upload form and before the explore card', () => {
+    renderPage();
+    const uploadForm = screen.getByTestId('upload-form-stub');
+    const exploreCard = screen.getByTestId('explore-card-stub');
+    const badge = screen
+      .getByRole('link', { name: /sign in to turn it on/i })
+      .closest('[role="status"]') as HTMLElement;
+    expect(badge).toBeInTheDocument();
+    expect(
+      uploadForm.compareDocumentPosition(badge) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      exploreCard.compareDocumentPosition(badge) &
+        Node.DOCUMENT_POSITION_PRECEDING
+    ).toBe(Node.DOCUMENT_POSITION_PRECEDING);
   });
 });
 

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -114,7 +114,9 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
       <header className={styles.pageHeader}>
         <h1 className={styles.title}>Convert your notes</h1>
         <p className={styles.subtitle}>
-          Drop a file and get a clean Anki deck in seconds
+          Drop a file and get a deck you don&apos;t have to fix — proper cloze,
+          atomic cards, the right note types. Notion, PDF, Markdown, HTML, Word,
+          and CSV too.
         </p>
       </header>
       <OnboardingTour
@@ -128,6 +130,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           <span> to convert</span>
         </div>
       )}
+      <UploadForm setErrorMessage={setErrorMessage} aiOn={isAiOn} />
       <div className={styles.aiOffBadge} role="status">
         {aiBadgeState === 'on' && (
           <>
@@ -175,7 +178,6 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           </>
         )}
       </div>
-      <UploadForm setErrorMessage={setErrorMessage} aiOn={isAiOn} />
       <ExploreCard />
       <section className={pageStyles.howItWorks}>
         <h2 className={pageStyles.howItWorksHeading}>How it works</h2>

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-upload-page-clarity.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-upload-page-clarity.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-upload-page-clarity",
+  "date": "2026-05-31",
+  "type": "style",
+  "title": "The upload page now says what kind of deck you'll get before you drop a file"
+}


### PR DESCRIPTION
## What
Rewrites the `/upload` page subtitle to name the deck quality and supported formats, and moves the AI on/off status badge from above the dropzone to below the upload form (before the explore card).

## Why
Hotjar shows visitors who land on `/upload` start an upload 34.8% of the time vs 42.5% on the homepage. Root cause (pm + designer): the header restated the dropzone instead of selling the outcome, and the AI-status warning badge sat above the dropzone as noise competing with the primary action. Target: close the gap toward the homepage's 42.5% activation rate.

## How
Copy + JSX reorder only — no new component, no logic, no CSS, no analytics changes.
- Subtitle now reads "Drop a file and get a deck you don't have to fix — proper cloze, atomic cards, the right note types. Notion, PDF, Markdown, HTML, Word, and CSV too."
- The entire `aiOffBadge` block (with its `role="status"`, the `aiBadgeState` memo, and all three `track()` view events) moved intact to sit after `<UploadForm />` and before `<ExploreCard />`. No badge copy or logic change.

## Measuring success
`upload_started` rate on `/upload` (Hotjar + the existing `upload_page_viewed` to upload funnel). Watch the 34.8% baseline move toward the homepage's 42.5%. The badge-view events (`upload_ai_anon/on/off_badge_viewed`) still fire, so badge engagement remains comparable post-move.

## Testing
- Unit tests updated in `UploadPage.test.tsx`: subtitle assertion now checks the new copy + format list; new test asserts the AI badge renders after the upload form and before the explore card via `compareDocumentPosition`.
- Scoped run: 13/13 UploadPage tests pass. Full web suite green (178 files), web typecheck green, Biome lint clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Copy + reorder verified in the rendered page; badge now sits under the dropzone in anon/on/off states.

## Changelog
"The upload page now says what kind of deck you'll get before you drop a file" — web/src/pages/WhatsNewPage/changelog/2026-05-31-upload-page-clarity.json

## Risks
Low — no logic touched. Subtitle is longer, so on narrow viewports it wraps to ~3 lines; acceptable. Rollback is a straight revert. sonar-scanner not run locally (SONAR_TOKEN unset); change is copy + JSX reorder with no new functions, so it falls under the trivial-change exception — expect a clean Sonar pass.

## Goal alignment
Activation is the upload funnel's biggest near-term lever. Closing a ~8-point gap between `/upload` and the homepage compounds directly into more decks created and more users retained, moving toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782833439&installation_id=132681956&pr_number=2988&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2988&signature=f481a57240a3f73953ff1d42b0e37716acdaff54f4776ff5b6184de6d61a0e4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->