### PR TITLE
fix: guard upload page text nodes against browser translation

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -296,3 +296,68 @@ describe('UploadPage analytics', () => {
   });
 });
 
+const collectUnwrappedTextNodes = (root: HTMLElement): string[] => {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const offenders: string[] = [];
+  let node = walker.nextNode();
+  while (node != null) {
+    const hasVisibleText = (node.textContent ?? '').trim().length > 0;
+    const parentMixesElements =
+      (node.parentElement?.childElementCount ?? 0) > 0;
+    const parentIsBadgeContainer =
+      node.parentElement?.className.includes('aiOffBadgeBody') ?? false;
+    if (hasVisibleText && (parentMixesElements || parentIsBadgeContainer)) {
+      offenders.push(node.textContent ?? '');
+    }
+    node = walker.nextNode();
+  }
+  return offenders;
+};
+
+describe('UploadPage AI badge survives browser translation', () => {
+  beforeEach(() => {
+    fakeUser = null;
+    fakeLocals = undefined;
+    globalThis.localStorage.clear();
+    globalThis.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    fakeUser = null;
+    fakeLocals = undefined;
+    globalThis.localStorage.clear();
+  });
+
+  const badgeFor = (label: RegExp): HTMLElement => {
+    const badgeLabel = screen.getByText(label);
+    return badgeLabel.closest('[role="status"]') as HTMLElement;
+  };
+
+  it('renders no bare text nodes in the anon branch', () => {
+    renderPage();
+    expect(collectUnwrappedTextNodes(badgeFor(/AI is off/))).toEqual([]);
+  });
+
+  it('renders no bare text nodes in the free branch', () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: false, subscriber: false };
+    renderPage();
+    expect(collectUnwrappedTextNodes(badgeFor(/AI is off/))).toEqual([]);
+  });
+
+  it('renders no bare text nodes in the on branch', () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: true, subscriber: false };
+    globalThis.localStorage.setItem('claude-ai-flashcards', 'true');
+    renderPage();
+    expect(collectUnwrappedTextNodes(badgeFor(/AI is on/))).toEqual([]);
+  });
+
+  it('renders no bare text nodes in the off branch', () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: true, subscriber: false };
+    renderPage();
+    expect(collectUnwrappedTextNodes(badgeFor(/AI is off/))).toEqual([]);
+  });
+});
+

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -167,11 +167,11 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
               <span className={styles.badgeSuccess}>AI is on</span>
             </button>
             <span className={styles.aiOffBadgeBody}>
-              {' '}Cards are written by Claude.{' '}
+              <span>{' '}Cards are written by Claude.{' '}</span>
               <Link to="/card-options?returnTo=/upload#pdf-ai">
                 Manage in Settings
               </Link>
-              .
+              <span>.</span>
             </span>
           </>
         )}
@@ -187,8 +187,10 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
               <span className={styles.badgeWarning}>AI is off</span>
             </button>
             <span className={styles.aiOffBadgeBody}>
-              {' '}You&apos;ll get rule-based cards from your file&apos;s
-              structure. Turn on Claude cards.
+              <span>
+                {' '}You&apos;ll get rule-based cards from your file&apos;s
+                structure. Turn on Claude cards.
+              </span>
             </span>
           </>
         )}
@@ -196,15 +198,17 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           <>
             <span className={styles.badgeWarning}>AI is off</span>
             <span className={styles.aiOffBadgeBody}>
-              {' '}You&apos;ll get rule-based cards from your file&apos;s
-              structure.{' '}
+              <span>
+                {' '}You&apos;ll get rule-based cards from your file&apos;s
+                structure.{' '}
+              </span>
               <Link
                 to="/pricing"
                 onClick={() => track('upload_ai_free_badge_clicked')}
               >
                 Upgrade to write cards with Claude
               </Link>
-              .
+              <span>.</span>
             </span>
           </>
         )}
@@ -219,7 +223,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
               >
                 Sign in to turn it on
               </Link>
-              .
+              <span>.</span>
             </span>
           </>
         )}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-upload-translate.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-upload-translate.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-upload-translate",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "The upload page no longer breaks when the browser translates it"
+}


### PR DESCRIPTION
## What
Wraps every bare text node in the upload page's AI badge conditional branches (`aiBadgeState` on/off/free/anon) in a `<span>`, so React reconciles elements instead of raw text nodes.

## Why
Top unresolved prod error group: "Failed to execute 'insertBefore' on 'Node': …not a child of this node" on /upload — 35 occurrences May 31 → Jun 5, plus a sibling "removeChild" group ×4. Google Translate and similar extensions wrap bare text nodes in `<font>` tags; when the badge's conditional branches re-render, React's reconciler fails insertBefore/removeChild on the relocated text nodes. PR #3091 fixed the sidebar collapse-rail instance; this is a second, distinct cause in the same error group.

## How
Standard React-vs-Translate mitigation: text inside an element survives `<font>` wrapping because React only reconciles the span, not the text node's siblings. The new spans sit inside the inline `aiOffBadgeBody` span — outside the `.aiOffBadge` flex-gap container — so layout and visual output are unchanged (no `display: contents` needed). Whitespace-only `{' '}` nodes are left bare; Translate does not wrap them. The rest of the page was scanned: the reattach banner already wraps its text, and the remaining mixed text+link content is unconditional, so it is never reconciled in/out.

Google Translate itself can't run in jsdom, so the tests assert the structural invariant instead: no non-whitespace bare text node in any of the four badge branches (a TreeWalker-based regression guard that fails if anyone reintroduces the pattern).

Sonar note: SONAR_TOKEN is not configured in this environment, so sonar-scanner was not run locally — expect the CI Sonar analysis to be the first pass. The diff is span-wrapping plus a test helper; low smell risk.

## Measuring success
The error_events group "Failed to execute 'insertBefore' on 'Node'" on https://2anki.net/upload stops accruing new occurrences after deploy (it averaged ~7/day over the last 5 days). Existing `upload_ai_badge_viewed` tracking stays intact as the denominator.

## Testing
- Unit tests added: 4 regression tests in `web/src/pages/UploadPage/UploadPage.test.tsx` — one per badge state, asserting no bare text nodes via TreeWalker (all 4 failed before the fix; 21/21 pass after). Full web suite: 1684 passed.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs manual browser pass (375px + golden path) before merge.

## Changelog
"The upload page no longer breaks when the browser translates it" — `web/src/pages/WhatsNewPage/changelog/2026-06-05-upload-translate.json`

## Risks
Low — markup-only change inside an inline span. The one thing to eyeball in the browser pass is badge text spacing in all four states (anon by default; the others need a signed-in/paying session). Rollback is a one-commit revert.

## Goal alignment
The upload page is the core conversion surface; a hard crash for every user running page translation (international, EU-leaning user base) is a direct funnel leak. Removing it keeps non-English users converting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269599&installation_id=132681956&pr_number=3117&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3117&signature=b3d169189dfc65ec57481e070e8554ce512547ce6d05a9eea1ced4df19e6c466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander for this merge (2026-06-05); automated suites green.
