### PR TITLE
fix: rate-limit POST /upload/retry-with-credential by IP

### DIFF
--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -205,3 +205,132 @@ describe('Upload file — multer error handling', () => {
     );
   });
 });
+
+describe('UploadController.retryPdfWithCredential rate limit', () => {
+  test('returns 429 when the limiter rejects the IP', async () => {
+    const repository = {
+      deleteUpload: jest.fn(),
+      getUploadsByOwner: jest.fn().mockResolvedValue([]),
+      findByIdAndOwner: jest.fn().mockResolvedValue(null),
+      findByKey: jest.fn().mockResolvedValue(null),
+      findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue([]),
+      getLastUploadForUser: jest.fn().mockResolvedValue(null),
+      getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
+      findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
+      insertNativeDeck: jest.fn(),
+    };
+    const notionRepository: INotionRepository = {
+      getNotionData: jest.fn() as INotionRepository['getNotionData'],
+      saveNotionToken: jest.fn() as INotionRepository['saveNotionToken'],
+      getNotionToken: jest.fn() as INotionRepository['getNotionToken'],
+      deleteBlocksByOwner: jest.fn() as INotionRepository['deleteBlocksByOwner'],
+      deleteNotionData: jest.fn() as INotionRepository['deleteNotionData'],
+      markTokenInvalid: jest.fn().mockResolvedValue(undefined),
+      clearTokenInvalid: jest.fn().mockResolvedValue(undefined),
+      setReconnectEmailSent: jest.fn().mockResolvedValue(true),
+    };
+    const uploadService = new UploadService(repository, {} as JobRepository, buildUsersRepo());
+    const notionService = new NotionService(notionRepository);
+
+    const blockingLimiter = { check: jest.fn().mockReturnValue(false) };
+    const controller = new UploadController(
+      uploadService,
+      notionService,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      blockingLimiter
+    );
+
+    const jsonSpy = jest.fn();
+    let capturedStatus = 0;
+
+    const req = {
+      file: { path: '/tmp/does-not-need-to-exist.pdf', originalname: 'foo.pdf' },
+      body: {},
+      headers: { 'x-forwarded-for': '10.0.0.1' },
+      socket: { remoteAddress: '10.0.0.1' },
+    } as unknown as express.Request;
+
+    const res = {
+      locals: {},
+      status: (code: number) => {
+        capturedStatus = code;
+        return { json: jsonSpy } as unknown as express.Response;
+      },
+    } as unknown as express.Response;
+
+    await controller.retryPdfWithCredential(req, res);
+
+    expect(blockingLimiter.check).toHaveBeenCalledTimes(1);
+    expect(capturedStatus).toBe(429);
+    expect(jsonSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('Too many password attempts'),
+      })
+    );
+  });
+
+  test('returns 400 when no file is provided (before rate limit check)', async () => {
+    const repository = {
+      deleteUpload: jest.fn(),
+      getUploadsByOwner: jest.fn().mockResolvedValue([]),
+      findByIdAndOwner: jest.fn().mockResolvedValue(null),
+      findByKey: jest.fn().mockResolvedValue(null),
+      findAllByObjectIdAndOwner: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue([]),
+      getLastUploadForUser: jest.fn().mockResolvedValue(null),
+      getLastReconvertibleUpload: jest.fn().mockResolvedValue(null),
+      findByOwnerAndDedupeKey: jest.fn().mockResolvedValue(null),
+      insertNativeDeck: jest.fn(),
+    };
+    const notionRepository: INotionRepository = {
+      getNotionData: jest.fn() as INotionRepository['getNotionData'],
+      saveNotionToken: jest.fn() as INotionRepository['saveNotionToken'],
+      getNotionToken: jest.fn() as INotionRepository['getNotionToken'],
+      deleteBlocksByOwner: jest.fn() as INotionRepository['deleteBlocksByOwner'],
+      deleteNotionData: jest.fn() as INotionRepository['deleteNotionData'],
+      markTokenInvalid: jest.fn().mockResolvedValue(undefined),
+      clearTokenInvalid: jest.fn().mockResolvedValue(undefined),
+      setReconnectEmailSent: jest.fn().mockResolvedValue(true),
+    };
+    const uploadService = new UploadService(repository, {} as JobRepository, buildUsersRepo());
+    const notionService = new NotionService(notionRepository);
+
+    const blockingLimiter = { check: jest.fn().mockReturnValue(false) };
+    const controller = new UploadController(
+      uploadService,
+      notionService,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      blockingLimiter
+    );
+
+    const jsonSpy = jest.fn();
+    let capturedStatus = 0;
+
+    const req = {
+      file: undefined,
+      body: {},
+      headers: {},
+      socket: { remoteAddress: '10.0.0.1' },
+    } as unknown as express.Request;
+
+    const res = {
+      locals: {},
+      status: (code: number) => {
+        capturedStatus = code;
+        return { json: jsonSpy } as unknown as express.Response;
+      },
+    } as unknown as express.Response;
+
+    await controller.retryPdfWithCredential(req, res);
+
+    expect(blockingLimiter.check).not.toHaveBeenCalled();
+    expect(capturedStatus).toBe(400);
+  });
+});

--- a/src/controllers/Upload/UploadController.ts
+++ b/src/controllers/Upload/UploadController.ts
@@ -1,8 +1,13 @@
+import crypto from 'node:crypto';
 import express from 'express';
 import fs from 'node:fs';
 import multer from 'multer';
 
 import { getOwner } from '../../lib/User/getOwner';
+import {
+  InMemoryRateLimiter,
+  RateLimiter,
+} from '../../lib/rateLimit/InMemoryRateLimiter';
 import NotionService from '../../services/NotionService';
 import UploadService from '../../services/UploadService';
 import { getUploadHandler } from '../../lib/misc/GetUploadHandler';
@@ -25,15 +30,42 @@ const DROPBOX_PAGE_SIZE = 10;
 const GOOGLE_DRIVE_PAGE_SIZE = 10;
 const GOOGLE_DRIVE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
+const RETRY_PDF_WINDOW_MS = 60_000;
+const RETRY_PDF_PER_IP_MAX = 10;
+const RETRY_PDF_GLOBAL_MAX = 500;
+
+function resolveClientIp(req: express.Request): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string') {
+    return forwarded.split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress ?? 'unknown';
+}
+
+function hashIp(raw: string): string {
+  return crypto.createHash('sha256').update(raw).digest('hex');
+}
+
 class UploadController {
+  private readonly retryPdfRateLimiter: RateLimiter;
+
   constructor(
     private readonly service: UploadService,
     private readonly notionService: NotionService,
     private readonly getDropboxUploadsUseCase?: GetDropboxUploadsUseCase,
     private readonly deleteDropboxUploadUseCase?: DeleteDropboxUploadUseCase,
     private readonly getGoogleDriveUploadsUseCase?: GetGoogleDriveUploadsUseCase,
-    private readonly deleteGoogleDriveUploadUseCase?: DeleteGoogleDriveUploadUseCase
-  ) {}
+    private readonly deleteGoogleDriveUploadUseCase?: DeleteGoogleDriveUploadUseCase,
+    retryPdfRateLimiter?: RateLimiter
+  ) {
+    this.retryPdfRateLimiter =
+      retryPdfRateLimiter ??
+      new InMemoryRateLimiter({
+        windowMs: RETRY_PDF_WINDOW_MS,
+        perKeyMax: RETRY_PDF_PER_IP_MAX,
+        globalMax: RETRY_PDF_GLOBAL_MAX,
+      });
+  }
 
   async deleteUpload(req: express.Request, res: express.Response) {
     const owner = getOwner(res);
@@ -218,6 +250,19 @@ class UploadController {
     const uploadedFile = req.file;
     if (!uploadedFile) {
       return res.status(400).json({ message: 'No file provided.' });
+    }
+
+    const ipKey = hashIp(resolveClientIp(req));
+    if (!this.retryPdfRateLimiter.check(ipKey)) {
+      const unlinkPath = uploadedFile.path;
+      fs.promises.unlink(unlinkPath).catch((e) => {
+        console.error('[retryPdfWithCredential] temp file cleanup failed', {
+          error: e instanceof Error ? e.message : String(e),
+        });
+      });
+      return res
+        .status(429)
+        .json({ message: 'Too many password attempts. Please wait a minute and try again.' });
     }
 
     const credential = validatePdfCredential((req.body as Record<string, unknown>).credential);

--- a/src/lib/rateLimit/InMemoryRateLimiter.test.ts
+++ b/src/lib/rateLimit/InMemoryRateLimiter.test.ts
@@ -1,0 +1,57 @@
+import { InMemoryRateLimiter } from './InMemoryRateLimiter';
+
+describe('InMemoryRateLimiter', () => {
+  test('allows up to perKeyMax within the window for a single key', () => {
+    const limiter = new InMemoryRateLimiter({
+      windowMs: 1000,
+      perKeyMax: 3,
+      globalMax: 100,
+      now: () => 0,
+    });
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(false);
+  });
+
+  test('isolates buckets between distinct keys', () => {
+    const limiter = new InMemoryRateLimiter({
+      windowMs: 1000,
+      perKeyMax: 2,
+      globalMax: 100,
+      now: () => 0,
+    });
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(false);
+    expect(limiter.check('ip-b')).toBe(true);
+    expect(limiter.check('ip-b')).toBe(true);
+    expect(limiter.check('ip-b')).toBe(false);
+  });
+
+  test('resets the per-key bucket once the window elapses', () => {
+    let now = 0;
+    const limiter = new InMemoryRateLimiter({
+      windowMs: 1000,
+      perKeyMax: 1,
+      globalMax: 100,
+      now: () => now,
+    });
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-a')).toBe(false);
+    now = 1001;
+    expect(limiter.check('ip-a')).toBe(true);
+  });
+
+  test('rejects all callers once the global cap is reached', () => {
+    const limiter = new InMemoryRateLimiter({
+      windowMs: 1000,
+      perKeyMax: 10,
+      globalMax: 2,
+      now: () => 0,
+    });
+    expect(limiter.check('ip-a')).toBe(true);
+    expect(limiter.check('ip-b')).toBe(true);
+    expect(limiter.check('ip-c')).toBe(false);
+  });
+});

--- a/src/lib/rateLimit/InMemoryRateLimiter.ts
+++ b/src/lib/rateLimit/InMemoryRateLimiter.ts
@@ -1,0 +1,56 @@
+interface RateBucket {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimiter {
+  check(key: string): boolean;
+}
+
+export interface RateLimiterOptions {
+  windowMs: number;
+  perKeyMax: number;
+  globalMax: number;
+  now?: () => number;
+}
+
+export class InMemoryRateLimiter implements RateLimiter {
+  private readonly buckets = new Map<string, RateBucket>();
+  private globalBucket: RateBucket;
+  private readonly windowMs: number;
+  private readonly perKeyMax: number;
+  private readonly globalMax: number;
+  private readonly now: () => number;
+
+  constructor(options: RateLimiterOptions) {
+    this.windowMs = options.windowMs;
+    this.perKeyMax = options.perKeyMax;
+    this.globalMax = options.globalMax;
+    this.now = options.now ?? (() => Date.now());
+    this.globalBucket = { count: 0, resetAt: this.now() + this.windowMs };
+  }
+
+  check(key: string): boolean {
+    const now = this.now();
+
+    if (now >= this.globalBucket.resetAt) {
+      this.globalBucket = { count: 0, resetAt: now + this.windowMs };
+    }
+    if (this.globalBucket.count >= this.globalMax) {
+      return false;
+    }
+    this.globalBucket.count += 1;
+
+    const existing = this.buckets.get(key);
+    if (existing == null || now >= existing.resetAt) {
+      this.buckets.set(key, { count: 1, resetAt: now + this.windowMs });
+      return true;
+    }
+    if (existing.count >= this.perKeyMax) {
+      this.globalBucket.count -= 1;
+      return false;
+    }
+    existing.count += 1;
+    return true;
+  }
+}


### PR DESCRIPTION
## What

Adds a per-IP rate limiter in front of `POST /upload/retry-with-credential`. The handler now hashes the client IP, checks an in-memory `InMemoryRateLimiter` (10 requests / minute per IP, 500 global), and returns:

```
HTTP/1.1 429 Too Many Requests
{ "message": "Too many password attempts. Please wait a minute and try again." }
```

The temp file from `multer.dest = '/tmp'` is cleaned up on the 429 path so a script-driven attack can't fill the disk.

## Why

Security-review finding I1 (informational) on PR #2404: the attempt counter that surfaces the soft hint after 3 wrong passwords was client-side only — a script could POST unlimited wrong passwords against `/upload/retry-with-credential` without ever loading the UI. The risk was limited (the endpoint requires a PDF upload on each call and self-limits on CPU) but worth closing because the original spec's intent was a soft hint after 3 attempts.

## How

- New `src/lib/rateLimit/InMemoryRateLimiter.ts` — generalized version of the limiter in `ErrorEventController` (per-key window + global cap, injectable `now()`). Same algorithm, parameterized so different endpoints can pick different limits.
- `UploadController` constructs a default limiter at boot (10/min/IP, 500/min global) and accepts an injected limiter for tests.
- A failing limiter check returns 429 before the credential is read, before the PDF is decrypted, and after the multer temp file is unlinked.

## Tests

- `src/lib/rateLimit/InMemoryRateLimiter.test.ts` — covers per-key cap, key isolation, window reset, global cap. Uses an injected `now()` so the tests are deterministic.
- `src/controllers/Upload/UploadController.test.ts` — adds two tests: limiter rejects → 429; missing file → 400 short-circuit before the limiter is consulted.

## Browser check

Browser check: not applicable — server-side endpoint change, no `web/src/` files touched.

## Decisions made overnight (please review)

- Limits: 10/min/IP, 500/min global. Picked to be high enough for legitimate retries (a real user typing a password fast wouldn't hit it) and low enough that a script gets shut down quickly. Adjust if you want either bound tighter.
- Storage: in-memory, per-process. The existing `ErrorEventController` uses the same pattern; multi-process correctness is a separate concern that would need Redis if you want it later.
- Error copy: "Too many password attempts. Please wait a minute and try again." — direct per `VOICE.md`, no fake warmth. The client already classifies 429 → generic limit message; this PR doesn't depend on the client doing anything new.

Closes #2412

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114401&installation_id=132681956&pr_number=3082&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3082&signature=7521c0172e395a4b5640c7b55c81dbd0f6cfea593381a7005d7f0149d97fb9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->