### PR TITLE
refactor: share rate limiter across controllers + add Retry-After: 60 on 429

### DIFF
--- a/src/controllers/ErrorEventController.test.ts
+++ b/src/controllers/ErrorEventController.test.ts
@@ -1,9 +1,6 @@
 import { Request, Response } from 'express';
-import {
-  ErrorEventController,
-  InMemoryRateLimiter,
-  RateLimiter,
-} from './ErrorEventController';
+import { ErrorEventController } from './ErrorEventController';
+import { RateLimiter } from '../lib/rateLimit/InMemoryRateLimiter';
 import { IngestErrorEventUseCase } from '../usecases/events/IngestErrorEventUseCase';
 
 function makeIngestUseCase(result: 'accepted' | 'duplicate' = 'accepted'): IngestErrorEventUseCase {
@@ -12,10 +9,15 @@ function makeIngestUseCase(result: 'accepted' | 'duplicate' = 'accepted'): Inges
   } as unknown as IngestErrorEventUseCase;
 }
 
-function makeRes(): jest.Mocked<Pick<Response, 'status' | 'json' | 'end'>> & { _statusCode?: number; _body?: unknown } {
+function makeRes(): jest.Mocked<Pick<Response, 'status' | 'json' | 'end' | 'set'>> & {
+  _statusCode?: number;
+  _body?: unknown;
+  _headers: Record<string, string>;
+} {
   const res = {
     _statusCode: 0,
     _body: undefined as unknown,
+    _headers: {} as Record<string, string>,
     status(code: number) {
       this._statusCode = code;
       return this;
@@ -24,11 +26,17 @@ function makeRes(): jest.Mocked<Pick<Response, 'status' | 'json' | 'end'>> & { _
       this._body = body;
       return this;
     },
+    set(name: string, value: string) {
+      this._headers[name] = value;
+      return this;
+    },
     end() {
       return this;
     },
   };
-  return res as unknown as jest.Mocked<Pick<Response, 'status' | 'json' | 'end'>> & { _statusCode?: number; _body?: unknown };
+  return res as unknown as jest.Mocked<
+    Pick<Response, 'status' | 'json' | 'end' | 'set'>
+  > & { _statusCode?: number; _body?: unknown; _headers: Record<string, string> };
 }
 
 function makeReq(body: unknown, remoteAddress = '127.0.0.1'): Request {
@@ -84,6 +92,14 @@ describe('ErrorEventController.ingest', () => {
     expect(res._statusCode).toBe(429);
   });
 
+  it('sets Retry-After: 60 on a 429 response', async () => {
+    const exhaustedLimiter: RateLimiter = { check: () => false };
+    const controller = new ErrorEventController(makeIngestUseCase(), exhaustedLimiter);
+    const res = makeRes();
+    await controller.ingest(makeReq(VALID_BODY), res as unknown as Response);
+    expect(res._headers['Retry-After']).toBe('60');
+  });
+
   it('does not call the use case when the rate limit is exceeded', async () => {
     const useCase = makeIngestUseCase();
     const exhaustedLimiter: RateLimiter = { check: () => false };
@@ -102,29 +118,5 @@ describe('ErrorEventController.ingest', () => {
     const callArg = (executeSpy.mock.calls[0][0] as { ipHash: string; payload: unknown });
     expect(callArg.ipHash).not.toBe('192.168.1.1');
     expect(callArg.ipHash).toHaveLength(64);
-  });
-});
-
-describe('InMemoryRateLimiter', () => {
-  it.each([
-    [1, true],
-    [5, true],
-    [10, true],
-    [11, false],
-  ])('after %i requests from the same IP the %ith is %s', (count, expected) => {
-    const limiter = new InMemoryRateLimiter(60_000, 10, 1000);
-    let result = false;
-    for (let i = 0; i < count; i++) {
-      result = limiter.check('same-ip-hash');
-    }
-    expect(result).toBe(expected);
-  });
-
-  it('allows a second IP while the first is exhausted', () => {
-    const limiter = new InMemoryRateLimiter(60_000, 1, 1000);
-    limiter.check('ip-a');
-    limiter.check('ip-a');
-    const result = limiter.check('ip-b');
-    expect(result).toBe(true);
   });
 });

--- a/src/controllers/ErrorEventController.ts
+++ b/src/controllers/ErrorEventController.ts
@@ -1,69 +1,15 @@
-import crypto from 'node:crypto';
 import { Request, Response } from 'express';
 import { IngestErrorEventUseCase, ErrorEventPayload } from '../usecases/events/IngestErrorEventUseCase';
+import {
+  InMemoryRateLimiter,
+  RateLimiter,
+} from '../lib/rateLimit/InMemoryRateLimiter';
+import { hashIp, resolveClientIp } from '../lib/rateLimit/ipHelpers';
 
 const MAX_BODY_BYTES = 10 * 1024;
 const RATE_WINDOW_MS = 60_000;
 const PER_IP_MAX = 10;
 const GLOBAL_MAX = 1000;
-
-interface RateBucket {
-  count: number;
-  resetAt: number;
-}
-
-export interface RateLimiter {
-  check(ipHash: string): boolean;
-}
-
-export class InMemoryRateLimiter implements RateLimiter {
-  private readonly ipBuckets = new Map<string, RateBucket>();
-  private globalBucket: RateBucket;
-
-  constructor(
-    private readonly windowMs = RATE_WINDOW_MS,
-    private readonly perIpMax = PER_IP_MAX,
-    private readonly globalMax = GLOBAL_MAX
-  ) {
-    this.globalBucket = { count: 0, resetAt: Date.now() + this.windowMs };
-  }
-
-  check(ipHash: string): boolean {
-    const now = Date.now();
-
-    if (now >= this.globalBucket.resetAt) {
-      this.globalBucket = { count: 0, resetAt: now + this.windowMs };
-    }
-    if (this.globalBucket.count >= this.globalMax) {
-      return false;
-    }
-    this.globalBucket.count += 1;
-
-    const existing = this.ipBuckets.get(ipHash);
-    if (existing == null || now >= existing.resetAt) {
-      this.ipBuckets.set(ipHash, { count: 1, resetAt: now + this.windowMs });
-      return true;
-    }
-    if (existing.count >= this.perIpMax) {
-      this.globalBucket.count -= 1;
-      return false;
-    }
-    existing.count += 1;
-    return true;
-  }
-}
-
-function hashIp(raw: string): string {
-  return crypto.createHash('sha256').update(raw).digest('hex');
-}
-
-function resolveIp(req: Request): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string') {
-    return forwarded.split(',')[0].trim();
-  }
-  return req.socket?.remoteAddress ?? 'unknown';
-}
 
 function validatePayload(body: unknown): ErrorEventPayload | null {
   if (body == null || typeof body !== 'object' || Array.isArray(body)) {
@@ -94,7 +40,13 @@ export class ErrorEventController {
     private readonly ingestUseCase: IngestErrorEventUseCase,
     rateLimiter?: RateLimiter
   ) {
-    this.rateLimiter = rateLimiter ?? new InMemoryRateLimiter();
+    this.rateLimiter =
+      rateLimiter ??
+      new InMemoryRateLimiter({
+        windowMs: RATE_WINDOW_MS,
+        perKeyMax: PER_IP_MAX,
+        globalMax: GLOBAL_MAX,
+      });
   }
 
   async ingest(req: Request, res: Response): Promise<void> {
@@ -110,11 +62,12 @@ export class ErrorEventController {
       return;
     }
 
-    const rawIp = resolveIp(req);
+    const rawIp = resolveClientIp(req);
     const ipHash = hashIp(rawIp);
 
     const allowed = this.rateLimiter.check(ipHash);
     if (!allowed) {
+      res.set('Retry-After', '60');
       res.status(429).json({ error: 'Rate limit exceeded' });
       return;
     }

--- a/src/controllers/Upload/UploadController.test.ts
+++ b/src/controllers/Upload/UploadController.test.ts
@@ -246,6 +246,7 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
 
     const jsonSpy = jest.fn();
     let capturedStatus = 0;
+    const capturedHeaders: Record<string, string> = {};
 
     const req = {
       file: { path: '/tmp/does-not-need-to-exist.pdf', originalname: 'foo.pdf' },
@@ -256,6 +257,10 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
 
     const res = {
       locals: {},
+      set: (name: string, value: string) => {
+        capturedHeaders[name] = value;
+        return res;
+      },
       status: (code: number) => {
         capturedStatus = code;
         return { json: jsonSpy } as unknown as express.Response;
@@ -266,6 +271,7 @@ describe('UploadController.retryPdfWithCredential rate limit', () => {
 
     expect(blockingLimiter.check).toHaveBeenCalledTimes(1);
     expect(capturedStatus).toBe(429);
+    expect(capturedHeaders['Retry-After']).toBe('60');
     expect(jsonSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.stringContaining('Too many password attempts'),

--- a/src/controllers/Upload/UploadController.ts
+++ b/src/controllers/Upload/UploadController.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import express from 'express';
 import fs from 'node:fs';
 import multer from 'multer';
@@ -8,6 +7,7 @@ import {
   InMemoryRateLimiter,
   RateLimiter,
 } from '../../lib/rateLimit/InMemoryRateLimiter';
+import { hashIp, resolveClientIp } from '../../lib/rateLimit/ipHelpers';
 import NotionService from '../../services/NotionService';
 import UploadService from '../../services/UploadService';
 import { getUploadHandler } from '../../lib/misc/GetUploadHandler';
@@ -33,18 +33,6 @@ const GOOGLE_DRIVE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 const RETRY_PDF_WINDOW_MS = 60_000;
 const RETRY_PDF_PER_IP_MAX = 10;
 const RETRY_PDF_GLOBAL_MAX = 500;
-
-function resolveClientIp(req: express.Request): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string') {
-    return forwarded.split(',')[0].trim();
-  }
-  return req.socket?.remoteAddress ?? 'unknown';
-}
-
-function hashIp(raw: string): string {
-  return crypto.createHash('sha256').update(raw).digest('hex');
-}
 
 class UploadController {
   private readonly retryPdfRateLimiter: RateLimiter;
@@ -260,6 +248,7 @@ class UploadController {
           error: e instanceof Error ? e.message : String(e),
         });
       });
+      res.set('Retry-After', '60');
       return res
         .status(429)
         .json({ message: 'Too many password attempts. Please wait a minute and try again.' });

--- a/src/lib/rateLimit/ipHelpers.test.ts
+++ b/src/lib/rateLimit/ipHelpers.test.ts
@@ -1,0 +1,67 @@
+import crypto from 'node:crypto';
+import express from 'express';
+import { resolveClientIp, hashIp } from './ipHelpers';
+
+function makeReq(
+  headers: Record<string, unknown>,
+  remoteAddress?: string
+): express.Request {
+  return {
+    headers,
+    socket: { remoteAddress },
+  } as unknown as express.Request;
+}
+
+describe('resolveClientIp', () => {
+  it('returns the x-forwarded-for value when present', () => {
+    const req = makeReq({ 'x-forwarded-for': '203.0.113.7' }, '10.0.0.1');
+    expect(resolveClientIp(req)).toBe('203.0.113.7');
+  });
+
+  it('returns the first hop of a comma-separated x-forwarded-for', () => {
+    const req = makeReq(
+      { 'x-forwarded-for': '203.0.113.7, 70.41.3.18, 150.172.238.178' },
+      '10.0.0.1'
+    );
+    expect(resolveClientIp(req)).toBe('203.0.113.7');
+  });
+
+  it('trims whitespace around the first hop', () => {
+    const req = makeReq({ 'x-forwarded-for': '  203.0.113.7 , 70.41.3.18' });
+    expect(resolveClientIp(req)).toBe('203.0.113.7');
+  });
+
+  it('falls back to socket.remoteAddress when x-forwarded-for is missing', () => {
+    const req = makeReq({}, '198.51.100.4');
+    expect(resolveClientIp(req)).toBe('198.51.100.4');
+  });
+
+  it("returns 'unknown' when neither header nor remoteAddress is present", () => {
+    const req = makeReq({});
+    expect(resolveClientIp(req)).toBe('unknown');
+  });
+});
+
+describe('hashIp', () => {
+  it('produces a 64-character hex sha256 digest', () => {
+    const digest = hashIp('203.0.113.7');
+    expect(digest).toHaveLength(64);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(hashIp('203.0.113.7')).toBe(hashIp('203.0.113.7'));
+  });
+
+  it('matches a direct sha256 hex computation', () => {
+    const expected = crypto
+      .createHash('sha256')
+      .update('203.0.113.7')
+      .digest('hex');
+    expect(hashIp('203.0.113.7')).toBe(expected);
+  });
+
+  it('produces different digests for different inputs', () => {
+    expect(hashIp('203.0.113.7')).not.toBe(hashIp('203.0.113.8'));
+  });
+});

--- a/src/lib/rateLimit/ipHelpers.ts
+++ b/src/lib/rateLimit/ipHelpers.ts
@@ -1,0 +1,14 @@
+import crypto from 'node:crypto';
+import express from 'express';
+
+export function resolveClientIp(req: express.Request): string {
+  const forwarded = req.headers['x-forwarded-for'];
+  if (typeof forwarded === 'string') {
+    return forwarded.split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress ?? 'unknown';
+}
+
+export function hashIp(raw: string): string {
+  return crypto.createHash('sha256').update(raw).digest('hex');
+}


### PR DESCRIPTION
## What

Migrates `ErrorEventController` to the shared `InMemoryRateLimiter` from PR #3082. Extracts `resolveClientIp` + `hashIp` to `src/lib/rateLimit/ipHelpers.ts` so both controllers (ErrorEventController, UploadController) import from one place. Adds `Retry-After: 60` to both 429 responses per RFC 7231 §7.1.3.

Closes #3087.
Closes #3089.

## Why

Two copies of the rate limiter were in the tree after PR #3082 — one in `src/lib/rateLimit/` (the new one) and one inline in `ErrorEventController.ts` (the old one). Same pattern with `hashIp`/`resolveClientIp` helpers. Single source of truth so the next rate-limit fix (eviction, real-client-IP — #3088 — etc.) lands in one place.

`Retry-After: 60` was missing on both 429 sites; well-behaved API clients can now back off without hardcoding the interval.

## Sonar

`sonar-scanner` is not installed in this environment, so the local Sonar run was skipped — expect CI to run the rule engine. The change is a like-for-like extraction (no new branching, no nesting) plus a two-line header addition, so I don't anticipate new smells.

## Browser check

Browser check: not applicable — server-side refactor + header addition, no `web/src/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783146271&installation_id=132681956&pr_number=3090&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3090&signature=9deeb9e3313c396432b723bec5d9742661babcdbc856949b62d80bc74f520182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->