### PR TITLE
fix: return 401 for anonymous native Notion link requests

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -564,6 +564,33 @@ describe('NotionController', () => {
       expect(service.getNotionLinkInfo).not.toHaveBeenCalled();
     });
 
+    it('returns 401 for an anonymous caller when query.client is native', async () => {
+      service = {
+        getClientId: jest.fn().mockReturnValue('client-abc'),
+        getNotionLinkInfo: jest.fn(),
+      } as any;
+      controller = new NotionController(service);
+      req = { params: {}, query: { client: 'native' } };
+      res = {
+        status: jest.fn().mockReturnThis(),
+        send: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+        locals: {},
+      } as any;
+
+      await controller.getNotionLink(
+        req as express.Request,
+        res as express.Response
+      );
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        code: 'auth_required_for_native',
+        message: 'Authentication required for native app OAuth flow.',
+      });
+      expect(service.getNotionLinkInfo).not.toHaveBeenCalled();
+    });
+
     it('threads client=native into the link info when query.client is native', async () => {
       service = {
         getClientId: jest.fn().mockReturnValue('client-abc'),

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -212,12 +212,21 @@ class NotionController {
       return res.status(400).send();
     }
 
-    const linkInfo =
-      req.query.client === 'native'
-        ? await this.service.getNotionLinkInfo(res.locals.owner, {
-            client: 'native',
-          })
-        : await this.service.getNotionLinkInfo(res.locals.owner);
+    if (req.query.client === 'native') {
+      if (res.locals.owner == null) {
+        return res.status(401).json({
+          code: 'auth_required_for_native',
+          message: 'Authentication required for native app OAuth flow.',
+        });
+      }
+      const nativeLinkInfo = await this.service.getNotionLinkInfo(
+        res.locals.owner,
+        { client: 'native' }
+      );
+      return res.status(200).send(nativeLinkInfo);
+    }
+
+    const linkInfo = await this.service.getNotionLinkInfo(res.locals.owner);
     return res.status(200).send(linkInfo);
   }
 

--- a/src/routes/NotionRouter.ts
+++ b/src/routes/NotionRouter.ts
@@ -146,6 +146,17 @@ const NotionRouter = () => {
    *       guess that path because OAuth flows are commonly called "login";
    *       this endpoint is the canonical one.
    *     tags: [Notion]
+   *     parameters:
+   *       - in: query
+   *         name: client
+   *         required: false
+   *         schema:
+   *           type: string
+   *           enum: [native]
+   *         description: |
+   *           Pass `native` to get a link whose OAuth state is bound to the
+   *           authenticated user for the native app flow. Requires a valid
+   *           session — anonymous callers receive 401.
    *     responses:
    *       200:
    *         description: Notion link retrieved successfully
@@ -165,6 +176,11 @@ const NotionRouter = () => {
    *                   type: string
    *                   nullable: true
    *                   description: Connected workspace name
+   *       401:
+   *         description: |
+   *           Returned only for `client=native` without a valid session. The
+   *           native OAuth state is bound to the user, so authentication is
+   *           required. Body carries `code: auth_required_for_native`.
    */
   router.get(
     '/api/notion/get-notion-link',


### PR DESCRIPTION
## What
`GET /api/notion/get-notion-link?client=native` now returns 401 with `{ code: 'auth_required_for_native' }` for anonymous callers instead of throwing a 500.

## Why
Prod error_events (2026-06-05) showed repeated 500s — "owner must be a positive integer" — from anonymous hits on the native OAuth link endpoint, polluting the error dashboard. The route uses `OptionalAuthentication`, so `res.locals.owner` is undefined for anonymous callers; `buildNativeOAuthState` correctly refuses to sign a state without a real owner (owner binding is a deliberate security property from d584b50c551d and is unchanged here). The bug was letting the request reach the service at all.

## How
Guard clause in `NotionController.getNotionLink`: when `req.query.client === 'native'` and `res.locals.owner == null` (`== null`, not `!owner`, per the falsy-ID rule), respond 401 before calling the service. The anonymous web flow is untouched — it still returns a working public OAuth link. Swagger comment on the route documents the `client` query param and the 401.

## Measuring success
The recurring `owner must be a positive integer` entries from this endpoint stop appearing in prod error_events; anonymous native requests show as 401s in access logs instead of 500s.

## Testing
- Unit tests added: anonymous + `client=native` → 401 with `auth_required_for_native`, service never called (new, written failing-first).
- Existing tests cover the other contract points: authenticated + native → 200 with owner-bound state; anonymous without `client=native` → 200 public link; tampered/bare native state rejected on connect.
- `pnpm test src/controllers` (603 passing), `src/routes` + swagger tests (223 passing), `npx tsc -p . --noEmit` clean.

## Changelog
No entry — internal API hardening, no user-visible change (native-app API surface only).

## Sonar
Not run locally — `SONAR_TOKEN` is unset in this environment. Change is a single guard clause + swagger comments; expecting no findings, but flagging per rules/sonar.md.

## Risks
A native app client calling this endpoint without a session now gets 401 instead of 500 — strictly an improvement; the 500 carried no usable state either. Rollback: revert the commit.

## Goal alignment
Keeps the error dashboard signal clean so real conversion-path failures stay visible — indirect support for reliability at scale.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269304&installation_id=132681956&pr_number=3114&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3114&signature=b2dfaa893d1d734b4e99dc7e7d3a083895684cbab0b40b979fbf1bf8616ec0c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->