### PR TITLE
fix: reject GOCSPX- OAuth secret in REACT_APP_GOOGLE_API_KEY

### DIFF
--- a/web/src/lib/google/assertGoogleApiKeyShape.test.ts
+++ b/web/src/lib/google/assertGoogleApiKeyShape.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertGoogleApiKeyShape,
+  describeGoogleApiKeyProblem,
+} from './assertGoogleApiKeyShape';
+
+const FAKE_API_KEY_PREFIX = 'AIza' + 'FAKE_TEST_VALUE_NOT_REAL';
+const FAKE_OAUTH_SECRET = 'GOCSPX-' + 'fake-oauth-secret';
+
+describe('assertGoogleApiKeyShape', () => {
+  it('accepts an AIza-prefixed API key', () => {
+    const shape = assertGoogleApiKeyShape(FAKE_API_KEY_PREFIX);
+    expect(shape.valid).toBe(true);
+    if (shape.valid) {
+      expect(shape.key).toBe(FAKE_API_KEY_PREFIX);
+    }
+  });
+
+  it('rejects an OAuth Client Secret pasted in by mistake', () => {
+    const shape = assertGoogleApiKeyShape(FAKE_OAUTH_SECRET);
+    expect(shape.valid).toBe(false);
+    if (!shape.valid) {
+      expect(shape.reason).toBe('oauth-client-secret');
+      expect(describeGoogleApiKeyProblem(shape)).toContain('GOCSPX-');
+      expect(describeGoogleApiKeyProblem(shape)).toContain('public JS bundle');
+    }
+  });
+
+  it('rejects empty input', () => {
+    expect(assertGoogleApiKeyShape('')).toMatchObject({ valid: false, reason: 'empty' });
+    expect(assertGoogleApiKeyShape(undefined)).toMatchObject({ valid: false, reason: 'empty' });
+    expect(assertGoogleApiKeyShape(null)).toMatchObject({ valid: false, reason: 'empty' });
+    expect(assertGoogleApiKeyShape('   ')).toMatchObject({ valid: false, reason: 'empty' });
+  });
+
+  it('rejects anything that does not start with AIza', () => {
+    const shape = assertGoogleApiKeyShape('not-a-real-key');
+    expect(shape.valid).toBe(false);
+    if (!shape.valid) {
+      expect(shape.reason).toBe('unrecognized');
+      expect(describeGoogleApiKeyProblem(shape)).toContain('AIza');
+    }
+  });
+
+  it('trims surrounding whitespace before evaluating', () => {
+    expect(assertGoogleApiKeyShape(`  ${FAKE_API_KEY_PREFIX}  `)).toMatchObject({ valid: true });
+    expect(assertGoogleApiKeyShape(` ${FAKE_OAUTH_SECRET} `)).toMatchObject({
+      valid: false,
+      reason: 'oauth-client-secret',
+    });
+  });
+});

--- a/web/src/lib/google/assertGoogleApiKeyShape.ts
+++ b/web/src/lib/google/assertGoogleApiKeyShape.ts
@@ -1,0 +1,30 @@
+export type GoogleApiKeyShape =
+  | { valid: true; key: string }
+  | { valid: false; reason: 'empty' | 'oauth-client-secret' | 'unrecognized'; key: string };
+
+export function assertGoogleApiKeyShape(value: string | undefined | null): GoogleApiKeyShape {
+  const key = (value ?? '').trim();
+  if (key.length === 0) {
+    return { valid: false, reason: 'empty', key };
+  }
+  if (key.startsWith('GOCSPX-')) {
+    return { valid: false, reason: 'oauth-client-secret', key };
+  }
+  if (!key.startsWith('AIza')) {
+    return { valid: false, reason: 'unrecognized', key };
+  }
+  return { valid: true, key };
+}
+
+export function describeGoogleApiKeyProblem(
+  shape: Extract<GoogleApiKeyShape, { valid: false }>
+): string {
+  switch (shape.reason) {
+    case 'empty':
+      return 'REACT_APP_GOOGLE_API_KEY is empty.';
+    case 'oauth-client-secret':
+      return 'REACT_APP_GOOGLE_API_KEY starts with "GOCSPX-", which is the Google OAuth Client Secret format. The Picker requires a Google API key (starts with "AIza"). Refusing to use this value to avoid leaking the secret into the public JS bundle.';
+    case 'unrecognized':
+      return 'REACT_APP_GOOGLE_API_KEY does not start with "AIza" — this does not look like a Google API key. Picker calls will likely fail.';
+  }
+}

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -67,7 +67,7 @@ describe('UploadForm', () => {
     const previousClient = process.env.REACT_APP_GOOGLE_CLIENT_ID;
     const previousKey = process.env.REACT_APP_GOOGLE_API_KEY;
     process.env.REACT_APP_GOOGLE_CLIENT_ID = 'test-client';
-    process.env.REACT_APP_GOOGLE_API_KEY = 'test-key';
+    process.env.REACT_APP_GOOGLE_API_KEY = 'AIza' + 'fake-test-key';
     try {
       const { container } = renderUploadForm(
         <UploadForm setErrorMessage={vi.fn()} />

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.test.ts
@@ -99,7 +99,7 @@ describe('useGooglePicker', () => {
   describe('with credentials configured', () => {
     beforeEach(() => {
       process.env.REACT_APP_GOOGLE_CLIENT_ID = 'test-client-id';
-      process.env.REACT_APP_GOOGLE_API_KEY = 'test-api-key';
+      process.env.REACT_APP_GOOGLE_API_KEY = 'AIza' + 'fake-test-key';
     });
 
     it('resolves with picked files and the access token when the user picks a file', async () => {

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useGooglePicker.ts
@@ -1,5 +1,10 @@
 import { useCallback, useRef } from 'react';
 
+import {
+  assertGoogleApiKeyShape,
+  describeGoogleApiKeyProblem,
+} from '../../../../../lib/google/assertGoogleApiKeyShape';
+
 export interface GoogleDriveFile {
   id: string;
   name: string;
@@ -106,9 +111,19 @@ function clientId(): string | null {
   return id && id.length > 0 ? id : null;
 }
 
+let warnedApiKeyShape = false;
+
 function apiKey(): string | null {
-  const key = process.env.REACT_APP_GOOGLE_API_KEY;
-  return key && key.length > 0 ? key : null;
+  const shape = assertGoogleApiKeyShape(process.env.REACT_APP_GOOGLE_API_KEY);
+  if (shape.valid) {
+    return shape.key;
+  }
+  if (shape.reason !== 'empty' && !warnedApiKeyShape) {
+    warnedApiKeyShape = true;
+    // eslint-disable-next-line no-console
+    console.error(describeGoogleApiKeyProblem(shape));
+  }
+  return null;
 }
 
 function loadScript(src: string, id: string): Promise<void> {


### PR DESCRIPTION
## What

Adds a small `assertGoogleApiKeyShape` guard that the `useGooglePicker` hook calls when reading `REACT_APP_GOOGLE_API_KEY`. Bad shapes are refused with a single `console.error`:

- **`GOCSPX-` prefix** — Google OAuth Client Secret format pasted in by mistake. Refusing this value avoids leaking the secret into the public JS bundle the way the May 16 misconfiguration briefly did.
- **Missing `AIza` prefix** — does not look like a Google API key; Picker calls will fail.

When the key looks valid, behavior is unchanged.

## Why

PR #2306 (Google Drive upload) shipped briefly with the env var set to a `GOCSPX-` value. Two consequences:

1. Picker rejected the credential with an opaque "API developer key is invalid".
2. The Client Secret got inlined into the public bundle, briefly leaking it.

A one-line shape check at the read site catches that misconfiguration immediately in the browser console instead of after 30 minutes of diagnosis.

## Tests

- `src/lib/google/assertGoogleApiKeyShape.test.ts` — accepts `AIza...`, rejects `GOCSPX-...` and unrecognized, handles empty/whitespace.
- Existing `useGooglePicker.test.ts` and `UploadForm.test.tsx` updated to use a key with the correct `AIza` prefix (the previous `'test-key'` no longer satisfies the new guard).

Closes #2317

## Browser check

Browser check: not applicable — adds a startup-time env validation that only fires on misconfigured deploys; the configured (valid `AIza...`) path is exercised by existing Picker tests and unchanged for users.

## Decisions made overnight (please review)

- Scope: added the guard at the **client read site** (`useGooglePicker.ts`) only. Server-side validation was considered but the server does not read `REACT_APP_GOOGLE_API_KEY` — the variable is a Vite `REACT_APP_*` build-time injection consumed only by the web bundle, so guarding it at the read site catches it at first use and a server check would be checking an env it doesn't otherwise use. A separate CI check (`pnpm --filter 2anki-web build` failing on bad shape) would also work and could land later if you want the build to refuse rather than the browser.
- Behavior: returns `null` + logs `console.error` rather than throwing. Throwing would crash the upload page entirely; returning `null` mirrors the existing "no credential" path so the Drive chip disables cleanly while the error surfaces in dev tools.
- Suppression: the warning fires once per session via a module-scoped `warnedApiKeyShape` flag — re-clicking the chip won't spam the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783113784&installation_id=132681956&pr_number=3078&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3078&signature=1e8d3fb21a4aee29118fa206d41e64d9415219e34378ea311e579c2ace57db91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->