### PR TITLE
fix: gate Claude job restart on atomic status transition

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import fs from 'node:fs';
 import path from 'path';
 import express from 'express';
+import knex, { Knex } from 'knex';
 
 jest.mock('../usecases/uploads/GeneratePackagesUseCase', () => {
   return {
@@ -9,6 +10,12 @@ jest.mock('../usecases/uploads/GeneratePackagesUseCase', () => {
     default: jest.fn(),
   };
 });
+
+const mockGenerateDeckInfo = jest.fn();
+jest.mock('../lib/claude/ClaudeService', () => ({
+  ...jest.requireActual('../lib/claude/ClaudeService'),
+  generateDeckInfo: (...args: unknown[]) => mockGenerateDeckInfo(...args),
+}));
 
 jest.mock('../lib/integrations/stripe', () => ({
   getStripe: jest.fn().mockReturnValue({
@@ -750,5 +757,120 @@ describe('UploadService.handleUpload — multi-deck batch', () => {
       'conversion_succeeded',
       expect.objectContaining({ props: expect.objectContaining({ source: 'upload' }) })
     );
+  });
+});
+
+describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+  let db: Knex;
+  let workspaceBase: string;
+  let resolveDeckInfo: (() => void) | null = null;
+
+  beforeAll(() => {
+    workspaceBase = fs.mkdtempSync(path.join(os.tmpdir(), 'restart-guard-base-'));
+    process.env.WORKSPACE_BASE = workspaceBase;
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+    fs.rmSync(workspaceBase, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    mockGenerateDeckInfo.mockReset();
+    db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('jobs', (t) => {
+      t.increments('id');
+      t.string('owner').notNullable();
+      t.string('object_id').notNullable();
+      t.string('title');
+      t.string('type');
+      t.string('status');
+      t.timestamp('created_at').defaultTo(db.fn.now());
+      t.timestamp('last_edited_time');
+      t.string('job_reason_failure');
+      t.integer('card_count');
+    });
+    const workspaceDir = path.join(workspaceBase, 'job-obj-1');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, 'page.html'), '<html><body>Q/A</body></html>');
+  });
+
+  afterEach(async () => {
+    resolveDeckInfo = null;
+    await db.destroy();
+  });
+
+  function buildRestartRequest() {
+    return { params: { jobId: 'job-obj-1' }, body: {} } as unknown as express.Request;
+  }
+
+  it('fires exactly one worker when two restart requests race on the same done job', async () => {
+    await db('jobs').insert({
+      owner: '42',
+      object_id: 'job-obj-1',
+      title: 'Deck',
+      type: 'claude',
+      status: 'done',
+      last_edited_time: new Date(),
+    });
+
+    const deckInfoStarted = new Promise<void>((started) => {
+      mockGenerateDeckInfo.mockImplementation(() => {
+        started();
+        return new Promise(() => {
+          resolveDeckInfo = () => undefined;
+        });
+      });
+    });
+
+    const repo = buildRepository();
+    const jobRepository = new JobRepository(db);
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+
+    const firstResponse = buildResponse();
+    (firstResponse.res.locals as Record<string, unknown>).owner = 42;
+    const secondResponse = buildResponse();
+    (secondResponse.res.locals as Record<string, unknown>).owner = 42;
+
+    await Promise.all([
+      service.restartClaudeJob(buildRestartRequest(), firstResponse.res),
+      service.restartClaudeJob(buildRestartRequest(), secondResponse.res),
+    ]);
+
+    await deckInfoStarted;
+
+    expect(mockGenerateDeckInfo).toHaveBeenCalledTimes(1);
+
+    const statuses = [firstResponse.capturedStatus(), secondResponse.capturedStatus()];
+    expect(statuses).toContain(202);
+    expect(statuses).toContain(409);
+  });
+
+  it('does not fire a worker when the job is already in flight (non-terminal status)', async () => {
+    await db('jobs').insert({
+      owner: '42',
+      object_id: 'job-obj-1',
+      title: 'Deck',
+      type: 'claude',
+      status: 'step1_started',
+      last_edited_time: new Date(),
+    });
+
+    const repo = buildRepository();
+    const jobRepository = new JobRepository(db);
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+
+    const { res, capturedStatus } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.restartClaudeJob(buildRestartRequest(), res);
+
+    expect(mockGenerateDeckInfo).not.toHaveBeenCalled();
+    expect(capturedStatus()).toBe(409);
   });
 });

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -150,7 +150,11 @@ class UploadService {
       return;
     }
 
-    await this.jobRepository.updateJobStatus(job.object_id, owner, 'started');
+    const claimed = await this.jobRepository.restartJob(job.object_id, owner);
+    if (claimed == null) {
+      res.status(409).json({ error: 'This job is already running' });
+      return;
+    }
 
     this.runClaudeRestart(job.object_id, owner, workspaceDir, async (step) => {
       await this.jobRepository.updateJobStatus(job.object_id, owner, step);

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-restart-job-single-run.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-restart-job-single-run.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-restart-job-single-run",
+  "date": "2026-06-03",
+  "type": "fix",
+  "title": "Restarting a job runs it once, even if you click restart twice"
+}


### PR DESCRIPTION
## What
Routes the Claude upload job-restart path through the atomic conditional UPDATE so a double-click on restart can no longer spawn two workers against the same job row.

## Why
Refs #3021 (the #2387 line). `UploadService.restartClaudeJob` did a read of the job, then unconditionally called `updateJobStatus(..., 'started')`, then spawned the worker. That read-then-write bypassed the existing optimistic lock — two concurrent restart requests could both read a terminal status and both spawn a worker, double-processing the deck. User-visible outcome: clicking restart twice ran the job once.

## How
Replace the read-then-write at the spawn point with `JobRepository.restartJob(objectId, owner)` — the atomic `UPDATE ... WHERE object_id=? AND owner=? AND status IN (terminal) SET status='started' RETURNING *`. Only the request whose UPDATE matched a row (returned non-null) spawns the worker; the loser gets zero rows back and returns 409 without spawning. This mirrors `StartJobUseCase`, which already gates the Notion restart path the same way. No migration or version column — the conditional UPDATE is the lock, as intended.

## Measuring success
In prod logs, a restart that loses the race now returns HTTP 409 from `POST /api/upload/jobs/:jobId/restart` instead of a second 202. Concretely: for a given `object_id`, only one transition to `status='started'` occurs per terminal state, so there is no longer a window where two `runClaudeRestart` workers update the same job row (previously visible as interleaved step-status flapping on one `object_id`).

## Testing
- Unit tests added (outside-in from `restartClaudeJob`, real `JobRepository` on in-memory sqlite so the atomic UPDATE actually executes; only the worker boundary `generateDeckInfo` is mocked):
  - Two concurrent restarts on a `done` job -> `generateDeckInfo` called exactly once; one response 202, the other 409.
  - Restart on an already in-flight (non-terminal) job -> no worker spawned, 409.
- `JobRepository` already has optimistic-lock coverage (concurrent no-op test); no raw `knex.raw` SQL was added (`restartJob` is query-builder), so no new PG-dialect SQL-shape test was needed.
- Server tsc: clean. Web typecheck: clean. Affected Jest suites green (UploadService + JobRepository: 36 tests). Changelog loader (vitest): green.

## Browser check
Browser check: not applicable — changelog-only `web/src/` diff (new JSON entry); no rendered-component change.

## Changelog
`Restarting a job runs it once, even if you click restart twice` — `web/src/pages/WhatsNewPage/changelog/2026-06-03-restart-job-single-run.json`

## Sonar
`sonar-scanner` not run locally — no `SONAR_TOKEN` configured in this environment. The change is a single conditional swap in a service plus tests and one JSON entry; expect a clean Sonar pass, but flagging in case of a bounce.

## Risks
- The "already running" case now returns 409 instead of silently re-running. Low risk; the first click still gets 202. The second click correctly signals the job is already running.
- Rollback: revert the commit. No schema change, so revert is clean.

## Goal alignment
Job restart is part of the core convert-and-recover flow. Double-processing on a double-click wastes an LLM call (cost) and can produce a confused job state. Making restart idempotent keeps the conversion path reliable as concurrent usage scales toward 300K users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783090893&installation_id=132681956&pr_number=3037&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3037&signature=fb778098a45685742f75f70a163444a4ae601dd285b447cca3fa50d7d186f715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->