### PR TITLE
feat: copy invite link probe on deck-ready screen

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -61,6 +61,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_completed',
   'apkg_csv_exported',
   'make_another_deck_clicked',
+  'invite_link_copied',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -47,6 +47,7 @@ export const KNOWN_EVENTS = new Set([
   'onboarding_completed',
   'apkg_csv_exported',
   'make_another_deck_clicked',
+  'invite_link_copied',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -972,6 +972,106 @@ describe('UploadForm multi-deck batch', () => {
   });
 });
 
+describe('invite link copy', () => {
+  const loggedInData = {
+    user: { id: 1 },
+    locals: {
+      owner: 1,
+      patreon: false,
+      subscriber: false,
+      subscriptionInfo: { active: false, email: '', linked_email: '' },
+    },
+    linked_email: '',
+  } as unknown as ReturnType<typeof useUserLocals>['data'];
+
+  beforeEach(() => {
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    mockUseUserLocals.mockReturnValue({
+      data: loggedInData,
+      isLoading: false,
+      error: null,
+      isError: false,
+      refetch: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis as AnalyticsGlobals).gtag;
+    delete (globalThis as AnalyticsGlobals).hj;
+    vi.restoreAllMocks();
+  });
+
+  function stubSuccessFetch() {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      redirected: false,
+      status: 200,
+      headers: new Headers({
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': 'attachment; filename="deck.apkg"',
+        'X-Card-Count': '5',
+      }),
+      blob: () => Promise.resolve(new Blob(['fake'])),
+    }));
+  }
+
+  async function reachSuccessState() {
+    const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+    await waitFor(() => {
+      expect(container.querySelector('[class*="successPrimary"]')).not.toBeNull();
+    });
+    return container;
+  }
+
+  it('copies the invite link and fires invite_link_copied when a logged-in user clicks', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+    const { track } = await import('../../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    stubSuccessFetch();
+
+    const container = await reachSuccessState();
+    const copyBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Copy invite link'
+    ) as HTMLButtonElement;
+    expect(copyBtn).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(copyBtn);
+    });
+
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('https://2anki.net/');
+      expect(trackMock).toHaveBeenCalledWith('invite_link_copied');
+    });
+  });
+
+  it('does not show the invite link for anonymous users', async () => {
+    mockUseUserLocals.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      isError: false,
+      refetch: vi.fn(),
+    });
+    stubSuccessFetch();
+
+    const container = await reachSuccessState();
+    const copyBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent === 'Copy invite link'
+    );
+    expect(copyBtn).toBeUndefined();
+  });
+});
+
 describe('limit state', () => {
   beforeEach(() => {
     mockGet2ankiApi.mockReturnValue({

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -42,6 +42,8 @@ interface UploadFormProps {
 
 const FORMATS = ['.zip', '.html', '.md', '.pdf', '.epub', 'My Clippings.txt', '.docx', '.xlsx', '.pptx', '.csv', '.opml', '.brainstorms.json'];
 
+const INVITE_LINK = 'https://2anki.net/';
+
 const REJECTED_FALLBACK =
   'The server rejected the upload. Try again or email support@2anki.net.';
 const NETWORK_FALLBACK =
@@ -298,6 +300,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
   const isAuthenticated = userLocals?.user?.id != null;
   const [dayPassPending, setDayPassPending] = useState(false);
   const [dayPassError, setDayPassError] = useState<string | null>(null);
+  const [inviteCopied, setInviteCopied] = useState(false);
   const showSignInPrompt = userLocals != null && !isAuthenticated;
   const cardUsage = useCardUsage(isAuthenticated);
   const isUploadLocked =
@@ -768,6 +771,14 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
     </div>
   );
 
+  const handleCopyInvite = () => {
+    navigator.clipboard.writeText(INVITE_LINK).then(() => {
+      setInviteCopied(true);
+      track('invite_link_copied');
+      setTimeout(() => setInviteCopied(false), 1500);
+    });
+  };
+
   const renderSuccessState = () => (
     <div className={formStyles.stateContent}>
       <CheckCircleIcon className={formStyles.iconSuccess} />
@@ -827,6 +838,15 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       >
         Make another deck
       </button>
+      {isAuthenticated && (
+        <button
+          type="button"
+          className={formStyles.fallbackLink}
+          onClick={handleCopyInvite}
+        >
+          {inviteCopied ? 'Link copied' : 'Copy invite link'}
+        </button>
+      )}
       <div className={formStyles.feedbackPrompt}>
         <p className={formStyles.feedbackLabel}>How was your experience?</p>
         <FeedbackWidget page="/upload" compact />


### PR DESCRIPTION
Ships only the de-risk probe from the closed referral-loop spec (#3008): a bare **Copy invite link** button on the post-conversion success screen. Measures whether users will share at all — before we invest in reward machinery, tables, or attribution.

## What it does
- New quiet tertiary link (`Copy invite link` → `Link copied` 1.5s) on the deck-ready screen, **logged-in users only**, placed last — below the upsell and "Make another deck" so it never competes with the paid pitch.
- Copies `https://2anki.net/` (bare URL — no ref-param; a param that does nothing now is debt the real attribution PR would have to reconcile).
- Fires `invite_link_copied` via the existing `track()` pipe. No backend endpoint change.

## The decision this drives
A copy is the cheapest possible intent signal. The trio set the bar at **~10% copy-rate week 1** to greenlight building the full loop; 5–10% = re-probe with a reward promise; <5% = shelve. Query: count `invite_link_copied` ÷ `conversion_succeeded` over the same window via the `/ops` events surface — zero new instrumentation.

## Why two event lists changed
`invite_link_copied` added to **both** `web/src/lib/analytics/events.ts` (drives the `KnownEvent` union so `track()` compiles) and `src/types/AnalyticsEvents.ts` (server allowlist — without it every copy logs `unknown event` and the row is bucketed `unknown`, polluting the metric). The lists are maintained in parallel and already drift.

## Trio
pm + designer + engineer reviewed in parallel. Conflicts resolved: event name `invite_link_copied` (matches the label, 2:1 over `share_link_copied`); placement last + `.fallbackLink` quiet weight (designer owns hierarchy); inline copy not extracted (not the 3rd same occurrence per code-quality rule).

## Tests
`UploadForm.test.tsx` — logged-in click asserts `navigator.clipboard.writeText('https://2anki.net/')` + `track('invite_link_copied')`; anonymous render asserts the button is absent. Mocks at the external edge only (`track`, clipboard). Full web suite green, web typecheck + Biome clean.

## Notes
- **No changelog entry** — this is an unrewarded measurement probe with no user-facing benefit to announce; per the changelog rules, don't oversell.
- **Sonar not run locally** — `SONAR_TOKEN` not set in shell. Change is a 5-line handler + a button + two data-line additions; no complexity/nesting risk.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px

Notes: verified — logged-in deck-ready screen shows the quiet "Copy invite link" below "Make another deck", click copies https://2anki.net/, label flips to "Link copied".

🤖 Generated with [Claude Code](https://claude.com/claude-code)