### PR TITLE
perf: relax SQLite pragmas before genanki writes the .apkg collection

### DIFF
--- a/create_deck/helpers/write_apkg.py
+++ b/create_deck/helpers/write_apkg.py
@@ -10,6 +10,23 @@ import uuid
 
 from genanki import Deck, Package
 
+
+class FastPackage(Package):
+    """
+    Subclass of genanki.Package that sets `journal_mode=MEMORY` and
+    `synchronous=OFF` on the SQLite collection before any DDL/DML runs.
+
+    Justified because the .apkg SQLite collection is a build artifact written
+    once, finalized, and immediately consumed by the ZIP step. There is no
+    crash-recovery window where durability matters; the resulting file bytes
+    are unchanged.
+    """
+
+    def write_to_db(self, cursor, timestamp, id_gen):
+        cursor.execute('PRAGMA journal_mode=MEMORY')
+        cursor.execute('PRAGMA synchronous=OFF')
+        super().write_to_db(cursor, timestamp, id_gen)
+
 def sanitize_filename(filename):
     """
     Sanitize the filename by removing any character that is not alphanumeric, a space, or a hyphen.
@@ -145,7 +162,7 @@ def _write_new_apkg(deck_payloads, media_files):
         media_files (list): List of media files to be included in the package.
     """
     decks, first_deck_id = create_decks(deck_payloads)
-    package = Package(decks)
+    package = FastPackage(decks)
     existing_media = [f for f in media_files if os.path.exists(f)]
     if len(existing_media) < len(media_files):
         missing = set(media_files) - set(existing_media)

--- a/create_deck/tests/test_write_apkg.py
+++ b/create_deck/tests/test_write_apkg.py
@@ -3,7 +3,12 @@ import tempfile
 from unittest import TestCase, mock
 from genanki import Note, Model
 
-from helpers.write_apkg import sanitize_filename, _write_new_apkg, rename_temp_file
+from helpers.write_apkg import (
+    FastPackage,
+    sanitize_filename,
+    _write_new_apkg,
+    rename_temp_file,
+)
 
 class TestWriteApkg(TestCase):
     def setUp(self):
@@ -26,9 +31,9 @@ class TestWriteApkg(TestCase):
         for input_name, expected in test_cases:
             self.assertEqual(sanitize_filename(input_name), expected)
 
-    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.FastPackage')
     @mock.patch('helpers.write_apkg.os.replace')
-    def test_write_new_apkg_single_deck(self, mock_replace, mock_package):
+    def test_write_new_apkg_single_deck(self, mock_replace, mock_fast_package):
         note = Note(model=self.test_model, fields=['Q1', 'A1'])
         deck_payload = {
             "id": 1234567890,
@@ -42,18 +47,18 @@ class TestWriteApkg(TestCase):
                 _write_new_apkg([deck_payload], [])
                 
                 # Verify Package was created with correct deck
-                mock_package.assert_called_once()
-                created_deck = mock_package.call_args[0][0][0]
+                mock_fast_package.assert_called_once()
+                created_deck = mock_fast_package.call_args[0][0][0]
                 self.assertEqual(created_deck.name, "Test Deck")
                 self.assertEqual(str(created_deck.deck_id), "1234567890")
                 
                 # Verify file operations
-                mock_package.return_value.write_to_file.assert_called_once()
+                mock_fast_package.return_value.write_to_file.assert_called_once()
                 mock_replace.assert_called_once()
 
-    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.FastPackage')
     @mock.patch('helpers.write_apkg.os.replace')
-    def test_write_new_apkg_multiple_decks(self, mock_replace, mock_package):
+    def test_write_new_apkg_multiple_decks(self, mock_replace, mock_fast_package):
         note1 = Note(model=self.test_model, fields=['Q1', 'A1'])
         note2 = Note(model=self.test_model, fields=['Q2', 'A2'])
         
@@ -76,19 +81,19 @@ class TestWriteApkg(TestCase):
             with mock.patch('os.getcwd', return_value=tmpdir):
                 _write_new_apkg(deck_payloads, [])
                 
-                mock_package.assert_called_once()
-                created_decks = mock_package.call_args[0][0]
+                mock_fast_package.assert_called_once()
+                created_decks = mock_fast_package.call_args[0][0]
                 self.assertEqual(len(created_decks), 2)
                 self.assertEqual(created_decks[0].name, "Test Deck 1")
                 self.assertEqual(created_decks[1].name, "Test Deck 2")
                 
                 # Verify file operations
-                mock_package.return_value.write_to_file.assert_called_once()
+                mock_fast_package.return_value.write_to_file.assert_called_once()
                 mock_replace.assert_called_once()
 
-    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.FastPackage')
     @mock.patch('helpers.write_apkg.os.replace')
-    def test_write_new_apkg_with_media(self, mock_replace, mock_package):
+    def test_write_new_apkg_with_media(self, mock_replace, mock_fast_package):
         note = Note(model=self.test_model, fields=['Q1', 'A1'])
         deck_payload = {
             "id": 1234567890,
@@ -107,17 +112,17 @@ class TestWriteApkg(TestCase):
             with mock.patch('os.getcwd', return_value=tmpdir):
                 _write_new_apkg([deck_payload], media_files)
 
-                mock_package.assert_called_once()
-                package_instance = mock_package.return_value
+                mock_fast_package.assert_called_once()
+                package_instance = mock_fast_package.return_value
                 self.assertEqual(package_instance.media_files, media_files)
                 
                 # Verify file operations
-                mock_package.return_value.write_to_file.assert_called_once()
+                mock_fast_package.return_value.write_to_file.assert_called_once()
                 mock_replace.assert_called_once()
 
-    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.FastPackage')
     @mock.patch('helpers.write_apkg.os.replace')
-    def test_write_new_apkg_skips_missing_media(self, mock_replace, mock_package):
+    def test_write_new_apkg_skips_missing_media(self, mock_replace, mock_fast_package):
         note = Note(model=self.test_model, fields=['Q1', 'A1'])
         deck_payload = {
             "id": 1234567890,
@@ -134,18 +139,18 @@ class TestWriteApkg(TestCase):
             with mock.patch('os.getcwd', return_value=tmpdir):
                 _write_new_apkg([deck_payload], media_files)
 
-                package_instance = mock_package.return_value
+                package_instance = mock_fast_package.return_value
                 self.assertEqual(package_instance.media_files, [existing_path])
 
-    @mock.patch('helpers.write_apkg.Package')
+    @mock.patch('helpers.write_apkg.FastPackage')
     @mock.patch('helpers.write_apkg.os.replace')
-    def test_write_new_apkg_empty_deck_list(self, mock_replace, mock_package):
+    def test_write_new_apkg_empty_deck_list(self, mock_replace, mock_fast_package):
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch('os.getcwd', return_value=tmpdir):
                 _write_new_apkg([], [])
                 
-                mock_package.assert_called_once()
-                mock_package.return_value.write_to_file.assert_called_once()
+                mock_fast_package.assert_called_once()
+                mock_fast_package.return_value.write_to_file.assert_called_once()
                 mock_replace.assert_called_once()
                 
                 # Verify the default name is used
@@ -213,6 +218,51 @@ class TestWriteApkg(TestCase):
                 expected_filename = "safe_name-safe_id.apkg"
                 self.assertTrue(result.endswith(expected_filename))
                 self.assertTrue(os.path.exists(result))
-                
+
                 # Verify the file is in the expected directory
                 self.assertEqual(os.path.dirname(result), tmpdir)
+
+
+class TestFastPackagePragmas(TestCase):
+    def test_sets_memory_journal_and_off_synchronous_before_writing(self):
+        """FastPackage.write_to_db must set the fast pragmas before any DDL."""
+        package = FastPackage([])
+        cursor = mock.MagicMock()
+        id_gen = iter([1, 2, 3])
+
+        with mock.patch(
+            'genanki.package.Package.write_to_db',
+            return_value=None,
+        ) as super_write:
+            package.write_to_db(cursor, 1.0, id_gen)
+
+        execute_calls = [c.args[0] for c in cursor.execute.call_args_list]
+        self.assertIn('PRAGMA journal_mode=MEMORY', execute_calls)
+        self.assertIn('PRAGMA synchronous=OFF', execute_calls)
+        super_write.assert_called_once_with(cursor, 1.0, id_gen)
+
+    def test_pragmas_run_before_super_write_to_db(self):
+        """Pragmas must run before super().write_to_db so the schema DDL benefits."""
+        package = FastPackage([])
+        cursor = mock.MagicMock()
+        id_gen = iter([1, 2, 3])
+        call_order = []
+
+        cursor.execute.side_effect = lambda sql: call_order.append(('execute', sql))
+
+        def fake_super(self_, c, t, g):  # pragma: no cover - exercised below
+            call_order.append(('super_write', None))
+
+        with mock.patch(
+            'genanki.package.Package.write_to_db',
+            side_effect=fake_super,
+            autospec=True,
+        ):
+            package.write_to_db(cursor, 1.0, id_gen)
+
+        labels = [label for label, _ in call_order]
+        self.assertEqual(
+            labels,
+            ['execute', 'execute', 'super_write'],
+            f"Expected pragmas first, then super write_to_db. Got: {call_order}",
+        )


### PR DESCRIPTION
## What

Subclasses `genanki.Package` as `FastPackage` and sets `PRAGMA journal_mode=MEMORY` + `PRAGMA synchronous=OFF` on the SQLite cursor before any DDL runs. `_write_new_apkg` constructs `FastPackage(decks)` instead of `Package(decks)`.

```python
class FastPackage(Package):
    def write_to_db(self, cursor, timestamp, id_gen):
        cursor.execute('PRAGMA journal_mode=MEMORY')
        cursor.execute('PRAGMA synchronous=OFF')
        super().write_to_db(cursor, timestamp, id_gen)
```

## Cost recovered

From the original audit (`#2414`), measured on a 1000-card deck:

- Default pragmas: schema/index DDL takes **~58 ms**.
- `journal_mode=MEMORY` + `synchronous=OFF`: same DDL takes **~0.7 ms**.

That's an 83× cut on the sub-stage; the audit estimated **~29 % reduction in total Python-side wall-clock per `.apkg` build**.

## .apkg fidelity

Preserved. The pragmas only affect write-time durability — they do not change the resulting SQLite file contents, schema, row data, or layout inside the final ZIP. The build path is write-once → ZIP → done; there is no crash window where durability matters.

## Tests

- New `TestFastPackagePragmas` asserts both pragma statements are executed and that they run **before** the super class's `write_to_db`. Without that ordering the DDL would run under default pragmas and the optimization would not apply.
- Existing `_write_new_apkg` mocks switched from `Package` → `FastPackage` so they continue to assert against the actual symbol the code uses.

## Browser check

Browser check: not applicable — Python build-script change, no `web/src/` files touched.

Closes #2414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783114862&installation_id=132681956&pr_number=3084&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3084&signature=f9e1bc2ada3db9842e3f777e20a01a70276e09deb1cc7824c1c23cf450b04d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->