### PR TITLE
feat: resume abandoned checkouts straight back to payment

### DIFF
--- a/migrations/20260605000001_add_recovery_url_to_abandoned_checkout_recovery_emails.js
+++ b/migrations/20260605000001_add_recovery_url_to_abandoned_checkout_recovery_emails.js
@@ -5,6 +5,8 @@ exports.up = async (knex) => {
   });
 };
 
+// destructive — recovery_url values cannot be restored without re-processing
+// Stripe checkout.session.expired webhook events
 exports.down = async (knex) => {
   await knex.schema.alterTable('abandoned_checkout_recovery_emails', (t) => {
     t.dropColumn('recovery_url');

--- a/migrations/20260905000000_add_recovery_url_to_abandoned_checkout_recovery_emails.js
+++ b/migrations/20260905000000_add_recovery_url_to_abandoned_checkout_recovery_emails.js
@@ -1,0 +1,13 @@
+exports.up = async (knex) => {
+  await knex.schema.alterTable('abandoned_checkout_recovery_emails', (t) => {
+    t.text('recovery_url').nullable().defaultTo(null);
+    t.timestamp('recovery_url_expires_at', { useTz: true }).nullable().defaultTo(null);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('abandoned_checkout_recovery_emails', (t) => {
+    t.dropColumn('recovery_url');
+    t.dropColumn('recovery_url_expires_at');
+  });
+};

--- a/src/controllers/ResumeCheckoutController.test.ts
+++ b/src/controllers/ResumeCheckoutController.test.ts
@@ -1,0 +1,83 @@
+import type { Request, Response } from 'express';
+import ResumeCheckoutController from './ResumeCheckoutController';
+import { ResumeAbandonedCheckoutUseCase } from '../usecases/checkout/ResumeAbandonedCheckoutUseCase';
+import { InMemoryAbandonedCheckoutRecoveryRepository } from '../data_layer/AbandonedCheckoutRecoveryRepository';
+import type { EventsSink } from '../services/events/EventsSink';
+
+const TOKEN = 'f4b3a070-1f2e-4c3d-9a8b-7c6d5e4f3a2b';
+const STRIPE_URL = 'https://buy.stripe.com/r/live_abc123';
+const FUTURE = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+function makeRes(): jest.Mocked<Pick<Response, 'redirect'>> {
+  return { redirect: jest.fn() } as unknown as jest.Mocked<Pick<Response, 'redirect'>>;
+}
+
+function makeReq(token?: unknown): Request {
+  return { query: { token } } as unknown as Request;
+}
+
+describe('ResumeCheckoutController', () => {
+  let repo: InMemoryAbandonedCheckoutRecoveryRepository;
+  let controller: ResumeCheckoutController;
+  let eventsSink: jest.Mocked<Pick<EventsSink, 'record'>>;
+
+  beforeEach(() => {
+    repo = new InMemoryAbandonedCheckoutRecoveryRepository();
+    eventsSink = { record: jest.fn() };
+    controller = new ResumeCheckoutController(
+      new ResumeAbandonedCheckoutUseCase(repo),
+      eventsSink
+    );
+  });
+
+  it('302s to the Stripe recovery URL for a valid token', async () => {
+    await repo.claimSession('cs_1', 'alice@example.com', TOKEN, {
+      url: STRIPE_URL,
+      expiresAt: FUTURE,
+    });
+    const res = makeRes();
+
+    await controller.resume(makeReq(TOKEN), res as unknown as Response);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, STRIPE_URL);
+  });
+
+  it('302s to pricing when the token is unknown', async () => {
+    const res = makeRes();
+
+    await controller.resume(makeReq(TOKEN), res as unknown as Response);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, '/pricing?from=recovery');
+  });
+
+  it('302s to pricing when the token is missing', async () => {
+    const res = makeRes();
+
+    await controller.resume(makeReq(undefined), res as unknown as Response);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, '/pricing?from=recovery');
+  });
+
+  it('records an email_clicked event with resumed true on success', async () => {
+    await repo.claimSession('cs_1', 'alice@example.com', TOKEN, {
+      url: STRIPE_URL,
+      expiresAt: FUTURE,
+    });
+
+    await controller.resume(makeReq(TOKEN), makeRes() as unknown as Response);
+
+    expect(eventsSink.record).toHaveBeenCalledWith({
+      name: 'email_clicked',
+      props: { campaign: 'abandoned_checkout', resumed: true },
+    });
+  });
+
+  it('records an email_clicked event with resumed false on fallback', async () => {
+    await controller.resume(makeReq(TOKEN), makeRes() as unknown as Response);
+
+    expect(eventsSink.record).toHaveBeenCalledWith({
+      name: 'email_clicked',
+      props: { campaign: 'abandoned_checkout', resumed: false },
+    });
+  });
+});

--- a/src/controllers/ResumeCheckoutController.ts
+++ b/src/controllers/ResumeCheckoutController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import { ResumeAbandonedCheckoutUseCase } from '../usecases/checkout/ResumeAbandonedCheckoutUseCase';
+import type { EventsSink } from '../services/events/EventsSink';
+
+class ResumeCheckoutController {
+  constructor(
+    private readonly useCase: ResumeAbandonedCheckoutUseCase,
+    private readonly eventsSink: Pick<EventsSink, 'record'>
+  ) {}
+
+  async resume(req: Request, res: Response): Promise<void> {
+    const result = await this.useCase.execute(req.query.token);
+    this.eventsSink.record({
+      name: 'email_clicked',
+      props: { campaign: 'abandoned_checkout', resumed: result.resumed },
+    });
+    res.redirect(302, result.url);
+  }
+}
+
+export default ResumeCheckoutController;

--- a/src/data_layer/AbandonedCheckoutRecoveryRepository.test.ts
+++ b/src/data_layer/AbandonedCheckoutRecoveryRepository.test.ts
@@ -27,6 +27,44 @@ describe('InMemoryAbandonedCheckoutRecoveryRepository', () => {
     });
   });
 
+  describe('getRecoveryByToken', () => {
+    it('returns null for an unknown token', async () => {
+      const result = await repo.getRecoveryByToken('missing-token');
+      expect(result).toBeNull();
+    });
+
+    it('returns the recovery details stored by claimSession', async () => {
+      const expiresAt = new Date('2026-07-05T00:00:00Z');
+      await repo.claimSession('cs_abc', 'alice@example.com', 'tok-1', {
+        url: 'https://buy.stripe.com/r/live_abc',
+        expiresAt,
+      });
+
+      const result = await repo.getRecoveryByToken('tok-1');
+
+      expect(result).toEqual({
+        recoveryUrl: 'https://buy.stripe.com/r/live_abc',
+        recoveryUrlExpiresAt: expiresAt,
+      });
+    });
+
+    it('returns a null recoveryUrl when claimSession had no recovery details', async () => {
+      await repo.claimSession('cs_abc', 'alice@example.com', 'tok-1');
+
+      const result = await repo.getRecoveryByToken('tok-1');
+
+      expect(result).toEqual({ recoveryUrl: null, recoveryUrlExpiresAt: null });
+    });
+
+    it('returns a null recoveryUrl for tokens recorded by bulk sends', async () => {
+      await repo.recordEmailSend('alice@example.com', 'bulk-tok');
+
+      const result = await repo.getRecoveryByToken('bulk-tok');
+
+      expect(result).toEqual({ recoveryUrl: null, recoveryUrlExpiresAt: null });
+    });
+  });
+
   describe('recordEmailSend', () => {
     it('stores the token against the email', async () => {
       await repo.recordEmailSend('alice@example.com', 'bulk-tok');

--- a/src/data_layer/AbandonedCheckoutRecoveryRepository.ts
+++ b/src/data_layer/AbandonedCheckoutRecoveryRepository.ts
@@ -1,9 +1,25 @@
 import type { Knex } from 'knex';
 
+export interface CheckoutRecoveryDetails {
+  url: string;
+  expiresAt: Date | null;
+}
+
+export interface CheckoutRecoveryLookup {
+  recoveryUrl: string | null;
+  recoveryUrlExpiresAt: Date | null;
+}
+
 export interface IAbandonedCheckoutRecoveryRepository {
-  claimSession(sessionId: string, userEmail: string, token: string): Promise<boolean>;
+  claimSession(
+    sessionId: string,
+    userEmail: string,
+    token: string,
+    recovery?: CheckoutRecoveryDetails | null
+  ): Promise<boolean>;
   recordEmailSend(userEmail: string, token: string): Promise<void>;
   isMarketingOptedOut(userEmail: string): Promise<boolean>;
+  getRecoveryByToken(token: string): Promise<CheckoutRecoveryLookup | null>;
 }
 
 interface AbandonedCheckoutRecoveryRow {
@@ -11,6 +27,8 @@ interface AbandonedCheckoutRecoveryRow {
   user_email: string;
   sent_at: Date;
   token: string | null;
+  recovery_url: string | null;
+  recovery_url_expires_at: Date | string | null;
 }
 
 export class AbandonedCheckoutRecoveryRepository
@@ -20,9 +38,20 @@ export class AbandonedCheckoutRecoveryRepository
 
   constructor(private readonly database: Knex) {}
 
-  async claimSession(sessionId: string, userEmail: string, token: string): Promise<boolean> {
+  async claimSession(
+    sessionId: string,
+    userEmail: string,
+    token: string,
+    recovery: CheckoutRecoveryDetails | null = null
+  ): Promise<boolean> {
     const rows = await this.database<AbandonedCheckoutRecoveryRow>(this.table)
-      .insert({ session_id: sessionId, user_email: userEmail, token })
+      .insert({
+        session_id: sessionId,
+        user_email: userEmail,
+        token,
+        recovery_url: recovery?.url ?? null,
+        recovery_url_expires_at: recovery?.expiresAt ?? null,
+      })
       .onConflict('session_id')
       .ignore()
       .returning('session_id');
@@ -44,6 +73,22 @@ export class AbandonedCheckoutRecoveryRepository
       .first();
     return row != null;
   }
+
+  async getRecoveryByToken(token: string): Promise<CheckoutRecoveryLookup | null> {
+    const row = await this.database<AbandonedCheckoutRecoveryRow>(this.table)
+      .where('token', token)
+      .first();
+    if (row == null) {
+      return null;
+    }
+    return {
+      recoveryUrl: row.recovery_url ?? null,
+      recoveryUrlExpiresAt:
+        row.recovery_url_expires_at == null
+          ? null
+          : new Date(row.recovery_url_expires_at),
+    };
+  }
 }
 
 export class InMemoryAbandonedCheckoutRecoveryRepository
@@ -53,22 +98,40 @@ export class InMemoryAbandonedCheckoutRecoveryRepository
   private readonly optedOut = new Set<string>();
   private readonly tokensByEmail = new Map<string, string>();
   private readonly tokensBySessionId = new Map<string, string>();
+  private readonly recoveryByToken = new Map<string, CheckoutRecoveryLookup>();
 
-  async claimSession(sessionId: string, _userEmail: string, token: string): Promise<boolean> {
+  async claimSession(
+    sessionId: string,
+    _userEmail: string,
+    token: string,
+    recovery: CheckoutRecoveryDetails | null = null
+  ): Promise<boolean> {
     if (this.claimed.has(sessionId)) {
       return false;
     }
     this.claimed.add(sessionId);
     this.tokensBySessionId.set(sessionId, token);
+    this.recoveryByToken.set(token, {
+      recoveryUrl: recovery?.url ?? null,
+      recoveryUrlExpiresAt: recovery?.expiresAt ?? null,
+    });
     return true;
   }
 
   async recordEmailSend(userEmail: string, token: string): Promise<void> {
     this.tokensByEmail.set(userEmail, token);
+    this.recoveryByToken.set(token, {
+      recoveryUrl: null,
+      recoveryUrlExpiresAt: null,
+    });
   }
 
   async isMarketingOptedOut(userEmail: string): Promise<boolean> {
     return this.optedOut.has(userEmail);
+  }
+
+  async getRecoveryByToken(token: string): Promise<CheckoutRecoveryLookup | null> {
+    return this.recoveryByToken.get(token) ?? null;
   }
 
   seedOptedOut(userEmail: string): void {
@@ -92,6 +155,7 @@ export class InMemoryAbandonedCheckoutRecoveryRepository
     this.optedOut.clear();
     this.tokensByEmail.clear();
     this.tokensBySessionId.clear();
+    this.recoveryByToken.clear();
   }
 }
 

--- a/src/routes/CheckoutRouter.ts
+++ b/src/routes/CheckoutRouter.ts
@@ -3,11 +3,16 @@ import RequireAuthentication from './middleware/RequireAuthentication';
 import { optionalAuthMiddleware } from './middleware/optionalAuthMiddleware';
 import AutoSyncCheckoutController from '../controllers/AutoSyncCheckoutController';
 import PassCheckoutController from '../controllers/PassCheckoutController';
+import ResumeCheckoutController from '../controllers/ResumeCheckoutController';
 import UnlimitedCheckoutController from '../controllers/UnlimitedCheckoutController';
 import { AutoSyncCheckoutUseCase } from '../usecases/checkout/AutoSyncCheckoutUseCase';
 import { CreatePassCheckoutUseCase } from '../usecases/checkout/CreatePassCheckoutUseCase';
+import { ResumeAbandonedCheckoutUseCase } from '../usecases/checkout/ResumeAbandonedCheckoutUseCase';
 import { UnlimitedCheckoutUseCase } from '../usecases/checkout/UnlimitedCheckoutUseCase';
 import { getStripe } from '../lib/integrations/stripe';
+import { getDatabase } from '../data_layer';
+import AbandonedCheckoutRecoveryRepository from '../data_layer/AbandonedCheckoutRecoveryRepository';
+import { getEventsSink } from '../services/events/eventsSinkInstance';
 
 const DEFAULT_MAX_SUBSCRIBERS = 50;
 
@@ -82,6 +87,37 @@ const CheckoutRouter = () => {
       return controller.createSession(req, res);
     }
   );
+
+  /**
+   * @swagger
+   * /checkout/resume:
+   *   get:
+   *     summary: Resume an abandoned Stripe checkout
+   *     description: |
+   *       Redirects the recovery-email recipient back to their expired Stripe
+   *       Checkout session via the Stripe-hosted recovery URL. The token is the
+   *       single-use UUID minted when the recovery email was sent. Unknown,
+   *       malformed, or expired tokens fall back to the pricing page — the
+   *       endpoint never fails user-visibly.
+   *     tags: [Payments]
+   *     parameters:
+   *       - in: query
+   *         name: token
+   *         schema:
+   *           type: string
+   *           format: uuid
+   *         description: Recovery token from the abandoned-checkout email
+   *     responses:
+   *       302:
+   *         description: Redirect to the Stripe recovery URL or to /pricing
+   */
+  router.get('/checkout/resume', (req, res) => {
+    const useCase = new ResumeAbandonedCheckoutUseCase(
+      new AbandonedCheckoutRecoveryRepository(getDatabase())
+    );
+    const controller = new ResumeCheckoutController(useCase, getEventsSink());
+    return controller.resume(req, res);
+  });
 
   return router;
 };

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -372,6 +372,51 @@ describe('WebhookRouter — checkout_completed funnel join', () => {
     );
   });
 
+  it('marks checkout_completed as recovered when the session was recovered', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_recovered',
+          mode: 'subscription',
+          recovered_from: 'cs_expired_original',
+          metadata: { user_id: '42' },
+        },
+      },
+    };
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    expect(mockTrack).toHaveBeenCalledWith(
+      'checkout_completed',
+      expect.objectContaining({
+        props: expect.objectContaining({ recovered: true }),
+      })
+    );
+  });
+
+  it('omits the recovered prop for a non-recovered session', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_not_recovered',
+          mode: 'subscription',
+          recovered_from: null,
+          metadata: { user_id: '42' },
+        },
+      },
+    };
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    const [, options] = mockTrack.mock.calls.find((c) => c[0] === 'checkout_completed') as [
+      string,
+      { props: Record<string, unknown> },
+    ];
+    expect(options.props).not.toHaveProperty('recovered');
+  });
+
   it('emits checkout_completed even when no pricing_variant is set', async () => {
     mockWebhookEvent = {
       type: 'checkout.session.completed',
@@ -588,8 +633,61 @@ describe('WebhookRouter — checkout.session.expired', () => {
 
     const res = await postWebhook();
     expect(res.status).toBe(200);
-    expect(mockClaimSession).toHaveBeenCalledWith('cs_expired_abc', 'buyer@example.com', expect.any(String));
+    expect(mockClaimSession).toHaveBeenCalledWith('cs_expired_abc', 'buyer@example.com', expect.any(String), null);
     expect(mockSendAbandonedCheckoutRecoveryEmail).toHaveBeenCalledWith('buyer@example.com', expect.any(String));
+  });
+
+  it('passes the Stripe recovery URL and expiry through to the claim', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.expired',
+      data: {
+        object: {
+          id: 'cs_expired_recovery',
+          customer_details: { email: 'buyer@example.com' },
+          after_expiration: {
+            recovery: {
+              enabled: true,
+              url: 'https://buy.stripe.com/r/live_abc123',
+              expires_at: 1781913600,
+            },
+          },
+        },
+      },
+    };
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    expect(mockClaimSession).toHaveBeenCalledWith(
+      'cs_expired_recovery',
+      'buyer@example.com',
+      expect.any(String),
+      {
+        url: 'https://buy.stripe.com/r/live_abc123',
+        expiresAt: new Date(1781913600 * 1000),
+      }
+    );
+  });
+
+  it('passes a null recovery when Stripe omits the recovery URL', async () => {
+    mockWebhookEvent = {
+      type: 'checkout.session.expired',
+      data: {
+        object: {
+          id: 'cs_expired_no_url',
+          customer_details: { email: 'buyer@example.com' },
+          after_expiration: { recovery: { enabled: true, url: null, expires_at: null } },
+        },
+      },
+    };
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    expect(mockClaimSession).toHaveBeenCalledWith(
+      'cs_expired_no_url',
+      'buyer@example.com',
+      expect.any(String),
+      null
+    );
   });
 
   it('does not send email when claim is a no-op (duplicate delivery)', async () => {
@@ -606,7 +704,7 @@ describe('WebhookRouter — checkout.session.expired', () => {
 
     const res = await postWebhook();
     expect(res.status).toBe(200);
-    expect(mockClaimSession).toHaveBeenCalledWith('cs_expired_dup', 'buyer@example.com', expect.any(String));
+    expect(mockClaimSession).toHaveBeenCalledWith('cs_expired_dup', 'buyer@example.com', expect.any(String), null);
     expect(mockSendAbandonedCheckoutRecoveryEmail).not.toHaveBeenCalled();
   });
 
@@ -666,7 +764,7 @@ describe('WebhookRouter — checkout.session.expired', () => {
 
     const res = await postWebhook();
     expect(res.status).toBe(200);
-    expect(mockClaimSession).toHaveBeenCalledWith('cs_expired_fallback', 'fallback@example.com', expect.any(String));
+    expect(mockClaimSession).toHaveBeenCalledWith('cs_expired_fallback', 'fallback@example.com', expect.any(String), null);
     expect(mockSendAbandonedCheckoutRecoveryEmail).toHaveBeenCalledWith('fallback@example.com', expect.any(String));
   });
 });

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -246,6 +246,10 @@ const WebhooksRouter = () => {
               ...(surface != null && surface !== ''
                 ? { surface }
                 : {}),
+              ...(typeof session.recovered_from === 'string' &&
+              session.recovered_from !== ''
+                ? { recovered: true }
+                : {}),
             },
           });
 
@@ -411,14 +415,27 @@ const WebhooksRouter = () => {
             id: string;
             customer_details?: { email?: string | null } | null;
             customer_email?: string | null;
+            after_expiration?: {
+              recovery?: { url?: string | null; expires_at?: number | null } | null;
+            } | null;
           };
           const sessionEmail =
             expiredSession.customer_details?.email ??
             expiredSession.customer_email ??
             null;
+          const recoveryUrl = expiredSession.after_expiration?.recovery?.url ?? null;
+          const recoveryExpiresAtSeconds =
+            expiredSession.after_expiration?.recovery?.expires_at;
+          const recoveryExpiresAt =
+            recoveryExpiresAtSeconds == null
+              ? null
+              : new Date(recoveryExpiresAtSeconds * 1000);
           await abandonedCheckoutRecoveryUseCase.execute(
             expiredSession.id,
-            sessionEmail
+            sessionEmail,
+            recoveryUrl == null
+              ? null
+              : { url: recoveryUrl, expiresAt: recoveryExpiresAt }
           );
           break;
         }

--- a/src/services/EmailService/EmailService.test.ts
+++ b/src/services/EmailService/EmailService.test.ts
@@ -64,3 +64,42 @@ describe('EmailService.sendNotionReconnectEmail', () => {
     expect(msg.html).not.toContain('unsubscribe');
   });
 });
+
+describe('EmailService.sendAbandonedCheckoutRecoveryEmail', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SENDGRID_API_KEY = 'test-key';
+    process.env.DOMAIN = 'https://2anki.net';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function lastMessage() {
+    const calls = send.mock.calls;
+    return calls[calls.length - 1][0] as { to: string; subject: string; html: string; text: string };
+  }
+
+  it('links the CTA to the checkout resume endpoint with the token', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendAbandonedCheckoutRecoveryEmail('buyer@example.com', 'tok-abc-123');
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('https://2anki.net/checkout/resume?token=tok-abc-123');
+    expect(msg.html).not.toContain('{{link}}');
+  });
+
+  it('keeps the unsubscribe link', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendAbandonedCheckoutRecoveryEmail('buyer@example.com', 'tok-abc-123');
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('https://2anki.net/unsubscribe?uid=tok-abc-123');
+    expect(msg.html).not.toContain('{{unsubscribeUrl}}');
+  });
+});

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -304,7 +304,7 @@ class EmailService implements IEmailService {
 
   async sendAbandonedCheckoutRecoveryEmail(to: string, token: string): Promise<void> {
     const domain = process.env.DOMAIN ?? 'https://2anki.net';
-    const link = `${domain}/pricing?from=recovery`;
+    const link = `${domain}/checkout/resume?token=${encodeURIComponent(token)}`;
     const unsubscribeUrl = `${domain}/unsubscribe?uid=${token}`;
     const markup = ABANDONED_CHECKOUT_RECOVERY_TEMPLATE
       .replace('{{link}}', link)

--- a/src/usecases/checkout/AutoSyncCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/AutoSyncCheckoutUseCase.test.ts
@@ -77,6 +77,21 @@ describe('AutoSyncCheckoutUseCase', () => {
     );
   });
 
+  test('enables Stripe session recovery on expiry', async () => {
+    mockCountActive.mockResolvedValue(0);
+    mockGetUserActiveSubscriptions.mockResolvedValue([]);
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
+
+    const uc = makeUseCase();
+    await uc.execute({ userEmail: 'user@example.com', userId: 42 });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        after_expiration: { recovery: { enabled: true } },
+      })
+    );
+  });
+
   test('stamps anon_id into metadata when present', async () => {
     mockCountActive.mockResolvedValue(0);
     mockGetUserActiveSubscriptions.mockResolvedValue([]);

--- a/src/usecases/checkout/AutoSyncCheckoutUseCase.ts
+++ b/src/usecases/checkout/AutoSyncCheckoutUseCase.ts
@@ -58,6 +58,7 @@ export class AutoSyncCheckoutUseCase {
       cancel_url: `${process.env.APP_URL ?? 'https://2anki.net'}/pricing`,
       customer_email: input.stripeCustomerId == null ? input.userEmail : undefined,
       customer: input.stripeCustomerId ?? undefined,
+      after_expiration: { recovery: { enabled: true } },
       metadata: {
         user_id: String(input.userId),
         ...optionalMetadata({

--- a/src/usecases/checkout/CreatePassCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/CreatePassCheckoutUseCase.test.ts
@@ -65,6 +65,19 @@ describe('CreatePassCheckoutUseCase', () => {
     );
   });
 
+  it('enables Stripe session recovery on expiry', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/24h' });
+
+    const uc = new CreatePassCheckoutUseCase(makeStripe(), 'price_24h', '24h');
+    await uc.execute({ userEmail: 'user@example.com', userId: 7 });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        after_expiration: { recovery: { enabled: true } },
+      })
+    );
+  });
+
   it('uses APP_URL env var for success and cancel URLs', async () => {
     process.env.APP_URL = 'https://staging.2anki.net';
     mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });

--- a/src/usecases/checkout/CreatePassCheckoutUseCase.ts
+++ b/src/usecases/checkout/CreatePassCheckoutUseCase.ts
@@ -50,6 +50,7 @@ export class CreatePassCheckoutUseCase {
       line_items: [{ price: this.priceId, quantity: 1 }],
       success_url: successUrl,
       cancel_url: `${appUrl}/pricing`,
+      after_expiration: { recovery: { enabled: true } },
       metadata,
     };
 

--- a/src/usecases/checkout/ResumeAbandonedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/ResumeAbandonedCheckoutUseCase.test.ts
@@ -1,0 +1,111 @@
+import { ResumeAbandonedCheckoutUseCase } from './ResumeAbandonedCheckoutUseCase';
+import { InMemoryAbandonedCheckoutRecoveryRepository } from '../../data_layer/AbandonedCheckoutRecoveryRepository';
+
+const TOKEN = 'f4b3a070-1f2e-4c3d-9a8b-7c6d5e4f3a2b';
+const STRIPE_URL = 'https://buy.stripe.com/r/live_abc123';
+const NOW = new Date('2026-06-05T12:00:00Z');
+const FUTURE = new Date('2026-07-05T12:00:00Z');
+const PAST = new Date('2026-06-01T12:00:00Z');
+
+describe('ResumeAbandonedCheckoutUseCase', () => {
+  let repo: InMemoryAbandonedCheckoutRecoveryRepository;
+  let useCase: ResumeAbandonedCheckoutUseCase;
+
+  beforeEach(() => {
+    repo = new InMemoryAbandonedCheckoutRecoveryRepository();
+    useCase = new ResumeAbandonedCheckoutUseCase(repo);
+  });
+
+  it('returns the Stripe recovery URL for a valid unexpired token', async () => {
+    await repo.claimSession('cs_1', 'alice@example.com', TOKEN, {
+      url: STRIPE_URL,
+      expiresAt: FUTURE,
+    });
+
+    const result = await useCase.execute(TOKEN, NOW);
+
+    expect(result).toEqual({ url: STRIPE_URL, resumed: true });
+  });
+
+  it('falls back to pricing when the recovery URL has expired', async () => {
+    await repo.claimSession('cs_1', 'alice@example.com', TOKEN, {
+      url: STRIPE_URL,
+      expiresAt: PAST,
+    });
+
+    const result = await useCase.execute(TOKEN, NOW);
+
+    expect(result).toEqual({ url: '/pricing?from=recovery', resumed: false });
+  });
+
+  it('treats a missing expiry as still valid', async () => {
+    await repo.claimSession('cs_1', 'alice@example.com', TOKEN, {
+      url: STRIPE_URL,
+      expiresAt: null,
+    });
+
+    const result = await useCase.execute(TOKEN, NOW);
+
+    expect(result).toEqual({ url: STRIPE_URL, resumed: true });
+  });
+
+  it('falls back for an unknown token', async () => {
+    const result = await useCase.execute(TOKEN, NOW);
+
+    expect(result).toEqual({ url: '/pricing?from=recovery', resumed: false });
+  });
+
+  it('falls back when the token row has no recovery URL (bulk send)', async () => {
+    await repo.recordEmailSend('alice@example.com', TOKEN);
+
+    const result = await useCase.execute(TOKEN, NOW);
+
+    expect(result).toEqual({ url: '/pricing?from=recovery', resumed: false });
+  });
+
+  it.each([
+    ['non-string input', 42],
+    ['array input', [TOKEN]],
+    ['undefined input', undefined],
+    ['malformed token', 'not-a-uuid'],
+    ['sql-ish token', "' OR 1=1 --"],
+  ])('falls back without querying the repository on %s', async (_label, token) => {
+    const spy = jest.spyOn(repo, 'getRecoveryByToken');
+
+    const result = await useCase.execute(token, NOW);
+
+    expect(result).toEqual({ url: '/pricing?from=recovery', resumed: false });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['http (not https)', 'http://buy.stripe.com/r/live_abc'],
+    ['non-Stripe host', 'https://evil.example.com/r/live_abc'],
+    ['stripe.com lookalike suffix', 'https://notstripe.com/r/live_abc'],
+    ['stripe.com in path only', 'https://evil.example.com/stripe.com'],
+    ['not a URL', 'javascript:alert(1)'],
+  ])('falls back when the stored URL is %s', async (_label, url) => {
+    await repo.claimSession('cs_1', 'alice@example.com', TOKEN, {
+      url,
+      expiresAt: FUTURE,
+    });
+
+    const result = await useCase.execute(TOKEN, NOW);
+
+    expect(result).toEqual({ url: '/pricing?from=recovery', resumed: false });
+  });
+
+  it('accepts checkout.stripe.com as a recovery host', async () => {
+    await repo.claimSession('cs_1', 'alice@example.com', TOKEN, {
+      url: 'https://checkout.stripe.com/c/pay/recovered_abc',
+      expiresAt: FUTURE,
+    });
+
+    const result = await useCase.execute(TOKEN, NOW);
+
+    expect(result).toEqual({
+      url: 'https://checkout.stripe.com/c/pay/recovered_abc',
+      resumed: true,
+    });
+  });
+});

--- a/src/usecases/checkout/ResumeAbandonedCheckoutUseCase.ts
+++ b/src/usecases/checkout/ResumeAbandonedCheckoutUseCase.ts
@@ -1,0 +1,62 @@
+import type { IAbandonedCheckoutRecoveryRepository } from '../../data_layer/AbandonedCheckoutRecoveryRepository';
+
+export const RESUME_FALLBACK_DESTINATION = '/pricing?from=recovery';
+
+const TOKEN_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface ResumeCheckoutResult {
+  url: string;
+  resumed: boolean;
+}
+
+const FALLBACK: ResumeCheckoutResult = {
+  url: RESUME_FALLBACK_DESTINATION,
+  resumed: false,
+};
+
+function isStripeCheckoutUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') {
+    return false;
+  }
+  const host = parsed.hostname;
+  return host === 'stripe.com' || host.endsWith('.stripe.com');
+}
+
+export class ResumeAbandonedCheckoutUseCase {
+  constructor(
+    private readonly repository: Pick<
+      IAbandonedCheckoutRecoveryRepository,
+      'getRecoveryByToken'
+    >
+  ) {}
+
+  async execute(token: unknown, now: Date = new Date()): Promise<ResumeCheckoutResult> {
+    if (typeof token !== 'string' || !TOKEN_PATTERN.test(token)) {
+      return FALLBACK;
+    }
+
+    const recovery = await this.repository.getRecoveryByToken(token);
+    if (recovery?.recoveryUrl == null) {
+      return FALLBACK;
+    }
+
+    const expired =
+      recovery.recoveryUrlExpiresAt != null &&
+      recovery.recoveryUrlExpiresAt.getTime() <= now.getTime();
+    if (expired) {
+      return FALLBACK;
+    }
+
+    if (isStripeCheckoutUrl(recovery.recoveryUrl)) {
+      return { url: recovery.recoveryUrl, resumed: true };
+    }
+    return FALLBACK;
+  }
+}

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
@@ -201,6 +201,19 @@ describe('UnlimitedCheckoutUseCase', () => {
     );
   });
 
+  it('enables Stripe session recovery on expiry', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
+
+    const uc = new UnlimitedCheckoutUseCase(makeStripe(), MONTHLY_PRICE_ID, YEARLY_PRICE_ID);
+    await uc.execute({ userEmail: 'user@example.com', userId: 14, interval: 'month' });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        after_expiration: { recovery: { enabled: true } },
+      })
+    );
+  });
+
   it('does not log raw Stripe customer IDs', async () => {
     mockStripeCreateSession.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
     const consoleSpy = jest.spyOn(console, 'info').mockImplementation(() => {});

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
@@ -37,6 +37,7 @@ export class UnlimitedCheckoutUseCase {
       cancel_url: `${appUrl}/pricing`,
       customer_email: input.stripeCustomerId == null ? input.userEmail : undefined,
       customer: input.stripeCustomerId ?? undefined,
+      after_expiration: { recovery: { enabled: true } },
       metadata: {
         user_id: String(input.userId),
         ...optionalMetadata({

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.test.ts
@@ -17,6 +17,7 @@ function makeRepo(
     claimSession: jest.fn().mockResolvedValue(claimed),
     recordEmailSend: jest.fn().mockResolvedValue(undefined),
     isMarketingOptedOut: jest.fn().mockResolvedValue(optedOut),
+    getRecoveryByToken: jest.fn().mockResolvedValue(null),
   };
 }
 
@@ -50,12 +51,67 @@ describe('SendAbandonedCheckoutRecoveryOnExpiryUseCase', () => {
     expect(repo.claimSession).toHaveBeenCalledWith(
       'cs_test_abc123',
       'alice@example.com',
-      expect.any(String)
+      expect.any(String),
+      null
     );
     expect(emailService.sendAbandonedCheckoutRecoveryEmail).toHaveBeenCalledWith(
       'alice@example.com',
       expect.any(String)
     );
+  });
+
+  it('passes recovery details through to claimSession when provided', async () => {
+    const repo = makeRepo(true);
+    const emailService = makeEmailService();
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(repo, emailService);
+    const recovery = {
+      url: 'https://buy.stripe.com/r/live_abc',
+      expiresAt: new Date('2026-07-05T00:00:00Z'),
+    };
+
+    await useCase.execute('cs_with_recovery', 'alice@example.com', recovery);
+
+    expect(repo.claimSession).toHaveBeenCalledWith(
+      'cs_with_recovery',
+      'alice@example.com',
+      expect.any(String),
+      recovery
+    );
+  });
+
+  it('logs recovery URL presence without logging the URL itself', async () => {
+    const repo = makeRepo(true);
+    const emailService = makeEmailService();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(repo, emailService);
+
+    await useCase.execute('cs_log_check', 'alice@example.com', {
+      url: 'https://buy.stripe.com/r/live_secret',
+      expiresAt: null,
+    });
+
+    expect(infoSpy).toHaveBeenCalledWith('checkout.session.expired.recovery_url', {
+      present: true,
+      session_id_hash: 'hashed:cs_log_check',
+    });
+    const logged = infoSpy.mock.calls.map((c) => JSON.stringify(c)).join('\n');
+    expect(logged).not.toContain('live_secret');
+    infoSpy.mockRestore();
+  });
+
+  it('logs recovery URL absence when Stripe omitted it', async () => {
+    const repo = makeRepo(true);
+    const emailService = makeEmailService();
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(repo, emailService);
+
+    await useCase.execute('cs_no_recovery', 'alice@example.com');
+
+    expect(infoSpy).toHaveBeenCalledWith('checkout.session.expired.recovery_url', {
+      present: false,
+      session_id_hash: 'hashed:cs_no_recovery',
+    });
+    infoSpy.mockRestore();
   });
 
   it('passes a non-empty token to the email service', async () => {
@@ -92,7 +148,8 @@ describe('SendAbandonedCheckoutRecoveryOnExpiryUseCase', () => {
     expect(repo.claimSession).toHaveBeenCalledWith(
       'cs_test_abc123',
       'alice@example.com',
-      expect.any(String)
+      expect.any(String),
+      null
     );
     expect(emailService.sendAbandonedCheckoutRecoveryEmail).not.toHaveBeenCalled();
   });
@@ -134,6 +191,7 @@ describe('SendAbandonedCheckoutRecoveryOnExpiryUseCase', () => {
       }),
       recordEmailSend: jest.fn().mockResolvedValue(undefined),
       isMarketingOptedOut: jest.fn().mockResolvedValue(false),
+      getRecoveryByToken: jest.fn().mockResolvedValue(null),
     };
     const emailService = makeEmailService();
     const useCase = new SendAbandonedCheckoutRecoveryOnExpiryUseCase(repo, emailService);

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryOnExpiryUseCase.ts
@@ -1,5 +1,8 @@
 import hashToken from '../../lib/misc/hashToken';
-import type { IAbandonedCheckoutRecoveryRepository } from '../../data_layer/AbandonedCheckoutRecoveryRepository';
+import type {
+  CheckoutRecoveryDetails,
+  IAbandonedCheckoutRecoveryRepository,
+} from '../../data_layer/AbandonedCheckoutRecoveryRepository';
 import type { IEmailService } from '../../services/EmailService/EmailService';
 import type { EventsSink } from '../../services/events/EventsSink';
 
@@ -10,13 +13,22 @@ export class SendAbandonedCheckoutRecoveryOnExpiryUseCase {
     private readonly eventsSink?: Pick<EventsSink, 'record'>
   ) {}
 
-  async execute(sessionId: string, email: string | null): Promise<void> {
+  async execute(
+    sessionId: string,
+    email: string | null,
+    recovery: CheckoutRecoveryDetails | null = null
+  ): Promise<void> {
     if (email == null) {
       console.warn('checkout.session.expired.no_email', {
         session_id_hash: hashToken(sessionId),
       });
       return;
     }
+
+    console.info('checkout.session.expired.recovery_url', {
+      present: recovery != null,
+      session_id_hash: hashToken(sessionId),
+    });
 
     const optedOut = await this.repository.isMarketingOptedOut(email);
     if (optedOut) {
@@ -27,7 +39,7 @@ export class SendAbandonedCheckoutRecoveryOnExpiryUseCase {
     }
 
     const token = crypto.randomUUID();
-    const claimed = await this.repository.claimSession(sessionId, email, token);
+    const claimed = await this.repository.claimSession(sessionId, email, token, recovery);
     if (claimed) {
       await this.emailService.sendAbandonedCheckoutRecoveryEmail(email, token);
       console.info('checkout.session.expired.recovery_sent', {

--- a/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.test.ts
+++ b/src/usecases/ops/SendAbandonedCheckoutRecoveryUseCase.test.ts
@@ -31,6 +31,7 @@ function makeRepo(optedOut = false): jest.Mocked<IAbandonedCheckoutRecoveryRepos
     claimSession: jest.fn().mockResolvedValue(true),
     recordEmailSend: jest.fn().mockResolvedValue(undefined),
     isMarketingOptedOut: jest.fn().mockResolvedValue(optedOut),
+    getRecoveryByToken: jest.fn().mockResolvedValue(null),
   };
 }
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-checkout-resume.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-checkout-resume.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-checkout-resume",
+  "date": "2026-06-05",
+  "type": "feature",
+  "title": "Pick up an unfinished checkout right where you left off — the reminder email now links straight back to payment"
+}


### PR DESCRIPTION
## What
Recovery emails for abandoned checkouts now take the buyer straight back to payment instead of restarting at `/pricing`. All three Stripe Checkout creates (Unlimited, Auto Sync, passes) enable `after_expiration.recovery`; the `checkout.session.expired` webhook stores the Stripe-minted recovery URL against the existing per-session claim row; the email CTA links to a new `GET /checkout/resume?token=<uuid>` endpoint that 302s to the Stripe recovery URL — or to `/pricing?from=recovery` when the token is unknown, expired, or has no stored URL. Recovered conversions are stamped `recovered: true` on `checkout_completed` via Stripe's `recovered_from`.

## Why
Closes #3002. Prod funnel showed 147 `paywall_upgrade_clicked` → 16 `checkout_completed` over 8 days; the recovery email targeted that gap but restarted the whole flow. The Stripe recovery URL is a one-click copy of the abandoned session — card entry is the only remaining step. Scope is items 1 + 2 of the issue; item 3 (earlier trigger) is explicitly deferred until we can size warm-abandoner volume, and item 4 (allowlist work) is mooted because the CTA routes through our own endpoint.

## How
- Migration adds nullable `recovery_url` + `recovery_url_expires_at` to `abandoned_checkout_recovery_emails` (kanel regen not run here — repository uses its own row type; `pnpm kanel` on next migration cycle picks it up).
- `SendAbandonedCheckoutRecoveryOnExpiryUseCase` takes an optional recovery param, persists it through `claimSession`, and logs `checkout.session.expired.recovery_url { present }` — the shadow test the issue asked for. Watch this log to confirm Stripe attaches the URL on real expiries.
- `ResumeAbandonedCheckoutUseCase` validates the token (UUID shape before any DB hit), checks expiry, and only ever redirects to `https` URLs on `stripe.com`/`*.stripe.com`; everything else falls back to pricing. Never fails user-visibly.
- The bulk send path (`SendAbandonedCheckoutRecoveryUseCase`) is untouched — its tokens have no stored recovery URL, so its emails resolve to the same `/pricing?from=recovery` destination as before, now with click tracking.

## Measuring success
- `email_clicked { campaign: 'abandoned_checkout', resumed: true|false }` — click-through and resume rate of the recovery email.
- `checkout_completed { recovered: true }` — recovered conversions, joinable to revenue.
- `checkout.session.expired.recovery_url { present }` in prod logs — validates the issue's open question about the payload shape.

## Testing
- Unit tests added/extended: `ResumeAbandonedCheckoutUseCase` (token expiry, unknown/malformed token, host allowlist, resume lands on the stored Stripe URL), `ResumeCheckoutController` (302 targets + events), `SendAbandonedCheckoutRecoveryOnExpiryUseCase` (recovery passthrough, presence logging without leaking the URL, marketing_opt_out exclusion and no-double-send retained), `WebhookRouter` (recovery extraction incl. null case, `recovered` attribution), all three checkout use cases (`after_expiration` param), `EmailService` (CTA + unsubscribe link), repository in-memory contract.
- Full server suite green except `runParserCanary`/`DeckParser` which fail in this worktree for a known environmental reason (missing `create_deck` Python venv) — unrelated to this diff; CI runs them with the venv.
- Sonar: not run locally — `SONAR_TOKEN` unset in this environment; expect the CI analysis on the PR.

## Browser check
Browser check: not applicable — only `web/src/` file is a changelog JSON entry (changelog-only diff)

## Changelog
"Pick up an unfinished checkout right where you left off — the reminder email now links straight back to payment" (`web/src/pages/WhatsNewPage/changelog/2026-06-05-checkout-resume.json`)

## Security review
Self-review against `.claude/rules/security.md` — **Alexander: please still run `/security-review` before merge (payments surface).**
- Resume token: existing `crypto.randomUUID()` (CSPRNG, no Math.random / S2245); 1:1 unique-column mapping token→session row, so no cross-user resolution (the issue's stated risk). Expiry enforced from Stripe's `after_expiration.recovery.expires_at`; expired tokens fall back to pricing.
- Open redirect: the endpoint redirects only to (a) a URL received inside a signature-verified Stripe webhook (raw-body HMAC via `stripe.webhooks.constructEvent`, unchanged) and re-validated at redirect time as `https` + `stripe.com`/`*.stripe.com`, or (b) the fixed relative `/pricing?from=recovery`. No user-controlled destination reaches `res.redirect`.
- CWE-532: recovery URL and token are never logged — presence boolean + hashed session id only; a test asserts the URL doesn't leak into logs. Events carry only `campaign` + `resumed`.
- Injection: token checked against a UUID regex before any DB lookup; query-builder only, no `knex.raw`.
- ID presence checks use `value == null`.
- Commercial-email rules intact: `{{unsubscribeUrl}}` kept (test), `marketing_opt_out` exclusion and `claimSession` idempotency unchanged (tests).

## Risks
- If Stripe omits `recovery.url` on expiry (open question in the issue), behavior degrades to exactly today's flow — email still sends, CTA falls back to `/pricing?from=recovery`. The presence log tells us within ~24h of the first real expiry.
- `after_expiration` on session create is rejected only for `ui_mode: elements` (we use hosted) — verified against Stripe API reference for v22 types; covered by create-param tests.
- Rollback: revert the PR; the two new columns are nullable and inert.

## Goal alignment
Directly attacks the largest measured leak in landing → paid (147 upgrade clicks → 16 completions). Fewer abandoned checkouts = more paying users funding the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783276791&installation_id=132681956&pr_number=3130&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3130&signature=0b2aeb1431e7515c0c7488293d7e17d8f9d1d900c7268431b952a2236fcc9d17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->