### PR TITLE
fix: guard null Notion search query before toString

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -400,6 +400,40 @@ describe('NotionController', () => {
     });
   });
 
+  describe('search — empty query', () => {
+    it('treats a null query as empty and searches without throwing', async () => {
+      const searchResult = { results: [] };
+      service = {
+        getNotionLinkInfo: jest.fn().mockResolvedValue({ isConnected: true }),
+        search: jest.fn().mockResolvedValue(searchResult),
+      } as any;
+      controller = new NotionController(service);
+      req = { body: { query: null }, params: {}, query: {} };
+
+      await controller.search(req as express.Request, res as express.Response);
+
+      expect(service.search).toHaveBeenCalledWith('', 'owner1');
+      expect(res.json).toHaveBeenCalledWith(searchResult);
+      expect(res.status).not.toHaveBeenCalledWith(500);
+    });
+
+    it('treats an absent query as empty and searches without throwing', async () => {
+      const searchResult = { results: [] };
+      service = {
+        getNotionLinkInfo: jest.fn().mockResolvedValue({ isConnected: true }),
+        search: jest.fn().mockResolvedValue(searchResult),
+      } as any;
+      controller = new NotionController(service);
+      req = { body: {}, params: {}, query: {} };
+
+      await controller.search(req as express.Request, res as express.Response);
+
+      expect(service.search).toHaveBeenCalledWith('', 'owner1');
+      expect(res.json).toHaveBeenCalledWith(searchResult);
+      expect(res.status).not.toHaveBeenCalledWith(500);
+    });
+  });
+
   describe('searchTopLevelPages — Unauthorized', () => {
     it('returns structured JSON with notion_unauthorized code — no HTML in message', async () => {
       const unauthorizedError = new APIResponseError({

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -136,7 +136,7 @@ class NotionController {
         return res.status(401).json({ code: 'notion_unauthorized', message: 'Notion is not connected.' });
       }
 
-      const query = req.body.query.toString() || '';
+      const query = (req.body.query ?? '').toString();
       const result = await this.service.search(query, getOwner(res));
       res.json(result);
     } catch (err) {


### PR DESCRIPTION
## What
Guards `req.body.query` before calling `.toString()` in the Notion `search` controller, coalescing a null/undefined/empty query to `''` so the search proceeds (and returns empty) instead of throwing.

## Why
`const query = req.body.query.toString() || ''` evaluated `.toString()` on the raw value *before* the `|| ''` fallback could apply. When a client posted `{query: null}` or omitted the field, this threw `TypeError: Cannot read properties of null (reading 'toString')`, which the try/catch turned into an error response — the endpoint failed on what should be a valid empty search. Prod error logs show 5 occurrences in 24h.

## How
`const query = (req.body.query ?? '').toString()` — `??` covers `null` and `undefined` per the repo's absence convention. One-line source change.

## Measuring success
The `TypeError: Cannot read properties of null (reading 'toString')` stack from `NotionController.search` disappears from prod error logs; the endpoint returns search results (or an empty result set) for `{query: null}` / omitted-query requests.

## Testing
- Unit tests added: `search` with `body.query` null, and with `body.query` absent — both assert `service.search` is called with `''` and no 500 is sent. Confirmed they fail against the old line (service.search never called, .toString threw), pass after the fix. Full file 24/24 green; `tsc -p . --noEmit` clean.

## Sonar
Not run locally — no `SONAR_TOKEN` configured in this environment. Change is a one-line null-guard plus colocated tests; no new complexity, nesting, or security sink.

## Changelog
No entry — edge-case server hardening (null/empty Notion search query) with no perceptible user-facing behavior change.

## Risks
Minimal. An empty query now reaches `service.search('')` rather than erroring; the service already handled empty-string queries on the happy path. No schema, auth, or external-API contract change.

## Goal alignment
Removes a recurring server error on the Notion search path that the user hits during the upload/convert flow — fewer broken interactions on the core conversion journey supports the 300K-user scale goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782879274&installation_id=132681956&pr_number=3004&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3004&signature=ab86f357116c5e0f23114eba86862050ca77cc97545a8c42311c7d922f63861d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->