### PR TITLE
fix: page ops errors list and surface message action failures

### DIFF
--- a/web/src/pages/OpsPage/ContactMessagesTab.test.tsx
+++ b/web/src/pages/OpsPage/ContactMessagesTab.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ContactMessage } from '../../lib/backend/Backend';
+import ContactMessagesTab from './ContactMessagesTab';
+
+const mockListContactMessages = vi.fn();
+const mockAcknowledgeContactMessage = vi.fn();
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({
+    listContactMessages: mockListContactMessages,
+    acknowledgeContactMessage: mockAcknowledgeContactMessage,
+  }),
+}));
+
+const buildMessage = (
+  overrides: Partial<ContactMessage> = {}
+): ContactMessage => ({
+  id: 1,
+  name: 'A reporter',
+  email: 'reporter@example.com',
+  message: 'Conversion failed on a large export.',
+  attachments: null,
+  is_acknowledged: false,
+  created_at: '2026-05-30T12:00:00.000Z',
+  ...overrides,
+});
+
+describe('ContactMessagesTab acknowledge action', () => {
+  beforeEach(() => {
+    mockListContactMessages.mockResolvedValue([buildMessage()]);
+    mockAcknowledgeContactMessage.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('marks a message as read when the request succeeds', async () => {
+    mockAcknowledgeContactMessage.mockResolvedValue(undefined);
+    render(<ContactMessagesTab />);
+
+    const button = await screen.findByRole('button', { name: 'Mark as read' });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Acknowledged' })
+      ).toBeInTheDocument()
+    );
+    expect(mockAcknowledgeContactMessage).toHaveBeenCalledWith(1, true);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  test('reverts the toggle and shows an error when the request fails', async () => {
+    mockAcknowledgeContactMessage.mockRejectedValue(new Error('500'));
+    render(<ContactMessagesTab />);
+
+    const button = await screen.findByRole('button', { name: 'Mark as read' });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        "Couldn't mark this message as read. Try again."
+      )
+    );
+    expect(
+      screen.getByRole('button', { name: 'Mark as read' })
+    ).toBeInTheDocument();
+  });
+
+  test('scopes the failure error to the message that failed', async () => {
+    mockListContactMessages.mockResolvedValue([
+      buildMessage({ id: 1, name: 'First reporter' }),
+      buildMessage({ id: 2, name: 'Second reporter' }),
+    ]);
+    mockAcknowledgeContactMessage.mockRejectedValue(new Error('500'));
+    render(<ContactMessagesTab />);
+
+    const buttons = await screen.findAllByRole('button', {
+      name: 'Mark as read',
+    });
+    fireEvent.click(buttons[0]);
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('alert')).toHaveLength(1)
+    );
+  });
+});

--- a/web/src/pages/OpsPage/ContactMessagesTab.tsx
+++ b/web/src/pages/OpsPage/ContactMessagesTab.tsx
@@ -9,6 +9,9 @@ export default function ContactMessagesTab() {
   const [messages, setMessages] = useState<ContactMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<number | null>(null);
+  const [failedId, setFailedId] = useState<number | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
     get2ankiApi()
@@ -19,12 +22,29 @@ export default function ContactMessagesTab() {
   }, []);
 
   async function handleToggle(id: number, nextValue: boolean) {
-    await get2ankiApi().acknowledgeContactMessage(id, nextValue);
+    setPendingId(id);
+    setFailedId(null);
+    setActionError(null);
     setMessages((prev) =>
-      prev.map((m) =>
-        m.id === id ? { ...m, is_acknowledged: nextValue } : m
-      )
+      prev.map((m) => (m.id === id ? { ...m, is_acknowledged: nextValue } : m))
     );
+    try {
+      await get2ankiApi().acknowledgeContactMessage(id, nextValue);
+    } catch {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === id ? { ...m, is_acknowledged: !nextValue } : m
+        )
+      );
+      setFailedId(id);
+      setActionError(
+        nextValue
+          ? "Couldn't mark this message as read. Try again."
+          : "Couldn't reopen this message. Try again."
+      );
+    } finally {
+      setPendingId(null);
+    }
   }
 
   if (loading) {
@@ -55,7 +75,13 @@ export default function ContactMessagesTab() {
       </header>
       <ul className={styles.messageList}>
         {messages.map((m) => (
-          <MessageCard key={m.id} message={m} onToggle={handleToggle} />
+          <MessageCard
+            key={m.id}
+            message={m}
+            onToggle={handleToggle}
+            isPending={pendingId === m.id}
+            error={failedId === m.id ? actionError : null}
+          />
         ))}
       </ul>
     </div>
@@ -65,9 +91,16 @@ export default function ContactMessagesTab() {
 interface MessageCardProps {
   message: ContactMessage;
   onToggle: (id: number, nextValue: boolean) => void;
+  isPending: boolean;
+  error: string | null;
 }
 
-function MessageCard({ message, onToggle }: Readonly<MessageCardProps>) {
+function MessageCard({
+  message,
+  onToggle,
+  isPending,
+  error,
+}: Readonly<MessageCardProps>) {
   const attachments: string[] = (() => {
     try {
       return message.attachments ? JSON.parse(message.attachments) : [];
@@ -107,9 +140,10 @@ function MessageCard({ message, onToggle }: Readonly<MessageCardProps>) {
           type="button"
           className={sharedStyles.btnSmall}
           aria-pressed={acked}
+          disabled={isPending}
           onClick={() => onToggle(message.id, !acked)}
         >
-          {acked ? 'Acknowledged' : 'Mark as read'}
+          {pendingLabel(acked, isPending)}
         </button>
         {!acked && (
           <a
@@ -119,7 +153,19 @@ function MessageCard({ message, onToggle }: Readonly<MessageCardProps>) {
             Reply
           </a>
         )}
+        {error != null && (
+          <span role="alert" className={styles.messageActionError}>
+            {error}
+          </span>
+        )}
       </div>
     </li>
   );
+}
+
+function pendingLabel(acked: boolean, isPending: boolean): string {
+  if (isPending) {
+    return 'Saving…';
+  }
+  return acked ? 'Acknowledged' : 'Mark as read';
 }

--- a/web/src/pages/OpsPage/ErrorsTab.tsx
+++ b/web/src/pages/OpsPage/ErrorsTab.tsx
@@ -8,6 +8,7 @@ import { useErrorGroups } from './useErrorGroups';
 import { buildCopyArtifact } from './buildCopyArtifact';
 import { parseUserAgent } from './parseUserAgent';
 import { resolveErrorGroup, reopenErrorGroup } from './resolveErrorGroup';
+import { ERROR_PAGE_SIZE, resolveErrorPage } from './errorPagination';
 
 const SOURCE_OPTIONS: { value: ErrorSource; label: string }[] = [
   { value: 'all', label: 'All' },
@@ -316,12 +317,21 @@ export default function ErrorsTab() {
   const status: ErrorStatus =
     rawStatus === 'resolved' || rawStatus === 'all' ? rawStatus : 'unresolved';
   const selectedHash = searchParams.get('id');
+  const rawPage = searchParams.get('page');
+  const requestedPage = (() => {
+    const parsed = Number(rawPage);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+  })();
 
   const { data, isLoading, error, refetch } = useErrorGroups({
     source,
     sort,
     status,
+    limit: ERROR_PAGE_SIZE,
+    offset: requestedPage * ERROR_PAGE_SIZE,
   });
+
+  const pageInfo = resolveErrorPage(rawPage, data?.totalGroups ?? 0);
 
   const selectedGroup =
     data?.groups.find((g) => g.message_hash === selectedHash) ?? null;
@@ -336,13 +346,27 @@ export default function ErrorsTab() {
     setSearchParams(params, { replace: true });
   };
 
+  const setFilterParam = (key: string, value: string | null) => {
+    const params = new URLSearchParams(searchParams);
+    if (value == null || value === '') {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+    params.delete('page');
+    params.delete('id');
+    setSearchParams(params, { replace: true });
+  };
+
   const selectGroup = (hash: string | null) => updateParam('id', hash);
   const setSource = (s: ErrorSource) =>
-    updateParam('source', s === 'all' ? null : s);
+    setFilterParam('source', s === 'all' ? null : s);
   const setStatus = (s: ErrorStatus) =>
-    updateParam('status', s === 'unresolved' ? null : s);
+    setFilterParam('status', s === 'unresolved' ? null : s);
   const toggleSort = () =>
-    updateParam('sort', sort === 'last_seen' ? 'occurrences' : 'last_seen');
+    setFilterParam('sort', sort === 'last_seen' ? 'occurrences' : 'last_seen');
+  const goToPage = (next: number) =>
+    updateParam('page', next <= 0 ? null : String(next));
 
   const countLabel = status === 'all' ? 'total' : status;
 
@@ -565,17 +589,60 @@ export default function ErrorsTab() {
       </div>
 
       {data != null && (
-        <p
+        <div
           style={{
-            fontSize: 'var(--text-xs)',
-            color: 'var(--color-text-tertiary)',
-            margin: 0,
-            fontVariantNumeric: 'tabular-nums',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '0.5rem',
+            flexWrap: 'wrap',
           }}
         >
-          {data.totalGroups} {countLabel} group
-          {data.totalGroups === 1 ? '' : 's'}
-        </p>
+          <p
+            style={{
+              fontSize: 'var(--text-xs)',
+              color: 'var(--color-text-tertiary)',
+              margin: 0,
+              fontVariantNumeric: 'tabular-nums',
+            }}
+          >
+            {data.totalGroups === 0
+              ? `0 ${countLabel} groups`
+              : `${pageInfo.rangeStart}–${pageInfo.rangeEnd} of ${data.totalGroups} ${countLabel} group${data.totalGroups === 1 ? '' : 's'}`}
+          </p>
+
+          {pageInfo.pageCount > 1 && (
+            <div
+              style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}
+            >
+              <button
+                type="button"
+                className={sharedStyles.btnSmall}
+                disabled={!pageInfo.hasPrev}
+                onClick={() => goToPage(pageInfo.page - 1)}
+              >
+                Previous
+              </button>
+              <span
+                style={{
+                  fontSize: 'var(--text-xs)',
+                  color: 'var(--color-text-tertiary)',
+                  fontVariantNumeric: 'tabular-nums',
+                }}
+              >
+                Page {pageInfo.page + 1} of {pageInfo.pageCount}
+              </span>
+              <button
+                type="button"
+                className={sharedStyles.btnSmall}
+                disabled={!pageInfo.hasNext}
+                onClick={() => goToPage(pageInfo.page + 1)}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/web/src/pages/OpsPage/ErrorsTab.tsx
+++ b/web/src/pages/OpsPage/ErrorsTab.tsx
@@ -369,6 +369,11 @@ export default function ErrorsTab() {
     updateParam('page', next <= 0 ? null : String(next));
 
   const countLabel = status === 'all' ? 'total' : status;
+  const groupPlural = data?.totalGroups === 1 ? '' : 's';
+  const groupRangeLabel =
+    data?.totalGroups === 0
+      ? `0 ${countLabel} groups`
+      : `${pageInfo.rangeStart}–${pageInfo.rangeEnd} of ${data?.totalGroups} ${countLabel} group${groupPlural}`;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
@@ -606,9 +611,7 @@ export default function ErrorsTab() {
               fontVariantNumeric: 'tabular-nums',
             }}
           >
-            {data.totalGroups === 0
-              ? `0 ${countLabel} groups`
-              : `${pageInfo.rangeStart}–${pageInfo.rangeEnd} of ${data.totalGroups} ${countLabel} group${data.totalGroups === 1 ? '' : 's'}`}
+            {groupRangeLabel}
           </p>
 
           {pageInfo.pageCount > 1 && (

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -857,6 +857,12 @@
   display: flex;
   gap: 0.5rem;
   align-items: center;
+  flex-wrap: wrap;
+}
+
+.messageActionError {
+  font-size: var(--text-xs);
+  color: var(--color-danger, #dc2626);
 }
 
 /* ── Performance tab ────────────────────────────────────────────── */

--- a/web/src/pages/OpsPage/errorPagination.test.ts
+++ b/web/src/pages/OpsPage/errorPagination.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest';
+
+import { ERROR_PAGE_SIZE, resolveErrorPage } from './errorPagination';
+
+describe('resolveErrorPage', () => {
+  test('first page of a single full page has no neighbours', () => {
+    const info = resolveErrorPage(null, ERROR_PAGE_SIZE);
+
+    expect(info).toEqual({
+      page: 0,
+      pageCount: 1,
+      offset: 0,
+      rangeStart: 1,
+      rangeEnd: ERROR_PAGE_SIZE,
+      hasPrev: false,
+      hasNext: false,
+    });
+  });
+
+  test('middle page exposes both neighbours and the correct offset', () => {
+    const info = resolveErrorPage('1', 130, 50);
+
+    expect(info).toMatchObject({
+      page: 1,
+      pageCount: 3,
+      offset: 50,
+      rangeStart: 51,
+      rangeEnd: 100,
+      hasPrev: true,
+      hasNext: true,
+    });
+  });
+
+  test('last partial page caps rangeEnd at the total and disables next', () => {
+    const info = resolveErrorPage('2', 130, 50);
+
+    expect(info).toMatchObject({
+      page: 2,
+      pageCount: 3,
+      offset: 100,
+      rangeStart: 101,
+      rangeEnd: 130,
+      hasPrev: true,
+      hasNext: false,
+    });
+  });
+
+  test('out-of-range page clamps to the last available page', () => {
+    const info = resolveErrorPage('99', 130, 50);
+
+    expect(info.page).toBe(2);
+    expect(info.offset).toBe(100);
+    expect(info.hasNext).toBe(false);
+  });
+
+  test('negative or non-numeric page falls back to the first page', () => {
+    expect(resolveErrorPage('-3', 130, 50).page).toBe(0);
+    expect(resolveErrorPage('abc', 130, 50).page).toBe(0);
+  });
+
+  test('zero results report an empty range and a single page', () => {
+    const info = resolveErrorPage(null, 0, 50);
+
+    expect(info).toMatchObject({
+      page: 0,
+      pageCount: 1,
+      offset: 0,
+      rangeStart: 0,
+      rangeEnd: 0,
+      hasPrev: false,
+      hasNext: false,
+    });
+  });
+});

--- a/web/src/pages/OpsPage/errorPagination.ts
+++ b/web/src/pages/OpsPage/errorPagination.ts
@@ -1,0 +1,35 @@
+export const ERROR_PAGE_SIZE = 50;
+
+export interface ErrorPageInfo {
+  page: number;
+  pageCount: number;
+  offset: number;
+  rangeStart: number;
+  rangeEnd: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+}
+
+export function resolveErrorPage(
+  rawPage: string | null,
+  totalGroups: number,
+  pageSize: number = ERROR_PAGE_SIZE
+): ErrorPageInfo {
+  const parsed = Number(rawPage);
+  const requested = Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+  const pageCount = Math.max(1, Math.ceil(totalGroups / pageSize));
+  const page = Math.min(requested, pageCount - 1);
+  const offset = page * pageSize;
+  const rangeStart = totalGroups === 0 ? 0 : offset + 1;
+  const rangeEnd = Math.min(offset + pageSize, totalGroups);
+
+  return {
+    page,
+    pageCount,
+    offset,
+    rangeStart,
+    rangeEnd,
+    hasPrev: page > 0,
+    hasNext: page < pageCount - 1,
+  };
+}


### PR DESCRIPTION
## What
Two self-contained polish fixes on the internal `/ops` pages.

**Errors tab** — the list fetched a fixed first 50 error groups with no way to reach the rest. The `useErrorGroups` hook already accepted `limit`/`offset`, but the tab never passed them. This wires a `page` URL param into the existing offset support and adds Previous/Next controls plus a range summary (`51–100 of 130 unresolved groups`). Changing any filter clears the page so you never land on an out-of-range offset.

**Messages tab** — the acknowledge action awaited the API and updated state on resolve only. A failed `PATCH` threw unhandled, leaving the button stuck and giving the user no feedback. The toggle is now optimistic, reverts on failure, shows a `Saving…` state while in flight, and renders a scoped, retryable error on the affected card only.

## Why
Leftover rough edges on the `/ops` tooling after Conversions, Upload-funnel, and Showcase were fixed earlier this session. Both items were surfacing-existing-data / error-handling fixes (the same pattern as the funnel/showcase work) — no new backend surface.

**Affected-user count was intentionally not added.** The errors endpoint returns `MAX(e.user_id)` — a single representative id, not a distinct affected-user count. Surfacing a real count needs a backend query change (e.g. `COUNT(DISTINCT user_id)`), which is out of scope for this frontend-only PR. Noted here for a follow-up.

## How
- `errorPagination.ts` — pure `resolveErrorPage(rawPage, total, pageSize)` helper; clamps out-of-range pages, computes the display range and prev/next availability.
- `ErrorsTab.tsx` — passes `limit`/`offset` from the `page` param; filter changes drop `page` + `id`.
- `ContactMessagesTab.tsx` — optimistic toggle with per-card pending + error state.

No backend / response-shape change, so no raw-rows-to-client concern.

## Measuring success
Operator-facing internal tooling — success is navigability: the Errors tab footer shows `N–M of T` and the Next button advances the offset; a forced acknowledge failure (e.g. offline) reverts the toggle and shows the inline error instead of a stuck button.

## Testing
- `errorPagination.test.ts` — 6 cases: first/middle/last page, out-of-range clamp, non-numeric fallback, empty result.
- `ContactMessagesTab.test.tsx` — 3 cases: success flips label, failure reverts + shows alert, failure error is scoped to the one card.
- Full OpsPage suite green (25 files, 105 tests). Web typecheck + Biome lint + server tsc all clean.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Verified via the rendering test suite (ContactMessagesTab.test.tsx renders the real component and asserts on the rendered buttons/alert; OpsPage suite renders ErrorsTab). I could not start the dev server from the agent — please tick after a quick golden-path pass on `/ops`. Not merging; opened ready for your review.

## Changelog
No entry — internal `/ops` tooling, no user-visible change a regular user would notice.

## Risks
Low. Frontend-only, no API change. Pagination reuses offset support the hook already shipped; if `page` is malformed it falls back to page 0. Rollback is a straight revert.

## Sonar
`sonar-scanner` is installed locally but `SONAR_TOKEN` is unset, so an anonymous run fails with "Project not found" — expect CI's Sonar pass to be the first real run. The diff uses only native `<button>` elements, an early-return label helper (no nested ternary), and a single `role="alert"` live region, so no new a11y / complexity smells are expected.

## Goal alignment
Indirect: better internal tooling lets us triage client errors and respond to inbound support faster, which protects the conversion/retention surface as we scale toward 300K. No direct user-facing change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/2991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782834984&installation_id=132681956&pr_number=2991&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F2991&signature=6cd30d531c3d643d47503b58b9a27bae9266af8240c91b8729daaefad6c0b244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->