### PR TITLE
fix: serve index.html with no-cache so deploys don't strand clients

### DIFF
--- a/src/controllers/IndexController/sendIndex.test.ts
+++ b/src/controllers/IndexController/sendIndex.test.ts
@@ -2,6 +2,7 @@ import { Response } from 'express';
 
 import { sendIndex } from './sendIndex';
 import { getIndexFileContents } from './getIndexFileContents';
+import { INDEX_HTML_CACHE_CONTROL } from '../../lib/mountWebBuild';
 
 jest.mock('./getIndexFileContents');
 
@@ -30,6 +31,18 @@ describe('sendIndex', () => {
 
     expect(res.status).not.toHaveBeenCalled();
     expect(res.send).toHaveBeenCalledWith('<html>ready</html>');
+  });
+
+  it('marks the shell no-cache so stale clients pick up new builds', () => {
+    mockedGet.mockReturnValue('<html>ready</html>');
+    const res = buildResponse();
+
+    sendIndex(res);
+
+    expect(res.set).toHaveBeenCalledWith(
+      'Cache-Control',
+      INDEX_HTML_CACHE_CONTROL
+    );
   });
 
   it('responds 503 with Retry-After when the build is mid-deploy', () => {

--- a/src/controllers/IndexController/sendIndex.ts
+++ b/src/controllers/IndexController/sendIndex.ts
@@ -1,10 +1,12 @@
 import express from 'express';
 import { getIndexFileContents } from './getIndexFileContents';
+import { INDEX_HTML_CACHE_CONTROL } from '../../lib/mountWebBuild';
 
 const BUILD_PENDING_BODY =
   'The site is being updated. Refresh in a few seconds.';
 
 export const sendIndex = (response: express.Response) => {
+  response.set('Cache-Control', INDEX_HTML_CACHE_CONTROL);
   const html = getIndexFileContents();
   if (html == null) {
     response.set('Retry-After', '5');

--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -106,6 +106,7 @@ function mockResponse(): express.Response {
     status: jest.fn().mockReturnThis(),
     json: jest.fn().mockReturnThis(),
     send: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
   } as unknown as express.Response;
 }
 

--- a/src/lib/mountWebBuild.test.ts
+++ b/src/lib/mountWebBuild.test.ts
@@ -1,0 +1,69 @@
+import express from 'express';
+import fs from 'fs';
+import http from 'http';
+import os from 'os';
+import path from 'path';
+
+import { INDEX_HTML_CACHE_CONTROL, mountWebBuild } from './mountWebBuild';
+
+describe('mountWebBuild', () => {
+  let buildDir: string;
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll((done) => {
+    buildDir = fs.mkdtempSync(path.join(os.tmpdir(), 'web-build-'));
+    fs.writeFileSync(path.join(buildDir, 'index.html'), '<html>app</html>');
+    fs.mkdirSync(path.join(buildDir, 'assets'));
+    fs.writeFileSync(
+      path.join(buildDir, 'assets', 'app-abc123.css'),
+      'body{}'
+    );
+
+    const app = express();
+    mountWebBuild(app, buildDir);
+    server = app.listen(0, () => {
+      const address = server.address();
+      if (address == null || typeof address === 'string') {
+        done(new Error('expected an ephemeral port'));
+        return;
+      }
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      fs.rmSync(buildDir, { recursive: true, force: true });
+      done();
+    });
+  });
+
+  it('serves / with the no-cache header so clients revalidate the shell', async () => {
+    const response = await fetch(`${baseUrl}/`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe(
+      INDEX_HTML_CACHE_CONTROL
+    );
+  });
+
+  it('serves /index.html with the no-cache header', async () => {
+    const response = await fetch(`${baseUrl}/index.html`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe(
+      INDEX_HTML_CACHE_CONTROL
+    );
+  });
+
+  it('keeps hashed assets immutable for a year', async () => {
+    const response = await fetch(`${baseUrl}/assets/app-abc123.css`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=31536000, immutable'
+    );
+  });
+});

--- a/src/lib/mountWebBuild.ts
+++ b/src/lib/mountWebBuild.ts
@@ -1,0 +1,22 @@
+import express from 'express';
+import http from 'http';
+import path from 'path';
+
+export const INDEX_HTML_CACHE_CONTROL = 'no-cache, must-revalidate';
+
+const revalidateIndexHtml = (res: http.ServerResponse, filePath: string) => {
+  if (path.basename(filePath) === 'index.html') {
+    res.setHeader('Cache-Control', INDEX_HTML_CACHE_CONTROL);
+  }
+};
+
+export const mountWebBuild = (app: express.Express, buildDir: string) => {
+  app.use(
+    '/assets',
+    express.static(path.join(buildDir, 'assets'), {
+      immutable: true,
+      maxAge: '1y',
+    })
+  );
+  app.use(express.static(buildDir, { setHeaders: revalidateIndexHtml }));
+};

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ if (existsSync(localEnvFile)) {
 }
 
 import { BUILD_DIR } from './lib/constants';
+import { mountWebBuild } from './lib/mountWebBuild';
 import ErrorHandler from './routes/middleware/ErrorHandler';
 import { makeErrorCaptureMiddleware } from './routes/middleware/ErrorCaptureMiddleware';
 import { ErrorEventRepository } from './data_layer/ErrorEventRepository';
@@ -152,14 +153,7 @@ const serve = async () => {
   attachAnkifySessionProxy(app, server, ankifySessionValidate);
 
   app.use('/templates', express.static(templateDir));
-  app.use(
-    '/assets',
-    express.static(`${BUILD_DIR}/assets`, {
-      immutable: true,
-      maxAge: '1y',
-    })
-  );
-  app.use(express.static(BUILD_DIR));
+  mountWebBuild(app, BUILD_DIR);
 
   // API Documentation
   app.use(swaggerRouter());

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-fresh-after-updates.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-fresh-after-updates.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-fresh-after-updates",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "The site loads the latest version right after an update instead of a broken page"
+}


### PR DESCRIPTION
## What
Every path that serves `index.html` now responds with `Cache-Control: no-cache, must-revalidate`: the build-dir static handler (directory index `/` and `/index.html`) and the SPA catch-all (`sendIndex`, including its 503 build-pending response). Hashed `/assets` keep `public, max-age=31536000, immutable`.

## Why
Prod error_events clustered ~20 events after the 2026-06-03 deploy: "Unable to preload CSS for …/assets/*.css" and "Failed to fetch dynamically imported module" — clients holding a cached stale `index.html` requested hashed chunks from a different build. The client-side reload recovery (`web/src/lib/chunkReload.ts`) is defeated when the reload re-fetches the same cached shell. Users hit a broken page right after every deploy until their cache expired.

## How
Extracted the build-dir static wiring from `server.ts` into `src/lib/mountWebBuild.ts` so it is testable over real HTTP. `express.static`'s `setHeaders` applies the no-cache header only when the served file is `index.html`; `sendIndex` sets the same header (shared `INDEX_HTML_CACHE_CONTROL` constant) before sending the shell on SPA fall-through routes.

## Measuring success
The "Unable to preload CSS" / "Failed to fetch dynamically imported module" cluster in `error_events` should not recur after the next deploy. Verify with `curl -sI https://2anki.net/ | grep -i cache-control` → `no-cache, must-revalidate`, and `curl -sI https://2anki.net/assets/<any-chunk>` → `immutable`.

## Testing
- Unit tests added: `src/lib/mountWebBuild.test.ts` (real express app on an ephemeral port — `/` and `/index.html` get no-cache, `/assets/*` stays immutable), `sendIndex.test.ts` (SPA fall-through sets the header). `StripeController.test.ts` response fixture gained the `set` mock that `sendIndex` now requires.

Sonar: not run locally — `SONAR_TOKEN` unset on this machine; small diff, expect CI analysis to cover it.

Browser check: not applicable — only `web/src/` file is a changelog entry; server-side header change with no rendered output.

## Changelog
"The site loads the latest version right after an update instead of a broken page" (`web/src/pages/WhatsNewPage/changelog/2026-06-05-fresh-after-updates.json`).

## Risks
Slightly more revalidation traffic for the shell (it's a few KB; `no-cache` still allows conditional 304s). Rollback is reverting one commit. Note: any CDN/proxy in front must respect the header — nginx on the box passes it through.

## Goal alignment
A broken page immediately after every deploy is the opposite of "simplest, fastest" — this removes a recurring first-impression failure for returning users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269461&installation_id=132681956&pr_number=3116&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3116&signature=4b4e9c8d000c936d9a37f3b30e7d8b3f4234a4c1e6daa5129b42ca7e765f77f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->