### PR TITLE
perf: skip cheerio.load on card content without <img> or <del>

### DIFF
--- a/src/lib/parser/DeckParser.locateTags.test.ts
+++ b/src/lib/parser/DeckParser.locateTags.test.ts
@@ -1,0 +1,60 @@
+import { setupTests } from '../../test/configure-jest';
+import CardOption from './Settings/CardOption';
+import { DeckParser } from './DeckParser';
+import Note from './Note';
+import Workspace from './WorkSpace';
+
+beforeEach(() => setupTests());
+
+function makeParser(): DeckParser {
+  const workspace = new Workspace(true, 'fs');
+  return new DeckParser({
+    name: 'noop.html',
+    settings: new CardOption({ cherry: 'false' }),
+    files: [{ name: 'noop.html', contents: '<html></html>' }],
+    noLimits: true,
+    workspace,
+  });
+}
+
+describe('DeckParser.locateTags substring guard', () => {
+  test('extracts <del> tags from the back when present', () => {
+    const parser = makeParser();
+    const note = new Note('What is X?', 'It is Y. <del>biology,unit-3</del>');
+
+    parser.locateTags(note, []);
+
+    expect(note.tags).toEqual(expect.arrayContaining(['biology', 'unit-3']));
+    expect(note.back).not.toContain('<del>');
+  });
+
+  test('extracts <del> tags from the front when present', () => {
+    const parser = makeParser();
+    const note = new Note('What is X? <del>chemistry</del>', 'It is Y.');
+
+    parser.locateTags(note, []);
+
+    expect(note.tags).toContain('chemistry');
+    expect(note.name).not.toContain('<del>');
+  });
+
+  test('leaves note untouched when neither side contains <del>', () => {
+    const parser = makeParser();
+    const note = new Note('What is X?', 'It is Y.');
+
+    parser.locateTags(note, []);
+
+    expect(note.tags).toEqual([]);
+    expect(note.name).toBe('What is X?');
+    expect(note.back).toBe('It is Y.');
+  });
+
+  test('still appends deck-global tags even when no <del> is present', () => {
+    const parser = makeParser();
+    const note = new Note('What is X?', 'It is Y.');
+
+    parser.locateTags(note, ['chapter-1', 'midterm']);
+
+    expect(note.tags).toEqual(['chapter-1', 'midterm']);
+  });
+});

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -543,6 +543,10 @@ export class DeckParser {
         continue;
       }
 
+      if (!i.includes('<del')) {
+        continue;
+      }
+
       const dom = cheerio.load(i);
       const deletionsDOM = dom('del');
       deletionsDOM.each((_i: number, elem: Element) => {
@@ -558,6 +562,8 @@ export class DeckParser {
   }
 
   private embedImagesInCardContent(content: string, card: Note, ws: Workspace): string {
+    if (!content.includes('<img')) return content;
+
     const dom = cheerio.load(content);
     const images = dom('img');
     if (images.length === 0) return content;


### PR DESCRIPTION
## What

`DeckParser.embedImagesInCardContent` and `DeckParser.locateTags` both called `cheerio.load(content)` unconditionally for every card-side:

- `embedImagesInCardContent` runs twice per card (front + back) for the `<img>` scan.
- `locateTags` runs twice per card (`card.name`, `card.back`) for the `<del>` scan.

For decks where the card content has neither `<img>` nor `<del>` — the common case — every load was wasted.

This PR substring-guards each `cheerio.load`:

```ts
if (!content.includes('<img')) return content;       // embedImagesInCardContent
if (!i.includes('<del')) continue;                   // locateTags inner loop
```

The inner `dom('img')` / `dom('del')` selectors already returned empty on absent tags, so the guards are strict subsets of current behavior on the serialized HTML inputs the parser sees.

## Cost recovered

From the original audit (`#2413`): **208 ms for 1000 cards** with no images and no `<del>` annotations (~0.21 ms/card × 4 wasted `cheerio.load` calls).

## Fidelity

Output for cards that contain `<img>` / `<del>` is unchanged. Existing tests for these paths still cover the present-tag branches; this PR adds a small unit test that exercises both branches of `locateTags` directly.

## Caveat

Relies on the invariant that input is already serialized HTML (entities escaped). If a double-decode upstream produced literal `<del>` in card text, the guard would silently skip. Both call sites are downstream of `cheerio.load(...).html()`, so this invariant already holds for the build path.

Closes #2413

## Browser check

Browser check: not applicable — server-side parser perf, no `web/src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114029&installation_id=132681956&pr_number=3079&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3079&signature=284c142632da0cd4895b2719bb648ed56e9827ea220aa349f4b5561cabec0e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->