### PR TITLE
fix: reject null-owner Notion connect with 401

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -651,6 +651,26 @@ describe('NotionController', () => {
       expect(res.redirect).toHaveBeenCalledWith('/notion');
     });
 
+    it('returns 401 and never calls connectToNotion when the owner is missing', async () => {
+      service = buildConnectService();
+      controller = new NotionController(service);
+      req = { query: { code: 'auth-code' } };
+      res = {
+        redirect: jest.fn().mockReturnThis(),
+        clearCookie: jest.fn().mockReturnThis(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+        locals: {},
+      } as any;
+
+      await controller.connect(req as express.Request, res as express.Response);
+
+      expect(service.connectToNotion).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(401);
+      const body = (res.json as jest.Mock).mock.calls[0]?.[0];
+      expect(body.code).toBe('notion_unauthorized');
+    });
+
     it('preserves the login: branch and does not call connectToNotion', async () => {
       service = buildConnectService();
       controller = new NotionController(service);

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -115,9 +115,17 @@ class NotionController {
       return res.redirect(`/api/users/auth/notion?code=${encodeURIComponent(code as string)}`);
     }
 
+    const owner = res.locals.owner;
+    if (owner == null) {
+      return res.status(401).json({
+        code: 'notion_unauthorized',
+        message: 'Sign in before connecting Notion.',
+      });
+    }
+
     try {
       const authorizationCode = code as string;
-      await this.service.connectToNotion(authorizationCode, res.locals.owner);
+      await this.service.connectToNotion(authorizationCode, owner);
       if (stateStr === 'native') {
         return res.redirect(NATIVE_NOTION_RETURN_URL);
       }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-01-notion-connect-signed-out.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-01-notion-connect-signed-out.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-01-notion-connect-signed-out",
+  "date": "2026-06-01",
+  "type": "fix",
+  "title": "Connecting Notion while signed out now asks you to sign in instead of failing"
+}


### PR DESCRIPTION
## What
Guards the Notion OAuth connect callback against a missing owner. When `res.locals.owner` is `null`/`undefined`, the controller now returns a clean `401 notion_unauthorized` before any token work, instead of passing an undefined owner into the `notion_tokens` upsert and 500-ing on the NOT NULL constraint.

## Why
Over the last 48h a `notion_tokens` upsert threw once: `null value in column "owner" of relation "notion_tokens" violates not-null constraint`. The `/api/notion/connect` route uses `OptionalAuthentication`, so `res.locals.owner` is legitimately absent when the session is missing or expired. The old code proceeded to `connectToNotion(code, undefined)` → `saveNotionToken` and surfaced an opaque 500. User-visible outcome: connecting Notion while signed out now gets a clear auth response instead of a silent failure.

## How
A guard at the controller boundary (after the `login:` redirect branch, before any token work) using `owner == null` — covers both `null` and `undefined` while letting falsy-but-valid IDs through (CWE-754). Auth check stays at the controller, not in the repo (security.md).

## Measuring success
The constraint error string `null value in column "owner" of relation "notion_tokens"` should drop to zero in prod logs after deploy. Anonymous connect attempts will instead show a 401 on `GET /api/notion/connect` with `code: notion_unauthorized` and never reach `saveNotionToken`.

## Testing
- Unit test added: `connect` returns 401 with `notion_unauthorized` and never calls `connectToNotion` when the owner is missing. Verified it fails for the right reason first (`connectToNotion` called with `("auth-code", undefined)`), then passes after the guard. Full `NotionController.test.ts` suite green (25/25). Server `tsc -p .` clean.

## Browser check
Browser check: not applicable — the only `web/src/` file is a changelog JSON entry (no rendered logic); the fix is server-side.

## Changelog
`Connecting Notion while signed out now asks you to sign in instead of failing` (`web/src/pages/WhatsNewPage/changelog/2026-06-01-notion-connect-signed-out.json`)

## Security review
Touches Notion OAuth (auth + external-API). Self-review against security.md:
- Auth at the boundary, not deep in the repo (CWE-862) — guard is in the controller.
- `owner == null`, not `!owner` (CWE-754).
- No token/authorization-code logging added (CWE-532).
- 401 returns a fixed structured message, no stack/DB text (CWE-209).
- Webhook-signature rule N/A (this is the OAuth redirect callback, not a webhook).
No new findings.

`sonar-scanner` not run locally — `SONAR_TOKEN` unset on this machine. The change is one early-return guard clause (single `if`, leads with the positive `owner == null` check, no new function, no nesting, no type assertions), so a Sonar bounce is unlikely; flagging here so reviewers know to expect the CI analysis rather than a local report.

## Risks
Low. The guard only affects the unauthenticated connect path, which previously 500-ed anyway. Authenticated connect (web and native) is unchanged — existing tests cover both. Rollback: revert the single guard block.

## Goal alignment
Removes a hard failure on the Notion connect path — the entry point to the core convert flow. A signed-out user mid-connect now gets a clear next step instead of a broken state, which keeps the funnel from landing → connect → upload intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782940062&installation_id=132681956&pr_number=3016&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3016&signature=6e40124e3fac98c801d180e58b16acf07155cf48b70b2c68bdf9f4a041f87230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->