### PR TITLE
feat: replace native confirm in account deletion with in-app dialog

### DIFF
--- a/web/src/pages/AccountPage/components/AccountDeletion.test.tsx
+++ b/web/src/pages/AccountPage/components/AccountDeletion.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AccountDeletion } from './AccountDeletion';
+
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom'
+    );
+  return { ...actual, useNavigate: () => navigate };
+});
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <AccountDeletion />
+    </MemoryRouter>
+  );
+}
+
+describe('AccountDeletion', () => {
+  it('opens the confirmation dialog when Delete account is clicked', () => {
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete account' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Delete account?' })
+    ).toBeInTheDocument();
+  });
+
+  it('closes the dialog and does not navigate when Cancel is clicked', () => {
+    navigate.mockClear();
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete account' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to /delete-account when the dialog confirm is clicked', () => {
+    navigate.mockClear();
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete account' }));
+
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    const confirm = within(dialog).getByRole('button', {
+      name: 'Delete account',
+    });
+    fireEvent.click(confirm);
+
+    expect(navigate).toHaveBeenCalledWith('/delete-account');
+  });
+});

--- a/web/src/pages/AccountPage/components/AccountDeletion.tsx
+++ b/web/src/pages/AccountPage/components/AccountDeletion.tsx
@@ -1,23 +1,84 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDialog } from '../../../lib/hooks/useDialog';
+import sharedStyles from '../../../styles/shared.module.css';
 import styles from '../AccountPage.module.css';
 
 export function AccountDeletion() {
+  const navigate = useNavigate();
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  const close = () => setIsOpen(false);
+  const dialogRef = useDialog(isOpen, close);
+
+  useEffect(() => {
+    if (isOpen) {
+      cancelRef.current?.focus();
+    } else {
+      triggerRef.current?.focus();
+    }
+  }, [isOpen]);
+
   return (
     <div className={styles.dangerSection}>
       <h4 className={styles.dangerTitle}>Delete account</h4>
       <div className={styles.dangerNotice}>
         All your data will be permanently deleted. This cannot be undone.
       </div>
-      <a
-        href="/delete-account"
+      <button
+        ref={triggerRef}
+        type="button"
         className={styles.dangerButton}
-        onClick={(e) => {
-          if (!confirm('Delete your account? This cannot be undone.')) {
-            e.preventDefault();
-          }
-        }}
+        onClick={() => setIsOpen(true)}
       >
         Delete account
-      </a>
+      </button>
+      <dialog
+        ref={dialogRef}
+        className={sharedStyles.dialog}
+        aria-labelledby="delete-account-dialog-title"
+      >
+        <div className={sharedStyles.modalCardNarrow}>
+          <div className={sharedStyles.modalHeader}>
+            <h4
+              id="delete-account-dialog-title"
+              className={sharedStyles.modalHeaderTitle}
+            >
+              Delete account?
+            </h4>
+            <button
+              type="button"
+              aria-label="close"
+              onClick={close}
+              className={sharedStyles.modalClose}
+            >
+              &times;
+            </button>
+          </div>
+          <section className={sharedStyles.modalBody}>
+            All your data will be permanently deleted. This cannot be undone.
+          </section>
+          <div className={sharedStyles.modalFooter}>
+            <button
+              ref={cancelRef}
+              type="button"
+              className={sharedStyles.btnSecondary}
+              onClick={close}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className={sharedStyles.btnDanger}
+              onClick={() => navigate('/delete-account')}
+            >
+              Delete account
+            </button>
+          </div>
+        </div>
+      </dialog>
     </div>
   );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-account-delete-confirm.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-account-delete-confirm.json
@@ -1,0 +1,1 @@
+{ "id": "2026-06-03-account-delete-confirm", "date": "2026-06-03", "type": "style", "title": "Delete account confirmation now matches the app theme and language" }


### PR DESCRIPTION
## What
Replaces the native `confirm(...)` in the account-deletion flow with a styled in-app `<dialog>` opened via the existing `useDialog` hook. The "Delete account" control is now a `<button>` that opens a two-step confirmation: headline "Delete account?", the existing warning body, a red/danger "Delete account" primary, and a "Cancel" secondary. Navigation to the existing `/delete-account` flow goes through React Router `navigate`.

## Why
Closes #2360. The native confirm dialog ignores the app theme and the VOICE.md copy guide, and reads as a system popup rather than part of the product. The in-app modal matches the SettingsModal pattern and the Stripe/Linear destructive-confirm UX (Cancel focused by default).

## How
- `AccountDeletion.tsx`: `isOpen` state drives `useDialog(isOpen, close)`; the hook handles `showModal`/`close` + Escape (native + jsdom fallback). Markup mirrors `SettingsModal` using shared classes (`dialog`, `modalCardNarrow`, `modalHeader`, `modalHeaderTitle`, `modalBody`, `modalFooter`, `modalClose`, `btnDanger`, `btnSecondary`) with `aria-labelledby` on the title.
- Cancel button gets focus on open via a ref+effect; focus returns to the trigger button on close.
- `/delete-account` is a real authed SPA route (`DeleteAccountPage`), so `navigate('/delete-account')` is correct — no full-page reload needed.

## Measuring success
No new server metric. The flow is verified by the colocated Vitest suite and a browser check; in production, account-deletion requests continue to hit `/delete-account` as before — no backend behavior changed.

## Testing
- Unit tests added (`AccountDeletion.test.tsx`):
  - Clicking "Delete account" opens the dialog (headline "Delete account?" visible)
  - Cancel closes the dialog and does not navigate
  - Confirm navigates to `/delete-account`
- `pnpm --filter 2anki-web typecheck` — green
- `pnpm --filter 2anki-web test src/pages/AccountPage/components/AccountDeletion.test.tsx` — 3/3 green
- `pnpm --filter 2anki-web lint` — green
- Sonar: `sonar-scanner` is installed but `SONAR_TOKEN` is unset locally, so it was not run with auth. Small UI change (one component, no new HTTP/HTML-render/zip/path code) — expect CI's Sonar pass; flagging in case of a bounce.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Dev-server check pending Alexander — boxes left unticked, not verified in a browser by the agent.

## Risks
Low. Single presentational component; no auth/payment/backend change. If the modal misbehaved, the fallback is the prior native confirm (full revert of one file). The trigger and confirm buttons share the label "Delete account"; the confirm lives inside the dialog so users see only one at a time.

## Goal alignment
Simpler/more beautiful: a destructive action now uses the app's own confirmation UI and copy rather than a jarring browser popup — consistent with the Stripe/Linear register the product targets. No scale impact, but it removes a rough edge in the account flow.

## Docs
No user-docs change — restyle of an existing confirmation, flow unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783090529&installation_id=132681956&pr_number=3035&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3035&signature=d5097737bace766e9af831752ca7447845edc0fc61aab648a376d244cf2b64a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->