### PR TITLE
fix: correct PDF-questions copy to name Claude, not Vertex AI

### DIFF
--- a/src/controllers/CardOptionsController/supportedOptions.ts
+++ b/src/controllers/CardOptionsController/supportedOptions.ts
@@ -119,7 +119,7 @@ const supportedOptions = (): CardOptionDetail[] => {
     new CardOptionDetail(
       'vertex-ai-pdf-questions',
       'Generate questions from PDF uploads',
-      'Use Vertex AI to draft questions from your PDFs. Your content is sent to Google Cloud for processing.',
+      'Drafts questions from your PDF using Claude (Anthropic). Your PDF content is sent to Anthropic for processing.',
       false
     ),
     new CardOptionDetail(

--- a/web/src/pages/DocsPage/content/cards/ai-flashcards.md
+++ b/web/src/pages/DocsPage/content/cards/ai-flashcards.md
@@ -1,6 +1,6 @@
 ---
 title: AI flashcard generation
-description: When 2anki should write the cards for you — Claude for any PDF, Vertex AI for question generation.
+description: When 2anki should write the cards for you — Claude for any PDF, and a PDF-only question generator that also uses Claude.
 ---
 
 Two card options send your source to an AI model instead of running the normal toggle/bullet parser. Use them when your source isn't already shaped like flashcards — long-form PDFs, lecture transcripts, dense study material — and you want the model to pull the question-answer pairs out for you.
@@ -40,15 +40,15 @@ Useful instructions:
 
 Skip instructions like "make great flashcards" or "explain everything" — the model already tries to do that.
 
-## Generate Questions from Single PDF File Uploads (Vertex AI)
+## Generate Questions from Single PDF File Uploads
 
-A narrower option, scoped to single PDFs. Sends the PDF to Google Vertex AI to generate question-and-answer pairs page by page.
+A narrower option, scoped to single PDFs. Sends the PDF to Anthropic Claude to generate question-and-answer pairs page by page.
 
 1. Open the settings panel before uploading.
 2. Switch **Generate Questions from Single PDF File Uploads** on.
 3. Upload a single PDF. ZIPs and Markdown don't use this path.
 
-Use this when you want question generation tuned to a specific page-by-page rhythm, or when Claude's output for a particular textbook looks off. The output runs through the same packaging step, so the resulting `.apkg` opens in Anki just like any other.
+Use this when you want question generation tuned to a specific page-by-page rhythm. The output runs through the same packaging step, so the resulting `.apkg` opens in Anki just like any other.
 
 ## Storage and privacy
 

--- a/web/src/pages/DocsPage/content/cards/card-options.md
+++ b/web/src/pages/DocsPage/content/cards/card-options.md
@@ -72,7 +72,7 @@ Card options change how 2anki turns your source into flashcards. Most are off-or
 | Option | Default | What it does |
 |---|---|---|
 | Process PDF Files | On | Converts PDFs found in ZIP uploads. Turn off to skip PDFs and speed up large archives. |
-| Generate Questions from Single PDF File Uploads | Off | Sends the PDF to Google Vertex AI to generate questions. Paid; sends content to Google Cloud. |
+| Generate Questions from Single PDF File Uploads | Off | Sends the PDF to Anthropic Claude to generate questions. Paid; sends content to Anthropic. |
 | Generate Flashcards with Claude AI | Off | Sends content to Anthropic Claude and uses its output as the deck. Paid. |
 | User instructions | — | Free-form prompt sent to Claude when **Generate Flashcards with Claude AI** is on. Example: *"Focus on USMLE high-yield. Skip the introduction."* |
 | Convert Image Quiz HTML to Anki Cards | Off | Uses OCR to pull image-and-answer pairs from HTML quizzes. Premium experimental. |

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-pdf-questions-claude.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-pdf-questions-claude.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-pdf-questions-claude",
+  "date": "2026-06-03",
+  "type": "fix",
+  "title": "PDF question generation shows that it sends your content to Claude (Anthropic), not Google Cloud"
+}


### PR DESCRIPTION
## What
The "Generate questions from PDF uploads" card option (setting key `vertex-ai-pdf-questions`) told users their content was sent to **Google Vertex AI / Google Cloud**. The code path actually sends it to **Anthropic Claude** — `convertPDFToHTML.ts` calls `getAnthropicClient()` + `convertWithClaude`, and no Google Cloud SDK exists anywhere in the repo. This corrects the user-facing label, description, and docs to name the real processor. The persisted setting key is left unchanged.

## Why
Misleading, privacy-relevant disclosure: we told users their PDF content went to Google when it goes to Anthropic. Corrects the processor disclosure so users can make an informed choice about where their study material is sent. Ties to the privacy-accuracy work in #3057 / #2074.

User-visible outcome: the PDF question-generation option and its docs now accurately state that content goes to Claude (Anthropic), not Google Cloud.

## How
- `src/controllers/CardOptionsController/supportedOptions.ts` — corrected the option's description text. **Setting key `vertex-ai-pdf-questions` is unchanged** (it's persisted in users' stored settings and parsed in `CardOption.ts` as `vertexAIPDFQuestions`; renaming it would break stored settings and the parse). Only human-facing text changed.
- `web/src/pages/DocsPage/content/cards/card-options.md` — table row now says "Sends the PDF to Anthropic Claude … sends content to Anthropic."
- `web/src/pages/DocsPage/content/cards/ai-flashcards.md` — frontmatter description, the section heading, and body text now name Claude; removed a now-meaningless "when Claude's output looks off" comparison (both options use Claude).
- The internal `(vertex)` log label in `PrepareDeck.ts` is **left as-is** — it's not user-facing.

## Measuring success
This is a copy correction, not a behavior change, so there's no metric to watch. Confirmation is visual: the Card options docs and the option description render "Anthropic / Claude" with no "Vertex" or "Google Cloud" anywhere user-facing. `grep -rin "vertex\|google cloud" src web/src` returns only the persisted key, the internal log label, the bug-report key list, and an unrelated privacy.md frontmatter TODO.

## Testing
- No new unit test: this is a string-only change. The existing `CardOptionsController.test.ts` references the setting **key** (`vertex-ai-pdf-questions`), which is unchanged, so it still passes. The changelog loader test passes (id unique, filename matches, JSON valid).
- Verified server tsc clean (only a pre-existing `highlight.js` module-resolution error present on clean main in this env), web tsc clean.

## Browser check
Browser check: not applicable — the only `web/src` changes are docs-content Markdown (rendered text) and a changelog JSON entry; no component/logic change, no console-affecting code.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-03-pdf-questions-claude.json` — "PDF question generation shows that it sends your content to Claude (Anthropic), not Google Cloud" (`type: fix`). Privacy-relevant correction to what users are told about where their data goes.

## Risks
Very low — copy-only. The persisted setting key and all runtime behavior are untouched, so existing users' saved settings keep working. Rollback is a one-commit revert.

Note: `sonar-scanner` was not run — no scanner/token in this environment and the change is a single string literal plus docs/JSON, which falls under the doc/typo skip criterion in `.claude/rules/sonar.md`.

## Goal alignment
Trust is a conversion input. Telling users their study material goes to a processor that it doesn't reach is a privacy-accuracy defect; correcting it keeps the product honest about data handling, which matters for the self-directed learners we're trying to grow past 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783106006&installation_id=132681956&pr_number=3060&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3060&signature=4471b8cd3063ab3bc591adbe924c9e0181cde64919ea3d789b8fe280c27b6dd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->