### PR TITLE
feat: add enrich-anki-deck landing page

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -6,7 +6,7 @@ sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/con
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
-sonar.cpd.exclusions=src/migrations/**,web/src/generated/**,web/src/schemas/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.cpd.exclusions=src/migrations/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,web/src/pages/ConvertLandingPage/convertLandingConfig.ts,web/src/pages/ConvertHubPage/convertHubGroups.ts,web/src/pages/LandingPage/copy/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.javascript.file.suffixes=.js,.jsx
 sonar.typescript.file.suffixes=.ts,.tsx

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/dat
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
-sonar.cpd.exclusions=src/migrations/**,src/data_layer/public/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,web/src/pages/ConvertLandingPage/convertLandingConfig.ts,web/src/pages/LandingPage/copy/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.cpd.exclusions=src/migrations/**,src/data_layer/public/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,web/src/pages/ConvertLandingPage/convertLandingConfig.ts,web/src/pages/ConvertHubPage/convertHubGroups.ts,web/src/pages/LandingPage/copy/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info,web/coverage/lcov.info
 

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -175,6 +175,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://2anki.net/convert/enrich-anki-deck</loc>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/answers/fsrs-explained</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(26);
+    expect(files).toHaveLength(27);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );
@@ -96,6 +96,9 @@ describe('emitLandingPages', () => {
     ).toBe(true);
     expect(
       files.some((p) => p.endsWith('convert/html-to-anki/index.html'))
+    ).toBe(true);
+    expect(
+      files.some((p) => p.endsWith('convert/enrich-anki-deck/index.html'))
     ).toBe(true);
     expect(
       files.some((p) => p.endsWith('convert/apkg-to-csv/index.html'))

--- a/web/src/pages/ConvertHubPage/convertHubGroups.ts
+++ b/web/src/pages/ConvertHubPage/convertHubGroups.ts
@@ -103,6 +103,12 @@ const FILE_FORMATS: RawEntry[] = [
     blurb:
       'Upload an .apkg and download a spreadsheet of every card to edit or share.',
   },
+  {
+    slug: 'enrich-anki-deck',
+    anchor: 'Enrich an AnKing deck',
+    blurb:
+      'Drop an .apkg you study and get it back translated, clozed, or enriched with examples.',
+  },
 ];
 
 const LANGUAGE_TOOLS: RawEntry[] = [

--- a/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
+++ b/web/src/pages/ConvertLandingPage/ConvertLandingPage.test.tsx
@@ -126,8 +126,22 @@ describe('ConvertLandingPage', () => {
     );
   });
 
-  it('covers all 15 supported input types', () => {
-    expect(CONVERT_LANDING_PAGES.size).toBe(15);
+  it('covers all 16 supported input types', () => {
+    expect(CONVERT_LANDING_PAGES.size).toBe(16);
+  });
+
+  it('resolves /convert/enrich-anki-deck to the deck enrichment landing', () => {
+    const copy = CONVERT_LANDING_PAGES.get('enrich-anki-deck');
+    expect(copy?.pathname).toBe('/convert/enrich-anki-deck');
+    expect(copy?.h1).toBe('Make your AnKing deck work better for you');
+    expect(copy?.ctaHref).toBe('/transform');
+    expect(copy?.ctaLabel).toBe('Enrich my deck');
+  });
+
+  it('renders the enrich-deck CTA pointing at the transform upload page', () => {
+    renderAtSlug('enrich-anki-deck');
+    const cta = screen.getByRole('link', { name: 'Enrich my deck' });
+    expect(cta).toHaveAttribute('href', '/transform');
   });
 
   it('serves dedicated EPUB and Kindle highlight converter pages', () => {

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -184,6 +184,7 @@ const apkgToCsv: LandingCopy = {
     { label: 'Convert a CSV or Excel sheet to Anki', href: '/convert/csv-to-anki' },
     { label: 'Convert Anki notes to Notion', href: '/anki-to-notion' },
     { label: 'Convert an HTML file to Anki', href: '/convert/html-to-anki' },
+    { label: 'Enrich an AnKing deck', href: '/convert/enrich-anki-deck' },
     { label: 'Browse every converter', href: '/convert' },
   ],
   pathname: '/convert/apkg-to-csv',
@@ -528,6 +529,56 @@ const kindleToAnki: LandingCopy = {
   ],
 };
 
+const enrichAnkiDeck: LandingCopy = {
+  relatedLinks: [
+    { label: 'Export an Anki deck to CSV', href: '/convert/apkg-to-csv' },
+    { label: 'Build a USMLE deck from your notes', href: '/usmle-anki' },
+    { label: 'See paid plans', href: '/pricing' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
+  pathname: '/convert/enrich-anki-deck',
+  title: 'Enrich an Anki deck — translate, cloze, and add examples | 2anki',
+  description:
+    'Drop an existing .apkg and get it back translated, clozed, or enriched with examples, hints, and images. Works on the AnKing deck and any deck you own. Paid plan, up to 250 notes per job.',
+  h1: 'Make your AnKing deck work better for you',
+  subhead:
+    'Drop an .apkg you already study and get it back translated, clozed, or enriched with examples, hints, and images. Your cards, rebuilt the way you learn — not a new deck to start over on.',
+  ctaLabel: 'Enrich my deck',
+  ctaHref: '/transform',
+  whatComesAcross: [
+    {
+      title: 'Translate the back into your language',
+      body: 'Pick a target language and we translate the answer field on every card, keeping the front as-is. Study a Step 1 deck in the language you think in, without rewriting a single card by hand.',
+    },
+    {
+      title: 'Turn fronts into cloze blanks',
+      body: 'We convert a basic front into a cloze deletion so you recall the key term instead of reading it. Good for a vocab deck or a fact-dense deck where recognition was hiding gaps in recall.',
+    },
+    {
+      title: 'Add examples, hints, and images',
+      body: 'Add a worked example or a one-line hint to the back, or attach a real photo or diagram pulled from a stock-photo or Wikimedia source. The original front and back stay intact — enrichment is appended, not swapped in.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Do you change my cards or replace them?',
+      a: 'We append. Translation writes to the answer field, cloze rewrites the front into a deletion, and examples, hints, and images are added to the back. The note type and your existing fields stay. You review the result in Anki and keep whatever you like.',
+    },
+    {
+      q: 'Does this work on the AnKing deck?',
+      a: 'Yes. Any .apkg you own works — the AnKing deck, a deck from AnkiWeb, or one you built yourself. We read the file you upload; there is no connection to AnkiWeb and nothing is shared back.',
+    },
+    {
+      q: 'Do you keep the originals?',
+      a: 'Your uploaded deck is never altered. You download a new .apkg with the transforms applied, so the deck you already study stays exactly as it is until you choose to import the enriched version.',
+    },
+    {
+      q: "What's the limit per job?",
+      a: 'Up to 250 notes per transform. For a larger deck, split it into subdecks of 250 or fewer and run each through — the enriched pieces import alongside each other in Anki.',
+    },
+  ],
+};
+
 export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['notion-to-anki', notionToAnki],
   ['pdf-to-anki', pdfToAnki],
@@ -544,4 +595,5 @@ export const CONVERT_LANDING_PAGES: ReadonlyMap<string, LandingCopy> = new Map([
   ['language-reactor-to-anki', languageReactorToAnki],
   ['epub-to-anki', epubToAnki],
   ['kindle-to-anki', kindleToAnki],
+  ['enrich-anki-deck', enrichAnkiDeck],
 ]);

--- a/web/src/pages/LandingPage/copy/medical-lecture-slides.ts
+++ b/web/src/pages/LandingPage/copy/medical-lecture-slides.ts
@@ -6,6 +6,7 @@ const medicalLectureSlidesCopy: LandingCopy = {
     { label: 'Build USMLE Anki decks from your notes', href: '/usmle-anki' },
     { label: 'Make nursing flashcards from lecture slides', href: '/nursing-flashcards' },
     { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Enrich an AnKing deck', href: '/convert/enrich-anki-deck' },
     { label: 'Browse every converter', href: '/convert' },
   ],
   pathname: '/anki-from-medical-lecture-slides',

--- a/web/src/pages/LandingPage/copy/usmle.ts
+++ b/web/src/pages/LandingPage/copy/usmle.ts
@@ -5,6 +5,7 @@ const usmleCopy: LandingCopy = {
     { label: 'Make nursing flashcards from lecture slides', href: '/nursing-flashcards' },
     { label: 'Turn medical lecture slides into Anki cards', href: '/anki-from-medical-lecture-slides' },
     { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Enrich an AnKing deck', href: '/convert/enrich-anki-deck' },
     { label: 'Browse every converter', href: '/convert' },
   ],
   pathname: '/usmle-anki',

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-04-anking-enrichment-landing.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-04-anking-enrichment-landing.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-04-anking-enrichment-landing",
+  "date": "2026-06-04",
+  "type": "feature",
+  "title": "Enrich an existing AnKing deck — translate the back, turn fronts into cloze, or add examples and images"
+}


### PR DESCRIPTION
## What
Adds a new SEO landing page at `/convert/enrich-anki-deck` for enriching an existing Anki deck — translate the back into another language, turn fronts into cloze deletions, or append examples, hints, and images. The page points users at the paid `/transform` flow (TransformApkgUseCase, paid-plan gate, 250-note cap surfaced in the copy). This is Bet A from the PM trio's competitive analysis: capture the high-intent "add cloze to AnKing deck" / "translate Anki deck" / "enrich Anki cards with AI" search clusters and route them to the paywall.

## Why
The trio competitive analysis flagged deck enrichment as our strongest underserved query cluster — owners of large shared decks (the AnKing deck in particular) searching for one specific transform. We already ship the capability (`TransformApkgUseCase`); we had no landing page pointing search traffic at it. No issue number — net-new feature from the overnight competitive analysis.

## How
- New `enrichAnkiDeck` `LandingCopy` entry at the bottom of `convertLandingConfig.ts`, keyed `enrich-anki-deck`. Reuses the existing `ConvertLandingPage` / `LandingPage` components — no new component. Uses the existing `ctaHref`/`ctaLabel` path so the hero renders a CTA button to `/transform` instead of the generic upload form.
- Copy ported verbatim from the seo-content draft (`Documentation/landing-drafts/anking-enrichment.md`): hero, three transform blocks (`whatComesAcross`), four FAQs, footer note.
- Hub group entry under **Files** in `convertHubGroups.ts` — the module-load assertion in that file throws if any landing slug lacks a hub entry, so this is required, not optional.
- Sitemap entry (monthly, priority 0.9) mirroring `/convert/kindle-to-anki`.
- Inbound `relatedLinks` with anchor "Enrich an AnKing deck" from `/usmle-anki`, `/anki-from-medical-lecture-slides`, and `/convert/apkg-to-csv` (the medical + existing-.apkg cluster).
- The App route (`/convert/:slug`) and the prerender script both auto-discover from `CONVERT_LANDING_PAGES`, so no `App.tsx` or prerender-source edit was needed.

## Measuring success
Track organic sessions landing on `/convert/enrich-anki-deck` (analytics pageview) and the click-through rate on the "Enrich my deck" CTA → `/transform`. The downstream signal is paid-plan transform jobs originating from `signupOrigin === '/convert/enrich-anki-deck'` (persisted via `persistSignupOrigin` on the landing). If the page ranks and converts, transform-job volume attributed to that origin rises.

## Testing
- Unit tests added (web/vitest):
  - `/convert/enrich-anki-deck` resolves to the new entry with the expected `h1`, `ctaHref` (`/transform`), and `ctaLabel`.
  - The rendered hero CTA links to `/transform`.
  - Landing-page count bumped 15 → 16 in the config coverage test.
  - Prerender emits `convert/enrich-anki-deck/index.html`; count bumped 26 → 27.
- Existing `it.each` over `CONVERT_LANDING_PAGES` now also renders this page's H1 and all FAQ questions.
- Full web suite green: `pnpm --filter 2anki-web test` (1683 passing), `typecheck`, and `lint` all clean. Note: the local box defaulted to Node v22.2.0 which breaks the jsdom `require(ESM)` chain; verified green under the `.nvmrc`-pinned Node 22.20.0 (what CI uses).
- sonar-scanner skipped per `.claude/rules/sonar.md` — this PR is pure declarative config/copy + test edits with no new or modified functions/logic; expect no Sonar bounce.

## Browser check
Browser check: not applicable — pure config/copy addition. The new page reuses the unchanged ConvertLandingPage/LandingPage components; route resolution and the CTA target (`/transform`) are asserted in the rendering test rather than a live drive.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-04-anking-enrichment-landing.json` — "Enrich an existing AnKing deck — translate the back, turn fronts into cloze, or add examples and images"

## Decisions made overnight (please review)
- **CTA goes to `/transform`, not the generic upload form.** This page sells a paid transform, so the hero renders a button to the transform upload page rather than the free converter's drag-drop. If you'd rather the page also accept a direct drop, say so and I'll wire the upload form in.
- **Inbound anchor text is "Enrich an AnKing deck"** (per the task brief), which overrides the longer anchors the seo-content draft proposed ("Enrich an Anki deck you already study" / "Translate or cloze an existing deck"). Shorter anchor, AnKing-specific. Easy to swap if you prefer the draft's phrasing.
- **Hub entry placed in the Files group.** It's the only group that already holds an `.apkg`-input converter (`apkg-to-csv`). A dedicated "Enrich" group felt premature for one entry.
- **Did not ship the A/B hero variants** from the draft (variants B/C for the translate / generic-enrich clusters). Shipped variant A (the AnKing-ownership hero) only. Variant testing can follow once this ranks.

## Risks
Low — content + config only, no auth/payments/migrations touched. Worst case is a copy or routing tweak. Rollback is a single revert; the route disappears with the config entry.

## Goal alignment
Moves us toward 300K users by opening a high-intent organic-search surface (deck enrichment / AnKing) that routes qualified traffic to the paid transform flow — both top-of-funnel acquisition and paid conversion in one page.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783202457&installation_id=132681956&pr_number=3098&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3098&signature=ce6c2e91a540ae18506c044f9a2dd893cd2676a1699796306a66dd4b9e2e7bbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->