### PR TITLE
docs: always print the PR link when a PR goes ready

### DIFF
--- a/.claude/agents/engineer.md
+++ b/.claude/agents/engineer.md
@@ -69,6 +69,8 @@ When given a spec or issue:
 9. **Run `/check`** — parallel tsc + web typecheck + web vitest. Everything green before pushing.
 10. **Open the PR.** Title uses a conventional commit prefix (`fix:`, `feat:`, `chore:`, `refactor:`, `test:`, `docs:`) followed by an imperative summary.
 
+**Always end with the PR link.** Whenever you open a PR or flip one to ready, print the full `https://github.com/2anki/server/pull/<n>` URL as the last line of your reply so Alexander can click straight through.
+
 ### When the work originated from a draft spec PR
 
 `/spec-draft-pr` opens a draft PR on a branch like `feat/spec-<slug>` containing only `Documentation/specs/<slug>.md`. When you start implementation, take that PR over rather than branching again:
@@ -76,7 +78,7 @@ When given a spec or issue:
 - `gh pr checkout <n>` onto the existing branch; do not stack a new branch on top.
 - Commit the implementation on the same branch.
 - Before the final push, `git rm Documentation/specs/<slug>.md` in a `chore: remove implemented spec for …` commit. The spec text stays recoverable via `git log -p -- Documentation/specs/<slug>.md`; we keep the folder lean.
-- `gh pr edit <n> --title "<type>: <feature name>"` and `gh pr ready <n>` to graduate the PR. Replace the body with the engineer template below.
+- `gh pr edit <n> --title "<type>: <feature name>"` and `gh pr ready <n>` to graduate the PR. Replace the body with the engineer template below. Print the PR link (`https://github.com/2anki/server/pull/<n>`) as the last line of your reply.
 
 Before considering a task done, remove any scaffolding, debug logs, or temporary code added during implementation.
 

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -42,6 +42,7 @@ When `$ARGUMENTS` is a PR number or URL (or you can find a draft PR titled `spec
    gh pr ready <n>
    ```
    Update the PR body to the engineer template in `.claude/agents/engineer.md` (What / Why / How / Measuring success / Testing / Risks / Goal alignment). Keep the link to the trio synthesis if it was useful.
+10. **Print the PR link.** Once the PR is ready, end your reply with the full `https://github.com/2anki/server/pull/<n>` URL as the last line so Alexander can click straight through.
 
 Before merging:
 - All checks green.
@@ -58,7 +59,7 @@ If `$ARGUMENTS` is a raw spec (pasted body or a path to a `.md` file with no ass
 1. Read the spec.
 2. Follow the engineer workflow above.
 3. Suggest a branch name. Format: `<type>/<short-slug>` using a conventional commit prefix (`fix/`, `feat/`, `chore/`, `refactor/`, `test/`). Do **not** use `docs/` for an implementation branch.
-4. Once confirmed, create the branch, commit in logical chunks. If the work changes user-visible behavior, add a changelog entry per CLAUDE.md > Changelog (separate `chore: add changelog entry …` commit). If the work adds or changes a user-visible feature (stricter than the changelog trigger — see step 7 of the primary path), also update the in-app user docs under `web/src/pages/DocsPage/content/` and register any new MDX page in `web/src/pages/DocsPage/sidebar.ts`, in a separate `docs: update user docs …` commit. Run `/check`, then open the PR (not draft) with `gh pr create` using the engineer template.
+4. Once confirmed, create the branch, commit in logical chunks. If the work changes user-visible behavior, add a changelog entry per CLAUDE.md > Changelog (separate `chore: add changelog entry …` commit). If the work adds or changes a user-visible feature (stricter than the changelog trigger — see step 7 of the primary path), also update the in-app user docs under `web/src/pages/DocsPage/content/` and register any new MDX page in `web/src/pages/DocsPage/sidebar.ts`, in a separate `docs: update user docs …` commit. Run `/check`, then open the PR (not draft) with `gh pr create` using the engineer template. End your reply with the full `https://github.com/2anki/server/pull/<n>` URL as the last line.
 
 In this path there is no spec file in the repo to remove — skip the spec-cleanup commit.
 


### PR DESCRIPTION
## What
The engineer agent and `/implement` command now end their reply with the full `https://github.com/2anki/server/pull/<n>` URL whenever a PR is opened or flipped to ready.

## Why
Alexander asked for the PR link every time a PR is ready, so it's one click away instead of buried in the reply.

## How
Added a standing "print the PR link" instruction at each PR-finalizing point in `.claude/agents/engineer.md` (step 10 + the spec-takeover graduate step) and `.claude/commands/implement.md` (primary + fallback paths). `spec-draft-pr.md` already returned the URL.

## Testing
Docs-only; no code change.

## Risks
None — instruction text in `.claude/`.

## Goal alignment
Tightens the ship loop; no direct user impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783108528&installation_id=132681956&pr_number=3067&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3067&signature=b8664f3beb6fa91a36be8d5a6be19e0cbcf87cf56947e874232e9d2cbd490b03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->