### PR TITLE
perf: stream HTML AI generation with a sliding-window pool

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -136,6 +136,108 @@ describe('PrepareDeck — Claude AI flashcards branch', () => {
   });
 });
 
+describe('PrepareDeck — HTML generation concurrency window', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function deckArrayFor(label: string) {
+    return [
+      {
+        name: label,
+        image: '',
+        style: null,
+        id: 100000000000000,
+        settings: { template: 'specialstyle' },
+        cards: [
+          {
+            name: label,
+            back: 'Back',
+            tags: [],
+            cloze: false,
+            number: 0,
+            enableInput: false,
+            answer: '',
+            media: [],
+          },
+        ],
+      },
+    ];
+  }
+
+  it('keeps at most 3 calls in flight, slides the window, and returns results in source order', async () => {
+    const fileCount = 7;
+    const files = Array.from({ length: fileCount }, (_, i) => ({
+      name: `page-${i}.html`,
+      contents: `<p>page ${i}</p>`,
+    }));
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const resolvers: Array<(value: unknown) => void> = [];
+    const callOrder: number[] = [];
+
+    generateDeckInfo.mockImplementation((html: string) => {
+      const index = Number(/page (\d+)/.exec(html)![1]);
+      callOrder.push(index);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise((resolve) => {
+        resolvers[index] = (value) => {
+          inFlight -= 1;
+          resolve(value);
+        };
+      });
+    });
+
+    const settings = makeSettings({ 'claude-ai-flashcards': 'true' });
+    const prepared = PrepareDeck({
+      name: 'export.zip',
+      files,
+      settings,
+      noLimits: true,
+      workspace: makeWorkspace(),
+    });
+
+    const flush = () => new Promise((r) => setImmediate(r));
+    const waitUntil = async (predicate: () => boolean) => {
+      for (let i = 0; i < 100 && !predicate(); i++) {
+        await flush();
+      }
+    };
+
+    await waitUntil(() => callOrder.length >= 3);
+
+    expect(inFlight).toBe(3);
+
+    const resolveOrder = [2, 0, 1, 5, 3, 6, 4];
+    for (const index of resolveOrder) {
+      await waitUntil(() => Boolean(resolvers[index]));
+      resolvers[index](deckArrayFor(`page-${index}`));
+      await flush();
+    }
+
+    const result = await prepared;
+
+    expect(generateDeckInfo).toHaveBeenCalledTimes(fileCount);
+    expect(maxInFlight).toBe(3);
+
+    const configuredDecks = CustomExporterMock.mock.results[0].value.configure.mock
+      .calls[0][0] as Array<{ name: string }>;
+    expect(configuredDecks.map((d) => d.name)).toEqual([
+      'page-0',
+      'page-1',
+      'page-2',
+      'page-3',
+      'page-4',
+      'page-5',
+      'page-6',
+    ]);
+
+    expect(result.cardCount).toBe(fileCount);
+  });
+});
+
 describe('PrepareDeck — PDF text-vs-image gate', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -24,6 +24,27 @@ import Workspace from '../../../lib/parser/WorkSpace';
 import fs from 'fs';
 import path from 'path';
 
+const HTML_GENERATION_CONCURRENCY = 3;
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const runnerCount = Math.min(concurrency, items.length);
+  const runners = new Array(runnerCount).fill(null).map(async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  });
+  await Promise.all(runners);
+  return results;
+}
+
 interface PrepareDeckResult {
   name: string;
   apkg: Buffer;
@@ -252,16 +273,12 @@ export async function PrepareDeck(
       userId: input.userId ?? null,
       comprehensive: input.settings.aiComprehensive,
     };
-    const deckInfoArrays: DeckInfo[][] = [];
-    for (let i = 0; i < htmlFiles.length; i += 3) {
-      const batch = htmlFiles.slice(i, i + 3);
-      const batchResults = await Promise.all(
-        batch.map((f) =>
-          generateDeckInfo(f.contents!.toString(), mediaFilesForHtmlFile(f.name, mediaFiles), userInstructions, input.onProgress, cardStyle, input.settings.cardSize, fieldMapping, generateDeckInfoOptions)
-        )
-      );
-      deckInfoArrays.push(...batchResults);
-    }
+    const deckInfoArrays: DeckInfo[][] = await mapWithConcurrency(
+      htmlFiles,
+      HTML_GENERATION_CONCURRENCY,
+      (f) =>
+        generateDeckInfo(f.contents!.toString(), mediaFilesForHtmlFile(f.name, mediaFiles), userInstructions, input.onProgress, cardStyle, input.settings.cardSize, fieldMapping, generateDeckInfoOptions)
+    );
     const deckInfo = deckInfoArrays.flatMap((decks, i) => {
       const prefix = deckPrefixFromFilePath(htmlFiles[i].name);
       return decks

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-02-ai-multipage-faster.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-02-ai-multipage-faster.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-02-ai-multipage-faster",
+  "date": "2026-06-02",
+  "type": "fix",
+  "title": "Multi-page Notion imports with AI flashcards convert faster"
+}


### PR DESCRIPTION
## What
The AI flashcard path (`PrepareDeck`'s Claude branch) used to run HTML/Markdown files through `generateDeckInfo` in fixed batches of 3 behind a barrier — each batch waited for its slowest call before the next batch could start. This swaps that batch barrier for a bounded sliding-window pool of the **same** max concurrency (3): three calls stay in flight at all times, and the next file starts the instant one finishes.

## Why
On multi-page Notion exports, the batch barrier left up to two of the three slots idle while a batch waited on its slowest Claude call. A user importing a multi-page export with AI flashcards on saw inter-batch stalls that added up across the deck. The sliding window removes those gaps.

**Peak concurrency is unchanged at 3** — the number of in-flight Claude calls and the rate-limit exposure are identical to today. Only the scheduling changes.

## How
- New local index-preserving helper `mapWithConcurrency(items, concurrency, worker)` in `PrepareDeck.ts`: N worker loops (capped at `Math.min(concurrency, items.length)`) pull from a shared cursor and write each result back to its source index. The existing `runWithSemaphore` in `ClaudeService.ts` is not exported and returns `PromiseSettledResult` (swallows rejections), which would change today's `Promise.all` error-propagation semantics — so a small local pool that lets rejections propagate is the faithful replacement.
- Concurrency stays a named constant `HTML_GENERATION_CONCURRENCY = 3`.
- Results remain index-aligned, so `deckInfoArrays` ordering and the per-file `deckPrefixFromFilePath` logic are byte-for-byte unchanged. Only scheduling moved.

## Measuring success
`[PrepareDeck] Claude branch: generateDeckInfo done { durationMs, htmlFilesProcessed }` — for a given `htmlFilesProcessed` count > 3, the `durationMs` should trend down versus the batch-barrier baseline because the slowest call in a window no longer blocks the next file from starting.

## Testing
- Unit tests added (colocated in `PrepareDeck.test.ts`): mocks `generateDeckInfo` at the Claude edge and drives 7 HTML files with a controlled deferred/counter pattern. Asserts (a) all 7 files processed, (b) results returned in source-file order (deck names `page-0`…`page-6`), and (c) at most 3 calls ever in flight (`maxInFlight === 3`). Resolves the deferreds out of order (`[2,0,1,5,3,6,4]`) to prove the window slides — under the old batch barrier this resolution order would deadlock the test.
- No Python/full-pipeline dependency — mocked at `generateDeckInfo`, so it runs without the genanki venv.
- `npx tsc -p . --noEmit` clean. Changelog loader vitest green.
- sonar-scanner: not run locally — no `SONAR_TOKEN` configured in this environment. Expect the analysis on CI; the change is a small local helper plus a loop-to-pool swap, no new security surface.

## Browser check
Browser check: not applicable — the only `web/src/` file is a changelog JSON entry, no rendered behavior change.

## Changelog
`Multi-page Notion imports with AI flashcards convert faster` (`web/src/pages/WhatsNewPage/changelog/2026-06-02-ai-multipage-faster.json`, type `fix`).

## Risks
- Behavior parity hinges on index-preserving results — covered by the source-order assertion in the test.
- Error semantics: the local pool lets the first rejection propagate (matching the old `Promise.all`), rather than swallowing it like `runWithSemaphore`. No silent partial-success change.
- **Peak concurrency unchanged at 3 — no added rate-limit risk.** Rollback is a one-commit revert; no migration, no schema, no env.

## Goal alignment
Faster AI conversions on multi-page exports make the core "drop something in, get a clean deck back" loop quicker for paid users running large Notion imports — directly on the simpler/faster axis of the 300K-user goal, with zero added infra cost or rate-limit exposure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783015800&installation_id=132681956&pr_number=3027&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3027&signature=28dae50d464f674a9f95aa76073cf4c4cdf3ed79d267c93419d85d362c2ec9a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->