### PR TITLE
feat: add Material Design card template

### DIFF
--- a/src/services/officialTemplates.test.ts
+++ b/src/services/officialTemplates.test.ts
@@ -20,8 +20,23 @@ describe('getOfficialTemplates', () => {
         'official-abhiyan-cloze',
         'official-alex-deluxe-basic',
         'official-alex-deluxe-cloze',
+        'official-material-basic',
+        'official-material-cloze',
       ])
     );
+  });
+
+  it('wires the Material basic template with its files', () => {
+    const material = templates.find((t) => t.id === 'official-material-basic');
+    expect(material?.noteType.tmpls[0].qfmt).toContain('{{Front}}');
+    expect(material?.noteType.css).toContain('.md-card');
+  });
+
+  it('wires the Material cloze template with its highlight styling', () => {
+    const material = templates.find((t) => t.id === 'official-material-cloze');
+    expect(material?.noteType.type).toBe(1);
+    expect(material?.noteType.tmpls[0].qfmt).toContain('{{cloze:Text}}');
+    expect(material?.noteType.css).toContain('.cloze');
   });
 
   it('shapes each entry as a NoteTypeStarter', () => {

--- a/src/services/officialTemplates.ts
+++ b/src/services/officialTemplates.ts
@@ -373,6 +373,44 @@ export function getOfficialTemplates(): OfficialStarter[] {
       tags: ['alex_deluxe', 'blue', 'cloze'],
       modelName: 'Alex Deluxe Cloze',
     }),
+    variantStarter({
+      id: 'official-material-basic',
+      name: 'Material (Basic)',
+      description:
+        'Clean Material Design card — elevated surface, Roboto type, primary-blue answer accent. Light and dark ready',
+      baseType: 'basic',
+      ankiType: 0,
+      qfmtFile: 'material_basic_front.html',
+      afmtFile: 'material_basic_back.html',
+      cssFile: 'material.css',
+      flds: ABHIYAN_BASIC_FLDS,
+      previewData: {
+        Front: 'What is the capital of France?',
+        Back: 'Paris',
+        Tags: '',
+      },
+      tags: ['material', 'material-design'],
+      modelName: 'Material Basic',
+    }),
+    variantStarter({
+      id: 'official-material-cloze',
+      name: 'Material (Cloze)',
+      description:
+        'Material Design cloze deletion — blanks highlighted in primary blue, readable on light and dark backgrounds',
+      baseType: 'cloze',
+      ankiType: 1,
+      qfmtFile: 'material_cloze_front.html',
+      afmtFile: 'material_cloze_back.html',
+      cssFile: 'material_cloze_style.css',
+      flds: ABHIYAN_CLOZE_FLDS,
+      previewData: {
+        Text: 'The capital of {{c1::France}} is {{c2::Paris}}',
+        Extra: 'European geography',
+        Tags: '',
+      },
+      tags: ['material', 'material-design', 'cloze'],
+      modelName: 'Material Cloze',
+    }),
   ];
 
   return starters.filter((s): s is OfficialStarter => s !== null);

--- a/src/templates/material.css
+++ b/src/templates/material.css
@@ -1,0 +1,172 @@
+/* Material Design basic card for 2anki.
+   Renders offline — no @import, no web-font fetch.
+   Light and Anki night mode both handled via .nightMode / .night_mode. */
+
+/* DESIGN TOKENS (light) */
+:root {
+    --md-bg: #f1f3f4;
+    --md-card: #ffffff;
+    --md-on-surface: #202124;
+    --md-on-surface-muted: #5f6368;
+    --md-primary: #1a73e8;
+    --md-divider: #e0e0e0;
+    --md-radius: 12px;
+    --md-elevation: 0 1px 2px rgba(60, 64, 67, 0.30),
+                    0 2px 6px 2px rgba(60, 64, 67, 0.15);
+}
+
+/* BODY */
+html,
+body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Roboto, "Helvetica Neue", -apple-system, BlinkMacSystemFont,
+        "Segoe UI", "Noto Sans", "Noto Sans KR", Arial, sans-serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    text-align: left;
+    background-color: var(--md-bg);
+    color: var(--md-on-surface);
+    -webkit-font-smoothing: antialiased;
+    padding: 16px;
+    min-height: 100vh;
+}
+
+/* SURFACE + CARD */
+.md-surface {
+    margin: 0 auto 16px auto;
+    width: 100%;
+    max-width: 42em;
+    box-sizing: border-box;
+}
+
+.md-card {
+    background-color: var(--md-card);
+    color: var(--md-on-surface);
+    border-radius: var(--md-radius);
+    box-shadow: var(--md-elevation);
+    padding: 24px;
+    box-sizing: border-box;
+    overflow-wrap: anywhere;
+}
+
+.md-card.back {
+    border-top: 3px solid var(--md-primary);
+}
+
+/* TYPE SCALE */
+.md-label {
+    font-size: 0.72em;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--md-on-surface-muted);
+    margin-bottom: 8px;
+}
+
+.md-label-accent {
+    color: var(--md-primary);
+}
+
+.md-headline {
+    font-size: 1.25em;
+    font-weight: 500;
+    line-height: 1.4;
+}
+
+.md-body {
+    font-size: 1em;
+    font-weight: 400;
+}
+
+.md-row {
+    margin: 0;
+}
+
+.md-row + .md-row {
+    margin-top: 12px;
+}
+
+/* LINKS — Material primary, no underline until hover */
+.md-card a,
+.md-card a:link,
+.md-card a:visited {
+    color: var(--md-primary);
+    text-decoration: none;
+}
+
+.md-card a:hover,
+.md-card a:active {
+    text-decoration: underline;
+}
+
+/* TAGS — Material outlined chips */
+.tags {
+    margin-bottom: 16px;
+}
+
+.tag {
+    font-size: 0.72em;
+    font-weight: 500;
+    padding: 5px 12px;
+    display: inline-block;
+    border-radius: 16px;
+    border: 1px solid var(--md-divider);
+    color: var(--md-on-surface-muted);
+    margin: 0 8px 8px 0;
+    line-height: 1.2;
+}
+
+/* IMAGES */
+img {
+    object-fit: contain;
+    margin: 8px auto 0 auto;
+    display: block;
+    width: auto;
+    max-width: 100%;
+    border-radius: 8px;
+}
+
+/* ANKI TEMPLATE WIZARDRY */
+:not(.backtemplate) .backonly {
+    display: none;
+}
+
+.backtemplate .backonly {
+    display: block;
+}
+
+.backtemplate .frontonly {
+    display: none;
+}
+
+/* NIGHT MODE — Material dark surfaces */
+.nightMode,
+.night_mode {
+    --md-bg: #121212;
+    --md-card: #1e1e1e;
+    --md-on-surface: #e8eaed;
+    --md-on-surface-muted: #9aa0a6;
+    --md-primary: #8ab4f8;
+    --md-divider: #3c4043;
+    --md-elevation: 0 1px 2px rgba(0, 0, 0, 0.60),
+                    0 2px 6px 2px rgba(0, 0, 0, 0.40);
+}
+
+.nightMode body,
+.night_mode body {
+    background-color: var(--md-bg);
+    color: var(--md-on-surface);
+}
+
+/* Resize image add-on compatibility (matches abhiyan) */
+.mobile .card img {
+    height: unset !important;
+    width: unset !important;
+}

--- a/src/templates/material_basic_back.html
+++ b/src/templates/material_basic_back.html
@@ -1,0 +1,1 @@
+<div class="backtemplate">{{FrontSide}}</div>

--- a/src/templates/material_basic_front.html
+++ b/src/templates/material_basic_front.html
@@ -1,0 +1,37 @@
+<script>
+    /* SPLIT HIERARCHICAL TAGS */
+    var tagEl = document.querySelector('.tags');
+    if (tagEl) {
+        var tags = tagEl.innerHTML.split(' ');
+        var html = '';
+        tags.forEach(function(tag) {
+            if (tag.includes('::')) {
+                var topleveltag = tag.substring(0, tag.indexOf("::"));
+                var bottomleveltag = tag.substring(tag.lastIndexOf("::") + 2);
+            } else {
+                var bottomleveltag = tag;
+            }
+            var newTag = '<span class="tag ' + topleveltag + ' ' + bottomleveltag + '">' + bottomleveltag + '</span>';
+            html += newTag;
+        });
+        tagEl.innerHTML = html;
+    }
+</script>
+
+<div class="md-surface">
+    <div class="md-card front">
+        {{#Tags}}
+        <div class="tags md-row">{{Tags}}</div>{{/Tags}}
+        <div class="md-label">Question</div>
+        <div class="question md-row md-headline">
+            {{Front}}
+        </div>
+    </div>
+</div>
+
+<div class="md-surface backonly">
+    <div class="md-card back">
+        <div class="md-label md-label-accent">Answer</div>
+        <div class="md-row md-body">{{Back}}</div>
+    </div>
+</div>

--- a/src/templates/material_cloze_back.html
+++ b/src/templates/material_cloze_back.html
@@ -1,0 +1,37 @@
+<script>
+    /* SPLIT HIERARCHICAL TAGS */
+    var tagEl = document.querySelector('.tags');
+    if (tagEl) {
+        var tags = tagEl.innerHTML.split(' ');
+        var html = '';
+        tags.forEach(function(tag) {
+            if (tag.includes('::')) {
+                var topleveltag = tag.substring(0, tag.indexOf("::"));
+                var bottomleveltag = tag.substring(tag.lastIndexOf("::") + 2);
+            } else {
+                var bottomleveltag = tag;
+            }
+            var newTag = '<span class="tag ' + topleveltag + ' ' + bottomleveltag + '">' + bottomleveltag + '</span>';
+            html += newTag;
+        });
+        tagEl.innerHTML = html;
+    }
+</script>
+
+<div class="md-surface">
+    <div class="md-card front">
+        {{#Tags}}
+        <div class="tags md-row">{{Tags}}</div>{{/Tags}}
+        <div class="question md-row md-headline">
+            {{cloze:Text}}
+        </div>
+    </div>
+</div>
+{{#Extra}}
+<div class="md-surface">
+    <div class="md-card extra">
+        <div class="md-label">Notes</div>
+        {{Extra}}
+    </div>
+</div>
+{{/Extra}}

--- a/src/templates/material_cloze_front.html
+++ b/src/templates/material_cloze_front.html
@@ -1,0 +1,29 @@
+<script>
+    /* SPLIT HIERARCHICAL TAGS */
+    var tagEl = document.querySelector('.tags');
+    if (tagEl) {
+        var tags = tagEl.innerHTML.split(' ');
+        var html = '';
+        tags.forEach(function(tag) {
+            if (tag.includes('::')) {
+                var topleveltag = tag.substring(0, tag.indexOf("::"));
+                var bottomleveltag = tag.substring(tag.lastIndexOf("::") + 2);
+            } else {
+                var bottomleveltag = tag;
+            }
+            var newTag = '<span class="tag ' + topleveltag + ' ' + bottomleveltag + '">' + bottomleveltag + '</span>';
+            html += newTag;
+        });
+        tagEl.innerHTML = html;
+    }
+</script>
+
+<div class="md-surface">
+    <div class="md-card front">
+        {{#Tags}}
+        <div class="tags md-row">{{Tags}}</div>{{/Tags}}
+        <div class="question md-row md-headline">
+            {{cloze:Text}}
+        </div>
+    </div>
+</div>

--- a/src/templates/material_cloze_style.css
+++ b/src/templates/material_cloze_style.css
@@ -1,0 +1,160 @@
+/* Material Design cloze card for 2anki.
+   Renders offline — no @import, no web-font fetch.
+   Light and Anki night mode both handled via .nightMode / .night_mode. */
+
+/* DESIGN TOKENS (light) */
+:root {
+    --md-bg: #f1f3f4;
+    --md-card: #ffffff;
+    --md-on-surface: #202124;
+    --md-on-surface-muted: #5f6368;
+    --md-primary: #1a73e8;
+    --md-cloze: #1a73e8;
+    --md-cloze-bg: rgba(26, 115, 232, 0.12);
+    --md-divider: #e0e0e0;
+    --md-radius: 12px;
+    --md-elevation: 0 1px 2px rgba(60, 64, 67, 0.30),
+                    0 2px 6px 2px rgba(60, 64, 67, 0.15);
+}
+
+/* BODY */
+html,
+body {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: Roboto, "Helvetica Neue", -apple-system, BlinkMacSystemFont,
+        "Segoe UI", "Noto Sans", "Noto Sans KR", Arial, sans-serif;
+    font-weight: 400;
+    font-size: 18px;
+    line-height: 1.6;
+    text-align: left;
+    background-color: var(--md-bg);
+    color: var(--md-on-surface);
+    -webkit-font-smoothing: antialiased;
+    padding: 16px;
+    min-height: 100vh;
+}
+
+/* SURFACE + CARD */
+.md-surface {
+    margin: 0 auto 16px auto;
+    width: 100%;
+    max-width: 42em;
+    box-sizing: border-box;
+}
+
+.md-card {
+    background-color: var(--md-card);
+    color: var(--md-on-surface);
+    border-radius: var(--md-radius);
+    box-shadow: var(--md-elevation);
+    padding: 24px;
+    box-sizing: border-box;
+    overflow-wrap: anywhere;
+}
+
+.md-card.extra {
+    color: var(--md-on-surface-muted);
+    font-size: 0.95em;
+}
+
+/* TYPE SCALE */
+.md-label {
+    font-size: 0.72em;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--md-on-surface-muted);
+    margin-bottom: 8px;
+}
+
+.md-headline {
+    font-size: 1.25em;
+    font-weight: 500;
+    line-height: 1.4;
+}
+
+.md-row {
+    margin: 0;
+}
+
+/* LINKS */
+.md-card a,
+.md-card a:link,
+.md-card a:visited {
+    color: var(--md-primary);
+    text-decoration: none;
+}
+
+.md-card a:hover,
+.md-card a:active {
+    text-decoration: underline;
+}
+
+/* CLOZE — Material primary pill, reads on light and dark */
+.cloze {
+    font-weight: 600;
+    color: var(--md-cloze);
+    background-color: var(--md-cloze-bg);
+    border-radius: 6px;
+    padding: 1px 6px;
+}
+
+/* TAGS — Material outlined chips */
+.tags {
+    margin-bottom: 16px;
+}
+
+.tag {
+    font-size: 0.72em;
+    font-weight: 500;
+    padding: 5px 12px;
+    display: inline-block;
+    border-radius: 16px;
+    border: 1px solid var(--md-divider);
+    color: var(--md-on-surface-muted);
+    margin: 0 8px 8px 0;
+    line-height: 1.2;
+}
+
+/* IMAGES */
+img {
+    object-fit: contain;
+    margin: 8px auto 0 auto;
+    display: block;
+    width: auto;
+    max-width: 100%;
+    border-radius: 8px;
+}
+
+/* NIGHT MODE — Material dark surfaces */
+.nightMode,
+.night_mode {
+    --md-bg: #121212;
+    --md-card: #1e1e1e;
+    --md-on-surface: #e8eaed;
+    --md-on-surface-muted: #9aa0a6;
+    --md-primary: #8ab4f8;
+    --md-cloze: #8ab4f8;
+    --md-cloze-bg: rgba(138, 180, 248, 0.16);
+    --md-divider: #3c4043;
+    --md-elevation: 0 1px 2px rgba(0, 0, 0, 0.60),
+                    0 2px 6px 2px rgba(0, 0, 0, 0.40);
+}
+
+.nightMode body,
+.night_mode body {
+    background-color: var(--md-bg);
+    color: var(--md-on-surface);
+}
+
+/* Resize image add-on compatibility (matches abhiyan) */
+.mobile .card img {
+    height: unset !important;
+    width: unset !important;
+}

--- a/web/src/pages/DocsPage/content/cards/templates.md
+++ b/web/src/pages/DocsPage/content/cards/templates.md
@@ -20,7 +20,7 @@ If you just want cards from your notes, you don't have to touch this page — 2a
 Open [2anki.net/templates](https://2anki.net/templates). Three sections show up, in order:
 
 - **Your note types** — anything you've created or customized in the browser (logged-in only).
-- **Official 2anki templates** — handcrafted designs we ship and maintain. Examples: Abhiyan Night Mode, Alexander Deluxe Blue, Only Notion.
+- **Official 2anki templates** — handcrafted designs we ship and maintain. Examples: Abhiyan Night Mode, Alexander Deluxe Blue, Material, Only Notion.
 - **Starter note types** — the bare-bones n2a-basic, n2a-cloze, n2a-input, n2a-mcq, and Image Occlusion templates that 2anki uses by default.
 
 Each card has a small preview of the front. Click the card name to open a full-size **Front / Back** preview side-by-side.

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-material-template.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-material-template.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-material-template",
+  "date": "2026-06-03",
+  "type": "feature",
+  "title": "New Material card template — elevated cards that stay clean in light and dark"
+}


### PR DESCRIPTION
## What
Adds **Material (Basic)** and **Material (Cloze)** to the official template gallery, alongside Abhiyan and Alexander Deluxe.

Closes #221.

## Why
#221 asked for a Material design option. Read as a card template (not an app reskin — the app-theme reading was declined in 2020 and the app has since moved to its own design tokens). More beautiful-deck options, and unlike Abhiyan (always dark), Material is genuinely light in Anki light mode and dark in night mode — so it serves night-mode reviewers cleanly.

## How
- 6 template assets in `src/templates/`: basic + cloze front/back HTML and two CSS files. Material elevation, 12px radius, Roboto system stack (no web-font fetch — cards render offline), primary-blue answer accent and cloze pill.
- Light/dark handled via CSS custom properties re-declared under `.nightMode` / `.night_mode` (the same hook abhiyan uses). Light primary `#1a73e8` is AA on white; dark primary `#8ab4f8` is AA on `#1e1e1e`.
- Mirrors abhiyan's field structure (`Front`/`Back`/`Tags`, `Text`/`Extra`/`Tags`) and hierarchical-tag splitter, so it reuses `ABHIYAN_BASIC_FLDS` / `ABHIYAN_CLOZE_FLDS`.
- Registered via two `variantStarter({...})` blocks in `officialTemplates.ts`.

## Measuring success
Template adoption in the gallery; Material picked by users who review in dark mode.

## Testing
- `officialTemplates.test.ts` extended: the two new IDs appear, and dedicated assertions confirm the files resolve (`{{Front}}` / `{{cloze:Text}}` in qfmt, `.md-card` / `.cloze` in css) — guards against a filename typo silently dropping a template (`variantStarter` returns null on an unreadable file). The existing `validateTemplateFields` check passes for both. 8/8 green.
- Web changelog loader 7/7, web typecheck clean.

## Risks
Highest-risk spot (designer-flagged): the cloze pill + answer accent in Anki night mode — needs a real night-mode toggle on both card types to confirm legibility. No runtime web logic changed.

## Goal alignment
Beautiful decks — a clean, modern template that works in both light and night mode, the latter being the default for many mobile reviewers.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: the only `web/src/` changes are a one-word addition to the templates docs list and a changelog JSON — no interactive runtime change. Agent did not verify in a browser; the meaningful check is importing a Material deck into Anki and toggling night mode (boxes left for Alexander).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783098741&installation_id=132681956&pr_number=3040&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3040&signature=7fc3c930e4fb8694832dfc94da1e3a9e9266a0c055296c9df45342da72f6a31e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
