### PR TITLE
perf: rebuild uploads dedupe index CONCURRENTLY

### DIFF
--- a/migrations/20260903000001_uploads_dedupe_index_concurrent.js
+++ b/migrations/20260903000001_uploads_dedupe_index_concurrent.js
@@ -1,0 +1,15 @@
+exports.config = { transaction: false };
+
+exports.up = async (knex) => {
+  await knex.schema.raw('DROP INDEX IF EXISTS uploads_owner_dedupe_key_unique');
+  await knex.schema.raw(
+    'CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uploads_owner_dedupe_key_unique ON uploads (owner, dedupe_key) WHERE dedupe_key IS NOT NULL'
+  );
+};
+
+exports.down = async (knex) => {
+  await knex.schema.raw('DROP INDEX IF EXISTS uploads_owner_dedupe_key_unique');
+  await knex.schema.raw(
+    'CREATE UNIQUE INDEX IF NOT EXISTS uploads_owner_dedupe_key_unique ON uploads (owner, dedupe_key) WHERE dedupe_key IS NOT NULL'
+  );
+};


### PR DESCRIPTION
## What
A new migration drops the blocking `uploads_owner_dedupe_key_unique` partial unique index and rebuilds it with `CREATE UNIQUE INDEX CONCURRENTLY`. Index-only change — no column, type, or kanel change.

## Why
The merged migration `20260903000000_add_dedupe_key_to_uploads.js` (PR #3070) built the index inside Knex's default transaction with a plain `CREATE UNIQUE INDEX`. That takes a SHARE lock blocking INSERT/UPDATE/DELETE on `uploads` — a hot write table — for the build duration. Sub-second at today's volume, but a write stall waiting to happen at 300K-user scale. Flagged by migration-reviewer on PR #3070.

## How
- New migration `20260903000001_uploads_dedupe_index_concurrent.js`, timestamp sorts after the merged one.
- `exports.config = { transaction: false }` — `CONCURRENTLY` cannot run inside a transaction block (Postgres: `CREATE INDEX CONCURRENTLY cannot run inside a transaction block`).
- `up`: `DROP INDEX IF EXISTS` then `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS` with the exact name/columns/predicate from the merged migration.
- `down`: drop + recreate the plain (non-concurrent) index, restoring the merged migration's state.
- Idempotent via `IF EXISTS` / `IF NOT EXISTS` so a failed concurrent build (which can leave an INVALID index) re-runs cleanly.

## Measuring success
On the next deploy, the startup migration runner logs the migration as applied. Confirm on prod: `\d uploads` shows `uploads_owner_dedupe_key_unique` and `SELECT indisvalid FROM pg_index ... = t` (valid, not INVALID). No write-lock spike on `uploads` during deploy.

## Testing
Verified against local Postgres by reproducing the post-merge precondition (plain index present), then:
- `up` SQL rebuilds CONCURRENTLY → `indisvalid = t`.
- Confirmed `CREATE INDEX CONCURRENTLY` errors inside `BEGIN ... ROLLBACK`, proving `transaction: false` is required.
- `down` SQL restores the plain index → `indisvalid = t`.
- Simulated an INVALID leftover index (`indisvalid = f`); re-running `up` clears it and rebuilds valid — idempotent recovery confirmed.

Verified psql index line after `up`:
```
"uploads_owner_dedupe_key_unique" UNIQUE, btree (owner, dedupe_key) WHERE dedupe_key IS NOT NULL
```

## Browser check
Browser check: not applicable — backend migration only

## Changelog
No entry — internal-only, no user-visible change.

## Risks
Low. CONCURRENTLY builds run longer than a plain build and can leave an INVALID index on failure — the `IF EXISTS`/`IF NOT EXISTS` guards make re-running the migration the recovery path. Rollback: `down` restores the plain index (a brief write lock during rollback rebuild, acceptable for a manual rollback).

## Goal alignment
Removes a write-lock stall on the `uploads` hot path that would surface as conversion-time latency as we scale toward 300K users. Pure infra hardening — no UX change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114301&installation_id=132681956&pr_number=3081&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3081&signature=752cfbeb09f84815704f9ec24b060306c705b695b1c2ed40c985d7a5b3939ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->