### PR TITLE
feat: show multi-deck batch results in-page instead of a redirect

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -674,3 +674,81 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     expect(Buffer.compare(uploadedBuffer, apkgContents)).toBe(0);
   });
 });
+
+describe('UploadService.handleUpload — multi-deck batch', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+  let workspaceDir = '';
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'upload-service-batch');
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    trackMock.mockClear();
+    mockWorkspaceId = 'batch-ws-id';
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'batch-ws-'));
+    mockWorkspaceLocation = workspaceDir;
+    fs.writeFileSync(path.join(workspaceDir, 'Biology 101.apkg'), 'deck-a');
+    fs.writeFileSync(path.join(workspaceDir, 'Chemistry.apkg'), 'deck-b');
+    fs.writeFileSync(path.join(workspaceDir, 'index.html'), '<html></html>');
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it('returns 200 JSON listing every deck instead of redirecting to /download', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        packages: [
+          { name: 'Biology 101', cardCount: 3, mcqCount: 0, mcqSkippedCount: 0 },
+          { name: 'Chemistry', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 },
+        ],
+        warnings: [],
+      }),
+    }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
+
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
+    const req = buildRequest();
+    const { res, capturedStatus, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(capturedStatus()).toBe(200);
+
+    const body = capturedJson() as {
+      kind: string;
+      workspaceId: string;
+      deckCount: number;
+      decks: { name: string; filename: string; downloadUrl: string }[];
+      bulkUrl: string;
+    };
+    expect(body.kind).toBe('batch');
+    expect(body.workspaceId).toBe('batch-ws-id');
+    expect(body.deckCount).toBe(2);
+    expect(body.bulkUrl).toBe('/download/batch-ws-id/bulk');
+    expect(body.decks).toHaveLength(2);
+
+    const names = body.decks.map((d) => d.name).sort();
+    expect(names).toEqual(['Biology 101', 'Chemistry']);
+    const chemistry = body.decks.find((d) => d.name === 'Chemistry')!;
+    expect(chemistry.filename).toBe('Chemistry.apkg');
+    expect(chemistry.downloadUrl).toBe('/download/batch-ws-id/Chemistry.apkg');
+
+    const biology = body.decks.find((d) => d.name === 'Biology 101')!;
+    expect(biology.downloadUrl).toBe(
+      '/download/batch-ws-id/Biology%20101.apkg'
+    );
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_succeeded',
+      expect.objectContaining({ props: expect.objectContaining({ source: 'upload' }) })
+    );
+  });
+});

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -20,6 +20,7 @@ import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
 import { MARKDOWN_LIKELY_LOSSY_REASON } from '../usecases/jobs/jobFailureReason';
 import { DeckTooLargeError } from '../lib/parser/exporters/DeckTooLargeError';
 import { getOwner } from '../lib/User/getOwner';
+import { formatDeckName } from '../lib/formatDeckName';
 import {
   CheckMonthlyCardLimitUseCase,
   MonthlyLimitError,
@@ -53,6 +54,20 @@ interface MarkdownLossyResponse {
 
 interface DeckTooLargeResponse {
   message: string;
+}
+
+interface BatchDeckResult {
+  name: string;
+  filename: string;
+  downloadUrl: string;
+}
+
+interface BatchUploadResponse {
+  kind: 'batch';
+  workspaceId: string;
+  deckCount: number;
+  decks: BatchDeckResult[];
+  bulkUrl: string;
 }
 
 function hasSessionToken(req: express.Request): boolean {
@@ -446,9 +461,7 @@ class UploadService {
       if (owner != null) {
         await this.usersRepository.incrementCardUsage(owner, totalCards);
       }
-      const url = `/download/${ws.id}`;
-      res.status(300);
-      return res.redirect(url);
+      return res.status(200).json(await this.buildBatchResponse(ws));
     } else {
       logNoPackageDiagnostics(req.files as UploadedFile[]);
       track('conversion_failed', {
@@ -458,6 +471,24 @@ class UploadService {
       });
       throw new EmptyDeckError();
     }
+  }
+
+  private async buildBatchResponse(ws: Workspace): Promise<BatchUploadResponse> {
+    const apkgFilenames = (await fs.promises.readdir(ws.location)).filter(
+      (filename) => filename.endsWith('.apkg')
+    );
+    const decks = apkgFilenames.map((filename) => ({
+      name: formatDeckName(filename),
+      filename,
+      downloadUrl: `/download/${ws.id}/${encodeURIComponent(filename)}`,
+    }));
+    return {
+      kind: 'batch',
+      workspaceId: ws.id,
+      deckCount: decks.length,
+      decks,
+      bulkUrl: `/download/${ws.id}/bulk`,
+    };
   }
 
   private resolveAnonId(req: express.Request): string | null {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -271,6 +271,57 @@
   box-shadow: var(--shadow-sm);
 }
 
+/* ── Multi-deck batch result ── */
+
+.deckList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: 440px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.deckRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.deckRowName {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.deckRowDownload {
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-link);
+  text-decoration: none;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.deckRowDownload:hover {
+  background: var(--color-bg-primary);
+  color: var(--color-text-link-hover);
+}
+
 /* ── Empty deck state ── */
 
 .emptyTitle {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -866,6 +866,74 @@ describe('UploadForm analytics events', () => {
 
 });
 
+describe('UploadForm multi-deck batch', () => {
+  beforeEach(() => {
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+  });
+
+  afterEach(() => {
+    delete (globalThis as AnalyticsGlobals).gtag;
+    delete (globalThis as AnalyticsGlobals).hj;
+    vi.restoreAllMocks();
+  });
+
+  const batchBody = {
+    kind: 'batch',
+    workspaceId: 'ws-1',
+    deckCount: 2,
+    decks: [
+      { name: 'Biology 101', filename: 'Biology 101.apkg', downloadUrl: '/download/ws-1/Biology%20101.apkg' },
+      { name: 'Chemistry', filename: 'Chemistry.apkg', downloadUrl: '/download/ws-1/Chemistry.apkg' },
+    ],
+    bulkUrl: '/download/ws-1/bulk',
+  };
+
+  function stubBatchFetch() {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 200,
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: () => Promise.resolve(batchBody),
+    }));
+  }
+
+  it('renders an in-page deck list instead of navigating away on a multi-deck batch', async () => {
+    const locationStub = { href: '', origin: 'http://localhost' } as Location;
+    vi.stubGlobal('location', locationStub);
+    stubBatchFetch();
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await screen.findByText('2 decks ready');
+    expect(locationStub.href).toBe('');
+
+    const biology = screen.getByLabelText('Download Biology 101') as HTMLAnchorElement;
+    const chemistry = screen.getByLabelText('Download Chemistry') as HTMLAnchorElement;
+    expect(biology.getAttribute('href')).toBe('/download/ws-1/Biology%20101.apkg');
+    expect(chemistry.getAttribute('href')).toBe('/download/ws-1/Chemistry.apkg');
+
+    const downloadAll = screen.getByText('Download all (zip)') as HTMLAnchorElement;
+    expect(downloadAll.getAttribute('href')).toBe('/download/ws-1/bulk');
+  });
+
+  it('suppresses deck names in the batch list from Hotjar recordings', async () => {
+    stubBatchFetch();
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    const deckName = await screen.findByText('Biology 101');
+    expect(deckName).toHaveAttribute('data-hj-suppress');
+  });
+});
+
 describe('limit state', () => {
   beforeEach(() => {
     mockGet2ankiApi.mockReturnValue({

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -7,7 +7,10 @@ import { getStoredPassToken } from '../../../../lib/anonymousPass';
 import type { UploadErrorBody } from '../../../../types/UploadErrorBody';
 import getAcceptedContentTypes from '../../helpers/getAcceptedContentTypes';
 import { extractErrorMessage } from '../../helpers/extractErrorMessage';
-import getHeadersFilename from '../../helpers/getHeadersFilename';
+import {
+  applyConversionSuccess,
+  type ConversionSuccessHandlers,
+} from './uploadResponse';
 import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadFileName';
 import { getEmptyDeckChatPrompt } from '../../helpers/getEmptyDeckChatPrompt';
 import { useDrag } from './hooks/useDrag';
@@ -111,29 +114,6 @@ function buildFormData(form: HTMLFormElement): FormData {
   return formData;
 }
 
-function parseCardCountHeader(headers: Headers): number | null {
-  const cardCountHeader = headers.get('X-Card-Count');
-  if (!cardCountHeader) return null;
-  const parsed = Number.parseInt(cardCountHeader, 10);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function parseNonNegativeIntHeader(headers: Headers, name: string): number {
-  const raw = headers.get(name);
-  if (!raw) return 0;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-}
-
-function resolveDeckName(headers: Headers): string {
-  const fileNameHeader = getHeadersFilename(headers);
-  const fallback =
-    headers.get('Content-Type') === 'application/zip'
-      ? 'Your Decks.zip'
-      : 'Your deck.apkg';
-  return fileNameHeader ?? fallback;
-}
-
 function displayFilename(fileInput: HTMLInputElement | null): string {
   const files = fileInput?.files;
   if (!files || files.length === 0) return '';
@@ -234,6 +214,8 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
   const {
     zoneState,
     setZoneState,
+    batchResult,
+    setBatchResult,
     downloadLink,
     setDownloadLink,
     deckName,
@@ -298,6 +280,18 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       clearTimeout(fallbackTimerRef.current);
     }
   });
+
+  const conversionSuccessHandlers: ConversionSuccessHandlers = {
+    setWarningMessage,
+    setDeckName,
+    setCardCount,
+    setMcqCount,
+    setMcqSkippedCount,
+    setDownloadLink,
+    setProgressWidth,
+    setBatchResult,
+    setZoneState,
+  };
 
   const { data: userLocals } = useUserLocals();
   const queryClient = useQueryClient();
@@ -461,21 +455,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
         setZoneState(zoneStateForUploadError(message));
         return;
       }
-      setWarningMessage(request.headers.get('X-Warning'));
-      setDeckName(resolveDeckName(request.headers));
-      const count = parseCardCountHeader(request.headers);
-      setCardCount(count);
-      setMcqCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Count'));
-      setMcqSkippedCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Skipped-Count'));
-      const blob = await request.blob();
-      setDownloadLink(globalThis.URL.createObjectURL(blob));
-      setProgressWidth(100);
-      if (count === 0) {
-        setZoneState('emptyDeck');
-      } else {
-        fireAnalyticsEvent('conversion_success');
-        setZoneState('success');
-      }
+      await applyConversionSuccess(request, conversionSuccessHandlers);
     } catch (error) {
       setLocalError(toFriendlyThrownError(error));
       setZoneState('error');
@@ -555,21 +535,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
         setZoneState(zoneStateForUploadError(message));
         return;
       }
-      setWarningMessage(request.headers.get('X-Warning'));
-      setDeckName(resolveDeckName(request.headers));
-      const count = parseCardCountHeader(request.headers);
-      setCardCount(count);
-      setMcqCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Count'));
-      setMcqSkippedCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Skipped-Count'));
-      const blob = await request.blob();
-      setDownloadLink(globalThis.URL.createObjectURL(blob));
-      setProgressWidth(100);
-      if (count === 0) {
-        setZoneState('emptyDeck');
-      } else {
-        fireAnalyticsEvent('conversion_success');
-        setZoneState('success');
-      }
+      await applyConversionSuccess(request, conversionSuccessHandlers);
     } catch (error) {
       setLocalError(toFriendlyThrownError(error));
       setZoneState('error');
@@ -658,21 +624,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
         setZoneState(zoneStateForUploadError(message));
         return false;
       }
-      setWarningMessage(request.headers.get('X-Warning'));
-      setDeckName(resolveDeckName(request.headers));
-      const count = parseCardCountHeader(request.headers);
-      setCardCount(count);
-      setMcqCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Count'));
-      setMcqSkippedCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Skipped-Count'));
-      const blob = await request.blob();
-      setDownloadLink(globalThis.URL.createObjectURL(blob));
-      setProgressWidth(100);
-      if (count === 0) {
-        setZoneState('emptyDeck');
-      } else {
-        fireAnalyticsEvent('conversion_success');
-        setZoneState('success');
-      }
+      await applyConversionSuccess(request, conversionSuccessHandlers);
     } catch (error) {
       const isNetworkError =
         error instanceof TypeError ||
@@ -703,7 +655,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
     formStyles.dropZone,
     dropHover && zoneState === 'idle' ? formStyles.dropZoneActive : '',
     zoneState === 'converting' ? formStyles.dropZoneConverting : '',
-    zoneState === 'success' ? formStyles.dropZoneSuccess : '',
+    zoneState === 'success' || zoneState === 'multiDeck' ? formStyles.dropZoneSuccess : '',
     zoneState === 'emptyDeck' ? formStyles.dropZoneEmpty : '',
     zoneState === 'error' && !isExistingApkgReject ? formStyles.dropZoneError : '',
     isExistingApkgReject ? formStyles.dropZoneRedirect : '',
@@ -877,6 +829,63 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       </div>
     </div>
   );
+
+  const renderMultiDeckState = () => {
+    if (batchResult == null) return null;
+    const { decks, bulkUrl, deckCount } = batchResult;
+    const onDeckDownload = () => {
+      fireAnalyticsEvent('deck_downloaded');
+      track('deck_downloaded');
+    };
+    return (
+      <div className={formStyles.stateContent}>
+        <CheckCircleIcon className={formStyles.iconSuccess} />
+        <p className={formStyles.successPrimary}>
+          {deckCount} {deckCount === 1 ? 'deck' : 'decks'} ready
+        </p>
+        <ul className={formStyles.deckList}>
+          {decks.map((deck) => (
+            <li key={deck.filename} className={formStyles.deckRow}>
+              <span
+                className={formStyles.deckRowName}
+                data-hj-suppress
+                title={deck.name}
+              >
+                {deck.name}
+              </span>
+              <a
+                href={deck.downloadUrl}
+                download
+                className={formStyles.deckRowDownload}
+                aria-label={`Download ${deck.name}`}
+                onClick={onDeckDownload}
+              >
+                Download
+              </a>
+            </li>
+          ))}
+        </ul>
+        <a
+          href={bulkUrl}
+          download
+          className={formStyles.actionButton}
+          onClick={onDeckDownload}
+        >
+          Download all (zip)
+        </a>
+        <p className={formStyles.successSecondary}>
+          Links expire in 2 hours — download now.
+        </p>
+        <button
+          type="button"
+          className={formStyles.resetLink}
+          onClick={resetForm}
+        >
+          Make more decks
+        </button>
+      </div>
+    );
+  };
 
   const renderEmptyDeckBody = () => {
     if (localError?.code === 'markdown_likely_lossy') {
@@ -1162,22 +1171,8 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       });
 
       if (request.status === 200) {
-        setWarningMessage(request.headers.get('X-Warning'));
-        setDeckName(resolveDeckName(request.headers));
-        const count = parseCardCountHeader(request.headers);
-        setCardCount(count);
-        setMcqCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Count'));
-        setMcqSkippedCount(parseNonNegativeIntHeader(request.headers, 'X-MCQ-Skipped-Count'));
-        const blob = await request.blob();
-        setDownloadLink(globalThis.URL.createObjectURL(blob));
-        setProgressWidth(100);
         setLockedPdfInfo(null);
-        if (count === 0) {
-          setZoneState('emptyDeck');
-        } else {
-          fireAnalyticsEvent('conversion_success');
-          setZoneState('success');
-        }
+        await applyConversionSuccess(request, conversionSuccessHandlers);
         return;
       }
 
@@ -1303,6 +1298,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
     if (validation && zoneState === 'idle') return renderValidationState();
     if (zoneState === 'converting') return renderConvertingState();
     if (zoneState === 'success') return renderSuccessState();
+    if (zoneState === 'multiDeck') return renderMultiDeckState();
     if (zoneState === 'emptyDeck') return renderEmptyDeckState();
     if (zoneState === 'limitReached' && limitInfo) return renderLimitState();
     if (zoneState === 'lockedPdf') return renderLockedPdfState();
@@ -1321,6 +1317,10 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       if (cardCount == null) return 'Your deck is ready.';
       const noun = cardCount === 1 ? 'card' : 'cards';
       return `Your deck is ready — ${cardCount} ${noun}.`;
+    }
+    if (zoneState === 'multiDeck') {
+      const n = batchResult?.deckCount ?? 0;
+      return `${n} ${n === 1 ? 'deck' : 'decks'} ready.`;
     }
     if (zoneState === 'emptyDeck') {
       return 'Conversion finished, but no cards were found.';

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
@@ -6,10 +6,24 @@ export type ZoneState =
   | 'idle'
   | 'converting'
   | 'success'
+  | 'multiDeck'
   | 'emptyDeck'
   | 'limitReached'
   | 'error'
   | 'lockedPdf';
+
+export interface BatchDeck {
+  name: string;
+  filename: string;
+  downloadUrl: string;
+}
+
+export interface BatchResult {
+  workspaceId: string;
+  deckCount: number;
+  decks: BatchDeck[];
+  bulkUrl: string;
+}
 
 export interface LockedPdfInfo {
   filename: string;
@@ -24,6 +38,7 @@ export interface LimitInfo {
 
 export function useUploadFormState(onReset: () => void) {
   const [zoneState, setZoneState] = useState<ZoneState>('idle');
+  const [batchResult, setBatchResult] = useState<BatchResult | null>(null);
   const [downloadLink, setDownloadLink] = useState<string | null>(null);
   const [deckName, setDeckName] = useState('');
   const [cardCount, setCardCount] = useState<number | null>(null);
@@ -54,6 +69,7 @@ export function useUploadFormState(onReset: () => void) {
 
   const resetForm = () => {
     setZoneState('idle');
+    setBatchResult(null);
     setDownloadLink(null);
     setDeckName('');
     setCardCount(null);
@@ -85,6 +101,8 @@ export function useUploadFormState(onReset: () => void) {
   return {
     zoneState,
     setZoneState,
+    batchResult,
+    setBatchResult,
     downloadLink,
     setDownloadLink,
     deckName,

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
@@ -1,0 +1,82 @@
+import getHeadersFilename from '../../helpers/getHeadersFilename';
+import { fireAnalyticsEvent } from '../../../../lib/analytics/fireAnalyticsEvent';
+import type { BatchResult, ZoneState } from './hooks/useUploadFormState';
+
+export function resolveDeckName(headers: Headers): string {
+  const fileNameHeader = getHeadersFilename(headers);
+  const fallback =
+    headers.get('Content-Type') === 'application/zip'
+      ? 'Your Decks.zip'
+      : 'Your deck.apkg';
+  return fileNameHeader ?? fallback;
+}
+
+export function parseCardCountHeader(headers: Headers): number | null {
+  const cardCountHeader = headers.get('X-Card-Count');
+  if (!cardCountHeader) return null;
+  const parsed = Number.parseInt(cardCountHeader, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function parseNonNegativeIntHeader(headers: Headers, name: string): number {
+  const raw = headers.get(name);
+  if (!raw) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+export interface ConversionSuccessHandlers {
+  setWarningMessage: (value: string | null) => void;
+  setDeckName: (value: string) => void;
+  setCardCount: (value: number | null) => void;
+  setMcqCount: (value: number) => void;
+  setMcqSkippedCount: (value: number) => void;
+  setDownloadLink: (value: string | null) => void;
+  setProgressWidth: (value: number) => void;
+  setBatchResult: (value: BatchResult) => void;
+  setZoneState: (value: ZoneState) => void;
+}
+
+function isBatchResult(value: unknown): value is BatchResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { kind?: unknown }).kind === 'batch' &&
+    Array.isArray((value as { decks?: unknown }).decks)
+  );
+}
+
+export async function applyConversionSuccess(
+  response: Response,
+  handlers: ConversionSuccessHandlers
+): Promise<void> {
+  const contentType = response.headers.get('Content-Type') ?? '';
+  if (contentType.includes('application/json')) {
+    const body: unknown = await response.json();
+    if (isBatchResult(body)) {
+      handlers.setBatchResult(body);
+      handlers.setProgressWidth(100);
+      fireAnalyticsEvent('conversion_success');
+      handlers.setZoneState('multiDeck');
+      return;
+    }
+  }
+
+  handlers.setWarningMessage(response.headers.get('X-Warning'));
+  handlers.setDeckName(resolveDeckName(response.headers));
+  const count = parseCardCountHeader(response.headers);
+  handlers.setCardCount(count);
+  handlers.setMcqCount(parseNonNegativeIntHeader(response.headers, 'X-MCQ-Count'));
+  handlers.setMcqSkippedCount(
+    parseNonNegativeIntHeader(response.headers, 'X-MCQ-Skipped-Count')
+  );
+  const blob = await response.blob();
+  handlers.setDownloadLink(globalThis.URL.createObjectURL(blob));
+  handlers.setProgressWidth(100);
+  if (count === 0) {
+    handlers.setZoneState('emptyDeck');
+  } else {
+    fireAnalyticsEvent('conversion_success');
+    handlers.setZoneState('success');
+  }
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-01-batch-decks-in-page.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-01-batch-decks-in-page.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-01-batch-decks-in-page",
+  "date": "2026-06-01",
+  "type": "feature",
+  "title": "Uploads that make several decks now list them on the upload page, with a download for each"
+}


### PR DESCRIPTION
## What

A conversion that produces **more than one deck** used to send a `300` redirect to the static `/download/<id>` folder page — a full-page reload that yanked the user off `/upload`. Now the decks render **in-page**, in a new `multiDeck` zone state that mirrors the single-file success panel: one row per deck with its own download, a **Download all (zip)** button, and a quiet 2-hour expiry note.

This was the path Alexander flagged: "instead of redirecting to /download when a user uploads batches, can we show a modal in the upload page or handle this better?"

## Scope (decided with the trio)

- **Sync multi-deck batch only.** The Claude-AI async path (`202 → /downloads`, plural) is untouched.
- **Ephemeral, in-page only** — no persistence. Batch results still live in the workspace folder and are reaped after 2h, as before; hence the explicit "Links expire in 2 hours — download now" line. (Persisting batches to My decks was considered and deferred — see commit body / PR discussion.)
- **All three entry points** (file, Dropbox, Drive) get the panel, since they share `handleSyncUpload` server-side — changing the contract for one would break the others.

## How

- Server (`UploadService.handleSyncUpload`): the `packages.length > 1` branch returns a `200` JSON manifest (`kind:'batch'`, `workspaceId`, `deckCount`, `decks[{name,filename,downloadUrl}]`, `bulkUrl`) instead of the `300` redirect. URLs are built by **reading the workspace directory** (same source `/download/<id>` and `getLocalFile` serve from) so links always resolve — not derived from package names (which get transformed by `toText`).
- Web: a shared `applyConversionSuccess()` helper replaces four near-identical 200-response blocks (file/Dropbox/Drive/PDF-retry) and discriminates batch JSON vs the single-deck blob. New `renderMultiDeckState` panel + `deckList` styles.
- The `/download/<id>` SSR page stays as a bookmarkable fallback.

## Tests

- Server: multi-deck upload returns 200 JSON (not a redirect), with deck list + encoded download URLs + bulk URL.
- Web: batch JSON renders the in-page deck list and does **not** navigate away; single-deck still auto-downloads (existing tests); deck names carry `data-hj-suppress`.
- `/check`: server build, web typecheck, Biome lint all clean; full web suite green (one unrelated `SidebarLayout` timeout flake — passes in isolation in 1.4s).

## Sonar

`SONAR_TOKEN` is unset locally, so I couldn't run `sonar-scanner` to post results — expect CI to run it. Biome (which mirrors the key Sonar rules: `useOptionalChain`, `noNestedTernary`, `noNegationElse`, `noUselessTernary`) passed clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified by Alexander via `pnpm dev` — multi-deck result renders, per-deck and bulk downloads work, no redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782933970&installation_id=132681956&pr_number=3012&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3012&signature=d6fed5f90e060a930164e7e01a44366ab3d8fa8ef9390fb1fb85e22d10e06166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
