### PR TITLE
feat: tag upload_started with device class for mobile-demand read

### DIFF
--- a/src/lib/analytics/classifyDevice.test.ts
+++ b/src/lib/analytics/classifyDevice.test.ts
@@ -1,0 +1,41 @@
+import { classifyDevice } from './classifyDevice';
+
+describe('classifyDevice', () => {
+  it.each([
+    [undefined, 'unknown'],
+    [null, 'unknown'],
+    ['', 'unknown'],
+    ['   ', 'unknown'],
+  ] as const)('returns "unknown" for missing/empty UA (%p)', (ua, expected) => {
+    expect(classifyDevice(ua)).toBe(expected);
+  });
+
+  it.each([
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148',
+    'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/120.0 Mobile Safari/537.36',
+    'Mozilla/5.0 (iPod touch; CPU iPhone OS 16_0 like Mac OS X) Mobile/15E148',
+  ])('classifies phones as mobile (%p)', (ua) => {
+    expect(classifyDevice(ua)).toBe('mobile');
+  });
+
+  it.each([
+    'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1',
+    'Mozilla/5.0 (Linux; Android 13; SM-X710) AppleWebKit/537.36 Chrome/120.0 Safari/537.36',
+  ])('classifies tablets as tablet (%p)', (ua) => {
+    expect(classifyDevice(ua)).toBe('tablet');
+  });
+
+  it.each([
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15',
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0 Safari/537.36',
+  ])('classifies laptops/desktops as desktop (%p)', (ua) => {
+    expect(classifyDevice(ua)).toBe('desktop');
+  });
+
+  it('treats an Android tablet (no "Mobile" token) as tablet, not mobile', () => {
+    const androidTablet =
+      'Mozilla/5.0 (Linux; Android 13; SM-T970) AppleWebKit/537.36 Chrome/120.0 Safari/537.36';
+    expect(classifyDevice(androidTablet)).toBe('tablet');
+  });
+});

--- a/src/lib/analytics/classifyDevice.ts
+++ b/src/lib/analytics/classifyDevice.ts
@@ -1,0 +1,13 @@
+export type DeviceClass = 'mobile' | 'tablet' | 'desktop' | 'unknown';
+
+const TABLET_PATTERN = /iPad|Tablet|PlayBook|Silk|(Android(?!.*Mobile))/i;
+const MOBILE_PATTERN = /Mobi|iPhone|iPod|Windows Phone|BlackBerry|Opera Mini|IEMobile/i;
+
+export function classifyDevice(userAgent: string | undefined | null): DeviceClass {
+  if (typeof userAgent !== 'string' || userAgent.trim().length === 0) {
+    return 'unknown';
+  }
+  if (TABLET_PATTERN.test(userAgent)) return 'tablet';
+  if (MOBILE_PATTERN.test(userAgent)) return 'mobile';
+  return 'desktop';
+}

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -34,6 +34,7 @@ import Deck from '../lib/parser/Deck';
 import { isHTMLFile, isMarkdownFile } from '../lib/storage/checks';
 import { FileSizeInMegaBytes } from '../lib/misc/file';
 import { track } from './events/track';
+import { classifyDevice } from '../lib/analytics/classifyDevice';
 import {
   isPdfPasswordSentinel,
   parsePdfPasswordSentinel,
@@ -248,7 +249,10 @@ class UploadService {
       track('upload_started', {
         userId: owner != null ? Number(owner) : null,
         anonymousId: this.resolveAnonId(req),
-        props: { source: this.resolveUploadSource(req) },
+        props: {
+          source: this.resolveUploadSource(req),
+          device: classifyDevice(req.headers['user-agent']),
+        },
       });
 
       if (owner && settings.claudeAIFlashcards) {

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -251,7 +251,7 @@ class UploadService {
         anonymousId: this.resolveAnonId(req),
         props: {
           source: this.resolveUploadSource(req),
-          device: classifyDevice(req.headers['user-agent']),
+          device: classifyDevice(req.headers?.['user-agent']),
         },
       });
 


### PR DESCRIPTION
## Why

The iOS/macOS native-app strategy (trio review, 2026-06-03) was decided as **app-only $21, one-time guardrailed — but instrument demand first**. The PM's flag: most Anki authoring happens at a desk, so before building anything we need to know whether meaningful conversion traffic already comes from mobile browsers. We had no server-side signal — `upload_started` carried `source` but not device.

## What

- New pure helper `src/lib/analytics/classifyDevice.ts` — classifies a request User-Agent into `mobile | tablet | desktop | unknown`. Android tablets (no `Mobile` token) correctly fall to `tablet`, not `mobile`.
- `upload_started` now carries `device` alongside `source`, so the build/no-build call rests on real data. Query with `props->>'device'` against the events table.
- Scoped to the attempt event (the demand signal). Success-rate-by-device can be added later if volume justifies the native app.

## Tests

`classifyDevice.test.ts` — 13 cases (missing/empty UA, phones, tablets, desktops, the Android-tablet edge). All green. Server `tsc --noEmit` clean.

## Notes

- No changelog entry — internal telemetry, no user-visible behavior change.
- Browser check: not applicable — server-only change, no `web/src/` files touched.
- Sonar not run locally — `SONAR_TOKEN` not configured on this machine. Change is a pure regex classifier with full test coverage plus a one-prop addition; low complexity risk. Expect the CI Sonar pass to be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783101347&installation_id=132681956&pr_number=3049&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3049&signature=d37610c4bd6375a03aa97e07caafca27aeef85db8072ad9d5340153df2ebe158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->