### PR TITLE
feat: add Preview button to template cards

### DIFF
--- a/web/src/pages/TemplatesPage/TemplatesPage.module.css
+++ b/web/src/pages/TemplatesPage/TemplatesPage.module.css
@@ -144,6 +144,31 @@
   cursor: progress;
 }
 
+.previewBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.875rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.previewBtn:hover {
+  background: var(--color-bg-secondary);
+}
+
+.previewBtn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .secondaryActions {
   display: inline-flex;
   align-items: center;

--- a/web/src/pages/TemplatesPage/TemplatesPage.test.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.test.tsx
@@ -197,6 +197,22 @@ describe('TemplatesPage', () => {
     expect(screen.getByText('Back')).toBeInTheDocument();
   });
 
+  it('opens a preview dialog when the Preview button is clicked', async () => {
+    getDefaults.mockResolvedValue([sampleStarter]);
+    renderPage();
+
+    const previewButton = await screen.findByRole('button', {
+      name: /preview clean basic/i,
+    });
+    fireEvent.click(previewButton);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-labelledby', 'note-type-preview-title');
+    expect(screen.getByText('Front')).toBeInTheDocument();
+    expect(screen.getByText('Back')).toBeInTheDocument();
+  });
+
   it('closes the preview when Escape is pressed', async () => {
     getDefaults.mockResolvedValue([sampleStarter]);
     renderPage();

--- a/web/src/pages/TemplatesPage/TemplatesPage.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useDialog } from '../../lib/hooks/useDialog';
 import sharedStyles from '../../styles/shared.module.css';
 import DownloadIcon from '../../components/icons/DownloadIcon';
+import EyeIcon from '../../components/icons/EyeIcon';
 import PencilIcon from '../../components/icons/PencilIcon';
 import TrashIcon from '../../components/icons/TrashIcon';
 import styles from './TemplatesPage.module.css';
@@ -90,6 +91,15 @@ function NoteTypeCard({
           >
             <DownloadIcon width={14} height={14} />
             {busy ? 'Preparing…' : 'Download'}
+          </button>
+          <button
+            type="button"
+            className={styles.previewBtn}
+            onClick={() => onPreview(starter)}
+            aria-label={`Preview ${starter.name}`}
+          >
+            <EyeIcon width={14} height={14} />
+            Preview
           </button>
           <div className={styles.secondaryActions}>
             <Link

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-templates-preview-button.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-templates-preview-button.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-templates-preview-button",
+  "date": "2026-06-03",
+  "type": "feature",
+  "title": "Note types — preview any card layout before downloading with the new Preview button"
+}


### PR DESCRIPTION
## What
Each card on `/templates` now has an explicit **Preview** button next to Download. It opens the same front/back preview dialog that clicking the template name already opens.

## Why
Today the preview only opens when the user clicks the template *name* — an undiscoverable affordance. Most users don't know the name is interactive, so the preview never gets seen before download. A labeled button next to Download surfaces preview-before-download as a first-class action.

## How
- Added an `EyeIcon` secondary-weight button in the card's `styles.actions` row, placed immediately after the primary Download button so Download stays the primary action.
- The button calls the existing `onPreview(starter)` handler — no new state or logic.
- New `.previewBtn` CSS mirrors `.downloadBtn`'s pill shape (same padding, font, `radius-full`) but with outline/secondary coloring (`color-bg-primary` background, `1px` `color-border`) so the two sit cleanly side by side.
- Kept the name-click preview as a second affordance (the name remains a `<button>`).
- `aria-label="Preview <name>"`; icon is decorative (`aria-hidden`, baked into `EyeIcon`); real keyboard-focusable `<button>`.

## Measuring success
This is a discoverability affordance — success shows up as a higher share of `/templates` sessions that open the preview dialog before a download (the preview modal mount is the signal). No new server log line; behavior is client-side.

## Testing
- Unit test added: "opens a preview dialog when the Preview button is clicked" in `TemplatesPage.test.tsx`, mirroring the existing name-click test. All 9 TemplatesPage tests pass; changelog loader test passes.
- `pnpm typecheck` and `pnpm lint` (Biome) clean in the worktree.


## Sonar
`sonar-scanner` is installed but `SONAR_TOKEN` is unset, so it was not run. Change is small (one button + one CSS class, no new functions or branching) — expect no new code smells.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-03-templates-preview-button.json` — "Note types — preview any card layout before downloading with the new Preview button"

## Risks
Low. Pure additive UI on one page. Rollback is reverting the single commit. The name-click preview is untouched.

## Goal alignment
Simpler/faster: users see the card layout before downloading instead of discovering by accident that the name is clickable — fewer wrong downloads, less friction on the note-types surface that feeds the conversion flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783100739&installation_id=132681956&pr_number=3048&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3048&signature=23f17e6178c1061d8c4791311cdf8b036b3c8be988bf070a93f4776ef2393e64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Merge authorized by the repo owner (Alexander) via explicit instruction. Boxes ticked on that authority — the automation agent did not independently run a browser; CI (tsc + lint + vitest/jest + playwright) is green.
