### PR TITLE
chore: do not dump menus, execute mechanical glue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Every PR is checked against both — does it make the experience simpler/faster/
 - First push of a new branch: if the `pre-push` hook blocks with a WIP/false-positive warning on an otherwise-clean branch, re-run with `git push -u origin <branch> --no-verify` (the hook false-positives on a new branch's first push; only bypass when the branch is genuinely clean).
 - Touching auth, payments, or external-API integration? Run `/security-review` before merge.
 - After merge, clean up local: `git checkout main && git pull --ff-only`, confirm the PR is `MERGED` via `gh pr view <branch> --json state`, then `git branch -D <branch>` (squash-merges leave the tip unreachable from main, so `-d` refuses). `git fetch --prune origin` drops stale remote-tracking refs; `git worktree list` then `git worktree remove <path>` (or `git worktree prune` if the dir is already gone) clears unused worktrees.
+- **When Alexander asks to check out a PR, just do it.** Run `gh pr checkout <n>` yourself. If `gh` complains the branch is `already used by worktree at .claude/worktrees/agent-*`, that's an agent worktree from a previous run — the PR is already on the remote, the agent's local copy is redundant. Unlock + remove it (`git worktree unlock <path> && git worktree remove <path>`), then re-run `gh pr checkout <n>`. Do not return a menu of options for Alexander to copy-paste — pick the right answer and execute it.
 - GitHub issues for follow-ups that need cross-cutting visibility, labels, or contributor pickup. Commit bodies for inline scope notes that travel with the change.
 
 ## Working speed
@@ -75,6 +76,7 @@ Every PR is checked against both — does it make the experience simpler/faster/
 ## Process
 
 - Surface assumptions before coding. If a request has multiple valid interpretations, present them — don't pick silently. If something is unclear, stop and ask. If a simpler approach exists, say so.
+- **Execute, don't menu.** "Multiple interpretations" applies to *what* to do; it does not license menus of *how to do it*. When the answer is a sequence of mechanical sub-steps with one obvious right path (resolve a worktree conflict on `gh pr checkout`, drop two named stashes after a wave merges, run `pnpm install` before a dev server) — pick the right path and execute. A response that hands Alexander "option A vs option B" for mechanical glue is a failure mode. Reserve confirmation for destructive/irreversible steps (force-push, branch -D on unmerged work, anything in the `Executing actions with care` list).
 - Every changed line should trace directly to the user's request. If a diff includes lines that don't connect back to what was asked, remove them before committing.
 - TDD by default: failing test → verify it fails for the right reason → simplest pass → refactor. If asked to skip tests, confirm first.
 - Outside-in testing. Mock only external dependencies (HTTP, third-party APIs, email) — never internal services.


### PR DESCRIPTION
## What
Adds two CLAUDE.md rules surfaced by today's friction with Claude Code:

1. **Git** — when Alexander asks to check out a PR, do it. Resolve the agent-worktree conflict (`already used by worktree at .claude/worktrees/agent-*`) by removing the stale worktree, then re-run `gh pr checkout`. Don't return a copy-paste menu.
2. **Process** — "multiple interpretations" applies to *what* to build, not to a menu of *how to do it*. When sub-steps have one obvious right path, execute. Reserve confirmation for destructive/irreversible steps.

## Why
Both happened in the same session. After PR #3068 the engineer-agent worktree still held `fix/notion-block-render-gaps`, so `gh pr checkout 3068` failed. The response was a two-option menu of `cd into the worktree` vs `unlock + remove + checkout`. That's exactly the kind of menu Alexander shouldn't have to read — there's one right answer, pick it.

## How
Two single-line additions to CLAUDE.md, in the relevant sections so future runs hit them in context.

## Test plan
- [ ] Next session, asked to check out a PR whose branch is held by an agent worktree: assistant unlocks + removes the worktree, runs `gh pr checkout`, reports the new branch.
- [ ] No menus for mechanical glue (stash drops, dev-server port conflicts, lockfile re-runs).

No changelog entry — internal-only docs change, no user-visible behavior.

`Browser check: not applicable — CLAUDE.md edit, no web/src/ change.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783110225&installation_id=132681956&pr_number=3071&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3071&signature=5f285bd77e0eae3a9717df1aa28f50d35fdc4d1958725e5f351481a3df88bfcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->