### PR TITLE
fix: reword Send to Anki button to follow the voice guide

### DIFF
--- a/web/src/pages/DownloadsPage/components/SendToAnkifyButton.test.tsx
+++ b/web/src/pages/DownloadsPage/components/SendToAnkifyButton.test.tsx
@@ -73,7 +73,7 @@ describe('SendToAnkifyButton', () => {
   it('dispatches the upload for lifetime (patreon) users', async () => {
     mockLocalsData = { locals: { patreon: true }, autoSyncActive: false };
     renderButton();
-    const button = await screen.findByRole('button', { name: /send this to my anki/i });
+    const button = await screen.findByRole('button', { name: /send to anki/i });
     await waitFor(() => expect(button).not.toBeDisabled());
     fireEvent.click(button);
     await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(42));
@@ -83,7 +83,7 @@ describe('SendToAnkifyButton', () => {
   it('dispatches the upload for Auto Sync subscribers', async () => {
     mockLocalsData = { locals: { patreon: false }, autoSyncActive: true };
     renderButton();
-    const button = await screen.findByRole('button', { name: /send this to my anki/i });
+    const button = await screen.findByRole('button', { name: /send to anki/i });
     await waitFor(() => expect(button).not.toBeDisabled());
     fireEvent.click(button);
     await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(42));

--- a/web/src/pages/DownloadsPage/components/SendToAnkifyButton.tsx
+++ b/web/src/pages/DownloadsPage/components/SendToAnkifyButton.tsx
@@ -48,7 +48,7 @@ export default function SendToAnkifyButton({ uploadId, filename }: Props) {
       return `${counts}${sync}`;
     }
     if (dispatch.isError) return 'Try again';
-    return 'Send this to my Anki';
+    return 'Send to Anki';
   })();
 
   const title = (() => {


### PR DESCRIPTION
## What
Rewords the dispatch button on the Downloads page from "Send this to my Anki" to **"Send to Anki"**.

## Why
Fixes #2391. The old label violated VOICE.md in two ways: it used "my" (banned in button labels — the email-template rule spells this out: "Verify email" not "Verify my email") and "this" (filler). The new label is sentence case, imperative, names the surface, and is the shortest compliant form.

This button shows only to Auto Sync subscribers and lifetime users on the Downloads page; the dispatch behavior, pending label, success counts, and hover title are unchanged.

## How
One string change in `SendToAnkifyButton.tsx`'s `label` resolver, plus the two component-test role matchers that asserted the old text. No new test added — this is a pure copy change to an already-tested component.

## Measuring success
No metric — cosmetic label change. Confirmed by the rendered button reading "Send to Anki" once the page is opened by an eligible user.

## Testing
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` (Biome) — clean
- `SendToAnkifyButton.test.tsx` — 3/3 pass with the updated matchers

sonar-scanner: no `SONAR_TOKEN` in this environment, so the local Sonar run was skipped. This is a one-line copy change with no new logic, so a Sonar bounce is unlikely.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Copy-only label change; not browser-verified in this environment — please tick after a local check.

## Changelog
No changelog entry — minor label wording on a button most users never see (Auto Sync / lifetime only), no behavior change.

## Risks
Negligible. Worst case is a stale screenshot in docs referencing the old label. Rollback is a one-line revert.

## Goal alignment
Voice consistency keeps the product feeling like one coherent, quiet tool — small trust signal that compounds across the 300K-user goal. Marginal but in the right direction.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995775&installation_id=132681956&pr_number=3023&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3023&signature=a6f5217aa65a5200af94df4c42fc88a3c2af6099e96a9f7a77166d20d360641a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->