### PR TITLE
fix: give Drive shape-hint its own class at secondary weight

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -146,6 +146,11 @@
   color: var(--color-text-tertiary);
 }
 
+.shapeHint {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
 .fileInput {
   position: absolute;
   width: 1px;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -81,6 +81,27 @@ describe('UploadForm', () => {
     }
   });
 
+  test('renders the Drive shape-hint with its own shapeHint class', () => {
+    const previousClient = process.env.REACT_APP_GOOGLE_CLIENT_ID;
+    const previousKey = process.env.REACT_APP_GOOGLE_API_KEY;
+    process.env.REACT_APP_GOOGLE_CLIENT_ID = 'test-client';
+    process.env.REACT_APP_GOOGLE_API_KEY = 'AIza' + 'fake-test-key';
+    try {
+      const { container } = renderUploadForm(
+        <UploadForm setErrorMessage={vi.fn()} />
+      );
+      const hint = Array.from(
+        container.querySelectorAll('#upload-panel-google-drive span')
+      ).find((el) => el.textContent?.includes('Docs work best'));
+      expect(hint).toBeDefined();
+      expect(hint?.className).toMatch(/shapeHint/);
+      expect(hint?.className).not.toMatch(/dropHint/);
+    } finally {
+      process.env.REACT_APP_GOOGLE_CLIENT_ID = previousClient;
+      process.env.REACT_APP_GOOGLE_API_KEY = previousKey;
+    }
+  });
+
   test('renders the Google Drive chip disabled when env vars are missing', () => {
     const previousClient = process.env.REACT_APP_GOOGLE_CLIENT_ID;
     const previousKey = process.env.REACT_APP_GOOGLE_API_KEY;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1545,7 +1545,7 @@ function UploadForm({ setErrorMessage, aiOn = false }: Readonly<UploadFormProps>
             <span className={formStyles.dropText}>
               Pick a Doc, Sheet, Slide, or file from your Google Drive.
             </span>
-            <span className={formStyles.dropHint}>
+            <span className={formStyles.shapeHint}>
               Docs work best as a bulleted outline — top bullet asks, indented bullet answers.
             </span>
             <button


### PR DESCRIPTION
## What
Gives the Google Drive panel's shape-hint ("Docs work best as a bulleted outline — top bullet asks, indented bullet answers.") its own `shapeHint` CSS class at `--color-text-secondary`, instead of reusing the `dropHint` class shared with the tiny "or" divider (tertiary). Size unchanged (`--text-sm`). Copy unchanged. The "or" divider keeps `dropHint` untouched.

## Why
Fixes #2313. The hint is instructional content at the point of choice; sharing the divider's tertiary styling under-weighted it. Users picking a Drive file now get guidance that reads as guidance.

## How
One class swap in `UploadForm.tsx` + a new 4-line `.shapeHint` rule in `UploadForm.module.css`. `--color-text-secondary` is defined in all themes (light/dark/gold) in `base.css`.

## Decisions made overnight (please review)
Visual weight: bumped the Drive shape-hint from tertiary to secondary text color via its own class; size unchanged. Designer rationale: instructional content at point-of-choice shouldn't share styling with a divider. If you want it stronger/weaker, adjust `.shapeHint` in `UploadForm.module.css`.

## Measuring success
No new instrumentation — visual-weight tweak. Existing `upload_started` / Drive-path conversion events are the downstream signal; the regression guard is the new unit test asserting the hint carries `shapeHint` and not `dropHint`.

## Testing
- Unit tests added: `renders the Drive shape-hint with its own shapeHint class` in `UploadForm.test.tsx` (asserts the hint span uses `shapeHint`, not `dropHint`). Full web suite: 199 files / 1723 tests green; typecheck + Biome lint green.
- sonar-scanner not run locally — one class swap + 5 CSS lines + one test; expecting no Sonar findings.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: overnight autonomous run — not browser-verified. Please eyeball the Drive panel hint at /upload (click the Google Drive chip) before merging.

## Changelog
No entry — borderline subtle style tweak; a one-shade text-color change on one hint line isn't something a user would consciously notice in What's New.

## Risks
CSS-only contrast change scoped to one span; worst case it looks slightly too strong, fixed by editing `.shapeHint`. Rollback: revert the commit.

## Goal alignment
Micro-polish on the upload surface — clearer at-the-point-of-choice guidance for the Drive path supports the "simplest, fastest" mission; negligible scale impact, justified by tiny cost.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783281134&installation_id=132681956&pr_number=3140&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3140&signature=3ce484af04edc79c4119b01af2996ca5fea9df17d2115eb83aa6d78ee95946bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander (standing waiver, overnight run 2026-06-05/06); automated suites green.
