### PR TITLE
fix: stub the anki global so image occlusion template previews cleanly

### DIFF
--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.test.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.test.ts
@@ -182,4 +182,24 @@ describe('buildPreviewDocument', () => {
     expect(doc).toContain('.card { color: black; }');
     expect(doc).toContain('<div class="card">Q</div>');
   });
+
+  it('stubs the anki global before the card body so image-occlusion setup cannot throw', () => {
+    const imageOcclusion: AnkiNoteType = {
+      ...basic,
+      name: 'Image Occlusion',
+      tmpls: [
+        {
+          name: 'Card 1',
+          ord: 0,
+          qfmt: '<div id="err"></div><script>try{anki.imageOcclusion.setup();}catch(e){document.getElementById("err").innerHTML=`Error loading image occlusion.<br><br>${e}`;}</script>',
+          afmt: '{{FrontSide}}',
+        },
+      ],
+    };
+    const doc = buildPreviewDocument(imageOcclusion, {}, 'front');
+    const stubIndex = doc.indexOf('window.anki=');
+    const bodyIndex = doc.indexOf('<body>');
+    expect(stubIndex).toBeGreaterThan(-1);
+    expect(stubIndex).toBeLessThan(bodyIndex);
+  });
 });

--- a/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
+++ b/web/src/pages/TemplatesPage/renderNoteTypePreview.ts
@@ -70,7 +70,7 @@ export function buildPreviewDocument(
   side: 'front' | 'back'
 ): string {
   const body = renderCardSide(noteType, previewData, side);
-  return `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>
+  return `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><script>window.anki={imageOcclusion:{setup(){}}};</script><style>
 html { font-size: clamp(8px, 2.5vw, 16px); }
 :where(h1) { font-size: 1.4em; }
 :where(h2) { font-size: 1.25em; }

--- a/web/src/pages/WhatsNewPage/changelog/2026-05-31-image-occlusion-template-preview.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-05-31-image-occlusion-template-preview.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-05-31-image-occlusion-template-preview",
+  "date": "2026-05-31",
+  "type": "fix",
+  "title": "Image occlusion template on the templates page previews the card instead of a script error"
+}


### PR DESCRIPTION
## What

The Image Occlusion preview on `/templates` shows **"Error loading image occlusion. ReferenceError: Can't find variable: anki"** instead of the card.

## Why

Anki's Image Occlusion note type (`src/templates/n2a-io.json`) ships a front/back `<script>` that calls `anki.imageOcclusion.setup()`. That `anki` global only exists inside Anki's own webview. In the preview iframe (`sandbox="allow-scripts"`) the call throws `ReferenceError`, and the template's own `catch` block writes the error into the visible `#err` div. The existing CSS only hides `#image-occlusion-canvas` and the in-container `<script>` — but `#err` and the script are *siblings* of the container, so the error leaked through.

## Fix

Inject a no-op `anki` stub into the preview document `<head>`, before the card body, so the setup script resolves the global and does nothing instead of throwing. The empty canvas and the "install in Anki to see masks" message already cover the rest of the UX.

One-line diff in `renderNoteTypePreview.ts` + a regression test asserting the stub is emitted before `<body>`.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Verified at the unit level (`renderNoteTypePreview.test.ts`, 13 passing); please confirm the `/templates` Image Occlusion card renders without the error banner on localhost before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782848883&installation_id=132681956&pr_number=3001&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3001&signature=3032af66d8030396a310b3544cb1800dae94193a387a91336f9e9ef92d433c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->