### PR TITLE
fix: kill-switch service worker to recover stranded PWA installs

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,36 @@
+/*
+ * Kill-switch service worker.
+ *
+ * 2anki.net was served from Netlify with vite-plugin-pwa (registerType
+ * 'autoUpdate') until 2025-10-21. Visitors during that window registered a
+ * Workbox service worker at https://2anki.net/sw.js that precached the whole
+ * app shell. After 2anki.net moved off Netlify, that worker keeps answering
+ * navigations from its stale precache: Convert fails with a 404 and the UI
+ * never updates, no matter how many times the user reloads.
+ *
+ * The current app registers no service worker. This file exists only so those
+ * stale registrations pick it up on their next update check (browsers re-fetch
+ * the top-level SW script bypassing the HTTP cache). It wipes every cache,
+ * unregisters itself, and reloads any open windows onto the live site — so a
+ * stranded install recovers the next time it is opened online. It never
+ * intercepts fetches (no fetch handler), so it is inert for everyone whose
+ * browser was not already carrying the old registration.
+ */
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheKeys = await caches.keys();
+      await Promise.all(cacheKeys.map((key) => caches.delete(key)));
+      await self.clients.claim();
+      const windows = await self.clients.matchAll({ type: 'window' });
+      await Promise.all(
+        windows.map((client) => client.navigate(client.url).catch(() => {})),
+      );
+      await self.registration.unregister();
+    })(),
+  );
+});


### PR DESCRIPTION
## What

Add `web/public/sw.js` — a kill-switch service worker served at `https://2anki.net/sw.js`. It clears all caches, unregisters itself, and reloads open windows onto the live site. The current app registers **no** service worker, so this file is inert for anyone whose browser isn't already carrying an old registration — only stale workers fetch it.

## Why

`2anki.net` was Netlify-hosted with `vite-plugin-pwa` (`registerType: 'autoUpdate'`) from the Vite migration until **2025-10-21**, when the PWA was disabled (old repo `2anki/web`, commit `a2799aa83de7`). Visitors during that window registered a Workbox service worker at `2anki.net/sw.js` that **precached the entire app shell**. After `2anki.net` moved off Netlify to the current box, that worker keeps serving the stale precache:

- Convert 404s, the UI never updates no matter how many reloads — the months-old UI seen in Hotjar and the "same page each time I click convert" support report this week.
- `2anki.net/sw.js` currently returns the SPA-fallback HTML (not valid JS), so the stale workers' update checks fail and they persist **indefinitely**.

Serving a real script at that exact URL is the only way to clear them.

## How recovery works

Browsers re-fetch the top-level SW script bypassing the HTTP cache on each update check (and the stale build's own code re-`register()`s `/sw.js` on every load). On the user's next online open, the stale worker sees a changed `/sw.js`, installs this one, which `skipWaiting()` → on activate wipes caches, `clients.claim()`, navigates open windows to the network (now the current app), and `unregister()`s. One online launch recovers them.

## Scope notes

- **Origin-correct:** the zombie workers are on the `2anki.net` origin (Netlify-era), not `2anki.netlify.app` — that host only ever served the pre-Vite CRA build (no SW) and is already redirect-stubbed. So the fix belongs in the app Express serves, not in `deploy/netlify-redirect`.
- Does **not** affect `/check`: `web/public/**` is outside Biome's lint scope (`src/**`, `tests/**`) and outside tsc/vitest.
- No source registers this worker — intentional. It must never be installed on unaffected users.

## Limits

Only recovers an install the next time it's opened **online**. Dormant installs never reopened can't be reached — unavoidable, no server push to a PWA.

## Browser check

Browser check: not applicable — no `web/src` change; adds a static recovery asset that is inert for unaffected users and can only be exercised by a pre-existing stale service worker registration.

No changelog entry — recovery plumbing; no behavior change for anyone not already stranded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782882035&installation_id=132681956&pr_number=3009&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3009&signature=1dfdce958000f1288d57edc9fcc5f09a99a8ab19e85c12cb7b88ce46b2628f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->