### PR TITLE
fix: retry photo-to-deck when Claude response is truncated

### DIFF
--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.test.ts
@@ -189,6 +189,47 @@ describe('PhotoToFlashcardsUseCase', () => {
     });
   });
 
+  describe('max_tokens truncation retry', () => {
+    const TRUNCATED_RESPONSE = STUB_CLAUDE_RESPONSE.slice(0, 40);
+
+    it('retries once with a higher max_tokens and succeeds on a complete response', async () => {
+      mockMessageCreate
+        .mockResolvedValueOnce({
+          stop_reason: 'max_tokens',
+          content: [{ type: 'text', text: TRUNCATED_RESPONSE }],
+          usage: { input_tokens: 100, output_tokens: 4096 },
+        })
+        .mockResolvedValueOnce({
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: STUB_CLAUDE_RESPONSE }],
+          usage: { input_tokens: 100, output_tokens: 200 },
+        });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      const result = await useCase.execute({ ...BASE_INPUT, isPaying: true });
+      expect(result.cardCount).toBe(2);
+      expect(mockMessageCreate).toHaveBeenCalledTimes(2);
+      expect(mockMessageCreate.mock.calls[0][0].max_tokens).toBe(4096);
+      expect(mockMessageCreate.mock.calls[1][0].max_tokens).toBe(8192);
+    });
+
+    it('throws 422 when the retry is also truncated mid-JSON', async () => {
+      mockMessageCreate.mockResolvedValue({
+        stop_reason: 'max_tokens',
+        content: [{ type: 'text', text: TRUNCATED_RESPONSE }],
+        usage: { input_tokens: 100, output_tokens: 8192 },
+      });
+      const useCase = new PhotoToFlashcardsUseCase(makeEventsStub());
+      await expect(
+        useCase.execute({ ...BASE_INPUT, isPaying: true })
+      ).rejects.toMatchObject({
+        status: 422,
+        message:
+          "Couldn't read the cards from this photo. Try a clearer or less dense image.",
+      });
+      expect(mockMessageCreate).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('tag plumbing', () => {
     it('writes tags from Claude Vision response into deck_info.json', async () => {
       mockMessageCreate.mockResolvedValueOnce({

--- a/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
+++ b/src/usecases/imageOcclusion/PhotoToFlashcardsUseCase.ts
@@ -135,6 +135,8 @@ function resolvePrompt(
 
 const INPUT_COST_PER_MILLION = 3;
 const OUTPUT_COST_PER_MILLION = 15;
+const VISION_MAX_TOKENS = 4096;
+const VISION_RETRY_MAX_TOKENS = 8192;
 
 function findPython(): string {
   const envOverride = process.env.PYTHON ?? process.env.ANKI_PYTHON;
@@ -431,34 +433,45 @@ export class PhotoToFlashcardsUseCase {
     const mcqEnabled = (input.mcqEnabled ?? false) && input.isPaying;
     const mode = input.mode ?? DEFAULT_PHOTO_MODE;
 
-    const response = await client.messages.create({
-      model: 'claude-sonnet-4-5',
-      max_tokens: 4096,
-      messages: [
-        {
-          role: 'user',
-          content: [
-            {
-              type: 'image',
-              source: {
-                type: 'base64',
-                media_type: input.mediaType,
-                data: input.imageBase64,
+    const createVisionMessage = (maxTokens: number) =>
+      client.messages.create({
+        model: 'claude-sonnet-4-5',
+        max_tokens: maxTokens,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: input.mediaType,
+                  data: input.imageBase64,
+                },
               },
-            },
-            {
-              type: 'text',
-              text: resolvePrompt(
-                mode,
-                input.cardStyle ?? DEFAULT_PHOTO_CARD_STYLE,
-                input.density ?? DEFAULT_PHOTO_DENSITY,
-                mcqEnabled
-              ),
-            },
-          ],
-        },
-      ],
-    });
+              {
+                type: 'text',
+                text: resolvePrompt(
+                  mode,
+                  input.cardStyle ?? DEFAULT_PHOTO_CARD_STYLE,
+                  input.density ?? DEFAULT_PHOTO_DENSITY,
+                  mcqEnabled
+                ),
+              },
+            ],
+          },
+        ],
+      });
+
+    let response = await createVisionMessage(VISION_MAX_TOKENS);
+    if (response.stop_reason === 'max_tokens') {
+      console.warn('[Claude] Vision response truncated at max_tokens, retrying', {
+        source: 'photo',
+        maxTokens: VISION_MAX_TOKENS,
+        retryMaxTokens: VISION_RETRY_MAX_TOKENS,
+      });
+      response = await createVisionMessage(VISION_RETRY_MAX_TOKENS);
+    }
 
     const rawText = response.content
       .filter((b) => b.type === 'text')

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-photo-dense-cards.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-photo-dense-cards.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-photo-dense-cards",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "Photo flashcards handle dense photos with many cards"
+}


### PR DESCRIPTION
## What
Photo-to-deck retries the Claude vision call once at a higher token budget when the response is truncated, instead of failing the conversion with misleading advice.

## Why
Prod error_events (2026-05-30): POST `/api/image-occlusion/photo-to-deck` threw `SyntaxError: Expected ',' or '}' after property value in JSON` from `parseClaudeVisionResponse`, and the user got a 422 saying "Try a clearer or less dense image" — the photo was fine. Root cause: the vision call hardcoded `max_tokens: 4096` and never checked `response.stop_reason`, so dense photos (many cards) came back cut off mid-JSON.

## How
After the vision call, check `response.stop_reason === 'max_tokens'`. On truncation, retry once with `max_tokens: 8192` using the identical request. If the retry also truncates, fall through to the existing partial-JSON salvage and 422 path unchanged. Same stop_reason pattern `ClaudeService` already uses for chunked deck generation. Cost impact: only truncated responses pay for a second call (input tokens re-billed once for that request); no latency change on the happy path.

## Measuring success
`vision_parse_failed` log events (structured `console.log` in `PhotoToFlashcardsUseCase`) should drop for dense photos; the retry logs `[Claude] Vision response truncated at max_tokens, retrying` with `source: 'photo'` — grep prod logs for that line to count how often the retry fires and saves a conversion.

## Testing
- Unit tests added: truncated first response + complete retry → success with second call at `max_tokens` 8192; truncation on both calls → 422 with the existing safe message and exactly 2 API calls.
- Full `src/usecases/imageOcclusion` suite green (76 tests); server tsc clean.

## Browser check
Browser check: not applicable — changelog-only web change (server-side fix)

## Changelog
"Photo flashcards handle dense photos with many cards" (`web/src/pages/WhatsNewPage/changelog/2026-06-05-photo-dense-cards.json`)

## Risks
A retry doubles vision input cost for the truncated case only. If Claude truncates at 8192 too, behavior is identical to before the fix (salvage, then 422). Rollback: revert the commit.

## Goal alignment
Dense photos are exactly the high-value use case (lecture slides, textbook pages); failing them with wrong advice pushes users away from the photo flow. This keeps the "drop something in, get a deck back" promise.

Note: sonar-scanner not run locally — SONAR_TOKEN unset in this environment; expect the CI Sonar analysis to be the first scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269357&installation_id=132681956&pr_number=3115&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3115&signature=7b9ea364164af05cbf1d8b8a7f32b66a5ce89424e6213a92c2239f9455fcc734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->