### PR TITLE
test: CSP smoke for Google sign-in script-src

### DIFF
--- a/web/tests/csp-google-signin.spec.ts
+++ b/web/tests/csp-google-signin.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+const REQUIRED_SCRIPT_SRC_ORIGINS = [
+  'https://accounts.google.com',
+  'https://apis.google.com',
+];
+
+test.describe('CSP smoke: Google origins stay allowlisted', () => {
+  test('script-src in index.html allows both accounts.google.com and apis.google.com', async ({ page }) => {
+    const cspViolations: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() !== 'error') return;
+      const text = msg.text();
+      if (text.includes('Content Security Policy') || text.includes('Refused to load')) {
+        cspViolations.push(text);
+      }
+    });
+
+    await page.goto('/');
+
+    const cspContent = await page
+      .locator('meta[http-equiv="Content-Security-Policy"]')
+      .first()
+      .getAttribute('content');
+
+    expect(
+      cspContent,
+      'meta[http-equiv="Content-Security-Policy"] must be present in web/index.html'
+    ).not.toBeNull();
+
+    const scriptSrcMatch = cspContent?.match(/script-src([^;]+)/);
+    expect(
+      scriptSrcMatch,
+      'CSP must include a script-src directive — none was found'
+    ).not.toBeNull();
+    const scriptSrc = scriptSrcMatch?.[1] ?? '';
+
+    for (const origin of REQUIRED_SCRIPT_SRC_ORIGINS) {
+      expect(
+        scriptSrc,
+        `CSP script-src is missing ${origin}. ` +
+          'PR #2306 added the Google Drive picker which loads ' +
+          'apis.google.com/js/api.js and accounts.google.com/gsi/client. ' +
+          'Both must stay in script-src or Google sign-in and Drive Picker ' +
+          'silently break. If you intentionally removed one, also update ' +
+          'this test and the matching code paths.'
+      ).toContain(origin);
+    }
+
+    const offending = cspViolations.filter((text) =>
+      REQUIRED_SCRIPT_SRC_ORIGINS.some((origin) => text.includes(origin.replace('https://', '')))
+    );
+    expect(offending, `Unexpected CSP violations for Google origins:\n${offending.join('\n')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Adds `web/tests/csp-google-signin.spec.ts`, a Playwright spec that loads `/` and asserts the inline CSP meta tag in `web/index.html` keeps both `https://accounts.google.com` and `https://apis.google.com` under `script-src`. Fails with a directly actionable message if either origin gets dropped.

## Why

PR #2306 introduced the Google Drive picker (loads `apis.google.com/js/api.js` and `accounts.google.com/gsi/client`). When the CSP was tightened later without those origins, Sign in with Google silently broke for hours before a user reported it. CI had no signal because no test rendered `index.html` and inspected the rendered CSP. This test gives that signal — it runs in the existing Playwright workflow on any change under `web/**` and the `web/index.html` watch path.

## How

- Reads the rendered `meta[http-equiv="Content-Security-Policy"]` and asserts each required origin is in the `script-src` directive.
- Also subscribes to `console` events and asserts no `Content Security Policy` errors for the Google hostnames appear during the `/` load. The first assertion is the primary signal; the second is belt-and-braces in case a future change moves the CSP into headers.

## Tests

The new spec runs on every Playwright workflow trigger. No other test files needed to change.

## Browser check

Browser check: not applicable — adds a Playwright spec under `web/tests/`. No `web/src/` runtime code change.

## Decisions made overnight (please review)

- Scope: just the two Google origins from the original incident. The issue mentioned extending to Hotjar / Stripe / Notion picker as a follow-up; I held that scope to the bug we actually hit, so the test stays a single targeted regression check instead of a kitchen-sink CSP audit. Adding more origins is one line each if you want them.
- Approach: assert the rendered meta tag rather than only watch for console violations. Inline meta CSP can be inspected deterministically without third-party network; the console-violation pass is best-effort because it depends on the Google scripts actually attempting to load on `/`.

Closes #2353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114568&installation_id=132681956&pr_number=3083&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3083&signature=441a7bc2d1c9854f689e0baa9f313b53e88d1aee161f4c4e79d50ca9d11f43e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->