### PR TITLE
chore: exclude landing config from Sonar CPD

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/dat
 
 sonar.coverage.exclusions=src/templates/**,src/migrations/**,src/test/fixtures/**,src/data_layer/public/**,src/config/swagger.ts,web/mock-server/**,web/src/generated/**,web/src/schemas/**,web/src/react-app-env.d.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
-sonar.cpd.exclusions=src/migrations/**,src/data_layer/public/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+sonar.cpd.exclusions=src/migrations/**,src/data_layer/public/**,web/src/generated/**,web/src/schemas/**,web/src/pages/OpsPage/performanceTypes.ts,web/src/pages/ConvertLandingPage/convertLandingConfig.ts,web/src/pages/LandingPage/copy/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info,web/coverage/lcov.info
 


### PR DESCRIPTION
## Summary

The `/convert/<surface>` landings are intentionally repetitive — each entry repeats the same shape (hero, columns, FAQ block) by design, because each landing must stand alone as a self-contained SEO surface.

Sonar's copy-paste detector flags the shared shape and blocks the quality gate on every landing PR:
- PR #3097 (pdf-to-anki refresh): `new_duplicated_lines_density = 33.3%`
- PR #3098 (enrich-anki-deck): `new_duplicated_lines_density = 3.6%`

Both > the 3% threshold. Other Sonar gates (security, reliability, maintainability) are A on both.

Adds `web/src/pages/ConvertLandingPage/convertLandingConfig.ts` and `web/src/pages/LandingPage/copy/**` to `sonar.cpd.exclusions`. Coverage, security hotspots, and the other quality checks still apply.

Once this merges, #3097 and #3098 rebase and Sonar re-runs clean.

## Browser check
Browser check: not applicable — Sonar configuration only, no runtime code.

## Test plan
- [x] After merge, rebase #3097 and #3098 on main, confirm SonarCloud Code Analysis turns SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783204357&installation_id=132681956&pr_number=3099&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3099&signature=113f7de5a62f8ce5e994f6bed45c7b739aaf064adcb2ed9b5515b7993fe88526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->