### PR TITLE
fix: empty deck explains toggles become cards

### DIFF
--- a/src/data_layer/normalizeFailureReasons.test.ts
+++ b/src/data_layer/normalizeFailureReasons.test.ts
@@ -1,4 +1,5 @@
 import { normalizeFailureReasons } from './normalizeFailureReasons';
+import { EMPTY_DECK_FAILURE_REASON } from '../usecases/jobs/jobFailureReason';
 
 describe('normalizeFailureReasons', () => {
   it('excludes monthly_limit quota blocks entirely', () => {
@@ -27,8 +28,7 @@ describe('normalizeFailureReasons', () => {
   it('buckets the empty-deck prose message to empty_deck', () => {
     const result = normalizeFailureReasons([
       {
-        reason:
-          "No cards in this deck yet. 2anki turns Notion toggle blocks into flashcards — the toggle title becomes the question, what's inside is the answer. Wrap your key terms in toggles in Notion, then convert again.",
+        reason: EMPTY_DECK_FAILURE_REASON,
         count: 4,
       },
     ]);

--- a/src/usecases/jobs/jobFailureReason.test.ts
+++ b/src/usecases/jobs/jobFailureReason.test.ts
@@ -34,6 +34,12 @@ describe('jobFailureReasonFromError', () => {
     expect(reason).toBe(EMPTY_DECK_FAILURE_REASON);
   });
 
+  it('keeps the ops-matched empty-deck prefix intact', () => {
+    expect(
+      EMPTY_DECK_FAILURE_REASON.startsWith('No cards in this deck yet.')
+    ).toBe(true);
+  });
+
   it('returns MARKDOWN_LIKELY_LOSSY_REASON for EmptyDeckError with markdown sourceFormat', () => {
     const reason = jobFailureReasonFromError(new EmptyDeckError('markdown'), 'job-md');
     expect(reason).toBe(MARKDOWN_LIKELY_LOSSY_REASON);

--- a/src/usecases/jobs/jobFailureReason.ts
+++ b/src/usecases/jobs/jobFailureReason.ts
@@ -7,7 +7,7 @@ export const NOTION_TOKEN_EXPIRED_REASON =
   'notion_token_expired';
 
 export const EMPTY_DECK_FAILURE_REASON =
-  "No cards in this deck yet. 2anki turns Notion toggle blocks into flashcards — the toggle title becomes the question, what's inside is the answer. Wrap your key terms in toggles in Notion, then convert again.";
+  "No cards in this deck yet. 2anki makes a card from every Notion toggle — the toggle title becomes the question, what's inside becomes the answer. Wrap your key terms in toggles, then convert again.";
 
 export const MARKDOWN_LIKELY_LOSSY_REASON =
   'Notion Markdown exports flatten toggles — re-export this page as HTML and the toggles become flashcards.';

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -483,11 +483,11 @@ describe('DownloadsPage failure reason panel', () => {
     expect(screen.queryByText(/Your page title has a "\/" in it/)).not.toBeInTheDocument();
   });
 
-  it('renders failure panel content for empty deck errors', () => {
+  it('renders the toggle teaching copy and docs CTA for empty deck errors', () => {
     mockJobs = [
       buildJob({
         status: 'failed',
-        job_reason_failure: 'No cards in this deck yet. 2anki turns Notion toggle blocks into flashcards — the toggle title becomes the question, what\'s inside is the answer. Wrap your key terms in toggles in Notion, then convert again.',
+        job_reason_failure: 'No cards in this deck yet. 2anki makes a card from every Notion toggle — the toggle title becomes the question, what\'s inside becomes the answer. Wrap your key terms in toggles, then convert again.',
       }),
     ];
     renderAt('/downloads');
@@ -495,10 +495,12 @@ describe('DownloadsPage failure reason panel', () => {
     const statusButton = screen.getByRole('button', { name: /Show failure reason/i });
     fireEvent.click(statusButton);
 
-    expect(screen.queryByText(/Learn more/)).not.toBeInTheDocument();
+    expect(screen.getByText(/makes a card from every Notion toggle/i)).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'See how toggles become cards' });
+    expect(cta).toHaveAttribute('href', '/documentation/cards/notion-blocks');
   });
 
-  it('does not show Learn more link for non-empty-deck errors', () => {
+  it('does not show the toggles docs CTA for non-empty-deck errors', () => {
     mockJobs = [
       buildJob({
         status: 'failed',
@@ -510,7 +512,7 @@ describe('DownloadsPage failure reason panel', () => {
     const statusButton = screen.getByRole('button', { name: /Show failure reason/i });
     fireEvent.click(statusButton);
 
-    expect(screen.queryByText(/Learn more/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'See how toggles become cards' })).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -122,6 +122,27 @@ describe('ConversionResult — failed variant', () => {
     expect(screen.getByRole('link', { name: 'Reconnect Notion' })).toBeInTheDocument();
   });
 
+  it('shows the toggle teaching copy and docs CTA for an empty deck without falling through to Check status', () => {
+    const emptyDeckReason =
+      "No cards in this deck yet. 2anki makes a card from every Notion toggle — the toggle title becomes the question, what's inside becomes the answer. Wrap your key terms in toggles, then convert again.";
+    render(
+      <MemoryRouter>
+        <ConversionResult
+          variant="failed"
+          title="Empty Notion page"
+          failureReason={emptyDeckReason}
+          source="notion"
+          onMapColumns={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/makes a card from every Notion toggle/i)).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'See how toggles become cards' });
+    expect(cta.getAttribute('href')).toBe('/documentation/cards/notion-blocks');
+    expect(screen.queryByText(/Check status/i)).toBeNull();
+  });
+
   it('shows a subpages recovery hint when the server reports a too-large OOM failure', () => {
     const tooLargeReason =
       'This page is too large for us to convert in one go. Split it into smaller pages — or convert it section by section — and try again.';

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -10,6 +10,11 @@ import styles from './ConversionResult.module.css';
 type Source = 'notion' | 'upload' | 'dropbox' | 'drive';
 
 const NOTION_TOKEN_EXPIRED_REASON = 'notion_token_expired';
+const EMPTY_DECK_REASON_PREFIX = 'No cards in this deck yet.';
+const TOGGLES_DOCS_LABEL = 'See how toggles become cards';
+const TOGGLES_DOCS_HREF = '/documentation/cards/notion-blocks';
+const EMPTY_DECK_TEACHING_COPY =
+  "2anki makes a card from every Notion toggle — the toggle title becomes the question, what's inside becomes the answer. Wrap your key terms in toggles, then convert again.";
 
 interface ProcessingProps {
   variant: 'processing';
@@ -65,6 +70,20 @@ function FailedVariant({ failureReason, source, onMapColumns }: Omit<FailedProps
         <a href="/notion" className={sharedStyles.btnPrimary}>
           Reconnect Notion
         </a>
+      </div>
+    );
+  }
+
+  if (failureReason.startsWith(EMPTY_DECK_REASON_PREFIX)) {
+    return (
+      <div>
+        <p>{EMPTY_DECK_TEACHING_COPY}</p>
+        <Link
+          to={TOGGLES_DOCS_HREF}
+          className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+        >
+          {TOGGLES_DOCS_LABEL}
+        </Link>
       </div>
     );
   }

--- a/web/src/pages/PreviewPage/PreviewPage.test.tsx
+++ b/web/src/pages/PreviewPage/PreviewPage.test.tsx
@@ -194,6 +194,25 @@ describe('PreviewPage tally counts', () => {
   });
 });
 
+describe('PreviewPage empty state', () => {
+  it('teaches the toggle pattern and links to the toggles doc when there are no blocks', () => {
+    mockUsePreviewStream.mockReturnValue(makeStreamReturn([]));
+
+    renderPreview();
+
+    expect(
+      screen.getByText('Nothing to turn into cards yet')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/makes a card from every toggle on this page/i)
+    ).toBeInTheDocument();
+    const cta = screen.getByRole('link', {
+      name: 'See how toggles become cards',
+    });
+    expect(cta).toHaveAttribute('href', '/documentation/cards/notion-blocks');
+  });
+});
+
 describe('PreviewPage Convert to Anki CTA', () => {
   it('renders the Convert to Anki button', () => {
     mockUsePreviewStream.mockReturnValue(makeStreamReturn([]));

--- a/web/src/pages/PreviewPage/PreviewPage.tsx
+++ b/web/src/pages/PreviewPage/PreviewPage.tsx
@@ -244,8 +244,10 @@ export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
             {blocks.length === 0 && (
               <EmptyState
                 icon="📄"
-                title="Nothing to preview"
-                description="This page has no blocks to preview."
+                title="Nothing to turn into cards yet"
+                description="2anki makes a card from every toggle on this page — the toggle title becomes the question, what's inside becomes the answer. This page has no toggles yet. Add a few in Notion, then preview again."
+                actionLabel="See how toggles become cards"
+                actionHref="/documentation/cards/notion-blocks"
               />
             )}
             {blocks.map((block) => (

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-empty-deck-explains-toggles.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-empty-deck-explains-toggles.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-empty-deck-explains-toggles",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "An empty deck or preview explains that every Notion toggle becomes a card, with a link to how it works"
+}


### PR DESCRIPTION
## What
The "nothing to turn into cards" moment now teaches the same toggle->card pattern on two surfaces and links to docs instead of dead-ending: the preview empty state (`/preview/<id>`) and the empty-deck failure panel on `/downloads`.

## Why
Fixes #2806. Both surfaces previously dead-ended — the preview said "Nothing to preview / This page has no blocks to preview" with no next step, and the empty-deck failure panel fell through to the generic "Check status" branch. A user whose Notion page had no toggles had no way to learn that toggles are what become cards.

## How
- Preview empty state: new title/description teaching the toggle pattern, plus the docs CTA via EmptyState's existing `actionLabel`/`actionHref` props (no component change).
- `ConversionResult` FailedVariant: dedicated empty-deck branch (matches the `No cards in this deck yet.` prefix) rendering the tightened copy + the same docs CTA, instead of falling through to the generic branch.
- `EMPTY_DECK_FAILURE_REASON` reworded but still starts with `No cards in this deck yet.` so `normalizeFailureReasons` keeps bucketing it as `empty_deck`.
- CTA on both surfaces: label `See how toggles become cards`, href `/documentation/cards/notion-blocks` (in-app React Router route).

## Decisions made overnight (please review)
- **Preserved the `No cards in this deck yet.` prefix** for the ops matcher in `normalizeFailureReasons.ts`, overriding the designer's alternate opening. If you prefer her wording, the prefix in `normalizeFailureReasons.ts` (`KNOWN_PROSE_BUCKETS`) must be updated in lockstep or the `empty_deck` analytics series silently breaks. A test now locks the prefix.
- **CTA label `See how toggles become cards` is identical on both surfaces.**
- **In-app docs link only.** I found the route: `notion-blocks.md` is served at `/documentation/cards/notion-blocks` (DocsPage mounts `/documentation/*` and resolves the slug `cards/notion-blocks`). EmptyState renders an internal `<Link>` only, so this is a valid in-app target — CTA shipped on both surfaces, not omitted.
- Deliberately did NOT redesign other failure strings, did NOT touch `MARKDOWN_LIKELY_LOSSY_REASON`, and added no new assets, routes, or toggles.

## Measuring success
The `empty_deck` series in the ops conversion-errors dashboard (fed by `normalizeFailureReasons`) must keep accumulating after this ships — the prefix-lock test guards the contract. Clicks on the docs CTA surface as pageviews on `/documentation/cards/notion-blocks` from the downloads/preview referrers.

## Testing
- Unit tests added/updated:
  - `jobFailureReason.test.ts` — locks the `No cards in this deck yet.` prefix.
  - `normalizeFailureReasons.test.ts` — imports `EMPTY_DECK_FAILURE_REASON` instead of re-pasting the literal; still buckets to `empty_deck`.
  - `ConversionResult.test.tsx` — new empty-deck case renders teaching copy + docs CTA and does NOT fall through to "Check status".
  - `DownloadsPage.test.tsx` — was asserting the CTA absent for empty deck; now asserts the new CTA + copy present, and absent for non-empty-deck errors.
  - `PreviewPage.test.tsx` — empty-state render asserts new title/description + CTA href.
- Server: `tsc -p . --noEmit` clean; jobFailureReason + normalizeFailureReasons suites green (42 tests).
- Web: `tsc --noEmit` clean; affected vitest green (57 tests); `biome lint` clean on changed files.
- Sonar: not run locally (no SONAR_TOKEN configured) — expect CI Sonar to run. Change is copy + one early-return branch, low complexity.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path verification left for Alexander (runs the dev server). Touches web/src with runtime-visible UI on the preview empty state and the downloads empty-deck panel.

## Risks
Low. The only behavior contract at risk is the ops `empty_deck` bucket, which depends on the `No cards in this deck yet.` prefix — locked by a test. Rollback is a straight revert.

## Goal alignment
Removes a dead-end at the exact moment a user discovers 2anki produced nothing, teaching the one thing they need (toggles -> cards) with a path to docs. Recovering these users from a silent failure feeds activation/retention, which the growth analysis flags as the current leak toward 300K.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783240510&installation_id=132681956&pr_number=3102&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3102&signature=5932b03cde39683b6e0ed845171542b3ff45bb8d0b32a9fa02c8cfdacc67179e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->