### PR TITLE
feat: add Image field to Abhiyan Night Mode templates

### DIFF
--- a/src/services/officialTemplates.test.ts
+++ b/src/services/officialTemplates.test.ts
@@ -88,4 +88,20 @@ describe('getOfficialTemplates', () => {
     }
     expect(failures).toEqual([]);
   });
+
+  it('exposes an Image field on Abhiyan basic and references it in the template', () => {
+    const abhiyanBasic = templates.find((t) => t.id === 'official-abhiyan-basic');
+    expect(abhiyanBasic?.noteType.flds.map((f) => f.name)).toContain('Image');
+    expect(abhiyanBasic?.noteType.tmpls[0].qfmt).toContain('{{#Image}}');
+    expect(abhiyanBasic?.noteType.tmpls[0].qfmt).toContain('{{Image}}');
+    expect(abhiyanBasic?.previewData).toHaveProperty('Image');
+  });
+
+  it('exposes an Image field on Abhiyan cloze and references it in the template', () => {
+    const abhiyanCloze = templates.find((t) => t.id === 'official-abhiyan-cloze');
+    expect(abhiyanCloze?.noteType.flds.map((f) => f.name)).toContain('Image');
+    expect(abhiyanCloze?.noteType.tmpls[0].qfmt).toContain('{{#Image}}');
+    expect(abhiyanCloze?.noteType.tmpls[0].afmt).toContain('{{#Image}}');
+    expect(abhiyanCloze?.previewData).toHaveProperty('Image');
+  });
 });

--- a/src/services/officialTemplates.ts
+++ b/src/services/officialTemplates.ts
@@ -198,13 +198,15 @@ const CLOZE_PREVIEW = {
 const ABHIYAN_BASIC_FLDS = [
   { name: 'Front', ord: 0 },
   { name: 'Back', ord: 1 },
-  { name: 'Tags', ord: 2 },
+  { name: 'Image', ord: 2 },
+  { name: 'Tags', ord: 3 },
 ];
 
 const ABHIYAN_CLOZE_FLDS = [
   { name: 'Text', ord: 0 },
   { name: 'Extra', ord: 1 },
-  { name: 'Tags', ord: 2 },
+  { name: 'Image', ord: 2 },
+  { name: 'Tags', ord: 3 },
 ];
 
 const ALEX_BASIC_FLDS = [
@@ -319,6 +321,7 @@ export function getOfficialTemplates(): OfficialStarter[] {
       previewData: {
         Front: 'What is the capital of France?',
         Back: 'Paris',
+        Image: '',
         Tags: '',
       },
       tags: ['abhiyan', 'night-mode'],
@@ -337,6 +340,7 @@ export function getOfficialTemplates(): OfficialStarter[] {
       previewData: {
         Text: 'The capital of {{c1::France}} is {{c2::Paris}}',
         Extra: 'European geography',
+        Image: '',
         Tags: '',
       },
       tags: ['abhiyan', 'night-mode', 'cloze'],
@@ -387,6 +391,7 @@ export function getOfficialTemplates(): OfficialStarter[] {
       previewData: {
         Front: 'What is the capital of France?',
         Back: 'Paris',
+        Image: '',
         Tags: '',
       },
       tags: ['material', 'material-design'],
@@ -406,6 +411,7 @@ export function getOfficialTemplates(): OfficialStarter[] {
       previewData: {
         Text: 'The capital of {{c1::France}} is {{c2::Paris}}',
         Extra: 'European geography',
+        Image: '',
         Tags: '',
       },
       tags: ['material', 'material-design', 'cloze'],

--- a/src/templates/abhiyan.css
+++ b/src/templates/abhiyan.css
@@ -155,6 +155,10 @@ img {
     /* fix for Anki */
 }
 
+.image {
+    text-align: center;
+}
+
 
 /* ANKI TEMPLATE WIZARDRY */
 

--- a/src/templates/abhiyan_basic_front.html
+++ b/src/templates/abhiyan_basic_front.html
@@ -25,6 +25,9 @@
         <div class="question row">
             {{Front}}
         </div>
+        {{#Image}}
+        <div class="image row">{{Image}}</div>
+        {{/Image}}
     </div>
 </div>
 

--- a/src/templates/abhiyan_cloze_back.html
+++ b/src/templates/abhiyan_cloze_back.html
@@ -25,6 +25,9 @@
         <div class="question row">
             {{cloze:Text}}
         </div>
+        {{#Image}}
+        <div class="image row">{{Image}}</div>
+        {{/Image}}
     </div>
 </div>
 {{#Extra}}

--- a/src/templates/abhiyan_cloze_front.html
+++ b/src/templates/abhiyan_cloze_front.html
@@ -26,5 +26,8 @@
         <div class="question row">
             {{cloze:Text}}
         </div>
+        {{#Image}}
+        <div class="image row">{{Image}}</div>
+        {{/Image}}
     </div>
 </div>

--- a/src/templates/abhiyan_cloze_style.css
+++ b/src/templates/abhiyan_cloze_style.css
@@ -157,6 +157,10 @@ img {
     /* fix for Anki */
 }
 
+.image {
+    text-align: center;
+}
+
 
 /* ANKI TEMPLATE WIZARDRY */
 


### PR DESCRIPTION
## Summary

Restores the inline image affordance on the Abhiyan Night Mode starters
(basic + cloze). PR #2328 removed the broken `{{#text2 image}}` blocks
because the field was never declared on the note types — this adds the
field as a real, working capability.

- New `Image` field at ord 2 on `ABHIYAN_BASIC_FLDS` and `ABHIYAN_CLOZE_FLDS`
- Front templates render `{{#Image}}<div class="image row">{{Image}}</div>{{/Image}}` alongside the question
- Cloze back template carries the same block so the image stays visible on the answer side
- Default `previewData.Image = ''` so existing starters keep showing only the prompt
- New tests assert the Image field exists and the templates reference it; the existing `validateTemplateFields` check (added in #2328) still passes

## Decisions made overnight (please review)

- **Field ord placement**: chose `Image` at ord 2, pushed `Tags` to ord 3. Reasoning: the original `text2 image` was meant to render inline with the question, so keeping it adjacent to Front/Back/Text feels right. If you'd rather `Tags` stay at ord 2 and `Image` go last, I can flip the order.
- **Block location**: rendered after the `.question row` rather than inside it. Reasoning: keeps the image as its own block (`.image row`), so users can style or override it independently of the question copy.
- **Material starters also get the Image field** (they share `ABHIYAN_*_FLDS`). Reasoning: their templates don't reference `{{Image}}`, so the field is unused and harmless. Splitting the constants felt like premature abstraction. Push back if you'd prefer a `MATERIAL_*_FLDS` split.
- **CSS**: added a minimal `.image { text-align: center; }` rule to `abhiyan.css` and `abhiyan_cloze_style.css`. The existing `img { max-width: 100%; ... }` rule handles sizing; the wrapper just centers the image inside the row. Deliberately did NOT add layout opinions (margins, max-height) — those land better as user CSS overrides.

## Out of scope

- Image upload UX in the template editor (covered by image-occlusion flow per the issue)
- Alex Deluxe templates (the issue explicitly excludes them)

Fixes #2330

## Browser check
Browser check: not applicable — no `web/src/` files changed; Abhiyan templates render inside Anki, not on the web app.

## Test plan
- [x] `pnpm test src/services/officialTemplates.test.ts` — 10 tests pass (8 existing + 2 new)
- [ ] Open a starter from the Note Types editor on /templates/new and confirm the new Image field is editable
- [ ] Build a card with an image in the Image field and verify it renders alongside the question in Anki

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783165549&installation_id=132681956&pr_number=3094&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3094&signature=7773ba4bca604d80007e068355d23f9ecca1cfb001fcb4301fb0574164798b21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->