### PR TITLE
feat: source-aware subscription management on account page

### DIFF
--- a/src/routes/middleware/configureUserLocal.test.ts
+++ b/src/routes/middleware/configureUserLocal.test.ts
@@ -1,5 +1,6 @@
 import { configureUserLocal } from './configureUserLocal';
 import { InMemoryAnonymousPassRepository } from '../../data_layer/AnonymousPassRepository';
+import { InMemoryUserPassRepository } from '../../data_layer/UserPassRepository';
 import type { Request, Response } from 'express';
 
 function makeRes(): Response {
@@ -57,5 +58,128 @@ describe('configureUserLocal — anonymous pass token', () => {
     await configureUserLocal(req, res, noOpAuthService, noDatabase, anonRepo, now);
 
     expect(res.locals.subscriber).toBeUndefined();
+  });
+});
+
+describe('configureUserLocal — planSource', () => {
+  const now = new Date('2026-06-01T12:00:00Z');
+  const futureExpiry = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+  function makeAuthService(opts: { patreon: boolean; isSubscriber: boolean }) {
+    return {
+      getUserFrom: async () => ({
+        owner: 1,
+        email: 'learner@example.com',
+        patreon: opts.patreon,
+        chat_consent_at: null,
+      }),
+      getIsSubscriber: async () => opts.isSubscriber,
+      getSubscriptionInfo: async () => null,
+    } as never;
+  }
+
+  it("sets planSource 'apple' for an active apple:-prefixed unlimited pass with no Stripe sub", async () => {
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const userPassRepo = new InMemoryUserPassRepository();
+    userPassRepo.seed({
+      user_id: 1,
+      kind: 'unlimited',
+      expires_at: futureExpiry,
+      stripe_payment_intent_id: 'apple:txn_123',
+    });
+
+    const req = makeReq({}, { token: 't' });
+    const res = makeRes();
+
+    await configureUserLocal(
+      req,
+      res,
+      makeAuthService({ patreon: false, isSubscriber: false }),
+      noDatabase,
+      anonRepo,
+      now,
+      undefined,
+      userPassRepo
+    );
+
+    expect(res.locals.subscriber).toBe(true);
+    expect(res.locals.planSource).toBe('apple');
+  });
+
+  it("sets planSource 'stripe' when an active Stripe sub exists even if a pass is present", async () => {
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const userPassRepo = new InMemoryUserPassRepository();
+    userPassRepo.seed({
+      user_id: 1,
+      kind: 'unlimited',
+      expires_at: futureExpiry,
+      stripe_payment_intent_id: 'apple:txn_123',
+    });
+
+    const req = makeReq({}, { token: 't' });
+    const res = makeRes();
+
+    await configureUserLocal(
+      req,
+      res,
+      makeAuthService({ patreon: true, isSubscriber: true }),
+      noDatabase,
+      anonRepo,
+      now,
+      undefined,
+      userPassRepo
+    );
+
+    expect(res.locals.subscriber).toBe(true);
+    expect(res.locals.planSource).toBe('stripe');
+  });
+
+  it("sets planSource 'lifetime' for a patreon-only user with no sub and no pass", async () => {
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const userPassRepo = new InMemoryUserPassRepository();
+
+    const req = makeReq({}, { token: 't' });
+    const res = makeRes();
+
+    await configureUserLocal(
+      req,
+      res,
+      makeAuthService({ patreon: true, isSubscriber: false }),
+      noDatabase,
+      anonRepo,
+      now,
+      undefined,
+      userPassRepo
+    );
+
+    expect(res.locals.planSource).toBe('lifetime');
+  });
+
+  it('sets planSource null for a non-apple 24h pass with no sub and no patreon', async () => {
+    const anonRepo = new InMemoryAnonymousPassRepository();
+    const userPassRepo = new InMemoryUserPassRepository();
+    userPassRepo.seed({
+      user_id: 1,
+      kind: '24h',
+      expires_at: futureExpiry,
+      stripe_payment_intent_id: 'pi_stripe_daypass',
+    });
+
+    const req = makeReq({}, { token: 't' });
+    const res = makeRes();
+
+    await configureUserLocal(
+      req,
+      res,
+      makeAuthService({ patreon: false, isSubscriber: false }),
+      noDatabase,
+      anonRepo,
+      now,
+      undefined,
+      userPassRepo
+    );
+
+    expect(res.locals.subscriber).toBe(true);
+    expect(res.locals.planSource).toBeNull();
   });
 });

--- a/src/routes/middleware/configureUserLocal.ts
+++ b/src/routes/middleware/configureUserLocal.ts
@@ -1,13 +1,38 @@
 import { Request, Response } from 'express';
 import AuthenticationService from '../../services/AuthenticationService';
 import { Knex } from 'knex';
-import UserPassRepository from '../../data_layer/UserPassRepository';
+import UserPassRepository, {
+  IUserPassRepository,
+  UserPass,
+} from '../../data_layer/UserPassRepository';
 import {
   IAnonymousPassRepository,
   AnonymousPassRepository,
 } from '../../data_layer/AnonymousPassRepository';
 import { ValidateAnonymousPassUseCase } from '../../usecases/checkout/ValidateAnonymousPassUseCase';
 import { getStripe } from '../../lib/integrations/stripe';
+
+export type PlanSource = 'stripe' | 'apple' | 'lifetime' | null;
+
+function resolvePlanSource(
+  isSubscriber: boolean,
+  activePass: UserPass | null,
+  patreon: boolean
+): PlanSource {
+  if (isSubscriber) {
+    return 'stripe';
+  }
+  if (
+    activePass?.kind === 'unlimited' &&
+    activePass.stripe_payment_intent_id.startsWith('apple:')
+  ) {
+    return 'apple';
+  }
+  if (patreon === true) {
+    return 'lifetime';
+  }
+  return null;
+}
 
 function resolveStripe() {
   const key = process.env.STRIPE_KEY;
@@ -24,7 +49,8 @@ export async function configureUserLocal(
   database: Knex,
   anonPassRepo?: IAnonymousPassRepository,
   now?: Date,
-  validateAnonymousPass?: ValidateAnonymousPassUseCase
+  validateAnonymousPass?: ValidateAnonymousPassUseCase,
+  userPassRepo?: IUserPassRepository
 ) {
   const user = await authService.getUserFrom(req.cookies.token);
   if (user) {
@@ -33,15 +59,21 @@ export async function configureUserLocal(
     res.locals.patreon = user.patreon;
     res.locals.chat_consent_at = user.chat_consent_at ?? null;
     const isSubscriber = await authService.getIsSubscriber(database, user.email);
+    let activePass: UserPass | null = null;
     if (isSubscriber) {
       res.locals.subscriber = true;
     } else {
-      const passRepo = new UserPassRepository(database);
-      const activePass = await passRepo.findActive(user.owner, now ?? new Date());
+      const passRepo = userPassRepo ?? new UserPassRepository(database);
+      activePass = await passRepo.findActive(user.owner, now ?? new Date());
       res.locals.subscriber = activePass != null;
       res.locals.passExpiresAt = activePass?.expires_at.toISOString() ?? null;
       res.locals.passKind = activePass?.kind ?? null;
     }
+    res.locals.planSource = resolvePlanSource(
+      isSubscriber,
+      activePass,
+      user.patreon === true
+    );
     res.locals.subscriptionInfo = await authService.getSubscriptionInfo(
       database,
       user.email

--- a/web/src/lib/backend/getUserLocals.ts
+++ b/web/src/lib/backend/getUserLocals.ts
@@ -14,6 +14,7 @@ interface GetUserLocalsResponse {
     };
     passExpiresAt?: string | null;
     passKind?: '24h' | '7d' | 'unlimited' | null;
+    planSource?: 'stripe' | 'apple' | 'lifetime' | null;
   };
   linked_email: string;
   user?: Users & {

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { SubscriptionManagement } from './SubscriptionManagement';
+import type { StripeSubscriptionsState } from '../../../lib/hooks/useStripeSubscriptions';
+
+vi.mock('../../../lib/hooks/useStripeSubscriptions', () => ({
+  useStripeSubscriptions: vi.fn(),
+}));
+
+import { useStripeSubscriptions } from '../../../lib/hooks/useStripeSubscriptions';
+
+const mockUseStripeSubscriptions = useStripeSubscriptions as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+const user = { email: 'learner@example.com', name: 'Learner' };
+
+function withQueryClient(ui: ReactNode) {
+  const client = new QueryClient();
+  return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+function stubStripeActive() {
+  mockUseStripeSubscriptions.mockReturnValue({
+    subscriptions: [],
+    view: {
+      kind: 'active',
+      subscription: {
+        id: 'sub_1',
+        status: 'active',
+        cancel_at_period_end: false,
+        current_period_end: 1893456000,
+        cancel_at: null,
+        canceled_at: null,
+        plan: { amount: 1000, currency: 'usd', interval: 'month' },
+      },
+    },
+    isLoading: false,
+    refetch: vi.fn().mockResolvedValue(undefined),
+  } as unknown as StripeSubscriptionsState);
+}
+
+describe('SubscriptionManagement', () => {
+  beforeEach(() => {
+    mockUseStripeSubscriptions.mockReset();
+  });
+
+  it("shows Apple management copy and no Stripe controls for planSource 'apple'", () => {
+    render(
+      <SubscriptionManagement
+        user={user}
+        locals={{ subscriber: true, planSource: 'apple' }}
+        hasActivePlan
+        onRefetch={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByText(/Billed through Apple/)).toBeTruthy();
+    expect(screen.getByText(/Apple Account settings/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Cancel at period end' })).toBeNull();
+    expect(screen.queryByLabelText('Subscription email')).toBeNull();
+    expect(mockUseStripeSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it("shows lifetime copy and no controls for planSource 'lifetime'", () => {
+    render(
+      <SubscriptionManagement
+        user={user}
+        locals={{ subscriber: true, planSource: 'lifetime' }}
+        hasActivePlan
+        onRefetch={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByText(/Lifetime access/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Cancel at period end' })).toBeNull();
+    expect(screen.queryByLabelText('Subscription email')).toBeNull();
+    expect(mockUseStripeSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it("renders the existing Stripe controls for planSource 'stripe'", () => {
+    stubStripeActive();
+
+    render(
+      withQueryClient(
+        <SubscriptionManagement
+          user={user}
+          locals={{ subscriber: true, planSource: 'stripe' }}
+          hasActivePlan
+          onRefetch={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel at period end' })).toBeTruthy();
+    expect(mockUseStripeSubscriptions).toHaveBeenCalledWith(true);
+  });
+
+  it('renders existing Stripe controls when planSource is unset (safe default)', () => {
+    stubStripeActive();
+
+    render(
+      withQueryClient(
+        <SubscriptionManagement
+          user={user}
+          locals={{ subscriber: true }}
+          hasActivePlan
+          onRefetch={vi.fn().mockResolvedValue(undefined)}
+        />
+      )
+    );
+
+    expect(screen.getByRole('button', { name: 'Cancel at period end' })).toBeTruthy();
+    expect(mockUseStripeSubscriptions).toHaveBeenCalledWith(true);
+  });
+
+  it('renders nothing when the user is not a subscriber', () => {
+    const { container } = render(
+      <SubscriptionManagement
+        user={user}
+        locals={{ subscriber: false }}
+        hasActivePlan={false}
+        onRefetch={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockUseStripeSubscriptions).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -14,6 +14,7 @@ interface User {
 
 interface LocalsData {
   subscriber?: boolean;
+  planSource?: 'stripe' | 'apple' | 'lifetime' | null;
   subscriptionInfo?: {
     linked_email?: string;
     email?: string;
@@ -46,7 +47,46 @@ const formatPlan = (sub: StripeSubscriptionSummary): string | null => {
   return plan.interval ? `${price} / ${plan.interval}` : price;
 };
 
-export function SubscriptionManagement({
+function AppleSubscriptionManagement() {
+  return (
+    <section className={styles.section}>
+      <p className={styles.statusLine}>Unlimited · Billed through Apple</p>
+      <p className={sharedStyles.smallDescription}>
+        Manage or cancel this subscription in your Apple Account settings: open
+        Settings on your iPhone or iPad, tap your name, then Subscriptions.
+      </p>
+    </section>
+  );
+}
+
+function LifetimeSubscriptionManagement() {
+  return (
+    <section className={styles.section}>
+      <p className={styles.statusLine}>Lifetime access</p>
+      <p className={sharedStyles.smallDescription}>No renewal, no billing.</p>
+    </section>
+  );
+}
+
+export function SubscriptionManagement(props: SubscriptionManagementProps) {
+  const { locals } = props;
+
+  if (!locals?.subscriber) {
+    return null;
+  }
+
+  if (locals.planSource === 'apple') {
+    return <AppleSubscriptionManagement />;
+  }
+
+  if (locals.planSource === 'lifetime') {
+    return <LifetimeSubscriptionManagement />;
+  }
+
+  return <StripeSubscriptionManagement {...props} />;
+}
+
+function StripeSubscriptionManagement({
   user,
   locals,
   hasActivePlan,


### PR DESCRIPTION
## What
Adds `res.locals.planSource` (`'stripe' | 'apple' | 'lifetime' | null`) in `configureUserLocal`, and branches the account page's `SubscriptionManagement` on it: Apple subscribers see Apple-settings management copy with no Stripe controls; lifetime users see lifetime copy with no controls; Stripe and null/unset render the existing screen unchanged.

## Why
Fast-follow to #2971 (Apple IAP). Today the account screen drives every plan through the Stripe cancel + email-link flow. That's wrong for an Apple subscription — cancellation lives in Apple Account settings, not Stripe — and noise for lifetime access, which has no billing to manage. This must land before the iOS app ships to the App Store; otherwise the first Apple subscriber lands on a screen offering Stripe cancel buttons that can't touch their Apple-billed subscription.

## How
- `configureUserLocal` computes `planSource` once with explicit precedence **stripe > apple > lifetime** (resolved across the trio): a real Stripe subscription (`getIsSubscriber`) always wins so a cancellable recurring charge is never hidden; an `apple:`-prefixed **unlimited** pass (the prefix is written into `stripe_payment_intent_id` by `RedeemAppleTransactionUseCase`) maps to `'apple'`; `patreon === true` maps to `'lifetime'`; everything else — including non-Apple Day/Week passes — falls to `null`, leaving current behavior unchanged.
- No new query, endpoint, or migration. The pass row already returns from `findActive`. The Apple branch requires both the `apple:` prefix **and** `kind === 'unlimited'`, so an Apple consumable Day/Week pass does not get the (wrong) recurring-subscription Apple copy — it falls to `null`.
- The Stripe-subscriber branch skips the pass lookup entirely (planSource is `'stripe'` regardless), so there's no added DB read on that hot path.
- Frontend: `SubscriptionManagement` is now a thin dispatcher with early returns (no nested ternaries) that renders `AppleSubscriptionManagement` / `LifetimeSubscriptionManagement` (pure, hook-free) or delegates to the unchanged `StripeSubscriptionManagement`. The Apple/lifetime branches never call `useStripeSubscriptions` or the email-link/cancellation hooks.
- `planSource` is mapped to an explicit typed locals field on the client (`getUserLocals.ts`); the raw pass row is never sent.

## Measuring success
After the iOS app ships, an Apple subscriber loading `/account` hits `users/debug/locals` and the response carries `locals.planSource: "apple"`. Confirm via the `users/debug/locals` payload (or a prod psql check that a user with an `apple:`-prefixed `unlimited` row in `user_passes` and no active Stripe sub resolves to `'apple'`). Until then the change is invisible to all existing users — every current path resolves to `'stripe'` or `null`.

## Testing
- Server (`configureUserLocal.test.ts`): apple:-prefixed unlimited pass → `'apple'`; active Stripe sub with a pass present → `'stripe'` (precedence); patreon-only → `'lifetime'`; non-Apple `24h` pass → `null`. Uses `InMemoryUserPassRepository` + injected `now`, outside-in.
- Web (`SubscriptionManagement.test.tsx`): `'apple'` → Apple copy, no "Cancel at period end" button, no email-link input, `useStripeSubscriptions` not called; `'lifetime'` → lifetime copy, no controls; `'stripe'` and unset → existing controls render with `useStripeSubscriptions(true)`; non-subscriber → renders nothing.
- `/check`: server tsc, web typecheck, full web vitest (1660 passed), web lint all green.
- Sonar: `sonar-scanner` is installed but `SONAR_TOKEN` is unset locally — not run. Change is small and uses early returns (no nesting/complexity), so a bounce is unlikely; flagging so reviewers can expect it if it surfaces.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Apple/lifetime branches are not reachable by any existing user (see Changelog). Visual check should confirm the Stripe path is unchanged.

## Changelog
No entry. The `'lifetime'` branch is **not reachable** by existing users today: `getIsSubscriber` checks only the `subscriptions` table, not `patreon`, so a patreon-only user gets `locals.subscriber = false` and `SubscriptionManagement` returns null before the lifetime branch can render. The `'apple'` branch is only reachable by Apple subscribers, of which none exist until the iOS app ships. Matching #2971's reasoning — no user-visible change lands with this PR.

## Risks
- A non-Apple user incorrectly seeing Apple copy would require a `user_passes` row with `kind = 'unlimited'` **and** an `apple:`-prefixed `stripe_payment_intent_id`; that prefix is written only by `RedeemAppleTransactionUseCase`, so no collision with Stripe consumables (which carry real `pi_`/`cs_` IDs).
- `planSource` is a display hint only — it gates no entitlement and the frontend's safe default (null/stripe → existing screen) means a missing or unexpected value can never hide a real Stripe user's cancel button. Rollback is a clean revert; no migration.

## Goal alignment
Removes a dead-end on the account screen for Apple subscribers — the right cancel path instead of Stripe buttons that can't touch an Apple-billed sub. Required groundwork for the iOS app's App Store launch, which opens a mobile acquisition channel toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783110018&installation_id=132681956&pr_number=3069&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3069&signature=945e553c33f7aaf181b5bb0d4a6e1b7a27ce84b77740424e22467eb2e1aa9fc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
