### PR TITLE
fix: give the conversion pool the full deploy grace to drain

### DIFF
--- a/src/lib/conversionPool.test.ts
+++ b/src/lib/conversionPool.test.ts
@@ -17,8 +17,26 @@ import { NOTION_TOKEN_EXPIRED_REASON } from '../usecases/jobs/jobFailureReason';
 import {
   resolveConversionWorkers,
   runConversionInWorker,
+  shutdownConversionPool,
   ConversionWorkerRequest,
 } from './conversionPool';
+
+interface FakePoolHandle {
+  close: jest.Mock<Promise<void>, []>;
+  destroy: jest.Mock<Promise<void>, []>;
+  queueSize: number;
+}
+
+function fakePoolHandle(
+  closeImpl: () => Promise<void>,
+  queueSize = 0
+): FakePoolHandle {
+  return {
+    close: jest.fn(closeImpl),
+    destroy: jest.fn().mockResolvedValue(undefined),
+    queueSize,
+  };
+}
 
 const baseRequest: ConversionWorkerRequest = {
   id: 'notion-page-id',
@@ -120,5 +138,59 @@ describe('runConversionInWorker', () => {
     await expect(
       runConversionInWorker(baseRequest, () => fakeKnex)
     ).rejects.toThrow('boom');
+  });
+});
+
+describe('shutdownConversionPool', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    errorSpy.mockRestore();
+  });
+
+  it('lets an in-flight conversion finish inside the budget without force-destroying', async () => {
+    let release: (() => void) | null = null;
+    const handle = fakePoolHandle(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+
+    const shutdown = shutdownConversionPool({
+      timeoutMs: 23_000,
+      handle: handle as never,
+    });
+
+    await jest.advanceTimersByTimeAsync(22_000);
+    release!();
+    await shutdown;
+
+    expect(handle.destroy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('force-destroys and names the dropped queue when the budget is exceeded', async () => {
+    const handle = fakePoolHandle(() => new Promise<void>(() => undefined), 3);
+
+    const shutdown = shutdownConversionPool({
+      timeoutMs: 23_000,
+      handle: handle as never,
+    });
+
+    await jest.advanceTimersByTimeAsync(23_000);
+    await shutdown;
+
+    expect(handle.destroy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('3 queued conversion(s)')
+    );
   });
 });

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -66,11 +66,11 @@ export async function runConversion(
 }
 
 export async function shutdownConversionPool(
-  options: { timeoutMs?: number } = {}
+  options: { timeoutMs?: number; handle?: Piscina } = {}
 ): Promise<void> {
-  if (!pool) return;
-  const handle = pool;
-  pool = null;
+  const handle = options.handle ?? pool;
+  if (handle == null) return;
+  if (handle === pool) pool = null;
   const drain = handle.close();
   if (options.timeoutMs == null) {
     await drain;
@@ -80,10 +80,14 @@ export async function shutdownConversionPool(
     const t = setTimeout(() => resolve('timeout'), options.timeoutMs);
     t.unref();
   });
-  const winner = await Promise.race([drain.then(() => 'drained' as const), timeout]);
+  const winner = await Promise.race([
+    drain.then(() => 'drained' as const),
+    timeout,
+  ]);
   if (winner === 'timeout') {
     console.error(
-      `Conversion pool did not drain within ${options.timeoutMs}ms — forcing destroy`
+      `Conversion pool did not drain within ${options.timeoutMs}ms — ` +
+        `forcing destroy, dropping ${handle.queueSize} queued conversion(s)`
     );
     await handle.destroy();
   }

--- a/src/lib/gracefulShutdown.ts
+++ b/src/lib/gracefulShutdown.ts
@@ -6,7 +6,11 @@ import { shutdownConversionPool } from './conversionPool';
 // 30s in ecosystem.blue-green.config.js). Reserve a safety margin so process.exit
 // fires before pm2's SIGKILL lands.
 export const SHUTDOWN_TIMEOUT_MS = 25_000;
-export const POOL_DRAIN_TIMEOUT_MS = 20_000;
+// The drain budget must stay just under SHUTDOWN_TIMEOUT_MS, not far below it:
+// an in-flight conversion that finishes between the old 20s ceiling and the 25s
+// hard exit was being force-destroyed with grace budget still on the clock.
+// 2s reserve covers the trailing database.destroy() before the hard exit fires.
+export const POOL_DRAIN_TIMEOUT_MS = 23_000;
 
 let shuttingDown = false;
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-conversion-survives-deploy.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-conversion-survives-deploy.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-conversion-survives-deploy",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "A conversion in progress keeps running through a deploy instead of being dropped"
+}


### PR DESCRIPTION
## What
Aligns the conversion pool's drain budget with the process graceful-shutdown window so a conversion that's still running when a deploy lands gets the full grace period to finish instead of being force-destroyed.

## Why
On deploy (blue-green, SIGINT graceful shutdown), the pool drained on a hardcoded 20 000ms ceiling while the overall shutdown window allows 25 000ms before the hard `process.exit`. A conversion that would have finished between 20s and 25s was force-destroyed with grace budget still on the clock — the user's in-flight upload/conversion was silently dropped. The ~25s graceful shutdown itself is expected and correct; the defect was the drain ceiling firing 5s early.

## How
- `POOL_DRAIN_TIMEOUT_MS`: 20 000 → 23 000. Sits just under the 25 000ms hard-exit ceiling, leaving a ~2s reserve for the trailing `database.destroy()`. The existing `POOL_DRAIN_TIMEOUT_MS < SHUTDOWN_TIMEOUT_MS` invariant test still holds (23s < 25s).
- The force-destroy log now names how many queued conversions are being dropped, so genuine deploy-time loss is diagnosable instead of a generic message.
- `shutdownConversionPool` gains an optional injectable `handle` so the drain race can be exercised under fake timers without spinning a real Piscina worker pool.

No migration, no auth, no payments, no cron/Stripe-sync touched. No new HTTP/HTML/zip/file-path surface.

## Measuring success
- Absence of the `forcing destroy, dropping N queued conversion(s)` line in deploy-window logs on `server-blue`/`server-green` means no in-flight loss. When it does appear, it now states N (the dropped count) for triage.
- During a deploy, a conversion that completes within ~23s of SIGINT should reach `done` rather than being killed mid-flight.

## Testing
- Unit tests added (`src/lib/conversionPool.test.ts`, fake timers):
  - in-flight conversion finishing inside the 23s budget is NOT force-destroyed (no `destroy()`, no error log) — the regression that reproduces the drop.
  - budget genuinely exceeded → `destroy()` called once and the log names the dropped queue size.
- `gracefulShutdown.test.ts` invariant test (`POOL_DRAIN < SHUTDOWN`) still passes at 23s/25s.
- Server `tsc -p . --noEmit` clean (also typechecks the test files, per deploy build).

## Browser check
Browser check: not applicable — the only `web/src/` file is a changelog JSON entry (no rendered logic change); backend timing fix has no UI.

## Changelog
`A conversion in progress keeps running through a deploy instead of being dropped` — `web/src/pages/WhatsNewPage/changelog/2026-05-31-conversion-survives-deploy.json`. In-flight conversions surviving a deploy is user-perceived, so the entry is warranted.

## Sonar
`sonar-scanner` is installed locally but `SONAR_TOKEN` is unset in this environment, so I did not run it. The change is two narrow edits (one constant, one function gaining an optional injectable param + a richer log string) with no new security-relevant surface — expect no new findings, but flagging in case CI's Sonar bounces.

## Risks
- Raising the drain budget to 23s means a stuck pool now blocks shutdown ~3s longer before force-destroy. Still inside the 25s hard exit and the 30s pm2 `kill_timeout`, so pm2 never escalates to SIGKILL on this path.
- Rollback: revert the constant to 20 000 — purely a timing value, no schema or API change.

## Goal alignment
Protects the core convert flow during deploys. Users mid-conversion when we ship no longer lose their deck — directly supports the "drop something in, get a clean deck back" promise and removes a silent failure that erodes trust at scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782834759&installation_id=132681956&pr_number=2989&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2989&signature=758718b431284650d8510d7a2ab8af7534e19f11e7601ff6bf5d4fee3dcc51cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->