### PR TITLE
feat: make another deck CTA on upload-success and downloads

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -60,6 +60,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_skipped',
   'onboarding_completed',
   'apkg_csv_exported',
+  'make_another_deck_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/analytics/events.make-another-deck.test.ts
+++ b/web/src/lib/analytics/events.make-another-deck.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { KNOWN_EVENTS } from './events';
+
+describe('make_another_deck_clicked event', () => {
+  it('is in the web allowlist', () => {
+    expect(KNOWN_EVENTS.has('make_another_deck_clicked')).toBe(true);
+  });
+
+  it('is in the server allowlist', () => {
+    const serverSource = readFileSync(
+      join(__dirname, '../../../../src/types/AnalyticsEvents.ts'),
+      'utf8'
+    );
+    expect(serverSource).toContain("'make_another_deck_clicked'");
+  });
+});

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -46,6 +46,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_skipped',
   'onboarding_completed',
   'apkg_csv_exported',
+  'make_another_deck_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/analytics/fireAnalyticsEvent.ts
+++ b/web/src/lib/analytics/fireAnalyticsEvent.ts
@@ -1,7 +1,8 @@
 export type ConversionEventName =
   | 'upload_started'
   | 'conversion_success'
-  | 'deck_downloaded';
+  | 'deck_downloaded'
+  | 'make_another_deck_clicked';
 
 interface AnalyticsWindow {
   hj?: (...args: unknown[]) => void;

--- a/web/src/pages/DownloadsPage/DownloadsPage.module.css
+++ b/web/src/pages/DownloadsPage/DownloadsPage.module.css
@@ -173,6 +173,12 @@
   color: var(--color-text-secondary);
 }
 
+.makeAnotherDeck {
+  display: flex;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
 .upgradeFooter a {
   color: var(--color-primary);
   font-weight: var(--font-medium);

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { DownloadsPage, renderJobStatusCell } from './DownloadsPage';
@@ -630,5 +630,93 @@ describe('DownloadsPage cancel_during_generating telemetry', () => {
       (c) => c.url === '/api/events/track' && c.body?.name === 'cancel_during_generating'
     );
     expect(analyticsCall).toBeUndefined();
+  });
+});
+
+describe('DownloadsPage make another deck CTA', () => {
+  let fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+
+  function LocationDisplay() {
+    const location = useLocation();
+    return <div data-testid="location-display">{location.pathname}</div>;
+  }
+
+  const renderWithLocation = () =>
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <MemoryRouter initialEntries={['/downloads']}>
+          <Routes>
+            <Route path="/downloads" element={<DownloadsPage setError={vi.fn()} />} />
+            <Route path="/upload" element={<LocationDisplay />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-03T12:00:00Z'));
+    fetchCalls = [];
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    globalThis.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (typeof url === 'string') {
+        try {
+          fetchCalls.push({ url, body: JSON.parse((init?.body as string) ?? '{}') });
+        } catch { /* ignore */ }
+      }
+      return Promise.resolve(new Response(null, { status: 200 }));
+    });
+    localStorage.clear();
+    mockUploads = [];
+    mockDropboxUploads = [];
+    mockGoogleDriveUploads = [];
+    mockJobs = [
+      buildJob({
+        status: 'done',
+        type: 'page',
+        title: 'Pharmacology Ch. 4',
+        download_key: 'deck-abc123.apkg',
+      }),
+    ];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    localStorage.clear();
+    delete (globalThis as AnalyticsGlobals).hj;
+    delete (globalThis as AnalyticsGlobals).gtag;
+  });
+
+  it('hides the CTA until a deck is downloaded', () => {
+    renderWithLocation();
+    expect(
+      screen.queryByRole('button', { name: 'Make another deck' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the CTA after a deck download fires', () => {
+    renderWithLocation();
+    fireEvent.click(screen.getByLabelText('Download Pharmacology Ch. 4'));
+    expect(
+      screen.getByRole('button', { name: 'Make another deck' })
+    ).toBeInTheDocument();
+  });
+
+  it('fires make_another_deck_clicked and navigates to /upload on click', () => {
+    const gtag = (globalThis as AnalyticsGlobals).gtag!;
+    renderWithLocation();
+    fireEvent.click(screen.getByLabelText('Download Pharmacology Ch. 4'));
+    fireEvent.click(screen.getByRole('button', { name: 'Make another deck' }));
+
+    expect(gtag).toHaveBeenCalledWith('event', 'make_another_deck_clicked');
+    const trackCall = fetchCalls.find(
+      (c) => c.url === '/api/events/track' && c.body?.name === 'make_another_deck_clicked'
+    );
+    expect(trackCall).toBeDefined();
+    expect(screen.getByTestId('location-display').textContent).toBe('/upload');
   });
 });

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import { useSearchParams, Link } from 'react-router-dom';
+import { useSearchParams, Link, useNavigate } from 'react-router-dom';
 
 import useUploads from './hooks/useUploads';
 import useJobs from './hooks/useJobs';
@@ -242,6 +242,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
   const [expandedFailureJobId, setExpandedFailureJobId] = useState<number | string | null>(null);
   const [mappingModalJob, setMappingModalJob] = useState<JobResponse | null>(null);
   const [hasDownloaded, setHasDownloaded] = useState(false);
+  const navigate = useNavigate();
 
   const rawFilter = searchParams.get('filter') ?? 'all';
   const activeFilter: FilterValue = VALID_FILTERS.has(rawFilter as FilterValue)
@@ -644,6 +645,22 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                   </div>
                 )}
               </div>
+
+              {hasDownloaded && (
+                <div className={styles.makeAnotherDeck}>
+                  <button
+                    type="button"
+                    className={sharedStyles.btnSecondary}
+                    onClick={() => {
+                      fireAnalyticsEvent('make_another_deck_clicked');
+                      track('make_another_deck_clicked');
+                      navigate('/upload');
+                    }}
+                  >
+                    Make another deck
+                  </button>
+                </div>
+              )}
 
               {showDeckFeedback && <DeckFeedbackPrompt />}
 

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -840,6 +840,44 @@ describe('UploadForm analytics events', () => {
     expect(calls).toHaveLength(0);
   });
 
+  it('fires make_another_deck_clicked when the success-state button is clicked', async () => {
+    const { track } = await import('../../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    const gtag = (globalThis as AnalyticsGlobals).gtag!;
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': 'attachment; filename="deck.apkg"',
+        'X-Card-Count': '5',
+      }),
+      blob: () => Promise.resolve(new Blob(['fake'])),
+    }));
+
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    const button = await screen.findByRole('button', { name: 'Make another deck' });
+    expect(button.className).toMatch(/btnSecondary/);
+
+    trackMock.mockClear();
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(gtag).toHaveBeenCalledWith('event', 'make_another_deck_clicked');
+    const clickedCalls = trackMock.mock.calls.filter(
+      ([name]) => name === 'make_another_deck_clicked'
+    );
+    expect(clickedCalls).toHaveLength(1);
+  });
+
   it('suppresses the uploaded filename in success copy from Hotjar recordings', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       redirected: false,

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -818,8 +818,12 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       <UpsellCard surface="upload_success_upsell" hideForAnonymous />
       <button
         type="button"
-        className={formStyles.actionButton}
-        onClick={resetForm}
+        className={sharedStyles.btnSecondary}
+        onClick={() => {
+          fireAnalyticsEvent('make_another_deck_clicked');
+          track('make_another_deck_clicked');
+          resetForm();
+        }}
       >
         Make another deck
       </button>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-make-another-deck.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-make-another-deck.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-make-another-deck",
+  "date": "2026-06-03",
+  "type": "feature",
+  "title": "Make another deck — a one-click button after a download to start your next deck"
+}


### PR DESCRIPTION
## What
Bumps the existing "Make another deck" button on the upload-success surface from a filled-primary reset link to secondary weight, and adds a matching "Make another deck" CTA on the DownloadsPage success surface that appears once a download has fired and navigates to /upload. Both clicks fire a new `make_another_deck_clicked` analytics event.

## Why
30d cohort: 1-deck users convert paid at 4.2%; 2+-deck users convert at 14.5% (~3.5x). The journey previously ended at download with no one-click path to deck #2. This gives users that path at both natural moments — just after generation, and on the downloads list.

This is workstream A of the second-deck nudge (smallest, churn-safe). Workstream B ships separately; the email nudge (C) is deferred.

## How
- `UploadForm.tsx`: success-state "Make another deck" button now uses `sharedStyles.btnSecondary` instead of the filled-primary `actionButton`; the click handler fires `make_another_deck_clicked` before `resetForm()`. Label unchanged.
- `DownloadsPage.tsx`: new CTA gated on `hasDownloaded`, rendered alongside the upsell/feedback success area, using the same secondary button style. Click fires the event and `navigate('/upload')` — no reattach state is seeded (fresh deck, not a retry).
- `make_another_deck_clicked` added to both `KNOWN_EVENTS` allowlists (web `events.ts` for `track` typing, server `AnalyticsEvents.ts` for the `/api/events/track` validator) and to `ConversionEventName` so `fireAnalyticsEvent` accepts it. One event name, two call sites — intentional, to count the nudge in aggregate.

## Measuring success
30d-cohort share of distinct users with at least 2 `deck_downloaded` events: query the `events` table where `name='deck_downloaded'`, group by `user_id`, count distinct users with count >= 2, divide by distinct downloaders. Leading indicator: volume of `make_another_deck_clicked` events (the click that precedes a second upload). Both surfaces emit the same event name, so the aggregate count is the metric; surface-level attribution is intentionally not split in v1.

## Testing
Unit tests added:
- `events.make-another-deck.test.ts` — asserts `make_another_deck_clicked` is in the web allowlist and present in the server `AnalyticsEvents.ts` source (mirrors the existing activation-event test pattern).
- `DownloadsPage.test.tsx` — CTA hidden before download, shown after a download fires, and on click fires `make_another_deck_clicked` (gtag + `/api/events/track`) and navigates to `/upload` (asserted via a `useLocation` route catcher).
- `UploadForm.test.tsx` — extends the success-state coverage to assert the button carries the `btnSecondary` class and that clicking it fires `make_another_deck_clicked` once.

Local `/check` (run under Node 22.20.0, per `.nvmrc`): server tsc clean, web typecheck clean, web Biome lint clean, full web Vitest suite 1649/1649 green.

Note on Sonar: `sonar-scanner` is not installed locally and `SONAR_TOKEN` is unset in this environment, so I did not run SonarCloud's rule engine before pushing — expect the analysis to run on CI. The change is small (one class swap, one event line in three files, one button plus a 3-line handler), so cognitive-complexity / nesting risk is low, but flagging the skip per the rule rather than going silent.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Alexander to verify before merge — the agent did not run the dev server. Please check: (1) generate a deck, see the success state, confirm "Make another deck" now reads as a secondary button and clicking it resets the form; (2) on /downloads after clicking a download, confirm the "Make another deck" CTA appears and routes to /upload.

## Risks
Low. No data-layer or migration changes. If the new event name is somehow rejected server-side, analytics fail silently (the `track` helper swallows fetch errors) and the buttons still work. Rollback is a straight revert of this single commit.

Shared-file note: `src/types/AnalyticsEvents.ts` is also touched by workstream B (which adds its own event line). This PR adds only `make_another_deck_clicked`; if B lands first, the merge is a one-line append with no conflict beyond ordering.

## Goal alignment
Directly targets the 300K-user goal's conversion lever: the trio's data shows second-deck users convert paid at ~3.5x the rate of one-deck users. Making deck #2 a one-click follow-on at the two highest-intent moments is the cheapest way to move users into the higher-converting cohort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783106484&installation_id=132681956&pr_number=3062&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3062&signature=643828bfa0b05edf4f1574ce7d800845c28d5301745064afacd971d87be5844e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
