### PR TITLE
docs: credit security reporter on the security page

### DIFF
--- a/web/src/pages/SecurityPage/SecurityPage.tsx
+++ b/web/src/pages/SecurityPage/SecurityPage.tsx
@@ -58,7 +58,12 @@ export default function SecurityPage() {
 
       <section className={pageStyles.section}>
         <h2>Acknowledgements</h2>
-        <p>No reports yet.</p>
+        <ul>
+          <li>
+            Bertie — server-side request forgery in the Notion bookmark and
+            media fetch. Fixed May 2026.
+          </li>
+        </ul>
       </section>
     </div>
   );


### PR DESCRIPTION
## What
Replaces the "No reports yet." placeholder in the Acknowledgements section of `/security` with the first credited report.

> Bertie — server-side request forgery in the Notion bookmark and media fetch. Fixed May 2026.

## Why
A responsible private disclosure flagged an SSRF in the Notion bookmark metadata fetch and the Ankify media fetch, both now fixed (#2977, #2978). The reporter explicitly asked to be credited, and the page's Rewards section already promises "we will add your name to the acknowledgements below once the issue is resolved." This honors that.

No code paths, severity claims, or reporter contact details on the public page — issue class + date only.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: trivial static-copy change to `/security`; Alexander authorized the merge.

## Changelog
No entry — content/acknowledgements update, not user-facing feature or fix behavior.

## Goal alignment
Credibility: rewarding responsible disclosure keeps good-faith researchers reporting privately rather than publicly, which protects users on the path to 300K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)