### PR TITLE
feat: add Basic Reversed and Type-the-answer starters

### DIFF
--- a/src/services/DefaultTemplatesService.test.ts
+++ b/src/services/DefaultTemplatesService.test.ts
@@ -1,0 +1,56 @@
+import {
+  getDefaultTemplates,
+  getBasicReversedNoteType,
+  getInputNoteType,
+} from './DefaultTemplatesService';
+import { validateTemplateFields } from '../lib/templates/validateTemplateFields';
+
+describe('getDefaultTemplates', () => {
+  const templates = getDefaultTemplates();
+
+  it('surfaces the Basic Reversed and Type the answer starters', () => {
+    const ids = templates.map((t) => t.id);
+    expect(ids).toContain('basic-reversed');
+    expect(ids).toContain('input-type-the-answer');
+  });
+
+  it('only references fields that exist on each note type', () => {
+    const failures: string[] = [];
+    for (const template of templates) {
+      const result = validateTemplateFields(template.noteType);
+      if (!result.ok) {
+        failures.push(`${template.id}: ${result.message}`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});
+
+describe('getBasicReversedNoteType', () => {
+  const noteType = getBasicReversedNoteType();
+
+  it('generates two card templates from the same Front + Back fields', () => {
+    expect(noteType.tmpls).toHaveLength(2);
+    expect(noteType.tmpls[0].qfmt).toContain('{{Front}}');
+    expect(noteType.tmpls[0].afmt).toContain('{{Back}}');
+    expect(noteType.tmpls[1].qfmt).toContain('{{Back}}');
+    expect(noteType.tmpls[1].afmt).toContain('{{Front}}');
+  });
+
+  it('declares exactly the Front and Back fields', () => {
+    expect(noteType.flds.map((f) => f.name)).toEqual(['Front', 'Back']);
+  });
+});
+
+describe('getInputNoteType', () => {
+  const noteType = getInputNoteType();
+
+  it('uses {{type:Back}} on the front so Anki diffs the typed answer', () => {
+    expect(noteType.tmpls[0].qfmt).toContain('{{type:Back}}');
+    expect(noteType.tmpls[0].afmt).toContain('{{type:Back}}');
+  });
+
+  it('declares Front and Back fields only', () => {
+    expect(noteType.flds.map((f) => f.name)).toEqual(['Front', 'Back']);
+  });
+});

--- a/src/services/DefaultTemplatesService.ts
+++ b/src/services/DefaultTemplatesService.ts
@@ -782,6 +782,139 @@ mjx-container {
   });
 }
 
+function getBasicReversedNoteType(): AnkiNoteType {
+  return noteType({
+    id: 1000000000016,
+    name: 'Basic (Reversed)',
+    tmpls: [
+      {
+        name: 'Card 1',
+        ord: 0,
+        qfmt: '<div class="front">\n  <h1>{{Front}}</h1>\n</div>',
+        afmt: '<div class="back">\n  <div class="question">{{Front}}</div>\n  <hr id="answer">\n  <div class="answer">{{Back}}</div>\n</div>',
+      },
+      {
+        name: 'Card 2',
+        ord: 1,
+        qfmt: '<div class="front">\n  <h1>{{Back}}</h1>\n</div>',
+        afmt: '<div class="back">\n  <div class="question">{{Back}}</div>\n  <hr id="answer">\n  <div class="answer">{{Front}}</div>\n</div>',
+      },
+    ],
+    flds: [
+      field('Front', 0),
+      field('Back', 1),
+    ],
+    css: `.card {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 20px;
+  text-align: center;
+  color: #1f2937;
+  background: #ffffff;
+  min-height: 100vh;
+  padding: 40px;
+  margin: 0;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card > * {
+  max-width: 600px;
+  width: 100%;
+}
+
+.front h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.question {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #6b7280;
+  margin-bottom: 20px;
+}
+
+.answer {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #111827;
+  margin-top: 20px;
+}
+
+hr {
+  border: none;
+  height: 2px;
+  background: #e5e7eb;
+  margin: 20px 0;
+  border-radius: 1px;
+}`,
+  });
+}
+
+function getInputNoteType(): AnkiNoteType {
+  return noteType({
+    id: 1000000000017,
+    name: 'Type the answer',
+    tmpls: [
+      {
+        name: 'Card 1',
+        ord: 0,
+        qfmt: '<div class="front">\n  <div class="prompt">{{Front}}</div>\n  <div class="input-row">{{type:Back}}</div>\n</div>',
+        afmt: '<div class="back">\n  <div class="prompt">{{Front}}</div>\n  <div class="input-row">{{type:Back}}</div>\n</div>',
+      },
+    ],
+    flds: [
+      field('Front', 0),
+      field('Back', 1),
+    ],
+    css: `.card {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 20px;
+  text-align: center;
+  color: #1f2937;
+  background: #ffffff;
+  min-height: 100vh;
+  padding: 40px;
+  margin: 0;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.card > * {
+  max-width: 600px;
+  width: 100%;
+}
+
+.prompt {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #111827;
+  margin-bottom: 24px;
+}
+
+.input-row {
+  font-size: 1.4rem;
+}
+
+input[type="text"] {
+  font-family: inherit;
+  font-size: 1.4rem;
+  padding: 12px 16px;
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 400px;
+  box-sizing: border-box;
+}`,
+  });
+}
+
 export function getDefaultTemplates(): DefaultTemplate[] {
   return [
     {
@@ -886,8 +1019,26 @@ export function getDefaultTemplates(): DefaultTemplate[] {
       },
       tags: ['math', 'science', 'equations'],
     },
+    {
+      id: 'basic-reversed',
+      name: 'Basic (Reversed)',
+      description: 'One note, two cards — forward and reverse. Standard for bidirectional language drills.',
+      baseType: 'basic',
+      noteType: getBasicReversedNoteType(),
+      previewData: { Front: '勉強', Back: 'study; to study' },
+      tags: ['basic', 'reversed', 'language'],
+    },
+    {
+      id: 'input-type-the-answer',
+      name: 'Type the answer',
+      description: 'Type your answer — Anki diffs it against the expected value. Standard for spelling and recall drills.',
+      baseType: 'basic',
+      noteType: getInputNoteType(),
+      previewData: { Front: 'Capital of France?', Back: 'Paris' },
+      tags: ['basic', 'input', 'type-the-answer'],
+    },
   ];
 }
 
-export { getBasicNoteType, getClozeNoteType, getVocabNoteType, getMedicalNoteType, getProgrammingNoteType, getMinimalNoteType, getQuoteNoteType, getMathNoteType };
+export { getBasicNoteType, getClozeNoteType, getVocabNoteType, getMedicalNoteType, getProgrammingNoteType, getMinimalNoteType, getQuoteNoteType, getMathNoteType, getBasicReversedNoteType, getInputNoteType };
 export type { DefaultTemplate, AnkiNoteType, AnkiField, AnkiCardType };


### PR DESCRIPTION
## Summary

Adds two starters to the `/templates/new` gallery so the catalog covers
Anki's "core six" expectation:

1. **Basic Reversed** (`basic-reversed`) — one note, two cards.
   Card 1 prompts Front → Back; Card 2 prompts Back → Front. Standard
   for bidirectional language drills.
2. **Type the answer** (`input-type-the-answer`) — uses `{{type:Back}}`
   on both sides so Anki renders the typed-answer diff. Standard for
   spelling and vocab recall.

Plus a colocated test asserting both starters pass `validateTemplateFields`
and that the per-noteType helpers wire the right card shape.

## Decisions made overnight (please review)

- **Two-field Input type instead of three.** The issue's sketch carried a separate `Input` field on top of `Front`/`Back`. The standard Anki convention is two fields with `{{type:Back}}` — the user types into the field whose value Anki then renders as the diff. Cleaner shape, fewer fields for the user to learn, identical UX. If you'd rather mirror `n2a-input.json`'s three-field shape (so it round-trips with the legacy converter), say the word and I'll add the third field.
- **Pure white card style for both starters.** Picked light, neutral CSS rather than the existing `getBasicNoteType()` gradient. Reasoning: the gradient is a strong stylistic choice; the new starters should read as "core Anki shapes" first, "stylistic variants" second. Either swap or take this as ground truth.
- **Japanese vocab example on Basic Reversed.** Matches the issue's suggestion (`勉強` / "study; to study"). It's the most legible reversed example for an English-reading audience — the front and back are clearly different so the user can tell at a glance how the second card is generated. Picked over a tougher example for explanatory power.
- **Skipped existing-test fixture updates.** The issue mentioned vitest fixtures in `TemplatesPage.test.tsx` / `EditorPage.test.tsx`, but those tests don't enumerate template IDs — they assert structural behaviour and don't break with new starters. Added the colocated unit test instead.

## Out of scope

- Consolidating `officialTemplates.ts` and `DefaultTemplatesService.ts` (sibling issue #2333)
- Adding image support to Basic Reversed (filed as a follow-up if asked)

Fixes #2332

## Browser check
Browser check: not applicable — no `web/src/` files changed; the gallery reads `getDefaultTemplates()` and the new starters render through the existing pipe.

## Test plan
- [x] `pnpm test src/services/DefaultTemplatesService.test.ts` — 6 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open `/templates/new`, pick each new starter, save, generate an `.apkg`, verify both card directions render for Basic Reversed and the typed-answer diff renders for Type the answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783166169&installation_id=132681956&pr_number=3096&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3096&signature=e91d199116487f5ccb1fffa66209146ef8dd14e2e87d71b7c339281707fb3184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->