### PR TITLE
fix: guard package generation against empty parse results

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -779,6 +779,58 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     expect(updateMock).toHaveBeenCalledTimes(1);
     expect(updateMock.mock.calls[0][4]).toBeNull();
   });
+
+  async function runAsyncUploadThatRejects(rejection: unknown): Promise<jest.Mock> {
+    let resolveFailed!: () => void;
+    const failedRecorded = new Promise<void>((r) => {
+      resolveFailed = r;
+    });
+    const updateJobStatusMock = jest
+      .fn()
+      .mockImplementation((_id: string, _owner: string, status: string) => {
+        if (status === 'failed') {
+          resolveFailed();
+        }
+        return Promise.resolve(undefined);
+      });
+    const jobRepository = {
+      create: jest.fn().mockResolvedValue(undefined),
+      updateJobStatus: updateJobStatusMock,
+      findJobById: jest.fn().mockResolvedValue(null),
+      deleteJob: jest.fn().mockResolvedValue(undefined),
+    } as unknown as JobRepository;
+
+    MockGeneratePackagesUseCase.mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(rejection),
+    }) as unknown as InstanceType<typeof GeneratePackagesUseCase>);
+
+    const service = new UploadService(buildRepository(), jobRepository, buildUsersRepo());
+    const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+    await failedRecorded;
+    return updateJobStatusMock;
+  }
+
+  it('records a non-empty failure reason when the worker rejects with an empty-message error', async () => {
+    const updateJobStatusMock = await runAsyncUploadThatRejects(new Error(''));
+
+    const failedCall = updateJobStatusMock.mock.calls.find((call) => call[2] === 'failed');
+    expect(failedCall).toBeDefined();
+    const reason = failedCall?.[3] as string;
+    expect(typeof reason).toBe('string');
+    expect(reason.trim()).not.toBe('');
+  });
+
+  it('records the designed empty-deck reason when the worker rejects with EmptyDeckError', async () => {
+    const updateJobStatusMock = await runAsyncUploadThatRejects(new EmptyDeckError());
+
+    const failedCall = updateJobStatusMock.mock.calls.find((call) => call[2] === 'failed');
+    expect(failedCall).toBeDefined();
+    expect(failedCall?.[3]).toMatch(/^No cards in this deck yet\./);
+  });
 });
 
 describe('UploadService.handleUpload — multi-deck batch', () => {

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -17,7 +17,10 @@ import { isLimitError } from '../lib/misc/isLimitError';
 import { handleUploadLimitError } from '../controllers/Upload/helpers/handleUploadLimitError';
 import { getUploadValidationError } from '../lib/upload/getUploadValidationError';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
-import { MARKDOWN_LIKELY_LOSSY_REASON } from '../usecases/jobs/jobFailureReason';
+import {
+  MARKDOWN_LIKELY_LOSSY_REASON,
+  jobFailureReasonFromError,
+} from '../usecases/jobs/jobFailureReason';
 import { DeckTooLargeError } from '../lib/parser/exporters/DeckTooLargeError';
 import { getOwner } from '../lib/User/getOwner';
 import { formatDeckName } from '../lib/formatDeckName';
@@ -104,6 +107,20 @@ function walkMediaFiles(dir: string): string[] {
     }
   }
   return results;
+}
+
+function resolveAsyncFailureReason(
+  err: unknown,
+  message: string,
+  jobId: string
+): string {
+  const isParserCrash =
+    err instanceof Error &&
+    (err as Error & { code?: string }).code === 'PARSER_CRASH';
+  if (err instanceof EmptyDeckError || isParserCrash || message.trim() === '') {
+    return jobFailureReasonFromError(err, jobId);
+  }
+  return message;
 }
 
 function logNoPackageDiagnostics(uploadedFiles: UploadedFile[]) {
@@ -398,7 +415,8 @@ class UploadService {
         } else {
           console.error('[UploadService] async job failed', { jobId: ws.id, message, err });
         }
-        await this.jobRepository.updateJobStatus(ws.id, owner, 'failed', message);
+        const reason = resolveAsyncFailureReason(err, message, ws.id);
+        await this.jobRepository.updateJobStatus(ws.id, owner, 'failed', reason);
       });
 
     return res.status(202).json({ jobId: ws.id });

--- a/src/usecases/uploads/GeneratePackagesUseCase.test.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.test.ts
@@ -152,6 +152,67 @@ describe('GeneratePackagesUseCase', () => {
     await expect(promise).rejects.toBeInstanceOf(EmptyDeckError);
   });
 
+  it('rejects with a non-empty parser-crash error when the worker error has no message', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('garbled.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', { type: 'error' });
+
+    const err = await promise.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message.trim()).not.toBe('');
+    expect((err as Error & { code?: string }).code).toBe('PARSER_CRASH');
+  });
+
+  it('rejects with a non-empty parser-crash error when the worker error message is blank', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('garbled.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', { type: 'error', message: '  ' });
+
+    const err = await promise.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message.trim()).not.toBe('');
+    expect((err as Error & { code?: string }).code).toBe('PARSER_CRASH');
+  });
+
+  it('preserves the markdown sourceFormat on EmptyDeckError across the worker boundary', async () => {
+    const emitter = makeWorkerEmitter();
+    const useCase = new GeneratePackagesUseCase();
+
+    const promise = useCase.execute(
+      false,
+      [makeFile('flat-export.md')],
+      makeSettings(),
+      makeWorkspace()
+    );
+
+    emitter.emit('message', {
+      type: 'error',
+      message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
+      name: 'EmptyDeckError',
+      sourceFormat: 'markdown',
+    });
+
+    const err = await promise.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(EmptyDeckError);
+    expect((err as EmptyDeckError).sourceFormat).toBe('markdown');
+  });
+
   it('preserves error name on the rejected Error for non-EmptyDeckError named errors', async () => {
     const emitter = makeWorkerEmitter();
     const useCase = new GeneratePackagesUseCase();

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -14,8 +14,34 @@ export interface PackageResult {
 
 type ProgressMessage = { type: 'progress'; step: string };
 type ResultMessage = { type: 'result'; packages: Package[]; warnings?: string[] };
-type ErrorMessage = { type: 'error'; message: string; name?: string };
+type ErrorMessage = {
+  type: 'error';
+  message?: string;
+  name?: string;
+  sourceFormat?: 'markdown';
+};
 type WorkerMessage = ProgressMessage | ResultMessage | ErrorMessage;
+
+function buildWorkerError(msg: ErrorMessage): Error {
+  if (msg.name === 'EmptyDeckError') {
+    return new EmptyDeckError(msg.sourceFormat);
+  }
+  if (msg.message != null && msg.message.trim() !== '') {
+    const e = new Error(msg.message);
+    if (msg.name != null) {
+      e.name = msg.name;
+    }
+    return e;
+  }
+  const fallback = new Error(
+    'Upload worker reported an error without a message'
+  ) as Error & { code: string };
+  fallback.code = 'PARSER_CRASH';
+  if (msg.name != null) {
+    fallback.name = msg.name;
+  }
+  return fallback;
+}
 
 class GeneratePackagesUseCase {
   execute(
@@ -43,15 +69,7 @@ class GeneratePackagesUseCase {
         if (msg.type === 'progress') {
           onProgress?.(msg.step);
         } else if (msg.type === 'error') {
-          if (msg.name === 'EmptyDeckError') {
-            reject(new EmptyDeckError());
-          } else {
-            const e = new Error(msg.message);
-            if (msg.name != null) {
-              e.name = msg.name;
-            }
-            reject(e);
-          }
+          reject(buildWorkerError(msg));
         } else {
           resolve({ packages: msg.packages ?? [], warnings: msg.warnings });
         }

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -23,6 +23,7 @@ import {
   buildVocabDeckFromEpub,
   buildVocabDeckFromKindleClippings,
 } from './BuildVocabDeckUseCase';
+import { EmptyDeckError } from '../jobs/EmptyDeckError';
 
 interface GenerationData {
   paying: boolean;
@@ -202,6 +203,7 @@ if (workerData != null) {
         type: 'error',
         message: err instanceof Error ? err.message : String(err),
         name: err instanceof Error ? err.name : undefined,
+        sourceFormat: err instanceof EmptyDeckError ? err.sourceFormat : undefined,
       })
     );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-05-empty-export-crash.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-05-empty-export-crash.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-05-empty-export-crash",
+  "date": "2026-06-05",
+  "type": "fix",
+  "title": "Uploads that produce no cards show what to fix instead of failing silently"
+}


### PR DESCRIPTION
## What
Recurring prod crash signature traced and closed. Every error thrown inside the upload worker thread is re-created in the parent at `new Error(msg.message)` in `GeneratePackagesUseCase`, so pm2 stack traces always point at that line regardless of where the worker actually failed. When the worker's error shape carried no usable message, that rebuild fabricated an empty-message error, and `handleAsyncUpload` wrote the empty string straight into `job_reason_failure`. This PR makes the rebuild safe, preserves `EmptyDeckError.sourceFormat` across the thread boundary, and guarantees every failed async job records the designed, non-empty failure reason.

## Symptom (sanitized)
```
Error: Cannot read properties of undefined (reading 'name')
    at Worker.<anonymous> (src/usecases/uploads/GeneratePackagesUseCase.ts:43:18)
```
and, at the same frame, bare `Error: ` entries with an empty message. Prod logs (May 19-24) show both. The `reading 'name'` message originates inside the worker tree (the `DeckParser.name` getter, guarded by #2656 — zero occurrences in prod logs after its deploy); the frame is the parent-side rebuild site, which is why the signature kept pointing at this file. The still-live defect is the empty-message rebuild: 3 jobs last week failed with `status='failed'` and an empty `job_reason_failure`, each within ~1s of creation.

## Why it broke
The parent assumed every worker error message is a non-empty string (`new Error(msg.message)`); the worker boundary can deliver shapes without one, producing `Error: ''`. Separately, `EmptyDeckError` was rebuilt as `new EmptyDeckError()` with no arguments, dropping the `markdown` source flavor, and the async failure path stored raw `err.message` instead of the designed reason copy, so zero-card uploads never showed the "No cards in this deck yet…" teaching copy on the Downloads page.

## How the fix works
- `buildWorkerError` (GeneratePackagesUseCase): missing/blank worker error message → non-empty `PARSER_CRASH`-coded error instead of an empty one; `EmptyDeckError` is rebuilt with its `sourceFormat`.
- `worker.ts` posts `sourceFormat` alongside the error name.
- `resolveAsyncFailureReason` (UploadService): `EmptyDeckError`, parser crashes, and blank messages route through `jobFailureReasonFromError(err, jobId)` — every failed job gets a designed, non-empty reason. All other reasons (pdf-password sentinel, Claude parse errors, docx failures) keep their existing raw messages, so dependent flows are untouched.

## Regression test
- `src/usecases/uploads/GeneratePackagesUseCase.test.ts`: worker error with no message / blank message rejects with a non-empty `PARSER_CRASH` error; `EmptyDeckError.sourceFormat === 'markdown'` survives the thread boundary. All three fail on main.
- `src/services/UploadService.test.ts`: async job failing with an empty-message error records a non-empty `job_reason_failure`; `EmptyDeckError` records the designed "No cards in this deck yet." reason. Both fail on main.
Verified round-trip: `git stash && pnpm test` → 5 failures; `git stash pop && pnpm test` → all green.

## What remains unverified
The original `reading 'name'` TypeError has not recurred in prod logs since #2656's deploy (2026-05-25 blue-green cutover onward shows zero occurrences); if a sibling unguarded `.name` read still exists in the worker tree, it will now surface with its real message and a non-empty job reason instead of this laundered signature, making it directly traceable.

Sonar: not run locally — `SONAR_TOKEN` unset in this environment; expect CI analysis on the PR.

Browser check: not applicable — server-side fix; the only `web/src/` file is a changelog entry (changelog-only bypass).

## Goal alignment
Conversions that fail must say why — a silent empty failure reads as a broken product and loses the user. Shipped fixes on the upload path compound retention toward 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783279150&installation_id=132681956&pr_number=3134&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3134&signature=db34a98b1fdd0fc39d07cf546609a20c5be6e0ff2cc4bd3258803c29c93edb94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->