### PR TITLE
fix: make YouTube card embeds responsive on narrow screens

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -10,6 +10,29 @@ import { EmptyDeckError } from '../../usecases/jobs/EmptyDeckError';
 
 beforeEach(() => setupTests());
 
+test('YouTube embeds are responsive so they fit narrow screens', async () => {
+  const html = `<html><head><title>Video</title></head>
+<body><article class="page sans"><header><h1 class="page-title">Video</h1></header><div class="page-body">
+<ul class="toggle"><li><details open=""><summary>Watch this</summary>
+<figure><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a></figure></details></li></ul>
+</div></article></body></html>`;
+
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'video.html',
+    settings: new CardOption({ cherry: 'false' }),
+    files: [{ name: 'video.html', contents: html }],
+    noLimits: true,
+    workspace,
+  });
+  await parser.build(workspace);
+
+  const back = parser.payload[0].cards[0].back;
+  expect(back).toContain('youtube.com/embed/dQw4w9WgXcQ');
+  expect(back).toContain('max-width:560px');
+  expect(back).not.toContain("width='560'");
+});
+
 test('deck style includes Notion highlight color rules for file uploads', async () => {
   const html = `<html><head><title>Colors</title><style>body { font-size: 16px; }</style></head>
 <body><article>

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -615,7 +615,11 @@ export class DeckParser {
     const id = this._getYouTubeID(card.back);
     if (id) {
       const ytSrc = getYouTubeEmbedLink(id);
-      card.back += `<iframe width='560' height='315' src='${ytSrc}' frameborder='0' allowfullscreen></iframe>`;
+      card.back +=
+        `<div style='position:relative;width:100%;max-width:560px;margin:0 auto;'>` +
+        `<div style='position:relative;padding-bottom:56.25%;height:0;'>` +
+        `<iframe src='${ytSrc}' style='position:absolute;top:0;left:0;width:100%;height:100%;border:0;' allowfullscreen></iframe>` +
+        `</div></div>`;
     }
 
     const soundCloudUrl = this.getSoundCloudURL(card.back);

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-01-youtube-embed-responsive.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-01-youtube-embed-responsive.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-01-youtube-embed-responsive",
+  "date": "2026-06-01",
+  "type": "fix",
+  "title": "YouTube videos on cards scale to fit the screen instead of overflowing on phones"
+}


### PR DESCRIPTION
## What
YouTube videos embedded on a card now scale to fit the screen instead of running off the right edge on phones.

## Why
The YouTube `<iframe>` was hard-coded to `width='560' height='315'`. On a ~375px phone viewport the 560px-wide player overflowed the card (#726). The SoundCloud embed right next to it already used `width='100%'`, so this just brings YouTube in line.

## How
Wrap the iframe in a fluid 16:9 container — `width:100%` capped at `max-width:560px`, with a `padding-bottom:56.25%` ratio box and an absolutely-positioned iframe filling it. Preserves the original max size on desktop, shrinks cleanly on mobile, keeps aspect ratio. The padding-bottom technique works in every Anki webview (no reliance on newer CSS).

## Test
Added a `DeckParser` test: a toggle whose answer contains a YouTube link produces a `youtube.com/embed/...` iframe inside a `max-width:560px` responsive wrapper and no longer emits `width='560'`. Confirmed it fails before the change and passes after.

`/check`: server tsc, web typecheck, web vitest (1596), web lint all green. (The 31 `DeckParser` jest failures present here are pre-existing — the genanki Python venv isn't set up in this environment; identical count on clean `main`.)

Sonar: not run locally (no `SONAR_TOKEN`); the change is a single markup string with no added complexity.

Browser check: not applicable — the only `web/src/` file is a changelog entry; no rendered UI changed.

Fixes #726

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782942150&installation_id=132681956&pr_number=3019&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3019&signature=59973b2e04db49d3509c011f4c7fb515abc57ad6fcbd91cfda4cf92914530706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->