### PR TITLE
fix: include method, path, and page url in client error reports

### DIFF
--- a/src/controllers/ErrorEventController.test.ts
+++ b/src/controllers/ErrorEventController.test.ts
@@ -156,6 +156,46 @@ describe('ErrorEventController.ingest', () => {
     expect(useCase.execute).toHaveBeenCalledTimes(1);
   });
 
+  it('falls back to the Referer header when the payload has no url', async () => {
+    const useCase = makeIngestUseCase();
+    const controller = new ErrorEventController(useCase);
+    const req = makeReq({ message: 'TypeError: x is null' });
+    (req.headers as Record<string, string>).referer = 'https://2anki.net/upload';
+    await controller.ingest(req, makeRes() as unknown as Response);
+    expect(useCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ url: 'https://2anki.net/upload' }),
+      })
+    );
+  });
+
+  it('keeps the payload url when both payload url and Referer are present', async () => {
+    const useCase = makeIngestUseCase();
+    const controller = new ErrorEventController(useCase);
+    const req = makeReq(VALID_BODY);
+    (req.headers as Record<string, string>).referer = 'https://2anki.net/other';
+    await controller.ingest(req, makeRes() as unknown as Response);
+    expect(useCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ url: 'https://2anki.net' }),
+      })
+    );
+  });
+
+  it('leaves url null when neither payload url nor Referer is present', async () => {
+    const useCase = makeIngestUseCase();
+    const controller = new ErrorEventController(useCase);
+    await controller.ingest(
+      makeReq({ message: 'TypeError: x is null' }),
+      makeRes() as unknown as Response
+    );
+    expect(useCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ url: null }),
+      })
+    );
+  });
+
   it('does not expose the raw IP in the response', async () => {
     const useCase = makeIngestUseCase();
     const executeSpy = jest.spyOn(useCase, 'execute');

--- a/src/controllers/ErrorEventController.ts
+++ b/src/controllers/ErrorEventController.ts
@@ -38,6 +38,20 @@ function validatePayload(body: unknown): ErrorEventPayload | null {
   };
 }
 
+function resolvePageUrl(
+  payloadUrl: string | null | undefined,
+  req: Request
+): string | null {
+  if (payloadUrl != null) {
+    return payloadUrl;
+  }
+  const referer = req.headers.referer;
+  if (typeof referer === 'string' && referer.length > 0) {
+    return referer;
+  }
+  return null;
+}
+
 export class ErrorEventController {
   private readonly rateLimiter: RateLimiter;
 
@@ -66,6 +80,7 @@ export class ErrorEventController {
       res.status(400).json({ error: 'Invalid payload' });
       return;
     }
+    payload.url = resolvePageUrl(payload.url, req);
 
     if (isBotUserAgent(payload.userAgent)) {
       res.status(202).end();

--- a/web/src/components/errors/helpers/getErrorMessage.test.ts
+++ b/web/src/components/errors/helpers/getErrorMessage.test.ts
@@ -38,10 +38,15 @@ describe('classifyError', () => {
   });
 
   test('a 404 from the .apkg preview endpoint says the deck is gone, not Notion', () => {
-    const err = Object.assign(new Error('Resource not found: 404 Not Found'), {
-      status: 404,
-      url: '/api/apkg/deck-abc123.apkg/cards',
-    });
+    const err = Object.assign(
+      new Error(
+        'Resource not found: GET /api/apkg/deck-abc123.apkg/cards status: 404 Not Found'
+      ),
+      {
+        status: 404,
+        url: '/api/apkg/deck-abc123.apkg/cards',
+      }
+    );
     const result = classifyError(err);
     expect(result.title).toBe('This deck is no longer available.');
     expect(result.title).not.toMatch(/Notion/i);
@@ -53,10 +58,15 @@ describe('classifyError', () => {
   });
 
   test('a 404 from a non-apkg endpoint keeps the Notion-page copy', () => {
-    const err = Object.assign(new Error('Resource not found: 404 Not Found'), {
-      status: 404,
-      url: '/api/notion/preview/xyz',
-    });
+    const err = Object.assign(
+      new Error(
+        'Resource not found: GET /api/notion/preview/xyz status: 404 Not Found'
+      ),
+      {
+        status: 404,
+        url: '/api/notion/preview/xyz',
+      }
+    );
     expect(classifyError(err).title).toBe("We couldn't open that Notion page.");
   });
 

--- a/web/src/lib/backend/api.test.ts
+++ b/web/src/lib/backend/api.test.ts
@@ -49,6 +49,18 @@ describe('api.get error tagging', () => {
     expect(caught?.status).toBe(503);
   });
 
+  it('tags a 404 with the method and request path', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 404, statusText: 'Not Found' })
+    );
+
+    await expect(
+      get('http://localhost/api/notion/page/abc')
+    ).rejects.toThrowError(
+      /Resource not found: GET \/api\/notion\/page\/abc status: 404/
+    );
+  });
+
   it('tags network failures with the URL', async () => {
     fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
 

--- a/web/src/lib/backend/api.ts
+++ b/web/src/lib/backend/api.ts
@@ -121,7 +121,7 @@ async function throwForErrorResponse(
   }
   if (response.status === NOT_FOUND) {
     throw taggedHttpError(
-      `Resource not found: ${response.status} ${response.statusText}`,
+      `Resource not found: GET ${pathOf(url)} status: ${response.status} ${response.statusText}`,
       'GET',
       url,
       response.status
@@ -141,7 +141,7 @@ async function throwForErrorResponse(
   );
 }
 
-function pathOf(url: string): string {
+export function pathOf(url: string): string {
   try {
     return new URL(url, globalThis.location?.origin ?? 'http://localhost').pathname;
   } catch {

--- a/web/src/lib/backend/getSharedDeck.test.ts
+++ b/web/src/lib/backend/getSharedDeck.test.ts
@@ -47,13 +47,13 @@ describe('getSharedDeck', () => {
       await expect(getSharedDeckMeta('t')).rejects.toThrow('Share not found');
     });
 
-    it('falls back to statusText when no JSON message is present', async () => {
+    it('falls back to method, path, and status when no JSON message is present', async () => {
       vi.mocked(globalThis.fetch).mockResolvedValue(
         new Response('', { status: 500, statusText: 'Internal Server Error' })
       );
 
       await expect(getSharedDeckMeta('t')).rejects.toThrow(
-        'Internal Server Error'
+        'HTTP error! GET /api/shares/t/meta status: 500, message: Internal Server Error'
       );
     });
   });
@@ -112,6 +112,16 @@ describe('getSharedDeck', () => {
 
       await expect(createDeckShare('uploads/x.apkg')).rejects.toThrow(
         'Upload not owned by you'
+      );
+    });
+
+    it('falls back to method, path, and status when no JSON message is present', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response('', { status: 500, statusText: 'Internal Server Error' })
+      );
+
+      await expect(createDeckShare('uploads/x.apkg')).rejects.toThrow(
+        'HTTP error! POST /api/shares status: 500, message: Internal Server Error'
       );
     });
   });

--- a/web/src/lib/backend/getSharedDeck.ts
+++ b/web/src/lib/backend/getSharedDeck.ts
@@ -1,10 +1,24 @@
+import { pathOf } from './api';
 import { ApkgPreviewBatch, ApkgPreviewMeta } from './getApkgPreview';
+
+async function shareApiError(
+  method: string,
+  url: string,
+  response: Response
+): Promise<Error> {
+  const data = (await response.json().catch(() => ({}))) as {
+    message?: string;
+  };
+  return new Error(
+    data.message ??
+      `HTTP error! ${method} ${pathOf(url)} status: ${response.status}, message: ${response.statusText}`
+  );
+}
 
 async function fetchShareApi<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
-    const data = await response.json().catch(() => ({ message: response.statusText }));
-    throw new Error((data as { message?: string }).message ?? response.statusText);
+    throw await shareApiError('GET', url, response);
   }
   return response.json() as Promise<T>;
 }
@@ -41,8 +55,7 @@ export async function createDeckShare(uploadKey: string): Promise<CreateShareRes
     body: JSON.stringify({ upload_key: uploadKey }),
   });
   if (!response.ok) {
-    const data = await response.json().catch(() => ({ message: response.statusText }));
-    throw new Error((data as { message?: string }).message ?? response.statusText);
+    throw await shareApiError('POST', '/api/shares', response);
   }
   return response.json() as Promise<CreateShareResponse>;
 }

--- a/web/src/pages/PreviewPage/PreviewPage.test.tsx
+++ b/web/src/pages/PreviewPage/PreviewPage.test.tsx
@@ -94,7 +94,9 @@ describe('PreviewPage deleted-page handling', () => {
     mockUsePreviewStream.mockReturnValue({
       data: undefined,
       isLoading: false,
-      error: new Error('Resource not found: 404 Not Found'),
+      error: new Error(
+        'Resource not found: GET /api/notion/page/abc status: 404 Not Found'
+      ),
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),


### PR DESCRIPTION
## What
Client error reports become diagnosable: the 404 throw in the web api client now names the method and request path, the shared-deck fallback errors do the same, and the server-side error ingest falls back to the `Referer` header when a report arrives without a page url.

## Why
The /ops/errors group "Resource not found: 404 Not Found" (×2) carried no method/path and its sample showed `URL: (none)` — impossible to act on. Sibling throw sites already embed `GET /api/... status: N` context; these did not.

## How
- `web/src/lib/backend/api.ts` — the 404 throw now reads `Resource not found: GET <path> status: 404 Not Found`, matching the existing `HTTP error! GET <path> status: ...` convention. `pathOf` is exported for reuse.
- `web/src/lib/backend/getSharedDeck.ts` — the two bare-`statusText` fallbacks (`fetchShareApi`, `createDeckShare`) now throw `HTTP error! <METHOD> <path> status: N, message: <statusText>` when the server body carries no message. Server-provided messages are preserved untouched — `SharedDeckPage` matches on them for its empty/revoked states.
- `src/controllers/ErrorEventController.ts` — when the payload has no `url`, the ingest falls back to the request's `Referer` header.

### Throw sites audited in `web/src/lib/backend/`
Fixed (lacked method/path and could surface as a contextless group):
1. `api.ts` 404 throw — the reported group's source.
2. `getSharedDeck.ts` `fetchShareApi` statusText fallback (GET `/api/shares/<token>/meta` and `/cards`).
3. `getSharedDeck.ts` `createDeckShare` statusText fallback (POST `/api/shares`).

Left as-is (already diagnosable or intentionally user-facing): `api.ts` network-error and generic HTTP throws (already carry method+path), all `UserNotice` throws (never reported), `Backend.ts` / `templates.ts` / `postLinkEmail.ts` / `cancelSubscription.ts` throws that name their operation (`Failed to delete job: 404 ...`, `Failed to link email: ...`) — unique message per operation, so their groups are already actionable — and the AI-template fallbacks, which are designed user-facing copy.

### About `URL: (none)`
`reportClientError` has sent `window.location.href` unconditionally since #3091 (covered by the existing test "captures url, lang, and translated"). The url-less samples come from stale cached pre-#3091 bundles, not from call sites skipping it — so the durable fix is server-side: the Referer fallback covers old bundles and any future sender that forgets the field.

### message_hash grouping
Changing the 404 message text changes `message_hash` grouping: the old "Resource not found: 404 Not Found" group stops growing (resolve it), and new per-path groups appear. Expected and intended — per-path grouping is the diagnosability win. Same applies to the shared-deck fallbacks.

## Measuring success
New events in `/ops/errors` for 404s read `Resource not found: GET /api/<path> status: 404 ...` and every sample shows a real `URL:` line (payload url or Referer). The legacy `Resource not found: 404 Not Found` group receives no new events after deploy.

## Testing
- Unit tests added:
  - vitest `api.test.ts`: 404 throws with method + path.
  - vitest `getSharedDeck.test.ts`: message-less GET/POST failures throw with method, path, and status; server messages preserved.
  - jest `ErrorEventController.test.ts`: Referer fallback when payload url is absent; payload url wins when both present; null when neither.
- Updated tests that asserted the old literal: `getErrorMessage.test.ts` (×2), `PreviewPage.test.tsx` (×1) — classification logic keys on the `status`/`url` props and the `404` substring, both preserved.
- Full web vitest suite (1706 tests), web typecheck, Biome lint, server tsc all green.

Sonar: not run — `SONAR_TOKEN` is not configured in this environment (scanner errors with "Project not found" anonymously). Expect the CI Sonar analysis to be the first rule-engine pass.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: not verified in a browser — error-path message text and server-side ingest only; no rendered surface changes. Boxes left for Alexander.

## Changelog
No entry — internal observability change, no user-visible behavior change.

## Risks
- Pages that pattern-match error text: `SharedDeckPage` matches `'404'`/server messages, `PreviewPage` and `getErrorMessage` match `404` + `status`/`url` props — all preserved (tests cover the classification paths).
- Old error groups stop growing under their old hash; resolve them after deploy.
- Rollback: revert the commit; no schema or data migration involved.

## Goal alignment
Indirect: faster diagnosis of client-side conversion-path failures means broken flows (preview 404s, share failures) get found and fixed sooner, protecting the upload → download funnel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783276100&installation_id=132681956&pr_number=3127&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3127&signature=ef7f3dea1667eec611b7188b613747cd88f8f0782341a9a445669caa6283b466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander (standing waiver from 2026-06-05 merges); automated suites green.
