### PR TITLE
fix: wrap long code blocks so they fit the card

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -33,6 +33,32 @@ test('YouTube embeds are responsive so they fit narrow screens', async () => {
   expect(back).not.toContain("width='560'");
 });
 
+test('deck style wraps long code blocks instead of overflowing the card', async () => {
+  const html = `<html><head><title>Code</title><style>
+body { line-height: 1.5; white-space: pre-wrap; }
+.code-wrap { white-space: pre-wrap; word-break: break-all; }
+</style></head>
+<body><article class="page sans"><header><h1 class="page-title">Code</h1></header><div class="page-body">
+<ul class="toggle"><li><details open=""><summary>How to print?</summary>
+<pre class="code code-wrap"><code>def foo():
+    return "a very long line of code that would otherwise run off the edge of the card"</code></pre></details></li></ul>
+</div></article></body></html>`;
+
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'code.html',
+    settings: new CardOption({ cherry: 'false' }),
+    files: [{ name: 'code.html', contents: html }],
+    noLimits: true,
+    workspace,
+  });
+  await parser.build(workspace);
+
+  const style = parser.payload[0].style ?? '';
+  expect(style).toMatch(/(\.code-wrap|pre)[^{}]*\{[^{}]*white-space:\s*pre-wrap/);
+  expect(parser.payload[0].cards[0].back).toContain('<pre');
+});
+
 test('deck style includes Notion highlight color rules for file uploads', async () => {
   const html = `<html><head><title>Colors</title><style>body { font-size: 16px; }</style></head>
 <body><article>

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -49,6 +49,13 @@ import { extractName } from '../extractDeckName';
 
 const MARKDOWN_SOURCE_RATIO_THRESHOLD = 0.8;
 
+// Notion code blocks export as <pre class="code code-wrap"> and rely on
+// .code-wrap { white-space: pre-wrap } to wrap long lines. extractStyles
+// strips every white-space: pre-wrap rule (it harms body/toggle text), which
+// left code blocks running off the edge of narrow cards. Re-apply wrapping to
+// code blocks only, appended last so it wins the cascade over the stripped rule.
+const CODE_WRAP_STYLE = '.code-wrap, pre { white-space: pre-wrap; }';
+
 function isMarkdownSourcedFiles(files: File[]): boolean {
   const contentFiles = files.filter(
     (f) => isMarkdownFile(f.name) || isHTMLFile(f.name)
@@ -346,8 +353,11 @@ export class DeckParser {
     const { dom, isNewFormat } = this.loadAndNormalizeDOM(contents);
 
     const extractedStyle = extractStyles(dom);
+    const baseStyle = extractedStyle
+      ? `${NOTION_STYLE}\n${extractedStyle}`
+      : NOTION_STYLE;
     const style = withFontSize(
-      extractedStyle ? `${NOTION_STYLE}\n${extractedStyle}` : NOTION_STYLE,
+      `${baseStyle}\n${CODE_WRAP_STYLE}`,
       this.settings.fontSize
     );
     let image: string | undefined = this.extractCoverImage(dom);

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-01-code-block-wrap.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-01-code-block-wrap.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-01-code-block-wrap",
+  "date": "2026-06-01",
+  "type": "fix",
+  "title": "Long code blocks wrap to fit the card instead of running off the edge"
+}


### PR DESCRIPTION
## What
Long code blocks now wrap to the width of the card instead of running off the right edge.

## Why
Notion exports code blocks as `<pre class="code code-wrap">` and relies on `.code-wrap { white-space: pre-wrap }` to wrap long lines while keeping newlines. `extractStyles` strips **every** `white-space: pre-wrap` rule — it has to, so that body and toggle text don't render literal source whitespace — but that also removed code wrapping. The result: a long line of code overflowed the card edge (worst on mobile). The bundled `notion.css` has the same gap, so this affected every deck, not just uploads.

## How
- Append a `.code-wrap, pre { white-space: pre-wrap; }` rule after the extracted style in `DeckParser`, so it wins the cascade over the stripped rule. Scoped to code blocks only — body/toggle whitespace stripping is untouched.
- Newlines were already preserved by the `<pre>` element; this only fixes long-line wrapping.

## Test
Added a `DeckParser` test that builds a deck with a long code line and asserts the deck style carries `white-space: pre-wrap` for code and that the card back keeps its `<pre>`. Confirmed it fails without the fix (the `.code-wrap` rule arrives as `{ word-break: break-all }`) and passes with it.

`/check`: server tsc, web typecheck, web vitest (1596), web lint all green. The 31 `DeckParser` jest failures are pre-existing in this environment (the genanki Python venv isn't set up — identical count on clean `main`) and unrelated to a CSS-string change.

Sonar: not run locally (no `SONAR_TOKEN` in this environment). The change is one constant plus a four-line restructure of the style assembly — no new complexity or nesting.

Browser check: not applicable — the only `web/src/` file is a changelog entry; no rendered UI changed.

Fixes #1451

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782941751&installation_id=132681956&pr_number=3018&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3018&signature=95393443d9f1e10989f0c0d7f5c71e41a05326362477b9f074bb66d790b0ac79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->