### PR TITLE
fix: persist monthly card-usage reset on month rollover

### DIFF
--- a/src/data_layer/UsersRepository.cardUsage.test.ts
+++ b/src/data_layer/UsersRepository.cardUsage.test.ts
@@ -1,0 +1,124 @@
+import knex, { Knex } from 'knex';
+
+import UsersRepository from './UsersRepository';
+import { startOfMonthUtc } from '../lib/User/startOfMonthUtc';
+
+async function makeDb(): Promise<Knex> {
+  const db = knex({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+  await db.schema.createTable('users', (t) => {
+    t.increments('id');
+    t.string('email');
+    t.integer('cards_used_this_month').notNullable().defaultTo(0);
+    t.timestamp('cards_month_started_at');
+  });
+  return db;
+}
+
+function previousMonthUtc(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15));
+}
+
+async function insertUser(
+  db: Knex,
+  cardsUsed: number,
+  startedAt: Date
+): Promise<number> {
+  const [id] = await db('users').insert({
+    email: 'card-usage@example.com',
+    cards_used_this_month: cardsUsed,
+    cards_month_started_at: startedAt,
+  });
+  return id;
+}
+
+async function readRow(db: Knex, id: number) {
+  return db('users')
+    .where({ id })
+    .select('cards_used_this_month', 'cards_month_started_at')
+    .first();
+}
+
+describe('UsersRepository card usage rollover (sqlite integration)', () => {
+  let db: Knex;
+  let repo: UsersRepository;
+
+  beforeEach(async () => {
+    db = await makeDb();
+    repo = new UsersRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('getCardUsage returns 0 and persists the reset when the month rolled over', async () => {
+    const now = new Date();
+    const id = await insertUser(db, 554, previousMonthUtc(now));
+
+    const usage = await repo.getCardUsage(id);
+
+    expect(usage.cards_used).toBe(0);
+    const row = await readRow(db, id);
+    expect(row.cards_used_this_month).toBe(0);
+    expect(new Date(row.cards_month_started_at).toISOString()).toBe(
+      startOfMonthUtc(now).toISOString()
+    );
+  });
+
+  it('getCardUsage leaves a current-month row untouched', async () => {
+    const now = new Date();
+    const id = await insertUser(db, 42, startOfMonthUtc(now));
+
+    const usage = await repo.getCardUsage(id);
+
+    expect(usage.cards_used).toBe(42);
+    const row = await readRow(db, id);
+    expect(row.cards_used_this_month).toBe(42);
+  });
+
+  it('incrementCardUsage across rollover resets the counter to the increment and moves the month', async () => {
+    const now = new Date();
+    const id = await insertUser(db, 554, previousMonthUtc(now));
+
+    await repo.incrementCardUsage(id, 30);
+
+    const row = await readRow(db, id);
+    expect(row.cards_used_this_month).toBe(30);
+    expect(new Date(row.cards_month_started_at).toISOString()).toBe(
+      startOfMonthUtc(now).toISOString()
+    );
+  });
+
+  it('incrementCardUsage within the same month accumulates', async () => {
+    const now = new Date();
+    const id = await insertUser(db, 40, startOfMonthUtc(now));
+
+    await repo.incrementCardUsage(id, 30);
+
+    const row = await readRow(db, id);
+    expect(row.cards_used_this_month).toBe(70);
+    expect(new Date(row.cards_month_started_at).toISOString()).toBe(
+      startOfMonthUtc(now).toISOString()
+    );
+  });
+});
+
+describe('UsersRepository.incrementCardUsage generated SQL (pg dialect)', () => {
+  it('uses bound parameters for the UTC month boundary in a single atomic update', () => {
+    const pg = knex({ client: 'pg' });
+    const repo = new UsersRepository(pg);
+
+    const sql = (
+      repo.incrementCardUsage(7, 30) as unknown as { toString(): string }
+    ).toString();
+
+    expect(sql).toMatch(
+      /^update "users" set "cards_used_this_month" = CASE WHEN cards_month_started_at < '[^']+' THEN 30 ELSE cards_used_this_month \+ 30 END, "cards_month_started_at" = CASE WHEN cards_month_started_at < '[^']+' THEN '[^']+' ELSE cards_month_started_at END where "id" = 7$/
+    );
+    expect(sql).not.toMatch(/date_trunc/);
+  });
+});

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex';
 import Users from './public/Users';
 import Subscriptions from './public/Subscriptions';
 import { isNewMonth } from '../lib/User/isNewMonth';
+import { startOfMonthUtc } from '../lib/User/startOfMonthUtc';
 import DeletedUserUsageRepository from './DeletedUserUsageRepository';
 import { emailHash } from '../lib/emailHash';
 
@@ -21,6 +22,11 @@ export interface ISignupCountryRepository {
 export interface IUserSignupCountsRepository {
   countTotalUsers(): Promise<number>;
   countSignupsSince(since: Date): Promise<number>;
+}
+
+function toDateOrNull(value: Date | string | number | null): Date | null {
+  if (value == null) return null;
+  return value instanceof Date ? value : new Date(value);
 }
 
 class UsersRepository {
@@ -286,9 +292,17 @@ class UsersRepository {
     if (!row) {
       return { cards_used: 0, month_started_at: null };
     }
-    const startedAt: Date | null = row.cards_month_started_at ?? null;
+    const startedAt = toDateOrNull(row.cards_month_started_at ?? null);
     if (startedAt && isNewMonth(startedAt, new Date())) {
-      return { cards_used: 0, month_started_at: startedAt };
+      const monthStart = startOfMonthUtc(new Date());
+      await this.database(this.table)
+        .where({ id })
+        .where('cards_month_started_at', '<', monthStart)
+        .update({
+          cards_used_this_month: 0,
+          cards_month_started_at: monthStart,
+        });
+      return { cards_used: 0, month_started_at: monthStart };
     }
     return {
       cards_used: row.cards_used_this_month ?? 0,
@@ -361,15 +375,17 @@ class UsersRepository {
 
   incrementCardUsage(id: string | number, cardCount: number) {
     if (cardCount <= 0) return Promise.resolve(0);
+    const monthStart = startOfMonthUtc(new Date());
     return this.database(this.table)
       .where({ id })
       .update({
         cards_used_this_month: this.database.raw(
-          `CASE WHEN cards_month_started_at < date_trunc('month', NOW()) THEN ? ELSE cards_used_this_month + ? END`,
-          [cardCount, cardCount]
+          `CASE WHEN cards_month_started_at < ? THEN ? ELSE cards_used_this_month + ? END`,
+          [monthStart, cardCount, cardCount]
         ),
         cards_month_started_at: this.database.raw(
-          `CASE WHEN cards_month_started_at < date_trunc('month', NOW()) THEN date_trunc('month', NOW()) ELSE cards_month_started_at END`
+          `CASE WHEN cards_month_started_at < ? THEN ? ELSE cards_month_started_at END`,
+          [monthStart, monthStart]
         ),
       });
   }

--- a/src/lib/User/startOfMonthUtc.test.ts
+++ b/src/lib/User/startOfMonthUtc.test.ts
@@ -1,0 +1,11 @@
+import { startOfMonthUtc } from './startOfMonthUtc';
+
+describe('startOfMonthUtc', () => {
+  it.each([
+    ['2026-06-05T13:45:00Z', '2026-06-01T00:00:00.000Z'],
+    ['2026-06-01T00:00:00Z', '2026-06-01T00:00:00.000Z'],
+    ['2026-12-31T23:59:59Z', '2026-12-01T00:00:00.000Z'],
+  ])('truncates %s to %s', (input, expected) => {
+    expect(startOfMonthUtc(new Date(input)).toISOString()).toBe(expected);
+  });
+});

--- a/src/lib/User/startOfMonthUtc.ts
+++ b/src/lib/User/startOfMonthUtc.ts
@@ -1,0 +1,3 @@
+export function startOfMonthUtc(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}

--- a/src/usecases/users/CheckMonthlyCardLimitUseCase.test.ts
+++ b/src/usecases/users/CheckMonthlyCardLimitUseCase.test.ts
@@ -1,3 +1,5 @@
+import knex, { Knex } from 'knex';
+
 import {
   CheckMonthlyCardLimitUseCase,
   MONTHLY_CARD_LIMIT,
@@ -78,5 +80,63 @@ describe('CheckMonthlyCardLimitUseCase', () => {
       expect(err.candidate).toBe(10);
       expect(err.reset_on).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     }
+  });
+});
+
+describe('CheckMonthlyCardLimitUseCase with a real repository (sqlite)', () => {
+  let db: Knex;
+  let repo: UsersRepository;
+  let useCase: CheckMonthlyCardLimitUseCase;
+
+  beforeEach(async () => {
+    db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('users', (t) => {
+      t.increments('id');
+      t.string('email');
+      t.integer('cards_used_this_month').notNullable().defaultTo(0);
+      t.timestamp('cards_month_started_at');
+    });
+    repo = new UsersRepository(db);
+    useCase = new CheckMonthlyCardLimitUseCase(repo);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function insertUserWithStaleMonth(cardsUsed: number): Promise<number> {
+    const now = new Date();
+    const previousMonth = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 15)
+    );
+    const [id] = await db('users').insert({
+      email: 'rollover@example.com',
+      cards_used_this_month: cardsUsed,
+      cards_month_started_at: previousMonth,
+    });
+    return id;
+  }
+
+  it('allows a free user with a huge stale counter once the month rolls over', async () => {
+    const userId = await insertUserWithStaleMonth(554);
+
+    await expect(
+      useCase.execute({ userId, candidateCardCount: 90, isPaying: false })
+    ).resolves.toBeUndefined();
+  });
+
+  it('blocks the same user after incrementing past the limit in the new month', async () => {
+    const userId = await insertUserWithStaleMonth(554);
+
+    await useCase.execute({ userId, candidateCardCount: 90, isPaying: false });
+    await repo.incrementCardUsage(userId, 90);
+
+    await expect(
+      useCase.execute({ userId, candidateCardCount: 20, isPaying: false })
+    ).rejects.toBeInstanceOf(MonthlyLimitError);
   });
 });

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-monthly-limit-rollover.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-monthly-limit-rollover.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-monthly-limit-rollover",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "Monthly card limit resets correctly when a new month starts"
+}


### PR DESCRIPTION
## What
Persists the monthly card-usage reset when a new month starts, and makes the rollover comparison in the usage increment use UTC calendar months consistently with the read path.

## Why
Revenue-critical prod bug, live since Jun 1: the 100-cards/month free limit silently stopped enforcing for every user whose `cards_month_started_at` was in a previous month. Verified in prod: a user row with `cards_used_this_month = 554` read back `quota_remaining: 100` on every check all June. Free users could convert without limit — the upgrade pressure the limit exists to create was gone.

## How
Mechanism:
- `UsersRepository.getCardUsage` detected the rollover via `isNewMonth` and returned `cards_used: 0` **without persisting anything** — the row stayed in the old month, so every read all month reported a fresh quota.
- `UsersRepository.incrementCardUsage` rolled over via `date_trunc('month', NOW())` — the **DB session timezone's** month boundary, diverging from `isNewMonth`'s UTC calendar-month semantics, and untestable locally (PG-only SQL).

Fix:
- `getCardUsage` now persists the reset atomically: `UPDATE … SET cards_used_this_month = 0, cards_month_started_at = <UTC month start> WHERE id = ? AND cards_month_started_at < <UTC month start>`. The guard makes the reset a no-op if a concurrent increment already rolled the row forward — no lost counts.
- `incrementCardUsage` keeps its single atomic CASE UPDATE but binds a JS-computed UTC month start (parameter bindings only, no interpolation) instead of `date_trunc('month', NOW())`. JS and SQL now share one rollover definition: UTC calendar month.
- New `src/lib/User/startOfMonthUtc.ts` is the single source of the boundary.

No change to the 100/month limit value or any copy.

## Measuring success
Prod query after deploy: free-tier rows with `cards_month_started_at < date_trunc('month', now() at time zone 'UTC')` AND recent activity should converge to zero (every quota read normalizes the row). The previously verified user row reads `quota_remaining: 100` once, then decrements with each conversion; `MonthlyLimitError` (logged by the conversion path) resumes firing for free users past 100.

## Testing
- Unit tests added:
  - `src/data_layer/UsersRepository.cardUsage.test.ts` — sqlite-backed: `getCardUsage` with previous-month `started_at` returns 0 **and** persists the reset (direct row read asserts 0 + new month); `incrementCardUsage` across rollover sets counter = increment and moves the month; same-month increment accumulates; plus a pg-dialect generated-SQL shape test (`knex({ client: 'pg' })`) asserting the bound-parameter CASE update and absence of `date_trunc`.
  - `src/usecases/users/CheckMonthlyCardLimitUseCase.test.ts` — non-mocked round trip with a real repository on sqlite: stale-month user with a 554 counter is allowed in the fresh month, then blocked after incrementing past 100.
  - `src/lib/User/startOfMonthUtc.test.ts`.
- TDD: all repository/use-case tests written first and observed failing (non-persisted reset; `date_trunc` unrunnable on sqlite).
- Server `tsc -p . --noEmit` clean; scoped suites green.
- Sonar: not run locally — `SONAR_TOKEN` unset on this machine; expect the CI analysis to cover it.

## Browser check
Browser check: not applicable — only `web/src/` file is a changelog JSON entry (attestation bypass: changelog-only diff).

## Changelog
"Monthly card limit resets correctly when a new month starts" (`web/src/pages/WhatsNewPage/changelog/2026-06-05-monthly-limit-rollover.json`)

## Risks
- This is the payment-pressure path — **run `/security-review` before merge.**
- A user mid-month at the moment of deploy keeps their already-counted usage; no data migration needed — rows self-heal on first read or increment.
- The read path now issues one extra UPDATE per user per month (first read after rollover only); negligible load.
- Rollback: revert the PR — behavior returns to the non-enforcing state, no schema change involved.

## Goal alignment
Restores the free-tier limit that drives upgrades — directly protects the conversion-to-paid funnel behind the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783273302&installation_id=132681956&pr_number=3124&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3124&signature=7f03574b81e5ce2767611ec2471c939da4b5019a8dbade431ed8275a48ee5c65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->