### PR TITLE
feat: let the model name the deck in chat done frames

### DIFF
--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -227,6 +227,7 @@ class ChatController {
         ...(result.cards != null ? { cards: result.cards } : {}),
         ...(result.contentBefore != null ? { contentBefore: result.contentBefore } : {}),
         ...(result.contentAfter != null ? { contentAfter: result.contentAfter } : {}),
+        ...(result.deckName != null ? { deckName: result.deckName } : {}),
       });
     } catch (err) {
       emitChatError(res, err);
@@ -279,6 +280,7 @@ class ChatController {
         ...(result.cards != null ? { cards: result.cards } : {}),
         ...(result.contentBefore != null ? { contentBefore: result.contentBefore } : {}),
         ...(result.contentAfter != null ? { contentAfter: result.contentAfter } : {}),
+        ...(result.deckName != null ? { deckName: result.deckName } : {}),
       });
     } catch (err) {
       emitChatError(res, err);

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -273,6 +273,68 @@ describe('ChatUseCase', () => {
       expect(result.contentAfter).toBeUndefined();
     });
 
+    it('extracts a trailing Deck: line as deckName and strips it from contentBefore', async () => {
+      const cards = [{ front: 'Q1', back: 'A1' }];
+      const responseText = `Here are your cards:\nDeck: Cell Biology — Mitosis\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+      });
+
+      expect(result.deckName).toBe('Cell Biology — Mitosis');
+      expect(result.contentBefore).toBe('Here are your cards:');
+    });
+
+    it('returns deckName when the Deck: line is the only prose before the block', async () => {
+      const cards = [{ front: 'Q1', back: 'A1' }];
+      const responseText = `Deck: Spanish Verbs\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+      });
+
+      expect(result.deckName).toBe('Spanish Verbs');
+      expect(result.contentBefore).toBeUndefined();
+    });
+
+    it('does not treat a mid-prose Deck: mention as the deck name', async () => {
+      const cards = [{ front: 'Q1', back: 'A1' }];
+      const responseText = `Deck: building is fun, as I always say.\nHere you go:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+      });
+
+      expect(result.deckName).toBeUndefined();
+      expect(result.contentBefore).toBe(
+        'Deck: building is fun, as I always say.\nHere you go:'
+      );
+    });
+
+    it('omits deckName when no Deck: line is present', async () => {
+      const cards = [{ front: 'Q1', back: 'A1' }];
+      const responseText = `Here are your cards:\n\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;
+      const { useCase } = buildUseCase(responseText);
+
+      const result = await useCase.execute({
+        user: FREE_USER,
+        content: 'Make cards',
+        conversationHistory: [],
+      });
+
+      expect(result.deckName).toBeUndefined();
+      expect(result.contentBefore).toBe('Here are your cards:');
+    });
+
     it('normalizes stray cloze cards to plain front/back when templateSlug is basic', async () => {
       const cards = [{ front: 'The capital of {{c1::France}} is Paris.', back: '' }];
       const responseText = `\`\`\`json\n${JSON.stringify(cards)}\n\`\`\``;

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -101,6 +101,8 @@ Use {{c1::...}}, {{c2::...}}, {{c3::...}} for separate blanks within the same ca
 
 Never output raw JSON without the code fence. Always include the opening \`\`\`json and closing \`\`\` markers.
 
+On the line immediately before the JSON code block, write \`Deck: <name>\` — a short, descriptive deck name (max 60 characters) for the cards, e.g. \`Deck: Cell Biology — Mitosis\`. Don't mention the deck name in the prose; that line is metadata, not conversation.
+
 Supported input on 2anki:
 - Best: Notion HTML export (.zip with toggles — toggles become front/back automatically)
 - Also: Markdown (.md), CSV, plain HTML, .apkg (existing Anki decks), PDF, .docx, .pptx, .xlsx
@@ -158,6 +160,9 @@ export interface SendMessageResult {
   contentBefore?: string;
   contentAfter?: string;
   cards?: ChatCard[];
+  /// Model-chosen deck name (see ExtractCardsResult.deckName). Only present
+  /// when the turn produced cards.
+  deckName?: string;
 }
 
 function buildAutoTitle(firstMessage: string): string {
@@ -187,6 +192,23 @@ export interface ExtractCardsResult {
   cards: ChatCard[] | undefined;
   contentBefore: string | undefined;
   contentAfter: string | undefined;
+  /// Model-chosen deck name, parsed from a trailing `Deck: <name>` line in
+  /// the prose before the JSON block (see the system prompt). Stripped from
+  /// `contentBefore` so it never renders as conversation text.
+  deckName: string | undefined;
+}
+
+/// Matches a `Deck: <name>` line at the very END of the (trimmed) prose that
+/// precedes the JSON block. Anchored at end-of-string so a "Deck:" mention
+/// mid-prose is left alone.
+const DECK_NAME_LINE = /(?:^|\n)\s*Deck:\s*(.{1,80})$/i;
+
+function splitDeckName(before: string): { deckName?: string; rest: string } {
+  const match = DECK_NAME_LINE.exec(before);
+  if (match == null) return { rest: before };
+  const deckName = match[1].trim();
+  if (deckName.length === 0) return { rest: before };
+  return { deckName, rest: before.slice(0, match.index).trim() };
 }
 
 function asMcqChatCard(item: Record<string, unknown>): ChatCard | null {
@@ -277,10 +299,12 @@ export function extractCards(text: string, mcqAllowed = false, forbidCloze = fal
     if (cards != null) {
       const before = text.slice(0, fencedMatch.index).trim();
       const after = text.slice(fencedMatch.index + fencedMatch[0].length).trim();
+      const { deckName, rest } = splitDeckName(before);
       return {
         cards,
-        contentBefore: before.length > 0 ? before : undefined,
+        contentBefore: rest.length > 0 ? rest : undefined,
         contentAfter: after.length > 0 ? after : undefined,
+        deckName,
       };
     }
   }
@@ -291,15 +315,22 @@ export function extractCards(text: string, mcqAllowed = false, forbidCloze = fal
     if (cards != null) {
       const before = text.slice(0, rawMatch.index).trim();
       const after = text.slice(rawMatch.index + rawMatch[0].length).trim();
+      const { deckName, rest } = splitDeckName(before);
       return {
         cards,
-        contentBefore: before.length > 0 ? before : undefined,
+        contentBefore: rest.length > 0 ? rest : undefined,
         contentAfter: after.length > 0 ? after : undefined,
+        deckName,
       };
     }
   }
 
-  return { cards: undefined, contentBefore: undefined, contentAfter: undefined };
+  return {
+    cards: undefined,
+    contentBefore: undefined,
+    contentAfter: undefined,
+    deckName: undefined,
+  };
 }
 
 export class ChatConversationNotFoundError extends Error {
@@ -544,7 +575,7 @@ export class ChatUseCase {
     await this.persistAssistantTurn(user.owner, conversationId, assistantContent);
 
     const forbidCloze = templateForbidsCloze(resolvedTemplate);
-    const { cards, contentBefore, contentAfter } = extractCards(
+    const { cards, contentBefore, contentAfter, deckName } = extractCards(
       assistantContent,
       mcqAllowed,
       forbidCloze
@@ -556,6 +587,7 @@ export class ChatUseCase {
       ...(cards != null ? { cards } : {}),
       ...(contentBefore != null ? { contentBefore } : {}),
       ...(contentAfter != null ? { contentAfter } : {}),
+      ...(deckName != null ? { deckName } : {}),
     };
   }
 


### PR DESCRIPTION
## What

Chat's deck names are currently derived client-side from the user's prompt (first ~60 chars) — producing names like *"make me cards about the krebs cycle pls"*. This lets the model pick the name instead.

## How

- **System prompt:** asks for a `Deck: <name>` line (≤60 chars) immediately before the JSON code block.
- **`extractCards`:** parses that **trailing** line (regex anchored at end-of-prose — a mid-sentence "Deck:" mention is left alone), strips it from `contentBefore` so it never renders as conversation text, returns it as `deckName`.
- **SSE done frames** (send + regenerate): optional `deckName` field. Unknown-key-tolerant clients (web, current native builds) ignore it — **non-breaking** either way.
- History path (`ConversationsUseCase`) inherits the stripping automatically via the shared `extractCards`.
- MCQ tool-use turns have no prose → no `deckName`; clients keep their heuristic fallback.

## Companion

Native app PR (consumes `deckName`, falls back to the prompt heuristic) follows in `Laer-Smart/2anki` — works regardless of which side ships first.

## Verification

- 314 tests pass (4 new: trailing-line extraction, only-prose-is-deck-line, mid-prose mention ignored, absent → undefined).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783279741&installation_id=132681956&pr_number=3135&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3135&signature=780451048b3c123b5d669baacfefcd39a8293c35af09a696ae98119fcf64374c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->