### PR TITLE
fix: capture scrubbed raw output for unknown upload errors

### DIFF
--- a/src/lib/anki/scrubPythonRawOutput.test.ts
+++ b/src/lib/anki/scrubPythonRawOutput.test.ts
@@ -1,0 +1,85 @@
+import {
+  buildUnknownPythonErrorContext,
+  scrubPythonRawOutput,
+} from './scrubPythonRawOutput';
+import { PythonExitError } from './buildPythonExitError';
+
+describe('scrubPythonRawOutput', () => {
+  it('keeps python file basenames from traceback paths', () => {
+    const raw =
+      'Traceback (most recent call last):\n  File "/app/create_deck/create_deck.py", line 12, in <module>';
+    expect(scrubPythonRawOutput(raw)).toBe(
+      'Traceback (most recent call last):\n  File "create_deck.py", line 12, in <module>'
+    );
+  });
+
+  it('redacts non-python absolute paths', () => {
+    const raw = "FileNotFoundError: /workspace/123/uploads/secret-notes.html";
+    expect(scrubPythonRawOutput(raw)).toBe('FileNotFoundError: [path]');
+  });
+
+  it('redacts quoted filenames containing user-named content', () => {
+    const raw =
+      "OSError: cannot open 'My Biology Deck Week 4.html' for reading";
+    expect(scrubPythonRawOutput(raw)).toBe(
+      'OSError: cannot open [file] for reading'
+    );
+  });
+
+  it('redacts email addresses', () => {
+    const raw = 'ValueError: bad value for student@example.com in field';
+    expect(scrubPythonRawOutput(raw)).toBe(
+      'ValueError: bad value for [email] in field'
+    );
+  });
+
+  it('redacts long token-like strings', () => {
+    const raw = `KeyError: secret_ntn_${'a'.repeat(40)}`;
+    expect(scrubPythonRawOutput(raw)).toBe('KeyError: [token]');
+  });
+
+  it('truncates output to 500 characters', () => {
+    const raw = 'KeyError: nested lookup failed\n'.repeat(100);
+    expect(scrubPythonRawOutput(raw)).toHaveLength(500);
+  });
+});
+
+describe('buildUnknownPythonErrorContext', () => {
+  it('returns context with scrubbed raw output for an unknown PythonExitError', () => {
+    const err = new PythonExitError('generic message', {
+      kind: 'unknown',
+      rawOutput: 'KeyError: /workspace/123/deck.html exploded',
+      code: 1,
+    });
+
+    expect(buildUnknownPythonErrorContext(err)).toEqual({
+      python_crash_kind: 'unknown',
+      python_exit_code: 1,
+      python_raw_output: 'KeyError: [path] exploded',
+    });
+  });
+
+  it('returns null for a classified PythonExitError', () => {
+    const err = new PythonExitError('markup message', {
+      kind: 'invalid-markup',
+      rawOutput: 'UserWarning: Field contained the following invalid HTML tags',
+      code: 1,
+    });
+
+    expect(buildUnknownPythonErrorContext(err)).toBeNull();
+  });
+
+  it('returns null for an unknown PythonExitError with empty raw output', () => {
+    const err = new PythonExitError('generic message', {
+      kind: 'unknown',
+      rawOutput: '',
+      code: null,
+    });
+
+    expect(buildUnknownPythonErrorContext(err)).toBeNull();
+  });
+
+  it('returns null for a plain Error', () => {
+    expect(buildUnknownPythonErrorContext(new Error('boom'))).toBeNull();
+  });
+});

--- a/src/lib/anki/scrubPythonRawOutput.test.ts
+++ b/src/lib/anki/scrubPythonRawOutput.test.ts
@@ -14,7 +14,7 @@ describe('scrubPythonRawOutput', () => {
   });
 
   it('redacts non-python absolute paths', () => {
-    const raw = "FileNotFoundError: /workspace/123/uploads/secret-notes.html";
+    const raw = 'FileNotFoundError: /workspace/123/uploads/secret-notes.html';
     expect(scrubPythonRawOutput(raw)).toBe('FileNotFoundError: [path]');
   });
 

--- a/src/lib/anki/scrubPythonRawOutput.ts
+++ b/src/lib/anki/scrubPythonRawOutput.ts
@@ -1,0 +1,40 @@
+import { PythonExitError } from './buildPythonExitError';
+
+const RAW_OUTPUT_MAX_LENGTH = 500;
+
+const QUOTED_FILENAME_PATTERN =
+  /(['"])[^'"\n]{0,200}\.(?:html?|md|markdown|csv|txt|zip|apkg|colpkg|pdf|png|jpe?g|gif|webp|xlsx)\1/gi;
+const ABSOLUTE_PATH_PATTERN = /(?:\/[\w.@%+~-]+){2,}/g;
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+const TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
+
+function redactPath(path: string): string {
+  const basename = path.slice(path.lastIndexOf('/') + 1);
+  return basename.endsWith('.py') ? basename : '[path]';
+}
+
+export function scrubPythonRawOutput(rawOutput: string): string {
+  return rawOutput
+    .replace(QUOTED_FILENAME_PATTERN, '[file]')
+    .replace(ABSOLUTE_PATH_PATTERN, redactPath)
+    .replace(EMAIL_PATTERN, '[email]')
+    .replace(TOKEN_PATTERN, '[token]')
+    .slice(0, RAW_OUTPUT_MAX_LENGTH);
+}
+
+export function buildUnknownPythonErrorContext(
+  err: Error
+): Record<string, unknown> | null {
+  if (
+    err instanceof PythonExitError &&
+    err.kind === 'unknown' &&
+    err.rawOutput !== ''
+  ) {
+    return {
+      python_crash_kind: err.kind,
+      python_exit_code: err.code,
+      python_raw_output: scrubPythonRawOutput(err.rawOutput),
+    };
+  }
+  return null;
+}

--- a/src/lib/anki/scrubPythonRawOutput.ts
+++ b/src/lib/anki/scrubPythonRawOutput.ts
@@ -2,10 +2,30 @@ import { PythonExitError } from './buildPythonExitError';
 
 const RAW_OUTPUT_MAX_LENGTH = 500;
 
-const QUOTED_FILENAME_PATTERN =
-  /(['"])[^'"\n]{0,200}\.(?:html?|md|markdown|csv|txt|zip|apkg|colpkg|pdf|png|jpe?g|gif|webp|xlsx)\1/gi;
+const SCRUBBED_FILE_EXTENSIONS = [
+  'html',
+  'htm',
+  'md',
+  'markdown',
+  'csv',
+  'txt',
+  'zip',
+  'apkg',
+  'colpkg',
+  'pdf',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'xlsx',
+];
+const QUOTED_FILENAME_PATTERN = new RegExp(
+  `(['"])[^'"\\n]{0,200}\\.(?:${SCRUBBED_FILE_EXTENSIONS.join('|')})\\1`,
+  'gi'
+);
 const ABSOLUTE_PATH_PATTERN = /(?:\/[\w.@%+~-]+){2,}/g;
-const EMAIL_PATTERN = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+const EMAIL_PATTERN = /[\w.+-]{1,64}@[\w-]{1,63}(?:\.[\w-]{1,63}){1,8}/g;
 const TOKEN_PATTERN = /\b[A-Za-z0-9_-]{32,}\b/g;
 
 function redactPath(path: string): string {

--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -193,7 +193,9 @@ describe('makeErrorCaptureMiddleware', () => {
     expect(context.python_crash_kind).toBe('unknown');
     expect(context.python_exit_code).toBe(1);
     expect(context.python_raw_output).toMatch(/^KeyError: \[path\] exploded/);
-    expect((context.python_raw_output as string).length).toBeLessThanOrEqual(500);
+    expect((context.python_raw_output as string).length).toBeLessThanOrEqual(
+      500
+    );
     expect(next).toHaveBeenCalledWith(err);
   });
 

--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -5,6 +5,7 @@ import {
   ErrorEventInsert,
 } from '../../data_layer/ErrorEventRepository';
 import { FallbackErrorPayload } from '../../lib/errorFallback';
+import { PythonExitError } from '../../lib/anki/buildPythonExitError';
 
 function makeRepository(
   existsResult = false
@@ -173,6 +174,53 @@ describe('makeErrorCaptureMiddleware', () => {
     ).resolves.not.toThrow();
 
     expect(next).toHaveBeenCalledWith(testError);
+  });
+
+  it('captures scrubbed raw output in context for an unknown PythonExitError', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+    const err = new PythonExitError('generic message', {
+      kind: 'unknown',
+      rawOutput: `KeyError: /workspace/123/deck.html exploded\n${'y'.repeat(2000)}`,
+      code: 1,
+    });
+
+    await middleware(err, makeReq(), makeRes(), next);
+
+    expect(repo.inserts).toHaveLength(1);
+    const context = repo.inserts[0].context as Record<string, unknown>;
+    expect(context.python_crash_kind).toBe('unknown');
+    expect(context.python_exit_code).toBe(1);
+    expect(context.python_raw_output).toMatch(/^KeyError: \[path\] exploded/);
+    expect((context.python_raw_output as string).length).toBeLessThanOrEqual(500);
+    expect(next).toHaveBeenCalledWith(err);
+  });
+
+  it('sets context to null for a classified PythonExitError', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+    const err = new PythonExitError('markup message', {
+      kind: 'invalid-markup',
+      rawOutput: 'UserWarning: Field contained the following invalid HTML tags',
+      code: 1,
+    });
+
+    await middleware(err, makeReq(), makeRes(), next);
+
+    expect(repo.inserts).toHaveLength(1);
+    expect(repo.inserts[0].context).toBeNull();
+  });
+
+  it('sets context to null for a plain Error', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+
+    await middleware(testError, makeReq(), makeRes(), next);
+
+    expect(repo.inserts[0].context).toBeNull();
   });
 
   it('calls writeFallback with db-outage phase when the repository insert fails', async () => {

--- a/src/routes/middleware/ErrorCaptureMiddleware.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.ts
@@ -6,6 +6,7 @@ import {
 } from '../../data_layer/ErrorEventRepository';
 import { FallbackErrorPayload } from '../../lib/errorFallback';
 import { resolveClientIp } from '../../lib/rateLimit/ipHelpers';
+import { buildUnknownPythonErrorContext } from '../../lib/anki/scrubPythonRawOutput';
 
 function sha256(value: string): string {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -47,6 +48,7 @@ export const makeErrorCaptureMiddleware = (
           release,
           ip_hash: ipHash,
           user_id: userId,
+          context: buildUnknownPythonErrorContext(err),
         };
         await repository.insert(row);
       }

--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -151,6 +151,25 @@ describe('ErrorHandler', () => {
     );
   });
 
+  test('never sends raw output to the client for an unknown PythonExitError', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    const err = new PythonExitError('generic message', {
+      kind: 'unknown',
+      rawOutput: 'KeyError: /workspace/123/deck.html exploded',
+      code: 1,
+    });
+
+    await ErrorHandler(res as unknown as express.Response, req, err);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json).toHaveBeenCalledWith({
+      code: 'unknown',
+      message: 'generic message',
+    });
+  });
+
   test('emits code=too_large for multer LIMIT_FILE_SIZE', async () => {
     const res = makeResponse(false);
     const req = makeRequest();


### PR DESCRIPTION
## What
Persists a scrubbed, truncated sample of the Python converter's raw output (stderr/stdout) whenever an upload error lands in the `'unknown'` UploadErrorCode bucket. The sample goes into the existing `error_events.context` jsonb via `ErrorCaptureMiddleware` — no new sink, no new table.

## Why
Fixes #2408. The `'unknown'` bucket is where unclassified Python crashes land, and today only the generic `err.message` ("Something went wrong on our end… job ID …") is stored. `PythonExitError.rawOutput` already carried the diagnostic signal but nothing persisted it, so there was no way to find the next failure class worth promoting to its own error code and bespoke copy.

## How
- New pure helper `src/lib/anki/scrubPythonRawOutput.ts`:
  - `scrubPythonRawOutput` redacts quoted user filenames (`'My Deck.html'` → `[file]`), non-Python absolute paths (`/workspace/…` → `[path]`, keeping `.py` basenames so tracebacks stay readable), emails (`[email]`), and 32+ char token-like strings (`[token]`), then truncates to 500 chars.
  - `buildUnknownPythonErrorContext` returns `{ python_crash_kind, python_exit_code, python_raw_output }` only for `PythonExitError` with `kind === 'unknown'` and non-empty raw output; null otherwise.
- `ErrorCaptureMiddleware` sets `context` on the inserted `error_events` row using that helper. Classified kinds (`invalid-markup`, `too-large`, …) and plain Errors get `context: null` — no extra capture.
- The client response in `ErrorHandler` is untouched; raw output never leaves the server (CWE-532 / CWE-209 guidance per the issue and `.claude/rules/security.md`).

## Measuring success
Ops query: `SELECT context->>'python_raw_output', count(*) FROM error_events WHERE source = 'server' AND context ? 'python_raw_output' GROUP BY 1 ORDER BY 2 DESC;` — after a week, bucket by message stem and pick the top-3 patterns per the issue.

## Testing
- Unit tests added:
  - `scrubPythonRawOutput.test.ts` — redaction of paths/filenames/emails/tokens, `.py` basename preservation, 500-char truncation, context builder gating (unknown vs classified vs plain Error vs empty raw output).
  - `ErrorCaptureMiddleware.test.ts` — unknown PythonExitError → row carries scrubbed/truncated context; classified PythonExitError and plain Error → `context: null`.
  - `ErrorHandler.test.ts` — response body for an unknown PythonExitError is exactly `{ code, message }`, no raw output.

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files in the diff.

## Changelog
No entry — internal-only observability, no user-visible change.

## Risks
Low. Capture is additive on the existing error path; the helper is pure and the middleware already fail-opens (fallback writer + `next(err)` on any capture failure). Scrubbing is conservative — if a redaction pattern over-matches, we lose diagnostic detail, never user privacy. Rollback: revert the single commit.

Sonar note: `sonar-scanner` not run locally — `SONAR_TOKEN` unset in this environment; change is small (one pure helper + one field on an insert), expect no findings.

## Goal alignment
Faster classification of conversion failures → better error copy → fewer abandoned uploads on the hot conversion path that drives the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783280648&installation_id=132681956&pr_number=3137&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3137&signature=3b2bab6f73963c07dd6652bd3f7f532197bb88e9f31d0f15a543b5208a05037f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->