### PR TITLE
feat: stamp release sha on client and server error events

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -60,7 +60,7 @@ jobs:
             aws --version
 
             pnpm --dir ${SERVER_DIR} run build
-            ASSET_BASE_URL="$ASSET_BASE_URL" pnpm --filter 2anki-web -C ${SERVER_DIR} build
+            ASSET_BASE_URL="$ASSET_BASE_URL" REACT_APP_RELEASE="$GIT_SHA" pnpm --filter 2anki-web -C ${SERVER_DIR} build
 
             echo "Syncing web/build/assets/ to s3://${SPACES_ASSETS_BUCKET}/assets/..."
             AWS_ACCESS_KEY_ID="$SPACES_ASSETS_ACCESS_KEY_ID" \

--- a/src/controllers/ErrorEventController.test.ts
+++ b/src/controllers/ErrorEventController.test.ts
@@ -196,6 +196,21 @@ describe('ErrorEventController.ingest', () => {
     );
   });
 
+  it('truncates an over-long release to 40 chars', async () => {
+    const useCase = makeIngestUseCase();
+    const executeSpy = jest.spyOn(useCase, 'execute');
+    const controller = new ErrorEventController(useCase);
+    const res = makeRes();
+    await controller.ingest(
+      makeReq({ ...VALID_BODY, release: 'a'.repeat(100) }),
+      res as unknown as Response
+    );
+    const callArg = executeSpy.mock.calls[0][0] as {
+      payload: { release: string | null };
+    };
+    expect(callArg.payload.release).toBe('a'.repeat(40));
+  });
+
   it('does not expose the raw IP in the response', async () => {
     const useCase = makeIngestUseCase();
     const executeSpy = jest.spyOn(useCase, 'execute');

--- a/src/controllers/ErrorEventController.ts
+++ b/src/controllers/ErrorEventController.ts
@@ -11,6 +11,7 @@ const RATE_WINDOW_MS = 60_000;
 const PER_IP_MAX = 10;
 const GLOBAL_MAX = 1000;
 const BOT_USER_AGENT_PATTERN = /bot|crawler|spider|slurp|applebot|leikibot/i;
+const MAX_RELEASE_LENGTH = 40;
 
 function isBotUserAgent(userAgent: string | null | undefined): boolean {
   return userAgent != null && BOT_USER_AGENT_PATTERN.test(userAgent);
@@ -29,7 +30,8 @@ function validatePayload(body: unknown): ErrorEventPayload | null {
     stack: typeof b.stack === 'string' ? b.stack : null,
     url: typeof b.url === 'string' ? b.url : null,
     userAgent: typeof b.userAgent === 'string' ? b.userAgent : null,
-    release: typeof b.release === 'string' ? b.release : null,
+    release:
+      typeof b.release === 'string' ? b.release.slice(0, MAX_RELEASE_LENGTH) : null,
     userId: typeof b.userId === 'number' ? b.userId : null,
     context:
       b.context != null && typeof b.context === 'object' && !Array.isArray(b.context)

--- a/src/env.example
+++ b/src/env.example
@@ -39,3 +39,6 @@ APPLE_IAP_APP_APPLE_ID=''
 APPLE_IAP_ENVIRONMENT='Production'
 # Get a free API key at https://www.pexels.com/api/. Required for the add_image transform on /transform when source=pexels.
 PEXELS_API_KEY=''
+# Release label stamped on captured error events (error_events.release).
+# Unset = falls back to GIT_SHA, then `git rev-parse --short HEAD`, then null.
+RELEASE=''

--- a/src/lib/release.test.ts
+++ b/src/lib/release.test.ts
@@ -1,0 +1,55 @@
+import { normalizeRelease, resolveRelease } from './release';
+
+const FULL_SHA = 'dc017dfee6f6a1b2c3d4e5f60718293a4b5c6d7e';
+
+describe('normalizeRelease', () => {
+  it('returns null for undefined', () => {
+    expect(normalizeRelease(undefined)).toBeNull();
+  });
+
+  it('returns null for empty and whitespace-only strings', () => {
+    expect(normalizeRelease('')).toBeNull();
+    expect(normalizeRelease('   ')).toBeNull();
+  });
+
+  it('shortens a full 40-char sha to 7 chars', () => {
+    expect(normalizeRelease(FULL_SHA)).toBe('dc017df');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeRelease('  abc1234\n')).toBe('abc1234');
+  });
+
+  it('caps non-sha values at 40 chars to fit the column', () => {
+    const long = 'x'.repeat(60);
+    expect(normalizeRelease(long)).toBe('x'.repeat(40));
+  });
+});
+
+describe('resolveRelease', () => {
+  it('prefers RELEASE over GIT_SHA and git lookup', () => {
+    const readGitSha = jest.fn(() => 'fff0000');
+    const release = resolveRelease(
+      { RELEASE: 'v1.2.3', GIT_SHA: FULL_SHA },
+      readGitSha
+    );
+    expect(release).toBe('v1.2.3');
+    expect(readGitSha).not.toHaveBeenCalled();
+  });
+
+  it('falls back to GIT_SHA when RELEASE is unset', () => {
+    const readGitSha = jest.fn(() => 'fff0000');
+    const release = resolveRelease({ GIT_SHA: FULL_SHA }, readGitSha);
+    expect(release).toBe('dc017df');
+    expect(readGitSha).not.toHaveBeenCalled();
+  });
+
+  it('falls back to git lookup when neither env var is set', () => {
+    const release = resolveRelease({}, () => 'abc1234\n');
+    expect(release).toBe('abc1234');
+  });
+
+  it('returns null when env vars are unset and git is unavailable', () => {
+    expect(resolveRelease({}, () => null)).toBeNull();
+  });
+});

--- a/src/lib/release.ts
+++ b/src/lib/release.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+
+const SHORT_SHA_LENGTH = 7;
+const MAX_RELEASE_LENGTH = 40;
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export function normalizeRelease(raw: string | null | undefined): string | null {
+  const trimmed = raw?.trim() ?? '';
+  if (trimmed === '') {
+    return null;
+  }
+  if (FULL_SHA_PATTERN.test(trimmed)) {
+    return trimmed.slice(0, SHORT_SHA_LENGTH);
+  }
+  return trimmed.slice(0, MAX_RELEASE_LENGTH);
+}
+
+function readGitShortSha(): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+    });
+  } catch {
+    return null;
+  }
+}
+
+interface ReleaseEnv {
+  RELEASE?: string;
+  GIT_SHA?: string;
+}
+
+export function resolveRelease(
+  env: ReleaseEnv = process.env,
+  readGitSha: () => string | null = readGitShortSha
+): string | null {
+  return (
+    normalizeRelease(env.RELEASE) ??
+    normalizeRelease(env.GIT_SHA) ??
+    normalizeRelease(readGitSha())
+  );
+}
+
+let cachedRelease: string | null | undefined;
+
+export function getRelease(): string | null {
+  if (cachedRelease === undefined) {
+    cachedRelease = resolveRelease();
+  }
+  return cachedRelease;
+}

--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -118,6 +118,26 @@ describe('makeErrorCaptureMiddleware', () => {
     expect(repo.inserts[0].user_id).toBeNull();
   });
 
+  it('stamps the release on inserted rows when provided', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo, undefined, 'abc1234');
+    const next = makeNext();
+
+    await middleware(testError, makeReq(), makeRes(), next);
+
+    expect(repo.inserts[0].release).toBe('abc1234');
+  });
+
+  it('sets release to null when no release is provided', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+
+    await middleware(testError, makeReq(), makeRes(), next);
+
+    expect(repo.inserts[0].release).toBeNull();
+  });
+
   it('calls next(err) even when the repository throws', async () => {
     const brokenRepo: IErrorEventRepository = {
       async insert() { throw new Error('DB down'); },

--- a/src/routes/middleware/ErrorCaptureMiddleware.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.ts
@@ -12,7 +12,8 @@ type FallbackWriter = (payload: FallbackErrorPayload) => void;
 
 export const makeErrorCaptureMiddleware = (
   repository: IErrorEventRepository,
-  writeFallback?: FallbackWriter
+  writeFallback?: FallbackWriter,
+  release: string | null = null
 ) => {
   return async (
     err: Error,
@@ -39,6 +40,7 @@ export const makeErrorCaptureMiddleware = (
           message,
           stack: err?.stack ?? null,
           url: req.originalUrl ?? null,
+          release,
           ip_hash: ipHash,
           user_id: userId,
         };

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import ErrorHandler from './routes/middleware/ErrorHandler';
 import { makeErrorCaptureMiddleware } from './routes/middleware/ErrorCaptureMiddleware';
 import { ErrorEventRepository } from './data_layer/ErrorEventRepository';
 import { writeFallbackError, drainFallbackFile } from './lib/errorFallback';
+import { getRelease } from './lib/release';
 
 // Server Endpoints
 import settingsRouter from './routes/SettingsRouter';
@@ -197,7 +198,7 @@ const serve = async () => {
   app.use(rejectScannerProbes);
   app.use(defaultRouter());
   const errorEventRepo = new ErrorEventRepository(database);
-  app.use(makeErrorCaptureMiddleware(errorEventRepo, writeFallbackError));
+  app.use(makeErrorCaptureMiddleware(errorEventRepo, writeFallbackError, getRelease()));
   app.use(
     (
       err: Error,

--- a/web/src/lib/release.test.ts
+++ b/web/src/lib/release.test.ts
@@ -1,0 +1,19 @@
+import { getClientRelease } from './release';
+
+describe('getClientRelease', () => {
+  it('returns the injected release', () => {
+    expect(getClientRelease('abc1234')).toBe('abc1234');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(getClientRelease(' abc1234\n')).toBe('abc1234');
+  });
+
+  it('returns null for an empty string', () => {
+    expect(getClientRelease('')).toBeNull();
+  });
+
+  it('returns null for whitespace only', () => {
+    expect(getClientRelease('   ')).toBeNull();
+  });
+});

--- a/web/src/lib/release.ts
+++ b/web/src/lib/release.ts
@@ -1,0 +1,9 @@
+export function getClientRelease(
+  raw: string | undefined = process.env.REACT_APP_RELEASE
+): string | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim();
+  return trimmed === '' ? null : trimmed;
+}

--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { reportClientError } from './reportClientError';
 import { UserNotice } from './errors/UserNotice';
+import { getClientRelease } from './release';
+
+vi.mock('./release', () => ({
+  getClientRelease: vi.fn(),
+}));
+
+const mockedGetClientRelease = vi.mocked(getClientRelease);
 
 const fetchSpy = vi.fn(() =>
   Promise.resolve(new Response(null, { status: 202 }))
@@ -10,6 +17,7 @@ beforeEach(() => {
   vi.stubGlobal('fetch', fetchSpy);
   vi.stubGlobal('navigator', { userAgent: 'Vitest/1.0' });
   fetchSpy.mockClear();
+  mockedGetClientRelease.mockReturnValue('abc1234');
 });
 
 afterEach(() => {
@@ -82,6 +90,21 @@ describe('reportClientError', () => {
     } finally {
       document.documentElement.classList.remove('translated-ltr');
     }
+  });
+
+  it('includes the injected release in the payload', () => {
+    reportClientError(new Error('release test'));
+    const [, init] = getLastCall();
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.release).toBe('abc1234');
+  });
+
+  it('omits release when none is available', () => {
+    mockedGetClientRelease.mockReturnValue(null);
+    reportClientError(new Error('no release'));
+    const [, init] = getLastCall();
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).not.toHaveProperty('release');
   });
 
   it('swallows a fetch failure without throwing', () => {

--- a/web/src/lib/reportClientError.ts
+++ b/web/src/lib/reportClientError.ts
@@ -1,4 +1,5 @@
 import { UserNotice } from './errors/UserNotice';
+import { getClientRelease } from './release';
 
 const ENDPOINT = '/api/events/errors';
 
@@ -38,7 +39,7 @@ export function reportClientError(
         : String(error);
     if (isTransientNetworkMessage(message)) return;
     const stack = error instanceof Error ? error.stack ?? null : null;
-    const release = process.env.REACT_APP_RELEASE ?? null;
+    const release = getClientRelease();
     const root = document.documentElement;
     const lang = root.lang || navigator.language || null;
     const translated =

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, loadEnv, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import {
   emitAnswersPages,
   emitLandingPages,
@@ -9,6 +10,31 @@ import {
   emitNotionMarketplacePage,
 } from './scripts/prerenderLandingPages';
 import { keepManifestSameOrigin } from './scripts/keepManifestSameOrigin';
+
+const SHORT_SHA_LENGTH = 7;
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+function shortenFullSha(value: string): string {
+  return FULL_SHA_PATTERN.test(value)
+    ? value.slice(0, SHORT_SHA_LENGTH)
+    : value;
+}
+
+function resolveRelease(envValue: string | undefined): string {
+  const fromEnv = envValue?.trim() ?? '';
+  if (fromEnv !== '') {
+    return shortenFullSha(fromEnv);
+  }
+  try {
+    const sha = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim();
+    return shortenFullSha(sha);
+  } catch {
+    return '';
+  }
+}
 
 function landingPrerender(): Plugin {
   return {
@@ -176,6 +202,9 @@ export default defineConfig(({ command, mode }) => {
         }
         return prev;
       }, {}),
+      'process.env.REACT_APP_RELEASE': JSON.stringify(
+        resolveRelease(process.env.REACT_APP_RELEASE ?? env.REACT_APP_RELEASE)
+      ),
     },
 
     // Additional configuration


### PR DESCRIPTION
## What
Stamps a short git sha onto every captured error event — web reporter payloads and server-side error capture — so `error_events.release` stops being permanently NULL.

## Why
The `/ops/errors` groups and the markdown export (`GET /api/ops/errors/export`, #3121) print `Release: (unknown)` on every sample because nothing ever populated the column. With a release on each row, errors correlate to the deploy that introduced them.

## How
- **Web**: `web/vite.config.ts` injects `process.env.REACT_APP_RELEASE` via define — env value first, `git rev-parse --short HEAD` fallback in try/catch, empty string when neither is available. Full 40-char shas are shortened to 7. Kept the repo's `REACT_APP_*` convention instead of introducing `VITE_RELEASE` — the reporter already read that key. Side fix: the define is now unconditional, so a missing `REACT_APP_RELEASE` in `web/.env` can no longer leave an un-replaced `process.env.*` literal that silently killed the whole reporter via its try/catch.
- **Server**: new `src/lib/release.ts` resolves `RELEASE` > `GIT_SHA` > git lookup (execFile, no shell) once and caches; `server.ts` passes it into `makeErrorCaptureMiddleware` at boot. Prod needs no new env — `deploy-blue-green.sh` already exports `GIT_SHA` into the pm2 runtime.
- **Deploy workflow**: web build now gets `REACT_APP_RELEASE="$GIT_SHA"`; the config shortens it.
- **Hardening**: `ErrorEventController` truncates client-supplied release to 40 chars so a hostile payload can't fail the varchar(40) insert.
- **Export**: `ExportErrorGroupsUseCase` already reads `sample.release` — no change needed; the `(unknown)` fallback now only fires for pre-existing rows.

Missing values degrade to NULL exactly as before. No new dependencies, no behavior flags.

## Measuring success
After the next deploy, new rows in `error_events` carry a 7-char sha: `SELECT release, COUNT(*) FROM error_events WHERE created_at > now() - interval '1 day' GROUP BY 1`. The export sample block shows `Release: <sha>` instead of `(unknown)`.

## Testing
- Unit tests added:
  - `src/lib/release.test.ts` — env precedence (RELEASE > GIT_SHA > git), 40-hex→7 shortening, null when all unavailable
  - `src/routes/middleware/ErrorCaptureMiddleware.test.ts` — inserted rows stamp the boot-time release; null default preserved
  - `src/controllers/ErrorEventController.test.ts` — over-long client release truncated to 40
  - `web/src/lib/release.test.ts` + `web/src/lib/reportClientError.test.ts` — payload includes the injected release; omitted when unavailable (mocked fetch)
- Server tsc, scoped Jest, web typecheck, full web Vitest (1710), Biome lint: all green.
- Sonar: not run — no `SONAR_TOKEN` configured in this environment; expect the CI analysis to be authoritative.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs manual pass or waiver — reporter change is fire-and-forget telemetry; dev server not started per workflow.

## Changelog
No entry — internal observability, no user-visible change.

## Risks
- `execFileSync` at vite config-eval and server boot: wrapped in try/catch with a 5s timeout; failure degrades to NULL (current behavior).
- The middleware signature gained an optional third param; all existing call sites and tests unaffected.
- Rollback: revert the PR; rows go back to NULL release.

## Goal alignment
Indirect: faster deploy-to-regression attribution in /ops/errors means conversion-path breakages get caught and reverted sooner, protecting the funnel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783276565&installation_id=132681956&pr_number=3129&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3129&signature=b7a123f9ccb0a0bf416d4839f21384ad52456a48eb9ce9131d79b1179a8f7ab0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander (standing waiver from 2026-06-05 merges); automated suites green.
