### PR TITLE
fix: surface unoconv stderr on PPT to PDF conversion failure

### DIFF
--- a/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.test.ts
+++ b/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.test.ts
@@ -1,0 +1,84 @@
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { convertPPTToPDF } from './ConvertPPTToPDF';
+import Workspace from '../../../lib/parser/WorkSpace';
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawn: jest.fn(),
+}));
+
+jest.mock('fs/promises', () => ({
+  ...jest.requireActual('fs/promises'),
+  writeFile: jest.fn().mockResolvedValue(undefined),
+  readFile: jest.fn().mockResolvedValue(Buffer.from('pdf-bytes')),
+}));
+
+const mockedSpawn = childProcess.spawn as jest.MockedFunction<
+  typeof childProcess.spawn
+>;
+
+function makeFailingProcess(
+  stderr: string,
+  exitCode: number
+): childProcess.ChildProcess {
+  const proc = new EventEmitter() as childProcess.ChildProcess;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  (
+    proc as unknown as { stdout: EventEmitter; stderr: EventEmitter }
+  ).stdout = stdoutEmitter;
+  (
+    proc as unknown as { stdout: EventEmitter; stderr: EventEmitter }
+  ).stderr = stderrEmitter;
+
+  setImmediate(() => {
+    stderrEmitter.emit('data', Buffer.from(stderr));
+    proc.emit('close', exitCode);
+  });
+
+  return proc;
+}
+
+describe('convertPPTToPDF', () => {
+  const workspace = { location: '/tmp/test-ws' } as Workspace;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('surfaces the subprocess stderr and exit code on failure', async () => {
+    const stderr =
+      'unoconv: Cannot connect to a running LibreOffice instance.';
+    mockedSpawn.mockReturnValue(makeFailingProcess(stderr, 251));
+
+    const result = await convertPPTToPDF(
+      'slides.pptx',
+      Buffer.from('fake'),
+      workspace
+    ).then(
+      () => ({ rejected: false, message: '' }),
+      (err: Error) => ({ rejected: true, message: err.message })
+    );
+
+    expect(result.rejected).toBe(true);
+    expect(result.message).toContain('251');
+    expect(result.message).toContain(stderr);
+  });
+
+  it('logs the subprocess stderr to the server console on failure', async () => {
+    const stderr = 'unoconv: Document export failed.';
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockedSpawn.mockReturnValue(makeFailingProcess(stderr, 251));
+
+    await convertPPTToPDF('slides.pptx', Buffer.from('fake'), workspace).catch(
+      () => undefined
+    );
+
+    const logged = errorSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(logged).toContain(stderr);
+    expect(logged).toContain('251');
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.ts
+++ b/src/infrastracture/adapters/fileConversion/ConvertPPTToPDF.ts
@@ -49,11 +49,19 @@ export function convertPPTToPDF(
             stderr
           );
           if (code !== 0) {
+            const trimmedStderr = stderr.trim();
+            const detail = trimmedStderr || stdout.trim() || '(no output)';
             await fs.writeFile(
               path.join(workspace.location, 'error.log'),
               `Conversion failed with code ${code}`
             );
-            reject(new Error(`Conversion failed with code ${code}`));
+            console.error(
+              `PPT to PDF conversion failed with exit code ${code}:`,
+              detail
+            );
+            reject(
+              new Error(`Conversion failed with code ${code}: ${detail}`)
+            );
           } else {
             resolve(await fs.readFile(pdfFile));
           }


### PR DESCRIPTION
## What
When a PowerPoint upload's `unoconv` PPT→PDF subprocess exits non-zero, the rejected error now carries the captured stderr (with exit code), and the same detail is logged via `console.error`. Previously the error was a bare `Conversion failed with code N` and the stderr was written only to a workspace log file that gets cleaned up.

## Why
Over the last 48h, `GeneratePackagesUseCase.ts:49` re-threw `Conversion failed with code 251` 5 times (clustered, one slot, 2026-06-01). The Python/unoconv subprocess stderr was captured nowhere reachable — no traceback in any pm2 out/error log — so every code-251 failure was blind. This change makes worker/subprocess failures non-blind: the actual LibreOffice/unoconv error text reaches the server logs.

## How
In `convertPPTToPDF`'s `close` handler, on non-zero exit: build `detail = stderr.trim() || stdout.trim() || '(no output)'`, append it to the `Error` message, and `console.error` it alongside the exit code. The message propagates unchanged through the worker thread (`worker.ts` serializes `err.message`) to `GeneratePackagesUseCase`, so the use-case-level rejection now also carries the detail. No env flag — stderr capture is the unconditional default. No secrets logged: only the subprocess error text and exit code.

## Measuring success
After deploy, the next PPT conversion that exits non-zero will log `PPT to PDF conversion failed with exit code <N>: <unoconv stderr>` to pm2 stdout (grep pm2 logs for `PPT to PDF conversion failed with exit code`). That will tell us what code 251 actually means — which we currently cannot determine from logs alone.

## Testing
- Unit tests added: `ConvertPPTToPDF.test.ts` — (1) failure surfaces stderr + exit code in the rejected error message; (2) failure logs stderr + exit code to `console.error`. `spawn` and `fs/promises` mocked at the external boundary per testing.md. Watched both fail for the right reason (stderr dropped, nothing logged) before implementing. Full `fileConversion` suite green (166 tests).

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files touched.

## Changelog
No entry — internal observability change, no user-visible behavior change.

## Sonar
`sonar-scanner` is installed but `SONAR_TOKEN` is unset locally, so it was not run; expect CI to run it. The change is small (one function, +stderr in an existing error + a `console.error`), no new HTTP/HTML/zip/path-from-input sinks.

## Risks
Low. The error message and a server log line grow longer; no behavior change for successful conversions. The unoconv stderr may include the uploaded file's basename — acceptable in operational pm2 logs (not a public artifact, not a secret), and necessary to debug. Rollback is a one-commit revert.

## Root cause: what does code 251 mean?
Could not determine from existing logs — that is precisely the gap this PR closes. 251 is the exit status `unoconv` returns; in practice it's most often "cannot connect to a running LibreOffice instance" or a LibreOffice export crash, but the captured stderr was never surfaced, so we can't confirm which. Once this ships, the next occurrence will print the real unoconv error and we'll know.

## Goal alignment
PPT/PPTX is one of the supported upload formats on the path to 300K users. A class of conversion failures was silently failing users with no way for us to diagnose. Making the failure visible is the prerequisite to fixing whatever code 251 actually is, recovering those conversions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782939896&installation_id=132681956&pr_number=3015&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3015&signature=537c52e38ed6d642197be2467bc99bdc6208ee9394b4060c8bdc0a2c43e19e6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->