### PR TITLE
fix: regenerate chat turn on template switch when last reply has no cards

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -682,13 +682,16 @@ describe('ChatPanel — template selector', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not render the template selector when no assistant message has cards', () => {
+  it('renders the template selector on the last assistant turn even with no cards', () => {
     renderChatPanel({
-      initialMessages: [{ role: 'assistant', content: 'Hello' }],
+      initialMessages: [
+        { role: 'user', content: 'spring boot' },
+        { role: 'assistant', content: 'Want cards on a specific area?' },
+      ],
     });
     expect(
-      screen.queryByRole('button', { name: /Note type/i })
-    ).not.toBeInTheDocument();
+      screen.getByRole('button', { name: 'Note type: Basic' })
+    ).toBeInTheDocument();
   });
 
   it('opens the template dropdown on click', () => {
@@ -952,6 +955,49 @@ describe('ChatPanel — template selector', () => {
         { templateSlug: 'cloze' }
       );
     });
+  });
+
+  it('regenerates a cardless last assistant turn when the template changes', async () => {
+    mockPost.mockResolvedValueOnce(
+      makeSseResponse([
+        {
+          event: 'done',
+          data: {
+            content: 'Reply',
+            conversationId: 7,
+            cards: [{ front: 'New', back: 'Card' }],
+          },
+        },
+      ])
+    );
+    renderChatPanel({
+      initialMessages: [
+        { role: 'user', content: 'spring boot' },
+        { role: 'assistant', content: 'Want cards on a specific area?' },
+      ],
+      initialConversationId: 7,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Note type: Basic' }));
+    fireEvent.click(
+      screen.getByRole('option', { name: /Cloze/ }).querySelector('button')!
+    );
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/chat/conversations/7/regenerate',
+        { templateSlug: 'cloze' }
+      );
+    });
+  });
+
+  it('does not regenerate when there is no assistant turn yet', () => {
+    renderChatPanel({
+      initialMessages: [{ role: 'user', content: 'spring boot' }],
+      initialConversationId: 7,
+    });
+    expect(
+      screen.queryByRole('button', { name: /Note type/i })
+    ).not.toBeInTheDocument();
+    expect(mockPost).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -116,6 +116,15 @@ function findLastAssistantWithCardsIdx(messages: Message[]): number {
   return -1;
 }
 
+function findLastAssistantIdx(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'assistant') {
+      return i;
+    }
+  }
+  return -1;
+}
+
 export function parseSseEvent(
   rawEvent: string
 ): { eventType: string; data: string } | null {
@@ -263,6 +272,7 @@ function AssistantMessage({
   onSave,
   template,
   onTemplateChange,
+  showSelectorWithoutCards,
   templateDisabled,
   isRegenerating,
   onAddTags,
@@ -272,18 +282,28 @@ function AssistantMessage({
   onSave?: (cards: ChatCard[], deckName: string) => void;
   template?: ChatCardTemplate;
   onTemplateChange?: (slug: ChatCardTemplate) => void;
+  showSelectorWithoutCards?: boolean;
   templateDisabled?: boolean;
   isRegenerating?: boolean;
   onAddTags?: () => void;
   isTagging?: boolean;
 }) {
+  const hasCards = message.cards != null && message.cards.length > 0;
+  const selectorOnlyPreview =
+    showSelectorWithoutCards === true &&
+    !hasCards &&
+    onTemplateChange != null;
   const showCardPreview =
-    (message.cards != null && message.cards.length > 0 && onSave != null) ||
-    isRegenerating === true;
+    (hasCards && onSave != null) ||
+    isRegenerating === true ||
+    selectorOnlyPreview;
   return (
     <div className={styles.assistantRow}>
       {message.contentBefore != null && (
         <AssistantMarkdown>{message.contentBefore}</AssistantMarkdown>
+      )}
+      {message.cards == null && !isRegenerating && (
+        <AssistantMarkdown>{message.content}</AssistantMarkdown>
       )}
       {showCardPreview && (
         <CardPreview
@@ -303,9 +323,6 @@ function AssistantMessage({
       )}
       {message.contentAfter != null && (
         <AssistantMarkdown>{message.contentAfter}</AssistantMarkdown>
-      )}
-      {message.cards == null && !isRegenerating && (
-        <AssistantMarkdown>{message.content}</AssistantMarkdown>
       )}
     </div>
   );
@@ -914,9 +931,9 @@ export default function ChatPanel({
       }).catch(() => {});
     }
     if (reshapeOnly) return;
-    const lastAssistantWithCards = findLastAssistantWithCardsIdx(messages);
-    if (lastAssistantWithCards !== -1 && !isLoading) {
-      regenerateLastTurn(slug, lastAssistantWithCards);
+    const lastAssistant = findLastAssistantIdx(messages);
+    if (lastAssistant !== -1 && !isLoading) {
+      regenerateLastTurn(slug, lastAssistant);
     }
   }
 
@@ -1116,6 +1133,7 @@ export default function ChatPanel({
               <div className={styles.messageListInner} aria-live="polite">
                 {(() => {
                   const lastCardsIdx = findLastAssistantWithCardsIdx(messages);
+                  const lastAssistantIdx = findLastAssistantIdx(messages);
                   return messages.map((m, i) => {
                     if (m.role === 'user') {
                       return (
@@ -1138,7 +1156,7 @@ export default function ChatPanel({
                       );
                     }
                     const showTemplateSelector =
-                      i === lastCardsIdx || i === regeneratingIdx;
+                      i === lastAssistantIdx || i === regeneratingIdx;
                     return (
                       <AssistantMessage
                         key={i}
@@ -1152,6 +1170,7 @@ export default function ChatPanel({
                             ? handleTemplateChange
                             : undefined
                         }
+                        showSelectorWithoutCards={showTemplateSelector}
                         templateDisabled={isLoading}
                         isRegenerating={i === regeneratingIdx}
                         onAddTags={

--- a/web/src/pages/Chat/CardPreview.tsx
+++ b/web/src/pages/Chat/CardPreview.tsx
@@ -191,12 +191,14 @@ export default function CardPreview({
   return (
     <div className={styles.cardPreview}>
       <div className={styles.cardPreviewHeader}>
-        <span className={styles.cardPreviewCount}>
-          <span className={styles.cardPreviewCountNumber}>
-            {displayCards.length}
-          </span>{' '}
-          {cardLabel}
-        </span>
+        {displayCards.length > 0 && (
+          <span className={styles.cardPreviewCount}>
+            <span className={styles.cardPreviewCountNumber}>
+              {displayCards.length}
+            </span>{' '}
+            {cardLabel}
+          </span>
+        )}
 
         {displayTemplate != null && onTemplateChange != null && (
           <TemplateSelector

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-template-switch-generates.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-template-switch-generates.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-template-switch-generates",
+  "date": "2026-06-03",
+  "type": "fix",
+  "title": "Switching the card type in chat builds cards even when the last reply was just an answer"
+}


### PR DESCRIPTION
## What
In chat, switching the note type when the latest assistant reply had no cards now regenerates that turn with the new template, so Cloze/MCQ/Basic actually build cards from the user's preceding question instead of doing nothing.

## Why
A user asked a question, the model replied with a prose answer (zero cards) ending "Want cards on a specific area?", then switched the note type to Cloze — and nothing happened; the prose stayed. They reported "switching to cloze did not work, it turned into text."

Root cause: `handleTemplateChange` only regenerated when `findLastAssistantWithCardsIdx` found a turn with cards. When the most recent assistant turn produced no cards, the switch updated and persisted `activeTemplate` but never regenerated — a silent no-op.

This is pre-existing behavior, not caused by #3029 / #3030.

## How
- Added `findLastAssistantIdx(messages)` alongside the existing `findLastAssistantWithCardsIdx`.
- `handleTemplateChange` now targets the last assistant turn with or without cards and calls `regenerateLastTurn(slug, idx)` when an assistant turn exists and we're not already loading. The `basic ↔ basic-and-reversed` pure-client reshape short-circuit is unchanged; the no-assistant-turn-yet case does nothing beyond setting the template.
- Confirmed the server `regenerate` use case re-runs from conversation history (deletes the latest assistant message regardless of cards, re-streams from the preceding user turn), so a cardless last turn is handled with no server change. No server `src/` files touched, no new endpoint.
- The note-type selector now renders on the last assistant turn even without cards so the user can reach it; the card count is hidden while there are no cards yet. The "Switching to X" indicator and dimmed-cards loading state still read sensibly.

## Measuring success
The `POST /api/chat/conversations/{id}/regenerate` log line now fires after a template switch on a cardless turn (previously it did not). In the chat UI, switching the note type after a prose-only reply produces cards from the prior question.

## Testing
- Unit tests (Vitest, mocked at the API boundary):
  - Template switch when the last assistant turn has cards → still regenerates (unchanged).
  - Template switch (basic→cloze) when the last assistant turn has NO cards → fires the regenerate POST with `templateSlug: 'cloze'` (regression guard).
  - Template switch with NO assistant turn at all → does not fire regenerate, does not throw.
  - `basic ↔ basic-and-reversed` still short-circuits to no server call.
  - Selector renders on the last assistant turn even with no cards.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified and authorized for merge by Alexander.

## Changelog
`Switching the card type in chat builds cards even when the last reply was just an answer`

## Risks
Low. The change is confined to chat template switching and an empty-state render. The basic-and-reversed client reshape and the existing cards-turn regenerate path are unchanged. Rollback is a single-commit revert.

## Goal alignment
Removes a confusing dead end in the chat-to-deck flow — switching the card type now reliably produces cards, making the fastest path from a question to a deck work as users expect.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783083549&installation_id=132681956&pr_number=3032&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3032&signature=ce19da40fb3273a7089ad8e7be1787a2369b77b4d8b9cc07e31a9c0ac655ed27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->