### PR TITLE
feat: track apkg_csv_exported on successful CSV export

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -50,6 +50,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_shown',
   'onboarding_skipped',
   'onboarding_completed',
+  'apkg_csv_exported',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -46,6 +46,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_shown',
   'onboarding_skipped',
   'onboarding_completed',
+  'apkg_csv_exported',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.test.tsx
@@ -4,6 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ApkgCsvExportForm from './ApkgCsvExportForm';
 
+const mockTrack = vi.fn();
+
+vi.mock('../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
 function makeApkgFile(name = 'deck.apkg'): File {
   return new File([new Uint8Array([0x50, 0x4b, 0x03, 0x04])], name, {
     type: 'application/octet-stream',
@@ -16,6 +22,7 @@ describe('ApkgCsvExportForm', () => {
   });
 
   afterEach(() => {
+    mockTrack.mockClear();
     vi.restoreAllMocks();
   });
 
@@ -64,6 +71,19 @@ describe('ApkgCsvExportForm', () => {
     expect(url).toBe('/api/apkg/csv');
     expect((init as RequestInit).method).toBe('post');
     expect((init as RequestInit).body).toBeInstanceOf(FormData);
+    expect(mockTrack).toHaveBeenCalledWith('apkg_csv_exported', { noteCount: 42 });
+  });
+
+  it('does not track an export when the server returns an error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+    render(<ApkgCsvExportForm />);
+    const input = screen.getByLabelText(/Choose \.apkg file/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makeApkgFile()] } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(mockTrack).not.toHaveBeenCalled();
   });
 
   it('surfaces the server error message on failure', async () => {

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.tsx
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.tsx
@@ -1,4 +1,5 @@
 import { type SyntheticEvent, useRef, useState } from 'react';
+import { track } from '../../lib/analytics/track';
 import styles from './ApkgCsvExportForm.module.css';
 
 type FormState =
@@ -94,6 +95,7 @@ function ApkgCsvExportForm() {
       const csvUrl = globalThis.URL.createObjectURL(blob);
       const csvName = `${deckName}.csv`;
       triggerDownload(csvUrl, csvName);
+      track('apkg_csv_exported', { noteCount });
       setState({ kind: 'success', deckName, noteCount, csvName, csvUrl });
     } catch (error) {
       const message =


### PR DESCRIPTION
## What
Wires the `apkg_csv_exported` analytics event at the success point of the `.apkg → CSV` export, with the real note count as `{ noteCount }`. Registers the event name in both the web and server `KNOWN_EVENTS` allowlists.

## Why
Fixes #2906. The export shipped with a promised success event (`track('apkg_csv_exported', { noteCount })`) that was never wired, so the entire `.apkg → CSV` export path is unmeasured — we can't see how often it's used or whether it converts to signups.

## How
- `ApkgCsvExportForm.tsx`: call `track('apkg_csv_exported', { noteCount })` right after a successful response, alongside the existing download trigger and success state. Matches the existing `track(...)` call style in the codebase.
- `web/src/lib/analytics/events.ts` and `src/types/AnalyticsEvents.ts`: add `apkg_csv_exported` to both hand-maintained `KNOWN_EVENTS` sets. The web set is load-bearing — `KnownEvent` is derived from it and gates the `track()` signature, so without it the call wouldn't typecheck. The server set keeps parity and avoids the `[events] unknown event received` warning at `/api/events/track`. The two sets are intentionally left separate (unifying them is #2772).

## Measuring success
After deploy, query the events sink for `name = 'apkg_csv_exported'` — a non-zero count with `props->>'noteCount'` populated confirms the export is firing. Before this PR the count is structurally zero.

## Testing
- Unit tests added: extended `ApkgCsvExportForm.test.tsx` — asserts a successful export calls `track` with `'apkg_csv_exported'` and `{ noteCount: 42 }` (from the `X-Card-Count` header), plus a negative case that an errored export (401) does not track. The analytics edge (`lib/analytics/track`) is mocked; no internal services are mocked.

## Browser check
Browser check: not applicable — analytics instrumentation, no rendered UI change

## Changelog
No changelog — internal analytics instrumentation, not user-visible.

## Sonar
sonar-scanner not run locally — no `SONAR_TOKEN` configured in this environment. Change is a one-line track call plus two allowlist additions; expect no new code smells.

## Risks
Minimal. `track()` failures are already swallowed silently and never break the user flow. Rollback is reverting the single call site.

## Goal alignment
Instrumenting the `.apkg → CSV` export makes a previously-invisible conversion surface measurable, so the trio can see whether it earns its place in the funnel toward the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782995827&installation_id=132681956&pr_number=3025&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3025&signature=04c514b898bc0af4d159b3bf69896ea28558e145103b3e6f2cca5a407aad8d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->