### PR TITLE
feat: record density in vision_photo_converted event

### DIFF
--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -600,6 +600,36 @@ describe('PhotoToFlashcardsUseCase', () => {
         })
       );
     });
+
+    it('tracks the requested density in the analytics event', async () => {
+      const events = makeEventsStub(0);
+      const useCase = new PhotoToFlashcardsUseCase(events);
+      await useCase.execute({ ...BASE_INPUT, isPaying: true, density: 'dense' });
+      const { track } = jest.requireMock(
+        '../../services/events/track'
+      ) as { track: jest.Mock };
+      expect(track).toHaveBeenCalledWith(
+        'vision_photo_converted',
+        expect.objectContaining({
+          props: expect.objectContaining({ density: 'dense' }),
+        })
+      );
+    });
+
+    it('tracks density: balanced when density is absent', async () => {
+      const events = makeEventsStub(0);
+      const useCase = new PhotoToFlashcardsUseCase(events);
+      await useCase.execute({ ...BASE_INPUT, isPaying: false });
+      const { track } = jest.requireMock(
+        '../../services/events/track'
+      ) as { track: jest.Mock };
+      expect(track).toHaveBeenCalledWith(
+        'vision_photo_converted',
+        expect.objectContaining({
+          props: expect.objectContaining({ density: 'balanced' }),
+        })
+      );
+    });
   });
 
   describe('MCQ emission', () => {

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -530,6 +530,7 @@ export class PhotoToFlashcardsUseCase {
         tile_count: tiles,
         source_mode: mode,
         card_style: input.cardStyle ?? DEFAULT_PHOTO_CARD_STYLE,
+        density: input.density ?? DEFAULT_PHOTO_DENSITY,
       },
     });
 


### PR DESCRIPTION
## What
Adds the user's requested `density` setting (`sparse` | `balanced` | `dense`) to the `vision_photo_converted` analytics event. Falls back to `DEFAULT_PHOTO_DENSITY` (`balanced`) when the request omitted density. Server-side, single property on the existing `track` props object — no new code path.

## Why
Closes the measurement gap in #2633 (tracked under #3021): the event already records `card_count` (the output) but not the density the user asked for (the input), so we cannot see the sparse/balanced/dense distribution and cannot tell whether the default is the right one or whether anyone reaches for the other two.

## How
One line added to the `vision_photo_converted` `props` in `PhotoToFlashcardsUseCase`: `density: input.density ?? DEFAULT_PHOTO_DENSITY`. Both `input.density` (type `PhotoDensity`) and the default constant are already in scope at the event site. `vision_photo_converted` is already in the server `KNOWN_EVENTS` allowlist and is fired server-side only, so no allowlist change and no web-side change.

## Measuring success
In the analytics sink, group `vision_photo_converted` by `props.density` over a rolling window — the three buckets (`sparse`, `balanced`, `dense`) now appear with non-null values. Before this PR the field is absent on every row; after, every new event carries it. That distribution is the signal for whether the default density should change.

## Testing
- Unit tests added (mock the `services/events/track` analytics sink boundary only):
  - tracks the requested density (`dense`) in the event props
  - falls back to `balanced` when `density` is absent
- Full `PhotoToFlashcardsUseCase.test.ts`: 64 passed.
- Both new tests verified failing first (missing `density` prop), then passing after the source change.

## Browser check
Not applicable — server-only change, no `web/src/` files touched.

## Changelog
No entry — internal analytics measurement, no user-visible behavior change.

## Sonar
`sonar-scanner` is installed but `SONAR_TOKEN` is unset in this environment, so a local run wasn't possible. Skipped per the trivial-change exemption: this is a single property addition to an existing object literal — no new function, branch, or nesting for the rule engine to flag.

## Risks
Minimal. The added prop is a bounded enum value with a safe default; no behavior change to deck generation, no new I/O, no LLM/cost impact. Rollback is a one-line revert.

## Goal alignment
Measurement, not a user-facing feature: knowing the real sparse/balanced/dense split tells the trio whether the current default serves most learners or whether density should be surfaced/retuned. Better prioritization of the vision-photo flow — a high-intent conversion surface — moves us toward the 300K-user goal by directing effort at what learners actually pick.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783104027&installation_id=132681956&pr_number=3054&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3054&signature=66c2d83d072eaf99e71d367844ae1abb07a3785bc20e23509b868c51379479ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->