### PR TITLE
security: trust proxy + req.ip so per-IP rate limits use real client IP

### DIFF
--- a/src/controllers/SubscriptionClaimController.ts
+++ b/src/controllers/SubscriptionClaimController.ts
@@ -3,14 +3,7 @@ import type { ClaimSubscriptionUseCase } from '../usecases/subscriptions/ClaimSu
 import type { ConfirmSubscriptionClaimUseCase } from '../usecases/subscriptions/ConfirmSubscriptionClaimUseCase';
 import { emailHash } from '../lib/emailHash';
 import hashToken from '../lib/misc/hashToken';
-
-function getClientIp(req: Request): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string') {
-    return forwarded.split(',')[0]?.trim() ?? req.ip ?? 'unknown';
-  }
-  return req.ip ?? 'unknown';
-}
+import { resolveClientIp } from '../lib/rateLimit/ipHelpers';
 
 export class SubscriptionClaimController {
   constructor(
@@ -27,7 +20,7 @@ export class SubscriptionClaimController {
       return;
     }
 
-    const ip = getClientIp(req);
+    const ip = resolveClientIp(req);
     const result = await this.claimUseCase.execute({
       userId,
       submittedEmail,
@@ -47,7 +40,7 @@ export class SubscriptionClaimController {
       return;
     }
 
-    const ip = getClientIp(req);
+    const ip = resolveClientIp(req);
     const ipHashValue = hashToken(ip);
     const placeholderEmailHash = hashToken('unknown');
 

--- a/src/lib/rateLimit/ipHelpers.test.ts
+++ b/src/lib/rateLimit/ipHelpers.test.ts
@@ -4,15 +4,26 @@ import { resolveClientIp, hashIp } from './ipHelpers';
 
 function makeReq(
   headers: Record<string, unknown>,
-  remoteAddress?: string
+  remoteAddress?: string,
+  ip?: string
 ): express.Request {
   return {
+    ip,
     headers,
     socket: { remoteAddress },
   } as unknown as express.Request;
 }
 
 describe('resolveClientIp', () => {
+  it('prefers req.ip and ignores a conflicting x-forwarded-for', () => {
+    const req = makeReq(
+      { 'x-forwarded-for': '1.2.3.4' },
+      '10.0.0.1',
+      '203.0.113.7'
+    );
+    expect(resolveClientIp(req)).toBe('203.0.113.7');
+  });
+
   it('returns the x-forwarded-for value when present', () => {
     const req = makeReq({ 'x-forwarded-for': '203.0.113.7' }, '10.0.0.1');
     expect(resolveClientIp(req)).toBe('203.0.113.7');

--- a/src/lib/rateLimit/ipHelpers.ts
+++ b/src/lib/rateLimit/ipHelpers.ts
@@ -2,9 +2,17 @@ import crypto from 'node:crypto';
 import express from 'express';
 
 export function resolveClientIp(req: express.Request): string {
+  // req.ip is set by Express when 'trust proxy' is configured; it respects the
+  // trust setting and ignores attacker-prepended X-Forwarded-For hops. Fall
+  // back to the raw header + socket address for tests and for hypothetical
+  // call sites where trust proxy isn't on the app instance.
+  if (typeof req.ip === 'string' && req.ip.length > 0) {
+    return req.ip;
+  }
   const forwarded = req.headers['x-forwarded-for'];
   if (typeof forwarded === 'string') {
-    return forwarded.split(',')[0].trim();
+    const first = forwarded.split(',')[0].trim();
+    if (first.length > 0) return first;
   }
   return req.socket?.remoteAddress ?? 'unknown';
 }

--- a/src/routes/ShareRouter.ts
+++ b/src/routes/ShareRouter.ts
@@ -12,6 +12,7 @@ import DownloadService from '../services/DownloadService';
 import DownloadRepository from '../data_layer/DownloadRepository';
 import UploadRepository from '../data_layer/UploadRespository';
 import { getDatabase } from '../data_layer';
+import { resolveClientIp } from '../lib/rateLimit/ipHelpers';
 
 const MAX_REQUESTS_PER_IP_PER_MINUTE = 100;
 const MAX_DOWNLOADS_PER_TOKEN_PER_HOUR = 10;
@@ -25,14 +26,6 @@ interface Counter {
 
 const ipCounters = new Map<string, Counter>();
 const tokenDownloadCounters = new Map<string, Counter>();
-
-function getClientIp(req: Request): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string') {
-    return forwarded.split(',')[0]?.trim() ?? req.ip ?? 'unknown';
-  }
-  return req.ip ?? 'unknown';
-}
 
 function checkCounter(
   map: Map<string, Counter>,
@@ -54,7 +47,7 @@ function checkCounter(
 }
 
 function ipRateLimit(req: Request, res: Response, next: NextFunction) {
-  const ip = getClientIp(req);
+  const ip = resolveClientIp(req);
   if (checkCounter(ipCounters, ip, MAX_REQUESTS_PER_IP_PER_MINUTE, ONE_MINUTE_MS)) {
     next();
   } else {

--- a/src/routes/middleware/ErrorCaptureMiddleware.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.ts
@@ -2,17 +2,10 @@ import crypto from 'node:crypto';
 import { Request, Response, NextFunction } from 'express';
 import { IErrorEventRepository, ErrorEventInsert } from '../../data_layer/ErrorEventRepository';
 import { FallbackErrorPayload } from '../../lib/errorFallback';
+import { resolveClientIp } from '../../lib/rateLimit/ipHelpers';
 
 function sha256(value: string): string {
   return crypto.createHash('sha256').update(value).digest('hex');
-}
-
-function resolveIp(req: Request): string {
-  const forwarded = req.headers['x-forwarded-for'];
-  if (typeof forwarded === 'string') {
-    return forwarded.split(',')[0].trim();
-  }
-  return req.socket?.remoteAddress ?? 'unknown';
 }
 
 type FallbackWriter = (payload: FallbackErrorPayload) => void;
@@ -30,7 +23,7 @@ export const makeErrorCaptureMiddleware = (
     try {
       const message = err?.message ?? String(err);
       const messageHash = sha256(message);
-      const ipHash = sha256(resolveIp(req));
+      const ipHash = sha256(resolveClientIp(req));
 
       const isDuplicate = await repository.existsWithinWindow(
         messageHash,

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,6 +131,8 @@ function registerSignalHandlers(server: http.Server, database: Knex) {
 const serve = async () => {
   const templateDir = path.join(__dirname, 'templates');
   const app = express();
+  // nginx on the same box terminates SSL and forwards over loopback; trust exactly one hop.
+  app.set('trust proxy', 1);
   const server = http.createServer(app);
 
   app.use(webhookRouter());


### PR DESCRIPTION
## What

Configures Express `trust proxy` to `1` (one trusted hop — the on-box nginx that terminates SSL) and updates `src/lib/rateLimit/ipHelpers.ts` `resolveClientIp` to prefer `req.ip` over manually parsing `X-Forwarded-For`. Also migrates the three remaining controllers that still parse the header inline (`SubscriptionClaimController`, `ShareRouter`, `ErrorCaptureMiddleware`) to import from the shared helper.

Closes #3088.

## Why

The rate limiters added in #3082 + #3090 (and the per-IP guards in subscription claim + share + error capture) key on the client IP. Without `trust proxy`, an attacker can prepend an arbitrary `X-Forwarded-For: 1.2.3.4` to every request — nginx appends its observed source as a second hop, but the app reads the first hop, so the attacker controls the rate-limit key. With `trust proxy = 1`, Express ignores the attacker-prepended hop and `req.ip` returns the real client IP that nginx saw.

## Browser check

Browser check: not applicable — server-side trust-proxy config + IP helper migration, no `web/src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783162981&installation_id=132681956&pr_number=3093&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3093&signature=4549129999c6a2511b3a24810e4fe213f302aff6e93520fb7851e0d5c5b74af1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->