### PR TITLE
fix: make Basic chat template a contract, never ship cloze

### DIFF
--- a/src/usecases/chat/ChatDeckUseCase.test.ts
+++ b/src/usecases/chat/ChatDeckUseCase.test.ts
@@ -1,4 +1,4 @@
-import { ChatDeckUseCase, looksLikeCloze, transformBlankToCloze, type ChatDeckCard } from './ChatDeckUseCase';
+import { ChatDeckUseCase, looksLikeCloze, transformBlankToCloze, normalizeBasicCard, type ChatDeckCard } from './ChatDeckUseCase';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
 
 jest.mock('../../lib/parser/exporters/CustomExporter');
@@ -103,9 +103,9 @@ describe('ChatDeckUseCase.execute basic-and-reversed template', () => {
   it('does not add reversed card when back is empty', async () => {
     const useCase = new ChatDeckUseCase();
     await useCase.execute({
-      deckName: 'Cloze set',
+      deckName: 'Empty back set',
       templateSlug: 'basic-and-reversed',
-      cards: [{ front: 'Capital of France is {{c1::Paris}}.', back: '' }],
+      cards: [{ front: 'A standalone prompt with no answer', back: '' }],
     });
     const Mock = CustomExporter as unknown as jest.Mock;
     const configure = Mock.mock.results[0].value.configure as jest.Mock;
@@ -140,7 +140,7 @@ describe('ChatDeckUseCase.execute cloze content under a basic template label', (
     }));
   });
 
-  it('exports cloze:true from the front content even when templateSlug is basic', async () => {
+  it('exports a normalized basic card when stray cloze content arrives under templateSlug basic', async () => {
     const useCase = new ChatDeckUseCase();
     await useCase.execute({
       deckName: 'Mismatched',
@@ -150,9 +150,85 @@ describe('ChatDeckUseCase.execute cloze content under a basic template label', (
     const Mock = CustomExporter as unknown as jest.Mock;
     const configure = Mock.mock.results[0].value.configure as jest.Mock;
     const deckInfo = configure.mock.calls[0][0] as Array<{
-      cards: Array<{ cloze: boolean }>;
+      cards: Array<{ cloze: boolean; name: string; back: string }>;
+    }>;
+    expect(deckInfo[0].cards[0].cloze).toBe(false);
+    expect(deckInfo[0].cards[0].name).not.toContain('{{c');
+    expect(deckInfo[0].cards[0].back).not.toContain('{{c');
+    expect(deckInfo[0].cards[0].name).toBe('The capital of France is [...].');
+    expect(deckInfo[0].cards[0].back).toBe('Paris');
+  });
+
+  it('normalizes stray cloze when templateSlug is basic-and-reversed', async () => {
+    const useCase = new ChatDeckUseCase();
+    await useCase.execute({
+      deckName: 'Reversed mismatch',
+      templateSlug: 'basic-and-reversed',
+      cards: [{ front: 'The capital of France is {{c1::Paris}}.', back: '' }],
+    });
+    const Mock = CustomExporter as unknown as jest.Mock;
+    const configure = Mock.mock.results[0].value.configure as jest.Mock;
+    const deckInfo = configure.mock.calls[0][0] as Array<{
+      cards: Array<{ cloze: boolean; name: string; back: string }>;
+    }>;
+    for (const card of deckInfo[0].cards) {
+      expect(card.cloze).toBe(false);
+      expect(card.name).not.toContain('{{c');
+      expect(card.back).not.toContain('{{c');
+    }
+  });
+
+  it('keeps cloze:true when templateSlug is cloze', async () => {
+    const useCase = new ChatDeckUseCase();
+    await useCase.execute({
+      deckName: 'Cloze deck',
+      templateSlug: 'cloze',
+      cards: [{ front: 'The capital of France is {{c1::Paris}}.', back: '' }],
+    });
+    const Mock = CustomExporter as unknown as jest.Mock;
+    const configure = Mock.mock.results[0].value.configure as jest.Mock;
+    const deckInfo = configure.mock.calls[0][0] as Array<{
+      cards: Array<{ cloze: boolean; name: string }>;
     }>;
     expect(deckInfo[0].cards[0].cloze).toBe(true);
+    expect(deckInfo[0].cards[0].name).toBe('The capital of France is {{c1::Paris}}.');
+  });
+});
+
+describe('normalizeBasicCard', () => {
+  it('converts a single cloze front into a blanked front with the answer on the back', () => {
+    expect(
+      normalizeBasicCard({ front: 'The capital of {{c1::France}} is Paris.', back: '' })
+    ).toEqual({
+      front: 'The capital of [...] is Paris.',
+      back: 'France',
+    });
+  });
+
+  it('joins multiple cloze answers on the back and blanks each on the front', () => {
+    expect(
+      normalizeBasicCard({
+        front: '{{c1::Mitochondria}} is the {{c2::powerhouse}} of the cell.',
+        back: '',
+      })
+    ).toEqual({
+      front: '[...] is the [...] of the cell.',
+      back: 'Mitochondria, powerhouse',
+    });
+  });
+
+  it('strips HTML-embedded cloze markers while keeping surrounding markup', () => {
+    expect(
+      normalizeBasicCard({ front: '<p>Capital: {{c1::Oslo}}</p>', back: '' })
+    ).toEqual({
+      front: '<p>Capital: [...]</p>',
+      back: 'Oslo',
+    });
+  });
+
+  it('leaves a plain front/back card untouched', () => {
+    const card = { front: 'What is the capital of Norway?', back: 'Oslo' };
+    expect(normalizeBasicCard(card)).toEqual(card);
   });
 });
 

--- a/src/usecases/chat/ChatDeckUseCase.ts
+++ b/src/usecases/chat/ChatDeckUseCase.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { randomUUID, createHash } from 'node:crypto';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
+import { templateForbidsCloze } from './chatTemplates';
 
 export interface ChatDeckCard {
   front: string;
@@ -30,10 +31,21 @@ function randomDeckId(): number {
 }
 
 const CLOZE_PATTERN = /\{\{c\d+::/;
+const CLOZE_REPLACE_PATTERN = /\{\{c\d+::([\s\S]*?)\}\}/g;
 const BLANK_PATTERN = /_{2,}/;
 
 export function looksLikeCloze(front: string): boolean {
   return CLOZE_PATTERN.test(front);
+}
+
+export function normalizeBasicCard(card: ChatDeckCard): ChatDeckCard {
+  if (!looksLikeCloze(card.front)) return card;
+  const answers: string[] = [];
+  const front = card.front.replace(CLOZE_REPLACE_PATTERN, (_match, answer: string) => {
+    answers.push(answer.trim());
+    return '[...]';
+  });
+  return { ...card, front, back: answers.join(', ') };
 }
 
 export function transformBlankToCloze(card: ChatDeckCard): ChatDeckCard {
@@ -66,10 +78,13 @@ export class ChatDeckUseCase {
     fs.mkdirSync(workspaceDir, { recursive: true });
 
     try {
-      const normalizedCards = expandForTemplate(
-        cards.map((c) => (isMcqCard(c) ? c : transformBlankToCloze(c))),
-        templateSlug
-      );
+      const forbidCloze = templateForbidsCloze(templateSlug);
+      const preparedCards = cards.map((c) => {
+        if (isMcqCard(c)) return c;
+        const withCloze = transformBlankToCloze(c);
+        return forbidCloze ? normalizeBasicCard(withCloze) : withCloze;
+      });
+      const normalizedCards = expandForTemplate(preparedCards, templateSlug);
       const deckInfo = [
         {
           name: deckName,

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -272,6 +272,74 @@ describe('ChatUseCase', () => {
       expect(result.contentBefore).toBeUndefined();
       expect(result.contentAfter).toBeUndefined();
     });
+
+    it('normalizes stray cloze cards to plain front/back when templateSlug is basic', async () => {
+      const cards = [{ front: 'The capital of {{c1::France}} is Paris.', back: '' }];
+      const responseText = `\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make basic cards',
+        conversationHistory: [],
+        templateSlug: 'basic',
+      });
+
+      expect(result.cards).toEqual([
+        { front: 'The capital of [...] is Paris.', back: 'France' },
+      ]);
+    });
+
+    it('joins multiple cloze answers on the back when templateSlug is basic', async () => {
+      const cards = [
+        { front: '{{c1::Mitochondria}} is the {{c2::powerhouse}} of the cell.', back: '' },
+      ];
+      const responseText = `\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make basic cards',
+        conversationHistory: [],
+        templateSlug: 'basic',
+      });
+
+      expect(result.cards).toEqual([
+        { front: '[...] is the [...] of the cell.', back: 'Mitochondria, powerhouse' },
+      ]);
+    });
+
+    it('normalizes stray cloze when templateSlug is basic-and-reversed', async () => {
+      const cards = [{ front: 'The capital of {{c1::France}} is Paris.', back: '' }];
+      const responseText = `\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make reversible cards',
+        conversationHistory: [],
+        templateSlug: 'basic-and-reversed',
+      });
+
+      expect(result.cards).toEqual([
+        { front: 'The capital of [...] is Paris.', back: 'France' },
+      ]);
+    });
+
+    it('passes cloze cards through untouched when templateSlug is cloze', async () => {
+      const cards = [{ front: 'The capital of {{c1::France}} is Paris.', back: '' }];
+      const responseText = `\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cloze cards',
+        conversationHistory: [],
+        templateSlug: 'cloze',
+      });
+
+      expect(result.cards).toEqual(cards);
+    });
   });
 
   describe('message persistence', () => {

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -4,7 +4,8 @@ import type { IConversationsRepository } from '../../data_layer/ConversationsRep
 import { logClaudeUsage } from '../../lib/claude/logClaudeUsage';
 import { buildAttachmentBlocks, type ChatAttachment } from './buildAttachmentBlocks';
 import { extractAttachmentText, buildAttachmentTextBlock } from './extractAttachmentText';
-import { isChatCardTemplate, templatePromptSuffix, type ChatCardTemplate } from './chatTemplates';
+import { isChatCardTemplate, templatePromptSuffix, templateForbidsCloze, type ChatCardTemplate } from './chatTemplates';
+import { looksLikeCloze, normalizeBasicCard } from './ChatDeckUseCase';
 
 const REQUIRED_MCQ_OPTION_COUNT = 4;
 
@@ -206,7 +207,7 @@ function asMcqChatCard(item: Record<string, unknown>): ChatCard | null {
   };
 }
 
-function parseCardItem(item: unknown, mcqAllowed: boolean): ChatCard | null {
+function parseCardItem(item: unknown, mcqAllowed: boolean, forbidCloze: boolean): ChatCard | null {
   if (item == null || typeof item !== 'object') return null;
   const record = item as Record<string, unknown>;
   const looksLikeMcq = record.options !== undefined || record.correct_index !== undefined;
@@ -218,11 +219,16 @@ function parseCardItem(item: unknown, mcqAllowed: boolean): ChatCard | null {
   }
   if (typeof record.front === 'string' && typeof record.back === 'string') {
     const tags = parseTagsField(record.tags);
-    return {
+    const base: ChatCard = {
       front: record.front,
       back: record.back,
       ...(tags != null ? { tags } : {}),
     };
+    if (forbidCloze && looksLikeCloze(base.front)) {
+      const normalized = normalizeBasicCard(base);
+      return { ...base, front: normalized.front, back: normalized.back };
+    }
+    return base;
   }
   return null;
 }
@@ -244,7 +250,7 @@ export function rewriteAssistantContentWithTaggedCards(
   return content;
 }
 
-function parseCardArray(raw: string, mcqAllowed: boolean): ChatCard[] | undefined {
+function parseCardArray(raw: string, mcqAllowed: boolean, forbidCloze: boolean): ChatCard[] | undefined {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw.trim());
@@ -254,16 +260,16 @@ function parseCardArray(raw: string, mcqAllowed: boolean): ChatCard[] | undefine
   if (!Array.isArray(parsed)) return undefined;
   const cards: ChatCard[] = [];
   for (const item of parsed) {
-    const card = parseCardItem(item, mcqAllowed);
+    const card = parseCardItem(item, mcqAllowed, forbidCloze);
     if (card != null) cards.push(card);
   }
   return cards.length > 0 ? cards : undefined;
 }
 
-export function extractCards(text: string, mcqAllowed = false): ExtractCardsResult {
+export function extractCards(text: string, mcqAllowed = false, forbidCloze = false): ExtractCardsResult {
   const fencedMatch = /```json\s*([\s\S]*?)```/.exec(text);
   if (fencedMatch != null) {
-    const cards = parseCardArray(fencedMatch[1], mcqAllowed);
+    const cards = parseCardArray(fencedMatch[1], mcqAllowed, forbidCloze);
     if (cards != null) {
       const before = text.slice(0, fencedMatch.index).trim();
       const after = text.slice(fencedMatch.index + fencedMatch[0].length).trim();
@@ -277,7 +283,7 @@ export function extractCards(text: string, mcqAllowed = false): ExtractCardsResu
 
   const rawMatch = /((?:^|\n)\s*)(\[\s*\{[\s\S]*\}\s*\])/.exec(text);
   if (rawMatch != null) {
-    const cards = parseCardArray(rawMatch[2], mcqAllowed);
+    const cards = parseCardArray(rawMatch[2], mcqAllowed, forbidCloze);
     if (cards != null) {
       const before = text.slice(0, rawMatch.index).trim();
       const after = text.slice(rawMatch.index + rawMatch[0].length).trim();
@@ -533,7 +539,12 @@ export class ChatUseCase {
 
     await this.persistAssistantTurn(user.owner, conversationId, assistantContent);
 
-    const { cards, contentBefore, contentAfter } = extractCards(assistantContent, mcqAllowed);
+    const forbidCloze = templateForbidsCloze(resolvedTemplate);
+    const { cards, contentBefore, contentAfter } = extractCards(
+      assistantContent,
+      mcqAllowed,
+      forbidCloze
+    );
 
     return {
       content: assistantContent,

--- a/src/usecases/chat/ConversationsUseCase.ts
+++ b/src/usecases/chat/ConversationsUseCase.ts
@@ -4,7 +4,7 @@ import type {
   ConversationWithMessages,
 } from '../../data_layer/ConversationsRepository';
 import { extractCards, ChatCard } from './ChatUseCase';
-import { isChatCardTemplate } from './chatTemplates';
+import { isChatCardTemplate, templateForbidsCloze } from './chatTemplates';
 
 const MAX_TITLE_LENGTH = 120;
 
@@ -54,11 +54,12 @@ export class InvalidDraftError extends Error {
 function hydrateMessages(
   conv: ConversationWithMessages
 ): ConversationMessageView[] {
+  const forbidCloze = templateForbidsCloze(conv.templateSlug);
   return conv.messages.map((m) => {
     if (m.role !== 'assistant') {
       return m;
     }
-    const { cards, contentBefore, contentAfter } = extractCards(m.content, true);
+    const { cards, contentBefore, contentAfter } = extractCards(m.content, true, forbidCloze);
     return {
       ...m,
       ...(cards != null ? { cards } : {}),

--- a/src/usecases/chat/chatTemplates.test.ts
+++ b/src/usecases/chat/chatTemplates.test.ts
@@ -17,8 +17,14 @@ describe('isChatCardTemplate', () => {
 });
 
 describe('templatePromptSuffix', () => {
-  it('returns empty string for basic template', () => {
-    expect(templatePromptSuffix('basic')).toBe('');
+  it('returns a non-empty suffix for basic that forbids cloze and mcq', () => {
+    const suffix = templatePromptSuffix('basic');
+    expect(suffix.length).toBeGreaterThan(0);
+    expect(suffix).toMatch(/front/i);
+    expect(suffix).toMatch(/back/i);
+    expect(suffix).toMatch(/\{\{c/);
+    expect(suffix).toMatch(/cloze/i);
+    expect(suffix).toMatch(/multiple.choice|mcq/i);
   });
 
   it('returns a non-empty suffix for basic-and-reversed', () => {

--- a/src/usecases/chat/chatTemplates.ts
+++ b/src/usecases/chat/chatTemplates.ts
@@ -16,7 +16,14 @@ export function isChatCardTemplate(value: unknown): value is ChatCardTemplate {
 }
 
 const TEMPLATE_PROMPT_SUFFIX: Record<ChatCardTemplate, string> = {
-  basic: '',
+  basic: `
+TEMPLATE OVERRIDE — basic front/back (this overrides any earlier instruction about cloze or multiple-choice cards):
+
+EVERY card you emit must be a plain front/back pair. For each card:
+- "front" holds the question or prompt
+- "back" holds the answer and must be non-empty
+- Do NOT use {{cN::...}} cloze syntax anywhere
+- Do NOT produce multiple-choice (MCQ) cards or answer-option lists`,
   'basic-and-reversed': `
 TEMPLATE OVERRIDE — basic + reverse:
 Each card will appear in Anki as BOTH a question→answer AND answer→question pair. Make sure every card makes sense in both directions (e.g. terms and definitions, language pairs).`,
@@ -59,4 +66,13 @@ Rules:
 
 export function templatePromptSuffix(slug: ChatCardTemplate): string {
   return TEMPLATE_PROMPT_SUFFIX[slug];
+}
+
+const CLOZE_FORBIDDING_TEMPLATES: ReadonlySet<ChatCardTemplate> = new Set([
+  'basic',
+  'basic-and-reversed',
+]);
+
+export function templateForbidsCloze(slug: string | null | undefined): boolean {
+  return isChatCardTemplate(slug) && CLOZE_FORBIDDING_TEMPLATES.has(slug);
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-basic-no-cloze.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-basic-no-cloze.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-basic-no-cloze",
+  "date": "2026-06-03",
+  "type": "fix",
+  "title": "Basic chat decks keep plain front and back cards — no stray cloze markers"
+}


### PR DESCRIPTION
## What
The chat card-template picker becomes a contract for **Basic**: a user who picks Basic (or Basic + reversed) never receives cloze cards with raw `{{cN::}}` markers — not in the preview, not on reload of a saved conversation, and not in the exported `.apkg`.

## Why
Closes #2975. The picker was advisory. Note type was decided by **content** (`cloze: looksLikeCloze(c.front)`) while the `basic` prompt suffix was the empty string, so the model's stray cloze cards leaked straight through. Prod confirmed it: 1 of 2 basic conversations leaked cloze, and a user screenshot showed the raw markers.

## How — two layers
**Layer A — non-empty `basic` prompt suffix.** `TEMPLATE_PROMPT_SUFFIX.basic` now instructs: every card is a plain front/back pair, no `{{cN::}}` cloze, no MCQ, `back` must be non-empty. It mirrors the existing cloze/mcq override pattern and rides inside the cached `cache_control: ephemeral` system prompt — **no token-cost regression after the first turn**.

**Layer B — post-parse normalization guard.** The prompt is a request, not a guarantee. New `normalizeBasicCard` (next to `looksLikeCloze`/`transformBlankToCloze` in `ChatDeckUseCase`, reusing the existing cloze regex) inverts `transformBlankToCloze`: `The capital of {{c1::France}} is Paris.` → front `The capital of [...] is Paris.`, back `France`. Multiple clozes blank each on the front and join the answers on the back. `extractCards` threads a `forbidCloze` flag through `parseCardArray` → `parseCardItem`, applied at **both** fresh generation (`ChatUseCase`) and reload of persisted conversations (`ConversationsUseCase`), so basic and basic-and-reversed never surface raw markers. `ChatDeckUseCase`'s export path normalizes the same way and exports the **Basic** note type, not cloze. `cloze` and `mcq` templates pass through untouched.

## Measuring success
The download endpoint (`ChatDeckController`) builds decks with `cloze: false` for any card under a basic template; a basic deck's card `name`/`back` contains no `{{c`. Confirm in prod by sampling a chat conversion with `templateSlug=basic` — the served `.apkg` should carry `n2a-basic` notes only, and the preview JSON should show no `{{c` in any front/back.

## Testing
- Unit tests added/updated (real collaborators, only the Claude SDK edge mocked):
  - `chatTemplates.test.ts`: basic suffix is non-empty and forbids cloze + MCQ.
  - `ChatDeckUseCase.test.ts`: `normalizeBasicCard` single/multi-cloze + HTML + passthrough; export emits normalized Basic cards under `basic` and `basic-and-reversed`; cloze template still exports `cloze:true`.
  - `ChatUseCase.test.ts`: `templateSlug=basic` normalizes stray `{{c1::X}}` to plain front/back with X on the back; multi-cloze joins answers; `basic-and-reversed` also normalizes; `cloze` passes through untouched.
- Full `src/usecases/chat/` suite: 160 passing. `tsc -p . --noEmit` clean.
- `sonar-scanner` not run locally — `SONAR_TOKEN` unset on this machine; expect the analysis on the PR. Change is small and within existing helper patterns.

## Browser check
Browser check: not applicable — server-only change, the only `web/src` file is a changelog entry.

## Risks
Normalization only fires when the resolved template forbids cloze (basic / basic-and-reversed); `cloze` and `mcq` are untouched, so no regression to those flows. Rollback is a straight revert.

## Changelog
`Basic chat decks keep plain front and back cards — no stray cloze markers`

## Goal alignment
Removes a broken-output failure mode on the chat conversion path — the deck users get matches the template they chose, which is core to the "drop something in, get a clean deck back" mission and to trust at scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783077770&installation_id=132681956&pr_number=3029&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3029&signature=7bf63f2eb1f8476e9d630835217b9ecc3891bacddb1904e73be2dbcee71fea00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->