### PR TITLE
docs: link security acknowledgement to reporter handle

### DIFF
--- a/web/src/pages/SecurityPage/SecurityPage.tsx
+++ b/web/src/pages/SecurityPage/SecurityPage.tsx
@@ -60,8 +60,15 @@ export default function SecurityPage() {
         <h2>Acknowledgements</h2>
         <ul>
           <li>
-            Bertie — server-side request forgery in the Notion bookmark and
-            media fetch. Fixed May 2026.
+            <a
+              href="https://github.com/endscene665"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              endscene665
+            </a>{' '}
+            — server-side request forgery in the Notion bookmark and media
+            fetch. Fixed May 2026.
           </li>
         </ul>
       </section>


### PR DESCRIPTION
## What
Changes the Acknowledgements entry on `/security` from the bare name `Bertie` to the handle `endscene665`, linked to https://github.com/endscene665.

## Why
The SSRF reporter (#2977, #2978; credited in #2996) followed up asking to be credited under their chosen handle with a link to their GitHub profile rather than a first name. This honors that preference.

Link uses the repo's standard external-link attributes (`target="_blank" rel="noopener noreferrer"`). No code paths, severity claims, or contact details — issue class + date only, same as before.

## Browser check
Browser check: not applicable — static copy change, swaps one text node for an equivalent anchor on `/security`; verified via web typecheck + Biome lint.

## Changelog
No entry — acknowledgements/content update, not a user-facing feature or fix.

## Goal alignment
Credibility: honoring a researcher's crediting preference keeps good-faith disclosure flowing privately, protecting users on the path to 300K.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782847504&installation_id=132681956&pr_number=3000&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3000&signature=6a1b55a800c55610cbd549c2f3eebfdfdf57470e06c6fd3dea2f6f810d48cc27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->