### PR TITLE
perf: stream transform notes through a sliding-window pool with caching

### DIFF
--- a/src/services/ankify/transformService.test.ts
+++ b/src/services/ankify/transformService.test.ts
@@ -111,28 +111,98 @@ describe('transformApkgNotes', () => {
     expect(result.failures[0].guid).toBe('g-b');
   });
 
-  it('respects the concurrency bound', async () => {
+  it('keeps at most `concurrency` calls in flight and slides the window as each finishes', async () => {
+    const total = 8;
+    const concurrency = 3;
     let inFlight = 0;
     let peak = 0;
-    const client = makeClient(async () => {
+    const release: Array<() => void> = new Array(total);
+    const started: Array<Promise<void>> = Array.from({ length: total }, () => {
+      let resolveStarted: () => void = () => {};
+      const p = new Promise<void>((r) => {
+        resolveStarted = r;
+      });
+      (p as Promise<void> & { fire: () => void }).fire = resolveStarted;
+      return p;
+    });
+    const fireStarted = (i: number) =>
+      (started[i] as Promise<void> & { fire: () => void }).fire();
+
+    const client = makeClient((req) => {
+      const index = Number(
+        (req as { messages: { content: string }[] }).messages[0].content.match(/\d+/)?.[0]
+      );
       inFlight += 1;
       peak = Math.max(peak, inFlight);
-      await new Promise((r) => setTimeout(r, 10));
-      inFlight -= 1;
+      fireStarted(index);
+      return new Promise((resolve) => {
+        release[index] = () => {
+          inFlight -= 1;
+          resolve({
+            content: [{ type: 'text', text: '{"hint":"x"}' }],
+            usage: { input_tokens: 0, output_tokens: 0 },
+          });
+        };
+      });
+    });
+
+    const notes = Array.from({ length: total }, (_, i) => sample(String(i)));
+    const job = transformApkgNotes({
+      notes,
+      transform: 'add_hint',
+      concurrency,
+      client: client as never,
+    });
+
+    await Promise.all([started[0], started[1], started[2]]);
+    expect(inFlight).toBe(concurrency);
+
+    const finishOrder = [2, 0, 1, 4, 3, 6, 7, 5];
+    let nextToStart = concurrency;
+    for (const idx of finishOrder) {
+      await started[idx];
+      expect(inFlight).toBeLessThanOrEqual(concurrency);
+      release[idx]();
+      if (nextToStart < total) {
+        await started[nextToStart];
+        nextToStart += 1;
+      }
+    }
+
+    const result = await job;
+
+    expect(peak).toBe(concurrency);
+    expect(result.notes).toHaveLength(total);
+    expect(result.usage.totalCalls).toBe(total);
+    expect(result.notes.map((n) => n.guid)).toEqual(notes.map((n) => n.guid));
+  });
+
+  it('caches the static system prompt across per-note calls', async () => {
+    const calls: Array<{ system: unknown }> = [];
+    const client = makeClient(async (req) => {
+      calls.push(req as { system: unknown });
       return {
-        content: [{ type: 'text', text: '{"hint":"x"}' }],
+        content: [{ type: 'text', text: '{"value":"x"}' }],
         usage: { input_tokens: 0, output_tokens: 0 },
       };
     });
 
-    const notes = Array.from({ length: 8 }, (_, i) => sample(String(i)));
     await transformApkgNotes({
-      notes,
-      transform: 'add_hint',
-      concurrency: 3,
+      notes: [sample('a'), sample('b')],
+      transform: 'translate_back',
+      targetLanguage: 'Spanish',
       client: client as never,
     });
 
-    expect(peak).toBeLessThanOrEqual(3);
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(call.system).toEqual([
+        {
+          type: 'text',
+          text: expect.any(String),
+          cache_control: { type: 'ephemeral' },
+        },
+      ]);
+    }
   });
 });

--- a/src/services/ankify/transformService.ts
+++ b/src/services/ankify/transformService.ts
@@ -52,10 +52,16 @@ async function mapWithConcurrency<T>(
   worker: (item: T, index: number) => Promise<void>
 ): Promise<void> {
   const size = concurrency > 0 ? concurrency : 1;
-  for (let i = 0; i < items.length; i += size) {
-    const slice = items.slice(i, i + size);
-    await Promise.all(slice.map((item, j) => worker(item, i + j)));
+  let next = 0;
+  async function pump(): Promise<void> {
+    while (next < items.length) {
+      const index = next;
+      next += 1;
+      await worker(items[index], index);
+    }
   }
+  const poolSize = Math.min(size, items.length);
+  await Promise.all(Array.from({ length: poolSize }, () => pump()));
 }
 
 function extractText(response: Message): string {
@@ -86,7 +92,7 @@ async function runTransformCall(
   const response = await client.messages.create({
     model: TRANSFORM_MODEL,
     max_tokens: TRANSFORM_MAX_TOKENS,
-    system,
+    system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
     messages: [{ role: 'user', content: user }],
   });
   const payload = parseJsonPayload(extractText(response));

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-02-transform-faster.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-02-transform-faster.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-02-transform-faster",
+  "date": "2026-06-02",
+  "type": "feature",
+  "title": "Large transform jobs finish faster"
+}


### PR DESCRIPTION
## What
Two perf changes to the Ankify `.apkg` transform path, both in `src/services/ankify/transformService.ts`:

1. **Sliding-window concurrency** — `mapWithConcurrency` is now a true worker pool instead of a batch barrier.
2. **Prompt caching** — the per-note Claude call marks the static system prompt with `cache_control: { type: 'ephemeral' }`.

## Why
Bulk transform jobs (100+ notes) are user-perceived slow. The old `mapWithConcurrency` processed notes in fixed batches of `size` and `await`ed `Promise.all` on each batch — every batch stalled on its **slowest** note before the next batch could start, leaving workers idle on the tail of each batch. The system prompt is identical across every note in a job but was rebuilt and re-sent uncached on each call.

User-visible outcome: large transform jobs finish faster (no inter-batch idle gaps), and repeat calls in a job get cheaper/slightly faster via the prompt cache.

## How
- **Pool:** `Math.min(size, items.length)` workers each loop, pulling the next index off a shared `next` counter until the list is exhausted. As soon as a worker's call resolves it pulls the next item — no barrier. **Peak concurrency is unchanged** (still `size`, default 5) for rate-limit safety. Index-correct results and the usage aggregation (`inputTokens`/`outputTokens`/`totalCalls`/`elapsedMs`) are preserved exactly.
- **Caching:** `system` was a plain string; it's now `[{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }]`, matching the chat path. Only the static system block is cached — per-note user content is not.

### LLM cost/latency note
- **Latency:** no change to peak concurrency or per-call model/tokens; the speedup comes from removing inter-batch idle time. Prompt-cache hits shave a small amount off input-processing latency on repeated calls.
- **Token/cost delta:** additive savings only. Cached system tokens bill at the reduced cache-read rate after the first call in a job; nothing increases.
- **Prompt caching applies:** yes — the system prompt is static across all notes in a job, so calls 2..N hit the cache.

## Measuring success
The existing `[transform] job complete` log line carries `elapsedMs`, `notesIn`, and `concurrency`. For comparable `notesIn`/`concurrency`, `elapsedMs` should drop on bulk jobs. Prompt-cache effectiveness is visible in the Anthropic dashboard as cache-read input tokens on the transform model.

## Testing
- Unit tests (`transformService.test.ts`):
  - Sliding-window: deterministic, no wall-clock. Workers resolve out of order via manual deferreds; asserts at most `size` in flight at any point, peak == `size`, all notes processed, results in input order, `totalCalls` correct. (This test hangs against the old batch barrier — index 3 can't start until all of 0,1,2 finish — so it's a real regression guard.)
  - Caching: asserts every `messages.create` call receives a `system` block carrying `cache_control: { type: 'ephemeral' }`.
- `npx tsc -p . --noEmit`: clean.
- Jest for the file: 6/6 green.

## Browser check
Browser check: not applicable — the only `web/src/` file is a changelog JSON entry.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-02-transform-faster.json` — "Large transform jobs finish faster"

## Sonar
Not run locally — no `SONAR_TOKEN`/scanner configured in this environment. Change is small and self-contained (one helper rewrite + one argument shape change); flag if CI bounces.

## Risks
- **Peak concurrency unchanged** (still `size`, default 5) — same peak load on the Anthropic API, no new rate-limit exposure.
- **Caching is additive** — if the prompt cache is unavailable, calls behave exactly as before (uncached system block), no behavior change.
- Rollback: revert the single commit; both changes are isolated to one file.

## Goal alignment
Faster bulk transforms make a paid surface feel quicker on exactly the large jobs power users run, and cheaper Claude calls protect margin as transform volume scales — both serve the 300K-user growth goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783015842&installation_id=132681956&pr_number=3028&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3028&signature=dd2214b70b90872a93a3ddc5a2acc642226a1fb837e0a1397578c2e2d4f7426c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->