### PR TITLE
fix: stop sidebar collapse-rail insertBefore error and capture url on client error reports

### DIFF
--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -452,6 +452,15 @@ describe('Sidebar collapse toggle', () => {
     expect(aside.contains(rail)).toBe(false);
   });
 
+  it('renders the collapse rail as a sibling inside the component tree, not portaled to document.body', () => {
+    const { container } = renderSidebar();
+    const aside = screen.getByRole('complementary', { name: 'Main navigation' });
+    const rail = screen.getByRole('button', { name: 'Collapse sidebar' });
+    expect(container.contains(rail)).toBe(true);
+    expect(rail.parentElement).toBe(aside.parentElement);
+    expect(document.body.contains(rail)).toBe(true);
+  });
+
   it('renders the rail label, flipping between Collapse and Expand', () => {
     renderSidebar();
     const toggle = screen.getByRole('button', { name: 'Collapse sidebar' });

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { createPortal } from 'react-dom';
 import { Link, useLocation } from 'react-router-dom';
 import { useTheme } from '../../lib/hooks/useTheme';
 import { useCardUsage } from '../../lib/hooks/useCardUsage';
@@ -237,291 +236,288 @@ export function Sidebar({
   };
 
   return (
-    <aside
-      id={drawerId}
-      className={`${styles.sidebar} ${isOpen ? styles.sidebarOpen : ''} ${collapsed ? styles.sidebarCollapsed : ''}`}
-      aria-label="Main navigation"
-      data-testid="app-sidebar"
-      data-collapsed={collapsed ? 'true' : 'false'}
-      onMouseEnter={onSidebarInteraction}
-      onFocus={onSidebarInteraction}
-    >
-      <div className={styles.sidebarHeader}>
-        <Link
-          className={styles.sidebarLogo}
-          to="/"
-          aria-label="2anki home"
-          onClick={handleNavClick()}
-        >
-          <img src={logoSrc} alt="" />
-        </Link>
-      </div>
-      {typeof document !== 'undefined' &&
-        createPortal(
-          <button
-            type="button"
-            onClick={onToggleClick}
-            className={`${styles.collapseRail} ${
-              collapsed ? styles.collapseRailCollapsed : ''
-            }`}
-            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-            aria-expanded={!collapsed}
-          >
-            <span className={styles.collapseRailLine} aria-hidden="true" />
-            <span className={styles.collapseRailContent} aria-hidden="true">
-              {collapsed ? (
-                <ArrowRightIcon width={16} height={16} />
-              ) : (
-                <ArrowLeftIcon width={16} height={16} />
-              )}
-              {collapsed ? 'Expand' : 'Collapse'}
-            </span>
-          </button>,
-          document.body
-        )}
-      <nav className={styles.sidebarNav}>
-        <div className={styles.sidebarGroup}>
-          <SidebarRow
-            href="/upload"
-            pathname={pathname}
-            matchPrefix={false}
+    <>
+      <aside
+        id={drawerId}
+        className={`${styles.sidebar} ${isOpen ? styles.sidebarOpen : ''} ${collapsed ? styles.sidebarCollapsed : ''}`}
+        aria-label="Main navigation"
+        data-testid="app-sidebar"
+        data-collapsed={collapsed ? 'true' : 'false'}
+        onMouseEnter={onSidebarInteraction}
+        onFocus={onSidebarInteraction}
+      >
+        <div className={styles.sidebarHeader}>
+          <Link
+            className={styles.sidebarLogo}
+            to="/"
+            aria-label="2anki home"
             onClick={handleNavClick()}
-            icon={ArrowUpTrayIcon}
           >
-            {getVisibleText('navigation.upload')}
-          </SidebarRow>
-          <SidebarRow
-            href="/notion"
-            pathname={pathname}
-            onClick={handleNavClick()}
-            icon={ArrowRightIcon}
-          >
-            Notion to Anki
-          </SidebarRow>
-          <SidebarRow
-            href="/templates"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={SwatchIcon}
-          >
-            Note types
-          </SidebarRow>
-          <SidebarRow
-            href="/print"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={PrinterIcon}
-          >
-            {getVisibleText('navigation.print')}
-          </SidebarRow>
-          <SidebarRow
-            href="/chat"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={ChatBubbleIcon}
-          >
-            Chat
-          </SidebarRow>
-          <SidebarRow
-            href="/mindmaps"
-            pathname={pathname}
-            onClick={handleNavClick()}
-            icon={ShareIcon}
-          >
-            Mind maps
-          </SidebarRow>
-          <SidebarRow
-            href="/image-occlusion"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={RectangleGroupIcon}
-          >
-            Image Occlusion
-          </SidebarRow>
-          <SidebarRow
-            href="/photo-to-deck"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={CameraIcon}
-          >
-            Photo to deck
-          </SidebarRow>
-          <SidebarRow
-            href="/import"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={ArrowLeftIcon}
-          >
-            Anki to Notion
-          </SidebarRow>
-          <SidebarRow
-            href="/transform"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={RefreshIcon}
-          >
-            Transform
-          </SidebarRow>
-          {showAnkify && (
-            <SidebarRow
-              href="/ankify"
-              pathname={pathname}
-              onClick={handleNavClick()}
-              icon={SparklesIcon}
-            >
-              Auto Sync
-            </SidebarRow>
-          )}
+            <img src={logoSrc} alt="" />
+          </Link>
         </div>
-        <div className={styles.sidebarGroup}>
-          <p className={styles.sidebarGroupLabel}>Library</p>
-          <SidebarRow
-            href="/downloads"
-            pathname={pathname}
-            onClick={handleNavClick()}
-            icon={LayersIcon}
-          >
-            {getVisibleText('navigation.myDecks')}
-          </SidebarRow>
-          {showFavorites && (
-            <SidebarRow
-              href="/favorites"
-              pathname={pathname}
-              matchPrefix={false}
-              onClick={handleNavClick()}
-              icon={StarIcon}
-            >
-              Favorites
-            </SidebarRow>
-          )}
-          <SidebarRow
-            href="/card-options"
-            pathname={pathname}
-            matchPrefix={false}
-            onClick={handleNavClick()}
-            icon={SettingsIcon}
-          >
-            Settings
-          </SidebarRow>
-        </div>
-        <div className={styles.sidebarGroup}>
-          <p className={styles.sidebarGroupLabel}>Resources</p>
-          <SidebarRow
-            href="/documentation"
-            pathname={pathname}
-            onClick={handleNavClick()}
-            icon={BookOpenIcon}
-          >
-            {getVisibleText('navigation.docs')}
-          </SidebarRow>
-          {showPricing && (
-            <SidebarRow
-              href="/pricing"
-              pathname={pathname}
-              matchPrefix={false}
-              onClick={handleNavClick()}
-              icon={CreditCardIcon}
-            >
-              {getVisibleText('navigation.pricing')}
-            </SidebarRow>
-          )}
-        </div>
-        {showAdminGroup && (
+        <nav className={styles.sidebarNav}>
           <div className={styles.sidebarGroup}>
-            {showKi && (
+            <SidebarRow
+              href="/upload"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={ArrowUpTrayIcon}
+            >
+              {getVisibleText('navigation.upload')}
+            </SidebarRow>
+            <SidebarRow
+              href="/notion"
+              pathname={pathname}
+              onClick={handleNavClick()}
+              icon={ArrowRightIcon}
+            >
+              Notion to Anki
+            </SidebarRow>
+            <SidebarRow
+              href="/templates"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={SwatchIcon}
+            >
+              Note types
+            </SidebarRow>
+            <SidebarRow
+              href="/print"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={PrinterIcon}
+            >
+              {getVisibleText('navigation.print')}
+            </SidebarRow>
+            <SidebarRow
+              href="/chat"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={ChatBubbleIcon}
+            >
+              Chat
+            </SidebarRow>
+            <SidebarRow
+              href="/mindmaps"
+              pathname={pathname}
+              onClick={handleNavClick()}
+              icon={ShareIcon}
+            >
+              Mind maps
+            </SidebarRow>
+            <SidebarRow
+              href="/image-occlusion"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={RectangleGroupIcon}
+            >
+              Image Occlusion
+            </SidebarRow>
+            <SidebarRow
+              href="/photo-to-deck"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={CameraIcon}
+            >
+              Photo to deck
+            </SidebarRow>
+            <SidebarRow
+              href="/import"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={ArrowLeftIcon}
+            >
+              Anki to Notion
+            </SidebarRow>
+            <SidebarRow
+              href="/transform"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={RefreshIcon}
+            >
+              Transform
+            </SidebarRow>
+            {showAnkify && (
               <SidebarRow
-                href="/ki"
+                href="/ankify"
                 pathname={pathname}
                 onClick={handleNavClick()}
-                icon={CommandLineIcon}
+                icon={SparklesIcon}
               >
-                KI
+                Auto Sync
               </SidebarRow>
             )}
-            {showOps && (
-              <OpsSidebarFolder
+          </div>
+          <div className={styles.sidebarGroup}>
+            <p className={styles.sidebarGroupLabel}>Library</p>
+            <SidebarRow
+              href="/downloads"
+              pathname={pathname}
+              onClick={handleNavClick()}
+              icon={LayersIcon}
+            >
+              {getVisibleText('navigation.myDecks')}
+            </SidebarRow>
+            {showFavorites && (
+              <SidebarRow
+                href="/favorites"
                 pathname={pathname}
-                collapsed={collapsed}
-                onNavigate={handleNavClick()}
-              />
+                matchPrefix={false}
+                onClick={handleNavClick()}
+                icon={StarIcon}
+              >
+                Favorites
+              </SidebarRow>
+            )}
+            <SidebarRow
+              href="/card-options"
+              pathname={pathname}
+              matchPrefix={false}
+              onClick={handleNavClick()}
+              icon={SettingsIcon}
+            >
+              Settings
+            </SidebarRow>
+          </div>
+          <div className={styles.sidebarGroup}>
+            <p className={styles.sidebarGroupLabel}>Resources</p>
+            <SidebarRow
+              href="/documentation"
+              pathname={pathname}
+              onClick={handleNavClick()}
+              icon={BookOpenIcon}
+            >
+              {getVisibleText('navigation.docs')}
+            </SidebarRow>
+            {showPricing && (
+              <SidebarRow
+                href="/pricing"
+                pathname={pathname}
+                matchPrefix={false}
+                onClick={handleNavClick()}
+                icon={CreditCardIcon}
+              >
+                {getVisibleText('navigation.pricing')}
+              </SidebarRow>
             )}
           </div>
-        )}
-      </nav>
-      <div className={styles.sidebarTheme}>
-        {collapsed ? <ThemeToggle /> : <ThemeSwitcher />}
-        {!collapsed && (
-          <Link
-            to="/whats-new"
-            onClick={handleNavClick()}
-            className={styles.whatsNewLink}
-          >
-            What's new
-          </Link>
-        )}
-      </div>
-      <div className={styles.sidebarSpacer} />
-      <div className={styles.identity}>
-        <span className={styles.identityEmail} title={email ?? undefined}>
-          {email ?? 'Account'}
-        </span>
-        <span className={styles.identityPlan}>{planLabel}</span>
-        {showUsage && usage && (
-          <CardUsageCounter used={usage.cards_used} limit={usage.cards_limit} />
-        )}
-      </div>
-      <div className={styles.sidebarGroup}>
-        <SidebarRow
-          href="/account"
-          pathname={pathname}
-          matchPrefix={false}
-          onClick={handleNavClick()}
-          icon={UserCircleIcon}
-        >
-          {getVisibleText('navigation.account')}
-        </SidebarRow>
-        <a
-          className={styles.sidebarRow}
-          href="/users/logout"
-          onClick={handleNavClick(onLogOut)}
-          title={getVisibleText('navigation.logout')}
-        >
-          <ArrowRightOnRectangleIcon width={20} height={20} />
-          <span className={styles.sidebarRowLabel}>
-            {getVisibleText('navigation.logout')}
-          </span>
-        </a>
-      </div>
-      <div className={styles.sidebarMore}>
-        <div className={styles.sidebarMoreLinks}>
-          <Link to="/contact" onClick={handleNavClick()}>
-            {getVisibleText('navigation.contact')}
-          </Link>
-          <Link
-            to="/documentation/misc/privacy-policy"
-            onClick={handleNavClick()}
-          >
-            {getVisibleText('navigation.legal.privacy')}
-          </Link>
-          <Link
-            to="/documentation/misc/terms-of-service"
-            onClick={handleNavClick()}
-          >
-            {getVisibleText('navigation.legal.terms')}
-          </Link>
-          <Link to="/about" onClick={handleNavClick()}>
-            {getVisibleText('navigation.legal.about')}
-          </Link>
+          {showAdminGroup && (
+            <div className={styles.sidebarGroup}>
+              {showKi && (
+                <SidebarRow
+                  href="/ki"
+                  pathname={pathname}
+                  onClick={handleNavClick()}
+                  icon={CommandLineIcon}
+                >
+                  KI
+                </SidebarRow>
+              )}
+              {showOps && (
+                <OpsSidebarFolder
+                  pathname={pathname}
+                  collapsed={collapsed}
+                  onNavigate={handleNavClick()}
+                />
+              )}
+            </div>
+          )}
+        </nav>
+        <div className={styles.sidebarTheme}>
+          {collapsed ? <ThemeToggle /> : <ThemeSwitcher />}
+          {!collapsed && (
+            <Link
+              to="/whats-new"
+              onClick={handleNavClick()}
+              className={styles.whatsNewLink}
+            >
+              What's new
+            </Link>
+          )}
         </div>
-
-      </div>
-    </aside>
+        <div className={styles.sidebarSpacer} />
+        <div className={styles.identity}>
+          <span className={styles.identityEmail} title={email ?? undefined}>
+            {email ?? 'Account'}
+          </span>
+          <span className={styles.identityPlan}>{planLabel}</span>
+          {showUsage && usage && (
+            <CardUsageCounter used={usage.cards_used} limit={usage.cards_limit} />
+          )}
+        </div>
+        <div className={styles.sidebarGroup}>
+          <SidebarRow
+            href="/account"
+            pathname={pathname}
+            matchPrefix={false}
+            onClick={handleNavClick()}
+            icon={UserCircleIcon}
+          >
+            {getVisibleText('navigation.account')}
+          </SidebarRow>
+          <a
+            className={styles.sidebarRow}
+            href="/users/logout"
+            onClick={handleNavClick(onLogOut)}
+            title={getVisibleText('navigation.logout')}
+          >
+            <ArrowRightOnRectangleIcon width={20} height={20} />
+            <span className={styles.sidebarRowLabel}>
+              {getVisibleText('navigation.logout')}
+            </span>
+          </a>
+        </div>
+        <div className={styles.sidebarMore}>
+          <div className={styles.sidebarMoreLinks}>
+            <Link to="/contact" onClick={handleNavClick()}>
+              {getVisibleText('navigation.contact')}
+            </Link>
+            <Link
+              to="/documentation/misc/privacy-policy"
+              onClick={handleNavClick()}
+            >
+              {getVisibleText('navigation.legal.privacy')}
+            </Link>
+            <Link
+              to="/documentation/misc/terms-of-service"
+              onClick={handleNavClick()}
+            >
+              {getVisibleText('navigation.legal.terms')}
+            </Link>
+            <Link to="/about" onClick={handleNavClick()}>
+              {getVisibleText('navigation.legal.about')}
+            </Link>
+          </div>
+        </div>
+      </aside>
+      <button
+        type="button"
+        onClick={onToggleClick}
+        className={`${styles.collapseRail} ${
+          collapsed ? styles.collapseRailCollapsed : ''
+        }`}
+        aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        aria-expanded={!collapsed}
+      >
+        <span className={styles.collapseRailLine} aria-hidden="true" />
+        <span className={styles.collapseRailContent} aria-hidden="true">
+          {collapsed ? (
+            <ArrowRightIcon width={16} height={16} />
+          ) : (
+            <ArrowLeftIcon width={16} height={16} />
+          )}
+          {collapsed ? 'Expand' : 'Collapse'}
+        </span>
+      </button>
+    </>
   );
 }

--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -54,11 +54,34 @@ describe('reportClientError', () => {
     expect(body.userAgent).toBe('Vitest/1.0');
   });
 
-  it('includes context when provided', () => {
+  it('includes caller context merged with the translate breadcrumbs', () => {
     reportClientError(new Error('ctx test'), { route: '/upload' });
     const [, init] = getLastCall();
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
-    expect(body.context).toEqual({ route: '/upload' });
+    expect(body.context).toMatchObject({ route: '/upload' });
+  });
+
+  it('captures url, lang, and translated for the next investigator', () => {
+    reportClientError(new Error('translate test'));
+    const [, init] = getLastCall();
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.url).toBe(window.location.href);
+    const context = body.context as Record<string, unknown>;
+    expect(context).toHaveProperty('lang');
+    expect(context.translated).toBe(false);
+  });
+
+  it('flags translated when Chrome Translate has added its html class', () => {
+    document.documentElement.classList.add('translated-ltr');
+    try {
+      reportClientError(new Error('translated page'));
+      const [, init] = getLastCall();
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      const context = body.context as Record<string, unknown>;
+      expect(context.translated).toBe(true);
+    } finally {
+      document.documentElement.classList.remove('translated-ltr');
+    }
   });
 
   it('swallows a fetch failure without throwing', () => {

--- a/web/src/lib/reportClientError.ts
+++ b/web/src/lib/reportClientError.ts
@@ -14,15 +14,21 @@ export function reportClientError(
         : String(error);
     const stack = error instanceof Error ? error.stack ?? null : null;
     const release = process.env.REACT_APP_RELEASE ?? null;
+    const root = document.documentElement;
+    const lang = root.lang || navigator.language || null;
+    const translated =
+      root.classList.contains('translated-ltr') ||
+      root.classList.contains('translated-rtl');
 
     const payload: Record<string, unknown> = {
       message,
       source: 'web',
+      url: window.location.href,
       userAgent: navigator.userAgent,
+      context: { ...context, lang, translated },
     };
     if (stack != null) payload.stack = stack;
     if (release != null) payload.release = release;
-    if (context != null) payload.context = context;
 
     fetch(ENDPOINT, {
       method: 'POST',


### PR DESCRIPTION
## What
The sidebar collapse-rail (the hover pill that toggles the sidebar) was rendered via `createPortal(<button>, document.body)`. This PR drops the portal and renders the rail as a `position: fixed` sibling of the `<aside>` inside the same React subtree. It also expands the client error reporter to capture `url`, `lang`, and `translated`.

## Why
We saw a recurring `Failed to execute 'insertBefore' on 'Node'` error class (28 hits in 7 days, climbing) — 100% Chromium/Edge on Windows, 100% anonymous users. Chrome's built-in "Translate this page" wraps and removes children of `document.body` between renders; React's reconciler then can't find the portaled button's anchor sibling and throws. The error fires through the error boundary, so most users never saw a visible crash — but it pollutes our error stream and points at a real reconciliation hazard.

The reporter currently sends `url: null`, so we can't see which page an error originated on. Capturing `url` + Chrome Translate markers gives the next investigator the breadcrumbs to confirm the hypothesis.

## How
- **Sidebar:** removed the `createPortal` import and render the rail `<button>` as a sibling of `<aside>` inside a fragment. The rail CSS is already `position: fixed` with viewport-relative `top/left`, so visual placement is unchanged — React just owns its own DOM subtree now and no longer reaches into `document.body`, which third-party Chrome extensions and Translate mutate freely.
- **Reporter:** `url = window.location.href` (top-level field the server `validatePayload` already accepts); `lang = document.documentElement.lang || navigator.language || null` and `translated = html.classList.contains('translated-ltr' | 'translated-rtl')` ride inside the existing `context` JSONB column. No migration, no server change.

## Measuring success
- The `insertBefore` error class in the error-events stream should drop to ~0 for new sessions after deploy (it was 28/7d and climbing).
- New rows in `error_events` now carry a non-null `url`, and `context.translated` / `context.lang` are populated — query: `select url, context->>'translated', context->>'lang' from error_events where source = 'web' order by created_at desc limit 50`.

## Testing
- Web vitest: 1671 passed (194 files), incl. the two affected files.
- Sidebar: added a test asserting the rail renders as a sibling inside the component tree (in the render container, sharing a parent with `<aside>`), not portaled to `document.body`.
- Reporter: added tests asserting `url`, `lang`, and `translated` are present on the posted payload, and that `translated` flips to `true` when the Chrome Translate `translated-ltr` class is on the html root. Existing context test updated to `toMatchObject` since `context` now always carries the breadcrumbs.
- Server `EventsRouter` jest suite: 12 passed (controller already accepted `url`/`context`).
- `/check` equivalent green: server tsc, web typecheck, web vitest, Biome lint.

Note on Node: the local default node was 22.2.0, which lacks `require(esm)` and breaks the jsdom test env (unrelated to this change); ran everything on 22.20.0 (matches `.nvmrc` / CI). sonar-scanner not installed locally — expect a possible Sonar pass on CI; the change adds no new branches/complexity (rail button moved, a few const reads added).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified the collapse rail renders, toggles, and is positioned identically (fixed, viewport-relative); rail is hidden below 1024px as before.

## Changelog
No changelog entry — bug fix is for a non-visible console error reported through the error boundary; users did not see a UI crash.

## Decisions made overnight (please review)

- Chose to **drop the portal** rather than retarget it to `<div id="portal-root">`. The portal intent was to render the hover pill outside the `<aside>` clip — a `position: fixed` sibling achieves the same visual outcome without crossing into `document.body` (which third-party Chrome extensions and Translate mutate freely). If you would rather keep portaling but to an app-owned root, swap the change to render the existing `<aside>`-sibling `<div>` as a `<div id="portal-root">` inside `#root` and re-add `createPortal` against that ref. Two-line swap.
- Captured `url` + `lang` + `translated` (in `context`) on the error reporter, **not** capturing the full navigator object — keeps PII out of `error_events` while giving the next investigator enough to confirm the Chrome Translate hypothesis. If you want a wider breadcrumb (extension markers, plugin list), expand the keys passed into `context`.
- No design review since this is a bug fix with identical visual outcome — pixel-positioning of the collapse rail should be unchanged. If the rail moves after this PR, the new `position: fixed` `top/left/right` values are wrong; please flag.

## Risks
Low. The rail positioning is viewport-relative (`position: fixed`), so child-vs-sibling placement is identical on desktop where it is visible (it is `display: none` below 1024px). The one ancestor that sets `transform` on `.sidebar` is the mobile media query — but the rail is hidden there, so no containing-block surprise. Rollback is a straight revert of one commit.

## Goal alignment
Toward 300K users: removes a recurring error from our observability stream so real regressions are not buried in noise, and the `url`/Translate breadcrumbs make the next client-side incident diagnosable in minutes instead of guesswork. A quieter, more reliable Chromium experience for anonymous (pre-signup) visitors directly protects the top of the funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783156921&installation_id=132681956&pr_number=3091&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3091&signature=1a0a92f968673611c0a5c9269101f7a7b503cc2c9800c217fbb6d9173ab6f164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->