### PR TITLE
docs: document cloze hint convention

### DIFF
--- a/web/src/pages/DocsPage/content/cards/card-types.md
+++ b/web/src/pages/DocsPage/content/cards/card-types.md
@@ -49,6 +49,16 @@ Cloze hides part of a sentence. You see "The capital of France is [...]" and typ
 </details>
 ```
 
+### Cloze hints
+
+To show a hint instead of `[...]`, append `::your hint` after the answer inside the code-formatted cloze. The hint takes the place of the blank on the front, so you get a nudge before you recall the answer.
+
+```
+- The capital of France is `Paris::capital`
+```
+
+That renders the front as "The capital of France is [capital]", with Paris as the answer.
+
 You can also use Anki's native cloze syntax directly when you want explicit numbering or hints:
 
 ```


### PR DESCRIPTION
## What
Adds a short "Cloze hints" subsection to the Card types docs, explaining how to show a hint instead of `[...]` in a cloze deletion: append `::your hint` after the answer inside the code-formatted cloze.

## Why
Closes #99. Cloze hints already work today — in a code-formatted cloze, appending `::hint` after the answer produces an Anki hinted cloze that renders as `[hint]` instead of `[...]`. Nothing in the conversion code needed to change; users just needed to know the convention. Per Alexander's "document + close" decision.

## How
Edited the existing Cloze section in `web/src/pages/DocsPage/content/cards/card-types.md`, placing the subsection right before the native-cloze-syntax note. Used a neutral example (`Paris::capital` → renders `[capital]`). Sentence-case heading, no implementation details, no internal file/function names. No sidebar change — the page is already registered.

## Measuring success
The `/documentation/cards/card-types` page renders the new "Cloze hints" subsection. Success is qualitative — fewer support questions about why clozes show `[...]` with no label.

## Testing
- No new code; documents existing behavior.
- `pnpm --filter 2anki-web typecheck` — passes
- `pnpm --filter 2anki-web lint` — passes
- DocsPage Vitest suite (loader, content-links, sidebar) — passes (full web suite 1614 tests green)

## Browser check
Browser check: not applicable — docs-content-only Markdown change (adds a subsection of static prose and a code example to an existing page; no component, route, or runtime behavior touched).

## Changelog
No entry — this documents existing behavior. No behavior changed, so no user-visible change to announce.

## Risks
Minimal — static prose addition to one existing docs page. Rollback is reverting the single commit.

## Goal alignment
Removes friction for learners who want hinted clozes but can't discover the convention. A clearer docs surface reduces drop-off for power users building richer decks, supporting the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783099062&installation_id=132681956&pr_number=3041&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3041&signature=3073a59aa121d1adc32124ee781f2273212f72faac55df1f0ca58ae66e0a8daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->