### PR TITLE
ci: serve the web app from Netlify instead of redirecting to prod

### DIFF
--- a/deploy/netlify-redirect/index.html
+++ b/deploy/netlify-redirect/index.html
@@ -1,5 +1,0 @@
-<!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"><title>2anki</title>
-<meta http-equiv="refresh" content="0; url=https://2anki.net/">
-<link rel="canonical" href="https://2anki.net/"></head>
-<body><p>Moved to <a href="https://2anki.net/">2anki.net</a>.</p></body></html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,21 +1,6 @@
+# Every context — production, branch deploys, and deploy previews — builds and
+# serves the real web app from web/build. SPA fallback and the /api proxy to
+# 2anki.net live in web/public/_redirects, which Vite copies into web/build.
 [build]
-  publish = "deploy/netlify-redirect"
-  command = "echo 'redirect-only site; no build'"
-
-# Production stays a redirect-only mirror — bounce everything to the real app.
-[[context.production.redirects]]
-  from = "/*"
-  to = "https://2anki.net/:splat"
-  status = 301
-  force = true
-
-# Deploy previews and branch deploys build and serve the real web app, so the
-# frontend can be tested on a Netlify URL. Production is unaffected: its publish
-# dir still meta-refreshes to 2anki.net even without the redirect rule above.
-[context.deploy-preview]
-  command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter 2anki-web build"
-  publish = "web/build"
-
-[context.branch-deploy]
   command = "corepack enable && pnpm install --frozen-lockfile && pnpm --filter 2anki-web build"
   publish = "web/build"


### PR DESCRIPTION
## What

Make Netlify build and serve the current web app (`web/build`) in **every** context, instead of acting as a redirect-only mirror to `2anki.net`.

- `[build]` now runs `pnpm --filter 2anki-web build` → publishes `web/build`.
- Removes the production `301 /* → 2anki.net` redirect.
- Deletes the now-dead `deploy/netlify-redirect/` stub.
- The redundant `[context.deploy-preview]` / `[context.branch-deploy]` blocks fold into `[build]`.

SPA fallback and the `/api` proxy to `2anki.net` are already in `web/public/_redirects`, which Vite copies into `web/build` — no extra Netlify config needed.

## Why

Several Netlify projects (e.g. `test.2anki.net`) were still serving a months-old pre-Vite build, which is how a user this week hit a 404 on Convert — the app reported on in support was the stale Netlify-hosted frontend, not current `2anki.net`. We want those projects relinked to this repo to build & serve the **current** app so they stop going stale.

## Trade-off (please confirm intent)

This reverses #2936's single-canonical-host design. After this, each linked Netlify site serves a full frontend that calls the `2anki.net` API via the proxy, so **each site must be kept current** and could be indexed as a duplicate of `2anki.net`. `netlify.toml` is repo-wide, so this one change applies to **all** linked sites — you can't make one redirect and another build-web through this file alone. If the goal for some sites is just "no stale UI," redirecting them to `2anki.net` is the more robust option for those.

## Browser check

Browser check: not applicable — deploy config only, no `web/src` changes and no change to the app's rendered output.

No changelog entry — internal deploy config.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782880692&installation_id=132681956&pr_number=3007&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3007&signature=93413c6da46efcba08b477b7a9c26ec5ec9be1e7cf26026ffa45459e13f02c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->