### PR TITLE
fix: keep signed-in card-limit hits off the anonymous screen

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -496,6 +496,26 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     );
   });
 
+  it('treats an authenticated request whose owner is unresolved as a logged-in limit, not anonymous', async () => {
+    mockPackages([{ name: 'deck', cardCount: 22 }]);
+    const usersRepo = buildUsersRepo();
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      usersRepo
+    );
+    const req = buildRequest({
+      cookies: { token: 'a-valid-session-token' },
+    } as Partial<express.Request>);
+    const { res, capturedSend, redirectedTo } = responseWithRedirect();
+
+    await service.handleUpload(req, res);
+
+    expect(redirectedTo()).toBe('/limit?kind=card_count');
+    expect(capturedSend()).toBeNull();
+  });
+
   it('sends the deck for an anonymous conversion at or under 21 cards without incrementing usage', async () => {
     mockPackages([{ name: 'deck', cardCount: 21 }]);
     const usersRepo = buildUsersRepo();

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -25,6 +25,7 @@ import {
   MonthlyLimitError,
   AnonymousCardCapError,
   ANONYMOUS_CARD_CAP,
+  MONTHLY_CARD_LIMIT,
 } from '../usecases/users/CheckMonthlyCardLimitUseCase';
 import { generateDeckInfo, DeckInfo, ClaudeParseError } from '../lib/claude/ClaudeService';
 import CustomExporter from '../lib/parser/exporters/CustomExporter';
@@ -52,6 +53,11 @@ interface MarkdownLossyResponse {
 
 interface DeckTooLargeResponse {
   message: string;
+}
+
+function hasSessionToken(req: express.Request): boolean {
+  const token = (req.cookies as Record<string, unknown> | undefined)?.token;
+  return typeof token === 'string' && token.length > 0;
 }
 
 function walkHtmlFiles(dir: string): string[] {
@@ -365,16 +371,24 @@ class UploadService {
 
     const totalCards = packages.reduce((s, p) => s + (p.cardCount ?? 0), 0);
     const owner = getOwner(res);
+    const authenticated = hasSessionToken(req);
 
-    if (owner == null && totalCards > ANONYMOUS_CARD_CAP) {
-      throw new AnonymousCardCapError(totalCards, ANONYMOUS_CARD_CAP);
-    }
     if (owner != null) {
       await new CheckMonthlyCardLimitUseCase(this.usersRepository).execute({
         userId: owner,
         candidateCardCount: totalCards,
         isPaying: paying,
       });
+    } else if (totalCards > ANONYMOUS_CARD_CAP) {
+      if (authenticated) {
+        throw new MonthlyLimitError(
+          MONTHLY_CARD_LIMIT,
+          MONTHLY_CARD_LIMIT,
+          totalCards,
+          new Date().toISOString()
+        );
+      }
+      throw new AnonymousCardCapError(totalCards, ANONYMOUS_CARD_CAP);
     }
 
     const first = packages[0];

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-logged-in-limit-screen.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-logged-in-limit-screen.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-logged-in-limit-screen",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Hitting the card limit while signed in shows the upgrade view, not the sign-up screen"
+}


### PR DESCRIPTION
## What
Stops a signed-in user who hits the card limit from being redirected to `/limit?kind=anonymous` — the anonymous "sign up free" screen. The sync upload path now decides anonymous-vs-logged-in by both the resolved owner and the presence of a session token, so an authenticated request never gets the anonymous cap.

## Why
Server-side root cause behind the client mitigation in #2980. `handleSyncUpload` decided "anonymous" purely from `res.locals.owner == null`. When an authenticated request reached the conversion path without a resolved owner (reported on a Notion retry), it threw `AnonymousCardCapError`, which emits the `?kind=anonymous` redirect — nonsensical for someone already logged in. #2980 hid this client-side; this removes the server source of the mislabel.

## How
In `handleSyncUpload`, lead with the owner-present check (Sonar S7735). Only throw `AnonymousCardCapError` when the request is genuinely ownerless **and** carries no `token` cookie. An authenticated-but-ownerless request falls to the regular `MonthlyLimitError` (`/limit?kind=card_count`, the upgrade view). Owner presence uses `owner == null`, not `!owner`, so a `0` id is never rejected (CWE-754). New `hasSessionToken(req)` helper reads `req.cookies.token`.

## Measuring success
`paywall_shown` track events with `props.kind = 'anonymous'` should only fire for requests with `userId: null`. After this ships, a `kind: 'anonymous'` event paired with a non-null `userId` (or any authenticated session) should drop to zero. Query the events store for `paywall_shown` where `kind = 'anonymous'` and `userId is not null`.

## Testing
- Unit test added: an authenticated request (token cookie present) over the 21-card anonymous cap with no resolved owner now redirects to `/limit?kind=card_count`, not `/limit?kind=anonymous`. Existing anonymous-cap and logged-in monthly-cap tests still pass (17/17 in `UploadService.test.ts`).
- Server `tsc -p . --noEmit`: green. Web typecheck, changelog vitest, and Biome lint: green.

## Browser check
Browser check: not applicable — only `web/src/` change is the changelog JSON; the fix is server-side with no rendered-component change.

## Changelog
`Hitting the card limit while signed in shows the upgrade view, not the sign-up screen` (`web/src/pages/WhatsNewPage/changelog/2026-05-31-logged-in-limit-screen.json`).

## Risks
Low. A genuinely anonymous over-cap conversion still hits the anonymous cap. Only the authenticated-but-ownerless edge changes — it now lands on the upgrade view instead of the sign-up view. Rollback is a single-file revert.

`sonar-scanner` not run locally — `SONAR_TOKEN` is unset in this environment. Change is a small branch reorder plus one pure helper; expect no new security findings, but reviewers should watch for a Sonar bounce.

## Goal alignment
Removes a confusing dead-end for signed-in learners hitting the limit — they see the upgrade path instead of a sign-up screen they can't use, protecting the free→paid conversion step that the 300K-user goal depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782834819&installation_id=132681956&pr_number=2990&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2990&signature=a6903a6b1d08356448233e4151038191a40c6b5a4a769b3d520e737cf44d167c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->