### PR TITLE
fix: map Notion API failures to typed upload error codes

### DIFF
--- a/src/lib/notion/toNotionUploadError.test.ts
+++ b/src/lib/notion/toNotionUploadError.test.ts
@@ -1,0 +1,78 @@
+import { APIErrorCode, APIResponseError } from '@notionhq/client';
+
+import { toNotionUploadError } from './toNotionUploadError';
+
+function makeAPIResponseError(code: string, status: number): APIResponseError {
+  const err = Object.create(APIResponseError.prototype) as APIResponseError;
+  Object.assign(err, {
+    name: 'APIResponseError',
+    message: `notion internal detail for ${code}`,
+    code,
+    status,
+  });
+  return err;
+}
+
+describe('toNotionUploadError', () => {
+  it('maps an unauthorized Notion error to 401 notion_unauthorized', () => {
+    const result = toNotionUploadError(
+      makeAPIResponseError(APIErrorCode.Unauthorized, 401)
+    );
+
+    expect(result).toEqual({
+      status: 401,
+      body: {
+        code: 'notion_unauthorized',
+        message: 'Your Notion connection expired. Reconnect Notion and try again.',
+      },
+    });
+  });
+
+  it('maps an object-not-found Notion error to 404 notion_object_not_found', () => {
+    const result = toNotionUploadError(
+      makeAPIResponseError(APIErrorCode.ObjectNotFound, 404)
+    );
+
+    expect(result).toEqual({
+      status: 404,
+      body: {
+        code: 'notion_object_not_found',
+        message:
+          "We couldn't open that Notion page. Share it with the 2anki integration in Notion, then try again.",
+      },
+    });
+  });
+
+  it('maps a rate-limited Notion error to 429 notion_rate_limit', () => {
+    const result = toNotionUploadError(
+      makeAPIResponseError(APIErrorCode.RateLimited, 429)
+    );
+
+    expect(result).toEqual({
+      status: 429,
+      body: {
+        code: 'notion_rate_limit',
+        message: 'Notion is rate-limiting us right now. Wait a minute and convert again.',
+      },
+    });
+  });
+
+  it('never echoes the Notion error message back to the client', () => {
+    const result = toNotionUploadError(
+      makeAPIResponseError(APIErrorCode.Unauthorized, 401)
+    );
+
+    expect(result?.body.message).not.toContain('notion internal detail');
+  });
+
+  it('returns null for other Notion API error codes', () => {
+    expect(
+      toNotionUploadError(makeAPIResponseError(APIErrorCode.ValidationError, 400))
+    ).toBeNull();
+  });
+
+  it('returns null for non-Notion errors', () => {
+    expect(toNotionUploadError(new Error('plain failure'))).toBeNull();
+    expect(toNotionUploadError(undefined)).toBeNull();
+  });
+});

--- a/src/lib/notion/toNotionUploadError.ts
+++ b/src/lib/notion/toNotionUploadError.ts
@@ -1,0 +1,40 @@
+import { APIErrorCode, APIResponseError } from '@notionhq/client';
+
+import type { UploadErrorBody } from '../../types/UploadErrorBody';
+
+export interface NotionUploadError {
+  status: number;
+  body: UploadErrorBody;
+}
+
+const NOTION_UPLOAD_ERRORS: Partial<Record<APIErrorCode, NotionUploadError>> = {
+  [APIErrorCode.Unauthorized]: {
+    status: 401,
+    body: {
+      code: 'notion_unauthorized',
+      message: 'Your Notion connection expired. Reconnect Notion and try again.',
+    },
+  },
+  [APIErrorCode.ObjectNotFound]: {
+    status: 404,
+    body: {
+      code: 'notion_object_not_found',
+      message:
+        "We couldn't open that Notion page. Share it with the 2anki integration in Notion, then try again.",
+    },
+  },
+  [APIErrorCode.RateLimited]: {
+    status: 429,
+    body: {
+      code: 'notion_rate_limit',
+      message: 'Notion is rate-limiting us right now. Wait a minute and convert again.',
+    },
+  },
+};
+
+export function toNotionUploadError(error: unknown): NotionUploadError | null {
+  if (error instanceof APIResponseError) {
+    return NOTION_UPLOAD_ERRORS[error.code] ?? null;
+  }
+  return null;
+}

--- a/src/lib/sendErrorResponse.test.ts
+++ b/src/lib/sendErrorResponse.test.ts
@@ -1,0 +1,103 @@
+import { APIErrorCode, APIResponseError } from '@notionhq/client';
+import { Response } from 'express';
+
+import sendErrorResponse from './sendErrorResponse';
+
+interface FakeResponse {
+  statusCode: number;
+  body: unknown;
+  status: jest.Mock;
+  json: jest.Mock;
+  send: jest.Mock;
+}
+
+const makeResponse = (): FakeResponse => {
+  const state = { statusCode: 200, body: undefined } as FakeResponse;
+  state.status = jest.fn((code: number) => {
+    state.statusCode = code;
+    return state;
+  });
+  state.json = jest.fn((body: unknown) => {
+    state.body = body;
+    return state;
+  });
+  state.send = jest.fn(() => state);
+  return state;
+};
+
+const makeAPIResponseError = (code: string, status: number): APIResponseError => {
+  const err = Object.create(APIResponseError.prototype) as APIResponseError;
+  Object.assign(err, {
+    name: 'APIResponseError',
+    message: 'API token is invalid.',
+    code,
+    status,
+  });
+  return err;
+};
+
+describe('sendErrorResponse', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    [APIErrorCode.Unauthorized, 401, 'notion_unauthorized'],
+    [APIErrorCode.ObjectNotFound, 404, 'notion_object_not_found'],
+    [APIErrorCode.RateLimited, 429, 'notion_rate_limit'],
+  ] as const)(
+    'sends %s as status %i with code %s',
+    (apiCode, status, uploadCode) => {
+      const res = makeResponse();
+
+      sendErrorResponse(
+        makeAPIResponseError(apiCode, status),
+        res as unknown as Response
+      );
+
+      expect(res.statusCode).toBe(status);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: uploadCode })
+      );
+    }
+  );
+
+  it('does not echo the Notion error message for mapped codes', () => {
+    const res = makeResponse();
+
+    sendErrorResponse(
+      makeAPIResponseError(APIErrorCode.Unauthorized, 401),
+      res as unknown as Response
+    );
+
+    expect((res.body as { message: string }).message).not.toContain(
+      'API token is invalid'
+    );
+  });
+
+  it('keeps the existing shape for unmapped Notion API errors', () => {
+    const res = makeResponse();
+
+    sendErrorResponse(
+      makeAPIResponseError(APIErrorCode.ValidationError, 400),
+      res as unknown as Response
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json).toHaveBeenCalledWith({ message: 'API token is invalid.' });
+  });
+
+  it('keeps the existing 500 shape for non-Notion errors', () => {
+    const res = makeResponse();
+
+    sendErrorResponse(new Error('boom'), res as unknown as Response);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Unknown error.' });
+  });
+});

--- a/src/lib/sendErrorResponse.ts
+++ b/src/lib/sendErrorResponse.ts
@@ -2,6 +2,9 @@ import { Response } from 'express';
 
 import { APIErrorCode, APIResponseError } from '@notionhq/client';
 
+import { toNotionUploadError } from './notion/toNotionUploadError';
+import type { UploadErrorBody } from '../types/UploadErrorBody';
+
 function isExpectedUserError(error: unknown): boolean {
   if (!(error instanceof APIResponseError)) return false;
   // Notion returning Unauthorized means the user revoked access or
@@ -15,9 +18,15 @@ export default function sendErrorResponse(
   response: Response
 ) {
   let status = 500;
-  let body = { message: 'Unknown error.' };
+  let body: { message: string } | UploadErrorBody = {
+    message: 'Unknown error.',
+  };
 
-  if (error instanceof APIResponseError) {
+  const notionError = toNotionUploadError(error);
+  if (notionError) {
+    status = notionError.status;
+    body = notionError.body;
+  } else if (error instanceof APIResponseError) {
     status = error.status;
     body = { message: error.message };
   }

--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -1,8 +1,15 @@
+import { APIErrorCode, APIResponseError } from '@notionhq/client';
 import express from 'express';
 import multer from 'multer';
 
 import ErrorHandler from './ErrorHandler';
 import { PythonExitError } from '../../lib/anki/buildPythonExitError';
+
+const makeAPIResponseError = (code: string, status: number): APIResponseError => {
+  const err = Object.create(APIResponseError.prototype) as APIResponseError;
+  Object.assign(err, { name: 'APIResponseError', message: code, code, status });
+  return err;
+};
 
 const makeRequest = (): express.Request =>
   ({
@@ -179,6 +186,45 @@ describe('ErrorHandler', () => {
     const err = new multer.MulterError('LIMIT_PART_COUNT');
 
     await ErrorHandler(res as unknown as express.Response, req, err);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'unknown' })
+    );
+  });
+
+  test.each([
+    [APIErrorCode.Unauthorized, 401, 'notion_unauthorized'],
+    [APIErrorCode.ObjectNotFound, 404, 'notion_object_not_found'],
+    [APIErrorCode.RateLimited, 429, 'notion_rate_limit'],
+  ] as const)(
+    'emits %s as status %i with code %s',
+    async (apiCode, status, uploadCode) => {
+      const res = makeResponse(false);
+      const req = makeRequest();
+
+      await ErrorHandler(
+        res as unknown as express.Response,
+        req,
+        makeAPIResponseError(apiCode, status)
+      );
+
+      expect(res.statusCode).toBe(status);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: uploadCode })
+      );
+    }
+  );
+
+  test('keeps code=unknown for unmapped Notion API errors', async () => {
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    await ErrorHandler(
+      res as unknown as express.Response,
+      req,
+      makeAPIResponseError(APIErrorCode.ValidationError, 400)
+    );
 
     expect(res.statusCode).toBe(400);
     expect(res.json).toHaveBeenCalledWith(

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -9,6 +9,7 @@ import { preserveFilesForDebugging } from '../../lib/debug/preserveFilesForDebug
 import { shouldShareFilesForDebugging } from './shouldShareFilesForDebugging';
 import * as cheerio from 'cheerio';
 import { PythonExitError, toUploadErrorCode } from '../../lib/anki/buildPythonExitError';
+import { toNotionUploadError } from '../../lib/notion/toNotionUploadError';
 import type { UploadErrorBody, UploadErrorCode } from '../../types/UploadErrorBody';
 
 const transporter = nodemailer.createTransport({
@@ -104,6 +105,12 @@ export default async function ErrorHandler(
   if (err instanceof multer.MulterError) {
     const multerBody = toMulterErrorBody(err);
     res.status(multerBody.status).json({ code: multerBody.code, message: multerBody.message });
+    return;
+  }
+
+  const notionError = toNotionUploadError(err);
+  if (notionError) {
+    res.status(notionError.status).json(notionError.body);
     return;
   }
 

--- a/src/types/UploadErrorBody.ts
+++ b/src/types/UploadErrorBody.ts
@@ -14,6 +14,7 @@ export type UploadErrorCode =
   | 'worker_timeout'
   | 'notion_rate_limit'
   | 'notion_object_not_found'
+  | 'notion_unauthorized'
   | 'apkg_too_large_for_anki'
   | 'zip_invalid'
   | 'unknown';

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-06-notion-error-messages.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-06-notion-error-messages.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-06-notion-error-messages",
+  "date": "2026-06-06",
+  "type": "fix",
+  "title": "Expired Notion connections and missing pages show what happened instead of a generic error"
+}


### PR DESCRIPTION
## What
Notion API failures (expired/revoked token, page not shared with the integration, rate limiting) now reach the client as the typed `UploadErrorBody` envelope — `{ code, message }` with the correct HTTP status (401/404/429) — instead of `code: 'unknown'` at 400 or a raw Notion message with no code.

## Why
Fixes #2409. The client has shipped per-code copy for `notion_unauthorized`, `notion_rate_limit`, and `notion_object_not_found` since #3085 (`getErrorMessage.ts`, `api.ts` reads 401 bodies), but the server never emitted those codes — users hitting the three most common Notion-side failures got the generic fallback, or copy that depended on string-matching Notion's prose.

## How
- New shared classifier `src/lib/notion/toNotionUploadError.ts`: maps `APIErrorCode.Unauthorized` → 401 `notion_unauthorized`, `ObjectNotFound` → 404 `notion_object_not_found`, `RateLimited` → 429 `notion_rate_limit`. Generic per-code messages — never echoes the Notion error message (client owns copy).
- Wired at both HTTP boundaries: `ErrorHandler` (async route errors, e.g. unhandled `withRetry` rejections from `getPage`/`getBlocks`) and `sendErrorResponse` (NotionController/ApkgController catch paths — `search`, `previewPage`, etc., where expired tokens actually surface).
- `notion_unauthorized` added to the server `UploadErrorCode` union (`src/types/UploadErrorBody.ts`). The web union already covers the other two; the client handles `notion_unauthorized` via `api.ts`/`classifyError`, so no web source change needed.
- Unmapped errors keep their existing shape (400 `unknown` in ErrorHandler; raw status/message in sendErrorResponse). No auth logic touched — error shaping only.

## Measuring success
Prod logs: the `[notion] expected user error unauthorized` info line in `sendErrorResponse` keeps firing, but responses now carry `code: notion_unauthorized` — verify with a 401 response body spot-check after deploy. Client-side, the "Reconnect Notion" action link renders from the code instead of the "api token is invalid" string match.

## Testing
- Unit tests added: `src/lib/notion/toNotionUploadError.test.ts` (all three mappings, no-internals-leak, null for unmapped/non-Notion), `src/lib/sendErrorResponse.test.ts` (new — typed envelope for mapped codes, existing shape preserved for unmapped/non-Notion), `ErrorHandler.test.ts` extended (status + code per mapping, `unknown` preserved for unmapped Notion errors).
- Server tsc clean; full Jest suite green except `DeckParser.test.ts`/`runParserCanary.test.ts`, which fail in this worktree without the Python venv (pre-existing, reproduced with this diff stashed; CI provisions Python).
- Web vitest: 1722 passed (changelog loader uniqueness covered).
- Sonar not run locally — no `SONAR_TOKEN` configured in this environment; expect the CI analysis to be authoritative.

## Browser check
Browser check: not applicable — web diff is changelog-only (attestation hook bypasses changelog-only diffs)

## Changelog
"Expired Notion connections and missing pages show what happened instead of a generic error" (`2026-06-06-notion-error-messages.json`)

## Risks
Clients that string-matched the raw Notion 401 message still work — `classifyError` checks the code first and falls back to the string match. The only consumer-visible change for unmapped paths is none; mapped paths swap a leaked Notion message for generic copy. Rollback: revert the single commit.

## Goal alignment
Expired Notion tokens are a recurring support theme; a clear "Reconnect Notion" action instead of a dead-end generic error keeps Notion users converting instead of emailing support or churning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783281026&installation_id=132681956&pr_number=3138&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3138&signature=13eeb5becd6f84f8ce04273e3e0df8774a3bd609fcd3a375e1930b9d9eeedda6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->