### PR TITLE
feat: revoke Apple Sign-in token on account deletion

### DIFF
--- a/migrations/20260901000000_add_refresh_token_to_oauth_identities.js
+++ b/migrations/20260901000000_add_refresh_token_to_oauth_identities.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.alterTable('oauth_identities', (t) => {
+    t.text('refresh_token').nullable().defaultTo(null);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('oauth_identities', (t) => {
+    t.dropColumn('refresh_token');
+  });
+};

--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -1041,6 +1041,9 @@ describe('UsersController.loginWithApple', () => {
     MockedOauthIdentitiesRepo.prototype.link = jest
       .fn()
       .mockResolvedValue(undefined);
+    MockedOauthIdentitiesRepo.prototype.updateRefreshToken = jest
+      .fn()
+      .mockResolvedValue(undefined);
   });
 
   const buildAppleController = (overrides?: {
@@ -1139,7 +1142,54 @@ describe('UsersController.loginWithApple', () => {
     expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
       'apple',
       'apple-sub-001',
-      20
+      20,
+      undefined
+    );
+  });
+
+  it('stores the Apple refresh token on the linked identity when present', async () => {
+    const register = jest.fn().mockResolvedValue([{ id: 20 }]);
+    const loginWithApple = jest.fn().mockResolvedValue({
+      subject: 'apple-sub-001',
+      email: 'apple@example.com',
+      emailVerified: true,
+      refreshToken: 'apple-refresh-555',
+    });
+    const { controller } = buildAppleController({ register, loginWithApple });
+
+    await controller.loginWithApple(buildReq(), buildAppleRes());
+
+    expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
+      'apple',
+      'apple-sub-001',
+      20,
+      'apple-refresh-555'
+    );
+  });
+
+  it('refreshes the stored token when the identity already exists', async () => {
+    MockedOauthIdentitiesRepo.prototype.findByProviderAndSubject = jest
+      .fn()
+      .mockResolvedValue({ user_id: 20, provider: 'apple', subject: 'apple-sub-001' });
+    MockedOauthIdentitiesRepo.prototype.updateRefreshToken = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    const getUserById = jest.fn().mockResolvedValue({ id: 20, email: 'apple@example.com' });
+    const loginWithApple = jest.fn().mockResolvedValue({
+      subject: 'apple-sub-001',
+      email: 'apple@example.com',
+      emailVerified: true,
+      refreshToken: 'apple-refresh-rotated',
+    });
+
+    const { controller } = buildAppleController({ getUserById, loginWithApple });
+
+    await controller.loginWithApple(buildReq(), buildAppleRes());
+
+    expect(MockedOauthIdentitiesRepo.prototype.updateRefreshToken).toHaveBeenCalledWith(
+      'apple',
+      'apple-sub-001',
+      'apple-refresh-rotated'
     );
   });
 
@@ -1172,7 +1222,8 @@ describe('UsersController.loginWithApple', () => {
     expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
       'apple',
       'apple-sub-001',
-      21
+      21,
+      undefined
     );
   });
 
@@ -1231,6 +1282,123 @@ describe('UsersController.loginWithApple', () => {
     await controller.loginWithApple(buildReq(), res);
 
     expect(res.redirect).toHaveBeenCalledWith('/login');
+  });
+});
+
+describe('UsersController.deleteAccount — Apple token revocation', () => {
+  const MockedOauthIdentitiesRepo =
+    OauthIdentitiesRepository as jest.MockedClass<typeof OauthIdentitiesRepository>;
+  const SubscriptionServiceMock = SubscriptionService as unknown as {
+    cancelUserSubscriptions: jest.Mock;
+  };
+
+  beforeEach(() => {
+    MockedOauthIdentitiesRepo.mockClear();
+    SubscriptionServiceMock.cancelUserSubscriptions = jest
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  const buildDeleteController = (overrides?: {
+    refreshToken?: string | null;
+    revokeAppleToken?: jest.Mock;
+    deleteUser?: jest.Mock;
+  }) => {
+    MockedOauthIdentitiesRepo.prototype.findRefreshTokenByUserAndProvider = jest
+      .fn()
+      .mockResolvedValue(overrides?.refreshToken ?? null);
+    const deleteUser = overrides?.deleteUser ?? jest.fn().mockResolvedValue(undefined);
+    const userService = {
+      getUserById: jest
+        .fn()
+        .mockResolvedValue({ id: 42, email: 'apple@example.com' }),
+      deleteUser,
+    } as unknown as UsersService;
+    const authService = {
+      revokeAppleToken:
+        overrides?.revokeAppleToken ?? jest.fn().mockResolvedValue(true),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    return { controller, userService, authService, deleteUser };
+  };
+
+  const buildDeleteReq = () =>
+    ({ body: {}, cookies: {}, headers: {}, query: {} } as unknown as express.Request);
+
+  const buildDeleteRes = () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    return { json, status } as unknown as express.Response & {
+      json: jest.Mock;
+      status: jest.Mock;
+    };
+  };
+
+  it('revokes the stored Apple refresh token before deleting the user', async () => {
+    const revokeAppleToken = jest.fn().mockResolvedValue(true);
+    const deleteUser = jest.fn().mockResolvedValue(undefined);
+    const { controller } = buildDeleteController({
+      refreshToken: 'apple-refresh-del',
+      revokeAppleToken,
+      deleteUser,
+    });
+    const res = buildDeleteRes();
+
+    await controller.deleteAccount(
+      buildDeleteReq(),
+      Object.assign(res, { locals: { owner: '42' } }) as unknown as express.Response
+    );
+
+    expect(revokeAppleToken).toHaveBeenCalledWith('apple-refresh-del');
+    const revokeOrder = revokeAppleToken.mock.invocationCallOrder[0];
+    const deleteOrder = deleteUser.mock.invocationCallOrder[0];
+    expect(revokeOrder).toBeLessThan(deleteOrder);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('completes deletion without revoking when no Apple identity token exists', async () => {
+    const revokeAppleToken = jest.fn();
+    const deleteUser = jest.fn().mockResolvedValue(undefined);
+    const { controller } = buildDeleteController({
+      refreshToken: null,
+      revokeAppleToken,
+      deleteUser,
+    });
+    const res = buildDeleteRes();
+
+    await controller.deleteAccount(
+      buildDeleteReq(),
+      Object.assign(res, { locals: { owner: '42' } }) as unknown as express.Response
+    );
+
+    expect(revokeAppleToken).not.toHaveBeenCalled();
+    expect(deleteUser).toHaveBeenCalledWith('42');
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('still deletes the account when Apple revocation throws', async () => {
+    const revokeAppleToken = jest
+      .fn()
+      .mockRejectedValue(new Error('apple revoke down'));
+    const deleteUser = jest.fn().mockResolvedValue(undefined);
+    const { controller } = buildDeleteController({
+      refreshToken: 'apple-refresh-del',
+      revokeAppleToken,
+      deleteUser,
+    });
+    const res = buildDeleteRes();
+
+    await controller.deleteAccount(
+      buildDeleteReq(),
+      Object.assign(res, { locals: { owner: '42' } }) as unknown as express.Response
+    );
+
+    expect(deleteUser).toHaveBeenCalledWith('42');
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 });
 
@@ -2170,7 +2338,8 @@ describe('UsersController.loginWithAppleNative', () => {
     expect(MockedOauthIdentitiesRepo.prototype.link).toHaveBeenCalledWith(
       'apple',
       'native-sub-001',
-      30
+      30,
+      undefined
     );
   });
 

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -17,6 +17,7 @@ import { MagicLinkRateLimitError } from '../services/UsersService';
 import { MONTHLY_CARD_LIMIT } from '../usecases/users/CheckMonthlyCardLimitUseCase';
 import UsersRepository from '../data_layer/UsersRepository';
 import OauthIdentitiesRepository from '../data_layer/OauthIdentitiesRepository';
+import { UsersId } from '../data_layer/public/Users';
 import { isPaying } from '../lib/isPaying';
 import NotionRepository from '../data_layer/NotionRespository';
 import hashToken from '../lib/misc/hashToken';
@@ -400,12 +401,30 @@ class UsersController {
         );
       }
 
+      await this.#revokeAppleTokenForOwner(user.id);
+
       await this.userService.deleteUser(owner);
       res.status(200).json({});
     } catch (error) {
       console.info('Delete account failed');
       console.error(error);
       return res.status(500).json({ message: 'Failed to delete account' });
+    }
+  }
+
+  async #revokeAppleTokenForOwner(userId: UsersId) {
+    try {
+      const oauthIdentitiesRepo = new OauthIdentitiesRepository(this.db);
+      const refreshToken = await oauthIdentitiesRepo.findRefreshTokenByUserAndProvider(
+        userId,
+        'apple'
+      );
+      if (refreshToken == null) {
+        return;
+      }
+      await this.authService.revokeAppleToken(refreshToken);
+    } catch (revokeError) {
+      console.error('Apple token revocation failed during account deletion:', revokeError);
     }
   }
 
@@ -745,9 +764,9 @@ class UsersController {
       return res.redirect('/login');
     }
 
-    const { subject, email } = loginRequest;
+    const { subject, email, refreshToken } = loginRequest;
     const rawName = this.parseAppleName(req.body);
-    const result = await this.#upsertAppleUser({ subject, email, rawName, req });
+    const result = await this.#upsertAppleUser({ subject, email, rawName, refreshToken, req });
 
     if (result === 'email_missing') {
       await this.recordError?.execute({ userId: null, surface: 'oauth_apple', code: 'oauth_email_missing' });
@@ -806,11 +825,13 @@ class UsersController {
     subject,
     email,
     rawName,
+    refreshToken,
     req,
   }: {
     subject: string;
     email: string | undefined;
     rawName: string | undefined;
+    refreshToken?: string;
     req: express.Request;
   }): Promise<
     | { user: { id: number; email?: string }; token: string }
@@ -826,13 +847,17 @@ class UsersController {
       : null;
     let isNewUser = false;
 
+    if (existingIdentity && refreshToken) {
+      await oauthIdentitiesRepo.updateRefreshToken('apple', subject, refreshToken);
+    }
+
     if (!user) {
       if (!email) {
         return 'email_missing';
       }
       const existingByEmail = await this.userService.getUserFrom(email);
       if (existingByEmail) {
-        await oauthIdentitiesRepo.link('apple', subject, existingByEmail.id);
+        await oauthIdentitiesRepo.link('apple', subject, existingByEmail.id, refreshToken);
         user = existingByEmail;
       } else {
         const hashedPassword = this.authService.getHashPassword(getRandomUUID());
@@ -840,7 +865,7 @@ class UsersController {
         user = await this.userService.getUserFrom(email);
         isNewUser = true;
         if (user) {
-          await oauthIdentitiesRepo.link('apple', subject, user.id);
+          await oauthIdentitiesRepo.link('apple', subject, user.id, refreshToken);
           if (rawName) {
             await new UsersRepository(this.db).updateName(user.id, rawName);
           }

--- a/src/data_layer/OauthIdentitiesRepository.test.ts
+++ b/src/data_layer/OauthIdentitiesRepository.test.ts
@@ -1,3 +1,5 @@
+process.env.THE_HASHING_SECRET = 'test-secret-for-jest';
+
 import knex, { Knex } from 'knex';
 
 import OauthIdentitiesRepository from './OauthIdentitiesRepository';
@@ -68,12 +70,21 @@ describe('OauthIdentitiesRepository', () => {
     expect(row).toBeNull();
   });
 
-  it('stores the refresh token passed to link', async () => {
+  it('encrypts the refresh token at rest when linking', async () => {
     const userId = await insertUser('user@example.com');
     await repo.link('apple', 'sub-apple', userId, 'apple-refresh-1');
 
     const row = await repo.findByProviderAndSubject('apple', 'sub-apple');
-    expect(row).toMatchObject({ refresh_token: 'apple-refresh-1' });
+    expect(row?.refresh_token).not.toBeNull();
+    expect(row?.refresh_token).not.toBe('apple-refresh-1');
+  });
+
+  it('returns the raw refresh token after a link round-trip', async () => {
+    const userId = await insertUser('user@example.com');
+    await repo.link('apple', 'sub-apple', userId, 'apple-refresh-1');
+
+    const token = await repo.findRefreshTokenByUserAndProvider(userId, 'apple');
+    expect(token).toBe('apple-refresh-1');
   });
 
   it('stores null when link is called without a refresh token', async () => {
@@ -84,17 +95,20 @@ describe('OauthIdentitiesRepository', () => {
     expect(row?.refresh_token).toBeNull();
   });
 
-  it('updates the refresh token for an existing identity', async () => {
+  it('updates the refresh token for an existing identity and encrypts it at rest', async () => {
     const userId = await insertUser('user@example.com');
     await repo.link('apple', 'sub-apple', userId, 'apple-refresh-old');
 
     await repo.updateRefreshToken('apple', 'sub-apple', 'apple-refresh-new');
 
     const row = await repo.findByProviderAndSubject('apple', 'sub-apple');
-    expect(row).toMatchObject({ refresh_token: 'apple-refresh-new' });
+    expect(row?.refresh_token).not.toBe('apple-refresh-new');
+
+    const token = await repo.findRefreshTokenByUserAndProvider(userId, 'apple');
+    expect(token).toBe('apple-refresh-new');
   });
 
-  it('reads back the refresh token by user and provider', async () => {
+  it('reads back the raw refresh token by user and provider', async () => {
     const userId = await insertUser('user@example.com');
     await repo.link('apple', 'sub-apple', userId, 'apple-refresh-2');
 

--- a/src/data_layer/OauthIdentitiesRepository.test.ts
+++ b/src/data_layer/OauthIdentitiesRepository.test.ts
@@ -28,6 +28,7 @@ describe('OauthIdentitiesRepository', () => {
         .inTable('users')
         .onDelete('CASCADE');
       t.timestamp('created_at').notNullable().defaultTo(database.fn.now());
+      t.text('refresh_token').nullable().defaultTo(null);
       t.unique(['provider', 'subject']);
     });
     repo = new OauthIdentitiesRepository(database);
@@ -65,5 +66,46 @@ describe('OauthIdentitiesRepository', () => {
 
     const row = await repo.findByProviderAndSubject('microsoft', 'sub-1');
     expect(row).toBeNull();
+  });
+
+  it('stores the refresh token passed to link', async () => {
+    const userId = await insertUser('user@example.com');
+    await repo.link('apple', 'sub-apple', userId, 'apple-refresh-1');
+
+    const row = await repo.findByProviderAndSubject('apple', 'sub-apple');
+    expect(row).toMatchObject({ refresh_token: 'apple-refresh-1' });
+  });
+
+  it('stores null when link is called without a refresh token', async () => {
+    const userId = await insertUser('user@example.com');
+    await repo.link('apple', 'sub-apple', userId);
+
+    const row = await repo.findByProviderAndSubject('apple', 'sub-apple');
+    expect(row?.refresh_token).toBeNull();
+  });
+
+  it('updates the refresh token for an existing identity', async () => {
+    const userId = await insertUser('user@example.com');
+    await repo.link('apple', 'sub-apple', userId, 'apple-refresh-old');
+
+    await repo.updateRefreshToken('apple', 'sub-apple', 'apple-refresh-new');
+
+    const row = await repo.findByProviderAndSubject('apple', 'sub-apple');
+    expect(row).toMatchObject({ refresh_token: 'apple-refresh-new' });
+  });
+
+  it('reads back the refresh token by user and provider', async () => {
+    const userId = await insertUser('user@example.com');
+    await repo.link('apple', 'sub-apple', userId, 'apple-refresh-2');
+
+    const token = await repo.findRefreshTokenByUserAndProvider(userId, 'apple');
+    expect(token).toBe('apple-refresh-2');
+  });
+
+  it('returns null from findRefreshTokenByUserAndProvider when no identity exists', async () => {
+    const userId = await insertUser('user@example.com');
+
+    const token = await repo.findRefreshTokenByUserAndProvider(userId, 'apple');
+    expect(token).toBeNull();
   });
 });

--- a/src/data_layer/OauthIdentitiesRepository.ts
+++ b/src/data_layer/OauthIdentitiesRepository.ts
@@ -1,5 +1,7 @@
 import { Knex } from 'knex';
 
+import hashToken from '../lib/misc/hashToken';
+import unHashToken from '../lib/misc/unHashToken';
 import OauthIdentities, {
   OauthIdentitiesInitializer,
 } from './public/OauthIdentities';
@@ -30,7 +32,7 @@ class OauthIdentitiesRepository {
       provider,
       subject,
       user_id: userId,
-      refresh_token: refreshToken ?? null,
+      refresh_token: refreshToken ? hashToken(refreshToken) : null,
     };
     await this.database(this.table).insert(row);
   }
@@ -42,7 +44,7 @@ class OauthIdentitiesRepository {
   ): Promise<void> {
     await this.database(this.table)
       .where({ provider, subject })
-      .update({ refresh_token: refreshToken });
+      .update({ refresh_token: hashToken(refreshToken) });
   }
 
   async findRefreshTokenByUserAndProvider(
@@ -54,7 +56,7 @@ class OauthIdentitiesRepository {
         .where({ user_id: userId, provider })
         .select('refresh_token')
         .first();
-    return row?.refresh_token ?? null;
+    return row?.refresh_token ? unHashToken(row.refresh_token) : null;
   }
 }
 

--- a/src/data_layer/OauthIdentitiesRepository.ts
+++ b/src/data_layer/OauthIdentitiesRepository.ts
@@ -23,14 +23,38 @@ class OauthIdentitiesRepository {
   async link(
     provider: string,
     subject: string,
-    userId: UsersId
+    userId: UsersId,
+    refreshToken?: string
   ): Promise<void> {
     const row: OauthIdentitiesInitializer = {
       provider,
       subject,
       user_id: userId,
+      refresh_token: refreshToken ?? null,
     };
     await this.database(this.table).insert(row);
+  }
+
+  async updateRefreshToken(
+    provider: string,
+    subject: string,
+    refreshToken: string
+  ): Promise<void> {
+    await this.database(this.table)
+      .where({ provider, subject })
+      .update({ refresh_token: refreshToken });
+  }
+
+  async findRefreshTokenByUserAndProvider(
+    userId: UsersId,
+    provider: string
+  ): Promise<string | null> {
+    const row: Pick<OauthIdentities, 'refresh_token'> | undefined =
+      await this.database(this.table)
+        .where({ user_id: userId, provider })
+        .select('refresh_token')
+        .first();
+    return row?.refresh_token ?? null;
   }
 }
 

--- a/src/data_layer/public/OauthIdentities.ts
+++ b/src/data_layer/public/OauthIdentities.ts
@@ -17,6 +17,8 @@ export default interface OauthIdentities {
   user_id: UsersId;
 
   created_at: Date;
+
+  refresh_token: string | null;
 }
 
 /** Represents the initializer for the table public.oauth_identities */
@@ -32,6 +34,8 @@ export interface OauthIdentitiesInitializer {
 
   /** Default value: CURRENT_TIMESTAMP */
   created_at?: Date;
+
+  refresh_token?: string | null;
 }
 
 /** Represents the mutator for the table public.oauth_identities */
@@ -45,4 +49,6 @@ export interface OauthIdentitiesMutator {
   user_id?: UsersId;
 
   created_at?: Date;
+
+  refresh_token?: string | null;
 }

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -564,7 +564,9 @@ describe('loginWithApple', () => {
       email: 'user@example.com',
       email_verified: true,
     });
-    mockedAxios.post = jest.fn().mockResolvedValue({ data: { id_token: idToken } });
+    mockedAxios.post = jest.fn().mockResolvedValue({
+      data: { id_token: idToken, refresh_token: 'apple-refresh-001' },
+    });
 
     const service = createService();
     const result = await service.loginWithApple('auth-code');
@@ -573,7 +575,24 @@ describe('loginWithApple', () => {
       subject: 'apple-sub-001',
       email: 'user@example.com',
       emailVerified: true,
+      refreshToken: 'apple-refresh-001',
     });
+  });
+
+  it('returns refreshToken undefined when Apple omits one', async () => {
+    const idToken = signIdToken({
+      iss: 'https://appleid.apple.com',
+      aud: SERVICES_ID,
+      sub: 'apple-sub-001b',
+      email: 'user@example.com',
+      email_verified: true,
+    });
+    mockedAxios.post = jest.fn().mockResolvedValue({ data: { id_token: idToken } });
+
+    const service = createService();
+    const result = await service.loginWithApple('auth-code');
+
+    expect(result).toMatchObject({ subject: 'apple-sub-001b', refreshToken: undefined });
   });
 
   it('accepts email_verified as the string "true"', async () => {
@@ -781,6 +800,66 @@ describe('loginWithApple algorithm pin', () => {
     const result = await service.loginWithApple('auth-code');
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('revokeAppleToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.APPLE_CLIENT_ID = 'com.example.2anki';
+    process.env.APPLE_TEAM_ID = 'TEAMID1234';
+    process.env.APPLE_KEY_ID = 'KEYID56789';
+    const { privateKey: sk } = crypto.generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+    process.env.APPLE_PRIVATE_KEY_B64 = Buffer.from(
+      sk.export({ type: 'pkcs8', format: 'pem' }) as string
+    ).toString('base64');
+  });
+
+  it('posts the refresh token to the Apple revoke endpoint', async () => {
+    mockedAxios.post = jest.fn().mockResolvedValue({ status: 200, data: {} });
+
+    const service = createService();
+    const result = await service.revokeAppleToken('apple-refresh-xyz');
+
+    expect(result).toBe(true);
+    const call = (mockedAxios.post as jest.Mock).mock.calls[0];
+    expect(call[0]).toBe('apple_login');
+    expect(call[1]).toBe('https://appleid.apple.com/auth/revoke');
+    expect(call[2]).toContain('token=apple-refresh-xyz');
+    expect(call[2]).toContain('token_type_hint=refresh_token');
+  });
+
+  it('treats a 400 from Apple (already revoked) as success', async () => {
+    const axiosError = Object.assign(new Error('bad request'), {
+      isAxiosError: true,
+      response: { status: 400 },
+    });
+    mockedAxios.post = jest.fn().mockRejectedValue(axiosError);
+
+    const service = createService();
+    const result = await service.revokeAppleToken('apple-refresh-xyz');
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false on an unexpected error', async () => {
+    mockedAxios.post = jest.fn().mockRejectedValue(new Error('network down'));
+
+    const service = createService();
+    const result = await service.revokeAppleToken('apple-refresh-xyz');
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when APPLE_CLIENT_ID is missing', async () => {
+    delete process.env.APPLE_CLIENT_ID;
+    mockedAxios.post = jest.fn();
+
+    const service = createService();
+    const result = await service.revokeAppleToken('apple-refresh-xyz');
+
+    expect(result).toBe(false);
+    expect(mockedAxios.post).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -1,6 +1,7 @@
 import qs from 'querystring';
 import crypto from 'crypto';
 
+import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { OAuth2Client } from 'google-auth-library';
@@ -54,6 +55,7 @@ const APPLE_JWKS_URL = 'https://appleid.apple.com/auth/keys';
 const APPLE_JWKS_TTL_MS = 60 * 60 * 1000;
 const APPLE_ISSUER = 'https://appleid.apple.com';
 const APPLE_TOKEN_URL = 'https://appleid.apple.com/auth/token';
+const APPLE_REVOKE_URL = 'https://appleid.apple.com/auth/revoke';
 
 interface AppleJwk {
   kid: string;
@@ -427,7 +429,11 @@ class AuthenticationService {
         redirect_uri: APPLE_REDIRECT_URI,
         grant_type: 'authorization_code',
       };
-      const result = await instrumentedAxios.post<{ id_token: string }>(
+      const result = await instrumentedAxios.post<{
+        id_token: string;
+        refresh_token?: string;
+        access_token?: string;
+      }>(
         'apple_login',
         APPLE_TOKEN_URL,
         qs.stringify(values),
@@ -436,6 +442,10 @@ class AuthenticationService {
         }
       );
       const idToken = result.data.id_token;
+      const refreshToken =
+        typeof result.data.refresh_token === 'string'
+          ? result.data.refresh_token
+          : undefined;
       const decoded = jwt.decode(idToken, { complete: true });
       if (!decoded || typeof decoded === 'string') {
         return undefined;
@@ -473,11 +483,38 @@ class AuthenticationService {
         typeof payload.email === 'string' && payload.email.length > 0
           ? payload.email
           : undefined;
-      return { subject, email, emailVerified: true as const };
+      return { subject, email, emailVerified: true as const, refreshToken };
     } catch (error) {
       console.info("Couldn't login with Apple");
       console.error(error);
       return undefined;
+    }
+  }
+
+  async revokeAppleToken(refreshToken: string): Promise<boolean> {
+    const clientId = process.env.APPLE_CLIENT_ID;
+    if (!clientId) {
+      return false;
+    }
+    try {
+      const clientSecret = this.mintAppleClientSecret();
+      const values = {
+        client_id: clientId,
+        client_secret: clientSecret,
+        token: refreshToken,
+        token_type_hint: 'refresh_token',
+      };
+      await instrumentedAxios.post('apple_login', APPLE_REVOKE_URL, qs.stringify(values), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+      return true;
+    } catch (error) {
+      const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+      if (status === 400 || status === 401) {
+        return true;
+      }
+      console.info("Couldn't revoke Apple token", { status: status ?? 'unknown' });
+      return false;
     }
   }
 


### PR DESCRIPTION
## What
When a user deletes their account, we now revoke their Sign in with Apple token against Apple's `/auth/revoke` endpoint. To make that possible, we capture and store the Apple `refresh_token` returned during the OAuth code exchange (it was previously discarded).

## Why
Sign in with Apple requires apps to revoke a user's tokens when their account is deleted (App Store / Apple developer requirement). Refs #2695, tracked under #3021. The deletion route existed but never revoked, and the refresh token needed for revocation was never stored — so storage had to come first.

## How
- **Apple-scope verification (the riskiest assumption):** the code-exchange in `loginWithApple` uses `grant_type: authorization_code`. Apple returns a `refresh_token` on that grant independent of the requested `name email` scope (scope governs id_token claims, not refresh-token issuance). The token was simply being thrown away by a `{ id_token: string }`-only response type. Storage will be populated, not perpetually null. Confirmed by widening the response type and capturing the field.
- Migration adds a nullable `refresh_token TEXT` column to `oauth_identities` (non-locking, no backfill; rollback drops the column). `OauthIdentities.ts` regenerated by running kanel against the real migrated schema (not hand-edited).
- `AuthenticationService.loginWithApple` returns `refreshToken`; the sign-in handler stores it on link and rotates it on re-login via `updateRefreshToken`. Native Apple sign-in has no refresh token, so it stores null.
- **Encrypted at rest (security-review finding, Medium):** the refresh token is stored as AES ciphertext using the same `THE_HASHING_SECRET`-backed `hashToken`/`unHashToken` round-trip the Notion OAuth token already uses, rather than plaintext. `link`/`updateRefreshToken` encrypt on write; `findRefreshTokenByUserAndProvider` decrypts on read so the revoke path still receives the raw token. Column stays `TEXT` (ciphertext is text) — no migration or kanel change.
- New `AuthenticationService.revokeAppleToken(refreshToken)` POSTs `client_id`/`client_secret`/`token`/`token_type_hint=refresh_token` form-encoded to `/auth/revoke` through `instrumentedAxios` (the `appleid.apple.com` host is already on the SSRF allowlist; no allowlist change). 400/401 (already revoked) is treated as success. The token and client secret are never logged.
- `deleteAccount` looks up the Apple refresh token before `deleteUser` (the row cascades on delete) and revokes best-effort — any failure is logged sanitized and never blocks deletion.

## Measuring success
On account deletion for an Apple user, look for the outbound-call record in observability: `service=apple_login`, `endpoint=appleid.apple.com/auth/revoke`. A `200` (or a `400/401` already-revoked) means the revoke landed. The absence of `Couldn't revoke Apple token` info logs alongside successful deletions confirms the path is healthy.

## Testing
- Unit tests added:
  - `AuthenticationService`: `loginWithApple` returns `refreshToken` (present and absent); `revokeAppleToken` posts the token to the revoke endpoint, treats 400 as success, returns false on unexpected error, returns false when `APPLE_CLIENT_ID` is unset.
  - `UsersControllers`: refresh token stored on link when present, rotated on existing identity, omitted (undefined) when Apple returns none; `deleteAccount` revokes before deleting, skips revoke when no token, and still completes deletion when revoke throws.
  - `OauthIdentitiesRepository` (real knex/sqlite schema with the new column): link encrypts the token at rest, the link round-trip returns the raw token, `updateRefreshToken` rotates and re-encrypts it, the stored value is never the raw token, `findRefreshTokenByUserAndProvider` decrypts on read and returns null when absent.
- Server `tsc --noEmit` clean; 155 tests pass across the three files (the encryption change split one repository test into encrypt-at-rest + round-trip).

## Browser check
Browser check: not applicable — no `web/src/` changes (server-only: auth service, controller, repository, migration).

## Changelog
No entry — internal compliance change. Users won't notice token revocation behavior; account deletion already worked from their perspective.

## Risks
- **Auth + external API path** — `/security-review` must run before merge (auth + Apple API integration). Flagging it here as pending.
- **Apple-scope assumption** — if Apple ever stopped returning a `refresh_token` on the authorization_code grant, stored tokens would be null and revoke would no-op (deletion still succeeds). Current behavior confirmed; documented above.
- **Revoke failure is non-blocking by design** — a revoke outage cannot strand a user's deletion. Tradeoff: a token could remain valid at Apple until its natural expiry if revoke fails; logged for follow-up.
- Sonar not run locally (no `SONAR_TOKEN` configured here). Change is small and low-complexity; flagging in case of a maintainability bounce.
- The encrypt-at-rest fix introduces no new control flow (two helper calls + a value-selecting ternary, mirroring the Notion convention), so Sonar maintainability risk on the follow-up commit is low.

## Goal alignment
Compliance work that keeps Sign in with Apple — a low-friction signup path that feeds the top of the funnel — in good standing with Apple. Losing Apple Sign-in to a policy violation would remove a conversion entry point on the path to 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783104866&installation_id=132681956&pr_number=3059&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3059&signature=8e8557833f73efe4c27139ad41ef738b478ba4eb0efba1664caa99034b8d9e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
