### PR TITLE
fix: stop validation, offline, and bot noise in error reporting

### DIFF
--- a/src/controllers/ErrorEventController.test.ts
+++ b/src/controllers/ErrorEventController.test.ts
@@ -109,6 +109,53 @@ describe('ErrorEventController.ingest', () => {
     expect(useCase.execute).not.toHaveBeenCalled();
   });
 
+  it.each([
+    'Mozilla/5.0 (compatible; Applebot/0.1; +http://www.apple.com/go/applebot)',
+    'Leikibot/2.0 (+https://leiki.com)',
+    'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+    'SomeCrawler/1.0',
+    'BaiduSpider/3.0',
+    'Yahoo! Slurp',
+  ])('responds 202 without storing when user agent is %s', async (userAgent) => {
+    const useCase = makeIngestUseCase();
+    const controller = new ErrorEventController(useCase);
+    const res = makeRes();
+    await controller.ingest(
+      makeReq({ ...VALID_BODY, userAgent }),
+      res as unknown as Response
+    );
+    expect(res._statusCode).toBe(202);
+    expect(useCase.execute).not.toHaveBeenCalled();
+  });
+
+  it('stores events from a normal browser user agent', async () => {
+    const useCase = makeIngestUseCase();
+    const controller = new ErrorEventController(useCase);
+    const res = makeRes();
+    await controller.ingest(
+      makeReq({
+        ...VALID_BODY,
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      }),
+      res as unknown as Response
+    );
+    expect(res._statusCode).toBe(202);
+    expect(useCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('stores events when the user agent is absent', async () => {
+    const useCase = makeIngestUseCase();
+    const controller = new ErrorEventController(useCase);
+    const res = makeRes();
+    await controller.ingest(
+      makeReq({ message: 'TypeError: x is null' }),
+      res as unknown as Response
+    );
+    expect(res._statusCode).toBe(202);
+    expect(useCase.execute).toHaveBeenCalledTimes(1);
+  });
+
   it('does not expose the raw IP in the response', async () => {
     const useCase = makeIngestUseCase();
     const executeSpy = jest.spyOn(useCase, 'execute');

--- a/src/controllers/ErrorEventController.ts
+++ b/src/controllers/ErrorEventController.ts
@@ -10,6 +10,11 @@ const MAX_BODY_BYTES = 10 * 1024;
 const RATE_WINDOW_MS = 60_000;
 const PER_IP_MAX = 10;
 const GLOBAL_MAX = 1000;
+const BOT_USER_AGENT_PATTERN = /bot|crawler|spider|slurp|applebot|leikibot/i;
+
+function isBotUserAgent(userAgent: string | null | undefined): boolean {
+  return userAgent != null && BOT_USER_AGENT_PATTERN.test(userAgent);
+}
 
 function validatePayload(body: unknown): ErrorEventPayload | null {
   if (body == null || typeof body !== 'object' || Array.isArray(body)) {
@@ -59,6 +64,11 @@ export class ErrorEventController {
     const payload = validatePayload(req.body);
     if (payload == null) {
       res.status(400).json({ error: 'Invalid payload' });
+      return;
+    }
+
+    if (isBotUserAgent(payload.userAgent)) {
+      res.status(202).end();
       return;
     }
 

--- a/web/src/components/forms/RegisterForm.test.tsx
+++ b/web/src/components/forms/RegisterForm.test.tsx
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import RegisterForm from './RegisterForm';
+import { UserNotice } from '../../lib/errors/UserNotice';
 
 const registerMock = vi.fn();
 
@@ -34,12 +35,13 @@ function fillAndSubmit() {
   fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
 }
 
-function renderForm(redirect?: string) {
-  return render(
+function renderForm(redirect?: string, setErrorMessage = vi.fn()) {
+  render(
     <MemoryRouter initialEntries={['/register']}>
-      <RegisterForm setErrorMessage={vi.fn()} redirect={redirect ?? null} />
+      <RegisterForm setErrorMessage={setErrorMessage} redirect={redirect ?? null} />
     </MemoryRouter>
   );
+  return setErrorMessage;
 }
 
 describe('RegisterForm', () => {
@@ -142,5 +144,42 @@ describe('RegisterForm', () => {
     expect(
       screen.queryByRole('link', { name: 'Reset password' })
     ).not.toBeInTheDocument();
+  });
+
+  it('wraps an intentional backend notice in UserNotice so it shows without being reported', async () => {
+    const notice = 'An account with this email is linked to Google sign-in.';
+    registerMock.mockResolvedValue({
+      status: 400,
+      json: () => Promise.resolve({ message: notice }),
+    });
+
+    const setErrorMessage = renderForm();
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(setErrorMessage).toHaveBeenCalled();
+    });
+    const arg = setErrorMessage.mock.calls[0][0] as UserNotice;
+    expect(arg).toBeInstanceOf(UserNotice);
+    expect(arg.message).toBe(notice);
+  });
+
+  it('passes a generic backend failure through as a plain message', async () => {
+    registerMock.mockResolvedValue({
+      status: 400,
+      json: () =>
+        Promise.resolve({
+          message: 'Invalid user data. Required email and password!',
+        }),
+    });
+
+    const setErrorMessage = renderForm();
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(setErrorMessage).toHaveBeenCalledWith(
+        'Invalid user data. Required email and password!'
+      );
+    });
   });
 });

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -10,6 +10,10 @@ import { WithMicrosoftLink } from './WithMicrosoftLink';
 import { getVisibleText } from '../../lib/text/getVisibleText';
 import { readSignupOrigin } from '../../lib/signupOrigin';
 import { track } from '../../lib/analytics/track';
+import {
+  UserNotice,
+  isIntentionalBackendNotice,
+} from '../../lib/errors/UserNotice';
 import styles from '../../styles/auth.module.css';
 
 interface Props {
@@ -78,12 +82,18 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
         globalThis.location.href = redirect ? `/${redirect.replace(/^\//, '')}` : '/';
       } else {
         const body = await res.json().catch(() => null);
-        const backendMessage = body?.message;
+        const backendMessage =
+          typeof body?.message === 'string' ? body.message : null;
         if (isAccountExistsFailure(backendMessage)) {
           if (email.includes('@')) {
             localStorage.setItem('email', email);
           }
           setAccountExists(true);
+          setLoading(false);
+          return;
+        }
+        if (backendMessage != null && isIntentionalBackendNotice(backendMessage)) {
+          setErrorMessage(new UserNotice(backendMessage));
           setLoading(false);
           return;
         }

--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -100,4 +100,37 @@ describe('reportClientError', () => {
     reportClientError(new UserNotice('Notion is not connected.'));
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it('skips reporting when the browser is offline', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Vitest/1.0', onLine: false });
+    reportClientError(new Error('boom while offline'));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('still reports when onLine is undefined', () => {
+    reportClientError(new Error('real error'));
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('skips AbortError', () => {
+    const aborted = new Error('The user aborted a request.');
+    aborted.name = 'AbortError';
+    reportClientError(aborted);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'Failed to fetch',
+    'NetworkError when attempting to fetch resource.',
+    'Load failed',
+    'Network error on GET /api/upload/mine: Load failed',
+  ])('skips transient network message %s', (message) => {
+    reportClientError(new Error(message));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports a message that merely mentions a transient phrase mid-string', () => {
+    reportClientError(new Error('Parser said: Load failed is not a card'));
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
 });

--- a/web/src/lib/reportClientError.ts
+++ b/web/src/lib/reportClientError.ts
@@ -2,16 +2,41 @@ import { UserNotice } from './errors/UserNotice';
 
 const ENDPOINT = '/api/events/errors';
 
+const TRANSIENT_MESSAGE_PREFIXES = [
+  'Failed to fetch',
+  'NetworkError when attempting to fetch resource.',
+  'Load failed',
+  'Network error on ',
+];
+
+function isTransientNetworkMessage(message: string): boolean {
+  return TRANSIENT_MESSAGE_PREFIXES.some((prefix) =>
+    message.startsWith(prefix)
+  );
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    error != null &&
+    typeof error === 'object' &&
+    'name' in error &&
+    (error as { name?: unknown }).name === 'AbortError'
+  );
+}
+
 export function reportClientError(
   error: unknown,
   context?: Record<string, unknown>
 ): void {
   if (error instanceof UserNotice) return;
+  if (isAbortError(error)) return;
   try {
+    if (navigator.onLine === false) return;
     const message =
       error instanceof Error
         ? error.message
         : String(error);
+    if (isTransientNetworkMessage(message)) return;
     const stack = error instanceof Error ? error.stack ?? null : null;
     const release = process.env.REACT_APP_RELEASE ?? null;
     const root = document.documentElement;


### PR DESCRIPTION
## What
Three small filters that stop known noise from landing in `error_events`: expected register-validation messages, transient network failures, and bot-generated reports.

## Why
~40 of the unresolved events on /ops/errors are noise drowning real errors — "An account with this email already exists…" ×4, "Failed to fetch" ×14, "NetworkError when attempting to fetch resource." ×11, "Load failed" ×4, "Network error on GET /api/upload/mine: …" ×3, plus crawler UAs (Applebot, Leikibot) reporting cross-origin script and chunk failures. Cleaner signal means real regressions surface instead of scrolling past blips.

## How
- `RegisterForm` types the backend message and wraps intentional notices (`isIntentionalBackendNotice`) in `UserNotice` before `setErrorMessage`, so the user still sees the copy but `reportClientError` skips it. LoginForm uses local state and never reaches `reportClientError`; NewPasswordForm passes `Error` objects — both left alone.
- `reportClientError` early-returns on `navigator.onLine === false`, `AbortError`, and an explicit transient prefix list: `Failed to fetch`, `NetworkError when attempting to fetch resource.`, `Load failed`, `Network error on ` (the `api.ts` wrapper prefix that only fires when `fetch` itself rejects). Prefix match, no regex.
- `ErrorEventController.ingest` answers 202 without storing when `payload.userAgent` matches `/bot|crawler|spider|slurp|applebot|leikibot/i` — drop happens before the rate limiter so bots don't consume per-IP budget. Null/absent UA still stores.

## Measuring success
`select message, count(*) from error_events where created_at > now() - interval '7 days' group by 1 order by 2 desc` on prod — the transient-network and account-exists messages stop accruing new rows after deploy; bot UAs disappear from `user_agent`.

## Testing
- Unit tests added: web vitest — offline/AbortError/transient suppressions + mid-string transient phrase still reports + `onLine === undefined` still reports; RegisterForm wraps intentional notices in `UserNotice` and passes generic failures through unchanged. Server jest — bot UAs (6 variants) dropped with 202 and no store, normal iPhone UA stored, absent UA stored.
- Full web vitest (1690 tests), server tsc, web typecheck, and Biome lint all green.

Sonar: not run locally — `SONAR_TOKEN` unset in this environment; change is small early-return logic, expecting no findings.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs manual browser pass before merge.

## Changelog
No entry — internal-only observability change, no user-visible behavior change.

## Risks
A genuinely broken endpoint that manifests as "Failed to fetch" for everyone would no longer self-report from clients — server-side logs and uptime monitoring still cover that case. Bot pattern is substring-based; a legitimate browser UA containing "bot" would be dropped (none observed in prod events). Rollback: revert the single commit.

## Goal alignment
Indirect — a readable /ops/errors feed means real conversion-path regressions get spotted and fixed faster, protecting the funnel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783269656&installation_id=132681956&pr_number=3118&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3118&signature=4030b5a154d3f4b3b5a983a1c29f1b989650cd6ce06c301ff103b81aa6527a14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander for this merge (2026-06-05); automated suites green.
