### PR TITLE
chore: enable typescript-lsp, sonarqube, stripe, playwright plugins

### DIFF
--- a/.claude/MCP_README.md
+++ b/.claude/MCP_README.md
@@ -2,6 +2,19 @@
 
 Three project-scoped MCP servers. None are required to use Claude Code on this repo; each one trades an extra dependency for a specific capability.
 
+## Project-enabled plugins (`.claude/settings.json`)
+
+`enabledPlugins` registers plugins for everyone who opens this repo in Claude Code. Pulled from the `claude-plugins-official` marketplace. None block normal work — each is opt-in capability.
+
+| Plugin | What it adds | Auth |
+| --- | --- | --- |
+| `typescript-lsp` | Type-aware navigation (go-to-def, find-refs, real TS errors) across `src/` and `web/`. | None — works immediately. |
+| `sonarqube` | SonarCloud's rule engine in-loop, before push — catches the cognitive-complexity / nesting / a11y smells that `/check` misses (see `rules/sonar.md`). | Uses existing `SONAR_TOKEN`. |
+| `stripe` | Inspect subscriptions/customers directly instead of prod psql + the `/ops` Sync button. | Needs Stripe key via `/mcp`. **Read-only scope; never point at a key with write access for routine debugging.** |
+| `playwright` | Browser automation — makes the browser-attestation golden-path check (localhost:3000, console at 375px) machine-verifiable instead of honor-system. | None for local drive. |
+
+Auth-gated plugins (`stripe`) stay inert until you wire credentials via `/mcp`; the enable flag alone is harmless.
+
 ## `ide` — built-in diagnostics
 
 Launches Claude Code's own MCP server. Surfaces TS diagnostics, file diffs, and the editor's open buffers so the model can read what you're actually staring at instead of guessing.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,10 +8,20 @@
         "source": "github",
         "repo": "JuliusBrussee/caveman"
       }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
     }
   },
   "enabledPlugins": {
-    "caveman@caveman": true
+    "caveman@caveman": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "sonarqube@claude-plugins-official": true,
+    "stripe@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## What

Enable four Claude Code plugins from the official marketplace, project-wide via `.claude/settings.json`. Each maps to this repo's stack and a documented pain point.

| Plugin | Why | Auth |
| --- | --- | --- |
| `typescript-lsp` | Type-aware nav (go-to-def, find-refs, real TS errors) across the TS server + `web/`. | None |
| `sonarqube` | SonarCloud's rule engine in-loop before push — closes the gap `rules/sonar.md` calls out (`/check` skips it, so smells surface post-push). | `SONAR_TOKEN` |
| `stripe` | Inspect subscriptions/customers directly vs prod psql + `/ops` Sync button. | `/mcp`, read-only |
| `playwright` | Makes the browser-attestation golden-path check verifiable, not honor-system. Already a dep in `web/`. | None local |

## Skipped on purpose

`posthog` / `sentry` — analytics here is **GA4**, and there's no Sentry in the codebase. `github` plugin — redundant with the existing `gh` CLI + github MCP.

## Notes

- Auth-gated plugins stay inert until creds are wired via `/mcp`; the enable flag alone is harmless.
- Per `rules/security.md`: keep the Stripe MCP key read-only, never point at prod write scope for routine debugging.
- Docs: each plugin + its auth need is recorded in `.claude/MCP_README.md`.
- No `web/src/` runtime change — config + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783104583&installation_id=132681956&pr_number=3058&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3058&signature=25be0bd7bef696b7f56a108afff6cbe4f474dbbfa659023f0f810ba849828eda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->