### PR TITLE
fix: strip sensitive query params from the address bar after use

### DIFF
--- a/web/src/lib/stripUrlParam.test.ts
+++ b/web/src/lib/stripUrlParam.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { stripUrlParam } from './stripUrlParam';
+
+describe('stripUrlParam', () => {
+  let replaceState: ReturnType<typeof vi.fn>;
+
+  function setLocation(pathname: string, search: string, hash = '') {
+    replaceState = vi.fn();
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      configurable: true,
+      value: { pathname, search, hash },
+    });
+    Object.defineProperty(globalThis, 'history', {
+      writable: true,
+      configurable: true,
+      value: { state: null, replaceState },
+    });
+  }
+
+  beforeEach(() => {
+    setLocation('/', '');
+  });
+
+  it('removes the named param from the address bar', () => {
+    setLocation('/auth/magic', '?token=secret-value');
+    stripUrlParam('token');
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/auth/magic');
+  });
+
+  it('keeps other params intact when stripping one', () => {
+    setLocation('/auth/magic', '?token=secret-value&redirect=anki');
+    stripUrlParam('token');
+    expect(replaceState).toHaveBeenCalledWith(
+      null,
+      '',
+      '/auth/magic?redirect=anki'
+    );
+  });
+
+  it('strips the Stripe session id and preserves the path', () => {
+    setLocation('/successful-checkout', '?session_id=cs_test_abc');
+    stripUrlParam('session_id');
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/successful-checkout');
+  });
+
+  it('preserves the hash fragment', () => {
+    setLocation('/account', '?token=secret-value', '#plan');
+    stripUrlParam('token');
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/account#plan');
+  });
+
+  it('does nothing when the param is absent', () => {
+    setLocation('/account', '');
+    stripUrlParam('token');
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/stripUrlParam.ts
+++ b/web/src/lib/stripUrlParam.ts
@@ -1,0 +1,18 @@
+export function stripUrlParam(param: string): void {
+  const replaceState = globalThis.history?.replaceState;
+  if (typeof replaceState !== 'function') {
+    return;
+  }
+
+  const params = new URLSearchParams(globalThis.location.search);
+  if (!params.has(param)) {
+    return;
+  }
+
+  params.delete(param);
+  const query = params.toString();
+  const cleaned = `${globalThis.location.pathname}${query ? `?${query}` : ''}${
+    globalThis.location.hash ?? ''
+  }`;
+  replaceState.call(globalThis.history, globalThis.history.state, '', cleaned);
+}

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
@@ -99,4 +99,19 @@ describe('MagicLinkPage', () => {
       screen.getByText('Something went wrong. Try again.')
     ).toBeInTheDocument();
   });
+
+  it('strips the token from the address bar after reading it', async () => {
+    globalThis.history.replaceState(
+      null,
+      '',
+      '/auth/magic?token=secret-value'
+    );
+    mockValidateMagicToken.mockReturnValue(new Promise(() => {}));
+    renderMagicLinkPage('?token=secret-value');
+
+    await waitFor(() => {
+      expect(globalThis.location.search).not.toContain('token');
+    });
+    expect(globalThis.location.pathname).toBe('/auth/magic');
+  });
 });

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useCookies } from 'react-cookie';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { getSearchPath } from '../../components/NavigationBar/helpers/getSearchPath';
+import { stripUrlParam } from '../../lib/stripUrlParam';
 import styles from '../../styles/auth.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 
@@ -33,6 +34,7 @@ function MagicLinkPage() {
 
     let cancelled = false;
     const validToken = token;
+    stripUrlParam('token');
 
     async function validateToken() {
       try {

--- a/web/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.test.ts
+++ b/web/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.test.ts
@@ -61,6 +61,43 @@ describe('useSubscriptionStatus purchase event', () => {
     expect(purchaseCalls).toHaveLength(1);
   }, 12000);
 
+  it('strips session_id from the address bar after capturing it', async () => {
+    const replaceState = vi.fn();
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      configurable: true,
+      value: {
+        href: 'https://2anki.net/successful-checkout?session_id=cs_test_xyz',
+        pathname: '/successful-checkout',
+        search: '?session_id=cs_test_xyz',
+        hash: '',
+      },
+    });
+    Object.defineProperty(globalThis, 'history', {
+      writable: true,
+      configurable: true,
+      value: { state: null, replaceState },
+    });
+
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ authenticated: false, hasActiveSubscription: false }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    );
+
+    const { useSubscriptionStatus } = await import('./useSubscriptionStatus');
+    renderHook(() => useSubscriptionStatus(), { wrapper: buildWrapper() });
+
+    await waitFor(() => {
+      expect(replaceState).toHaveBeenCalledWith(
+        null,
+        '',
+        '/successful-checkout'
+      );
+    });
+  });
+
   it('does not fire purchase when dedup key is already set in sessionStorage', async () => {
     const { track } = await import('../../../lib/analytics/track');
     const trackMock = vi.mocked(track);

--- a/web/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
+++ b/web/src/pages/SuccessfulCheckout/hooks/useSubscriptionStatus.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { track } from '../../../lib/analytics/track';
+import { stripUrlParam } from '../../../lib/stripUrlParam';
 
 interface SubscriptionStatus {
   authenticated: boolean;
@@ -38,9 +39,13 @@ export const useSubscriptionStatus = () => {
   const [shouldPoll, setShouldPoll] = useState(true);
   const [timeoutReached, setTimeoutReached] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
-  const sessionId = new URLSearchParams(globalThis.location.search).get(
-    'session_id'
+  const [sessionId] = useState(() =>
+    new URLSearchParams(globalThis.location.search).get('session_id')
   );
+
+  useEffect(() => {
+    stripUrlParam('session_id');
+  }, []);
 
   const query = useQuery({
     queryKey: ['subscription-status', sessionId],


### PR DESCRIPTION
## What
After the magic-link login page and the post-checkout return page read the values they need, the sensitive query param is removed from the displayed URL via `history.replaceState`. This covers the magic-link `token` and the Stripe checkout `session_id`.

## Why
A third-party session-recording integration captured secrets that were sitting in URLs and referrers. Two query params were left in the address bar after they were consumed, so they leaked into the document referrer and into analytics capture: the magic-link login token on `/auth/magic` and the Stripe checkout session id on the post-checkout return page. This strips both from the visible URL once they've been used.

## How
- New shared pure helper `web/src/lib/stripUrlParam.ts` reads `location.search`, deletes the named param, and rewrites the path with `history.replaceState` (state and hash preserved). It no-ops when the param is absent or when `history.replaceState` is unavailable.
- `MagicLinkPage` strips `token` immediately after capturing it into the effect's local, before validation runs.
- `useSubscriptionStatus` captures `session_id` once into state (so polling and the dedup key keep working) and strips it from the URL in a mount effect.

Auth and checkout behavior are unchanged — only the address bar, referrer, and analytics capture stop carrying the secret. Server-side token validation/TTL was deliberately not touched (tracked separately). The `?subscribed=1` return marker carries no secret and already has its own dismiss control, so it was left as-is.

## Measuring success
After a magic-link login and after a checkout return, the address bar shows the bare path (`/auth/magic`, `/successful-checkout`) with no `token`/`session_id`. In the third-party session-recording dashboard, captured page URLs and referrers for these routes no longer contain the token or `cs_..._` session id.

## Testing
- Unit tests added: `stripUrlParam` (removal, multi-param, hash preservation, absent-param no-op); `MagicLinkPage` strips `token` from the URL after reading it; `useSubscriptionStatus` strips `session_id` after capturing it.
- `pnpm --filter 2anki-web test` (3 files, 15 tests) green; `typecheck` green; Biome `lint` green.
- Sonar not run locally — no `SONAR_TOKEN` configured. Change is small with no new HTTP/HTML/zip/path-from-input sinks; expect a clean pass.

## Browser check
Browser check: not applicable — strips a query param from the address bar after it's consumed; no rendered-component change.

## Changelog
No changelog entry — security/URL hygiene, no perceptible behavior change.

## Risks
The post-checkout hook now reads `session_id` once into state instead of re-reading on every render; polling and the per-session dedup key are keyed off that captured value, so stripping the URL doesn't break them. Rollback is a straight revert of this branch.

## Goal alignment
Protects users' login and payment session secrets from leaking into referrers and third-party capture — trust and account safety are table stakes for growing past 300K users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782879390&installation_id=132681956&pr_number=3005&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3005&signature=8fe2dcd9e2cae717d685cee26dfa6211622b70abb6b61abb4664d8dd87015934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->