### PR TITLE
feat: persist client-supplied upload source on async uploads

### DIFF
--- a/migrations/20260902000000_add_source_to_uploads.js
+++ b/migrations/20260902000000_add_source_to_uploads.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.alterTable('uploads', (t) => {
+    t.text('source').nullable().defaultTo(null);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('uploads', (t) => {
+    t.dropColumn('source');
+  });
+};

--- a/src/data_layer/UploadRespository.sql.test.ts
+++ b/src/data_layer/UploadRespository.sql.test.ts
@@ -1,4 +1,37 @@
 import knex from 'knex';
+import UploadRepository from './UploadRespository';
+
+describe('UploadRepository.update generated SQL', () => {
+  it('inserts the source column alongside the existing upload fields', () => {
+    const pg = knex({ client: 'pg' });
+    const repo = new UploadRepository(pg);
+
+    const sql = (
+      repo.update(7, 'deck.apkg', 'key/deck.apkg', 1.5, 'app') as unknown as {
+        toString(): string;
+      }
+    ).toString();
+
+    expect(sql).toBe(
+      'insert into "uploads" ("filename", "key", "owner", "size_mb", "source") values (\'deck.apkg\', \'key/deck.apkg\', 7, 1.5, \'app\')'
+    );
+  });
+
+  it('inserts a null source when none is supplied', () => {
+    const pg = knex({ client: 'pg' });
+    const repo = new UploadRepository(pg);
+
+    const sql = (
+      repo.update(7, 'deck.apkg', 'key/deck.apkg', 1.5) as unknown as {
+        toString(): string;
+      }
+    ).toString();
+
+    expect(sql).toBe(
+      'insert into "uploads" ("filename", "key", "owner", "size_mb", "source") values (\'deck.apkg\', \'key/deck.apkg\', 7, 1.5, NULL)'
+    );
+  });
+});
 
 describe('UploadRepository.getLastReconvertibleUpload generated SQL', () => {
   it('filters apkg keys with a bound parameter and orders by created_at desc', () => {

--- a/src/data_layer/UploadRespository.ts
+++ b/src/data_layer/UploadRespository.ts
@@ -1,5 +1,6 @@
 import { Knex } from 'knex';
 import Uploads from './public/Uploads';
+import { UploadSource } from '../lib/upload/validateUploadSource';
 
 export interface LastUpload {
   filename: string;
@@ -25,7 +26,8 @@ export interface IUploadRepository {
     owner: number,
     filename: string,
     key: string,
-    size_mb: number
+    size_mb: number,
+    source?: UploadSource | null
   ): Promise<Uploads[]>;
   getLastUploadForUser(userId: number): Promise<LastUpload | null>;
   getLastReconvertibleUpload(
@@ -96,13 +98,15 @@ class UploadRepository implements IUploadRepository {
     owner: number,
     filename: string,
     key: string,
-    size_mb: number
+    size_mb: number,
+    source: UploadSource | null = null
   ): Promise<Uploads[]> {
     return this.database(this.table).insert({
       owner,
       filename,
       key,
       size_mb,
+      source,
     });
   }
 

--- a/src/data_layer/public/Uploads.ts
+++ b/src/data_layer/public/Uploads.ts
@@ -19,6 +19,8 @@ export default interface Uploads {
   size_mb: number | null;
 
   created_at: Date | null;
+
+  source: string | null;
 }
 
 /** Represents the initializer for the table public.uploads */
@@ -38,6 +40,8 @@ export interface UploadsInitializer {
 
   /** Default value: CURRENT_TIMESTAMP */
   created_at?: Date | null;
+
+  source?: string | null;
 }
 
 /** Represents the mutator for the table public.uploads */
@@ -55,4 +59,6 @@ export interface UploadsMutator {
   size_mb?: number | null;
 
   created_at?: Date | null;
+
+  source?: string | null;
 }

--- a/src/lib/upload/validateUploadSource.test.ts
+++ b/src/lib/upload/validateUploadSource.test.ts
@@ -1,0 +1,31 @@
+import { validateUploadSource } from './validateUploadSource';
+
+describe('validateUploadSource', () => {
+  it.each(['app', 'web', 'dropbox', 'google_drive'])(
+    'returns %s unchanged when it is on the allowlist',
+    (value) => {
+      expect(validateUploadSource(value)).toBe(value);
+    }
+  );
+
+  it('returns null for an unknown string', () => {
+    expect(validateUploadSource('mobile')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(validateUploadSource('')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(validateUploadSource(undefined)).toBeNull();
+    expect(validateUploadSource(null)).toBeNull();
+    expect(validateUploadSource(42)).toBeNull();
+    expect(validateUploadSource(['app'])).toBeNull();
+    expect(validateUploadSource({ source: 'app' })).toBeNull();
+  });
+
+  it('does not trim or normalize casing before matching', () => {
+    expect(validateUploadSource(' app ')).toBeNull();
+    expect(validateUploadSource('App')).toBeNull();
+  });
+});

--- a/src/lib/upload/validateUploadSource.ts
+++ b/src/lib/upload/validateUploadSource.ts
@@ -1,0 +1,17 @@
+export type UploadSource = 'app' | 'web' | 'dropbox' | 'google_drive';
+
+const ALLOWED_UPLOAD_SOURCES: readonly UploadSource[] = [
+  'app',
+  'web',
+  'dropbox',
+  'google_drive',
+];
+
+export function validateUploadSource(raw: unknown): UploadSource | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  return ALLOWED_UPLOAD_SOURCES.includes(raw as UploadSource)
+    ? (raw as UploadSource)
+    : null;
+}

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -81,8 +81,13 @@ function buildRepository(): IUploadRepository {
     findByKey: (_owner: number, _key: string) => Promise.resolve(null),
     findAllByObjectIdAndOwner: (_objectId: string, _owner: number) =>
       Promise.resolve([] as Uploads[]),
-    update: (_owner: number, _filename: string, _key: string, _size_mb: number) =>
-      Promise.resolve([] as Uploads[]),
+    update: (
+      _owner: number,
+      _filename: string,
+      _key: string,
+      _size_mb: number,
+      _source?: string | null
+    ) => Promise.resolve([] as Uploads[]),
     getLastUploadForUser: (_userId: number) => Promise.resolve(null),
     getLastReconvertibleUpload: (_userId: number) => Promise.resolve(null),
   };
@@ -680,6 +685,59 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     expect(mockStorageUploadFile).toHaveBeenCalledTimes(1);
     const [, uploadedBuffer] = mockStorageUploadFile.mock.calls[0] as [string, Buffer];
     expect(Buffer.compare(uploadedBuffer, apkgContents)).toBe(0);
+  });
+
+  async function runAsyncUploadWithBody(
+    body: Record<string, unknown>
+  ): Promise<jest.Mock> {
+    fs.writeFileSync(path.join(tmpDir, 'my-deck.apkg'), Buffer.from('apkg'));
+
+    let resolveUpdate!: () => void;
+    const updateCalled = new Promise<void>((r) => {
+      resolveUpdate = r;
+    });
+    const updateMock = jest.fn().mockImplementation(() => {
+      resolveUpdate();
+      return Promise.resolve([]);
+    });
+    const repo: IUploadRepository = { ...buildRepository(), update: updateMock };
+    const jobRepository = {
+      create: jest.fn().mockResolvedValue(undefined),
+      updateJobStatus: jest.fn().mockResolvedValue(undefined),
+      findJobById: jest.fn().mockResolvedValue(null),
+      deleteJob: jest.fn().mockResolvedValue(undefined),
+    } as unknown as JobRepository;
+
+    MockGeneratePackagesUseCase.mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        packages: [{ name: 'my-deck', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 }],
+      }),
+    }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
+
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const req = buildRequest({ body: { 'claude-ai-flashcards': 'true', ...body } });
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+    await updateCalled;
+    return updateMock;
+  }
+
+  it('persists source=app on the async Claude upload insert', async () => {
+    const updateMock = await runAsyncUploadWithBody({ source: 'app' });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    const args = updateMock.mock.calls[0];
+    expect(args[0]).toBe(42);
+    expect(args[4]).toBe('app');
+  });
+
+  it('persists null when the source is not on the allowlist', async () => {
+    const updateMock = await runAsyncUploadWithBody({ source: 'mobile-app-v2' });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock.mock.calls[0][4]).toBeNull();
   });
 });
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -36,6 +36,10 @@ import { FileSizeInMegaBytes } from '../lib/misc/file';
 import { track } from './events/track';
 import { classifyDevice } from '../lib/analytics/classifyDevice';
 import {
+  validateUploadSource,
+  UploadSource,
+} from '../lib/upload/validateUploadSource';
+import {
   isPdfPasswordSentinel,
   parsePdfPasswordSentinel,
 } from '../lib/pdf/pdfPasswordSentinel';
@@ -166,7 +170,13 @@ class UploadService {
     res.status(202).json({ jobId: job.object_id });
   }
 
-  private async promoteClaudeJobToUpload(objectId: string, workspaceDir: string, owner: string, totalCards = 0): Promise<void> {
+  private async promoteClaudeJobToUpload(
+    objectId: string,
+    workspaceDir: string,
+    owner: string,
+    totalCards = 0,
+    source: UploadSource | null = null
+  ): Promise<void> {
     const files = await fs.promises.readdir(workspaceDir);
     const apkgFilename = files.find((f) => f.endsWith('.apkg'));
     if (!apkgFilename) {
@@ -179,7 +189,7 @@ class UploadService {
     const key = storage.uniqify(objectId, owner, 200, 'apkg');
     await storage.uploadFile(key, apkgBuffer);
     const sizeMb = FileSizeInMegaBytes(apkgPath);
-    await this.uploadRepository.update(Number(owner), apkgFilename, key, sizeMb);
+    await this.uploadRepository.update(Number(owner), apkgFilename, key, sizeMb, source);
     await this.usersRepository.incrementCardUsage(Number(owner), totalCards);
     const job = await this.jobRepository.findJobById(objectId, owner);
     if (job) {
@@ -340,6 +350,7 @@ class UploadService {
     const title = files.length === 1 ? files[0].originalname : `${files.length} files`;
     await this.jobRepository.create(ws.id, owner, title, 'claude');
 
+    const source = this.resolvePersistedSource(req);
     const useCase = new GeneratePackagesUseCase();
     const ownerNumeric = Number(owner);
     const ownerId = Number.isFinite(ownerNumeric) && ownerNumeric > 0 ? ownerNumeric : null;
@@ -350,7 +361,7 @@ class UploadService {
       .then(async ({ packages }) => {
         if (packages.length > 0) {
           const totalCards = packages.reduce((s, p) => s + (p.cardCount ?? 0), 0);
-          await this.promoteClaudeJobToUpload(ws.id, ws.location, owner, totalCards);
+          await this.promoteClaudeJobToUpload(ws.id, ws.location, owner, totalCards, source);
         } else {
           logNoPackageDiagnostics(req.files as UploadedFile[]);
           await this.jobRepository.updateJobStatus(ws.id, owner, 'failed', 'No packages produced');
@@ -505,7 +516,16 @@ class UploadService {
     return typeof anonId === 'string' && anonId.length > 0 ? anonId : null;
   }
 
-  private resolveUploadSource(req: express.Request): 'upload' | 'google_drive' {
+  private resolvePersistedSource(req: express.Request): UploadSource | null {
+    const body = req.body as Record<string, unknown> | undefined;
+    return validateUploadSource(body?.source);
+  }
+
+  private resolveUploadSource(
+    req: express.Request
+  ): UploadSource | 'upload' | 'google_drive' {
+    const explicit = this.resolvePersistedSource(req);
+    if (explicit != null) return explicit;
     if (req.path?.includes('google_drive')) return 'google_drive';
     return 'upload';
   }


### PR DESCRIPTION
## What
Read, validate, and persist a client-supplied `source` field on uploads. The native app already sends `source=app` as a multipart field on `POST /api/upload/file`; the server now reads it at the boundary, validates it against an allowlist, and stores it on the `uploads` row.

## Why
Closes #2998. Lets us attribute decks by origin (native app vs web vs Dropbox vs Google Drive) in My Decks / Ops, so native-app uploads are distinguishable from everything else.

## How
- New pure helper `validateUploadSource(raw)` — allowlist of `app | web | dropbox | google_drive`; any unknown or non-string input returns `null` (never trust raw body input).
- `UploadService.handleUpload` → `handleAsyncUpload` resolves the validated source from `req.body.source` and threads it through `promoteClaudeJobToUpload` → `UploadRepository.update`. The repo `update` method + `IUploadRepository` interface gained an optional `source` param.
- Analytics: `resolveUploadSource` now prefers the validated body field before falling back to the path-derived value.
- Nullable `source` text column added to `uploads` via migration; `Uploads.ts` regenerated with kanel (not hand-edited).

**Scope limit (v1):** Only the async Claude path inserts an `uploads` row. Sync uploads stream the `.apkg` back without a DB insert, so `source` is captured for async uploads only. Adding persistence to the sync path is out of scope per the issue.

## Measuring success
Query the new column directly: `select source, count(*) from uploads where created_at > now() - interval '7 days' group by source;` — native-app uploads show up as `source = 'app'`, web/Dropbox/Drive bucket separately, and pre-change rows stay `null`.

## Testing
- Unit tests added:
  - `validateUploadSource.test.ts` — allowlist pass-through, unknown/empty/non-string/casing -> null (8 cases).
  - `UploadService.test.ts` — async path persists `source='app'`; garbage source persists `null`.
  - `UploadRespository.sql.test.ts` — generated INSERT includes the `source` column (with a value and with NULL), via a real pg-dialect knex.
- All touched suites green: 35 tests across 4 files. Full server `tsc --noEmit` clean (0 errors).

## Browser check
Browser check: not applicable — backend-only persistence change, no `web/src/` files touched.

## Migration
Adds `migrations/20260902000000_add_source_to_uploads.js` — nullable `text` column, no backfill, both `up` and `down` provided. Followed the lock-light nullable-add pattern. **migration-reviewer should look** at locking / backfill / rollback / kanel.

## Sonar
SonarCloud Automatic Analysis is enabled on this project, so the local `sonar-scanner` manual run refuses to run (it errors with "Automatic Analysis is enabled"). Analysis will run automatically on the PR. The change is small and adds no HTTP sinks, no raw SQL (query builder only), and no nesting.

## Changelog
No changelog — internal persistence plumbing with no user-visible behavior change.

## Risks
Low. Nullable column add, no backfill, no read path changes for existing flows. Rollback is the migration `down` (drop column). Worst case the column stays `null` for everyone, which matches today's behavior.

## Goal alignment
Indirectly supports the 300K-user goal: knowing which surface (native app vs web) drives uploads lets us see where conversions actually originate, which sharpens funnel prioritization.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783110688&installation_id=132681956&pr_number=3073&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3073&signature=b8e384814f704e4c67acefe07794b70ffdbeb469d57e7dd6b419c77c7cb0eb60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->