### PR TITLE
fix: guard remaining pages against browser-translation DOM edits

### DIFF
--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -569,6 +569,66 @@ describe('Sidebar auto-minimize', () => {
   });
 });
 
+const collectUnwrappedTextNodes = (root: HTMLElement): string[] => {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const offenders: string[] = [];
+  let node = walker.nextNode();
+  while (node != null) {
+    const hasVisibleText = (node.textContent ?? '').trim().length > 0;
+    const parentMixesElements =
+      (node.parentElement?.childElementCount ?? 0) > 0;
+    if (hasVisibleText && parentMixesElements) {
+      offenders.push(node.textContent ?? '');
+    }
+    node = walker.nextNode();
+  }
+  return offenders;
+};
+
+const wrapTextNodesInFont = (root: HTMLElement) => {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  let node = walker.nextNode();
+  while (node != null) {
+    if ((node.textContent ?? '').trim().length > 0) {
+      textNodes.push(node as Text);
+    }
+    node = walker.nextNode();
+  }
+  for (const textNode of textNodes) {
+    const font = document.createElement('font');
+    textNode.parentNode?.insertBefore(font, textNode);
+    font.appendChild(textNode);
+  }
+};
+
+describe('Sidebar collapse rail survives browser translation', () => {
+  beforeEachReset();
+
+  it('renders no bare text nodes next to the rail icon when expanded', () => {
+    renderSidebar();
+    const rail = screen.getByRole('button', { name: 'Collapse sidebar' });
+    expect(collectUnwrappedTextNodes(rail)).toEqual([]);
+  });
+
+  it('renders no bare text nodes next to the rail icon when collapsed', () => {
+    localStorage.setItem('sidebar.collapsed', 'true');
+    renderSidebar();
+    const rail = screen.getByRole('button', { name: 'Expand sidebar' });
+    expect(collectUnwrappedTextNodes(rail)).toEqual([]);
+  });
+
+  it('toggles after a translation tool wraps the rail text in font tags', () => {
+    renderSidebar();
+    const rail = screen.getByRole('button', { name: 'Collapse sidebar' });
+    wrapTextNodesInFont(rail);
+    fireEvent.click(rail);
+    expect(
+      screen.getByRole('button', { name: 'Expand sidebar' })
+    ).toBeInTheDocument();
+  });
+});
+
 describe('Sidebar More block', () => {
   it('renders the footer links', () => {
     renderSidebar();

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -515,7 +515,7 @@ export function Sidebar({
           ) : (
             <ArrowLeftIcon width={16} height={16} />
           )}
-          {collapsed ? 'Expand' : 'Collapse'}
+          <span>{collapsed ? 'Expand' : 'Collapse'}</span>
         </span>
       </button>
     </>

--- a/web/src/pages/DocsPage/DocContent.test.tsx
+++ b/web/src/pages/DocsPage/DocContent.test.tsx
@@ -50,6 +50,46 @@ describe('DocContent markdown link rewriting', () => {
   });
 });
 
+const wrapTextNodesInFont = (root: HTMLElement) => {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  let node = walker.nextNode();
+  while (node != null) {
+    if ((node.textContent ?? '').trim().length > 0) {
+      textNodes.push(node as Text);
+    }
+    node = walker.nextNode();
+  }
+  for (const textNode of textNodes) {
+    const font = document.createElement('font');
+    textNode.parentNode?.insertBefore(font, textNode);
+    font.appendChild(textNode);
+  }
+};
+
+function docAt(slug: string) {
+  return (
+    <MemoryRouter initialEntries={[`/documentation/${slug}`]}>
+      <Routes>
+        <Route path="/documentation/*" element={<DocContent slug={slug} />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('DocContent survives browser translation across navigation', () => {
+  it('renders the next doc after a translation tool wraps text in font tags', () => {
+    const { rerender } = render(docAt('start-here/what-is-2anki'));
+    const article = document.querySelector('article') as HTMLElement;
+    expect(article).not.toBeNull();
+    wrapTextNodesInFont(article);
+    rerender(docAt('start-here/connect-notion'));
+    expect(
+      screen.getByRole('heading', { level: 1, name: /connect notion/i }),
+    ).toBeInTheDocument();
+  });
+});
+
 describe('DocContent custom element embedding', () => {
   it('renders both overlapping-cloze demos from the markdown', () => {
     renderAt('cards/overlapping-cloze');

--- a/web/src/pages/DocsPage/DocContent.tsx
+++ b/web/src/pages/DocsPage/DocContent.tsx
@@ -157,7 +157,7 @@ export function DocContent({ slug }: Readonly<DocContentProps>) {
 
   if (!doc) {
     return (
-      <article className={styles.article}>
+      <article key={resolvedSlug} className={styles.article}>
         <h1>Not found</h1>
         <p>
           The page you are looking for does not exist.{' '}
@@ -172,7 +172,7 @@ export function DocContent({ slug }: Readonly<DocContentProps>) {
   const transformedBody = transformCallouts(body);
 
   return (
-    <article className={styles.article}>
+    <article key={resolvedSlug} className={styles.article}>
       <header className={styles.articleHeader}>
         {frontmatter.title && (
           <h1 className={styles.articleTitle}>{frontmatter.title}</h1>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-translate-sweep.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-translate-sweep.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-translate-sweep",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "Browser page translation no longer breaks the documentation pages or the sidebar"
+}


### PR DESCRIPTION
## What
Sweeps the remaining browser-translation reconciliation hazards beyond /upload: wraps the sidebar collapse-rail label in a span, and keys the docs article on its slug so navigating between doc pages remounts the markdown subtree instead of diffing it in place.

## Why
Google Translate (and similar tools) wraps bare text nodes in `<font>` tags; React then throws `insertBefore`/`removeChild` NotFoundError when it reconciles siblings of the moved node. PR #3117 fixed the upload page's AI badge, but prod still shows insertBefore on https://2anki.net/notion (Jun 5) and removeChild ×4 on https://2anki.net/documentation/start-here/what-is-2anki.

## How
- **Sidebar collapse rail** (`web/src/components/AppShell/Sidebar.tsx`) — shared chrome on /notion, /upload, /downloads. The rail rendered `{collapsed ? 'Expand' : 'Collapse'}` as a bare text node next to a conditionally swapped arrow icon; after Translate font-wraps the label, toggling makes React `insertBefore(newIcon, movedTextNode)` → crash. This matches the /notion insertBefore (the page is auth-gated, and #3091's earlier rail fix addressed the portal, not the bare text). Fix: span-wrap the label, same pattern as #3117.
- **DocContent** (`web/src/pages/DocsPage/DocContent.tsx`) — navigating between doc pages reconciles the ReactMarkdown output in place; mixed text+link paragraphs lose/gain text-node children, and React `removeChild`s translated text nodes that now live inside `<font>` wrappers → the docs removeChild group. Span-wrapping can't apply to markdown output, so the fix is `key={resolvedSlug}` on the `<article>`: a slug change tears down the old subtree wholesale (React removes only the article element, which Translate never moves) and mounts fresh.

**Swept and fixed:** `Sidebar` (collapse rail), `DocContent`.
**Swept and left unchanged** (conditionals are element-level, or text is a sole child handled via React's textContent fast path): `SearchPage` + `SearchContainer`/`SearchPresenter`/`SearchBar`/`ListSearchResults`/`SearchObjectEntry`/`ConnectNotion`, `DocsPage` shell, `DocsHome`, `DocsSidebar`, `DocsSearch`, `WipBanner`, `NavigationBar`/`NavbarItem`/`RightSide`, `PageLayout`, `Footer`, `HomePage`, `LoginForm`, `RegisterForm`, `DownloadsPage`, `MobileTopBar`.

Sonar note: SONAR_TOKEN is not configured in this environment, so sonar-scanner was not run locally. The diff is a span wrap, two `key` attributes, and tests — low smell risk.

## Measuring success
The `insertBefore` error group on https://2anki.net/notion and the `removeChild` group on /documentation/* stop accruing new occurrences after deploy. `context.translated` from #3091's reporter breadcrumbs confirms the affected sessions were translation sessions: `select url, context->>'translated' from error_events where source = 'web' and (error_message like '%insertBefore%' or error_message like '%removeChild%') order by created_at desc`.

## Testing
- `Sidebar.test.tsx`: 3 new tests — TreeWalker structural guard (no bare text next to the rail icon, expanded + collapsed) and a behavioral test that font-wraps the rail text (simulating Translate) then toggles. All 3 failed before the fix (the behavioral one with the exact prod `NotFoundError`); 55/55 pass after.
- `DocContent.test.tsx`: 1 new behavioral test — renders a doc, font-wraps every text node, navigates to the next doc, asserts the new page renders. Failed before the fix with the exact prod error ("The node to be removed is not a child of this node"); 6/6 pass after.
- Full web suite: 198 files, 1708 passed. Typecheck and Biome lint green.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: manual pass or waiver needed — things to eyeball: collapse-rail label spacing (expanded/collapsed) and docs page-to-page navigation (scroll-to-top still works, pager links).

## Changelog
"Browser page translation no longer breaks the documentation pages or the sidebar" — `web/src/pages/WhatsNewPage/changelog/2026-06-05-translate-sweep.json`

## Risks
Low. The span is inside the rail's flex content span, so layout is unchanged. The article `key` forces a remount per doc navigation — that is the intent (fresh subtree); the existing scroll/hash effect already runs per slug. Rollback is a one-commit revert.

## Goal alignment
Translation users are international learners — the EU-leaning core audience. A hard reconciliation crash on the docs (top-of-funnel for anonymous users) and on /notion (the core conversion surface) is a direct funnel leak; this closes the remaining known instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783276279&installation_id=132681956&pr_number=3128&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3128&signature=e1bf2d428a1b746aaba9e308fc83d94d54baaaca1ca0ad3680f4d34137df51d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander (standing waiver from 2026-06-05 merges); automated suites green.
