### PR TITLE
feat: export ops error groups as a Claude-ready markdown file

### DIFF
--- a/src/controllers/OpsErrorsController.test.ts
+++ b/src/controllers/OpsErrorsController.test.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { OpsErrorsController } from './OpsErrorsController';
 import { ListErrorGroupsUseCase } from '../usecases/ops/ListErrorGroupsUseCase';
+import { ExportErrorGroupsUseCase } from '../usecases/ops/ExportErrorGroupsUseCase';
 import { ResolveErrorGroupUseCase } from '../usecases/ops/ResolveErrorGroupUseCase';
 import { ReopenErrorGroupUseCase } from '../usecases/ops/ReopenErrorGroupUseCase';
 
@@ -30,16 +31,18 @@ function makeResponse() {
 
 function makeController() {
   const listExecute = jest.fn(async () => ({ groups: [], totalGroups: 0 }));
+  const exportExecute = jest.fn(async () => '# export');
   const resolveExecute = jest.fn(async () => {});
   const reopenExecute = jest.fn(async () => {});
 
   const controller = new OpsErrorsController(
     { execute: listExecute } as unknown as ListErrorGroupsUseCase,
+    { execute: exportExecute } as unknown as ExportErrorGroupsUseCase,
     { execute: resolveExecute } as unknown as ResolveErrorGroupUseCase,
     { execute: reopenExecute } as unknown as ReopenErrorGroupUseCase
   );
 
-  return { controller, listExecute, resolveExecute, reopenExecute };
+  return { controller, listExecute, exportExecute, resolveExecute, reopenExecute };
 }
 
 describe('OpsErrorsController.list', () => {

--- a/src/controllers/OpsErrorsController.ts
+++ b/src/controllers/OpsErrorsController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { ListErrorGroupsUseCase } from '../usecases/ops/ListErrorGroupsUseCase';
+import { ExportErrorGroupsUseCase } from '../usecases/ops/ExportErrorGroupsUseCase';
 import { ResolveErrorGroupUseCase } from '../usecases/ops/ResolveErrorGroupUseCase';
 import { ReopenErrorGroupUseCase } from '../usecases/ops/ReopenErrorGroupUseCase';
 import { ResolutionStatus } from '../data_layer/ErrorEventRepository';
@@ -31,6 +32,7 @@ function parseResolvedBy(owner: unknown): number | null {
 export class OpsErrorsController {
   constructor(
     private readonly listErrorGroupsUseCase: ListErrorGroupsUseCase,
+    private readonly exportErrorGroupsUseCase: ExportErrorGroupsUseCase,
     private readonly resolveErrorGroupUseCase: ResolveErrorGroupUseCase,
     private readonly reopenErrorGroupUseCase: ReopenErrorGroupUseCase
   ) {}
@@ -54,6 +56,28 @@ export class OpsErrorsController {
     } catch (error) {
       console.error('[ops] list error groups failed', error);
       res.status(500).json({ message: 'Failed to load error groups' });
+    }
+  }
+
+  async exportMarkdown(req: Request, res: Response): Promise<void> {
+    const source = parseSource(req.query.source);
+    const status = parseStatus(req.query.status);
+
+    try {
+      const markdown = await this.exportErrorGroupsUseCase.execute({
+        source,
+        status,
+      });
+      const date = new Date().toISOString().slice(0, 10);
+      res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="2anki-errors-${date}.md"`
+      );
+      res.status(200).send(markdown);
+    } catch (error) {
+      console.error('[ops] export error groups failed', error);
+      res.status(500).json({ message: 'Failed to export error groups' });
     }
   }
 

--- a/src/data_layer/ErrorEventRepository.test.ts
+++ b/src/data_layer/ErrorEventRepository.test.ts
@@ -1,6 +1,9 @@
+import knex from 'knex';
+
 import {
   ErrorEventRepository,
   ErrorEventInsert,
+  buildLatestSamplesQuery,
 } from './ErrorEventRepository';
 
 interface StoredRow {
@@ -241,5 +244,23 @@ describe('ErrorEventRepository.reopenGroup', () => {
 
     expect(whereSpy).toHaveBeenCalledWith('message_hash', 'b'.repeat(64));
     expect(delSpy).toHaveBeenCalled();
+  });
+});
+
+describe('buildLatestSamplesQuery — generated SQL shape', () => {
+  it('selects the latest row per message_hash without ip_hash', () => {
+    const pgKnex = knex({ client: 'pg' });
+    const sql = buildLatestSamplesQuery(pgKnex, [
+      'a'.repeat(64),
+      'b'.repeat(64),
+    ]).toString();
+    expect(sql).toContain(
+      'select "message_hash", "stack", "url", "user_agent", "release", "user_id" from "error_events"'
+    );
+    expect(sql).toContain('"id" in (select max("id") as "id" from "error_events"');
+    expect(sql).toContain(`"message_hash" in ('${'a'.repeat(64)}', '${'b'.repeat(64)}')`);
+    expect(sql).toContain('group by "message_hash"');
+    expect(sql).not.toContain('ip_hash');
+    pgKnex.destroy();
   });
 });

--- a/src/data_layer/ErrorEventRepository.ts
+++ b/src/data_layer/ErrorEventRepository.ts
@@ -39,13 +39,36 @@ export interface ListErrorGroupsOptions {
   status?: ResolutionStatus;
 }
 
+export interface ErrorSampleRow {
+  message_hash: string;
+  stack: string | null;
+  url: string | null;
+  user_agent: string | null;
+  release: string | null;
+  user_id: number | null;
+}
+
 export interface IErrorEventRepository {
   insert(row: ErrorEventInsert): Promise<void>;
   existsWithinWindow(messageHash: string, ipHash: string, windowMs: number): Promise<boolean>;
   listGroups(options: ListErrorGroupsOptions): Promise<ErrorGroupRow[]>;
   countGroups(source?: 'web' | 'server', status?: ResolutionStatus): Promise<number>;
+  latestSamples(messageHashes: string[]): Promise<ErrorSampleRow[]>;
   resolveGroup(messageHash: string, resolvedBy: number | null): Promise<void>;
   reopenGroup(messageHash: string): Promise<void>;
+}
+
+export function buildLatestSamplesQuery(
+  database: Knex,
+  messageHashes: string[]
+): Knex.QueryBuilder {
+  const latestIds = database('error_events')
+    .max('id as id')
+    .whereIn('message_hash', messageHashes)
+    .groupBy('message_hash');
+  return database('error_events')
+    .select('message_hash', 'stack', 'url', 'user_agent', 'release', 'user_id')
+    .whereIn('id', latestIds);
 }
 
 const RESOLVED_PREDICATE = 'MAX(r.resolved_at) >= MAX(e.created_at)';
@@ -156,6 +179,21 @@ export class ErrorEventRepository implements IErrorEventRepository {
       .from(inner.as('groups'))
       .first();
     return Number(result?.total ?? 0);
+  }
+
+  async latestSamples(messageHashes: string[]): Promise<ErrorSampleRow[]> {
+    if (messageHashes.length === 0) {
+      return [];
+    }
+    const rows = await buildLatestSamplesQuery(this.database, messageHashes);
+    return rows.map((r: Record<string, unknown>) => ({
+      message_hash: r.message_hash as string,
+      stack: (r.stack as string | null) ?? null,
+      url: (r.url as string | null) ?? null,
+      user_agent: (r.user_agent as string | null) ?? null,
+      release: (r.release as string | null) ?? null,
+      user_id: r.user_id == null ? null : Number(r.user_id),
+    }));
   }
 
   async resolveGroup(messageHash: string, resolvedBy: number | null): Promise<void> {

--- a/src/lib/errorFallback.test.ts
+++ b/src/lib/errorFallback.test.ts
@@ -24,6 +24,9 @@ function makeRepository(): IErrorEventRepository & { inserts: ErrorEventInsert[]
     async countGroups() {
       return 0;
     },
+    async latestSamples() {
+      return [];
+    },
     async resolveGroup() {},
     async reopenGroup() {},
   };

--- a/src/routes/OpsErrorsRouter.test.ts
+++ b/src/routes/OpsErrorsRouter.test.ts
@@ -31,10 +31,12 @@ jest.mock('./middleware/RequireOpsAccess', () => {
 
 const resolveGroupSpy = jest.fn(async () => {});
 const reopenGroupSpy = jest.fn(async () => {});
+const listGroupsSpy = jest.fn();
 
 jest.mock('../data_layer/ErrorEventRepository', () => ({
   ErrorEventRepository: class {
-    async listGroups() {
+    async listGroups(options: unknown) {
+      listGroupsSpy(options);
       return [
         {
           message_hash: 'a'.repeat(64),
@@ -55,6 +57,18 @@ jest.mock('../data_layer/ErrorEventRepository', () => ({
     }
     async countGroups() {
       return 1;
+    }
+    async latestSamples() {
+      return [
+        {
+          message_hash: 'a'.repeat(64),
+          stack: 'at App.tsx:10',
+          url: 'https://2anki.net',
+          user_agent: 'Mozilla/5.0',
+          release: 'abc12345',
+          user_id: 21770,
+        },
+      ];
     }
     async insert() {}
     async existsWithinWindow() { return false; }
@@ -137,6 +151,76 @@ describe('OpsErrorsRouter GET /api/ops/errors', () => {
         occurrences: expect.any(Number),
         resolved: expect.any(Boolean),
       });
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsErrorsRouter GET /api/ops/errors/export', () => {
+  beforeEach(() => {
+    listGroupsSpy.mockClear();
+  });
+
+  it('returns 401 without admin auth', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const res = await fetch(`${url}/api/ops/errors/export`);
+      expect(res.status).toBe(401);
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns a markdown attachment with group and sample detail', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const res = await fetch(`${url}/api/ops/errors/export`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('text/markdown');
+      expect(res.headers.get('content-disposition')).toMatch(
+        /^attachment; filename="2anki-errors-\d{4}-\d{2}-\d{2}\.md"$/
+      );
+      const body = await res.text();
+      expect(body).toContain('Investigate these production error groups from 2anki.net.');
+      expect(body).toContain('TypeError: x is null');
+      expect(body).toContain('- Occurrences: 3');
+      expect(body).toContain('at App.tsx:10');
+    } finally {
+      await close();
+    }
+  });
+
+  it('respects the status filter', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      await fetch(`${url}/api/ops/errors/export?status=resolved`);
+      expect(listGroupsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'resolved' })
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it('respects the source filter', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      await fetch(`${url}/api/ops/errors/export?source=server`);
+      expect(listGroupsSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'server' })
+      );
+    } finally {
+      await close();
+    }
+  });
+
+  it('never includes ip_hash in the export', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const res = await fetch(`${url}/api/ops/errors/export`);
+      const body = await res.text();
+      expect(body).not.toContain('ip_hash');
     } finally {
       await close();
     }

--- a/src/routes/OpsErrorsRouter.ts
+++ b/src/routes/OpsErrorsRouter.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import RequireOpsAccess from './middleware/RequireOpsAccess';
 import { OpsErrorsController } from '../controllers/OpsErrorsController';
 import { ListErrorGroupsUseCase } from '../usecases/ops/ListErrorGroupsUseCase';
+import { ExportErrorGroupsUseCase } from '../usecases/ops/ExportErrorGroupsUseCase';
 import { ResolveErrorGroupUseCase } from '../usecases/ops/ResolveErrorGroupUseCase';
 import { ReopenErrorGroupUseCase } from '../usecases/ops/ReopenErrorGroupUseCase';
 import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
@@ -12,9 +13,15 @@ const OpsErrorsRouter = () => {
   const database = getDatabase();
   const repository = new ErrorEventRepository(database);
   const listUseCase = new ListErrorGroupsUseCase(repository);
+  const exportUseCase = new ExportErrorGroupsUseCase(repository);
   const resolveUseCase = new ResolveErrorGroupUseCase(repository);
   const reopenUseCase = new ReopenErrorGroupUseCase(repository);
-  const controller = new OpsErrorsController(listUseCase, resolveUseCase, reopenUseCase);
+  const controller = new OpsErrorsController(
+    listUseCase,
+    exportUseCase,
+    resolveUseCase,
+    reopenUseCase
+  );
 
   /**
    * @swagger
@@ -49,6 +56,33 @@ const OpsErrorsRouter = () => {
    */
   router.get('/api/ops/errors', RequireOpsAccess, (req, res) =>
     controller.list(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/errors/export:
+   *   get:
+   *     summary: Export error groups as a Claude-ready markdown file
+   *     description: |
+   *       Internal endpoint locked to the ops owner. Returns 401 for everyone else.
+   *       One markdown document with an investigation preamble and a section per
+   *       group, each carrying the latest sample event. Never exposes ip_hash.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: query
+   *         name: source
+   *         schema: { type: string, enum: [web, server] }
+   *       - in: query
+   *         name: status
+   *         schema: { type: string, enum: [unresolved, resolved, all], default: unresolved }
+   *     responses:
+   *       200:
+   *         description: Markdown attachment
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/errors/export', RequireOpsAccess, (req, res) =>
+    controller.exportMarkdown(req, res)
   );
 
   /**

--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -22,6 +22,9 @@ function makeRepository(existsResult = false): IErrorEventRepository & { inserts
     async countGroups() {
       return 0;
     },
+    async latestSamples() {
+      return [];
+    },
     async resolveGroup() {},
     async reopenGroup() {},
   };
@@ -121,6 +124,7 @@ describe('makeErrorCaptureMiddleware', () => {
       async existsWithinWindow() { throw new Error('DB down'); },
       async listGroups() { return []; },
       async countGroups() { return 0; },
+      async latestSamples() { return []; },
       async resolveGroup() {},
       async reopenGroup() {},
     };
@@ -140,6 +144,7 @@ describe('makeErrorCaptureMiddleware', () => {
       async existsWithinWindow() { throw new Error('DB down'); },
       async listGroups() { return []; },
       async countGroups() { return 0; },
+      async latestSamples() { return []; },
       async resolveGroup() {},
       async reopenGroup() {},
     };

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -846,6 +846,7 @@ describe('SyncNotionPageToRacUseCase', () => {
       existsWithinWindow: jest.fn().mockResolvedValue(false),
       listGroups: jest.fn().mockResolvedValue([]),
       countGroups: jest.fn().mockResolvedValue(0),
+      latestSamples: jest.fn().mockResolvedValue([]),
       resolveGroup: jest.fn().mockResolvedValue(undefined),
       reopenGroup: jest.fn().mockResolvedValue(undefined),
     });

--- a/src/usecases/ops/ExportErrorGroupsUseCase.test.ts
+++ b/src/usecases/ops/ExportErrorGroupsUseCase.test.ts
@@ -1,0 +1,155 @@
+import { ExportErrorGroupsUseCase } from './ExportErrorGroupsUseCase';
+import {
+  ErrorGroupRow,
+  ErrorSampleRow,
+  IErrorEventRepository,
+  ListErrorGroupsOptions,
+  ResolutionStatus,
+} from '../../data_layer/ErrorEventRepository';
+
+const longUserAgent = `Mozilla/5.0 ${'x'.repeat(150)}`;
+
+const groupA: ErrorGroupRow = {
+  message_hash: 'a'.repeat(64),
+  message: 'TypeError: Cannot read properties of null',
+  stack: 'old stack A',
+  url: 'https://2anki.net/upload',
+  release: 'abc12345',
+  source: 'web',
+  user_id: null,
+  user_agent: 'Mozilla/5.0',
+  first_seen: '2026-05-01T00:00:00.000Z',
+  last_seen: '2026-06-04T10:00:00.000Z',
+  occurrences: 12,
+  resolved: false,
+  resolved_at: null,
+};
+
+const groupB: ErrorGroupRow = {
+  message_hash: 'b'.repeat(64),
+  message: 'Error: deck build\nfailed',
+  stack: null,
+  url: null,
+  release: null,
+  source: 'server',
+  user_id: 21770,
+  user_agent: null,
+  first_seen: '2026-05-20T00:00:00.000Z',
+  last_seen: '2026-06-05T08:00:00.000Z',
+  occurrences: 3,
+  resolved: false,
+  resolved_at: null,
+};
+
+const sampleA: ErrorSampleRow = {
+  message_hash: 'a'.repeat(64),
+  stack: 'at App.tsx:10\nat render',
+  url: 'https://2anki.net/upload',
+  user_agent: longUserAgent,
+  release: 'abc12345',
+  user_id: 42,
+};
+
+class FakeRepository implements IErrorEventRepository {
+  listGroupsCalls: ListErrorGroupsOptions[] = [];
+  latestSamplesCalls: string[][] = [];
+
+  constructor(
+    private readonly groups: ErrorGroupRow[],
+    private readonly samples: ErrorSampleRow[]
+  ) {}
+
+  async insert(): Promise<void> {}
+
+  async existsWithinWindow(): Promise<boolean> {
+    return false;
+  }
+
+  async listGroups(options: ListErrorGroupsOptions): Promise<ErrorGroupRow[]> {
+    this.listGroupsCalls.push(options);
+    return this.groups;
+  }
+
+  async countGroups(): Promise<number> {
+    return this.groups.length;
+  }
+
+  async latestSamples(messageHashes: string[]): Promise<ErrorSampleRow[]> {
+    this.latestSamplesCalls.push(messageHashes);
+    return this.samples;
+  }
+
+  async resolveGroup(): Promise<void> {}
+
+  async reopenGroup(): Promise<void> {}
+}
+
+const execute = async (
+  groups: ErrorGroupRow[],
+  samples: ErrorSampleRow[],
+  status: ResolutionStatus = 'unresolved',
+  source?: 'web' | 'server'
+) => {
+  const repository = new FakeRepository(groups, samples);
+  const useCase = new ExportErrorGroupsUseCase(repository);
+  const markdown = await useCase.execute({ status, source });
+  return { markdown, repository };
+};
+
+describe('ExportErrorGroupsUseCase', () => {
+  it('starts with the investigation preamble', async () => {
+    const { markdown } = await execute([groupA], [sampleA]);
+    expect(markdown.startsWith(
+      'Investigate these production error groups from 2anki.net. For each: root cause, severity, recommended fix.'
+    )).toBe(true);
+  });
+
+  it('renders one numbered section per group with message and counts', async () => {
+    const { markdown } = await execute([groupA, groupB], [sampleA]);
+    expect(markdown).toContain('## 1. TypeError: Cannot read properties of null');
+    expect(markdown).toContain('## 2. Error: deck build failed');
+    expect(markdown).toContain('- Occurrences: 12');
+    expect(markdown).toContain('- Source: server');
+    expect(markdown).toContain('- First seen: 2026-05-01T00:00:00.000Z');
+    expect(markdown).toContain('- Last seen: 2026-06-05T08:00:00.000Z');
+  });
+
+  it('includes the latest sample stack in a fenced block', async () => {
+    const { markdown } = await execute([groupA], [sampleA]);
+    expect(markdown).toContain('at App.tsx:10\nat render');
+    expect(markdown).toContain('- Release: abc12345');
+    expect(markdown).toContain('- URL: https://2anki.net/upload');
+    expect(markdown).toContain('- User: 42');
+  });
+
+  it('truncates the sample user agent', async () => {
+    const { markdown } = await execute([groupA], [sampleA]);
+    expect(markdown).not.toContain(longUserAgent);
+    expect(markdown).toContain(`${longUserAgent.slice(0, 100)}…`);
+  });
+
+  it('never includes ip_hash', async () => {
+    const { markdown } = await execute([groupA, groupB], [sampleA]);
+    expect(markdown).not.toContain('ip_hash');
+  });
+
+  it('passes status and source through and fetches samples per group hash', async () => {
+    const { repository } = await execute([groupA], [sampleA], 'resolved', 'web');
+    expect(repository.listGroupsCalls).toEqual([
+      {
+        limit: 200,
+        offset: 0,
+        source: 'web',
+        sort: 'occurrences',
+        status: 'resolved',
+      },
+    ]);
+    expect(repository.latestSamplesCalls).toEqual([['a'.repeat(64)]]);
+  });
+
+  it('reports when no groups match', async () => {
+    const { markdown, repository } = await execute([], []);
+    expect(markdown).toContain('No error groups match.');
+    expect(repository.latestSamplesCalls).toEqual([]);
+  });
+});

--- a/src/usecases/ops/ExportErrorGroupsUseCase.ts
+++ b/src/usecases/ops/ExportErrorGroupsUseCase.ts
@@ -1,0 +1,91 @@
+import {
+  ErrorGroupRow,
+  ErrorSampleRow,
+  IErrorEventRepository,
+  ResolutionStatus,
+} from '../../data_layer/ErrorEventRepository';
+
+const EXPORT_GROUP_LIMIT = 200;
+const USER_AGENT_MAX_LENGTH = 100;
+
+const PREAMBLE =
+  'Investigate these production error groups from 2anki.net. For each: root cause, severity, recommended fix.';
+
+export interface ExportErrorGroupsOptions {
+  source?: 'web' | 'server';
+  status: ResolutionStatus;
+}
+
+function singleLine(text: string): string {
+  return text.replaceAll(/\s+/g, ' ').trim();
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}…`;
+}
+
+function renderSample(sample: ErrorSampleRow | undefined): string[] {
+  if (sample == null) {
+    return [];
+  }
+  const userAgent =
+    sample.user_agent == null
+      ? '(none)'
+      : truncate(sample.user_agent, USER_AGENT_MAX_LENGTH);
+  const lines = [
+    '',
+    'Latest sample:',
+    '',
+    `- Release: ${sample.release ?? '(unknown)'}`,
+    `- URL: ${sample.url ?? '(none)'}`,
+    `- User agent: ${userAgent}`,
+    `- User: ${sample.user_id == null ? 'anonymous' : sample.user_id}`,
+  ];
+  if (sample.stack != null && sample.stack !== '') {
+    lines.push('', 'Stack:', '', '```', sample.stack, '```');
+  }
+  return lines;
+}
+
+function renderGroup(
+  group: ErrorGroupRow,
+  index: number,
+  sample: ErrorSampleRow | undefined
+): string {
+  return [
+    `## ${index + 1}. ${singleLine(group.message)}`,
+    '',
+    `- Source: ${group.source}`,
+    `- Occurrences: ${group.occurrences}`,
+    `- First seen: ${group.first_seen}`,
+    `- Last seen: ${group.last_seen}`,
+    ...renderSample(sample),
+  ].join('\n');
+}
+
+export class ExportErrorGroupsUseCase {
+  constructor(private readonly repository: IErrorEventRepository) {}
+
+  async execute(options: ExportErrorGroupsOptions): Promise<string> {
+    const groups = await this.repository.listGroups({
+      limit: EXPORT_GROUP_LIMIT,
+      offset: 0,
+      source: options.source,
+      sort: 'occurrences',
+      status: options.status,
+    });
+    if (groups.length === 0) {
+      return `${PREAMBLE}\n\nNo error groups match.\n`;
+    }
+    const samples = await this.repository.latestSamples(
+      groups.map((group) => group.message_hash)
+    );
+    const sampleByHash = new Map(
+      samples.map((sample) => [sample.message_hash, sample])
+    );
+    const sections = groups.map((group, index) =>
+      renderGroup(group, index, sampleByHash.get(group.message_hash))
+    );
+    return [PREAMBLE, '', sections.join('\n\n'), ''].join('\n');
+  }
+}

--- a/src/usecases/ops/ListErrorGroupsUseCase.test.ts
+++ b/src/usecases/ops/ListErrorGroupsUseCase.test.ts
@@ -47,6 +47,10 @@ class FakeRepository implements IErrorEventRepository {
     return this.total;
   }
 
+  async latestSamples(): Promise<[]> {
+    return [];
+  }
+
   async resolveGroup(): Promise<void> {}
 
   async reopenGroup(): Promise<void> {}
@@ -72,6 +76,7 @@ describe('ListErrorGroupsUseCase', () => {
       existsWithinWindow: jest.fn(async () => false),
       listGroups: listGroupsSpy,
       countGroups: countGroupsSpy,
+      latestSamples: jest.fn(async () => []),
       resolveGroup: jest.fn(),
       reopenGroup: jest.fn(),
     };

--- a/src/usecases/ops/ReopenErrorGroupUseCase.test.ts
+++ b/src/usecases/ops/ReopenErrorGroupUseCase.test.ts
@@ -7,6 +7,7 @@ function makeRepo(): IErrorEventRepository {
     existsWithinWindow: jest.fn(async () => false),
     listGroups: jest.fn(async () => []),
     countGroups: jest.fn(async () => 0),
+    latestSamples: jest.fn(async () => []),
     resolveGroup: jest.fn(async () => {}),
     reopenGroup: jest.fn(async () => {}),
   };

--- a/src/usecases/ops/ResolveErrorGroupUseCase.test.ts
+++ b/src/usecases/ops/ResolveErrorGroupUseCase.test.ts
@@ -7,6 +7,7 @@ function makeRepo(): IErrorEventRepository {
     existsWithinWindow: jest.fn(async () => false),
     listGroups: jest.fn(async () => []),
     countGroups: jest.fn(async () => 0),
+    latestSamples: jest.fn(async () => []),
     resolveGroup: jest.fn(async () => {}),
     reopenGroup: jest.fn(async () => {}),
   };

--- a/web/src/pages/OpsPage/ErrorsTab.test.tsx
+++ b/web/src/pages/OpsPage/ErrorsTab.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ErrorsTab from './ErrorsTab';
+
+describe('ErrorsTab download for Claude', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ groups: [], totalGroups: 0 }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('renders a download link pointing at the export endpoint', async () => {
+    render(
+      <MemoryRouter>
+        <ErrorsTab />
+      </MemoryRouter>
+    );
+
+    const link = await screen.findByRole('link', {
+      name: 'Download for Claude',
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      '/api/ops/errors/export?status=unresolved'
+    );
+  });
+
+  test('the download link carries the active filters', async () => {
+    render(
+      <MemoryRouter initialEntries={['/ops/errors?status=resolved&source=server']}>
+        <ErrorsTab />
+      </MemoryRouter>
+    );
+
+    const link = await screen.findByRole('link', {
+      name: 'Download for Claude',
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      '/api/ops/errors/export?status=resolved&source=server'
+    );
+  });
+});

--- a/web/src/pages/OpsPage/ErrorsTab.tsx
+++ b/web/src/pages/OpsPage/ErrorsTab.tsx
@@ -6,6 +6,7 @@ import styles from './OpsPage.module.css';
 import { ErrorGroup, ErrorSort, ErrorSource, ErrorStatus } from './errorsTypes';
 import { useErrorGroups } from './useErrorGroups';
 import { buildCopyArtifact } from './buildCopyArtifact';
+import { buildExportErrorsUrl } from './exportErrorsUrl';
 import { parseUserAgent } from './parseUserAgent';
 import { resolveErrorGroup, reopenErrorGroup } from './resolveErrorGroup';
 import { ERROR_PAGE_SIZE, resolveErrorPage } from './errorPagination';
@@ -435,6 +436,13 @@ export default function ErrorsTab() {
         </div>
 
         <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <a
+            className={sharedStyles.btnSmall}
+            href={buildExportErrorsUrl(status, source)}
+            download
+          >
+            Download for Claude
+          </a>
           <button
             type="button"
             className={sharedStyles.btnSmall}

--- a/web/src/pages/OpsPage/exportErrorsUrl.test.ts
+++ b/web/src/pages/OpsPage/exportErrorsUrl.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildExportErrorsUrl } from './exportErrorsUrl';
+
+describe('buildExportErrorsUrl', () => {
+  it('always carries the status and omits source for all', () => {
+    expect(buildExportErrorsUrl('unresolved', 'all')).toBe(
+      '/api/ops/errors/export?status=unresolved'
+    );
+  });
+
+  it('carries a specific source', () => {
+    expect(buildExportErrorsUrl('resolved', 'server')).toBe(
+      '/api/ops/errors/export?status=resolved&source=server'
+    );
+  });
+});

--- a/web/src/pages/OpsPage/exportErrorsUrl.ts
+++ b/web/src/pages/OpsPage/exportErrorsUrl.ts
@@ -1,0 +1,12 @@
+import { ErrorSource, ErrorStatus } from './errorsTypes';
+
+export function buildExportErrorsUrl(
+  status: ErrorStatus,
+  source: ErrorSource
+): string {
+  const params = new URLSearchParams({ status });
+  if (source !== 'all') {
+    params.set('source', source);
+  }
+  return `/api/ops/errors/export?${params.toString()}`;
+}


### PR DESCRIPTION
## What
Adds `GET /api/ops/errors/export` and a "Download for Claude" link on `/ops/errors` that downloads every matching error group as one markdown file shaped as a ready-to-paste investigation prompt.

## Why
Batch-investigating prod errors meant hand-querying the DB per group. This makes the whole batch one click: preamble ("Investigate these production error groups from 2anki.net. For each: root cause, severity, recommended fix.") plus a section per group with message, source, occurrences, first/last seen, and the latest sample event (stack, URL, truncated user agent, release, numeric user id).

## How
- Route → controller → use case → repository, behind the existing `RequireOpsAccess` middleware; same `status` (default `unresolved`) and `source` filters as the list endpoint. Swagger comment matches the file's style.
- `ErrorEventRepository.latestSamples(messageHashes)` fetches the latest event row per `message_hash` via `MAX(id)` per group (ids are serial, so max id = newest row) — one coherent sample instead of the list query's per-column `MAX()` mix. Selects only `message_hash, stack, url, user_agent, release, user_id`; `ip_hash` is never selected.
- Markdown assembly lives in `ExportErrorGroupsUseCase` (caps at 200 groups, sorted by occurrences desc); HTTP shaping (`text/markdown`, `Content-Disposition: attachment; filename="2anki-errors-YYYY-MM-DD.md"`) in the controller.
- The web link is a plain anchor — ops fetches are cookie-authenticated same-origin, so no JS download dance.

## Measuring success
`gh api` / nginx access log line for `GET /api/ops/errors/export 200` after the next batch-triage session; failure path logs `[ops] export error groups failed`.

## Testing
- Unit tests added: route-boundary tests (401 non-ops, 200 markdown with group message + count + sample stack, `status`/`source` filters passed through, `ip_hash` absent, attachment filename shape); `ExportErrorGroupsUseCase` markdown content incl. user-agent truncation and empty state; generated-SQL shape test for `buildLatestSamplesQuery` with `knex({ client: 'pg' })`; web tests that the link renders and carries the active filters.
- Server tsc, scoped Jest suites, full web vitest (1684 passed), web typecheck + Biome lint all green.
- sonar-scanner not run locally — `SONAR_TOKEN` is not configured in this environment; expect the CI Sonar analysis to be the first scan.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs manual browser pass before merge — verify the Download for Claude link on /ops/errors downloads a sensible .md with live data.

## Changelog
No entry — internal ops tooling, not visible to users.

## Risks
Ops-only surface. Worst case is a slow query on a huge error_events table (two indexed-ish scans capped at 200 groups); no user-facing path touched. Rollback = revert.

## Goal alignment
Indirect: faster prod-error triage keeps the conversion path healthy, which is what retains and grows users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783272044&installation_id=132681956&pr_number=3121&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3121&signature=7285d03e09613a9f5b059bb99f6c5f1822dfd16db0dd69e9775a8cca668ba07d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander for this merge (2026-06-05); automated suites green.
