### PR TITLE
feat: instrument abandoned-checkout recovery and tighten its copy

### DIFF
--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -6,6 +6,10 @@ jest.mock('../lib/integrations/stripe', () => ({
   getStripe: jest.fn(),
 }));
 
+jest.mock('../services/events/eventsSinkInstance', () => ({
+  getEventsSink: () => ({ record: jest.fn() }),
+}));
+
 const featureFlagStore: Array<{
   key: string;
   value: boolean;

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -30,6 +30,7 @@ import DownloadService from '../services/DownloadService';
 import ApkgPreviewService from '../services/ApkgPreviewService/ApkgPreviewService';
 import { NotionService } from '../services/NotionService/NotionService';
 import { getDatabase } from '../data_layer';
+import { getEventsSink } from '../services/events/eventsSinkInstance';
 import RequireOpsAccess from './middleware/RequireOpsAccess';
 import InactivityEmailRepository from '../data_layer/InactivityEmailRepository';
 import AbandonedCheckoutRecoveryRepository from '../data_layer/AbandonedCheckoutRecoveryRepository';
@@ -104,7 +105,11 @@ const OpsRouter = () => {
       emailService
     ),
     new GetPerformanceMetricsUseCase(performanceMetricsService),
-    new SendAbandonedCheckoutRecoveryUseCase(emailService, new AbandonedCheckoutRecoveryRepository(database)),
+    new SendAbandonedCheckoutRecoveryUseCase(
+      emailService,
+      new AbandonedCheckoutRecoveryRepository(database),
+      getEventsSink()
+    ),
     new GetReturnRateMetricsUseCase(new ReturnRateMetricsService(database)),
     new GetMindmapImageStatsUseCase(new MindmapRepository(database)),
     new GetMindmapStorageMetricsUseCase(mindmapStorageService),

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -18,6 +18,7 @@ import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { PersistStripeSessionUseCase } from '../usecases/checkout/PersistStripeSessionUseCase';
 import hashToken from '../lib/misc/hashToken';
 import { track } from '../services/events/track';
+import { getEventsSink } from '../services/events/eventsSinkInstance';
 import AbandonedCheckoutRecoveryRepository from '../data_layer/AbandonedCheckoutRecoveryRepository';
 import { SendAbandonedCheckoutRecoveryOnExpiryUseCase } from '../usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase';
 import { UserVisibleErrorsRepository } from '../data_layer/UserVisibleErrorsRepository';
@@ -44,7 +45,8 @@ const WebhooksRouter = () => {
   );
   const abandonedCheckoutRecoveryUseCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
     new AbandonedCheckoutRecoveryRepository(database),
-    getDefaultEmailService()
+    getDefaultEmailService(),
+    getEventsSink()
   );
   const recordErrorUseCase = new RecordUserVisibleErrorUseCase(
     new UserVisibleErrorsRepository(database)

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -314,7 +314,7 @@ class EmailService implements IEmailService {
     const msg = {
       to,
       from: this.defaultSender,
-      subject: 'Pick up where you left off on 2anki',
+      subject: 'Finish your 2anki Unlimited subscription',
       text,
       html: markup,
       replyTo: 'support@2anki.net',

--- a/src/services/EmailService/templates/abandoned-checkout-recovery.html
+++ b/src/services/EmailService/templates/abandoned-checkout-recovery.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="color-scheme" content="light dark" />
-  <title>2anki.net — Pick up where you left off</title>
+  <title>2anki.net — Finish your Unlimited subscription</title>
   <style>
     @media (prefers-color-scheme: dark) {
       body { background-color: #1a1a1a !important; }
@@ -34,12 +34,11 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <p style="margin: 0 0 16px;">You started a 2anki subscription and didn't finish checkout.</p>
-              <p style="margin: 0 0 16px;">From 1 June, the free plan covers 100 cards per month. Unlimited removes that ceiling and unlocks PDFs, larger Notion exports, and Print.</p>
+              <p style="margin: 0 0 16px;">You started a 2anki Unlimited subscription and didn't finish checkout.</p>
+              <p style="margin: 0 0 16px;">Most people who stop here hit a snag at payment, not a change of mind. If something broke or you have a question, reply to this email — Alexander reads every one.</p>
               <div style="text-align: center; margin: 0 0 24px;" class="email-cta">
                 <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Finish signing up</a>
               </div>
-              <p style="margin: 0 0 16px;">If checkout broke or you have a question, reply to this email — Alexander will read it.</p>
               <p style="margin: 0;">The 2anki Team</p>
             </td>
           </tr>

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
@@ -1,8 +1,13 @@
 import { SendAbandonedCheckoutRecoveryOnExpiryUseCase } from './SendAbandonedCheckoutRecoveryOnExpiryUseCase';
 import type { IAbandonedCheckoutRecoveryRepository } from '../../data_layer/AbandonedCheckoutRecoveryRepository';
 import type { IEmailService } from '../../services/EmailService/EmailService';
+import type { EventsSink } from '../../services/events/EventsSink';
 
 jest.mock('../../lib/misc/hashToken', () => (s: string) => `hashed:${s}`);
+
+function makeEventsSink(): jest.Mocked<Pick<EventsSink, 'record'>> {
+  return { record: jest.fn() };
+}
 
 function makeRepo(
   claimed = true,
@@ -137,5 +142,70 @@ describe('SendAbandonedCheckoutRecoveryOnExpiryUseCase', () => {
     await useCase.execute('cs_test_dup', 'bob@example.com');
 
     expect(emailService.sendAbandonedCheckoutRecoveryEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits email_batch_sent with campaign=abandoned_checkout and count 1 on a real send', async () => {
+    const repo = makeRepo(true);
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
+      repo,
+      emailService,
+      eventsSink
+    );
+
+    await useCase.execute('cs_test_event', 'alice@example.com');
+
+    expect(eventsSink.record).toHaveBeenCalledWith({
+      name: 'email_batch_sent',
+      props: { campaign: 'abandoned_checkout', count: 1 },
+    });
+  });
+
+  it('does not emit when the user opted out of marketing', async () => {
+    const repo = makeRepo(true, true);
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
+      repo,
+      emailService,
+      eventsSink
+    );
+
+    await useCase.execute('cs_opted_out', 'optout@example.com');
+
+    expect(eventsSink.record).not.toHaveBeenCalled();
+  });
+
+  it('does not emit when the email is missing', async () => {
+    const repo = makeRepo(true);
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
+      repo,
+      emailService,
+      eventsSink
+    );
+
+    await useCase.execute('cs_test_no_email', null);
+
+    expect(eventsSink.record).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('does not emit when the claim is a no-op duplicate', async () => {
+    const repo = makeRepo(false);
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(
+      repo,
+      emailService,
+      eventsSink
+    );
+
+    await useCase.execute('cs_test_dup_event', 'alice@example.com');
+
+    expect(eventsSink.record).not.toHaveBeenCalled();
   });
 });

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.ts
@@ -1,11 +1,13 @@
 import hashToken from '../../lib/misc/hashToken';
 import type { IAbandonedCheckoutRecoveryRepository } from '../../data_layer/AbandonedCheckoutRecoveryRepository';
 import type { IEmailService } from '../../services/EmailService/EmailService';
+import type { EventsSink } from '../../services/events/EventsSink';
 
 export class SendAbandonedCheckoutRecoveryOnExpiryUseCase {
   constructor(
     private readonly repository: IAbandonedCheckoutRecoveryRepository,
-    private readonly emailService: IEmailService
+    private readonly emailService: IEmailService,
+    private readonly eventsSink?: Pick<EventsSink, 'record'>
   ) {}
 
   async execute(sessionId: string, email: string | null): Promise<void> {
@@ -30,6 +32,10 @@ export class SendAbandonedCheckoutRecoveryOnExpiryUseCase {
       await this.emailService.sendAbandonedCheckoutRecoveryEmail(email, token);
       console.info('checkout.session.expired.recovery_sent', {
         session_id_hash: hashToken(sessionId),
+      });
+      this.eventsSink?.record({
+        name: 'email_batch_sent',
+        props: { campaign: 'abandoned_checkout', count: 1 },
       });
     }
   }

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.test.ts
@@ -1,6 +1,11 @@
 import { SendAbandonedCheckoutRecoveryUseCase } from './SendAbandonedCheckoutRecoveryUseCase';
 import type { IAbandonedCheckoutRecoveryRepository } from '../../data_layer/AbandonedCheckoutRecoveryRepository';
 import type { IEmailService } from '../../services/EmailService/EmailService';
+import type { EventsSink } from '../../services/events/EventsSink';
+
+function makeEventsSink(): jest.Mocked<Pick<EventsSink, 'record'>> {
+  return { record: jest.fn() };
+}
 
 function makeEmailService(): jest.Mocked<IEmailService> {
   return {
@@ -155,5 +160,72 @@ describe('SendAbandonedCheckoutRecoveryUseCase', () => {
     const [, persistedToken] = (repo.recordEmailSend as jest.Mock).mock.calls[0];
     expect(typeof persistedToken).toBe('string');
     expect(persistedToken.length).toBeGreaterThan(0);
+  });
+
+  it('emits email_batch_sent with campaign=abandoned_checkout and the real sent count', async () => {
+    const emailService = makeEmailService();
+    const repo = makeRepo(false);
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryUseCase(
+      emailService,
+      repo,
+      eventsSink
+    );
+
+    await useCase.execute(['alice@example.com', 'bob@example.com'], false);
+
+    expect(eventsSink.record).toHaveBeenCalledWith({
+      name: 'email_batch_sent',
+      props: { campaign: 'abandoned_checkout', count: 2 },
+    });
+  });
+
+  it('does not emit in a dry run', async () => {
+    const emailService = makeEmailService();
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryUseCase(
+      emailService,
+      undefined,
+      eventsSink
+    );
+
+    await useCase.execute(['alice@example.com'], true);
+
+    expect(eventsSink.record).not.toHaveBeenCalled();
+  });
+
+  it('does not emit when every candidate opted out', async () => {
+    const emailService = makeEmailService();
+    const repo = makeRepo(true);
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryUseCase(
+      emailService,
+      repo,
+      eventsSink
+    );
+
+    await useCase.execute(['optout@example.com'], false);
+
+    expect(eventsSink.record).not.toHaveBeenCalled();
+  });
+
+  it('emits the count of successful sends when some fail', async () => {
+    const emailService = makeEmailService();
+    emailService.sendAbandonedCheckoutRecoveryEmail.mockImplementationOnce(
+      () => Promise.reject(new Error('SendGrid 500'))
+    );
+    const eventsSink = makeEventsSink();
+    const useCase = new SendAbandonedCheckoutRecoveryUseCase(
+      emailService,
+      undefined,
+      eventsSink
+    );
+
+    await useCase.execute(['fails@example.com', 'works@example.com'], false);
+
+    expect(eventsSink.record).toHaveBeenCalledWith({
+      name: 'email_batch_sent',
+      props: { campaign: 'abandoned_checkout', count: 1 },
+    });
   });
 });

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.ts
@@ -1,5 +1,6 @@
 import type { IAbandonedCheckoutRecoveryRepository } from '../../data_layer/AbandonedCheckoutRecoveryRepository';
 import type { IEmailService } from '../../services/EmailService/EmailService';
+import type { EventsSink } from '../../services/events/EventsSink';
 
 export interface SendAbandonedCheckoutRecoveryResult {
   dryRun: boolean;
@@ -18,7 +19,8 @@ const isValidEmail = (value: string): boolean =>
 export class SendAbandonedCheckoutRecoveryUseCase {
   constructor(
     private readonly emailService: IEmailService,
-    private readonly repository?: IAbandonedCheckoutRecoveryRepository
+    private readonly repository?: IAbandonedCheckoutRecoveryRepository,
+    private readonly eventsSink?: Pick<EventsSink, 'record'>
   ) {}
 
   async execute(
@@ -65,6 +67,13 @@ export class SendAbandonedCheckoutRecoveryUseCase {
           error: error instanceof Error ? error.message : 'unknown',
         });
       }
+    }
+
+    if (sent > 0) {
+      this.eventsSink?.record({
+        name: 'email_batch_sent',
+        props: { campaign: 'abandoned_checkout', count: sent },
+      });
     }
 
     return {


### PR DESCRIPTION
## What
Makes the abandoned-checkout recovery email observable and rewrites its copy for people who already decided to buy. Both send paths now emit an `email_batch_sent` event, and the email stops re-pitching features.

## Why
The campaign is invisible in our funnel today — it emits only a `console.info`, no events row — so it doesn't appear alongside re-engagement and inactivity. Prod data: it has sent ~8 times ever, against an 89% upgrade→pay drop that's real per the subscriptions-table reconciliation. We can't tune what we can't see. The copy also re-pitched the feature list to someone who had already clicked buy, inviting them to re-decide.

## How
- `SendAbandonedCheckoutRecoveryOnExpiryUseCase` (single, webhook-triggered) emits `email_batch_sent` with `{ campaign: 'abandoned_checkout', count: 1 }` only on a real send — after the branch that already logged `recovery_sent`. No emit on the opt-out or missing-email early returns, and none on a no-op duplicate claim.
- `SendAbandonedCheckoutRecoveryUseCase` (bulk, ops) emits once with the real successful-send count, and only when `sent > 0`. No emit on dry runs or all-opted-out batches.
- Wiring: both use cases take an optional `EventsSink` constructor param (mirroring the inactivity scheduler's `eventsSink?` pattern), fed `getEventsSink()` at the two construction sites (`WebhookRouter`, `OpsRouter`). Typed as `Pick<EventsSink, 'record'>` so tests mock the edge. This is the lower-risk wiring versus reaching for the global `track()` inside the use case, and keeps the emit unit-testable.
- Copy: subject → `Finish your 2anki Unlimited subscription`; `<title>` updated; body para 1 names the Unlimited subscription; deleted the feature-re-pitch paragraph; added a reassurance paragraph above the CTA ("Most people who stop here hit a snag at payment, not a change of mind…"); removed the now-duplicate reply line below the CTA. CTA label, `{{link}}` destination, dark-mode/responsive blocks, mascot header, unsubscribe footer, and sign-off all unchanged.

## Measuring success
In the ops funnel / events table: `select props->>'count' from events where name = 'email_batch_sent' and props->>'campaign' = 'abandoned_checkout'`. The campaign now appears alongside `reengagement` and `inactivity`; previously it returned zero rows regardless of sends.

## Testing
- Unit tests added (Jest, colocated):
  - OnExpiry: emits with `campaign: 'abandoned_checkout', count: 1` on a real send; does NOT emit on opt-out, missing email, or no-op duplicate claim.
  - Bulk: emits with the real sent count; does NOT emit on dry run or all-opted-out; emits the successful count when some sends fail.
- `pnpm test` on the touched use case tests + `WebhookRouter.test.ts` + `EmailServiceUnsubscribe.test.ts`: all green (51 tests).
- `tsc -p . --noEmit`: clean.
- Sonar not run locally (no `SONAR_TOKEN` configured here); the change is an optional constructor param plus two `if`-guarded emits and HTML/subject edits — low complexity. Expect a clean Sonar pass; flagging in case of a bounce.

## Browser check
Browser check: not applicable — no `web/src/` files; server-side email template + instrumentation only.

## Changelog
No changelog entry — transactional email copy + internal instrumentation, no in-app What's New surface.

## Deferred / needs security review
Intentionally out of scope, to be handled in a separate security-reviewed PR (this PR has zero payment-path behavior change):
- Resume-to-checkout via Stripe `after_expiration.recovery` (so the link reopens the original session instead of `/pricing`).
- Triggering the recovery earlier than session expiry.
- Click-tracking to an external host.
Untouched here: every `stripe.checkout.sessions.create` call, webhook handler logic, `expires_at`, `after_expiration`, the `{{link}}` destination, and the EmailRedirectRouter.

## Risks
Low. The emit is guarded so it never fires on non-sends, and the sink param is optional so any unwired caller (and existing tests) behave as before. Rollback is a revert of one commit. Email copy change is reversible.

## Goal alignment
The 89% upgrade→pay drop is one of the larger leaks toward the 300K-user goal. This PR makes the recovery campaign measurable so we can iterate on it, and removes copy that pushed already-decided buyers to reconsider — a direct, low-risk step toward recovering paid conversions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782878228&installation_id=132681956&pr_number=3003&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3003&signature=95b2c14df2e7363833bf0ebbc0f0f00ec8f18fc74fa2f6ffd170a4cf82156886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->