### PR TITLE
feat: route upload conversion through the conversion pool

### DIFF
--- a/src/lib/conversionPool.load.test.ts
+++ b/src/lib/conversionPool.load.test.ts
@@ -1,0 +1,180 @@
+import os from 'node:os';
+import path from 'node:path';
+import GeneratePackagesUseCase from '../usecases/uploads/GeneratePackagesUseCase';
+import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
+import CardOption from './parser/Settings/CardOption';
+import Workspace from './parser/WorkSpace';
+import { UploadedFile } from './storage/types';
+import { getConversionPool, shutdownConversionPool } from './conversionPool';
+
+jest.setTimeout(60_000);
+
+const CONCURRENT_JOBS = 10;
+const POOL_THREADS = 2;
+
+function makeFile(name: string, contents: string): UploadedFile {
+  return {
+    fieldname: 'file',
+    originalname: name,
+    encoding: '7bit',
+    mimetype: 'application/octet-stream',
+    size: contents.length,
+    stream: null as never,
+    destination: '',
+    filename: name,
+    path: '',
+    buffer: Buffer.from(contents),
+    key: name,
+  };
+}
+
+function noCardHtml(index: number): string {
+  return `<html><head><title>empty-${index}</title></head><body></body></html>`;
+}
+
+interface JobSpec {
+  label: string;
+  file: UploadedFile;
+  expect: 'empty-deck-error' | 'empty-success' | 'apkg-rejection';
+  withProgressChannel: boolean;
+}
+
+function buildJobSpecs(): JobSpec[] {
+  const specs: JobSpec[] = [];
+  for (let i = 0; i < 4; i++) {
+    specs.push({
+      label: `no-cards-${i}.html`,
+      file: makeFile(`no-cards-${i}.html`, noCardHtml(i)),
+      expect: 'empty-deck-error',
+      withProgressChannel: i === 0,
+    });
+  }
+  for (let i = 0; i < 3; i++) {
+    specs.push({
+      label: `unsupported-${i}.xyz`,
+      file: makeFile(`unsupported-${i}.xyz`, `payload ${i}`),
+      expect: 'empty-success',
+      withProgressChannel: false,
+    });
+  }
+  for (let i = 0; i < 3; i++) {
+    specs.push({
+      label: `existing-deck-${i}.apkg`,
+      file: makeFile(`existing-deck-${i}.apkg`, `apkg bytes ${i}`),
+      expect: 'apkg-rejection',
+      withProgressChannel: i === 0,
+    });
+  }
+  return specs;
+}
+
+describe('conversion pool under concurrent upload load', () => {
+  const previousWorkers = process.env.CONVERSION_WORKERS;
+  const previousWorkspaceBase = process.env.WORKSPACE_BASE;
+  let errorSpy: jest.SpyInstance;
+  let results: PromiseSettledResult<{
+    packages: unknown[];
+    warnings?: string[];
+  }>[];
+  let specs: JobSpec[];
+
+  beforeAll(async () => {
+    process.env.CONVERSION_WORKERS = String(POOL_THREADS);
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'pool-load-workspaces');
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    specs = buildJobSpecs();
+    const useCase = new GeneratePackagesUseCase();
+    results = await Promise.allSettled(
+      specs.map((spec) =>
+        useCase.execute(
+          false,
+          [spec.file],
+          new CardOption({}),
+          new Workspace(true, 'fs'),
+          spec.withProgressChannel ? () => {} : undefined
+        )
+      )
+    );
+  });
+
+  afterAll(async () => {
+    await shutdownConversionPool({ timeoutMs: 15_000 });
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('did not drain')
+    );
+    errorSpy.mockRestore();
+    if (previousWorkers === undefined) {
+      delete process.env.CONVERSION_WORKERS;
+    } else {
+      process.env.CONVERSION_WORKERS = previousWorkers;
+    }
+    if (previousWorkspaceBase === undefined) {
+      delete process.env.WORKSPACE_BASE;
+    } else {
+      process.env.WORKSPACE_BASE = previousWorkspaceBase;
+    }
+  });
+
+  it('settles every one of the 10 concurrent jobs — none lost', () => {
+    expect(results).toHaveLength(CONCURRENT_JOBS);
+    for (const result of results) {
+      expect(['fulfilled', 'rejected']).toContain(result.status);
+    }
+  });
+
+  it('queues 10 jobs onto fewer threads and completes them all', () => {
+    const pool = getConversionPool();
+    expect(pool.options.maxThreads).toBe(POOL_THREADS);
+    expect(pool.queueSize).toBe(0);
+    expect(pool.completed).toBeGreaterThanOrEqual(CONCURRENT_JOBS);
+  });
+
+  it('rejects each no-card parse with EmptyDeckError across the pool boundary', () => {
+    const indices = specs
+      .map((spec, i) => (spec.expect === 'empty-deck-error' ? i : -1))
+      .filter((i) => i >= 0);
+    expect(indices).toHaveLength(4);
+    for (const i of indices) {
+      const result = results[i];
+      expect(result.status).toBe('rejected');
+      const reason = (result as PromiseRejectedResult).reason;
+      expect(reason).toBeInstanceOf(EmptyDeckError);
+    }
+  });
+
+  it('resolves each unsupported-type job with an empty package list', () => {
+    const indices = specs
+      .map((spec, i) => (spec.expect === 'empty-success' ? i : -1))
+      .filter((i) => i >= 0);
+    expect(indices).toHaveLength(3);
+    for (const i of indices) {
+      const result = results[i];
+      expect(result.status).toBe('fulfilled');
+      const value = (result as PromiseFulfilledResult<{ packages: unknown[] }>)
+        .value;
+      expect(value.packages).toEqual([]);
+    }
+  });
+
+  it('isolates each apkg rejection to its own job and names the right file', () => {
+    const indices = specs
+      .map((spec, i) => (spec.expect === 'apkg-rejection' ? i : -1))
+      .filter((i) => i >= 0);
+    expect(indices).toHaveLength(3);
+    for (const i of indices) {
+      const result = results[i];
+      expect(result.status).toBe('rejected');
+      const reason = (result as PromiseRejectedResult).reason as Error;
+      expect(reason).toBeInstanceOf(Error);
+      expect(reason.message).toContain(specs[i].file.originalname);
+    }
+  });
+
+  it('keeps failures from leaking into neighbouring successes', () => {
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(3);
+    expect(rejected).toHaveLength(7);
+  });
+});

--- a/src/lib/conversionPool.test.ts
+++ b/src/lib/conversionPool.test.ts
@@ -3,6 +3,14 @@ jest.mock('./storage/jobs/helpers/performConversion', () => ({
   default: jest.fn().mockResolvedValue(undefined),
 }));
 
+const mockPoolRun = jest.fn();
+jest.mock('piscina', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    run: (...args: unknown[]) => mockPoolRun(...args),
+  })),
+}));
+
 jest.mock('../data_layer/NotionRespository');
 jest.mock('../data_layer/BlocksCacheRepository');
 jest.mock('../data_layer/JobRepository');
@@ -17,9 +25,11 @@ import { NOTION_TOKEN_EXPIRED_REASON } from '../usecases/jobs/jobFailureReason';
 import {
   resolveConversionWorkers,
   runConversionInWorker,
+  runUploadGeneration,
   shutdownConversionPool,
   ConversionWorkerRequest,
 } from './conversionPool';
+import { UploadGenerationTask } from '../usecases/uploads/uploadGenerationTypes';
 
 interface FakePoolHandle {
   close: jest.Mock<Promise<void>, []>;
@@ -138,6 +148,53 @@ describe('runConversionInWorker', () => {
     await expect(
       runConversionInWorker(baseRequest, () => fakeKnex)
     ).rejects.toThrow('boom');
+  });
+});
+
+describe('runUploadGeneration', () => {
+  beforeEach(() => {
+    mockPoolRun.mockReset();
+  });
+
+  it('dispatches the task on the shared pool under the uploadGeneration name', async () => {
+    mockPoolRun.mockResolvedValueOnce({ ok: true, packages: [], warnings: [] });
+    const task = {
+      paying: false,
+      files: [],
+      settings: {},
+      workspace: {},
+      enqueuedAt: 1,
+      userId: null,
+    } as unknown as UploadGenerationTask;
+
+    const result = await runUploadGeneration(task);
+
+    expect(mockPoolRun).toHaveBeenCalledWith(task, {
+      name: 'uploadGeneration',
+      transferList: undefined,
+    });
+    expect(result).toEqual({ ok: true, packages: [], warnings: [] });
+  });
+
+  it('forwards the transfer list so progress ports reach the worker', async () => {
+    mockPoolRun.mockResolvedValueOnce({ ok: true, packages: [], warnings: [] });
+    const fakePort = { __port: true } as never;
+    const task = {
+      paying: true,
+      files: [],
+      settings: {},
+      workspace: {},
+      enqueuedAt: 1,
+      userId: 7,
+      progressPort: fakePort,
+    } as unknown as UploadGenerationTask;
+
+    await runUploadGeneration(task, [fakePort]);
+
+    expect(mockPoolRun).toHaveBeenCalledWith(task, {
+      name: 'uploadGeneration',
+      transferList: [fakePort],
+    });
   });
 });
 

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -1,7 +1,13 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import type { TransferListItem } from 'node:worker_threads';
 import Piscina from 'piscina';
 import knex, { Knex } from 'knex';
+import {
+  UPLOAD_GENERATION_TASK,
+  UploadGenerationResult,
+  UploadGenerationTask,
+} from '../usecases/uploads/uploadGenerationTypes';
 import performConversion from './storage/jobs/helpers/performConversion';
 import NotionAPIWrapper from '../services/NotionService/NotionAPIWrapper';
 import NotionRepository from '../data_layer/NotionRespository';
@@ -51,6 +57,7 @@ export function initConversionPool(): Piscina {
     execArgv,
     maxThreads,
     minThreads: 1,
+    resourceLimits: { maxOldGenerationSizeMb: 1024 },
   });
   return pool;
 }
@@ -63,6 +70,16 @@ export async function runConversion(
   request: ConversionWorkerRequest
 ): Promise<void> {
   await getConversionPool().run(request);
+}
+
+export async function runUploadGeneration(
+  task: UploadGenerationTask,
+  transferList?: TransferListItem[]
+): Promise<UploadGenerationResult> {
+  return getConversionPool().run(task, {
+    name: UPLOAD_GENERATION_TASK,
+    transferList: transferList as never, // piscina's TransferList type misinfers to StructuredSerializeOptions under lib.dom; the runtime expects an array
+  });
 }
 
 export async function shutdownConversionPool(

--- a/src/lib/conversionWorker.ts
+++ b/src/lib/conversionWorker.ts
@@ -2,9 +2,20 @@ import {
   runConversionInWorker,
   ConversionWorkerRequest,
 } from './conversionPool';
+import { runUploadGenerationInWorker } from '../usecases/uploads/worker';
+import {
+  UploadGenerationResult,
+  UploadGenerationTask,
+} from '../usecases/uploads/uploadGenerationTypes';
 
 export default async function conversionWorker(
   request: ConversionWorkerRequest
 ): Promise<void> {
   await runConversionInWorker(request);
+}
+
+export async function uploadGeneration(
+  task: UploadGenerationTask
+): Promise<UploadGenerationResult> {
+  return runUploadGenerationInWorker(task);
 }

--- a/src/usecases/uploads/GeneratePackagesUseCase.test.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.test.ts
@@ -48,7 +48,9 @@ describe('GeneratePackagesUseCase', () => {
   it('dispatches the generation task through the conversion pool', async () => {
     mockRunUploadGeneration.mockResolvedValueOnce({
       ok: true,
-      packages: [{ name: 'notes.apkg', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 }] as never,
+      packages: [
+        { name: 'notes.apkg', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 },
+      ] as never,
       warnings: [],
     });
     const useCase = new GeneratePackagesUseCase();
@@ -129,7 +131,12 @@ describe('GeneratePackagesUseCase', () => {
     });
     const useCase = new GeneratePackagesUseCase();
 
-    await useCase.execute(false, [makeFile('notes.html')], makeSettings(), makeWorkspace());
+    await useCase.execute(
+      false,
+      [makeFile('notes.html')],
+      makeSettings(),
+      makeWorkspace()
+    );
 
     const [task, transferList] = mockRunUploadGeneration.mock.calls[0];
     expect(task.progressPort).toBeUndefined();
@@ -139,12 +146,19 @@ describe('GeneratePackagesUseCase', () => {
   it('rejects when the pool worker reports an error', async () => {
     mockRunUploadGeneration.mockResolvedValueOnce({
       ok: false,
-      error: { message: "Cannot read properties of undefined (reading 'name')" },
+      error: {
+        message: "Cannot read properties of undefined (reading 'name')",
+      },
     });
     const useCase = new GeneratePackagesUseCase();
 
     await expect(
-      useCase.execute(false, [makeFile('bad.html')], makeSettings(), makeWorkspace())
+      useCase.execute(
+        false,
+        [makeFile('bad.html')],
+        makeSettings(),
+        makeWorkspace()
+      )
     ).rejects.toThrow("Cannot read properties of undefined (reading 'name')");
   });
 
@@ -153,7 +167,12 @@ describe('GeneratePackagesUseCase', () => {
     const useCase = new GeneratePackagesUseCase();
 
     await expect(
-      useCase.execute(false, [makeFile('crash.html')], makeSettings(), makeWorkspace())
+      useCase.execute(
+        false,
+        [makeFile('crash.html')],
+        makeSettings(),
+        makeWorkspace()
+      )
     ).rejects.toThrow('Worker crashed');
   });
 
@@ -161,14 +180,20 @@ describe('GeneratePackagesUseCase', () => {
     mockRunUploadGeneration.mockResolvedValueOnce({
       ok: false,
       error: {
-        message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
+        message:
+          'No cards found in your upload. Use .zip, .html, .md, or .csv.',
         name: 'EmptyDeckError',
       },
     });
     const useCase = new GeneratePackagesUseCase();
 
     await expect(
-      useCase.execute(false, [makeFile('empty.html')], makeSettings(), makeWorkspace())
+      useCase.execute(
+        false,
+        [makeFile('empty.html')],
+        makeSettings(),
+        makeWorkspace()
+      )
     ).rejects.toBeInstanceOf(EmptyDeckError);
   });
 
@@ -177,7 +202,12 @@ describe('GeneratePackagesUseCase', () => {
     const useCase = new GeneratePackagesUseCase();
 
     const err = await useCase
-      .execute(false, [makeFile('garbled.html')], makeSettings(), makeWorkspace())
+      .execute(
+        false,
+        [makeFile('garbled.html')],
+        makeSettings(),
+        makeWorkspace()
+      )
       .catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(Error);
@@ -193,7 +223,12 @@ describe('GeneratePackagesUseCase', () => {
     const useCase = new GeneratePackagesUseCase();
 
     const err = await useCase
-      .execute(false, [makeFile('garbled.html')], makeSettings(), makeWorkspace())
+      .execute(
+        false,
+        [makeFile('garbled.html')],
+        makeSettings(),
+        makeWorkspace()
+      )
       .catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(Error);
@@ -205,7 +240,8 @@ describe('GeneratePackagesUseCase', () => {
     mockRunUploadGeneration.mockResolvedValueOnce({
       ok: false,
       error: {
-        message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
+        message:
+          'No cards found in your upload. Use .zip, .html, .md, or .csv.',
         name: 'EmptyDeckError',
         sourceFormat: 'markdown',
       },
@@ -213,7 +249,12 @@ describe('GeneratePackagesUseCase', () => {
     const useCase = new GeneratePackagesUseCase();
 
     const err = await useCase
-      .execute(false, [makeFile('flat-export.md')], makeSettings(), makeWorkspace())
+      .execute(
+        false,
+        [makeFile('flat-export.md')],
+        makeSettings(),
+        makeWorkspace()
+      )
       .catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(EmptyDeckError);

--- a/src/usecases/uploads/GeneratePackagesUseCase.test.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.test.ts
@@ -1,32 +1,20 @@
-import { EventEmitter } from 'events';
-
-jest.mock('worker_threads', () => ({
-  Worker: jest.fn(),
-  workerData: null,
-  parentPort: null,
-  isMainThread: true,
-}));
-
-jest.mock('node:fs', () => ({
-  existsSync: jest.fn().mockReturnValue(false),
+jest.mock('../../lib/conversionPool', () => ({
+  runUploadGeneration: jest.fn(),
 }));
 
 jest.mock('../../lib/parser/WorkSpace');
 
 import GeneratePackagesUseCase from './GeneratePackagesUseCase';
-import { Worker } from 'worker_threads';
+import { runUploadGeneration } from '../../lib/conversionPool';
 import CardOption from '../../lib/parser/Settings/CardOption';
 import Workspace from '../../lib/parser/WorkSpace';
 import { UploadedFile } from '../../lib/storage/types';
 import { EmptyDeckError } from '../jobs/EmptyDeckError';
+import { UploadGenerationTask } from './uploadGenerationTypes';
 
-const MockWorker = Worker as jest.MockedClass<typeof Worker>;
-
-function makeWorkerEmitter(): EventEmitter {
-  const emitter = new EventEmitter();
-  MockWorker.mockImplementation(() => emitter as never);
-  return emitter;
-}
+const mockRunUploadGeneration = runUploadGeneration as jest.MockedFunction<
+  typeof runUploadGeneration
+>;
 
 function makeSettings(): CardOption {
   return new CardOption({});
@@ -57,188 +45,192 @@ describe('GeneratePackagesUseCase', () => {
     jest.clearAllMocks();
   });
 
-  it('resolves with packages and warnings when the worker sends a result message', async () => {
-    const emitter = makeWorkerEmitter();
-    const useCase = new GeneratePackagesUseCase();
-
-    const promise = useCase.execute(
-      false,
-      [makeFile('notes.html')],
-      makeSettings(),
-      makeWorkspace()
-    );
-
-    emitter.emit('message', {
-      type: 'result',
-      packages: [
-        { name: 'notes.apkg', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 },
-      ],
+  it('dispatches the generation task through the conversion pool', async () => {
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: true,
+      packages: [{ name: 'notes.apkg', cardCount: 5, mcqCount: 0, mcqSkippedCount: 0 }] as never,
       warnings: [],
     });
+    const useCase = new GeneratePackagesUseCase();
+    const files = [makeFile('notes.html')];
+    const settings = makeSettings();
+    const workspace = makeWorkspace();
 
-    const result = await promise;
+    const result = await useCase.execute(false, files, settings, workspace);
+
+    expect(mockRunUploadGeneration).toHaveBeenCalledTimes(1);
+    const [task] = mockRunUploadGeneration.mock.calls[0];
+    expect(task).toMatchObject({
+      paying: false,
+      files,
+      settings,
+      workspace,
+      userId: null,
+    });
     expect(result.packages).toHaveLength(1);
     expect(result.packages[0].name).toBe('notes.apkg');
     expect(result.warnings).toEqual([]);
   });
 
-  it('resolves with an empty packages array when the worker sends a result with undefined packages', async () => {
-    const emitter = makeWorkerEmitter();
+  it('passes paying and userId through to the pool task', async () => {
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: true,
+      packages: [],
+      warnings: [],
+    });
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
-      false,
-      [makeFile('empty.html')],
+    await useCase.execute(
+      true,
+      [makeFile('notes.html')],
       makeSettings(),
-      makeWorkspace()
+      makeWorkspace(),
+      undefined,
+      42
     );
 
-    emitter.emit('message', {
-      type: 'result',
-      packages: undefined,
-      warnings: undefined,
-    });
-
-    const result = await promise;
-    expect(result.packages).toEqual([]);
+    const [task] = mockRunUploadGeneration.mock.calls[0];
+    expect(task).toMatchObject({ paying: true, userId: 42 });
   });
 
-  it('rejects when the worker sends an error message', async () => {
-    const emitter = makeWorkerEmitter();
+  it('forwards progress messages from the pool worker to onProgress', async () => {
+    let progressDelivered: () => void = () => undefined;
+    const delivered = new Promise<void>((resolve) => {
+      progressDelivered = resolve;
+    });
+    const onProgress = jest.fn(() => progressDelivered());
+    mockRunUploadGeneration.mockImplementationOnce(
+      async (task: UploadGenerationTask) => {
+        task.progressPort?.postMessage('Parsing notes.html');
+        await delivered;
+        return { ok: true, packages: [], warnings: [] };
+      }
+    );
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
+    await useCase.execute(
       false,
-      [makeFile('bad.html')],
+      [makeFile('notes.html')],
       makeSettings(),
-      makeWorkspace()
+      makeWorkspace(),
+      onProgress
     );
 
-    emitter.emit('message', {
-      type: 'error',
-      message: "Cannot read properties of undefined (reading 'name')",
-    });
-
-    await expect(promise).rejects.toThrow(
-      "Cannot read properties of undefined (reading 'name')"
-    );
+    expect(onProgress).toHaveBeenCalledWith('Parsing notes.html');
+    const [task, transferList] = mockRunUploadGeneration.mock.calls[0];
+    expect(transferList).toEqual([task.progressPort]);
   });
 
-  it('rejects when the worker emits an error event', async () => {
-    const emitter = makeWorkerEmitter();
+  it('omits the progress channel when no onProgress callback is given', async () => {
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: true,
+      packages: [],
+      warnings: [],
+    });
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
-      false,
-      [makeFile('crash.html')],
-      makeSettings(),
-      makeWorkspace()
-    );
+    await useCase.execute(false, [makeFile('notes.html')], makeSettings(), makeWorkspace());
 
-    emitter.emit('error', new Error('Worker crashed'));
-
-    await expect(promise).rejects.toThrow('Worker crashed');
+    const [task, transferList] = mockRunUploadGeneration.mock.calls[0];
+    expect(task.progressPort).toBeUndefined();
+    expect(transferList).toBeUndefined();
   });
 
-  it('rejects with EmptyDeckError when the worker sends an error message with name EmptyDeckError', async () => {
-    const emitter = makeWorkerEmitter();
+  it('rejects when the pool worker reports an error', async () => {
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: false,
+      error: { message: "Cannot read properties of undefined (reading 'name')" },
+    });
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
-      false,
-      [makeFile('empty.html')],
-      makeSettings(),
-      makeWorkspace()
-    );
+    await expect(
+      useCase.execute(false, [makeFile('bad.html')], makeSettings(), makeWorkspace())
+    ).rejects.toThrow("Cannot read properties of undefined (reading 'name')");
+  });
 
-    emitter.emit('message', {
-      type: 'error',
-      message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
-      name: 'EmptyDeckError',
+  it('rejects when the pool run itself fails', async () => {
+    mockRunUploadGeneration.mockRejectedValueOnce(new Error('Worker crashed'));
+    const useCase = new GeneratePackagesUseCase();
+
+    await expect(
+      useCase.execute(false, [makeFile('crash.html')], makeSettings(), makeWorkspace())
+    ).rejects.toThrow('Worker crashed');
+  });
+
+  it('rejects with EmptyDeckError when the worker error is named EmptyDeckError', async () => {
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
+        name: 'EmptyDeckError',
+      },
     });
+    const useCase = new GeneratePackagesUseCase();
 
-    await expect(promise).rejects.toBeInstanceOf(EmptyDeckError);
+    await expect(
+      useCase.execute(false, [makeFile('empty.html')], makeSettings(), makeWorkspace())
+    ).rejects.toBeInstanceOf(EmptyDeckError);
   });
 
   it('rejects with a non-empty parser-crash error when the worker error has no message', async () => {
-    const emitter = makeWorkerEmitter();
+    mockRunUploadGeneration.mockResolvedValueOnce({ ok: false, error: {} });
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
-      false,
-      [makeFile('garbled.html')],
-      makeSettings(),
-      makeWorkspace()
-    );
+    const err = await useCase
+      .execute(false, [makeFile('garbled.html')], makeSettings(), makeWorkspace())
+      .catch((e: unknown) => e);
 
-    emitter.emit('message', { type: 'error' });
-
-    const err = await promise.catch((e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message.trim()).not.toBe('');
     expect((err as Error & { code?: string }).code).toBe('PARSER_CRASH');
   });
 
   it('rejects with a non-empty parser-crash error when the worker error message is blank', async () => {
-    const emitter = makeWorkerEmitter();
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: false,
+      error: { message: '  ' },
+    });
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
-      false,
-      [makeFile('garbled.html')],
-      makeSettings(),
-      makeWorkspace()
-    );
+    const err = await useCase
+      .execute(false, [makeFile('garbled.html')], makeSettings(), makeWorkspace())
+      .catch((e: unknown) => e);
 
-    emitter.emit('message', { type: 'error', message: '  ' });
-
-    const err = await promise.catch((e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message.trim()).not.toBe('');
     expect((err as Error & { code?: string }).code).toBe('PARSER_CRASH');
   });
 
-  it('preserves the markdown sourceFormat on EmptyDeckError across the worker boundary', async () => {
-    const emitter = makeWorkerEmitter();
+  it('preserves the markdown sourceFormat on EmptyDeckError across the pool boundary', async () => {
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
+        name: 'EmptyDeckError',
+        sourceFormat: 'markdown',
+      },
+    });
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
-      false,
-      [makeFile('flat-export.md')],
-      makeSettings(),
-      makeWorkspace()
-    );
+    const err = await useCase
+      .execute(false, [makeFile('flat-export.md')], makeSettings(), makeWorkspace())
+      .catch((e: unknown) => e);
 
-    emitter.emit('message', {
-      type: 'error',
-      message: 'No cards found in your upload. Use .zip, .html, .md, or .csv.',
-      name: 'EmptyDeckError',
-      sourceFormat: 'markdown',
-    });
-
-    const err = await promise.catch((e: unknown) => e);
     expect(err).toBeInstanceOf(EmptyDeckError);
     expect((err as EmptyDeckError).sourceFormat).toBe('markdown');
   });
 
   it('preserves error name on the rejected Error for non-EmptyDeckError named errors', async () => {
-    const emitter = makeWorkerEmitter();
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: false,
+      error: { message: 'some message', name: 'CustomError' },
+    });
     const useCase = new GeneratePackagesUseCase();
 
-    const promise = useCase.execute(
-      false,
-      [makeFile('other.html')],
-      makeSettings(),
-      makeWorkspace()
-    );
+    const err = await useCase
+      .execute(false, [makeFile('other.html')], makeSettings(), makeWorkspace())
+      .catch((e: unknown) => e);
 
-    emitter.emit('message', {
-      type: 'error',
-      message: 'some message',
-      name: 'CustomError',
-    });
-
-    const err = await promise.catch((e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).name).toBe('CustomError');
   });

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -1,39 +1,25 @@
+import { MessageChannel } from 'node:worker_threads';
 import Package from '../../lib/parser/Package';
 import CardOption from '../../lib/parser/Settings/CardOption';
 import { UploadedFile } from '../../lib/storage/types';
-import { Worker } from 'worker_threads';
-import path from 'path';
-import fs from 'node:fs';
 import Workspace from '../../lib/parser/WorkSpace';
 import { EmptyDeckError } from '../jobs/EmptyDeckError';
+import { runUploadGeneration } from '../../lib/conversionPool';
+import { UploadGenerationFailure } from './uploadGenerationTypes';
 
 export interface PackageResult {
   packages: Package[];
   warnings?: string[];
 }
 
-type ProgressMessage = { type: 'progress'; step: string };
-type ResultMessage = {
-  type: 'result';
-  packages: Package[];
-  warnings?: string[];
-};
-type ErrorMessage = {
-  type: 'error';
-  message?: string;
-  name?: string;
-  sourceFormat?: 'markdown';
-};
-type WorkerMessage = ProgressMessage | ResultMessage | ErrorMessage;
-
-function buildWorkerError(msg: ErrorMessage): Error {
-  if (msg.name === 'EmptyDeckError') {
-    return new EmptyDeckError(msg.sourceFormat);
+function buildWorkerError(failure: UploadGenerationFailure): Error {
+  if (failure.name === 'EmptyDeckError') {
+    return new EmptyDeckError(failure.sourceFormat);
   }
-  if (msg.message != null && msg.message.trim() !== '') {
-    const e = new Error(msg.message);
-    if (msg.name != null) {
-      e.name = msg.name;
+  if (failure.message != null && failure.message.trim() !== '') {
+    const e = new Error(failure.message);
+    if (failure.name != null) {
+      e.name = failure.name;
     }
     return e;
   }
@@ -41,14 +27,14 @@ function buildWorkerError(msg: ErrorMessage): Error {
     'Upload worker reported an error without a message'
   ) as Error & { code: string };
   fallback.code = 'PARSER_CRASH';
-  if (msg.name != null) {
-    fallback.name = msg.name;
+  if (failure.name != null) {
+    fallback.name = failure.name;
   }
   return fallback;
 }
 
 class GeneratePackagesUseCase {
-  execute(
+  async execute(
     paying: boolean,
     files: UploadedFile[],
     settings: CardOption,
@@ -56,32 +42,29 @@ class GeneratePackagesUseCase {
     onProgress?: (step: string) => void,
     userId: number | null = null
   ): Promise<PackageResult> {
-    return new Promise((resolve, reject) => {
-      const enqueuedAt = Date.now();
-      const data = { paying, files, settings, workspace, enqueuedAt, userId };
-      const workerTs = path.resolve(__dirname, './worker.ts');
-      const workerJs = path.resolve(__dirname, './worker.js');
-      const workerPath = fs.existsSync(workerTs) ? workerTs : workerJs;
-      const execArgv = workerPath.endsWith('.ts')
-        ? ['--require', 'tsx/cjs']
-        : [];
-      const worker = new Worker(workerPath, {
-        workerData: { data },
-        execArgv,
-        resourceLimits: { maxOldGenerationSizeMb: 1024 },
-      });
-
-      worker.on('message', (msg: WorkerMessage) => {
-        if (msg.type === 'progress') {
-          onProgress?.(msg.step);
-        } else if (msg.type === 'error') {
-          reject(buildWorkerError(msg));
-        } else {
-          resolve({ packages: msg.packages ?? [], warnings: msg.warnings });
-        }
-      });
-      worker.on('error', (error) => reject(error));
-    });
+    const enqueuedAt = Date.now();
+    const channel = onProgress ? new MessageChannel() : null;
+    channel?.port1.on('message', (step: string) => onProgress?.(step));
+    try {
+      const result = await runUploadGeneration(
+        {
+          paying,
+          files,
+          settings,
+          workspace,
+          enqueuedAt,
+          userId,
+          progressPort: channel?.port2,
+        },
+        channel ? [channel.port2] : undefined
+      );
+      if (result.ok) {
+        return { packages: result.packages, warnings: result.warnings };
+      }
+      throw buildWorkerError(result.error);
+    } finally {
+      channel?.port1.close();
+    }
   }
 }
 

--- a/src/usecases/uploads/uploadGenerationTypes.ts
+++ b/src/usecases/uploads/uploadGenerationTypes.ts
@@ -1,0 +1,27 @@
+import type { MessagePort } from 'node:worker_threads';
+import type Package from '../../lib/parser/Package';
+import type CardOption from '../../lib/parser/Settings/CardOption';
+import type Workspace from '../../lib/parser/WorkSpace';
+import type { UploadedFile } from '../../lib/storage/types';
+
+export interface UploadGenerationTask {
+  paying: boolean;
+  files: UploadedFile[];
+  settings: CardOption;
+  workspace: Workspace;
+  enqueuedAt: number;
+  userId: number | null;
+  progressPort?: MessagePort;
+}
+
+export interface UploadGenerationFailure {
+  message?: string;
+  name?: string;
+  sourceFormat?: 'markdown';
+}
+
+export type UploadGenerationResult =
+  | { ok: true; packages: Package[]; warnings: string[] }
+  | { ok: false; error: UploadGenerationFailure };
+
+export const UPLOAD_GENERATION_TASK = 'uploadGeneration';

--- a/src/usecases/uploads/worker.test.ts
+++ b/src/usecases/uploads/worker.test.ts
@@ -142,7 +142,10 @@ describe('runUploadGenerationInWorker', () => {
     } as unknown as MessagePort;
   }
 
-  function makeTask(file: UploadedFile, progressPort?: MessagePort): UploadGenerationTask {
+  function makeTask(
+    file: UploadedFile,
+    progressPort?: MessagePort
+  ): UploadGenerationTask {
     return {
       paying: false,
       files: [file],

--- a/src/usecases/uploads/worker.test.ts
+++ b/src/usecases/uploads/worker.test.ts
@@ -1,8 +1,13 @@
 import fs from 'fs';
-import { getFileContents } from './worker';
+import type { MessagePort } from 'node:worker_threads';
+import { getFileContents, runUploadGenerationInWorker } from './worker';
 import { UploadedFile } from '../../lib/storage/types';
+import CardOption from '../../lib/parser/Settings/CardOption';
+import Workspace from '../../lib/parser/WorkSpace';
+import { UploadGenerationTask } from './uploadGenerationTypes';
 
 jest.mock('fs');
+jest.mock('../../lib/parser/WorkSpace');
 
 const mockFs = jest.mocked(fs);
 
@@ -126,5 +131,85 @@ describe('getFileContents', () => {
     const result = getFileContents(file);
 
     expect(result).toEqual(content);
+  });
+});
+
+describe('runUploadGenerationInWorker', () => {
+  function makeFakePort(): MessagePort {
+    return {
+      postMessage: jest.fn(),
+      close: jest.fn(),
+    } as unknown as MessagePort;
+  }
+
+  function makeTask(file: UploadedFile, progressPort?: MessagePort): UploadGenerationTask {
+    return {
+      paying: false,
+      files: [file],
+      settings: new CardOption({}),
+      workspace: {} as Workspace,
+      enqueuedAt: Date.now(),
+      userId: null,
+      progressPort,
+    };
+  }
+
+  let infoSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+  });
+
+  it('returns a failure result with a non-empty message and error name when generation throws', async () => {
+    const file = makeFile({
+      originalname: 'existing.apkg',
+      filename: 'existing.apkg',
+      path: '',
+      buffer: Buffer.from('not really a deck'),
+    });
+
+    const result = await runUploadGenerationInWorker(makeTask(file));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('expected a failure result');
+    }
+    expect(result.error.message).toContain('already an Anki deck');
+    expect(result.error.name).toBe('Error');
+  });
+
+  it('closes the progress port even when generation throws', async () => {
+    const port = makeFakePort();
+    const file = makeFile({
+      originalname: 'existing.apkg',
+      filename: 'existing.apkg',
+      path: '',
+      buffer: Buffer.from('not really a deck'),
+    });
+
+    await runUploadGenerationInWorker(makeTask(file, port));
+
+    expect(port.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a success result with empty packages for an unsupported file type', async () => {
+    const file = makeFile({
+      originalname: 'notes.unsupported',
+      filename: 'notes.unsupported',
+      key: 'notes.unsupported',
+      path: '',
+      buffer: Buffer.from('plain text'),
+    });
+    const port = makeFakePort();
+
+    const result = await runUploadGenerationInWorker(makeTask(file, port));
+
+    expect(result).toEqual({ ok: true, packages: [], warnings: [] });
+    expect(port.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -1,4 +1,3 @@
-import { parentPort, workerData } from 'worker_threads';
 import { UploadedFile } from '../../lib/storage/types';
 import CardOption from '../../lib/parser/Settings/CardOption';
 import Package from '../../lib/parser/Package';
@@ -30,15 +29,10 @@ import {
   buildVocabDeckFromKindleClippings,
 } from './BuildVocabDeckUseCase';
 import { EmptyDeckError } from '../jobs/EmptyDeckError';
-
-interface GenerationData {
-  paying: boolean;
-  files: UploadedFile[];
-  settings: CardOption;
-  workspace: Workspace;
-  enqueuedAt?: number;
-  userId?: number | null;
-}
+import {
+  UploadGenerationResult,
+  UploadGenerationTask,
+} from './uploadGenerationTypes';
 
 export function getFileContents(
   file: UploadedFile,
@@ -207,21 +201,13 @@ async function processFile(
   return { packages, warnings };
 }
 
-async function doGenerationWork(data: GenerationData) {
-  const {
-    paying,
-    files,
-    settings,
-    workspace,
-    enqueuedAt,
-    userId = null,
-  } = data;
+async function doGenerationWork(
+  task: UploadGenerationTask,
+  onProgress: (step: string) => void
+): Promise<{ packages: Package[]; warnings: string[] }> {
+  const { paying, files, settings, workspace, enqueuedAt, userId } = task;
   let packages: Package[] = [];
   const warnings: string[] = [];
-
-  const onProgress = (step: string) => {
-    parentPort?.postMessage({ type: 'progress', step });
-  };
 
   for (const file of files) {
     const fileContents = getFileContents(file, enqueuedAt);
@@ -238,19 +224,29 @@ async function doGenerationWork(data: GenerationData) {
     warnings.push(...result.warnings);
   }
 
-  return { type: 'result', packages, warnings };
+  return { packages, warnings };
 }
 
-if (workerData != null) {
-  doGenerationWork(workerData.data)
-    .then((result) => parentPort?.postMessage(result))
-    .catch((err) =>
-      parentPort?.postMessage({
-        type: 'error',
+export async function runUploadGenerationInWorker(
+  task: UploadGenerationTask
+): Promise<UploadGenerationResult> {
+  const onProgress = (step: string) => {
+    task.progressPort?.postMessage(step);
+  };
+  try {
+    const { packages, warnings } = await doGenerationWork(task, onProgress);
+    return { ok: true, packages, warnings };
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
         message: err instanceof Error ? err.message : String(err),
         name: err instanceof Error ? err.name : undefined,
         sourceFormat:
           err instanceof EmptyDeckError ? err.sourceFormat : undefined,
-      })
-    );
+      },
+    };
+  } finally {
+    task.progressPort?.close();
+  }
 }


### PR DESCRIPTION
## What
Routes upload conversion through the shared piscina conversion pool instead of cold-spawning a `new Worker(...)` per request. The upload worker entry becomes a pool-compatible named export (`uploadGeneration`) on the existing `conversionWorker`; `GeneratePackagesUseCase` dispatches via a new `runUploadGeneration()` on the pool.

## Why
Fixes #2425. Cold-spawning a worker thread costs ~300 ms per upload. The pool primitive (#2418) has served Notion conversions in prod since ~May 18 with no pool-related incidents — uploads are the planned second customer. Expected ≥ 200 ms p50 reduction for small-file uploads.

## How
- `src/usecases/uploads/uploadGenerationTypes.ts` — shared task/result types (type-only imports, so the main thread doesn't load the parser tree through the pool module).
- `src/usecases/uploads/worker.ts` — self-executing `workerData` block removed; logic exposed as `runUploadGenerationInWorker(task)`. Progress posts to a transferred `MessagePort`; errors return as a discriminated `{ ok: false, error }` result.
- `src/lib/conversionWorker.ts` — named export `uploadGeneration` next to the default Notion task (piscina `name` dispatch).
- `src/lib/conversionPool.ts` — `runUploadGeneration(task, transferList)`; pool gains `resourceLimits: { maxOldGenerationSizeMb: 1024 }`.
- `src/usecases/uploads/GeneratePackagesUseCase.ts` — builds a `MessageChannel` only when `onProgress` is given, transfers `port2`, rebuilds errors with the same `buildWorkerError` from #3134.

Error contract preserved exactly (#3134): `EmptyDeckError` rehydrated with `sourceFormat`, error `name` preserved, `PARSER_CRASH` coded fallback for blank messages. `UploadService` failure-reason routing (`resolveAsyncFailureReason`, sentinel regexes) untouched.

Rebased on main 2026-06-05: the worker now carries the AnkiApp export routing from #3145 and the oxfmt formatting from #3136 inside the pool path; conflicts resolved preserving both the pool dispatch and the AnkiApp branch in `processFile`.

## Decisions made overnight (please review)
1. **One shared pool, not a sibling upload pool.** The issue offered both; the shared pool with piscina's `name` dispatch is less code and one concurrency budget. Consequence: uploads and Notion conversions now share `CONVERSION_WORKERS` (default 4) threads — uploads queue behind Notion jobs under load, where previously each upload got its own unbounded thread. That bounding is the point of the issue, but it is a saturation-behavior change worth a prod-load look.
2. **`resourceLimits: { maxOldGenerationSizeMb: 1024 }` applied pool-wide.** The old upload spawn carried this cap; one pool can't set it per-task. This newly caps Notion conversion workers at 1 GB heap — previously uncapped, where a heap blowout aborted the entire process. Now it kills only the worker/job. If a legit Notion conversion needs > 1 GB this is a regression for that job; watch for `ERR_WORKER_OUT_OF_MEMORY` in prod logs.
3. **Error transport is a discriminated result, not a thrown error.** Piscina's structured-clone of thrown errors drops custom props (`sourceFormat`, `code`), so the worker returns `{ ok: false, error: { message, name, sourceFormat } }` and the use case rebuilds via the unchanged `buildWorkerError`. A genuine worker crash (OOM, termination) still rejects the pool promise and propagates raw — equivalent to the old `worker.on('error')` path, and strictly better than the old silent-hang when a worker exited without a message.
4. **Progress over a transferred `MessagePort`.** Only created when `onProgress` is passed (sync uploads don't pay for it). A progress message racing job completion can be dropped at `port1.close()` — harmless, since UploadService writes the terminal job status right after. Progress only fires on the Claude path (`generateDeckInfo`), so plain-HTML uploads see no change.
5. **Pool worker thread now loads the upload parser tree at boot.** `conversionWorker.ts` imports `PrepareDeck` and friends — slightly slower thread warm-up, irrelevant once warm.
6. **No timeout added.** The old path had none; adding one is out of scope for a behavior-preserving refactor.

## Load verification
Prod isn't reachable from this environment, so the draft-blocking "prod-load sanity" is answered with a committed concurrency test plus a real-pipeline smoke (acceptance criteria adapted from #2427):

- **`src/lib/conversionPool.load.test.ts`** — 10 concurrent upload conversions dispatched through the production path (`GeneratePackagesUseCase` → `runUploadGeneration` → real Piscina pool → real worker threads), with `CONVERSION_WORKERS=2` so 10 jobs queue onto 2 threads. Asserts: all 10 settle (none lost), `pool.completed ≥ 10` with `queueSize 0` (no deadlock, no stuck queue), each result maps back to the job that produced it (rejection messages name their own input file — no cross-job result swapping), per-job errors stay isolated (4 `EmptyDeckError` parses + 3 `.apkg` rejections complete alongside 3 clean successes), and `shutdownConversionPool` drains without force-destroy (no worker leak). Two jobs carry transferred progress `MessagePort`s to exercise the transfer list under concurrency. Runs in ~1.5 s; fixtures stop short of the Python packaging step so CI runners without a create_deck venv stay green.
- **Real-pipeline smoke (local, not committed)** — toggle HTML through the actual pool: 1 card, 69 850-byte `.apkg` written by a real worker thread + real Python; `.apkg` input rejected with the coded message through the same pool path; pool drained clean on shutdown.

The remaining open question from decision 1 (upload latency when Notion jobs saturate the pool on the prod box) is by construction not answerable locally — watch median `[upload] tempfile dwell` after deploy (see Measuring success).

## Measuring success
- Median `[upload] tempfile dwell` `dwellMs` in prod logs — today includes the ~300 ms spawn (file is read inside the worker after spawn); expected to drop toward queue-wait-only.
- No new `PARSER_CRASH` / empty-reason failed jobs (`jobs.last_error`) after deploy.
- Watch for `ERR_WORKER_OUT_OF_MEMORY` (decision 2).

## Testing
- Unit: `GeneratePackagesUseCase` rewritten at the pool boundary — dispatch via pool, progress forwarding + transfer list, EmptyDeckError/sourceFormat/name/PARSER_CRASH preservation, pool-rejection propagation (11 tests). `runUploadGenerationInWorker` — failure shape with non-empty message + name, progress-port close on both paths (3 tests). `runUploadGeneration` — pool dispatch under the `uploadGeneration` name with transfer list (2 tests).
- Load: `conversionPool.load.test.ts` — 10 concurrent jobs through a real 2-thread pool (6 tests, see Load verification).
- Full server suite after rebase: 442 suites / 3 921 tests green (incl. DeckParser with the main checkout's venv symlinked).
- Real-pipeline smoke after rebase (actual piscina pool, real worker thread, real Python): toggle HTML → 1 card, 69 850-byte `.apkg`; `.apkg` upload → correct coded rejection through the pool path. MessagePort transfer verified (a non-transferred port would throw DataCloneError at `pool.run`).
- `tsc -p . --noEmit` clean; web typecheck + vitest (1 752 tests) + oxlint green.
- Sonar: not run — `SONAR_TOKEN` unset in this environment; expect a possible Sonar pass on CI.

## Changelog
No entry — internal perf plumbing; user-visible speedup will be confirmed by prod telemetry first.

## Risks
- Shared concurrency budget (decision 1): heavy Notion traffic can delay uploads and vice versa. Rollback: revert this PR; the old spawn path is self-contained.
- 1 GB cap on Notion workers (decision 2): a >1 GB Notion conversion now fails as a job instead of taking the process down — net safer, but new failure mode.
- Piscina `TransferList` type mis-infers under `lib: ["dom"]`; one `as never` cast at the pool boundary with inline justification.

## Goal alignment
Faster time-to-deck on every upload — the core "drop something in, get a clean deck back" loop — plus bounded conversion concurrency, which protects the box as we scale toward 300K users.
