### PR TITLE
fix: inherit a page's global tags into its sub-pages

### DIFF
--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -499,6 +499,38 @@ test('global tags per file are preserved in multi-file uploads', async () => {
   expect(deckB.cards[0].tags).not.toContain('alpha-tag');
 });
 
+test('global tags on a parent page carry into its sub-pages', async () => {
+  const parentHtml = `<html><head><title>Parent</title></head><body><article class="page sans"><header><h1 class="page-title">Parent</h1></header><div class="page-body">
+<p><del>parenttag</del></p>
+<ul class="toggle"><li><details open=""><summary>Parent Q</summary><p>Parent A</p></details></li></ul>
+<figure class="link-to-page"><a href="sub.html">Sub</a></figure>
+</div></article></body></html>`;
+  const subHtml = `<html><head><title>Sub</title></head><body><article class="page sans"><header><h1 class="page-title">Sub</h1></header><div class="page-body">
+<ul class="toggle"><li><details open=""><summary>Sub Q</summary><p>Sub A</p></details></li></ul>
+</div></article></body></html>`;
+
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'parent.html',
+    settings: new CardOption({ tags: 'true', cherry: 'false' }),
+    files: [
+      { name: 'parent.html', contents: parentHtml },
+      { name: 'sub.html', contents: subHtml },
+    ],
+    noLimits: true,
+    workspace,
+  });
+
+  parser.customExporter.save = jest.fn().mockResolvedValue('');
+  await parser.build(workspace);
+
+  const parentDeck = parser.payload[0];
+  const subDeck = parser.payload.find((d) => d.name.includes('Sub'));
+  expect(parentDeck.cards[0].tags).toContain('parenttag');
+  expect(subDeck).toBeDefined();
+  expect(subDeck!.cards[0].tags).toContain('parenttag');
+});
+
 test.todo('Input Cards ');
 test.todo('Test Basic Card');
 

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -340,7 +340,8 @@ export class DeckParser {
     fileName: string,
     contents: string,
     deckName: string,
-    decks: Deck[]
+    decks: Deck[],
+    inheritedGlobalTags: string[] = []
   ) {
     const { dom, isNewFormat } = this.loadAndNormalizeDOM(contents);
 
@@ -363,7 +364,9 @@ export class DeckParser {
       settings: this.settings,
     });
 
-    const fileGlobalTags = this.extractGlobalTags(dom);
+    const fileGlobalTags = [
+      ...new Set([...inheritedGlobalTags, ...this.extractGlobalTags(dom)]),
+    ];
 
     const toggleList = this.extractToggleLists(dom);
     const paragraphs = this.extractCardsFromParagraph(dom);
@@ -421,7 +424,8 @@ export class DeckParser {
           fileName,
           pageContent.toString(),
           `${name}::${subDeckName}`,
-          decks
+          decks,
+          fileGlobalTags
         );
       }
     }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-01-global-tags-subpages.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-01-global-tags-subpages.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-01-global-tags-subpages",
+  "date": "2026-06-01",
+  "type": "fix",
+  "title": "Global tags set on a page now apply to the cards in its sub-pages too"
+}


### PR DESCRIPTION
## What
A global tag set on a parent page now also tags the cards generated from its sub-pages.

## Why
Global tags (a struck-through, comma-separated line in the page body) were applied only to the page that declared them. When a page links out to sub-pages, each sub-page is parsed with its own fresh DOM and only saw the tags it declared itself — so the parent's global tags silently dropped off every sub-page card (#1123).

## How
`handleHTML` now takes an optional `inheritedGlobalTags`. The parent's resolved global tags are passed into the recursive sub-page parse and unioned (deduplicated) with whatever the sub-page declares, so the whole page tree shares one tag set. Top-level files in a multi-file upload are unaffected — they pass no inherited tags, so per-file isolation is preserved.

## Test
Added a `DeckParser` test: a parent page with a global tag and a link to a sub-page. After build, the sub-page's card carries the parent's tag. Confirmed it fails before the change (sub-page tags come back empty) and passes after. The existing per-file isolation test (`alpha-tag`/`beta-tag` stay separate across two top-level files) still passes.

`/check`: server tsc, web typecheck, web vitest (1596), web lint all green. The 31 `DeckParser` jest failures here are pre-existing — they call the genanki Python build, and the Python venv isn't set up in this environment (identical count on clean `main`). The new test mocks the exporter, so it runs without Python.

Sonar: not run locally (no `SONAR_TOKEN`); the change adds one optional parameter and a `Set`-based union — no new complexity or nesting.

Browser check: not applicable — the only `web/src/` file is a changelog entry; no rendered UI changed.

Fixes #1123

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782942491&installation_id=132681956&pr_number=3020&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3020&signature=68b1bf7301edd9c92868f5dcd0988be9808b22a28d1f8e8b81ae9b64559fb67a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->