### PR TITLE
docs: explain when restructuring toggles creates duplicate cards

### DIFF
--- a/web/src/pages/DocsPage/content/start-here/open-in-anki.md
+++ b/web/src/pages/DocsPage/content/start-here/open-in-anki.md
@@ -49,3 +49,16 @@ The first time you re-import a deck after this change, Anki shows its built-in "
 :::
 
 For Notion pages where you want updates to flow automatically without re-uploading, use [Sync](/documentation/sync/how-it-works) instead.
+
+### Why duplicates appear after restructuring toggles
+
+The card ID is anchored to the Notion block ID of the toggle. Notion preserves that block ID for some edits and replaces it for others:
+
+- **Editing the text inside a toggle** keeps the same block ID → re-import updates the existing card in place.
+- **Cutting a toggle and pasting it elsewhere** assigns a new block ID → re-import creates a new card next to the old one.
+- **Duplicating a toggle** (via right-click → Duplicate or ⌘D) assigns a new block ID to the copy → both cards appear after re-import.
+- **Moving a toggle by drag** within the same page usually preserves the block ID; moving across pages does not.
+
+If you re-import and see duplicate cards, the most likely cause is a cut-and-paste or duplicate-and-edit during the edit pass.
+
+**Workflow that avoids the duplicates:** edit toggle text in place. Restructure the page before the first conversion if you can — once a deck is live in Anki, treat the toggle layout as the anchor and change the contents, not the positions.


### PR DESCRIPTION
## What

Adds a `### Why duplicates appear after restructuring toggles` subsection to `/documentation/start-here/open-in-anki` describing which Notion edits preserve the block ID (and thus update existing cards in place) versus which edits assign a new block ID (and create duplicates on re-import).

The four cases covered: edit-in-place, cut/paste, duplicate, drag-move (same page vs across pages).

## Why

The "Use Notion ID" behavior is working as designed — the Notion block ID is the stability anchor — but a few users have reported duplicate cards after restructuring their pages and were never told *which* edits force a new ID. The fix is purely documentation: tell them which edits are safe, which ones aren't, and the workflow that avoids duplicates.

## Browser check

Browser check: not applicable — Markdown-only edit to a docs page (`web/src/pages/DocsPage/content/start-here/open-in-anki.md`). No runtime path changes; the existing docs loader renders the new section unchanged.

## Changelog

No changelog entry — internal docs addition; no product behavior change.

Closes #2156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114150&installation_id=132681956&pr_number=3080&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3080&signature=d765edbeedcc98dc812ea87ca50080f30eb3a739ab81d8d01da77c7089b88d18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->