### PR TITLE
fix: stop chat MCQ generation truncating at the token cap

### DIFF
--- a/src/routes/ChatRouter.ts
+++ b/src/routes/ChatRouter.ts
@@ -495,7 +495,7 @@ const ChatRouter = () => {
    *               templateSlug:
    *                 type: string
    *                 nullable: true
-   *                 enum: [basic, basic-and-reversed, cloze]
+   *                 enum: [basic, basic-and-reversed, cloze, mcq]
    *     responses:
    *       204:
    *         description: Template saved

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -704,6 +704,44 @@ describe('ChatUseCase', () => {
       expect(callArg.tool_choice).toEqual({ type: 'tool', name: 'emit_mcq_cards' });
     });
 
+    it('raises max_tokens on the MCQ tool path so structured output is not truncated', async () => {
+      const { anthropic, useCase } = buildUseCaseWithBlocks([
+        mcqToolBlock({
+          cards: [
+            {
+              front: 'Capital of Albania?',
+              options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+              correct_index: 0,
+            },
+          ],
+        }),
+      ]);
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'make mcq cards',
+        conversationHistory: [],
+        templateSlug: 'mcq',
+      });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(callArg.max_tokens).toBe(8192);
+    });
+
+    it('keeps the default max_tokens for non-MCQ templates', async () => {
+      const { anthropic, useCase } = buildUseCase('a basic reply');
+
+      await useCase.execute({
+        user: FREE_USER,
+        content: 'hello',
+        conversationHistory: [],
+        templateSlug: 'basic',
+      });
+
+      const callArg = anthropic.messages.stream.mock.calls[0][0];
+      expect(callArg.max_tokens).toBe(4096);
+    });
+
     it('extracts MCQ cards from the tool_use block for templateSlug=mcq', async () => {
       const { useCase } = buildUseCaseWithBlocks([
         mcqToolBlock({

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -63,6 +63,11 @@ const FREE_MODEL = 'claude-haiku-4-5-20251001';
 const PATREON_MODEL = 'claude-sonnet-4-6';
 const MAX_HISTORY_TURNS = 10;
 const MAX_TOKENS = 4096;
+// MCQ is emitted as forced tool-use JSON (stem + 4 options + rationale per
+// card). At 4096 the structured output truncates on multi-card batches, the
+// tool input never closes, extraction returns nothing, and the turn fails with
+// McqExtractionFailedError. Give the MCQ path more headroom so the JSON fits.
+const MCQ_MAX_TOKENS = 8192;
 const AUTO_TITLE_MAX_LENGTH = 60;
 
 const STUDY_ASSISTANT_SYSTEM_PROMPT = `You are a study assistant for 2anki, a tool that turns notes into Anki flashcards.
@@ -492,7 +497,7 @@ export class ChatUseCase {
 
     const stream = this.anthropic.messages.stream({
       model,
-      max_tokens: MAX_TOKENS,
+      max_tokens: mcqForced ? MCQ_MAX_TOKENS : MAX_TOKENS,
       system: [{ type: 'text', text: systemPromptText, cache_control: { type: 'ephemeral' } }],
       messages,
       ...(mcqForced

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-02-chat-mcq-truncation.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-02-chat-mcq-truncation.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-02-chat-mcq-truncation",
+  "date": "2026-06-02",
+  "type": "fix",
+  "title": "Multiple-choice cards in chat generate reliably for larger sets"
+}


### PR DESCRIPTION
## What
Selecting the **MCQ** template in chat now produces cards instead of failing.

## Why
MCQ cards are generated via a **forced tool-use** call — Claude must return structured JSON (stem + four options + rationale per card). The chat turn capped output at `max_tokens: 4096`. A multi-card MCQ batch blows past that, so the response truncates mid-JSON (`stop_reason: max_tokens`): the tool input block never closes, `extractMcqCardsFromToolUse` returns `undefined`, and `streamAssistantTurn` throws `McqExtractionFailedError` — the user gets a hard failure and zero cards. Free users hit it hardest (`mcqAllowed = patreon || mcqForced` lets them force MCQ on the smaller Haiku model under the same cap).

## How
- `ChatUseCase`: the MCQ (forced-tool) path now uses `MCQ_MAX_TOKENS = 8192` (matching the file-conversion path); non-MCQ turns keep `4096`.
- Drive-by: the `PATCH …/template` Swagger enum listed `[basic, basic-and-reversed, cloze]` but the backend already accepts `mcq` via `isChatCardTemplate` — added `mcq` so the docs match reality.

## Testing
- TDD: added a `ChatUseCase` test asserting the MCQ path requests `max_tokens: 8192` and non-MCQ stays `4096` (watched it fail at 4096 first). Full chat suite 56/56, server `tsc` clean, changelog loader green (1596).
- Ruled out (with code evidence): frontend wiring (sends `templateSlug` on every send), template validation (accepts `mcq`), and extraction logic — all correct. The token cap was the failure point.

## Risks
- Larger `max_tokens` raises per-MCQ-turn cost/latency slightly. Acceptable — the alternative is the feature failing. A pathological request could still exceed 8192; a follow-up could add `stop_reason`-aware graceful degradation (return the cards that parsed + a "shorten the request" note) instead of a hard throw. Noted, not in scope here.

## Goal alignment
Makes a paid/used surface (chat MCQ) actually work — simpler, more reliable path from notes to cards.

⚠️ Touches the Anthropic integration → please run `/security-review` before merge.

Browser check: not applicable — server-side token-budget change; the only `web/src/` file is a changelog entry, no rendered UI changed.

Sonar: not run locally (no `SONAR_TOKEN` in this environment).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783003022&installation_id=132681956&pr_number=3026&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3026&signature=3a34086a33eb12bce5110738b827d8f56b66a7781ab613688ca94b32aea1ef0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->