### PR TITLE
chore: enable caveman compression plugin by default in .claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,17 @@
   "env": {
     "CLAUDE_CODE_FORK_SUBAGENT": "1"
   },
+  "extraKnownMarketplaces": {
+    "caveman": {
+      "source": {
+        "source": "github",
+        "repo": "JuliusBrussee/caveman"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "caveman@caveman": true
+  },
   "permissions": {
     "allow": [
       "Bash(git commit *)",


### PR DESCRIPTION
## What
Adds `extraKnownMarketplaces` (caveman → `JuliusBrussee/caveman`) and `enabledPlugins` (`caveman@caveman`) to the committed `.claude/settings.json`, so the [caveman](https://github.com/JuliusBrussee/caveman) token-compression plugin is the default for anyone working in this repo.

## Why
Caveman makes Claude reply in terse, fragment-based "caveman speak" — ~65–75% fewer output tokens, technical substance preserved. Installed at user scope on my machine; this makes it the repo-wide default rather than a per-machine manual `claude plugin install`.

## Decisions made (please review — easy to override)
- **Scope:** chose repo-wide default over user-only. Assumption: you want every contributor + CI session in this repo on caveman. If not, close this — your user-scope install already gives *you* caveman everywhere.
- **Install method:** native Claude Code plugin marketplace, **not** the project's banned pipe-to-shell one-liner (`.claude/rules/security.md`, CWE-494). No remote code runs at config-load beyond Claude Code's own vetted plugin loader.

## Tradeoffs to weigh
- **Forces a third-party plugin on all contributors/CI.** On entering the repo, Claude Code will prompt each contributor to trust + install `JuliusBrussee/caveman`. Supply-chain surface the team should accept consciously.
- **Tension with repo norms.** This repo leans on detailed PR bodies, one-page specs, changelog entries, trio synthesis, browser attestation — caveman compresses toward terseness, which can thin those artifacts. The plugin's prompt exempts code/commits/PRs ("write normal"), but worth a conscious call.
- **Reversible:** delete the two keys, or run `claude plugin disable caveman@caveman`.

No changelog entry — internal tooling config, no user-visible product change.

Browser check: not applicable — `.claude/` config only, no `web/src/` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995174&installation_id=132681956&pr_number=3022&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3022&signature=277f6cbbef6da8208120e4bd37684de3fc7eecfee0906f893a363ec2f75051ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->