### PR TITLE
fix: strip cloze markers from MCQ question stems

### DIFF
--- a/src/usecases/chat/ChatDeckUseCase.test.ts
+++ b/src/usecases/chat/ChatDeckUseCase.test.ts
@@ -1,7 +1,29 @@
-import { ChatDeckUseCase, looksLikeCloze, transformBlankToCloze, normalizeBasicCard, type ChatDeckCard } from './ChatDeckUseCase';
+import { ChatDeckUseCase, looksLikeCloze, transformBlankToCloze, normalizeBasicCard, stripClozeFromStem, type ChatDeckCard } from './ChatDeckUseCase';
 import CustomExporter from '../../lib/parser/exporters/CustomExporter';
 
 jest.mock('../../lib/parser/exporters/CustomExporter');
+
+describe('stripClozeFromStem', () => {
+  it('replaces a single cloze span with a blank', () => {
+    expect(stripClozeFromStem('Spring Boot uses {{c1::auto-configuration}} to detect deps.')).toBe(
+      'Spring Boot uses _____ to detect deps.'
+    );
+  });
+
+  it('replaces multiple cloze spans with separate blanks', () => {
+    expect(stripClozeFromStem('{{c1::HTTP}} runs over {{c2::TCP}}.')).toBe('_____ runs over _____.');
+  });
+
+  it('leaves a stem without cloze syntax unchanged', () => {
+    expect(stripClozeFromStem('Which protocol runs over TCP?')).toBe('Which protocol runs over TCP?');
+  });
+
+  it('does not reveal the deleted answer text', () => {
+    const out = stripClozeFromStem('Spring Boot uses {{c1::auto-configuration}} to detect deps.');
+    expect(out).not.toContain('auto-configuration');
+    expect(out).not.toContain('{{c');
+  });
+});
 
 describe('ChatDeckUseCase.execute MCQ handling', () => {
   beforeEach(() => {

--- a/src/usecases/chat/ChatDeckUseCase.ts
+++ b/src/usecases/chat/ChatDeckUseCase.ts
@@ -38,6 +38,12 @@ export function looksLikeCloze(front: string): boolean {
   return CLOZE_PATTERN.test(front);
 }
 
+const MCQ_STEM_BLANK = '_____';
+
+export function stripClozeFromStem(front: string): string {
+  return front.replace(CLOZE_REPLACE_PATTERN, MCQ_STEM_BLANK);
+}
+
 export function normalizeBasicCard(card: ChatDeckCard): ChatDeckCard {
   if (!looksLikeCloze(card.front)) return card;
   const answers: string[] = [];

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -849,6 +849,58 @@ describe('ChatUseCase', () => {
       });
     });
 
+    it('blanks cloze markers in the MCQ stem without revealing the answer', async () => {
+      const { useCase } = buildUseCaseWithBlocks([
+        mcqToolBlock({
+          cards: [
+            {
+              front: 'Spring Boot uses {{c1::auto-configuration}} to detect deps.',
+              options: ['auto-configuration', 'reflection', 'a build plugin', 'manual wiring'],
+              correct_index: 0,
+              rationale: 'Auto-configuration wires beans from the classpath.',
+            },
+          ],
+        }),
+      ]);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'switch to multiple choice',
+        conversationHistory: [],
+        templateSlug: 'mcq',
+      });
+
+      const card = result.cards![0];
+      expect(card.front).not.toContain('{{c');
+      expect(card.front).not.toContain('auto-configuration');
+      expect(card.front).toContain('_____');
+      expect(card.options).toEqual(['auto-configuration', 'reflection', 'a build plugin', 'manual wiring']);
+      expect(card.correctIndex).toBe(0);
+    });
+
+    it('leaves a clean MCQ stem untouched', async () => {
+      const { useCase } = buildUseCaseWithBlocks([
+        mcqToolBlock({
+          cards: [
+            {
+              front: 'Capital of Albania?',
+              options: ['Tirana', 'Durrës', 'Vlorë', 'Shkodër'],
+              correct_index: 0,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'quiz me',
+        conversationHistory: [],
+        templateSlug: 'mcq',
+      });
+
+      expect(result.cards![0].front).toBe('Capital of Albania?');
+    });
+
     it('persists MCQ cards as a JSON code block that extractCards recovers on reload', async () => {
       const { messagesRepo, useCase } = buildUseCaseWithBlocks([
         { type: 'text', text: 'Here are your quiz cards:' },

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -5,7 +5,7 @@ import { logClaudeUsage } from '../../lib/claude/logClaudeUsage';
 import { buildAttachmentBlocks, type ChatAttachment } from './buildAttachmentBlocks';
 import { extractAttachmentText, buildAttachmentTextBlock } from './extractAttachmentText';
 import { isChatCardTemplate, templatePromptSuffix, templateForbidsCloze, type ChatCardTemplate } from './chatTemplates';
-import { looksLikeCloze, normalizeBasicCard } from './ChatDeckUseCase';
+import { looksLikeCloze, normalizeBasicCard, stripClozeFromStem } from './ChatDeckUseCase';
 
 const REQUIRED_MCQ_OPTION_COUNT = 4;
 
@@ -32,7 +32,11 @@ const MCQ_TOOL: Anthropic.Tool = {
         items: {
           type: 'object',
           properties: {
-            front: { type: 'string', description: 'The question stem' },
+            front: {
+              type: 'string',
+              description:
+                'The question stem. Must NOT contain cloze deletion syntax like {{c1::...}}; if basing a question on a cloze sentence, replace the deleted span with a blank (_____).',
+            },
             options: {
               type: 'array',
               description: 'Exactly four answer options',
@@ -199,7 +203,7 @@ function asMcqChatCard(item: Record<string, unknown>): ChatCard | null {
   if (correctIndex < 0 || correctIndex >= options.length) return null;
   const rationale = typeof item.rationale === 'string' ? item.rationale : '';
   return {
-    front,
+    front: stripClozeFromStem(front),
     back: '',
     options,
     correctIndex,

--- a/src/usecases/chat/chatTemplates.ts
+++ b/src/usecases/chat/chatTemplates.ts
@@ -60,6 +60,7 @@ Rules:
 - correct_index is the 0-based position of the right option (0, 1, 2, or 3)
 - rationale is a brief explanation of why the correct option is right
 - Do NOT include a "back" field
+- The "front" stem must NOT contain cloze deletion syntax like {{c1::...}}; if basing a question on a cloze sentence, replace the deleted span with a blank (_____)
 - Do NOT emit any front/back Q&A pairs or cloze cards — only MCQ cards are valid in this conversation`,
 };
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-mcq-no-cloze-markers.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-mcq-no-cloze-markers.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-mcq-no-cloze-markers",
+  "date": "2026-06-03",
+  "type": "fix",
+  "title": "Multiple-choice cards no longer show cloze markers in the question"
+}


### PR DESCRIPTION
## What
Strips cloze deletion syntax from multiple-choice question stems. Switching a chat deck to Multiple choice no longer produces MCQ cards whose `front` reads `Spring Boot uses {{c1::auto-configuration}} to detect deps.` — the `{{cN::...}}` markup is replaced with a blank (`_____`) and the answer is no longer revealed in the stem.

## Why
On a cloze→MCQ regenerate, the model reuses prior cloze sentences as MCQ stems and copies `{{c1::answer}}` straight into `front`. That leaks raw cloze syntax into the question and reveals the answer, defeating the question. Confirmed from the support inbox (cloze→MCQ switch).

This is pre-existing, not caused by #3029/#3030 — the `normalizeBasicCard` guard added in #3029 runs only on the JSON/text path (`parseCardItem`). The MCQ path is forced tool-use (`extractMcqCardsFromToolUse` → `asMcqChatCard`) and bypassed that guard entirely.

## How
Two layers:

1. **Deterministic stem guard (the real fix).** New `stripClozeFromStem(front)` in `ChatDeckUseCase.ts` reuses the existing cloze regex to replace every `{{cN::answer}}` span with `_____` — not with the revealed answer. `asMcqChatCard` calls it on `front` before returning the card, so it covers fresh generation, regenerate, and reload regardless of prompt behavior. The correct option still lives in `options`, so the card stays answerable.
2. **Prompt/schema guard (belt-and-suspenders).** The `MCQ_TOOL` `front` description and the `mcq` prompt suffix now state the stem must not contain `{{cN::...}}` and to use a blank instead.

## Measuring success
After deploy, a cloze→MCQ regenerate emits MCQ cards whose `front` contains `_____` and no `{{c`. The persisted assistant message JSON block (recoverable by `extractCards` on reload) carries the blanked stem, so the fix holds across reloads.

## Testing
- `stripClozeFromStem`: single cloze → one blank; multiple clozes → multiple blanks; no cloze → unchanged; answer text never appears in output.
- MCQ extraction path: a tool card whose `front` has `{{c1::X}}` returns a card with no `{{c`, containing `_____`, while `options`/`correctIndex` are untouched.
- Regression: a clean MCQ stem passes through unchanged.
- All 166 `src/usecases/chat/` tests pass; `tsc -p . --noEmit` clean.

Sonar not run locally — no `SONAR_TOKEN` configured. Change is a one-line regex helper plus two prompt strings; expect no new smells.

## Browser check
Browser check: not applicable — server-only change, only web/src file is a changelog entry

## Changelog
Multiple-choice cards no longer show cloze markers in the question

## Risks
Low. The helper only touches stems containing cloze syntax; clean stems are returned unchanged. No LLM cost or latency change.

## Goal alignment
Removes a broken-looking, unanswerable card from the chat MCQ flow — keeps the deck output clean, which is the core promise (beautiful cards). Reduces a support driver as chat usage scales.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783083355&installation_id=132681956&pr_number=3031&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3031&signature=27086420998f35378f95385c327c940f2723291079b6443271ed50d4ef061ecb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->