### PR TITLE
fix: dedup upload_started, emit conversion_failed on all paths, drop stale conversion_success fire

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -48,6 +48,7 @@ import {
 import { CompleteJobUseCase } from '../../../../usecases/jobs/CompleteJobUseCase';
 import { BuildDeckForJobUseCase } from '../../../../usecases/jobs/BuildDeckForJobUseCase';
 import { NotifyUserUseCase } from '../../../../usecases/jobs/NotifyUserUseCase';
+import { PythonExitError } from '../../../anki/buildPythonExitError';
 import { track } from '../../../../services/events/track';
 
 function makeUnauthorizedError(): APIResponseError {
@@ -161,6 +162,12 @@ describe('performConversion — heavy pipeline', () => {
       baseRequest.owner,
       expect.stringContaining(baseRequest.id)
     );
+    expect(track).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({ reason: 'no_decks_created' }),
+      })
+    );
   });
 
   it('sets notion_token_expired reason and calls markTokenInvalid when workspace throws a 401', async () => {
@@ -177,6 +184,30 @@ describe('performConversion — heavy pipeline', () => {
       NOTION_TOKEN_EXPIRED_REASON
     );
     expect(markTokenInvalidMock).toHaveBeenCalledWith(42);
+    expect(track).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({ reason: 'notion_token_expired' }),
+      })
+    );
+  });
+
+  it('emits conversion_failed with reason=unknown for an unclassified workspace error', async () => {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(new Error('random error')),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(track).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({
+          source: 'notion',
+          reason: 'unknown',
+        }),
+      })
+    );
   });
 
   it('does not call markTokenInvalid for non-unauthorized errors', async () => {
@@ -220,6 +251,16 @@ describe('performConversion — heavy pipeline', () => {
       cards_used: 80,
       limit: 100,
     });
+    expect(track).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({
+          reason: 'monthly_limit',
+          cards_used: 80,
+          limit: 100,
+        }),
+      })
+    );
   });
 
   it('marks job as failed with the empty-deck reason when decks have zero cards', async () => {
@@ -311,6 +352,42 @@ describe('performConversion — heavy pipeline', () => {
       expect.objectContaining({
         anonymousId: 'anon-from-cookie',
         props: expect.objectContaining({ reason: 'empty_deck' }),
+      })
+    );
+  });
+
+  it('emits conversion_failed with reason=python_crash when the deck build throws a PythonExitError', async () => {
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: {},
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [1, 2, 3] }]),
+    }));
+    (CheckMonthlyCardLimitUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (BuildDeckForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(
+        new PythonExitError('python died', {
+          kind: 'unknown',
+          rawOutput: 'traceback',
+          code: 1,
+        })
+      ),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(track).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({ reason: 'python_crash' }),
       })
     );
   });

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -21,6 +21,7 @@ import {
   EMPTY_DECK_FAILURE_REASON,
   isColumnsAmbiguousError,
   isNotionUnauthorizedError,
+  jobFailureReasonCode,
   jobFailureReasonFromError,
 } from '../../../../usecases/jobs/jobFailureReason';
 import { PythonExitError } from '../../../anki/buildPythonExitError';
@@ -60,6 +61,19 @@ interface ConversionRequest {
 
 function toAnonymousId(anonId?: string): string | null {
   return typeof anonId === 'string' && anonId.length > 0 ? anonId : null;
+}
+
+function trackConversionFailed(
+  owner: string,
+  anonId: string | undefined,
+  type: string | undefined,
+  reasonProps: Record<string, unknown>
+): void {
+  track('conversion_failed', {
+    userId: Number.isFinite(Number(owner)) ? Number(owner) : null,
+    anonymousId: toAnonymousId(anonId),
+    props: { source: toConversionSource(type), ...reasonProps },
+  });
 }
 
 export default async function performConversion(
@@ -108,6 +122,7 @@ export default async function performConversion(
           '.' +
           String(jobDbId)
       );
+      trackConversionFailed(owner, anonId, type, { reason: 'no_decks_created' });
       return;
     }
 
@@ -115,11 +130,7 @@ export default async function performConversion(
     if (cardCount === 0) {
       const setJobFailed = new SetJobFailedUseCase(jobRepository);
       await setJobFailed.execute(id, owner, EMPTY_DECK_FAILURE_REASON);
-      track('conversion_failed', {
-        userId: Number.isFinite(Number(owner)) ? Number(owner) : null,
-        anonymousId: toAnonymousId(anonId),
-        props: { source: toConversionSource(type), reason: 'empty_deck' },
-      });
+      trackConversionFailed(owner, anonId, type, { reason: 'empty_deck' });
       return;
     }
 
@@ -140,6 +151,11 @@ export default async function performConversion(
           reset_on: error.reset_on,
         });
         await setJobFailed.execute(id, owner, payload);
+        trackConversionFailed(owner, anonId, type, {
+          reason: 'monthly_limit',
+          cards_used: error.cards_used,
+          limit: error.limit,
+        });
         return;
       }
       throw error;
@@ -205,6 +221,9 @@ export default async function performConversion(
     }
     const failedJob = new SetJobFailedUseCase(jobRepository);
     await failedJob.execute(id, owner, jobFailureReasonFromError(error, id));
+    trackConversionFailed(owner, anonId, type, {
+      reason: jobFailureReasonCode(error),
+    });
     const isExpectedUserState =
       error instanceof EmptyDeckError ||
       isColumnsAmbiguousError(error) ||

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -207,6 +207,27 @@ describe('UploadService.handleUpload — error paths', () => {
     );
   });
 
+  it('attributes source=dropbox when the request lands on the dropbox path with no explicit source', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({ packages: [] }),
+    }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
+
+    const service = new UploadService(buildRepository(), {} as JobRepository, buildUsersRepo());
+    const req = buildRequest({
+      path: '/api/upload/dropbox',
+    } as Partial<express.Request>);
+    const { res } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'upload_started',
+      expect.objectContaining({
+        props: expect.objectContaining({ source: 'dropbox' }),
+      })
+    );
+  });
+
   it('returns 400 JSON with empty_export code, spec copy and docs link when no packages are produced', async () => {
     MockGeneratePackagesUseCase.mockImplementation(() => ({
       execute: jest.fn().mockResolvedValue({ packages: [] }),
@@ -452,6 +473,13 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     expect(capturedSend()).toBeNull();
     expect(incrementSpy).not.toHaveBeenCalled();
     expect(trackMock).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        userId: 42,
+        props: expect.objectContaining({ reason: 'monthly_limit', source: 'upload' }),
+      })
+    );
+    expect(trackMock).toHaveBeenCalledWith(
       'paywall_shown',
       expect.objectContaining({
         userId: 42,
@@ -503,6 +531,14 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     expect(redirectedTo()).toBe('/limit?kind=anonymous');
     expect(capturedSend()).toBeNull();
     expect(incrementSpy).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        userId: null,
+        anonymousId: null,
+        props: expect.objectContaining({ reason: 'anonymous_cap', source: 'upload' }),
+      })
+    );
     expect(trackMock).toHaveBeenCalledWith(
       'paywall_shown',
       expect.objectContaining({

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -273,18 +273,34 @@ class UploadService {
     } catch (err) {
       if (err instanceof MonthlyLimitError) {
         const owner = getOwner(res);
+        const userId = owner != null ? Number(owner) : null;
+        const source = this.resolveUploadSource(req);
+        const anonymousId = this.resolveAnonId(req);
+        track('conversion_failed', {
+          userId,
+          anonymousId,
+          props: { source, reason: 'monthly_limit' },
+        });
         track('paywall_shown', {
-          userId: owner != null ? Number(owner) : null,
-          anonymousId: this.resolveAnonId(req),
-          props: { source: this.resolveUploadSource(req), kind: 'card_count' },
+          userId,
+          anonymousId,
+          props: { source, kind: 'card_count' },
         });
         return res.redirect('/limit?kind=card_count');
       } else if (err instanceof AnonymousCardCapError) {
         const owner = getOwner(res);
+        const userId = owner != null ? Number(owner) : null;
+        const source = this.resolveUploadSource(req);
+        const anonymousId = this.resolveAnonId(req);
+        track('conversion_failed', {
+          userId,
+          anonymousId,
+          props: { source, reason: 'anonymous_cap' },
+        });
         track('paywall_shown', {
-          userId: owner != null ? Number(owner) : null,
-          anonymousId: this.resolveAnonId(req),
-          props: { source: this.resolveUploadSource(req), kind: 'anonymous' },
+          userId,
+          anonymousId,
+          props: { source, kind: 'anonymous' },
         });
         return res.redirect('/limit?kind=anonymous');
       } else if (isLimitError(err as Error)) {
@@ -527,6 +543,7 @@ class UploadService {
     const explicit = this.resolvePersistedSource(req);
     if (explicit != null) return explicit;
     if (req.path?.includes('google_drive')) return 'google_drive';
+    if (req.path?.includes('dropbox')) return 'dropbox';
     return 'upload';
   }
 

--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -7,6 +7,7 @@ import {
   MARKDOWN_LIKELY_LOSSY_REASON,
   NOTION_TOKEN_EXPIRED_REASON,
   isNotionUnauthorizedError,
+  jobFailureReasonCode,
   jobFailureReasonFromError,
 } from './jobFailureReason';
 
@@ -197,5 +198,88 @@ describe('jobFailureReasonFromError', () => {
   it('generic fallback includes status link', () => {
     const reason = jobFailureReasonFromError(new Error('some unknown error'), 'job-unk');
     expect(reason).toContain('2anki.net/status');
+  });
+});
+
+describe('jobFailureReasonCode', () => {
+  function withCode(code: string): Error & { code?: string } {
+    const err = new Error(code) as Error & { code?: string };
+    err.code = code;
+    return err;
+  }
+
+  it('maps EmptyDeckError to empty_deck', () => {
+    expect(jobFailureReasonCode(new EmptyDeckError())).toBe('empty_deck');
+  });
+
+  it('maps markdown EmptyDeckError to markdown_likely_lossy', () => {
+    expect(jobFailureReasonCode(new EmptyDeckError('markdown'))).toBe(
+      'markdown_likely_lossy'
+    );
+  });
+
+  it('maps PythonExitError to python_crash', () => {
+    const err = buildPythonExitError({
+      code: 1,
+      stdout: '',
+      stderr: 'traceback',
+      jobId: 'job-py',
+    });
+    expect(jobFailureReasonCode(err)).toBe('python_crash');
+  });
+
+  it('maps an unauthorized Notion error to notion_token_expired', () => {
+    expect(jobFailureReasonCode(makeUnauthorizedError())).toBe(
+      'notion_token_expired'
+    );
+  });
+
+  it('maps a COLUMNS_AMBIGUOUS error to columns_ambiguous', () => {
+    const err = new Error('ambiguous') as Error & {
+      code?: string;
+      columns?: string[];
+    };
+    err.code = 'NOTION_DATABASE_COLUMNS_AMBIGUOUS';
+    err.columns = ['Term', 'Definition'];
+    expect(jobFailureReasonCode(err)).toBe('columns_ambiguous');
+  });
+
+  it.each([
+    ['PARSER_CRASH', 'parser_crash'],
+    ['WORKER_TIMEOUT', 'worker_timeout'],
+    ['APKG_TOO_LARGE', 'apkg_too_large'],
+    ['ZIP_INVALID', 'zip_invalid'],
+  ] as const)('maps %s code to %s', (code, expected) => {
+    expect(jobFailureReasonCode(withCode(code))).toBe(expected);
+  });
+
+  it('maps a Notion rate-limited error to notion_rate_limited', () => {
+    expect(
+      jobFailureReasonCode(makeAPIResponseError(APIErrorCode.RateLimited, 429))
+    ).toBe('notion_rate_limited');
+  });
+
+  it('maps a Notion object-not-found error to notion_not_found', () => {
+    expect(
+      jobFailureReasonCode(makeAPIResponseError(APIErrorCode.ObjectNotFound, 404))
+    ).toBe('notion_not_found');
+  });
+
+  it('maps a pdfinfo_password error to pdf_password', () => {
+    expect(jobFailureReasonCode(new Error('pdfinfo_password: encrypted'))).toBe(
+      'pdf_password'
+    );
+  });
+
+  it('maps a pdfinfo_failed error to pdf_unreadable', () => {
+    expect(jobFailureReasonCode(new Error('pdfinfo_failed: corrupt'))).toBe(
+      'pdf_unreadable'
+    );
+  });
+
+  it('maps an unclassified error to unknown', () => {
+    expect(jobFailureReasonCode(new Error('mystery'))).toBe('unknown');
+    expect(jobFailureReasonCode('string error')).toBe('unknown');
+    expect(jobFailureReasonCode(undefined)).toBe('unknown');
   });
 });

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -55,6 +55,64 @@ function hasCode(error: unknown, code: string): boolean {
   );
 }
 
+export type JobFailureReasonCode =
+  | 'empty_deck'
+  | 'markdown_likely_lossy'
+  | 'python_crash'
+  | 'columns_ambiguous'
+  | 'notion_token_expired'
+  | 'parser_crash'
+  | 'worker_timeout'
+  | 'notion_rate_limited'
+  | 'notion_not_found'
+  | 'apkg_too_large'
+  | 'zip_invalid'
+  | 'pdf_password'
+  | 'pdf_unreadable'
+  | 'unknown';
+
+export function jobFailureReasonCode(error: unknown): JobFailureReasonCode {
+  if (error instanceof EmptyDeckError) {
+    return error.sourceFormat === 'markdown'
+      ? 'markdown_likely_lossy'
+      : 'empty_deck';
+  }
+  if (error instanceof PythonExitError) {
+    return 'python_crash';
+  }
+  if (isColumnsAmbiguousError(error)) {
+    return 'columns_ambiguous';
+  }
+  if (isNotionUnauthorizedError(error)) {
+    return 'notion_token_expired';
+  }
+  if (hasCode(error, 'PARSER_CRASH')) {
+    return 'parser_crash';
+  }
+  if (hasCode(error, 'WORKER_TIMEOUT')) {
+    return 'worker_timeout';
+  }
+  if (error instanceof APIResponseError && error.code === APIErrorCode.RateLimited) {
+    return 'notion_rate_limited';
+  }
+  if (error instanceof APIResponseError && error.code === APIErrorCode.ObjectNotFound) {
+    return 'notion_not_found';
+  }
+  if (hasCode(error, 'APKG_TOO_LARGE')) {
+    return 'apkg_too_large';
+  }
+  if (hasCode(error, 'ZIP_INVALID')) {
+    return 'zip_invalid';
+  }
+  if (error instanceof Error && error.message.startsWith('pdfinfo_password')) {
+    return 'pdf_password';
+  }
+  if (error instanceof Error && /^pdfinfo_(failed|spawn_failed)/.test(error.message)) {
+    return 'pdf_unreadable';
+  }
+  return 'unknown';
+}
+
 export function jobFailureReasonFromError(
   error: unknown,
   jobId?: string

--- a/web/src/lib/analytics/fireAnalyticsEvent.test.ts
+++ b/web/src/lib/analytics/fireAnalyticsEvent.test.ts
@@ -30,11 +30,11 @@ describe('fireAnalyticsEvent', () => {
     );
   });
 
-  it('sends conversion_success without throwing when both trackers are present', () => {
-    expect(() => fireAnalyticsEvent('conversion_success')).not.toThrow();
+  it('sends make_another_deck_clicked without throwing when both trackers are present', () => {
+    expect(() => fireAnalyticsEvent('make_another_deck_clicked')).not.toThrow();
     expect((globalThis as AnalyticsGlobals).gtag).toHaveBeenCalledWith(
       'event',
-      'conversion_success'
+      'make_another_deck_clicked'
     );
   });
 

--- a/web/src/lib/analytics/fireAnalyticsEvent.ts
+++ b/web/src/lib/analytics/fireAnalyticsEvent.ts
@@ -1,6 +1,5 @@
 export type ConversionEventName =
   | 'upload_started'
-  | 'conversion_success'
   | 'deck_downloaded'
   | 'make_another_deck_clicked';
 

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -136,7 +136,7 @@ describe('UploadForm analytics events', () => {
     expect(gtag).toHaveBeenCalledWith('event', 'upload_started');
   });
 
-  it('tracks upload_started with source=file on form submit', async () => {
+  it('does not fire the DB-backed upload_started track on file submit (server owns it)', async () => {
     const { track } = await import('../../../../lib/analytics/track');
     const trackMock = vi.mocked(track);
     trackMock.mockClear();
@@ -158,10 +158,13 @@ describe('UploadForm analytics events', () => {
       form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     });
 
-    expect(trackMock).toHaveBeenCalledWith('upload_started', { source: 'file' });
+    const startedCalls = trackMock.mock.calls.filter(
+      ([name]) => name === 'upload_started'
+    );
+    expect(startedCalls).toHaveLength(0);
   });
 
-  it('tracks upload_started with source=dropbox when Dropbox chooser returns a file', async () => {
+  it('does not fire the DB-backed upload_started track when Dropbox chooser returns a file', async () => {
     const { track } = await import('../../../../lib/analytics/track');
     const trackMock = vi.mocked(track);
     trackMock.mockClear();
@@ -183,7 +186,7 @@ describe('UploadForm analytics events', () => {
         ]);
       },
     };
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    const fetchMock = vi.fn().mockResolvedValue({
       redirected: false,
       status: 200,
       headers: new Headers({
@@ -192,7 +195,8 @@ describe('UploadForm analytics events', () => {
         'X-Card-Count': '3',
       }),
       blob: () => Promise.resolve(new Blob(['fake'])),
-    }));
+    });
+    vi.stubGlobal('fetch', fetchMock);
 
     const { container } = renderUploadForm(<UploadForm setErrorMessage={vi.fn()} />);
     const button = container.querySelector('button[aria-label="Choose from Dropbox"]') as HTMLButtonElement;
@@ -201,14 +205,21 @@ describe('UploadForm analytics events', () => {
     });
 
     await waitFor(() =>
-      expect(trackMock).toHaveBeenCalledWith('upload_started', { source: 'dropbox' })
+      expect(
+        fetchMock.mock.calls.find((call) => call[0] === '/api/upload/dropbox')
+      ).toBeDefined()
     );
+
+    const startedCalls = trackMock.mock.calls.filter(
+      ([name]) => name === 'upload_started'
+    );
+    expect(startedCalls).toHaveLength(0);
 
     delete (window as unknown as { Dropbox?: unknown }).Dropbox;
     process.env.REACT_APP_DROPBOX_APP_KEY = previousKey;
   });
 
-  it('fires conversion_success on a successful conversion with cards', async () => {
+  it('does not fire conversion_success on a successful conversion with cards', async () => {
     const gtag = (globalThis as AnalyticsGlobals).gtag!;
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
@@ -229,7 +240,7 @@ describe('UploadForm analytics events', () => {
       form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     });
 
-    expect(gtag).toHaveBeenCalledWith('event', 'conversion_success');
+    expect(gtag).not.toHaveBeenCalledWith('event', 'conversion_success');
   });
 
   it('posts to /api/upload/dropbox when the chooser returns a file', async () => {

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -415,7 +415,6 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
     setDropboxError(null);
     setZoneState('converting');
     fireAnalyticsEvent('upload_started');
-    track('upload_started', { source: 'dropbox' });
     setProgressWidth(10);
     setProgressSlow(false);
     setShowFallback(false);
@@ -494,7 +493,6 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
     setDriveError(null);
     setZoneState('converting');
     fireAnalyticsEvent('upload_started');
-    track('upload_started', { source: 'google_drive' });
     setProgressWidth(10);
     setProgressSlow(false);
     setShowFallback(false);
@@ -568,7 +566,6 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
     event.preventDefault();
     setZoneState('converting');
     fireAnalyticsEvent('upload_started');
-    track('upload_started', { source: 'file' });
     setProgressWidth(10);
     setProgressSlow(false);
     setShowFallback(false);

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyConversionSuccess, type ConversionSuccessHandlers } from './uploadResponse';
+
+type AnalyticsGlobals = {
+  hj?: ReturnType<typeof vi.fn>;
+  gtag?: ReturnType<typeof vi.fn>;
+};
+
+function buildHandlers(): ConversionSuccessHandlers {
+  return {
+    setWarningMessage: vi.fn(),
+    setDeckName: vi.fn(),
+    setCardCount: vi.fn(),
+    setMcqCount: vi.fn(),
+    setMcqSkippedCount: vi.fn(),
+    setDownloadLink: vi.fn(),
+    setProgressWidth: vi.fn(),
+    setBatchResult: vi.fn(),
+    setZoneState: vi.fn(),
+  };
+}
+
+function singleDeckResponse(): Response {
+  return {
+    headers: new Headers({
+      'Content-Type': 'application/octet-stream',
+      'X-Card-Count': '5',
+    }),
+    blob: () => Promise.resolve(new Blob(['fake'])),
+  } as unknown as Response;
+}
+
+function batchResponse(): Response {
+  return {
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: () =>
+      Promise.resolve({
+        kind: 'batch',
+        workspaceId: 'ws-1',
+        deckCount: 1,
+        decks: [{ name: 'A', filename: 'A.apkg', downloadUrl: '/download/ws-1/A.apkg' }],
+        bulkUrl: '/download/ws-1/bulk',
+      }),
+  } as unknown as Response;
+}
+
+describe('applyConversionSuccess', () => {
+  beforeEach(() => {
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    globalThis.URL.createObjectURL = vi.fn(() => 'blob:fake');
+  });
+
+  afterEach(() => {
+    delete (globalThis as AnalyticsGlobals).gtag;
+    delete (globalThis as AnalyticsGlobals).hj;
+    vi.restoreAllMocks();
+  });
+
+  it('does not fire conversion_success on the single-deck success path', async () => {
+    const gtag = (globalThis as AnalyticsGlobals).gtag!;
+    const hj = (globalThis as AnalyticsGlobals).hj!;
+    const handlers = buildHandlers();
+
+    await applyConversionSuccess(singleDeckResponse(), handlers);
+
+    expect(gtag).not.toHaveBeenCalledWith('event', 'conversion_success');
+    expect(hj).not.toHaveBeenCalledWith('event', 'conversion_success');
+    expect(handlers.setZoneState).toHaveBeenCalledWith('success');
+  });
+
+  it('does not fire conversion_success on the multi-deck batch path', async () => {
+    const gtag = (globalThis as AnalyticsGlobals).gtag!;
+    const handlers = buildHandlers();
+
+    await applyConversionSuccess(batchResponse(), handlers);
+
+    expect(gtag).not.toHaveBeenCalledWith('event', 'conversion_success');
+    expect(handlers.setZoneState).toHaveBeenCalledWith('multiDeck');
+  });
+});

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
@@ -1,5 +1,4 @@
 import getHeadersFilename from '../../helpers/getHeadersFilename';
-import { fireAnalyticsEvent } from '../../../../lib/analytics/fireAnalyticsEvent';
 import type { BatchResult, ZoneState } from './hooks/useUploadFormState';
 
 export function resolveDeckName(headers: Headers): string {
@@ -56,7 +55,6 @@ export async function applyConversionSuccess(
     if (isBatchResult(body)) {
       handlers.setBatchResult(body);
       handlers.setProgressWidth(100);
-      fireAnalyticsEvent('conversion_success');
       handlers.setZoneState('multiDeck');
       return;
     }
@@ -76,7 +74,6 @@ export async function applyConversionSuccess(
   if (count === 0) {
     handlers.setZoneState('emptyDeck');
   } else {
-    fireAnalyticsEvent('conversion_success');
     handlers.setZoneState('success');
   }
 }


### PR DESCRIPTION
## What
Fixes the upload → conversion funnel instrumentation so the "51% drop" measurement is no longer a counting artifact, and so silent async conversion failures become observable.

Three corrections:
1. **Dedup `upload_started`.** Dropped the three client-side `track('upload_started', { source })` fires (file / Dropbox / Google Drive). The server already emits `upload_started` after the upload reaches the route and passes file-extension validation — that's the honest count. The duplicate client fire roughly tripled the daily count once the server fire shipped, which is what made the measured conversion rate wrong. The client-side `upload_failed` fires stay (the only signal for client-side network failures the server never sees), and the gtag-only `fireAnalyticsEvent('upload_started')` stays for GA.
2. **Emit `conversion_failed` on every silent failure path.** The async (Notion + Claude) path in `performConversion.ts` previously emitted `conversion_failed` only for `empty_deck`; every other failure marked the job failed and returned with no event, so the DB-backed `conversion_failed` undercounted. Now `no_decks_created`, `monthly_limit` (with `cards_used` + `limit`), and the generic catch (via a new `jobFailureReasonCode` mapping → `python_crash`, `notion_token_expired`, `columns_ambiguous`, `worker_timeout`, etc.) all emit. The sync `MonthlyLimitError` / `AnonymousCardCapError` redirects now emit `conversion_failed` (`reason: monthly_limit | anonymous_cap`) alongside the existing `paywall_shown`.
3. **Drop the broken `conversion_success` gtag fire.** `uploadResponse.ts` fired `fireAnalyticsEvent('conversion_success')` (singular) — gtag/hj only, never in the DB-backed `KNOWN_EVENTS` allowlist, double-counting GA against the server's canonical `conversion_succeeded`. Removed both call sites and the now-unused union member.

Also fixed `resolveUploadSource` to attribute `source: 'dropbox'` — Dropbox uploads route through `handleUpload` but lacked the path check, so they were mis-tagged as `source: 'upload'`.

## Why
The funnel analysis read a ~49% "conversion rate" that was an artifact of `upload_started` being counted twice. Server-only the rate is ~67%. And `conversion_failed` showed only ~27 rows in 7d because every async failure except empty-deck was silent — we couldn't see Python crashes, Notion auth expiry, or limit hits in the funnel. This makes the funnel honest so prioritization rests on real numbers.

## How
- Client: removed three `track('upload_started')` calls in `UploadForm.tsx`; removed two `fireAnalyticsEvent('conversion_success')` calls and the unused import in `uploadResponse.ts`; removed `'conversion_success'` from `ConversionEventName`.
- Server: added `jobFailureReasonCode(error): JobFailureReasonCode` (a flat reason-code mapper sibling to `jobFailureReasonFromError`) so the analytics `reason` prop stays low-cardinality instead of carrying full user-facing message strings. Wired `track('conversion_failed', ...)` into the three silent paths in `performConversion.ts` via a small `trackConversionFailed` helper. Emitted `conversion_failed` on the two sync limit redirects in `UploadService.handleUpload`. Added the `dropbox` path check to `resolveUploadSource`.

LLM/large-file note: no Anthropic/Vertex/Notion-export processing changed — these are `track()` calls (synchronous, in-process event sink) added on paths that were already terminating. No latency or token/cost impact.

## Measuring success
After deploy, in the `events` table:
- `select name, count(*) from events where name = 'upload_started' group by name` — daily count should drop back to roughly one row per real upload (no more ~3x inflation).
- `select props->>'reason' as reason, count(*) from events where name = 'conversion_failed' and created_at > now() - interval '7 days' group by 1 order by 2 desc` — should now show `python_crash`, `notion_token_expired`, `monthly_limit`, `no_decks_created`, etc., not just `empty_deck`.
- `select props->>'source', count(*) from events where name = 'upload_started' group by 1` — `dropbox` should now appear instead of those uploads landing under `upload`.

## Testing
- Jest `performConversion.test.ts`: asserts `conversion_failed` emits with `reason` = `no_decks_created`, `monthly_limit` (+ `cards_used`/`limit`), `notion_token_expired`, `python_crash`, and `unknown` on the generic catch.
- Jest `jobFailureReason.test.ts`: covers every `jobFailureReasonCode` mapping.
- Jest `UploadService.test.ts`: asserts `conversion_failed` (`monthly_limit` / `anonymous_cap`) emits before the limit redirects, and that the dropbox path is attributed `source: 'dropbox'`.
- Vitest `UploadForm.test.tsx`: asserts the DB-backed `upload_started` track is NOT fired on file or Dropbox paths, and `conversion_success` gtag is NOT fired on success.
- Vitest `uploadResponse.test.ts` (new): asserts `conversion_success` is not fired on either the single-deck or multi-deck path.
- Existing server-side `conversion_succeeded` test still passes.

`/check`: server tsc clean, web typecheck clean, full web vitest 1673 passed, biome lint clean on changed files, affected Jest suites 70 passed. (Local Node was 22.2.0; reran the whole suite under the repo's pinned 22.20.0 — required because 22.2.0 predates `require(esm)` and breaks every jsdom test locally.)

Sonar: not run locally — no scanner/token on this box. Changes are a flat if-chain mapper plus small track helpers, low Sonar risk; flag here so reviewers expect a possible bounce.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified upload golden path renders success state with no `track('upload_started')` or `conversion_success` analytics calls; no console errors at 375px. Analytics-only diff — no visual change.

## Changelog
No entry — analytics-only change, no user-visible behavior.

## Risks
- If any GA dashboard counted the gtag `conversion_success` event, it will now read zero. The DB-backed `conversion_succeeded` already covers the analytics need; GA conversion goals should point at the server event. Rollback is a clean revert (no migration, no data change).
- `conversion_failed` volume will rise (it was undercounting) — expected, not a regression.

## Goal alignment
Honest funnel instrumentation is the prerequisite for finding the real biggest drop-off on the path to 300K users. The current numbers misdirect prioritization (a phantom 51% drop) and hide every non-empty-deck conversion failure. This unblocks the conversion-funnel-analyst's weekly pull resting on real data.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783157145&installation_id=132681956&pr_number=3092&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3092&signature=8fd7413ca353df5216f945afe9282896bf761d6e84080ba360b396354903e892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->