### PR TITLE
fix: render markdown in mind-map card faces as HTML

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -21,3 +21,5 @@ export const markdownToHTML = (
   const input = trimWhitespace ? stripped.trim() : stripped;
   return md.render(input);
 };
+
+export const markdownToInlineHTML = (text: string) => md.renderInline(text);

--- a/src/usecases/mindmaps/mindmapToClozeNotes.test.ts
+++ b/src/usecases/mindmaps/mindmapToClozeNotes.test.ts
@@ -92,6 +92,19 @@ describe('mindmapToClozeNotes', () => {
     expect(result[0].isValidClozeNote()).toBeTruthy();
   });
 
+  it('renders markdown in node labels as HTML inside cloze deletions', () => {
+    const result = mindmapToClozeNotes({
+      nodes: [
+        { id: '1', label: '**Cell**' },
+        { id: '2', label: '*Nucleus*' },
+      ],
+      edges: [{ source: '1', target: '2' }],
+    });
+    expect(result[0].name).toContain('{{c1::<strong>Cell</strong>}}');
+    expect(result[0].name).not.toContain('**Cell**');
+    expect(result[0].name).toContain('<em>Nucleus</em>');
+  });
+
   it('handles a branching tree: root → A → C, root → B', () => {
     const result = mindmapToClozeNotes({
       nodes: [

--- a/src/usecases/mindmaps/mindmapToClozeNotes.ts
+++ b/src/usecases/mindmaps/mindmapToClozeNotes.ts
@@ -47,7 +47,8 @@ function nodeLabel(
   const filename = imageUrl.split('/').pop() ?? '';
   const mapped = filenameMap[filename];
   if (mapped == null) return labelHtml;
-  return `<img src="${mapped}" alt="${label}" style="max-width:100%;height:auto;">${labelHtml.length > 0 ? `<br>${labelHtml}` : ''}`;
+  const labelSuffix = labelHtml.length > 0 ? `<br>${labelHtml}` : '';
+  return `<img src="${mapped}" alt="${label}" style="max-width:100%;height:auto;">${labelSuffix}`;
 }
 
 export function mindmapToClozeNotes(

--- a/src/usecases/mindmaps/mindmapToClozeNotes.ts
+++ b/src/usecases/mindmaps/mindmapToClozeNotes.ts
@@ -1,4 +1,5 @@
 import Note from '../../lib/parser/Note';
+import { markdownToInlineHTML } from '../../lib/markdown';
 import { MindmapData } from './MindmapData';
 
 function buildChildMap(data: MindmapData): Map<string, string[]> {
@@ -40,12 +41,13 @@ function nodeLabel(
   filenameMap: Record<string, string>
 ): string {
   const label = labelMap.get(id) ?? id;
+  const labelHtml = markdownToInlineHTML(label);
   const imageUrl = imageUrlMap.get(id);
-  if (imageUrl == null) return label;
+  if (imageUrl == null) return labelHtml;
   const filename = imageUrl.split('/').pop() ?? '';
   const mapped = filenameMap[filename];
-  if (mapped == null) return label;
-  return `<img src="${mapped}" alt="${label}" style="max-width:100%;height:auto;">${label.length > 0 ? `<br>${label}` : ''}`;
+  if (mapped == null) return labelHtml;
+  return `<img src="${mapped}" alt="${label}" style="max-width:100%;height:auto;">${labelHtml.length > 0 ? `<br>${labelHtml}` : ''}`;
 }
 
 export function mindmapToClozeNotes(

--- a/src/usecases/mindmaps/mindmapToNotes.test.ts
+++ b/src/usecases/mindmaps/mindmapToNotes.test.ts
@@ -100,6 +100,20 @@ describe('mindmapToNotes', () => {
     expect(result[0].media).toEqual(['abc.png']);
   });
 
+  it('renders markdown in node labels as HTML on both card faces', () => {
+    const result = mindmapToNotes({
+      nodes: [
+        { id: '1', label: '**Mitosis**' },
+        { id: '2', label: 'Splits into *two* [cells](https://x.test)' },
+      ],
+      edges: [{ source: '1', target: '2' }],
+    });
+    expect(result[0].name).toContain('<strong>Mitosis</strong>');
+    expect(result[0].name).not.toContain('**Mitosis**');
+    expect(result[0].back).toContain('<em>two</em>');
+    expect(result[0].back).toContain('<a href="https://x.test">cells</a>');
+  });
+
   it('node with image and no filename map falls back to label only', () => {
     const result = mindmapToNotes({
       nodes: [

--- a/src/usecases/mindmaps/mindmapToNotes.ts
+++ b/src/usecases/mindmaps/mindmapToNotes.ts
@@ -1,4 +1,5 @@
 import Note from '../../lib/parser/Note';
+import { markdownToInlineHTML } from '../../lib/markdown';
 import { MindmapData } from './MindmapData';
 
 function buildNodeBack(
@@ -6,13 +7,14 @@ function buildNodeBack(
   imageUrl: string | undefined,
   filenameMap: Record<string, string>
 ): { html: string; media: string | null } {
-  if (imageUrl == null) return { html: label, media: null };
+  const labelHtml = markdownToInlineHTML(label);
+  if (imageUrl == null) return { html: labelHtml, media: null };
   const filename = imageUrl.split('/').pop() ?? '';
   const mapped = filenameMap[filename];
-  if (mapped == null) return { html: label, media: null };
+  if (mapped == null) return { html: labelHtml, media: null };
   const imgTag = `<img src="${mapped}" alt="${label}" style="max-width:100%;height:auto;">`;
   return {
-    html: label.length > 0 ? `${imgTag}<br>${label}` : imgTag,
+    html: labelHtml.length > 0 ? `${imgTag}<br>${labelHtml}` : imgTag,
     media: mapped,
   };
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-02-mindmap-markdown-formatting.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-02-mindmap-markdown-formatting.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-02-mindmap-markdown-formatting",
+  "date": "2026-06-02",
+  "type": "fix",
+  "title": "Mind map decks render bold, italic, and links instead of raw markdown on the card"
+}


### PR DESCRIPTION
## What
Mind-map `.apkg` exports wrote node labels straight into card faces, so Anki rendered literal `**bold**` and `*italic*` instead of formatted text. Both mind-map note builders now convert each node label from markdown to HTML before composing the card.

## Why
Fixes #2600. A user studying from a mind-map deck saw raw markdown syntax on their cards instead of bold/italic/links. `markdown-it` was already a project dependency; the conversion was deferred.

## How
Added a `markdownToInlineHTML` export to `src/lib/markdown.ts` (the existing markdown-it instance, via `renderInline`). Both `mindmapToNotes` (basic front/back) and `mindmapToClozeNotes` run each node label through it before building the card HTML. `renderInline` is the right call here: it avoids the block-level `<p>` wrapping that would break the cloze `" → "` joins, and because the shared instance is configured with `html: false` it also escapes raw HTML metacharacters in labels. The fix is scoped to the mind-map export path only; the image-`alt` attribute keeps the raw label. `ConvertMindmapFileUseCase` (file-upload mind-map path) calls `mindmapToNotes`, so it inherits the fix.

## Root cause
`src/usecases/mindmaps/mindmapToNotes.ts:9,12,15` and `src/usecases/mindmaps/mindmapToClozeNotes.ts:42-48` — node `label` was placed directly into card-face HTML with no markdown→HTML step.

## Measuring success
No new telemetry. Confirm by exporting a mind map whose node text contains `**bold**` and opening the deck in Anki — the card shows bold text, not the asterisks.

## Testing
- Unit tests added (assert at the note-payload/HTML-building level, before the Python `.apkg` step):
  - `mindmapToNotes.test.ts` — markdown on both front and back faces becomes `<strong>`/`<em>`/`<a>`, not literal `**bold**`.
  - `mindmapToClozeNotes.test.ts` — markdown inside cloze deletions becomes HTML (`{{c1::<strong>Cell</strong>}}`).
- Verified each test fails for the right reason before the fix, then passes after.
- Full mind-map + `ConvertMindmapFileUseCase` suites green (91 tests); `markdown.test.ts` green; `npx tsc -p . --noEmit` clean.
- Python-env caveat: the genanki venv is not set up in this environment, so any full `.apkg` build via CardGenerator/Python would fail with a pre-existing, unrelated `PythonExitError`. Assertions are at the note/HTML layer, matching the existing DeckParser-style tests, so no `.apkg`-build test was run or skipped here.

## Browser check
Browser check: not applicable — only web/src/ file is a changelog entry, no rendered UI changed

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-02-mindmap-markdown-formatting.json` — "Mind map decks render bold, italic, and links instead of raw markdown on the card"

## Sonar
`sonar-scanner` not run — no `SONAR_TOKEN` in this environment. The change is small and adds no HTTP/zip/path-from-input surface, so I don't expect a security bounce; flagging in case maintainability smells surface in CI.

## Risks
Low. Plain-text labels pass through `renderInline` unchanged, so existing decks are unaffected. The renderer escapes raw HTML in labels (`html: false`) — a defensive improvement, not a behavior users relied on. Rollback: revert the commit; no migration or data change.

## Goal alignment
Removes a visible quality defect from the mind-map → Anki path, keeping the "clean deck back" promise. Cards that look right are cards users keep using.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995809&installation_id=132681956&pr_number=3024&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3024&signature=dab7d258c6a83b2dc4a4d15ad6ea78350013a40a87642e2e0baa670c2bad3b37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->