### PR TITLE
fix: harden native OAuth state against non-hex hmac

### DIFF
--- a/src/services/NotionService/nativeOAuthState.test.ts
+++ b/src/services/NotionService/nativeOAuthState.test.ts
@@ -49,6 +49,40 @@ describe('nativeOAuthState', () => {
     expect(verifyNativeOAuthState('native', SECRET, 1_000)).toBeNull();
   });
 
+  it('returns null for an equal-length non-hex signature without throwing', () => {
+    const state = buildNativeOAuthState(7, SECRET, 1_000);
+    const parts = state.split(':');
+    parts[3] = 'z'.repeat(parts[3].length);
+    const tampered = parts.join(':');
+    expect(() => verifyNativeOAuthState(tampered, SECRET, 1_000)).not.toThrow();
+    expect(verifyNativeOAuthState(tampered, SECRET, 1_000)).toBeNull();
+  });
+
+  it('returns null for an uppercase-hex signature', () => {
+    const state = buildNativeOAuthState(7, SECRET, 1_000);
+    const parts = state.split(':');
+    parts[3] = parts[3].toUpperCase();
+    expect(verifyNativeOAuthState(parts.join(':'), SECRET, 1_000)).toBeNull();
+  });
+
+  it('returns null for a too-short signature without throwing', () => {
+    const state = buildNativeOAuthState(7, SECRET, 1_000);
+    const parts = state.split(':');
+    parts[3] = parts[3].slice(0, 10);
+    const tampered = parts.join(':');
+    expect(() => verifyNativeOAuthState(tampered, SECRET, 1_000)).not.toThrow();
+    expect(verifyNativeOAuthState(tampered, SECRET, 1_000)).toBeNull();
+  });
+
+  it('returns null for a too-long signature without throwing', () => {
+    const state = buildNativeOAuthState(7, SECRET, 1_000);
+    const parts = state.split(':');
+    parts[3] = `${parts[3]}abcdef`;
+    const tampered = parts.join(':');
+    expect(() => verifyNativeOAuthState(tampered, SECRET, 1_000)).not.toThrow();
+    expect(verifyNativeOAuthState(tampered, SECRET, 1_000)).toBeNull();
+  });
+
   it('throws when building with a non-positive owner', () => {
     expect(() => buildNativeOAuthState(0, SECRET)).toThrow();
     expect(() => buildNativeOAuthState(-3, SECRET)).toThrow();

--- a/src/services/NotionService/nativeOAuthState.ts
+++ b/src/services/NotionService/nativeOAuthState.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 
 const NATIVE_PREFIX = 'native';
 const MAX_AGE_MS = 300_000;
+const HMAC_HEX = /^[0-9a-f]{64}$/;
 
 function sign(payload: string, secret: string): string {
   return crypto.createHmac('sha256', secret).update(payload).digest('hex');
@@ -52,10 +53,10 @@ export function verifyNativeOAuthState(
   if (now - timestamp > MAX_AGE_MS || timestamp - now > MAX_AGE_MS) {
     return null;
   }
-  const expected = sign(`${ownerStr}:${tsStr}`, secret);
-  if (expected.length !== providedHmac.length) {
+  if (!HMAC_HEX.test(providedHmac)) {
     return null;
   }
+  const expected = sign(`${ownerStr}:${tsStr}`, secret);
   const matches = crypto.timingSafeEqual(
     Buffer.from(expected, 'hex'),
     Buffer.from(providedHmac, 'hex')


### PR DESCRIPTION
## What
`verifyNativeOAuthState` now validates the provided HMAC is exactly 64 lowercase hex characters before `Buffer.from`/`crypto.timingSafeEqual`, returning `null` (treated as `invalid_state`) on mismatch.

## Why
Follow-up hardening to the native Notion OAuth state (the owner-binding work that just merged). Security review flagged a should-fix: the old guard compared only the *string length* of the provided hmac. An attacker supplying a 64-char but invalid-hex hmac (e.g. 64 non-hex chars) passed the length check, then `Buffer.from(providedHmac, 'hex')` yielded a short/empty buffer, and `timingSafeEqual(32-byte, 0-byte)` threw `RangeError`. With no try/catch in `verifyNativeOAuthState`, that throw escaped to the Express ErrorHandler as a **500 + logged stack** on the Notion OAuth callback, instead of the intended `twoanki://x-callback-url/notion-connected?error=invalid_state` redirect. Not forgeable — wrong status code plus log noise on an auth callback.

## How
`/^[0-9a-f]{64}$/.test(providedHmac)` before the buffer/compare. The expected digest is always 64 lowercase hex, so both buffers are guaranteed 32 bytes once the input is validated. The old length-only guard is removed as redundant. Uppercase-hex input is now also rejected, closing a parse path `Buffer.from(..., 'hex')` previously accepted. `timingSafeEqual` is kept for the actual comparison.

Legacy `state=native` from old app builds continues to be rejected to the deep link with `?error=invalid_state` (fail-closed) — unchanged.

## Measuring success
The Notion OAuth callback (`NotionController.connect` → `connectNative`) no longer emits a `RangeError: Input buffers must have the same byte length` 500 in prod logs / Sentry; malformed-state callbacks resolve to the `?error=invalid_state` deep-link redirect instead.

## Testing
- Unit tests added to `nativeOAuthState.test.ts`: equal-length non-hex hmac returns `null` and does not throw; uppercase-hex returns `null`; too-short and too-long hmacs return `null` and do not throw.
- Existing 11 `nativeOAuthState` cases and 27 `NotionController` cases stay green (42 total).

## Browser check
Browser check: not applicable — backend-only change, no `web/src/` files touched.

## Risks
Minimal. Pure tightening of an auth-callback validation path; the only behavior change is malformed input now redirects to `invalid_state` instead of throwing a 500, and uppercase-hex (never produced by `buildNativeOAuthState`, which emits lowercase) is now rejected. Rollback: revert the single commit.

## Changelog
No entry — the user-visible symptom (a callback 500) was an edge case never hit by a legitimate client; the fix changes only error-path status codes and log noise.

## Goal alignment
Sign in with Notion is a core onboarding path toward 300K users; a callback that 500s on malformed state degrades that flow and pollutes logs. Quieter, correctly-redirecting auth callbacks keep the funnel clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783112242&installation_id=132681956&pr_number=3075&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3075&signature=08107afd75feaebbab264ac6a0906ff1e03511aab548052f696c611db67d3a58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->