### PR TITLE
style: refresh PDF to Anki landing for text, scanned, and AI modes

### DIFF
--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -54,6 +54,28 @@ describe('ConvertLandingPage', () => {
     expect(screen.getByText(/Drop your files here/i)).toBeInTheDocument();
   });
 
+  it('renders the new Convert PDF to Anki H1 on the pdf-to-anki page', () => {
+    renderAtSlug('pdf-to-anki');
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'Convert PDF to Anki — flashcards from lecture slides and textbook chapters',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('cross-links pdf-to-anki to the AnKing enrichment and AI generator pages', () => {
+    const links = CONVERT_LANDING_PAGES.get('pdf-to-anki')?.relatedLinks ?? [];
+    expect(links).toContainEqual({
+      label: 'Enrich an AnKing deck',
+      href: '/convert/enrich-anki-deck',
+    });
+    expect(links).toContainEqual({
+      label: 'AI flashcard generator',
+      href: '/ai-flashcard-generator',
+    });
+  });
+
   it('renders NotFoundPage for an unknown slug', () => {
     renderAtSlug('unknown-format');
     expect(

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -38,6 +38,8 @@ const notionToAnki: LandingCopy = {
 
 const pdfToAnki: LandingCopy = {
   relatedLinks: [
+    { label: 'Enrich an AnKing deck', href: '/convert/enrich-anki-deck' },
+    { label: 'AI flashcard generator', href: '/ai-flashcard-generator' },
     { label: 'Convert PowerPoint slides to Anki', href: '/powerpoint-to-anki' },
     { label: 'Convert an HTML file to Anki', href: '/convert/html-to-anki' },
     { label: 'Convert Markdown and Obsidian notes to Anki', href: '/convert/markdown-to-anki' },
@@ -45,29 +47,33 @@ const pdfToAnki: LandingCopy = {
     { label: 'Browse every converter', href: '/convert' },
   ],
   pathname: '/convert/pdf-to-anki',
-  title: 'PDF to Anki — flashcards that work in Anki | 2anki',
+  title: 'Convert PDF to Anki — flashcards that work in Anki | 2anki',
   description:
-    'Turn a PDF into an Anki deck that imports clean — correct note types, images embedded, headings as decks. Drop a file, get a .apkg.',
-  h1: 'PDF to Anki — make flashcards from lecture slides',
+    'Convert a lecture PDF, slide export, or textbook chapter into a .apkg deck. Text becomes question-and-answer cards, scanned pages become image cards, and AI mode handles dense chapters.',
+  h1: 'Convert PDF to Anki — flashcards from lecture slides and textbook chapters',
   subhead:
-    'Drop a PDF and download a .apkg deck. Works with lecture notes, textbook chapters, and exported slides.',
+    'Drop a lecture PDF, slide export, or textbook chapter and download a .apkg deck. 2anki reads the text into question-and-answer cards, falls back to image cards when a page has no text, and can write cards with AI when the PDF is dense.',
   whatComesAcross: ankiFidelityProof,
   faqs: [
     {
-      q: 'Will it read a scanned PDF?',
-      a: 'Only if the scan includes a text layer. Most modern textbook exports and slide PDFs do. For a photo scan with no text, run it through OCR in macOS Preview or Adobe Acrobat first.',
+      q: 'How do text PDFs become cards?',
+      a: 'When a PDF carries a text layer, 2anki reads it and pairs the pages into cards — the text on one page becomes the front, the next page becomes the back. You get editable text cards you can fix in Anki in seconds, not flattened images.',
     },
     {
-      q: 'How does it decide what becomes a card?',
-      a: 'Headings name the deck and subdeck. Top-level bullets become card fronts; the next indent level or line becomes the back. You can edit the cards in Anki after — nothing is locked.',
+      q: 'What about scanned PDFs and slide decks?',
+      a: "A photo scan with no text layer can't be read as text. When there's no usable text, 2anki falls back to image cards: each page is paired with the next as a front-and-back image, so you still get a reviewable deck. For a true photo scan, add a text layer with OCR in macOS Preview or Adobe Acrobat first, then upload for text cards.",
+    },
+    {
+      q: 'Is there an AI mode for dense chapters?',
+      a: 'Yes. When a chapter is wall-to-wall prose with no clean front/back split, the AI flashcard mode reads the content and writes question-and-answer cards for you. They land as basic notes you can edit, tag, and move into a subdeck.',
     },
     {
       q: 'Can I upload a whole textbook?',
-      a: 'Yes. Large PDFs work, though big files take longer and create large decks. Uploading one chapter at a time keeps decks easier to review and share.',
+      a: 'Yes. Large PDFs work, though big files take longer and create large decks. Free accounts handle everyday lecture and chapter PDFs; paid plans lift the size limit. Uploading one chapter at a time keeps decks easier to review.',
     },
     {
       q: 'What happens to equations and diagrams?',
-      a: 'Diagrams come across as embedded images. Equations stored as images stay as images. Equations stored as text need MathJax enabled in your Anki card template to render.',
+      a: 'Equations stored as images stay as images. Equations stored as text need MathJax enabled in your Anki card template to render. In image mode, the full page comes across as an image so diagrams stay intact.',
     },
   ],
 };

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-04-pdf-to-anki-refresh.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-04-pdf-to-anki-refresh.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-04-pdf-to-anki-refresh",
+  "date": "2026-06-04",
+  "type": "style",
+  "title": "PDF to Anki page explains text, scanned, and AI modes upfront"
+}


### PR DESCRIPTION
## What
Rewrites the `/convert/pdf-to-anki` landing copy (the existing `pdfToAnki` entry in `convertLandingConfig.ts`) around the three PDF modes the code actually ships. Title and H1 now lead with the verb **Convert**. Adds internal cross-links to the AnKing enrichment page and the AI flashcard generator. No route, slug, or sitemap change.

## Why
Bet B from the competitive analysis: the PDF-to-Anki page is a high-intent search surface ("convert PDF to Anki", "PDF to flashcards", "AI flashcards from PDF") and the old copy under-explained what happens to text, scanned, and dense PDFs. Sharper, mode-aware copy improves the landing → upload conversion for one of our biggest organic doorways. Draft authored by seo-content at `Documentation/landing-drafts/pdf-to-anki.md`.

## How
Edited only the existing `pdfToAnki` `LandingCopy` object: `title`, `description`, `h1`, `subhead`, `relatedLinks`, and the five FAQs. The `LandingCopy` type has no free-form section fields, so the draft's three body sections were folded into the subhead and FAQ entries. Route key, slug, and pathname unchanged.

## Measuring success
Landing → upload conversion on `/convert/pdf-to-anki` in the funnel pull (same query the conversion-funnel-analyst runs weekly), plus organic impressions/clicks for the page in Search Console over the following 2–4 weeks. No new log line is warranted for a copy swap.

## Testing
- Unit tests added: `ConvertLandingPage.test.tsx` — asserts the new H1 string renders on `/convert/pdf-to-anki`, and asserts both new cross-links (`/convert/enrich-anki-deck`, `/ai-flashcard-generator`) are present in the config's `relatedLinks`.
- Existing suite still green: the title-fidelity test (`leads the import-to-Anki titles with fidelity in Anki`) still passes because the new title keeps "work in Anki"; the per-slug H1 and FAQ `it.each` tests pass.
- Full run: `web vitest` 48/48 passed, `web typecheck` clean, `web lint` clean, server `tsc` clean — all on Node 22.20.0 (`.nvmrc`).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Browser check: not applicable — copy-only swap inside an existing config entry; no rendered structure, component, or route changed. The page already renders these fields; only the strings differ.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-04-pdf-to-anki-refresh.json` — "PDF to Anki page explains text, scanned, and AI modes upfront" (type `style`).

## Decisions made overnight (please review)
1. **Downgraded the draft's text-mode copy to match reality.** The seo-content draft and old FAQ claimed text PDFs are parsed by structure — "a heading names the deck, the line under it becomes the front, the body becomes the back." The actual path (`convertPdfTextToHtml` → `synthesizeCardsFromPdf`) pairs **whole pages**: page *i* text = front, page *i+1* = back. I rewrote the copy to describe page-pairing honestly rather than ship an over-claim. If product wants the heading/line/body behavior, that's a code change, not copy.
2. **Removed the "diagrams come across as embedded images" claim from the text path.** In text mode, `extractPdfText` pulls text only — diagrams are not embedded. Diagrams survive in *image mode* (the full page is rendered as an image), so I moved that promise into the image-mode FAQ where it's true.
3. **Image-fallback phrasing.** Real behavior pairs non-overlapping pages (page 1 front / page 2 back, page 3 / page 4). I phrased it as "each page is paired with the next as a front-and-back image" — accurate enough for a learner without implying a sliding window.
4. **Title keeps "work in Anki" while leading with "Convert".** New title: `Convert PDF to Anki — flashcards that work in Anki | 2anki`. This satisfies both the draft's "lead with Convert" note and the existing `leads the import-to-Anki titles with fidelity in Anki` test, which requires the substring.
5. **`/convert/enrich-anki-deck` link points at a page a parallel agent is shipping.** That config entry does not exist on `main` yet. `relatedLinks` render as plain `<Link>`s with no build-time existence check, so this does not break the build. The link goes live the moment the enrichment PR merges. No `// TODO` needed in code — flagging it here instead. `/ai-flashcard-generator` is a real route + sitemap entry today.
6. **No SonarCloud local run.** This is a copy + test + changelog change with no new functions, components, or controllers — the rules exempt doc/changelog/test-only changes. Expect no Sonar maintainability or security findings; if one bounces it would be pre-existing.

## Risks
Low. Copy-only swap inside one config object. Worst case the new copy reads worse than the old — fully reversible by reverting one commit. No behavior, route, or data change. Rollback: revert the PR.

## Goal alignment
Moves toward 300K users by sharpening one of the highest-intent organic landing pages around the verbs people search and the modes the product actually delivers. Honest, specific copy (per VOICE.md) sets correct expectations before upload, which reduces the "it didn't do what I thought" drop-off after the first conversion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783202377&installation_id=132681956&pr_number=3097&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3097&signature=9d56d22ffa9a5fe5f11deef88f21725f40751a69c651b71d430a8b8c8293c112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->