### PR TITLE
fix: clear stale drive/dropbox state on upload source switch

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -22,6 +22,7 @@ import {
   type GoogleDriveFile,
 } from './hooks/useGooglePicker';
 import { UploadSourceChips, type UploadSource } from './UploadSourceChips';
+import { getStaleSourceState } from './helpers/getStaleSourceState';
 import { FeedbackWidget } from '../../../../components/FeedbackWidget/FeedbackWidget';
 import { useUserLocals } from '../../../../lib/hooks/useUserLocals';
 import { useCardUsage, CARD_USAGE_QUERY_KEY } from '../../../../lib/hooks/useCardUsage';
@@ -282,6 +283,20 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
       clearTimeout(fallbackTimerRef.current);
     }
   });
+
+  const handleSourceChange = (next: UploadSource) => {
+    const { clearDrive, clearDropbox } = getStaleSourceState(next);
+    if (clearDrive) {
+      setDriveFilename(null);
+      setDriveMimeType(null);
+      setDriveError(null);
+    }
+    if (clearDropbox) {
+      setDropboxFilename(null);
+      setDropboxError(null);
+    }
+    setSource(next);
+  };
 
   const conversionSuccessHandlers: ConversionSuccessHandlers = {
     setWarningMessage,
@@ -1479,7 +1494,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
               type="button"
               className={formStyles.changeSourceLink}
               aria-label="Change upload source"
-              onClick={() => setSource('local')}
+              onClick={() => handleSourceChange('local')}
             >
               ← Change source
             </button>
@@ -1522,7 +1537,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
               type="button"
               className={formStyles.changeSourceLink}
               aria-label="Change upload source"
-              onClick={() => setSource('local')}
+              onClick={() => handleSourceChange('local')}
             >
               ← Change source
             </button>
@@ -1561,7 +1576,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
         <div className={formStyles.chipsRow}>
           <UploadSourceChips
             active={source}
-            onChange={setSource}
+            onChange={handleSourceChange}
             dropboxAvailable={isDropboxConfigured}
             googleDriveAvailable={isGoogleDriveConfigured}
           />

--- a/web/src/pages/UploadPage/components/UploadForm/helpers/getStaleSourceState.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/helpers/getStaleSourceState.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { getStaleSourceState } from './getStaleSourceState';
+
+describe('getStaleSourceState', () => {
+  it('clears drive state when switching to local', () => {
+    expect(getStaleSourceState('local')).toEqual({
+      clearDrive: true,
+      clearDropbox: true,
+    });
+  });
+
+  it('clears drive state when switching to dropbox', () => {
+    expect(getStaleSourceState('dropbox')).toEqual({
+      clearDrive: true,
+      clearDropbox: false,
+    });
+  });
+
+  it('clears dropbox state when switching to google_drive', () => {
+    expect(getStaleSourceState('google_drive')).toEqual({
+      clearDrive: false,
+      clearDropbox: true,
+    });
+  });
+});

--- a/web/src/pages/UploadPage/components/UploadForm/helpers/getStaleSourceState.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/helpers/getStaleSourceState.ts
@@ -1,0 +1,13 @@
+import type { UploadSource } from '../UploadSourceChips';
+
+export interface StaleSourceState {
+  clearDrive: boolean;
+  clearDropbox: boolean;
+}
+
+export function getStaleSourceState(next: UploadSource): StaleSourceState {
+  return {
+    clearDrive: next !== 'google_drive',
+    clearDropbox: next !== 'dropbox',
+  };
+}


### PR DESCRIPTION
## Summary

`UploadForm` tracked `driveMimeType` (and `driveFilename`/`driveError`)
without resetting them when the user switched the upload source via the
chip row or the "Change source" link. The Dropbox panel had the same
latent leak the other direction.

The empty-deck path was the visible symptom: `getEmptyDeckChatPrompt`
prefers `driveMimeType` over the filename extension, so a stale Drive
mime would silently fire the Doc-flavoured chat prompt on a Notion-zip
failure.

This PR centralises the reset rule in a pure helper
`getStaleSourceState(next)` and routes every `setSource` call through
`handleSourceChange`, which fans the appropriate `null`-setters out
before flipping `source`.

- `web/src/pages/UploadPage/components/UploadForm/helpers/getStaleSourceState.ts` — pure helper, three cases
- `web/src/pages/UploadPage/components/UploadForm/helpers/getStaleSourceState.test.ts` — colocated test
- `UploadForm.tsx` — `handleSourceChange` wraps `setSource`, used by the chip row and both panel "Change source" links

## Decisions made overnight (please review)

- **Reset on switch, not on per-prompt branch.** Alternative would have been to make `getEmptyDeckChatPrompt` source-aware (only honour `driveMimeType` when current source is google_drive). Reset-on-switch wins because other consumers of `driveMimeType` (the Drive-specific submit-disabled logic, the upsell variant text) also benefit, and we don't have to thread `source` into every reader. The issue text explicitly suggests this direction too.
- **Symmetric Dropbox reset.** The bug as reported was Drive → local, but Dropbox had the same latent shape: filename/error survived a switch away. Reset both — keeps the rule simple and avoids a future regression in the other direction.
- **Did NOT touch `resetForm`.** The hook's `resetForm` already nulls all of these — only the source-switch path was leaky. Adding a second clearing site would mean two ways to "reset", which drifts.
- **Helper test, no full UploadForm test.** Wired the regression check at the helper level — the full component test would need to mock `useGooglePicker` and the upload submission flow, which is high blast-radius for a fix this small. The helper is the contract.

## Local test status

Local `pnpm vitest` is currently bouncing on a hoisting/ESM issue
(`html-encoding-sniffer` → `@exodus/bytes` `ERR_REQUIRE_ESM`) that
reproduces on `main` too — unrelated to this change. `pnpm typecheck`
(web) is clean. CI will exercise the new helper test.

Fixes #2314

## Browser check
Browser check: not applicable — pure state-reset wiring, no rendered output changes. Existing UploadForm tests cover the surface; the new helper test covers the rule.

## Test plan
- [x] `pnpm --filter 2anki-web typecheck`
- [ ] CI: vitest runs `getStaleSourceState.test.ts`
- [ ] Manual: pick a Google Doc in the Drive picker, click the chips back to Local, drag a Notion zip, force an empty deck — empty-deck chat prompt should be the Notion zip one

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783165993&installation_id=132681956&pr_number=3095&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3095&signature=af59d223c2ea60820d7b813b7cc667fb421a6f6486f2e3acde5c0554acdeb6c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->