### PR TITLE
feat: attribute paid checkouts to the surface that drove them

### DIFF
--- a/src/controllers/AutoSyncCheckoutController.ts
+++ b/src/controllers/AutoSyncCheckoutController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { AutoSyncCheckoutUseCase } from '../usecases/checkout/AutoSyncCheckoutUseCase';
 import { parsePricingVariant } from '../usecases/checkout/pricingVariant';
+import { parseCheckoutSurface } from '../usecases/checkout/checkoutSurface';
 
 class AutoSyncCheckoutController {
   constructor(private readonly useCase: AutoSyncCheckoutUseCase) {}
@@ -10,8 +11,9 @@ class AutoSyncCheckoutController {
     const userEmail = res.locals.email as string;
     const variant = parsePricingVariant(req.body?.variant);
     const anonId = (req.cookies?.anon_id as string | undefined) ?? undefined;
+    const surface = parseCheckoutSurface(req.body?.surface);
 
-    const result = await this.useCase.execute({ userId, userEmail, variant, anonId });
+    const result = await this.useCase.execute({ userId, userEmail, variant, anonId, surface });
     res.json(result);
   }
 }

--- a/src/controllers/PassCheckoutController.ts
+++ b/src/controllers/PassCheckoutController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { CreatePassCheckoutUseCase } from '../usecases/checkout/CreatePassCheckoutUseCase';
 import { parsePricingVariant } from '../usecases/checkout/pricingVariant';
+import { parseCheckoutSurface } from '../usecases/checkout/checkoutSurface';
 
 class PassCheckoutController {
   constructor(private readonly useCase: CreatePassCheckoutUseCase) {}
@@ -10,8 +11,9 @@ class PassCheckoutController {
     const userEmail = res.locals.email as string | undefined;
     const variant = parsePricingVariant(req.body?.variant);
     const anonId = (req.cookies?.anon_id as string | undefined) ?? undefined;
+    const surface = parseCheckoutSurface(req.body?.surface);
 
-    const result = await this.useCase.execute({ userId, userEmail, variant, anonId });
+    const result = await this.useCase.execute({ userId, userEmail, variant, anonId, surface });
     res.json(result);
   }
 }

--- a/src/controllers/UnlimitedCheckoutController.ts
+++ b/src/controllers/UnlimitedCheckoutController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { UnlimitedCheckoutUseCase, UnlimitedInterval } from '../usecases/checkout/UnlimitedCheckoutUseCase';
 import { parsePricingVariant } from '../usecases/checkout/pricingVariant';
+import { parseCheckoutSurface } from '../usecases/checkout/checkoutSurface';
 
 const VALID_INTERVALS: ReadonlySet<string> = new Set(['month', 'year']);
 
@@ -24,6 +25,7 @@ class UnlimitedCheckoutController {
       interval: interval as UnlimitedInterval,
       variant: parsePricingVariant(req.body?.variant),
       anonId,
+      surface: parseCheckoutSurface(req.body?.surface),
     });
     res.json(result);
   }

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -411,6 +411,47 @@ describe('WebhookRouter — checkout_completed funnel join', () => {
       expect.objectContaining({ userId: 9, anonymousId: null, props: expect.objectContaining({ variant: 'minimal' }) })
     );
   });
+
+  it('emits checkout_completed with surface when session metadata carries it', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_surface',
+          mode: 'subscription',
+          metadata: { user_id: '11', surface: 'pricing_page' },
+        },
+      },
+    };
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    expect(mockTrack).toHaveBeenCalledWith(
+      'checkout_completed',
+      expect.objectContaining({
+        userId: 11,
+        props: expect.objectContaining({ surface: 'pricing_page' }),
+      })
+    );
+  });
+
+  it('omits surface from checkout_completed props when metadata lacks it', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_no_surface',
+          mode: 'subscription',
+          metadata: { user_id: '12' },
+        },
+      },
+    };
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    const call = mockTrack.mock.calls.find((c) => c[0] === 'checkout_completed');
+    expect(call?.[1].props.surface).toBeUndefined();
+  });
 });
 
 describe('WebhookRouter — lifetime product-ID allowlist', () => {

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -230,6 +230,7 @@ const WebhooksRouter = () => {
           const passKind = sessionMeta.pass_kind as PassKind | undefined;
 
           const pricingVariant = sessionMeta.pricing_variant;
+          const surface = sessionMeta.surface;
           const anonId = sessionMeta.anon_id;
           const userIdMeta = Number.parseInt(sessionMeta.user_id ?? '', 10);
           track('checkout_completed', {
@@ -241,6 +242,9 @@ const WebhooksRouter = () => {
                 (session.mode === 'subscription' ? 'subscription' : 'payment'),
               ...(pricingVariant != null && pricingVariant !== ''
                 ? { variant: pricingVariant }
+                : {}),
+              ...(surface != null && surface !== ''
+                ? { surface }
                 : {}),
             },
           });

--- a/src/usecases/checkout/AutoSyncCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/AutoSyncCheckoutUseCase.test.ts
@@ -107,6 +107,36 @@ describe('AutoSyncCheckoutUseCase', () => {
     );
   });
 
+  test('stamps surface into metadata when provided', async () => {
+    mockCountActive.mockResolvedValue(0);
+    mockGetUserActiveSubscriptions.mockResolvedValue([]);
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
+
+    const uc = makeUseCase();
+    await uc.execute({ userEmail: 'user@example.com', userId: 42, surface: 'pricing_page' });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { user_id: '42', surface: 'pricing_page' },
+      })
+    );
+  });
+
+  test('omits surface from metadata when absent', async () => {
+    mockCountActive.mockResolvedValue(0);
+    mockGetUserActiveSubscriptions.mockResolvedValue([]);
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
+
+    const uc = makeUseCase();
+    await uc.execute({ userEmail: 'user@example.com', userId: 42 });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { user_id: '42' },
+      })
+    );
+  });
+
   test('does not log raw Stripe IDs in session creation args', async () => {
     mockCountActive.mockResolvedValue(0);
     mockGetUserActiveSubscriptions.mockResolvedValue([]);

--- a/src/usecases/checkout/AutoSyncCheckoutUseCase.ts
+++ b/src/usecases/checkout/AutoSyncCheckoutUseCase.ts
@@ -26,6 +26,7 @@ export class AutoSyncCheckoutUseCase {
     stripeCustomerId?: string | null;
     variant?: string;
     anonId?: string;
+    surface?: string;
   }): Promise<AutoSyncCheckoutResult> {
     console.info('auto_sync.checkout.started', { user_id: input.userId });
 
@@ -62,6 +63,9 @@ export class AutoSyncCheckoutUseCase {
           : {}),
         ...(input.anonId != null && input.anonId !== ''
           ? { anon_id: input.anonId }
+          : {}),
+        ...(input.surface != null && input.surface !== ''
+          ? { surface: input.surface }
           : {}),
       },
     };

--- a/src/usecases/checkout/CreatePassCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/CreatePassCheckoutUseCase.test.ts
@@ -143,6 +143,31 @@ describe('CreatePassCheckoutUseCase', () => {
     });
   });
 
+  describe('surface attribution', () => {
+    it('stamps surface into metadata when provided', async () => {
+      mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/s' });
+
+      const uc = new CreatePassCheckoutUseCase(makeStripe(), 'price_24h', '24h');
+      await uc.execute({ userEmail: 'user@example.com', userId: 7, surface: 'limit-wall' });
+
+      expect(mockStripeCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: { user_id: '7', pass_kind: '24h', surface: 'limit-wall' },
+        })
+      );
+    });
+
+    it('omits surface when none is supplied', async () => {
+      mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/s' });
+
+      const uc = new CreatePassCheckoutUseCase(makeStripe(), 'price_24h', '24h');
+      await uc.execute({ userEmail: 'user@example.com', userId: 7 });
+
+      const call = mockStripeCreateSession.mock.calls[0][0];
+      expect(call.metadata.surface).toBeUndefined();
+    });
+  });
+
   describe('anonymous mode (no userId / no userEmail)', () => {
     it('omits user_id from metadata and sets pass_anonymous=1', async () => {
       mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/anon' });

--- a/src/usecases/checkout/CreatePassCheckoutUseCase.ts
+++ b/src/usecases/checkout/CreatePassCheckoutUseCase.ts
@@ -18,6 +18,7 @@ export class CreatePassCheckoutUseCase {
     stripeCustomerId?: string | null;
     variant?: string;
     anonId?: string;
+    surface?: string;
   }): Promise<CreatePassCheckoutResult> {
     const appUrl = process.env.APP_URL ?? 'https://2anki.net';
     const isAnonymous = input.userId == null;
@@ -37,6 +38,9 @@ export class CreatePassCheckoutUseCase {
     }
     if (input.anonId != null && input.anonId !== '') {
       metadata.anon_id = input.anonId;
+    }
+    if (input.surface != null && input.surface !== '') {
+      metadata.surface = input.surface;
     }
 
     const sessionParams: StripeTypes.Checkout.SessionCreateParams = {

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
@@ -139,6 +139,37 @@ describe('UnlimitedCheckoutUseCase', () => {
     );
   });
 
+  it('stamps surface into metadata when provided', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
+
+    const uc = new UnlimitedCheckoutUseCase(makeStripe(), MONTHLY_PRICE_ID, YEARLY_PRICE_ID);
+    await uc.execute({
+      userEmail: 'user@example.com',
+      userId: 10,
+      interval: 'month',
+      surface: 'pricing_page',
+    });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { user_id: '10', surface: 'pricing_page' },
+      })
+    );
+  });
+
+  it('omits surface from metadata when absent', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
+
+    const uc = new UnlimitedCheckoutUseCase(makeStripe(), MONTHLY_PRICE_ID, YEARLY_PRICE_ID);
+    await uc.execute({ userEmail: 'user@example.com', userId: 11, interval: 'month' });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { user_id: '11' },
+      })
+    );
+  });
+
   it('does not log raw Stripe customer IDs', async () => {
     mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
     const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => {});

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
@@ -21,6 +21,7 @@ export class UnlimitedCheckoutUseCase {
     stripeCustomerId?: string | null;
     variant?: string;
     anonId?: string;
+    surface?: string;
   }): Promise<UnlimitedCheckoutResult> {
     console.info('unlimited.checkout.started', { user_id: input.userId, interval: input.interval });
 
@@ -41,6 +42,9 @@ export class UnlimitedCheckoutUseCase {
           : {}),
         ...(input.anonId != null && input.anonId !== ''
           ? { anon_id: input.anonId }
+          : {}),
+        ...(input.surface != null && input.surface !== ''
+          ? { surface: input.surface }
           : {}),
       },
     };

--- a/src/usecases/checkout/checkoutSurface.test.ts
+++ b/src/usecases/checkout/checkoutSurface.test.ts
@@ -1,0 +1,26 @@
+import { parseCheckoutSurface } from './checkoutSurface';
+
+describe('parseCheckoutSurface', () => {
+  it('keeps a clean surface label', () => {
+    expect(parseCheckoutSurface('limit-wall')).toBe('limit-wall');
+    expect(parseCheckoutSurface('upload_success_upsell')).toBe('upload_success_upsell');
+    expect(parseCheckoutSurface('pricing_page')).toBe('pricing_page');
+  });
+
+  it('lowercases and strips characters outside [a-z0-9_-]', () => {
+    expect(parseCheckoutSurface('Downloads Upsell!')).toBe('downloadsupsell');
+    expect(parseCheckoutSurface('LIMIT-WALL')).toBe('limit-wall');
+  });
+
+  it('caps the length so nothing unbounded reaches metadata', () => {
+    expect(parseCheckoutSurface('a'.repeat(100))).toBe('a'.repeat(40));
+  });
+
+  it('returns undefined for empty or non-string input', () => {
+    expect(parseCheckoutSurface('')).toBeUndefined();
+    expect(parseCheckoutSurface('   ')).toBeUndefined();
+    expect(parseCheckoutSurface(undefined)).toBeUndefined();
+    expect(parseCheckoutSurface(42)).toBeUndefined();
+    expect(parseCheckoutSurface({ surface: 'limit-wall' })).toBeUndefined();
+  });
+});

--- a/src/usecases/checkout/checkoutSurface.ts
+++ b/src/usecases/checkout/checkoutSurface.ts
@@ -1,0 +1,17 @@
+const MAX_SURFACE_LENGTH = 40;
+
+/**
+ * Bound the surface/ref attribution string before it lands in Stripe session
+ * metadata: lowercase, strip anything outside [a-z0-9_-], cap the length, and
+ * reject empty input so nothing arbitrary or unbounded is stored.
+ */
+export function parseCheckoutSurface(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, '')
+    .slice(0, MAX_SURFACE_LENGTH);
+  return cleaned === '' ? undefined : cleaned;
+}

--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -133,7 +133,7 @@ describe('UpsellCard', () => {
         surface: 'downloads_upsell',
         plan: 'day_pass',
       });
-      expect(mockStartPassCheckout).toHaveBeenCalledWith('24h');
+      expect(mockStartPassCheckout).toHaveBeenCalledWith('24h', undefined, 'downloads_upsell');
     });
   });
 
@@ -150,7 +150,7 @@ describe('UpsellCard', () => {
         surface: 'upload_success_upsell',
         plan: 'week_pass',
       });
-      expect(mockStartPassCheckout).toHaveBeenCalledWith('7d');
+      expect(mockStartPassCheckout).toHaveBeenCalledWith('7d', undefined, 'upload_success_upsell');
     });
   });
 

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -84,7 +84,7 @@ export function UpsellCard({ surface, hideForAnonymous = false }: UpsellCardProp
       plan: kind === '24h' ? 'day_pass' : 'week_pass',
     });
     setPendingKind(kind);
-    const result = await get2ankiApi().startPassCheckout(kind);
+    const result = await get2ankiApi().startPassCheckout(kind, undefined, surface);
     if ('url' in result) {
       globalThis.location.href = result.url;
       return;

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -434,11 +434,11 @@ export class Backend {
     await post(`${this.baseURL}users/debug/ankify-welcome-seen`, {});
   }
 
-  async startAutoSyncCheckout(variant?: string): Promise<
+  async startAutoSyncCheckout(variant?: string, surface?: string): Promise<
     { url: string } | { status: 'cap_reached' | 'already_subscribed' | 'error' }
   > {
     try {
-      const response = await post(`${this.baseURL}checkout/auto-sync`, { variant });
+      const response = await post(`${this.baseURL}checkout/auto-sync`, { variant, surface });
       if (response.status === 404) {
         return { status: 'cap_reached' };
       }
@@ -465,10 +465,11 @@ export class Backend {
 
   async startUnlimitedCheckout(
     interval: 'month' | 'year',
-    variant?: string
+    variant?: string,
+    surface?: string
   ): Promise<{ url: string } | { status: 'unavailable' | 'error' }> {
     try {
-      const response = await post(`${this.baseURL}checkout/unlimited`, { interval, variant });
+      const response = await post(`${this.baseURL}checkout/unlimited`, { interval, variant, surface });
       if (response.status === 503) {
         return { status: 'unavailable' };
       }
@@ -489,11 +490,12 @@ export class Backend {
 
   async startPassCheckout(
     kind: '24h' | '7d',
-    variant?: string
+    variant?: string,
+    surface?: string
   ): Promise<{ url: string } | { status: 'unavailable' | 'error' }> {
     const path = kind === '24h' ? 'checkout/pass/24h' : 'checkout/pass/7d';
     try {
-      const response = await post(`${this.baseURL}${path}`, { variant });
+      const response = await post(`${this.baseURL}${path}`, { variant, surface });
       if (response.status === 503) {
         return { status: 'unavailable' };
       }

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
@@ -192,7 +192,7 @@ describe('DeckFeedbackPrompt — Day Pass offer after positive rating', () => {
         surface: 'deck_feedback_sent',
         plan: 'day_pass',
       });
-      expect(startPassCheckout).toHaveBeenCalledWith('24h');
+      expect(startPassCheckout).toHaveBeenCalledWith('24h', undefined, 'deck_feedback_sent');
     });
   });
 

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
@@ -106,7 +106,7 @@ export function DeckFeedbackPrompt() {
       plan: 'day_pass',
     });
     setDayPassPending(true);
-    const result = await get2ankiApi().startPassCheckout('24h');
+    const result = await get2ankiApi().startPassCheckout('24h', undefined, UPSELL_SURFACE);
     if ('url' in result) {
       globalThis.location.href = result.url;
       return;

--- a/web/src/pages/LimitPage/LimitPage.test.tsx
+++ b/web/src/pages/LimitPage/LimitPage.test.tsx
@@ -115,7 +115,7 @@ describe('LimitPage', () => {
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Get Day Pass' }));
     await vi.waitFor(() => {
-      expect(mockStartPassCheckout).toHaveBeenCalledWith('24h');
+      expect(mockStartPassCheckout).toHaveBeenCalledWith('24h', undefined, 'limit-wall');
       expect(globalThis.location.href).toBe('https://checkout.stripe.com/pass');
     });
   });

--- a/web/src/pages/LimitPage/LimitPage.tsx
+++ b/web/src/pages/LimitPage/LimitPage.tsx
@@ -117,7 +117,7 @@ export function LimitPage() {
       setWeekPassPending(true);
     }
     try {
-      const result = await get2ankiApi().startPassCheckout(passKind);
+      const result = await get2ankiApi().startPassCheckout(passKind, undefined, REF);
       if ('url' in result) {
         globalThis.location.href = result.url;
         return;

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -555,7 +555,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
 
     await waitFor(() => {
-      expect(mockStartUnlimitedCheckout).toHaveBeenCalledWith('month', 'passes-first');
+      expect(mockStartUnlimitedCheckout).toHaveBeenCalledWith('month', 'passes-first', 'pricing_page');
     });
   });
 
@@ -568,7 +568,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
 
     await waitFor(() => {
-      expect(mockStartUnlimitedCheckout).toHaveBeenCalledWith('year', 'passes-first');
+      expect(mockStartUnlimitedCheckout).toHaveBeenCalledWith('year', 'passes-first', 'pricing_page');
     });
   });
 

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -144,7 +144,7 @@ export default function PricingPage({
     }
     track('paywall_upgrade_clicked', { surface: 'pricing_page', plan: 'auto_sync', variant: pricingOrder });
     setSubscribeError(null);
-    const result = await get2ankiApi().startAutoSyncCheckout(pricingOrder);
+    const result = await get2ankiApi().startAutoSyncCheckout(pricingOrder, 'pricing_page');
     if ('url' in result) {
       globalThis.location.href = result.url;
       return;
@@ -177,7 +177,7 @@ export default function PricingPage({
     } else {
       setWeekPassState('pending');
     }
-    const result = await get2ankiApi().startPassCheckout(kind, pricingOrder);
+    const result = await get2ankiApi().startPassCheckout(kind, pricingOrder, 'pricing_page');
     if ('url' in result) {
       globalThis.location.href = result.url;
       return;
@@ -196,7 +196,7 @@ export default function PricingPage({
     }
     track('paywall_upgrade_clicked', { surface: 'pricing_page', plan: 'unlimited', variant: pricingOrder });
     setUnlimitedPending(true);
-    const result = await get2ankiApi().startUnlimitedCheckout(billingCycle, pricingOrder);
+    const result = await get2ankiApi().startUnlimitedCheckout(billingCycle, pricingOrder, 'pricing_page');
     if ('url' in result) {
       globalThis.location.href = result.url;
       return;

--- a/web/src/pages/SearchPage/SearchPage.tsx
+++ b/web/src/pages/SearchPage/SearchPage.tsx
@@ -36,6 +36,7 @@ export function SearchPage({ setError }: Readonly<SearchPageProps>) {
     try {
       const result = await get2ankiApi().startPassCheckout(
         '24h',
+        undefined,
         'notion-limit-wall'
       );
       if ('url' in result) {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -1024,7 +1024,7 @@ describe('limit state', () => {
     });
 
     await waitFor(() => {
-      expect(startPassCheckout).toHaveBeenCalledWith('24h', 'upload-limit-wall');
+      expect(startPassCheckout).toHaveBeenCalledWith('24h', undefined, 'upload-limit-wall');
       expect(locationStub.href).toBe('https://checkout.stripe.com/pass');
     });
   });

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -321,7 +321,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
     setDayPassPending(true);
     track('paywall_upgrade_clicked', { surface: 'upload_limit_wall', plan: 'day_pass' });
     try {
-      const result = await get2ankiApi().startPassCheckout('24h', 'upload-limit-wall');
+      const result = await get2ankiApi().startPassCheckout('24h', undefined, 'upload-limit-wall');
       if ('url' in result) {
         globalThis.location.href = result.url;
         return;


### PR DESCRIPTION
## What
Thread a `surface` attribution field through the dynamic checkout path so `checkout_completed` can be joined to the surface that drove the conversion. The three checkout use cases (Unlimited, Auto Sync, Pass) now stamp a bounded `surface` into Stripe session metadata, mirroring the existing `pricing_variant` shape, and the `checkout.session.completed` webhook reads it back onto the `checkout_completed` event props (guarded — only present when non-empty).

## Why
We already emit `paywall_shown` and `paywall_upgrade_clicked` with a `surface` prop (limit-wall, upload_success_upsell, pricing_page, downloads_upsell, …), but `checkout_completed` only carried `plan`/`variant`. We could not see which surface actually converts to a paid checkout. This closes that gap for dynamic-session checkouts. Moves us toward the 300K-user goal by letting us measure which surfaces convert and double down on the ones that pay off.

## How
- New `parseCheckoutSurface` helper bounds the input (lowercase, strip to `[a-z0-9_-]`, cap 40 chars, reject empty) so nothing arbitrary or unbounded lands in Stripe metadata — same defensive role as `parsePricingVariant`.
- Controllers read `req.body.surface` through that helper and pass it to the use cases; use cases add `surface` to the session metadata only when present.
- WebhookRouter reads `sessionMeta.surface` and adds a `surface` prop to `checkout_completed`, guarded exactly like `variant`.
- Frontend: the three `Backend` starters accept an optional `surface` arg; each dynamic call site passes the surface it already tracks. SearchPage and UploadForm previously passed a surface label in the `variant` slot (where `parsePricingVariant` rejected it) — moved to the new surface slot.

**No amounts, prices, line items, mode, or checkout behavior changed.**

**Needs /security-review before merge — touches checkout.sessions.create.**

### Known limitation
Unlimited bought via the static `buy.stripe.com` payment link (used by the limit wall's Unlimited CTA) does NOT pass through these use cases, so those conversions won't carry surface metadata. This PR attributes only dynamic-session checkouts (passes + dynamic Unlimited on the pricing page). Closing the static-link gap is a separate decision (migrate the static link to a dynamic session), not in scope here.

## Measuring success
Query the analytics store for `checkout_completed` events and group by `props.surface`. After deploy, dynamic-session conversions (passes, pricing-page Unlimited/Auto Sync) will carry a non-null `surface`; static-link Unlimited conversions remain null (expected per the limitation above). A surface→checkout funnel can then be built against `paywall_shown` / `paywall_upgrade_clicked` which already carry the same labels.

## Testing
- Unit tests added/extended (Jest, server): `checkoutSurface.test.ts` (parser bounds), `UnlimitedCheckoutUseCase`, `AutoSyncCheckoutUseCase`, `CreatePassCheckoutUseCase` (metadata includes `surface` when provided, omits when absent), `WebhookRouter.test.ts` (`checkout_completed` props include `surface` when present, omit when absent). Stripe SDK mocked at the edge only.
- Web tests (Vitest) updated to assert the new positional `surface` argument on the affected call sites.
- `pnpm test <touched files>` green (67 server tests). `tsc -p . --noEmit` green (server + web). Affected web vitest green (145 tests). `biome lint` clean on touched files.
- sonar not run — no token.

## Browser check
Browser check: not applicable — adds an existing request-body field; no rendered output or interactive behavior changes.

## Changelog
No entry — internal instrumentation, no user-visible behavior change.

## Risks
Low. The metadata field is additive and guarded; absence omits the field. Worst case the prop is missing on some events (same as today). Rollback is a straight revert — no data migration, no schema change.

## Goal alignment
Lets the trio see which paywall surface converts to paid, so we can invest in the surfaces that drive revenue and signups — directly supporting the path to 300K users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782879685&installation_id=132681956&pr_number=3006&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3006&signature=42b4ac444533c9511314bf40deedd24ef027a0a4b4a106f5b89fba297d91a16f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->