### PR TITLE
feat: recent sources on upload page for one-click second deck

### DIFF
--- a/src/controllers/Upload/DropboxController.test.ts
+++ b/src/controllers/Upload/DropboxController.test.ts
@@ -36,6 +36,7 @@ function makeController(
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn().mockResolvedValue([]),
     getLastUploadForUser: jest.fn().mockResolvedValue(null),
+    getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
   };
   const notionRepository: INotionRepository = {
     getNotionData: jest.fn().mockResolvedValue({ owner: 1, token: '...' } as NotionTokens),

--- a/src/controllers/Upload/GoogleDriveController.test.ts
+++ b/src/controllers/Upload/GoogleDriveController.test.ts
@@ -35,6 +35,7 @@ function makeController(
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn().mockResolvedValue([]),
     getLastUploadForUser: jest.fn().mockResolvedValue(null),
+    getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
   };
   const notionRepository: INotionRepository = {
     getNotionData: jest.fn().mockResolvedValue({ owner: 1, token: '...' } as NotionTokens),

--- a/src/controllers/Upload/RecentSourcesController.test.ts
+++ b/src/controllers/Upload/RecentSourcesController.test.ts
@@ -1,0 +1,45 @@
+import { Request, Response } from 'express';
+
+import { RecentSourcesController } from './RecentSourcesController';
+import type { GetRecentSourcesUseCase } from '../../usecases/uploads/GetRecentSourcesUseCase';
+
+function buildMocks(sources: unknown[]) {
+  const useCase = {
+    execute: jest.fn().mockResolvedValue(sources),
+  } as unknown as GetRecentSourcesUseCase;
+  const controller = new RecentSourcesController(useCase);
+  const res = {
+    locals: { owner: 7 },
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  return { useCase, controller, res };
+}
+
+describe('RecentSourcesController.get', () => {
+  it('returns 200 with the use-case DTOs for the authenticated user', async () => {
+    const dto = {
+      id: 'page-1',
+      title: 'A page',
+      type: 'notion',
+      updatedAt: '2026-06-02T00:00:00.000Z',
+      convertUrl: '/preview/page-1',
+    };
+    const { controller, useCase, res } = buildMocks([dto]);
+
+    await controller.get({} as Request, res);
+
+    expect(useCase.execute).toHaveBeenCalledWith(7);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ sources: [dto] });
+  });
+
+  it('returns 200 with an empty list when there are no sources', async () => {
+    const { controller, res } = buildMocks([]);
+
+    await controller.get({} as Request, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ sources: [] });
+  });
+});

--- a/src/controllers/Upload/RecentSourcesController.ts
+++ b/src/controllers/Upload/RecentSourcesController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+
+import { GetRecentSourcesUseCase } from '../../usecases/uploads/GetRecentSourcesUseCase';
+
+export class RecentSourcesController {
+  constructor(private readonly useCase: GetRecentSourcesUseCase) {}
+
+  async get(_req: Request, res: Response): Promise<void> {
+    const userId = res.locals.owner as number;
+    const sources = await this.useCase.execute(userId);
+    res.status(200).json({ sources });
+  }
+}

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -74,6 +74,9 @@ describe('Upload file', () => {
       getLastUploadForUser: function (_userId: number) {
         return Promise.resolve(null);
       },
+      getLastReconvertibleUpload: function (_userId: number) {
+        return Promise.resolve(null);
+      },
     };
     const notionRepository: INotionRepository = {
       getNotionData: function (owner: string | number): Promise<NotionTokens> {
@@ -150,6 +153,7 @@ describe('Upload file — multer error handling', () => {
       findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
       update: jest.fn().mockResolvedValue([]),
       getLastUploadForUser: jest.fn().mockResolvedValue(null),
+      getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
     };
     const notionRepository: INotionRepository = {
       getNotionData: jest.fn() as INotionRepository['getNotionData'],

--- a/src/data_layer/NotionTopLevelPagesRepository.sql.test.ts
+++ b/src/data_layer/NotionTopLevelPagesRepository.sql.test.ts
@@ -1,0 +1,16 @@
+import knex from 'knex';
+
+import NotionTopLevelPagesRepository from './NotionTopLevelPagesRepository';
+
+describe('NotionTopLevelPagesRepository.getRecentByOwner generated SQL', () => {
+  it('orders by last_edited_time desc nulls last then cached_at desc and limits', () => {
+    const pg = knex({ client: 'pg' });
+    const repo = new NotionTopLevelPagesRepository(pg);
+
+    const sql = (repo.getRecentByOwner(7, 3) as unknown as { toString(): string }).toString();
+
+    expect(sql).toBe(
+      'select * from "notion_top_level_pages" where "owner" = 7 order by last_edited_time desc nulls last, "cached_at" desc limit 3'
+    );
+  });
+});

--- a/src/data_layer/NotionTopLevelPagesRepository.ts
+++ b/src/data_layer/NotionTopLevelPagesRepository.ts
@@ -13,6 +13,7 @@ export interface NotionTopLevelPageRow {
 
 export interface INotionTopLevelPagesRepository {
 	getByOwner(owner: number): Promise<NotionTopLevelPageRow[]>;
+	getRecentByOwner(owner: number, limit: number): Promise<NotionTopLevelPageRow[]>;
 	newestCachedAt(owner: number): Promise<Date | null>;
 	replaceForOwnerIfTokenStillValid(
 		owner: number,
@@ -34,6 +35,18 @@ export class NotionTopLevelPagesRepository
 		return this.database(this.tableName)
 			.where({ owner })
 			.orderBy("title", "asc")
+			.select<NotionTopLevelPageRow[]>("*");
+	}
+
+	getRecentByOwner(
+		owner: number,
+		limit: number,
+	): Promise<NotionTopLevelPageRow[]> {
+		return this.database(this.tableName)
+			.where({ owner })
+			.orderByRaw("last_edited_time desc nulls last")
+			.orderBy("cached_at", "desc")
+			.limit(limit)
 			.select<NotionTopLevelPageRow[]>("*");
 	}
 

--- a/src/data_layer/UploadRespository.sql.test.ts
+++ b/src/data_layer/UploadRespository.sql.test.ts
@@ -1,0 +1,20 @@
+import knex from 'knex';
+
+describe('UploadRepository.getLastReconvertibleUpload generated SQL', () => {
+  it('filters apkg keys with a bound parameter and orders by created_at desc', () => {
+    const pg = knex({ client: 'pg' });
+
+    const sql = pg('uploads')
+      .select('key', 'filename', 'created_at')
+      .where({ owner: 7 })
+      .whereNotNull('filename')
+      .whereRaw('lower(key) like ?', ['%.apkg'])
+      .orderBy('created_at', 'desc')
+      .first()
+      .toString();
+
+    expect(sql).toBe(
+      'select "key", "filename", "created_at" from "uploads" where "owner" = 7 and "filename" is not null and lower(key) like \'%.apkg\' order by "created_at" desc limit 1'
+    );
+  });
+});

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -6,6 +6,12 @@ export interface LastUpload {
   created_at: Date;
 }
 
+export interface LastReconvertibleUpload {
+  key: string;
+  filename: string;
+  created_at: Date;
+}
+
 export interface IUploadRepository {
   deleteUpload(owner: number, key: string): Promise<number>;
   getUploadsByOwner(owner: number): Promise<Uploads[]>;
@@ -22,6 +28,9 @@ export interface IUploadRepository {
     size_mb: number
   ): Promise<Uploads[]>;
   getLastUploadForUser(userId: number): Promise<LastUpload | null>;
+  getLastReconvertibleUpload(
+    userId: number
+  ): Promise<LastReconvertibleUpload | null>;
 }
 class UploadRepository implements IUploadRepository {
   private readonly table = 'uploads';
@@ -108,6 +117,29 @@ class UploadRepository implements IUploadRepository {
       return null;
     }
     return { filename: row.filename, created_at: row.created_at };
+  }
+
+  async getLastReconvertibleUpload(
+    userId: number
+  ): Promise<LastReconvertibleUpload | null> {
+    if (userId == null) {
+      return null;
+    }
+    const row = await this.database<Uploads>(this.table)
+      .select('key', 'filename', 'created_at')
+      .where({ owner: userId })
+      .whereNotNull('filename')
+      .whereRaw('lower(key) like ?', ['%.apkg'])
+      .orderBy('created_at', 'desc')
+      .first();
+    if (row == null || row.filename == null || row.created_at == null) {
+      return null;
+    }
+    return {
+      key: row.key,
+      filename: row.filename,
+      created_at: row.created_at,
+    };
   }
 }
 

--- a/src/routes/UploadRouter.ts
+++ b/src/routes/UploadRouter.ts
@@ -23,6 +23,9 @@ import { DeleteDropboxUploadUseCase } from '../usecases/uploads/DeleteDropboxUpl
 import { GetGoogleDriveUploadsUseCase } from '../usecases/uploads/GetGoogleDriveUploadsUseCase';
 import { DeleteGoogleDriveUploadUseCase } from '../usecases/uploads/DeleteGoogleDriveUploadUseCase';
 import DeleteJobUseCase from '../usecases/jobs/DeleteJobUseCase';
+import NotionTopLevelPagesRepository from '../data_layer/NotionTopLevelPagesRepository';
+import { GetRecentSourcesUseCase } from '../usecases/uploads/GetRecentSourcesUseCase';
+import { RecentSourcesController } from '../controllers/Upload/RecentSourcesController';
 
 const UploadRouter = () => {
   const router = express.Router();
@@ -40,6 +43,12 @@ const UploadRouter = () => {
   );
   const dropboxRepository = new DropboxRepository(database);
   const googleDriveRepository = new GoogleDriveRepository(database);
+  const recentSourcesController = new RecentSourcesController(
+    new GetRecentSourcesUseCase(
+      new NotionTopLevelPagesRepository(database),
+      new UploadRepository(database)
+    )
+  );
   const uploadController = new UploadController(
     uploadService,
     new NotionService(
@@ -240,6 +249,52 @@ const UploadRouter = () => {
    */
   router.get('/api/upload/mine', RequireAuthentication, (req, res) =>
     uploadController.getUploads(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/upload/recent-sources:
+   *   get:
+   *     summary: Get the user's recent re-convertible sources
+   *     description: Returns up to 3 recent Notion top-level pages and the user's last re-convertible upload, sorted by recency descending. Powers the Recent section on the upload page so deck #2 is one click.
+   *     tags: [Upload]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     responses:
+   *       200:
+   *         description: Recent sources retrieved successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 sources:
+   *                   type: array
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       id:
+   *                         type: string
+   *                       title:
+   *                         type: string
+   *                       type:
+   *                         type: string
+   *                         enum: [notion, remote_upload]
+   *                       updatedAt:
+   *                         type: string
+   *                         format: date-time
+   *                       convertUrl:
+   *                         type: string
+   *       401:
+   *         description: Authentication required
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   */
+  router.get('/api/upload/recent-sources', RequireAuthentication, (req, res) =>
+    recentSourcesController.get(req, res)
   );
 
   /**

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -84,6 +84,7 @@ function buildRepository(): IUploadRepository {
     update: (_owner: number, _filename: string, _key: string, _size_mb: number) =>
       Promise.resolve([] as Uploads[]),
     getLastUploadForUser: (_userId: number) => Promise.resolve(null),
+    getLastReconvertibleUpload: (_userId: number) => Promise.resolve(null),
   };
 }
 

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -62,6 +62,7 @@ export const KNOWN_EVENTS = new Set([
   'apkg_csv_exported',
   'make_another_deck_clicked',
   'invite_link_copied',
+  'recent_page_reconvert_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
+++ b/src/usecases/jobs/BuildDeckForJobUseCase.test.ts
@@ -35,6 +35,7 @@ function buildUploadRepository(): jest.Mocked<IUploadRepository> {
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn().mockResolvedValue([]),
     getLastUploadForUser: jest.fn().mockResolvedValue(null),
+    getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
   };
 }
 

--- a/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.test.ts
@@ -34,6 +34,7 @@ function makeUploadRepo(lastUpload: LastUpload | null = null): jest.Mocked<IUplo
     findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
     update: jest.fn(),
     getLastUploadForUser: jest.fn().mockResolvedValue(lastUpload),
+    getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
   };
 }
 

--- a/src/usecases/ops/SendInactivityWarningsUseCase.ts
+++ b/src/usecases/ops/SendInactivityWarningsUseCase.ts
@@ -16,6 +16,7 @@ class NoOpUploadRepository implements IUploadRepository {
   findAllByObjectIdAndOwner(): Promise<never[]> { return Promise.resolve([]); }
   update(): Promise<never[]> { return Promise.resolve([]); }
   getLastUploadForUser(): Promise<null> { return Promise.resolve(null); }
+  getLastReconvertibleUpload(): Promise<null> { return Promise.resolve(null); }
 }
 
 export class SendInactivityWarningsUseCase {

--- a/src/usecases/uploads/GetRecentSourcesUseCase.test.ts
+++ b/src/usecases/uploads/GetRecentSourcesUseCase.test.ts
@@ -1,0 +1,176 @@
+import { GetRecentSourcesUseCase } from './GetRecentSourcesUseCase';
+import type {
+  INotionTopLevelPagesRepository,
+  NotionTopLevelPageRow,
+} from '../../data_layer/NotionTopLevelPagesRepository';
+import type {
+  IUploadRepository,
+  LastReconvertibleUpload,
+} from '../../data_layer/UploadRespository';
+
+function notionPage(
+  overrides: Partial<NotionTopLevelPageRow>
+): NotionTopLevelPageRow {
+  return {
+    owner: 1,
+    notion_page_id: 'page-1',
+    title: 'A page',
+    icon: null,
+    url: null,
+    parent_type: 'workspace',
+    last_edited_time: new Date('2026-06-01T00:00:00.000Z'),
+    cached_at: new Date('2026-06-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function buildUseCase(
+  pages: NotionTopLevelPageRow[],
+  lastUpload: LastReconvertibleUpload | null
+) {
+  const recentByOwner = jest.fn().mockResolvedValue(pages);
+  const notionRepo = {
+    getByOwner: jest.fn(),
+    getRecentByOwner: recentByOwner,
+    newestCachedAt: jest.fn(),
+    replaceForOwnerIfTokenStillValid: jest.fn(),
+    deleteByOwner: jest.fn(),
+  } as unknown as INotionTopLevelPagesRepository;
+
+  const lastReconvertible = jest.fn().mockResolvedValue(lastUpload);
+  const uploadRepo = {
+    deleteUpload: jest.fn(),
+    getUploadsByOwner: jest.fn(),
+    findByIdAndOwner: jest.fn(),
+    findByKey: jest.fn(),
+    findAllByObjectIdAndOwner: jest.fn(),
+    update: jest.fn(),
+    getLastUploadForUser: jest.fn(),
+    getLastReconvertibleUpload: lastReconvertible,
+  } as unknown as IUploadRepository;
+
+  return {
+    useCase: new GetRecentSourcesUseCase(notionRepo, uploadRepo),
+    recentByOwner,
+    lastReconvertible,
+  };
+}
+
+describe('GetRecentSourcesUseCase', () => {
+  it('maps Notion pages to the DTO shape sorted by recency desc', async () => {
+    const { useCase } = buildUseCase(
+      [
+        notionPage({
+          notion_page_id: 'old',
+          title: 'Old page',
+          last_edited_time: new Date('2026-05-01T00:00:00.000Z'),
+        }),
+        notionPage({
+          notion_page_id: 'new',
+          title: 'New page',
+          last_edited_time: new Date('2026-06-02T00:00:00.000Z'),
+        }),
+      ],
+      null
+    );
+
+    const result = await useCase.execute(1);
+
+    expect(result).toEqual([
+      {
+        id: 'new',
+        title: 'New page',
+        type: 'notion',
+        updatedAt: '2026-06-02T00:00:00.000Z',
+        convertUrl: '/preview/new',
+      },
+      {
+        id: 'old',
+        title: 'Old page',
+        type: 'notion',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+        convertUrl: '/preview/old',
+      },
+    ]);
+  });
+
+  it('includes the last reconvertible upload and sorts it by recency', async () => {
+    const { useCase } = buildUseCase(
+      [
+        notionPage({
+          notion_page_id: 'p',
+          title: 'A page',
+          last_edited_time: new Date('2026-05-01T00:00:00.000Z'),
+        }),
+      ],
+      {
+        key: 'user-1/Biochem.apkg',
+        filename: 'Biochem.apkg',
+        created_at: new Date('2026-06-02T00:00:00.000Z'),
+      }
+    );
+
+    const result = await useCase.execute(1);
+
+    expect(result[0]).toEqual({
+      id: 'user-1/Biochem.apkg',
+      title: 'Biochem.apkg',
+      type: 'remote_upload',
+      updatedAt: '2026-06-02T00:00:00.000Z',
+      convertUrl: '/preview/apkg/user-1%2FBiochem.apkg',
+    });
+  });
+
+  it('caps the result at 3 items', async () => {
+    const { useCase } = buildUseCase(
+      [
+        notionPage({ notion_page_id: 'a', last_edited_time: new Date('2026-06-04T00:00:00.000Z') }),
+        notionPage({ notion_page_id: 'b', last_edited_time: new Date('2026-06-03T00:00:00.000Z') }),
+        notionPage({ notion_page_id: 'c', last_edited_time: new Date('2026-06-02T00:00:00.000Z') }),
+      ],
+      {
+        key: 'k.apkg',
+        filename: 'k.apkg',
+        created_at: new Date('2026-06-01T00:00:00.000Z'),
+      }
+    );
+
+    const result = await useCase.execute(1);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns an empty array when there are no sources', async () => {
+    const { useCase } = buildUseCase([], null);
+
+    const result = await useCase.execute(1);
+
+    expect(result).toEqual([]);
+  });
+
+  it('requests at most 3 Notion pages from the repository', async () => {
+    const { useCase, recentByOwner } = buildUseCase([], null);
+
+    await useCase.execute(42);
+
+    expect(recentByOwner).toHaveBeenCalledWith(42, 3);
+  });
+
+  it('falls back to cached_at when last_edited_time is null', async () => {
+    const { useCase } = buildUseCase(
+      [
+        notionPage({
+          notion_page_id: 'p',
+          last_edited_time: null,
+          cached_at: new Date('2026-06-05T00:00:00.000Z'),
+        }),
+      ],
+      null
+    );
+
+    const result = await useCase.execute(1);
+
+    expect(result[0].updatedAt).toBe('2026-06-05T00:00:00.000Z');
+  });
+});

--- a/src/usecases/uploads/GetRecentSourcesUseCase.ts
+++ b/src/usecases/uploads/GetRecentSourcesUseCase.ts
@@ -1,0 +1,69 @@
+import type {
+  INotionTopLevelPagesRepository,
+  NotionTopLevelPageRow,
+} from '../../data_layer/NotionTopLevelPagesRepository';
+import type {
+  IUploadRepository,
+  LastReconvertibleUpload,
+} from '../../data_layer/UploadRespository';
+
+export type RecentSourceType = 'notion' | 'remote_upload';
+
+export interface RecentSourceDto {
+  id: string;
+  title: string;
+  type: RecentSourceType;
+  updatedAt: string;
+  convertUrl: string;
+}
+
+const RECENT_LIMIT = 3;
+
+function toTime(value: Date | null): number {
+  if (value == null) return 0;
+  return new Date(value).getTime();
+}
+
+function notionToDto(row: NotionTopLevelPageRow): RecentSourceDto {
+  const updatedAt = row.last_edited_time ?? row.cached_at;
+  return {
+    id: row.notion_page_id,
+    title: row.title,
+    type: 'notion',
+    updatedAt: new Date(updatedAt).toISOString(),
+    convertUrl: `/preview/${encodeURIComponent(row.notion_page_id)}`,
+  };
+}
+
+function uploadToDto(upload: LastReconvertibleUpload): RecentSourceDto {
+  return {
+    id: upload.key,
+    title: upload.filename,
+    type: 'remote_upload',
+    updatedAt: new Date(upload.created_at).toISOString(),
+    convertUrl: `/preview/apkg/${encodeURIComponent(upload.key)}`,
+  };
+}
+
+export class GetRecentSourcesUseCase {
+  constructor(
+    private readonly notionPages: INotionTopLevelPagesRepository,
+    private readonly uploads: IUploadRepository
+  ) {}
+
+  async execute(userId: number): Promise<RecentSourceDto[]> {
+    const [pages, lastUpload] = await Promise.all([
+      this.notionPages.getRecentByOwner(userId, RECENT_LIMIT),
+      this.uploads.getLastReconvertibleUpload(userId),
+    ]);
+
+    const sources = pages.map(notionToDto);
+    if (lastUpload != null) {
+      sources.push(uploadToDto(lastUpload));
+    }
+
+    return sources
+      .sort((a, b) => toTime(new Date(b.updatedAt)) - toTime(new Date(a.updatedAt)))
+      .slice(0, RECENT_LIMIT);
+  }
+}

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -48,6 +48,7 @@ export const KNOWN_EVENTS = new Set([
   'apkg_csv_exported',
   'make_another_deck_clicked',
   'invite_link_copied',
+  'recent_page_reconvert_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -10,6 +10,7 @@ import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import styles from '../../styles/shared.module.css';
 import { ExploreCard } from './components/ExploreCard/ExploreCard';
 import { OnboardingTour } from './components/OnboardingTour/OnboardingTour';
+import { RecentSources } from './components/RecentSources/RecentSources';
 import UploadForm from './components/UploadForm/UploadForm';
 import pageStyles from './UploadPage.module.css';
 
@@ -224,6 +225,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
         )}
       </div>
       <UploadForm setErrorMessage={setErrorMessage} aiOn={isAiOn} />
+      {isSignedIn && <RecentSources />}
       <ExploreCard />
       <section className={pageStyles.howItWorks}>
         <h2 className={pageStyles.howItWorksHeading}>How it works</h2>

--- a/web/src/pages/UploadPage/components/RecentSources/RecentSources.module.css
+++ b/web/src/pages/UploadPage/components/RecentSources/RecentSources.module.css
@@ -1,0 +1,68 @@
+.section {
+  max-width: 800px;
+  margin: 1.5rem 0 0;
+}
+
+.heading {
+  margin: 0 0 0.5rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.title {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeAgo {
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+.action {
+  flex-shrink: 0;
+  color: var(--color-text-link);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  white-space: nowrap;
+}
+
+.action:hover {
+  color: var(--color-text-link-hover);
+  text-decoration: underline;
+}

--- a/web/src/pages/UploadPage/components/RecentSources/RecentSources.test.tsx
+++ b/web/src/pages/UploadPage/components/RecentSources/RecentSources.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import { RecentSources } from './RecentSources';
+import type { RecentSource } from './getRecentSources';
+
+const trackMock = vi.fn();
+vi.mock('../../../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+const getRecentSourcesMock = vi.fn();
+vi.mock('./getRecentSources', () => ({
+  getRecentSources: () => getRecentSourcesMock(),
+}));
+
+function renderRecentSources() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <RecentSources />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function source(overrides: Partial<RecentSource>): RecentSource {
+  return {
+    id: 'page-1',
+    title: 'Organic Chemistry',
+    type: 'notion',
+    updatedAt: new Date().toISOString(),
+    convertUrl: '/preview/page-1',
+    ...overrides,
+  };
+}
+
+describe('RecentSources', () => {
+  beforeEach(() => {
+    trackMock.mockReset();
+    getRecentSourcesMock.mockReset();
+  });
+
+  it('renders nothing when there are no recent sources', async () => {
+    getRecentSourcesMock.mockResolvedValue([]);
+
+    const { container } = renderRecentSources();
+
+    await waitFor(() => expect(getRecentSourcesMock).toHaveBeenCalled());
+    expect(container.querySelector('section')).toBeNull();
+  });
+
+  it('renders one Convert again link per source', async () => {
+    getRecentSourcesMock.mockResolvedValue([
+      source({ id: 'a', title: 'Anatomy', convertUrl: '/preview/a' }),
+      source({ id: 'b', title: 'Biochem', convertUrl: '/preview/b' }),
+      source({ id: 'c', title: 'Cardiology', convertUrl: '/preview/c' }),
+    ]);
+
+    renderRecentSources();
+
+    const links = await screen.findAllByRole('link', { name: 'Convert again' });
+    expect(links).toHaveLength(3);
+    expect(screen.getByText('Anatomy')).toBeInTheDocument();
+    expect(links[0]).toHaveAttribute('href', '/preview/a');
+  });
+
+  it('fires recent_page_reconvert_clicked with the source type on click', async () => {
+    getRecentSourcesMock.mockResolvedValue([
+      source({ id: 'a', type: 'remote_upload', convertUrl: '/preview/apkg/a' }),
+    ]);
+
+    renderRecentSources();
+
+    const link = await screen.findByRole('link', { name: 'Convert again' });
+    fireEvent.click(link);
+
+    expect(trackMock).toHaveBeenCalledWith('recent_page_reconvert_clicked', {
+      type: 'remote_upload',
+    });
+  });
+});

--- a/web/src/pages/UploadPage/components/RecentSources/RecentSources.tsx
+++ b/web/src/pages/UploadPage/components/RecentSources/RecentSources.tsx
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
+
+import { getDistance } from '../../../../lib/getDistance';
+import { track } from '../../../../lib/analytics/track';
+import { getRecentSources, RecentSource } from './getRecentSources';
+import styles from './RecentSources.module.css';
+
+function RecentSourceRow({ source }: Readonly<{ source: RecentSource }>) {
+  return (
+    <li className={styles.row}>
+      <div className={styles.meta}>
+        <span data-hj-suppress className={styles.title} title={source.title}>
+          {source.title}
+        </span>
+        <span className={styles.timeAgo}>{getDistance(source.updatedAt)} ago</span>
+      </div>
+      <Link
+        to={source.convertUrl}
+        className={styles.action}
+        onClick={() =>
+          track('recent_page_reconvert_clicked', { type: source.type })
+        }
+      >
+        Convert again
+      </Link>
+    </li>
+  );
+}
+
+export function RecentSources() {
+  const { data: sources } = useQuery({
+    queryKey: ['recentSources'],
+    queryFn: getRecentSources,
+  });
+
+  if (sources == null || sources.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={styles.section} aria-label="Recent">
+      <h2 className={styles.heading}>Recent</h2>
+      <ul className={styles.list}>
+        {sources.map((source) => (
+          <RecentSourceRow key={`${source.type}-${source.id}`} source={source} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default RecentSources;

--- a/web/src/pages/UploadPage/components/RecentSources/getRecentSources.ts
+++ b/web/src/pages/UploadPage/components/RecentSources/getRecentSources.ts
@@ -1,0 +1,26 @@
+export type RecentSourceType = 'notion' | 'remote_upload';
+
+export interface RecentSource {
+  id: string;
+  title: string;
+  type: RecentSourceType;
+  updatedAt: string;
+  convertUrl: string;
+}
+
+interface RecentSourcesResponse {
+  sources: RecentSource[];
+}
+
+export async function getRecentSources(): Promise<RecentSource[]> {
+  const response = await globalThis.fetch('/api/upload/recent-sources', {
+    method: 'GET',
+    credentials: 'include',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    return [];
+  }
+  const data = (await response.json()) as RecentSourcesResponse;
+  return Array.isArray(data.sources) ? data.sources : [];
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-03-recent-sources-on-upload.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-03-recent-sources-on-upload.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-03-recent-sources-on-upload",
+  "date": "2026-06-03",
+  "type": "feature",
+  "title": "Recent Notion pages and your last upload sit on the upload page for one-click reconversion"
+}


### PR DESCRIPTION
## What
Adds a `Recent` section below the dropzone on `/upload` showing up to 3 recent Notion top-level pages and the user's last re-convertible upload, each with a single "Convert again" link. Sorted by recency desc. Renders nothing when the list is empty, so first-time users see no extra noise.

## Why
1-deck users convert to paid at ~4.2%; 2+-deck users at ~14.5% (~3.5x). The 30-day cohort shows 235 of 387 signups download one deck, but only ~138 reach a second. The friction to deck #2 is "find the source again" — this removes it by making the second conversion one click. (Workstream B of the second-deck nudge; A is the post-download CTA, C/email is deferred.)

## Backend
- New `GET /api/upload/recent-sources` (route -> `RecentSourcesController` -> `GetRecentSourcesUseCase` -> `NotionTopLevelPagesRepository` + `UploadRepository`).
- Returns `RecentSourceDto[]` (`{ id, title, type: 'notion' | 'remote_upload', updatedAt, convertUrl }`) — no raw rows to the client.
- `getRecentByOwner(owner, 3)` on the Notion repo orders by `last_edited_time desc nulls last, cached_at desc` at the DB level (not in-memory).
- `getLastReconvertibleUpload(userId)` returns the most recent `.apkg` upload (re-convertible one-click via `/preview/apkg/<key>`). Non-apkg uploads need column mapping, so they are omitted from the one-click list per the v1 scope (option a: omit anything not silently re-fetchable).
- Notion rows map their `convertUrl` to the existing `/preview/<id>` route.

## Frontend
- New `web/src/pages/UploadPage/components/RecentSources/` — section renders below the dropzone (gated on `isSignedIn` to avoid a needless 401 fetch for anon visitors). Titles use `data-hj-suppress` and medium weight; relative time via the existing `getDistance` helper.
- Fires `recent_page_reconvert_clicked` (with `type`) on click.

## Measuring success
- New analytics event `recent_page_reconvert_clicked` (added to `KNOWN_EVENTS` server + web). Track its volume vs `deck_downloaded` to see how many second decks start from this surface.
- Endpoint usage: `GET /api/upload/recent-sources` request count in the access log.
- North-star: share of users reaching 2+ downloaded decks in the 30-day cohort.

## Test plan
- [ ] Three Notion pages + last upload show up, sorted by recency
- [ ] Empty state renders nothing (component returns null)
- [ ] Click "Convert again" routes to the source and fires `recent_page_reconvert_clicked`
- [ ] Dropzone is still the visible primary action at 375px

## Testing
- Unit tests added:
  - `GetRecentSourcesUseCase.test.ts` — DTO mapping, recency sort, 3-item cap, empty list, repo limit arg, `cached_at` fallback.
  - `RecentSourcesController.test.ts` — 200 + DTO shape for an authed user, empty list. (401 is handled by `RequireAuthentication` middleware before the controller, matching the existing pattern.)
  - `NotionTopLevelPagesRepository.sql.test.ts` + `UploadRespository.sql.test.ts` — generated-SQL assertions on a real PG-dialect knex (no connection) for the new `orderByRaw` / `whereRaw` queries.
  - `RecentSources.test.tsx` — renders nothing on empty, one link per source, click fires the event.
- Full suites green: server affected tests (61), full web vitest (1646), server + web typecheck, web Biome lint on changed files.
- **Sonar not run locally** — `sonar-scanner` not installed and `SONAR_TOKEN` unset in this environment. Change is small and follows existing patterns (no `any`, leads-with-positive, `== null`); expect low Sonar risk but flag in case of a bounce.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Alexander to verify before merge — agent did not run the dev server.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-03-recent-sources-on-upload.json` — "Recent Notion pages and your last upload sit on the upload page for one-click reconversion"

## Risks
- `getLastReconvertibleUpload` filters by `key like '%.apkg'`; only apkg uploads appear as a re-convertible upload row. Conservative by design — no broken "Convert again" links.
- Shared file `src/types/AnalyticsEvents.ts` is also touched by the parallel workstream A PR (`feat/make-another-deck-cta`). If A merges first, this branch needs a one-line rebase to add my event after theirs. No other overlap.
- Rollback: revert the PR; the endpoint and section are additive and gated on `isSignedIn` + non-empty data.

## Goal alignment
Directly targets the 300K-user goal by lifting paid conversion: the second deck is the strongest paid-conversion signal we have, and this removes the main friction to it. Additive, no change to the first-time upload flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783106802&installation_id=132681956&pr_number=3064&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3064&signature=77c47d69371ac38a42da46a6438db1d5571a1249ee543da22c19dd8512653643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
