### PR TITLE
fix: accept HEIC, HEIF, and untyped photos on photo-to-deck

### DIFF
--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PhotoToFlashcardsPage } from './PhotoToFlashcardsPage';
+import { prepareImageForVision } from '../../lib/image/prepareImageForVision';
 
 function renderPage() {
   return render(
@@ -135,7 +136,9 @@ describe('PhotoToFlashcardsPage', () => {
     const input = document.getElementById('photo-file-input') as HTMLInputElement;
     const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
     fireEvent.change(input, { target: { files: [pdf] } });
-    expect(screen.getByText('Use JPEG, PNG, WebP, or GIF.')).toBeTruthy();
+    expect(
+      screen.getByText('Use a photo format like JPEG, PNG, WebP, GIF, or HEIC.')
+    ).toBeTruthy();
   });
 
   it('rejects photos over 10 MB', () => {
@@ -145,6 +148,68 @@ describe('PhotoToFlashcardsPage', () => {
     const oversized = makePhoto('big.jpg', 'image/jpeg', 11 * 1024 * 1024);
     fireEvent.change(input, { target: { files: [oversized] } });
     expect(screen.getByText('Photo is over the 10 MB limit. Try a smaller image.')).toBeTruthy();
+  });
+
+  it.each([
+    ['iphone.heic', 'image/heic'],
+    ['samsung.heif', 'image/heif'],
+  ])('accepts %s (%s)', (name, type) => {
+    setLocals({ paying: true });
+    renderPage();
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto(name, type)] } });
+    expect(screen.getByRole('button', { name: `Remove ${name}` })).toBeTruthy();
+    expect(document.querySelector('[class*="notificationDanger"]')).toBeNull();
+  });
+
+  it('accepts a photo with an empty MIME type', () => {
+    setLocals({ paying: true });
+    renderPage();
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto('android-pick.jpg', '')] } });
+    expect(screen.getByRole('button', { name: 'Remove android-pick.jpg' })).toBeTruthy();
+    expect(document.querySelector('[class*="notificationDanger"]')).toBeNull();
+  });
+
+  it('rejects an oversized photo even when the MIME type is empty', () => {
+    setLocals({ paying: true });
+    renderPage();
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { files: [makePhoto('huge.heic', '', 11 * 1024 * 1024)] },
+    });
+    expect(screen.getByText('Photo is over the 10 MB limit. Try a smaller image.')).toBeTruthy();
+  });
+
+  it('shows the decode error per photo when the image cannot be read', async () => {
+    setLocals({ paying: true });
+    vi.mocked(prepareImageForVision).mockRejectedValueOnce(
+      new Error('Could not read the image')
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderPage();
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePhoto('broken.heic', 'image/heic')] } });
+    fireEvent.click(screen.getByText('Get cards'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not read the image')).toBeTruthy();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('lists HEIC and HEIF in the file picker accept attribute', () => {
+    renderPage();
+    const input = document.getElementById('photo-file-input') as HTMLInputElement;
+    const camera = document.getElementById('photo-camera-input') as HTMLInputElement;
+    for (const accept of [input.accept, camera.accept]) {
+      expect(accept).toContain('image/heic');
+      expect(accept).toContain('image/heif');
+      expect(accept).toContain('.heic');
+      expect(accept).toContain('.heif');
+    }
   });
 
   it('shows the specific 404 message when the route is disabled', async () => {
@@ -656,7 +721,9 @@ describe('PhotoToFlashcardsPage', () => {
       const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
       fireEvent.change(input, { target: { files: [makePhoto('ok.jpg'), pdf] } });
       expect(getThumbnails()).toHaveLength(1);
-      expect(screen.getByText('Use JPEG, PNG, WebP, or GIF.')).toBeTruthy();
+      expect(
+        screen.getByText('Use a photo format like JPEG, PNG, WebP, GIF, or HEIC.')
+      ).toBeTruthy();
     });
 
     it('exposes a multiple-file input so picker allows in-batch multi-select', () => {

--- a/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
+++ b/web/src/pages/PhotoToFlashcardsPage/PhotoToFlashcardsPage.tsx
@@ -6,9 +6,20 @@ import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabe
 import { track } from '../../lib/analytics/track';
 import styles from '../../styles/shared.module.css';
 import pageStyles from './PhotoToFlashcardsPage.module.css';
-import { prepareImageForVision } from '../../lib/image/prepareImageForVision';
+import {
+  prepareImageForVision,
+  type PreparedImage,
+} from '../../lib/image/prepareImageForVision';
 
-const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+const ALLOWED_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+];
+const PICKER_ACCEPT = [...ALLOWED_TYPES, '.heic', '.heif'].join(',');
 const MAX_SIZE_BYTES = 10 * 1024 * 1024;
 
 type Status = 'idle' | 'reading' | 'done';
@@ -73,11 +84,11 @@ function makePhotoId(): string {
 }
 
 function validatePhoto(file: File): string | null {
-  if (!ALLOWED_TYPES.includes(file.type)) {
-    return 'Use JPEG, PNG, WebP, or GIF.';
-  }
   if (file.size > MAX_SIZE_BYTES) {
     return 'Photo is over the 10 MB limit. Try a smaller image.';
+  }
+  if (file.type !== '' && !ALLOWED_TYPES.includes(file.type)) {
+    return 'Use a photo format like JPEG, PNG, WebP, GIF, or HEIC.';
   }
   return null;
 }
@@ -209,7 +220,17 @@ export function PhotoToFlashcardsPage() {
     photo: SelectedPhoto,
     name: string
   ): Promise<{ cardCount: number } | { error: string }> => {
-    const prepared = await prepareImageForVision(photo.file);
+    let prepared: PreparedImage;
+    try {
+      prepared = await prepareImageForVision(photo.file);
+    } catch (decodeError) {
+      return {
+        error:
+          decodeError instanceof Error
+            ? decodeError.message
+            : 'Could not read the image',
+      };
+    }
 
     const res = await fetch('/api/image-occlusion/photo-to-deck', {
       method: 'POST',
@@ -406,7 +427,7 @@ export function PhotoToFlashcardsPage() {
             ref={cameraInputRef}
             id="photo-camera-input"
             type="file"
-            accept={ALLOWED_TYPES.join(',')}
+            accept={PICKER_ACCEPT}
             capture="environment"
             onChange={handleCameraInput}
             hidden
@@ -428,7 +449,8 @@ export function PhotoToFlashcardsPage() {
                 Drop photos, paste, or click to add
               </span>
               <span className={pageStyles.dropzoneHint}>
-                JPEG, PNG, WebP, GIF — up to 10 MB each. Add as many as you need.
+                JPEG, PNG, WebP, GIF, HEIC — up to 10 MB each. Add as many as
+                you need.
               </span>
             </>
           ) : (
@@ -445,7 +467,7 @@ export function PhotoToFlashcardsPage() {
             ref={fileInputRef}
             id="photo-file-input"
             type="file"
-            accept={ALLOWED_TYPES.join(',')}
+            accept={PICKER_ACCEPT}
             multiple
             onChange={handleFileInput}
             hidden

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-iphone-photos.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-iphone-photos.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-iphone-photos",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "Photo to deck accepts iPhone and Samsung photos (HEIC and HEIF)"
+}


### PR DESCRIPTION
## What
The photo-to-deck upload validator accepts iPhone HEIC (`image/heic`), Samsung HEIF (`image/heif`), and files with an empty `file.type` (common from Android Files-app picks). Both file inputs' `accept` attributes now list the HEIC/HEIF MIME types plus `.heic`/`.heif` extensions for mobile pickers, and a decode failure surfaces a clear per-photo error instead of the generic crash message.

## Why
Closes #3125. Mobile users — the primary photo-to-deck audience — were blocked at the picker with "Use JPEG, PNG, WebP, or GIF." even though every photo is re-encoded to JPEG via canvas before the Claude call. Browser decodability is the only real requirement.

## How
- Size check runs first (no decoding of oversized files), then MIME: the existing 4 types + `image/heic` + `image/heif` + empty string.
- `prepareImageForVision`'s `loadImage` remains the real gate: a browser that can't decode HEIC (e.g. Chrome on Windows) fails with "Could not read the image" — now mapped to a per-photo error in `convertOnePhoto` instead of falling through to the generic catch.
- Rejection copy updated to "Use a photo format like JPEG, PNG, WebP, GIF, or HEIC." and the dropzone hint lists HEIC.

## Measuring success
`photo_upload_started` events from iOS Safari user agents should rise; support reports matching "photo format rejected" on `/photo-to-deck` should stop.

## Testing
- Unit tests added: HEIC-typed and HEIF-typed files accepted, empty-MIME file accepted, oversized file still rejected (including with empty MIME), `application/pdf` still rejected, decode failure shows "Could not read the image" per photo, both `accept` attributes carry HEIC/HEIF MIME types and extensions.
- Full web suite: 1722/1722 green. Typecheck + Biome lint green.
- Sonar: not run locally — `SONAR_TOKEN` unset on this machine; small validator-scoped diff, expecting CI analysis to cover it.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: manual pass or waiver needed — change is picker/validator behavior; verify a HEIC photo from an iPhone uploads on Safari.

## Changelog
"Photo to deck accepts iPhone and Samsung photos (HEIC and HEIF)" — `web/src/pages/WhatsNewPage/changelog/2026-06-05-iphone-photos.json`

## Risks
A browser that passes validation but can't decode HEIC (Chrome/Windows) now fails at convert time with "Could not read the image" — honest but later than before. Rollback: revert the single commit.

## Goal alignment
Photo to deck is a mobile-first conversion surface; HEIC is the default capture format on iPhone. Removing the rejection unblocks the largest mobile cohort at the first step of the funnel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783278850&installation_id=132681956&pr_number=3133&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3133&signature=724077d6b2cd5dcd2591b2c415814befb164d434fb3e566d248d6613a527ad7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->