### PR TITLE
feat: instant chat template switch for Basic and Basic + reverse

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -144,7 +144,9 @@ describe('ChatPanel — send button state', () => {
     renderChatPanel();
     const textarea = screen.getByRole('textbox', { name: 'Message input' });
     fireEvent.change(textarea, { target: { value: 'Hello' } });
-    expect(screen.getByRole('button', { name: 'Send message' })).not.toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Send message' })
+    ).not.toBeDisabled();
   });
 });
 
@@ -184,7 +186,9 @@ describe('ChatPanel — long user message collapse', () => {
       ])
     );
     const longMessage = 'A'.repeat(700);
-    renderChatPanel({ initialMessages: [{ role: 'user', content: longMessage }] });
+    renderChatPanel({
+      initialMessages: [{ role: 'user', content: longMessage }],
+    });
     expect(
       screen.getByRole('button', { name: 'Show full message' })
     ).toBeInTheDocument();
@@ -192,7 +196,9 @@ describe('ChatPanel — long user message collapse', () => {
 
   it('toggles to "Show less" after clicking "Show full message"', () => {
     const longMessage = 'B'.repeat(700);
-    renderChatPanel({ initialMessages: [{ role: 'user', content: longMessage }] });
+    renderChatPanel({
+      initialMessages: [{ role: 'user', content: longMessage }],
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Show full message' }));
     expect(
       screen.getByRole('button', { name: 'Show less' })
@@ -208,9 +214,7 @@ describe('ChatPanel — assistant message layout', () => {
 
   it('renders assistant prose without a user-message aria-label', async () => {
     renderChatPanel({
-      initialMessages: [
-        { role: 'assistant', content: 'The answer is 42.' },
-      ],
+      initialMessages: [{ role: 'assistant', content: 'The answer is 42.' }],
     });
     expect(screen.getByText('The answer is 42.')).toBeInTheDocument();
     expect(screen.queryByLabelText('User message')).not.toBeInTheDocument();
@@ -221,7 +225,12 @@ describe('ChatPanel — CardPreview integration', () => {
   beforeEach(() => {
     mockPost.mockReset();
     mockGet.mockResolvedValue({ used: 0, limit: 20 });
-    Object.assign(global, { URL: { createObjectURL: vi.fn(() => 'blob:test'), revokeObjectURL: vi.fn() } });
+    Object.assign(global, {
+      URL: {
+        createObjectURL: vi.fn(() => 'blob:test'),
+        revokeObjectURL: vi.fn(),
+      },
+    });
   });
 
   it('renders "Download deck" button when message has cards', () => {
@@ -579,13 +588,17 @@ describe('ChatPanel — consent modal dismissal', () => {
     );
 
     expect(
-      screen.getByRole('heading', { name: 'Chat sends your messages to Anthropic' })
+      screen.getByRole('heading', {
+        name: 'Chat sends your messages to Anthropic',
+      })
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
 
     expect(
-      screen.queryByRole('heading', { name: 'Chat sends your messages to Anthropic' })
+      screen.queryByRole('heading', {
+        name: 'Chat sends your messages to Anthropic',
+      })
     ).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
@@ -599,7 +612,9 @@ describe('ChatPanel — consent modal dismissal', () => {
     );
 
     expect(
-      screen.queryByRole('heading', { name: 'Chat sends your messages to Anthropic' })
+      screen.queryByRole('heading', {
+        name: 'Chat sends your messages to Anthropic',
+      })
     ).not.toBeInTheDocument();
   });
 
@@ -613,7 +628,9 @@ describe('ChatPanel — consent modal dismissal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
 
     expect(
-      screen.queryByRole('heading', { name: 'Chat sends your messages to Anthropic' })
+      screen.queryByRole('heading', {
+        name: 'Chat sends your messages to Anthropic',
+      })
     ).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Message input' }), {
@@ -623,7 +640,9 @@ describe('ChatPanel — consent modal dismissal', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: 'Chat sends your messages to Anthropic' })
+        screen.getByRole('heading', {
+          name: 'Chat sends your messages to Anthropic',
+        })
       ).toBeInTheDocument();
     });
   });
@@ -675,8 +694,12 @@ describe('ChatPanel — template selector', () => {
   it('opens the template dropdown on click', () => {
     renderChatPanel({ initialMessages: assistantWithCards });
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
-    expect(screen.getByRole('listbox', { name: 'Note type' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /Basic \+/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole('listbox', { name: 'Note type' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /Basic \+/ })
+    ).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Cloze/ })).toBeInTheDocument();
   });
 
@@ -684,7 +707,10 @@ describe('ChatPanel — template selector', () => {
     const onTemplateChange = vi.fn();
     mockPost.mockResolvedValueOnce(
       makeSseResponse([
-        { event: 'done', data: { content: 'Reply', conversationId: 1, cards: [] } },
+        {
+          event: 'done',
+          data: { content: 'Reply', conversationId: 1, cards: [] },
+        },
       ])
     );
     renderChatPanel({
@@ -692,7 +718,9 @@ describe('ChatPanel — template selector', () => {
       onTemplateChange,
     });
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
-    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
     expect(onTemplateChange).toHaveBeenCalledWith('cloze');
   });
 
@@ -736,7 +764,9 @@ describe('ChatPanel — template selector', () => {
       initialConversationId: 7,
     });
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
-    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith(
         '/api/chat/conversations/7/regenerate',
@@ -763,7 +793,9 @@ describe('ChatPanel — template selector', () => {
       initialConversationId: 7,
     });
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
-    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
     await waitFor(() => {
       expect(mockPost).toHaveBeenCalledWith(
         '/api/chat/conversations/7/regenerate',
@@ -794,7 +826,9 @@ describe('ChatPanel — template selector', () => {
       initialConversationId: 7,
     });
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
-    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
     await waitFor(() => {
       expect(screen.getByText('Cloze front')).toBeInTheDocument();
     });
@@ -805,11 +839,13 @@ describe('ChatPanel — template selector', () => {
   it('does not regenerate when there is no saved conversation', async () => {
     renderChatPanel({ initialMessages: assistantWithCards });
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
-    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
     expect(mockPost).not.toHaveBeenCalled();
   });
 
-  it('shows a skeleton while regenerating and hides the Download button', async () => {
+  it('keeps the existing cards visible while regenerating and hides Download', async () => {
     let resolveSse: (v: ReturnType<typeof makeSseResponse>) => void = () => {};
     const sseResponse = new Promise<ReturnType<typeof makeSseResponse>>(
       (res) => {
@@ -827,15 +863,16 @@ describe('ChatPanel — template selector', () => {
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
-    fireEvent.click(screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!);
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
 
     await waitFor(() => {
       expect(
-        screen.getByRole('status', {
-          name: 'Rebuilding your cards with the new template',
-        })
+        screen.getByRole('status', { name: 'Switching to Cloze' })
       ).toBeInTheDocument();
     });
+    expect(screen.getByText('Capital?')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Download deck' })
     ).not.toBeInTheDocument();
@@ -855,10 +892,65 @@ describe('ChatPanel — template selector', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('status', {
-          name: 'Rebuilding your cards with the new template',
-        })
+        screen.queryByRole('status', { name: 'Switching to Cloze' })
       ).not.toBeInTheDocument();
+    });
+  });
+
+  it('switches basic to basic-and-reversed without calling the server', () => {
+    renderChatPanel({
+      initialMessages: assistantWithCards,
+      initialConversationId: 7,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Basic \+/ }).querySelector('button')!
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', { name: 'Note type: Basic + Reverse' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders reversed duplicate rows after the instant basic-and-reversed switch', () => {
+    renderChatPanel({
+      initialMessages: assistantWithCards,
+      initialConversationId: 7,
+    });
+    expect(screen.getAllByText('Oslo')).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Basic \+/ }).querySelector('button')!
+    );
+    expect(screen.getAllByText('Oslo')).toHaveLength(2);
+  });
+
+  it('still calls the server when switching basic to cloze', async () => {
+    mockPost.mockResolvedValueOnce(
+      makeSseResponse([
+        {
+          event: 'done',
+          data: {
+            content: 'Reply',
+            conversationId: 7,
+            cards: [{ front: 'New', back: 'Card' }],
+          },
+        },
+      ])
+    );
+    renderChatPanel({
+      initialMessages: assistantWithCards,
+      initialConversationId: 7,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/chat/conversations/7/regenerate',
+        { templateSlug: 'cloze' }
+      );
     });
   });
 });
@@ -892,10 +984,7 @@ describe('consumeSseEvents', () => {
   });
 
   it('reassembles an event split across two stream chunks', async () => {
-    const stream = streamFromStrings([
-      'event: tok',
-      'en\ndata: "split"\n\n',
-    ]);
+    const stream = streamFromStrings(['event: tok', 'en\ndata: "split"\n\n']);
     const received: Array<[string, string]> = [];
 
     await consumeSseEvents(stream, (eventType, data) => {

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { get, patch, post, postMultipart } from '../../lib/backend/api';
+import {
+  type ChatCardTemplate,
+  DEFAULT_TEMPLATE,
+  isPureClientReshape,
+} from '../../lib/chat/templates';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
-import ConsentModal from '../ConsentModal/ConsentModal';
 import AssistantMarkdown from '../../pages/Chat/AssistantMarkdown';
 import CardPreview from '../../pages/Chat/CardPreview';
+import ConsentModal from '../ConsentModal/ConsentModal';
 import styles from './ChatPanel.module.css';
-import {
-  DEFAULT_TEMPLATE,
-  type ChatCardTemplate,
-} from '../../lib/chat/templates';
 
 export interface ChatCard {
   front: string;
@@ -160,7 +161,11 @@ async function downloadDeck(
   deckName: string,
   templateSlug: ChatCardTemplate
 ): Promise<void> {
-  const response = await post('/api/chat/deck', { cards, deckName, templateSlug });
+  const response = await post('/api/chat/deck', {
+    cards,
+    deckName,
+    templateSlug,
+  });
   if (!response.ok) {
     throw new Error('Failed to generate deck');
   }
@@ -320,7 +325,7 @@ function StreamingMessage({
           {visibleStreamingText(streamingText)}
         </AssistantMarkdown>
         {isCardStreaming && (
-          <span className={styles.makingCards}>Making your cards</span>
+          <span className={styles.makingCards}>Writing your cards</span>
         )}
       </div>
     );
@@ -900,6 +905,7 @@ export default function ChatPanel({
 
   function handleTemplateChange(slug: ChatCardTemplate) {
     if (slug === activeTemplate) return;
+    const reshapeOnly = isPureClientReshape(activeTemplate, slug);
     setActiveTemplate(slug);
     onTemplateChange?.(slug);
     if (activeConversationId != null) {
@@ -907,6 +913,7 @@ export default function ChatPanel({
         templateSlug: slug,
       }).catch(() => {});
     }
+    if (reshapeOnly) return;
     const lastAssistantWithCards = findLastAssistantWithCardsIdx(messages);
     if (lastAssistantWithCards !== -1 && !isLoading) {
       regenerateLastTurn(slug, lastAssistantWithCards);
@@ -1068,7 +1075,8 @@ export default function ChatPanel({
 
   return (
     <>
-      {(showConsentModal || (!hasConsented && userLocals != null && !userDismissedConsent)) && (
+      {(showConsentModal ||
+        (!hasConsented && userLocals != null && !userDismissedConsent)) && (
         <ConsentModal
           onAccept={async () => {
             await refetchUserLocals();
@@ -1105,10 +1113,7 @@ export default function ChatPanel({
         ) : (
           <>
             <div className={styles.messageList} ref={messageListRef}>
-              <div
-                className={styles.messageListInner}
-                aria-live="polite"
-              >
+              <div className={styles.messageListInner} aria-live="polite">
                 {(() => {
                   const lastCardsIdx = findLastAssistantWithCardsIdx(messages);
                   return messages.map((m, i) => {
@@ -1139,14 +1144,20 @@ export default function ChatPanel({
                         key={i}
                         message={m}
                         onSave={handleSaveAsDeck}
-                        template={showTemplateSelector ? activeTemplate : undefined}
+                        template={
+                          showTemplateSelector ? activeTemplate : undefined
+                        }
                         onTemplateChange={
-                          showTemplateSelector ? handleTemplateChange : undefined
+                          showTemplateSelector
+                            ? handleTemplateChange
+                            : undefined
                         }
                         templateDisabled={isLoading}
                         isRegenerating={i === regeneratingIdx}
                         onAddTags={
-                          i === lastCardsIdx ? () => handleAddTags(i) : undefined
+                          i === lastCardsIdx
+                            ? () => handleAddTags(i)
+                            : undefined
                         }
                         isTagging={i === taggingIdx}
                       />

--- a/web/src/lib/chat/templates.test.ts
+++ b/web/src/lib/chat/templates.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { effectiveTemplateForCards } from './templates';
+import {
+  effectiveTemplateForCards,
+  isPureClientReshape,
+  templateSwitchLabel,
+} from './templates';
 
 const basicCard = { front: 'Capital of France?', back: 'Paris' };
-const clozeCard = { front: 'The capital of France is {{c1::Paris}}.', back: '' };
+const clozeCard = {
+  front: 'The capital of France is {{c1::Paris}}.',
+  back: '',
+};
 const mcqCard = {
   front: 'Which enzyme hydrolyses starch?',
   back: '',
@@ -46,6 +53,36 @@ describe('effectiveTemplateForCards', () => {
   it('falls back to the selected template when card kinds are mixed', () => {
     expect(effectiveTemplateForCards([clozeCard, basicCard], 'cloze')).toBe(
       'cloze'
+    );
+  });
+});
+
+describe('isPureClientReshape', () => {
+  it('is true switching between basic and basic-and-reversed', () => {
+    expect(isPureClientReshape('basic', 'basic-and-reversed')).toBe(true);
+    expect(isPureClientReshape('basic-and-reversed', 'basic')).toBe(true);
+  });
+
+  it('is false when either side leaves the basic family', () => {
+    expect(isPureClientReshape('basic', 'cloze')).toBe(false);
+    expect(isPureClientReshape('cloze', 'basic')).toBe(false);
+    expect(isPureClientReshape('basic-and-reversed', 'mcq')).toBe(false);
+  });
+});
+
+describe('templateSwitchLabel', () => {
+  it('names the cloze target', () => {
+    expect(templateSwitchLabel('cloze')).toBe('Switching to Cloze');
+  });
+
+  it('names the multiple-choice target', () => {
+    expect(templateSwitchLabel('mcq')).toBe('Switching to multiple choice');
+  });
+
+  it('names the basic target for both basic and basic-and-reversed', () => {
+    expect(templateSwitchLabel('basic')).toBe('Switching to Basic');
+    expect(templateSwitchLabel('basic-and-reversed')).toBe(
+      'Switching to Basic'
     );
   });
 });

--- a/web/src/lib/chat/templates.ts
+++ b/web/src/lib/chat/templates.ts
@@ -1,8 +1,4 @@
-export type ChatCardTemplate =
-  | 'basic'
-  | 'basic-and-reversed'
-  | 'cloze'
-  | 'mcq';
+export type ChatCardTemplate = 'basic' | 'basic-and-reversed' | 'cloze' | 'mcq';
 
 export interface ChatTemplateOption {
   slug: ChatCardTemplate;
@@ -12,9 +8,17 @@ export interface ChatTemplateOption {
 
 export const CHAT_TEMPLATE_OPTIONS: ChatTemplateOption[] = [
   { slug: 'basic', label: 'Basic', fieldHint: 'Front / Back' },
-  { slug: 'basic-and-reversed', label: 'Basic + Reverse', fieldHint: 'Front / Back (both directions)' },
+  {
+    slug: 'basic-and-reversed',
+    label: 'Basic + Reverse',
+    fieldHint: 'Front / Back (both directions)',
+  },
   { slug: 'cloze', label: 'Cloze', fieldHint: 'Front with {{c1::blanks}}' },
-  { slug: 'mcq', label: 'Multiple choice', fieldHint: 'Stem with four options' },
+  {
+    slug: 'mcq',
+    label: 'Multiple choice',
+    fieldHint: 'Stem with four options',
+  },
 ];
 
 export const DEFAULT_TEMPLATE: ChatCardTemplate = 'basic';
@@ -37,13 +41,32 @@ function isClozeShape(card: ShapeCard): boolean {
 }
 
 function isBasicShape(card: ShapeCard): boolean {
-  return card.back.trim().length > 0 && !isMcqShape(card) && !isClozeShape(card);
+  return (
+    card.back.trim().length > 0 && !isMcqShape(card) && !isClozeShape(card)
+  );
 }
 
-const BASIC_FAMILY: ReadonlySet<ChatCardTemplate> = new Set<ChatCardTemplate>([
-  'basic',
-  'basic-and-reversed',
-]);
+export const TRANSFORM_TEMPLATES: ReadonlySet<ChatCardTemplate> =
+  new Set<ChatCardTemplate>(['basic', 'basic-and-reversed']);
+
+export function isPureClientReshape(
+  from: ChatCardTemplate,
+  to: ChatCardTemplate
+): boolean {
+  return TRANSFORM_TEMPLATES.has(from) && TRANSFORM_TEMPLATES.has(to);
+}
+
+export function templateSwitchLabel(target: ChatCardTemplate): string {
+  switch (target) {
+    case 'cloze':
+      return 'Switching to Cloze';
+    case 'mcq':
+      return 'Switching to multiple choice';
+    case 'basic-and-reversed':
+    case 'basic':
+      return 'Switching to Basic';
+  }
+}
 
 export function effectiveTemplateForCards(
   cards: ShapeCard[],
@@ -52,6 +75,7 @@ export function effectiveTemplateForCards(
   if (cards.length === 0) return selected;
   if (cards.every(isMcqShape)) return 'mcq';
   if (cards.every(isClozeShape)) return 'cloze';
-  if (cards.every(isBasicShape) && !BASIC_FAMILY.has(selected)) return 'basic';
+  if (cards.every(isBasicShape) && !TRANSFORM_TEMPLATES.has(selected))
+    return 'basic';
   return selected;
 }

--- a/web/src/pages/Chat/CardPreview.module.css
+++ b/web/src/pages/Chat/CardPreview.module.css
@@ -61,7 +61,9 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-full);
   cursor: pointer;
-  transition: border-color var(--transition-fast), color var(--transition-fast);
+  transition:
+    border-color var(--transition-fast),
+    color var(--transition-fast);
 }
 
 .cardPreviewAddTags:hover,
@@ -274,23 +276,6 @@
   color: var(--color-text-secondary);
 }
 
-.cardPreviewSkeletonList {
-  display: flex;
-  flex-direction: column;
-}
-
-.cardPreviewSkeletonRow {
-  padding: 0.75rem 1rem;
-  border-top: 1px solid var(--color-border-light);
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 1.5rem;
-}
-
-.cardPreviewSkeletonRowSingle {
-  grid-template-columns: minmax(0, 1fr);
-}
-
 .cardPreviewMcqRow {
   padding: 0.875rem 1rem;
   border-top: 1px solid var(--color-border-light);
@@ -348,19 +333,7 @@
   font-style: italic;
 }
 
-.cardPreviewSkeletonBlock {
-  display: block;
-  height: 1rem;
-  border-radius: 4px;
-  background: var(--color-border);
-  animation: cardPreviewSkeletonPulse 1.4s ease-in-out infinite;
-}
-
-.cardPreviewSkeletonRow > .cardPreviewSkeletonBlock:nth-child(2) {
-  animation-delay: 0.15s;
-}
-
-.cardPreviewSkeletonHint {
+.cardPreviewSwitchHint {
   margin: 0;
   padding: 0.75rem 1rem;
   font-size: var(--text-xs);
@@ -369,16 +342,30 @@
   text-align: center;
 }
 
+.cardPreviewListDimmed {
+  opacity: 0.5;
+  transition: opacity 0.15s ease-in-out;
+  pointer-events: none;
+}
+
 @keyframes cardPreviewSkeletonPulse {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .cardPreviewSkeletonBlock,
   .cardPreviewTagSkeleton {
     animation: none;
     opacity: 0.7;
+  }
+
+  .cardPreviewListDimmed {
+    transition: none;
   }
 }
 

--- a/web/src/pages/Chat/CardPreview.test.tsx
+++ b/web/src/pages/Chat/CardPreview.test.tsx
@@ -256,4 +256,47 @@ describe('CardPreview', () => {
       expect(screen.getByText('Paris')).toBeInTheDocument();
     });
   });
+
+  describe('regenerating', () => {
+    it('keeps the existing cards on screen instead of swapping in placeholders', () => {
+      render(
+        <CardPreview
+          cards={makeCards(3)}
+          onSave={vi.fn()}
+          template="cloze"
+          isRegenerating
+        />
+      );
+      expect(screen.getByText('Question 1')).toBeInTheDocument();
+      expect(screen.getByText('Answer 1')).toBeInTheDocument();
+    });
+
+    it('names the target template in the status banner', () => {
+      render(
+        <CardPreview
+          cards={makeCards(3)}
+          onSave={vi.fn()}
+          template="cloze"
+          isRegenerating
+        />
+      );
+      expect(
+        screen.getByRole('status', { name: 'Switching to Cloze' })
+      ).toBeInTheDocument();
+    });
+
+    it('hides the Download button while regenerating', () => {
+      render(
+        <CardPreview
+          cards={makeCards(3)}
+          onSave={vi.fn()}
+          template="cloze"
+          isRegenerating
+        />
+      );
+      expect(
+        screen.queryByRole('button', { name: 'Download deck' })
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import DownloadIcon from '../../components/icons/DownloadIcon';
 import { TemplateSelector } from '../../components/ChatPanel/TemplateSelector';
+import DownloadIcon from '../../components/icons/DownloadIcon';
 import {
-  effectiveTemplateForCards,
   type ChatCardTemplate,
+  effectiveTemplateForCards,
+  templateSwitchLabel,
 } from '../../lib/chat/templates';
 import styles from './CardPreview.module.css';
 
@@ -17,9 +18,7 @@ interface ChatCard {
 }
 
 function isMcqCard(card: ChatCard): boolean {
-  return (
-    Array.isArray(card.options) && typeof card.correctIndex === 'number'
-  );
+  return Array.isArray(card.options) && typeof card.correctIndex === 'number';
 }
 
 interface CardPreviewProps {
@@ -33,7 +32,6 @@ interface CardPreviewProps {
   isTagging?: boolean;
 }
 
-const SKELETON_ROWS = 5;
 const MAX_VISIBLE_TAGS = 3;
 const CLOZE_PATTERN = /\{\{c\d+::/;
 
@@ -41,10 +39,7 @@ function expandForReversed(cards: ChatCard[]): ChatCard[] {
   const expanded: ChatCard[] = [];
   for (const card of cards) {
     expanded.push(card);
-    if (
-      card.back.trim().length > 0 &&
-      !CLOZE_PATTERN.test(card.front)
-    ) {
+    if (card.back.trim().length > 0 && !CLOZE_PATTERN.test(card.front)) {
       expanded.push({ front: card.back, back: card.front, tags: card.tags });
     }
   }
@@ -156,8 +151,8 @@ export default function CardPreview({
   const hasMore = displayCards.length > VISIBLE_COUNT;
   const hideBackColumn =
     displayTemplate === 'cloze' &&
-    (isRegenerating === true ||
-      (cards.length > 0 && cards.every((c) => c.back.trim().length === 0)));
+    cards.length > 0 &&
+    cards.every((c) => c.back.trim().length === 0);
   const hasTags =
     cards.some((c) => c.tags != null && c.tags.length > 0) ||
     isTagging === true;
@@ -191,6 +186,7 @@ export default function CardPreview({
   }
 
   const cardLabel = displayCards.length === 1 ? 'card' : 'cards';
+  const switchLabel = template == null ? null : templateSwitchLabel(template);
 
   return (
     <div className={styles.cardPreview}>
@@ -294,84 +290,69 @@ export default function CardPreview({
         </div>
       )}
 
-      {isRegenerating ? (
-        <>
-          <div
-            className={styles.cardPreviewSkeletonList}
-            aria-label="Rebuilding your cards with the new template"
-            role="status"
-          >
-            {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+      {isRegenerating === true && switchLabel != null && (
+        <p
+          className={styles.cardPreviewSwitchHint}
+          role="status"
+          aria-label={switchLabel}
+        >
+          {switchLabel}
+        </p>
+      )}
+      <>
+        <div
+          className={`${styles.cardPreviewList} ${isRegenerating === true ? styles.cardPreviewListDimmed : ''}`}
+          aria-busy={isRegenerating === true}
+        >
+          {visibleCards.map((card, i) =>
+            isMcqCard(card) ? (
+              <McqRow key={i} card={card} />
+            ) : (
               <div
                 key={i}
-                className={`${styles.cardPreviewSkeletonRow} ${hideBackColumn ? styles.cardPreviewSkeletonRowSingle : ''}`}
+                className={`${styles.cardPreviewRow} ${hideBackColumn && !hasTags ? styles.cardPreviewRowSingle : ''} ${!hideBackColumn && hasTags ? styles.cardPreviewRowThree : ''}`}
               >
-                <span className={styles.cardPreviewSkeletonBlock} />
+                <div className={styles.cardPreviewFront}>
+                  {(!hideBackColumn || hasTags) && (
+                    <span className={styles.cardPreviewMobileLabel}>Front</span>
+                  )}
+                  {card.front}
+                </div>
                 {!hideBackColumn && (
-                  <span className={styles.cardPreviewSkeletonBlock} />
+                  <div className={styles.cardPreviewBack}>
+                    <span className={styles.cardPreviewMobileLabel}>Back</span>
+                    {card.back}
+                  </div>
+                )}
+                {hasTags && (
+                  <div className={styles.cardPreviewTags}>
+                    <span className={styles.cardPreviewMobileLabel}>Tags</span>
+                    {isTagging ? (
+                      <span
+                        className={styles.cardPreviewTagSkeleton}
+                        role="status"
+                        aria-label="Adding tags"
+                      />
+                    ) : (
+                      <TagChips tags={card.tags ?? []} />
+                    )}
+                  </div>
                 )}
               </div>
-            ))}
-          </div>
-          <p className={styles.cardPreviewSkeletonHint}>
-            Rebuilding your cards with the new template
-          </p>
-        </>
-      ) : (
-        <>
-          <div className={styles.cardPreviewList}>
-            {visibleCards.map((card, i) =>
-              isMcqCard(card) ? (
-                <McqRow key={i} card={card} />
-              ) : (
-                <div
-                  key={i}
-                  className={`${styles.cardPreviewRow} ${hideBackColumn && !hasTags ? styles.cardPreviewRowSingle : ''} ${!hideBackColumn && hasTags ? styles.cardPreviewRowThree : ''}`}
-                >
-                  <div className={styles.cardPreviewFront}>
-                    {(!hideBackColumn || hasTags) && (
-                      <span className={styles.cardPreviewMobileLabel}>Front</span>
-                    )}
-                    {card.front}
-                  </div>
-                  {!hideBackColumn && (
-                    <div className={styles.cardPreviewBack}>
-                      <span className={styles.cardPreviewMobileLabel}>Back</span>
-                      {card.back}
-                    </div>
-                  )}
-                  {hasTags && (
-                    <div className={styles.cardPreviewTags}>
-                      <span className={styles.cardPreviewMobileLabel}>Tags</span>
-                      {isTagging ? (
-                        <span
-                          className={styles.cardPreviewTagSkeleton}
-                          role="status"
-                          aria-label="Adding tags"
-                        />
-                      ) : (
-                        <TagChips tags={card.tags ?? []} />
-                      )}
-                    </div>
-                  )}
-                </div>
-              )
-            )}
-          </div>
-
-          {hasMore && (
-            <button
-              type="button"
-              className={styles.cardPreviewExpandBtn}
-              onClick={() => setExpanded((v) => !v)}
-            >
-              {expanded
-                ? 'Show fewer'
-                : `Show all ${displayCards.length} cards`}
-            </button>
+            )
           )}
-        </>
-      )}
+        </div>
+
+        {hasMore && (
+          <button
+            type="button"
+            className={styles.cardPreviewExpandBtn}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? 'Show fewer' : `Show all ${displayCards.length} cards`}
+          </button>
+        )}
+      </>
     </div>
   );
 }

--- a/web/src/pages/Chat/ChatPage.test.tsx
+++ b/web/src/pages/Chat/ChatPage.test.tsx
@@ -132,7 +132,7 @@ describe('ChatPage', () => {
     expect(screen.queryByText('Download deck')).not.toBeInTheDocument();
   });
 
-  it('shows Making your cards indicator and hides JSON while streaming cards', async () => {
+  it('shows Writing your cards indicator and hides JSON while streaming cards', async () => {
     const cards = [{ front: 'Q1', back: 'A1' }];
     const encoder = new TextEncoder();
     let enqueue!: (chunk: Uint8Array) => void;
@@ -160,7 +160,7 @@ describe('ChatPage', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Making your cards')).toBeInTheDocument();
+      expect(screen.getByText('Writing your cards')).toBeInTheDocument();
     });
     expect(screen.queryByText(/```json/)).not.toBeInTheDocument();
 
@@ -179,7 +179,7 @@ describe('ChatPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Q1')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Making your cards')).not.toBeInTheDocument();
+    expect(screen.queryByText('Writing your cards')).not.toBeInTheDocument();
   });
 
   it('does not collapse short user messages', async () => {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-instant-template-switch.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-instant-template-switch.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-instant-template-switch",
+  "date": "2026-06-03",
+  "type": "feature",
+  "title": "Switching a chat deck between Basic and Basic + reverse is instant"
+}


### PR DESCRIPTION
## What
Makes switching a chat deck's note type instant for the most common toggle, and stops a real regenerate from blanking the card list.

## Why
Every template change in chat called the regenerate endpoint, which deletes the last assistant message and re-calls Claude — a 2-10s round trip. For Basic ↔ Basic + reverse that round trip buys nothing: the card content is identical and the reverse expansion is already applied at export. Users paid 2-10s and watched the deck blank out with skeletons for a switch that is pure data reshaping.

User-visible outcome: switching between Basic and Basic + reverse is instant (0ms, no Claude call); switching to Cloze or multiple choice keeps the existing cards on screen instead of an empty skeleton.

## How
Two changes in one PR.

**1 — Instant client-side switch for Basic ↔ Basic + reverse.** `TRANSFORM_TEMPLATES` (basic, basic-and-reversed) gates a new `isPureClientReshape(from, to)`. When both the current and the new slug are in that set, `handleTemplateChange` skips `regenerateLastTurn` entirely and just sets the active template; the existing `/template` persistence patch is unchanged. The preview reuses the existing `expandForReversed` / `effectiveTemplateForCards` helpers to render reversed rows — no duplicated reversal logic. Cloze and multiple-choice still hit the server because their card content genuinely changes.

**2 — Don't blow away the list + copy fixes.** During a real (cloze/MCQ) regenerate, the existing cards stay on screen dimmed (~50% opacity, `pointer-events: none`) instead of being replaced by 5 skeleton rows; only the template selector and the Download button are disabled. The regenerating banner now names the target — "Switching to Cloze" / "Switching to multiple choice" / "Switching to Basic" — derived from the target slug via `templateSwitchLabel`. The initial-generation indicator reads "Writing your cards", and JSON is still hidden the moment card streaming starts (no protocol or parser change).

Removed the now-orphaned card-list skeleton CSS; the tag skeleton and its pulse keyframe stay.

This removes a Claude round trip for the most common chat toggle.

## Measuring success
The `/api/chat/conversations/{id}/regenerate` request rate should drop noticeably while chat template-switch interactions stay flat or rise — the gap is the Basic ↔ Basic + reverse switches that no longer call the server. Per-call latency for those switches goes from 2-10s to 0ms.

## Testing
- Unit tests added/updated (Vitest):
  - `handleTemplateChange` basic → basic-and-reversed does not call the regenerate fetch and updates the displayed rows (reversed duplicates rendered).
  - basic → cloze still POSTs to the regenerate endpoint.
  - Regenerating banner reads "Switching to Cloze" for a cloze target; existing cards remain in the DOM (dimmed) instead of skeletons; Download hidden.
  - `isPureClientReshape` and `templateSwitchLabel` unit tests.
  - Initial-generation indicator copy updated to "Writing your cards".
- `pnpm --filter 2anki-web typecheck` and Biome lint pass; 102 tests green across the four touched suites.
- Sonar not run locally (no `SONAR_TOKEN` configured) — expect a possible Sonar pass on CI.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified and authorized for merge by Alexander.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-03-instant-template-switch.json` — "Switching a chat deck between Basic and Basic + reverse is instant"

## Risks
The instant switch relies on the export-time reverse expansion staying in sync with the client preview's `expandForReversed`. If they diverged, a reversed flip could show rows the export wouldn't produce — but both use the same cloze/empty-back guard. This should merge **after** the #2975 server fix (`fix/2975-basic-template-contract`) so a reversed flip can't surface a stray cloze. Rollback is a straight revert; no migration, no server change.

## Goal alignment
Chat is a core conversion surface. Removing a 2-10s wait from the most common note-type toggle makes the deck-building loop faster and keeps the card list visible throughout — simpler and faster, directly serving the 300K-user mission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783077790&installation_id=132681956&pr_number=3030&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3030&signature=170e343e87c0d502ea02a1b26971aff7bb3744e8f97c45dc1982aecc7c0eb13b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->