### PR TITLE
feat: add time-to-first-deck and upload→download metrics to /ops

### DIFF
--- a/src/data_layer/EventsMetricsRepository.sql.test.ts
+++ b/src/data_layer/EventsMetricsRepository.sql.test.ts
@@ -1,0 +1,103 @@
+import knex from 'knex';
+
+import {
+  EventsMetricsRepository,
+  mapMedianMinutesRow,
+  mapUploadToDownloadRateRow,
+} from './EventsMetricsRepository';
+
+const cohortStart = new Date('2026-05-06T00:00:00.000Z');
+const sevenDaysAgo = new Date('2026-05-29T00:00:00.000Z');
+
+describe('EventsMetricsRepository generated SQL', () => {
+  const pg = knex({ client: 'pg' });
+  const repository = new EventsMetricsRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('computes the time-to-first-deck median over joined first-event subqueries', () => {
+    const { sql } = repository
+      .buildMedianMinutesToFirstDeckQuery(cohortStart)
+      .toSQL();
+
+    expect(sql).toBe(
+      'select percentile_cont(0.5) within group (order by extract(epoch from (downloads.first_download_at - accounts.account_at)) / 60) as median_minutes ' +
+        'from (select "user_id", min("created_at") as "account_at" from "events" where "name" = ? and "created_at" >= ? and "user_id" is not null group by "user_id") as "accounts" ' +
+        'inner join (select "user_id", min("created_at") as "first_download_at" from "events" where "name" = ? and "user_id" is not null group by "user_id") as "downloads" ' +
+        'on "downloads"."user_id" = "accounts"."user_id" ' +
+        'where downloads.first_download_at >= accounts.account_at'
+    );
+  });
+
+  it('binds account_created and deck_downloaded into the median query', () => {
+    const { bindings } = repository
+      .buildMedianMinutesToFirstDeckQuery(cohortStart)
+      .toSQL();
+
+    expect(bindings).toEqual([
+      'account_created',
+      cohortStart,
+      'deck_downloaded',
+    ]);
+  });
+
+  it('counts distinct coalesced actors per funnel stage for the upload-to-download rate', () => {
+    const { sql } = repository
+      .buildUploadToDownloadRateQuery(sevenDaysAgo)
+      .toSQL();
+
+    expect(sql).toBe(
+      'select count(distinct case when name = ? then COALESCE(user_id::text, anonymous_id) end) as uploaders, ' +
+        'count(distinct case when name = ? then COALESCE(user_id::text, anonymous_id) end) as downloaders ' +
+        'from "events" where "created_at" >= ? and "name" in (?, ?)'
+    );
+  });
+
+  it('binds the stage names and window into the rate query', () => {
+    const { bindings } = repository
+      .buildUploadToDownloadRateQuery(sevenDaysAgo)
+      .toSQL();
+
+    expect(bindings).toEqual([
+      'upload_started',
+      'deck_downloaded',
+      sevenDaysAgo,
+      'upload_started',
+      'deck_downloaded',
+    ]);
+  });
+});
+
+describe('mapMedianMinutesRow', () => {
+  it('returns null when the query yields no row', () => {
+    expect(mapMedianMinutesRow(undefined)).toBeNull();
+  });
+
+  it('returns null when percentile_cont returns null', () => {
+    expect(mapMedianMinutesRow({ median_minutes: null })).toBeNull();
+  });
+
+  it('returns the median as a number when the row carries a string', () => {
+    expect(mapMedianMinutesRow({ median_minutes: '42.5' })).toBe(42.5);
+  });
+});
+
+describe('mapUploadToDownloadRateRow', () => {
+  it('returns null when the query yields no row', () => {
+    expect(mapUploadToDownloadRateRow(undefined)).toBeNull();
+  });
+
+  it('returns null when there are no uploaders', () => {
+    expect(
+      mapUploadToDownloadRateRow({ uploaders: '0', downloaders: '0' })
+    ).toBeNull();
+  });
+
+  it('returns the rate as a percentage of distinct actors', () => {
+    expect(
+      mapUploadToDownloadRateRow({ uploaders: '80', downloaders: '20' })
+    ).toBe(25);
+  });
+});

--- a/src/data_layer/EventsMetricsRepository.ts
+++ b/src/data_layer/EventsMetricsRepository.ts
@@ -1,0 +1,94 @@
+import type { Knex } from 'knex';
+
+export interface IEventsMetricsRepository {
+  medianMinutesToFirstDeck(cohortStart: Date): Promise<number | null>;
+  uploadToDownloadRate(since: Date): Promise<number | null>;
+}
+
+export interface MedianMinutesRow {
+  median_minutes: number | string | null;
+}
+
+export interface UploadToDownloadRateRow {
+  uploaders: number | string;
+  downloaders: number | string;
+}
+
+export function mapMedianMinutesRow(
+  row: MedianMinutesRow | undefined
+): number | null {
+  if (row?.median_minutes == null) return null;
+  return Number(row.median_minutes);
+}
+
+export function mapUploadToDownloadRateRow(
+  row: UploadToDownloadRateRow | undefined
+): number | null {
+  if (row == null || Number(row.uploaders) === 0) return null;
+  return (Number(row.downloaders) / Number(row.uploaders)) * 100;
+}
+
+export class EventsMetricsRepository implements IEventsMetricsRepository {
+  constructor(private readonly database: Knex) {}
+
+  buildMedianMinutesToFirstDeckQuery(cohortStart: Date): Knex.QueryBuilder {
+    const accounts = this.database('events')
+      .select('user_id')
+      .min('created_at as account_at')
+      .where('name', 'account_created')
+      .where('created_at', '>=', cohortStart)
+      .whereNotNull('user_id')
+      .groupBy('user_id')
+      .as('accounts');
+
+    const downloads = this.database('events')
+      .select('user_id')
+      .min('created_at as first_download_at')
+      .where('name', 'deck_downloaded')
+      .whereNotNull('user_id')
+      .groupBy('user_id')
+      .as('downloads');
+
+    return this.database
+      .from(accounts)
+      .join(downloads, 'downloads.user_id', 'accounts.user_id')
+      .whereRaw('downloads.first_download_at >= accounts.account_at')
+      .select(
+        this.database.raw(
+          'percentile_cont(0.5) within group (order by extract(epoch from (downloads.first_download_at - accounts.account_at)) / 60) as median_minutes'
+        )
+      );
+  }
+
+  async medianMinutesToFirstDeck(cohortStart: Date): Promise<number | null> {
+    const row = (await this.buildMedianMinutesToFirstDeckQuery(
+      cohortStart
+    ).first()) as MedianMinutesRow | undefined;
+    return mapMedianMinutesRow(row);
+  }
+
+  buildUploadToDownloadRateQuery(since: Date): Knex.QueryBuilder {
+    return this.database('events')
+      .where('created_at', '>=', since)
+      .whereIn('name', ['upload_started', 'deck_downloaded'])
+      .select(
+        this.database.raw(
+          "count(distinct case when name = ? then COALESCE(user_id::text, anonymous_id) end) as uploaders",
+          ['upload_started']
+        ),
+        this.database.raw(
+          "count(distinct case when name = ? then COALESCE(user_id::text, anonymous_id) end) as downloaders",
+          ['deck_downloaded']
+        )
+      );
+  }
+
+  async uploadToDownloadRate(since: Date): Promise<number | null> {
+    const row = (await this.buildUploadToDownloadRateQuery(since).first()) as
+      | UploadToDownloadRateRow
+      | undefined;
+    return mapUploadToDownloadRateRow(row);
+  }
+}
+
+export default EventsMetricsRepository;

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -133,6 +133,8 @@ jest.mock('../services/ops/ConversionMetricsService', () => {
             { week: '2026-05-04', count: 3 },
             { week: '2026-05-11', count: 8 },
           ],
+          time_to_first_deck_median_minutes_30d: 42.5,
+          upload_to_download_rate_7d: 25,
         };
       }
     },
@@ -330,6 +332,8 @@ describe('OpsRouter /api/ops/conversion/metrics', () => {
           paid_conversion_success_rate_7d: expect.any(Number),
           conversion_errors_7d_top_reasons: expect.any(Array),
           failed_conversions_weekly: expect.any(Array),
+          time_to_first_deck_median_minutes_30d: expect.any(Number),
+          upload_to_download_rate_7d: expect.any(Number),
         })
       );
     } finally {

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -41,6 +41,7 @@ import { UserVisibleErrorsRepository } from '../data_layer/UserVisibleErrorsRepo
 import { MindmapRepository } from '../data_layer/MindmapRepository';
 import { GetMindmapImageStatsUseCase } from '../usecases/mindmaps/GetMindmapImageStatsUseCase';
 import { JobsMetricsRepository } from '../data_layer/JobsMetricsRepository';
+import { EventsMetricsRepository } from '../data_layer/EventsMetricsRepository';
 import { SyncStripeSubscriptionsUseCase } from '../usecases/ops/SyncStripeSubscriptionsUseCase';
 import { GetPricingAbFunnelUseCase } from '../usecases/ops/GetPricingAbFunnelUseCase';
 import { PricingAbFunnelService } from '../services/ops/PricingAbFunnelService';
@@ -68,7 +69,8 @@ const OpsRouter = () => {
   });
 
   const conversionMetricsService = new ConversionMetricsService(
-    new JobsMetricsRepository(database)
+    new JobsMetricsRepository(database),
+    new EventsMetricsRepository(database)
   );
   const performanceMetricsService = new PerformanceMetricsService(
     database,
@@ -173,7 +175,7 @@ const OpsRouter = () => {
    * @swagger
    * /api/ops/conversion/metrics:
    *   get:
-   *     summary: Conversion success/failure metrics from jobs table
+   *     summary: Conversion success/failure metrics from jobs table plus funnel metrics from events
    *     description: Internal endpoint locked to the ops owner. Returns 404 for everyone else.
    *     tags: [Ops]
    *     responses:

--- a/src/services/ops/ConversionMetricsService.test.ts
+++ b/src/services/ops/ConversionMetricsService.test.ts
@@ -1,3 +1,4 @@
+import type { IEventsMetricsRepository } from '../../data_layer/EventsMetricsRepository';
 import type { IJobsMetricsRepository } from '../../data_layer/JobsMetricsRepository';
 import type { ConversionErrorCount } from './ConversionMetricsService';
 import { ConversionMetricsService } from './ConversionMetricsService';
@@ -25,9 +26,31 @@ function makeStubRepo(overrides: Partial<IJobsMetricsRepository> = {}): IJobsMet
   };
 }
 
+function makeFailingEventsRepo(): IEventsMetricsRepository {
+  return {
+    medianMinutesToFirstDeck: jest
+      .fn()
+      .mockRejectedValue(new Error('db down')),
+    uploadToDownloadRate: jest.fn().mockRejectedValue(new Error('db down')),
+  };
+}
+
+function makeStubEventsRepo(
+  overrides: Partial<IEventsMetricsRepository> = {}
+): IEventsMetricsRepository {
+  return {
+    medianMinutesToFirstDeck: jest.fn().mockResolvedValue(null),
+    uploadToDownloadRate: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
 describe('ConversionMetricsService — graceful failure', () => {
   it('returns null for every metric when the repository throws', async () => {
-    const service = new ConversionMetricsService(makeFailingRepo());
+    const service = new ConversionMetricsService(
+      makeFailingRepo(),
+      makeFailingEventsRepo()
+    );
     const metrics = await service.getMetrics();
 
     expect(metrics.free_conversions_7d).toBeNull();
@@ -36,13 +59,16 @@ describe('ConversionMetricsService — graceful failure', () => {
     expect(metrics.paid_conversion_success_rate_7d).toBeNull();
     expect(metrics.conversion_errors_7d_top_reasons).toBeNull();
     expect(metrics.failed_conversions_weekly).toBeNull();
+    expect(metrics.time_to_first_deck_median_minutes_30d).toBeNull();
+    expect(metrics.upload_to_download_rate_7d).toBeNull();
   });
 });
 
 describe('ConversionMetricsService — shape assembly', () => {
   it('passes through free conversion count from the repository', async () => {
     const service = new ConversionMetricsService(
-      makeStubRepo({ countFreeConversions7d: jest.fn().mockResolvedValue(7) })
+      makeStubRepo({ countFreeConversions7d: jest.fn().mockResolvedValue(7) }),
+      makeStubEventsRepo()
     );
 
     const metrics = await service.getMetrics();
@@ -52,7 +78,8 @@ describe('ConversionMetricsService — shape assembly', () => {
 
   it('passes through paid conversion count from the repository', async () => {
     const service = new ConversionMetricsService(
-      makeStubRepo({ countPaidConversions7d: jest.fn().mockResolvedValue(3) })
+      makeStubRepo({ countPaidConversions7d: jest.fn().mockResolvedValue(3) }),
+      makeStubEventsRepo()
     );
 
     const metrics = await service.getMetrics();
@@ -62,7 +89,8 @@ describe('ConversionMetricsService — shape assembly', () => {
 
   it('passes through free success rate from the repository', async () => {
     const service = new ConversionMetricsService(
-      makeStubRepo({ computeFreeSuccessRate7d: jest.fn().mockResolvedValue(66.7) })
+      makeStubRepo({ computeFreeSuccessRate7d: jest.fn().mockResolvedValue(66.7) }),
+      makeStubEventsRepo()
     );
 
     const metrics = await service.getMetrics();
@@ -76,7 +104,8 @@ describe('ConversionMetricsService — shape assembly', () => {
       { reason: 'timeout', count: 2 },
     ];
     const service = new ConversionMetricsService(
-      makeStubRepo({ topFailureReasons7d: jest.fn().mockResolvedValue(reasons) })
+      makeStubRepo({ topFailureReasons7d: jest.fn().mockResolvedValue(reasons) }),
+      makeStubEventsRepo()
     );
 
     const metrics = await service.getMetrics();
@@ -86,7 +115,8 @@ describe('ConversionMetricsService — shape assembly', () => {
 
   it('produces a 12-week time series with zeroes for weeks with no data', async () => {
     const service = new ConversionMetricsService(
-      makeStubRepo({ failedConversionsWeekly: jest.fn().mockResolvedValue([]) })
+      makeStubRepo({ failedConversionsWeekly: jest.fn().mockResolvedValue([]) }),
+      makeStubEventsRepo()
     );
 
     const metrics = await service.getMetrics();
@@ -109,13 +139,59 @@ describe('ConversionMetricsService — shape assembly', () => {
       ]),
     });
 
-    const service = new ConversionMetricsService(repo);
+    const service = new ConversionMetricsService(repo, makeStubEventsRepo());
     const metrics = await service.getMetrics();
 
     const weekly = metrics.failed_conversions_weekly ?? [];
     const lastPoint = weekly[weekly.length - 1];
     expect(lastPoint?.count).toBe(4);
     expect(lastPoint?.week).toBe('2025-05-19');
+
+    jest.useRealTimers();
+  });
+
+  it('passes through the time-to-first-deck median from the events repository', async () => {
+    const service = new ConversionMetricsService(
+      makeStubRepo(),
+      makeStubEventsRepo({
+        medianMinutesToFirstDeck: jest.fn().mockResolvedValue(42.5),
+      })
+    );
+
+    const metrics = await service.getMetrics();
+
+    expect(metrics.time_to_first_deck_median_minutes_30d).toBe(42.5);
+  });
+
+  it('passes through the upload-to-download rate from the events repository', async () => {
+    const service = new ConversionMetricsService(
+      makeStubRepo(),
+      makeStubEventsRepo({
+        uploadToDownloadRate: jest.fn().mockResolvedValue(25),
+      })
+    );
+
+    const metrics = await service.getMetrics();
+
+    expect(metrics.upload_to_download_rate_7d).toBe(25);
+  });
+
+  it('queries the median over a 30-day cohort and the rate over 7 days', async () => {
+    const now = new Date('2025-05-19T00:00:00.000Z');
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+
+    const eventsRepo = makeStubEventsRepo();
+    const service = new ConversionMetricsService(makeStubRepo(), eventsRepo);
+
+    await service.getMetrics();
+
+    expect(eventsRepo.medianMinutesToFirstDeck).toHaveBeenCalledWith(
+      new Date('2025-04-19T00:00:00.000Z')
+    );
+    expect(eventsRepo.uploadToDownloadRate).toHaveBeenCalledWith(
+      new Date('2025-05-12T00:00:00.000Z')
+    );
 
     jest.useRealTimers();
   });

--- a/src/services/ops/ConversionMetricsService.ts
+++ b/src/services/ops/ConversionMetricsService.ts
@@ -1,3 +1,4 @@
+import type { IEventsMetricsRepository } from '../../data_layer/EventsMetricsRepository';
 import type { IJobsMetricsRepository } from '../../data_layer/JobsMetricsRepository';
 
 export type ConversionMetricKey =
@@ -6,7 +7,9 @@ export type ConversionMetricKey =
   | 'free_conversion_success_rate_7d'
   | 'paid_conversion_success_rate_7d'
   | 'conversion_errors_7d_top_reasons'
-  | 'failed_conversions_weekly';
+  | 'failed_conversions_weekly'
+  | 'time_to_first_deck_median_minutes_30d'
+  | 'upload_to_download_rate_7d';
 
 export interface ConversionErrorCount {
   reason: string;
@@ -25,18 +28,27 @@ export interface ConversionMetricsResponse {
   paid_conversion_success_rate_7d: number | null;
   conversion_errors_7d_top_reasons: ConversionErrorCount[] | null;
   failed_conversions_weekly: FailedConversionsWeekPoint[] | null;
+  time_to_first_deck_median_minutes_30d: number | null;
+  upload_to_download_rate_7d: number | null;
 }
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
 const WEEKLY_HISTORY_WEEKS = 12;
+const COHORT_WINDOW_DAYS = 30;
 
 export class ConversionMetricsService {
-  constructor(private readonly repository: IJobsMetricsRepository) {}
+  constructor(
+    private readonly repository: IJobsMetricsRepository,
+    private readonly eventsMetricsRepository: IEventsMetricsRepository
+  ) {}
 
   async getMetrics(): Promise<ConversionMetricsResponse> {
     const now = new Date();
     const sevenDaysAgoMs = now.getTime() - 7 * SECONDS_PER_DAY * 1000;
     const sevenDaysAgo = new Date(sevenDaysAgoMs);
+    const thirtyDaysAgo = new Date(
+      now.getTime() - COHORT_WINDOW_DAYS * SECONDS_PER_DAY * 1000
+    );
 
     const weekStarts = this.lastNIsoWeekStartsUtc(now, WEEKLY_HISTORY_WEEKS);
     const earliestStart = new Date(weekStarts[0]);
@@ -50,6 +62,8 @@ export class ConversionMetricsService {
       paidSuccessRate7d,
       topErrors7d,
       failedConversionsWeeklyRows,
+      timeToFirstDeck30d,
+      uploadToDownloadRate7d,
     ] = await Promise.allSettled([
       this.repository.countFreeConversions7d(sevenDaysAgo),
       this.repository.countPaidConversions7d(sevenDaysAgo),
@@ -57,6 +71,8 @@ export class ConversionMetricsService {
       this.repository.computePaidSuccessRate7d(sevenDaysAgo),
       this.repository.topFailureReasons7d(sevenDaysAgo),
       this.repository.failedConversionsWeekly(earliestStart, weekEnd),
+      this.eventsMetricsRepository.medianMinutesToFirstDeck(thirtyDaysAgo),
+      this.eventsMetricsRepository.uploadToDownloadRate(sevenDaysAgo),
     ]);
 
     const failedConversionsWeekly =
@@ -76,6 +92,14 @@ export class ConversionMetricsService {
       conversion_errors_7d_top_reasons:
         topErrors7d.status === 'fulfilled' ? topErrors7d.value : null,
       failed_conversions_weekly: failedConversionsWeekly,
+      time_to_first_deck_median_minutes_30d:
+        timeToFirstDeck30d.status === 'fulfilled'
+          ? timeToFirstDeck30d.value
+          : null,
+      upload_to_download_rate_7d:
+        uploadToDownloadRate7d.status === 'fulfilled'
+          ? uploadToDownloadRate7d.value
+          : null,
     };
   }
 

--- a/web/src/pages/OpsPage/ConversionsTab.test.tsx
+++ b/web/src/pages/OpsPage/ConversionsTab.test.tsx
@@ -35,6 +35,8 @@ const buildSampleMetrics = (
     week: `2026-02-${String((i % 28) + 1).padStart(2, '0')}`,
     count: i % 4,
   })),
+  time_to_first_deck_median_minutes_30d: 42,
+  upload_to_download_rate_7d: 25.4,
   ...overrides,
 });
 
@@ -73,6 +75,62 @@ describe('ConversionsTab', () => {
       '/api/ops/conversion/metrics',
       expect.objectContaining({ credentials: 'include' })
     );
+  });
+
+  test('renders the funnel cards from the response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => buildSampleMetrics(),
+    });
+
+    renderTab();
+
+    await waitFor(() => expect(screen.getByText('42 min')).toBeInTheDocument());
+    expect(screen.getByText('Time to first deck')).toBeInTheDocument();
+    expect(
+      screen.getByText('Median, accounts created in the last 30 days')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Upload → download rate')).toBeInTheDocument();
+    expect(screen.getByText('25.4%')).toBeInTheDocument();
+    expect(
+      screen.getByText('Distinct visitors, last 7 days')
+    ).toBeInTheDocument();
+  });
+
+  test('formats a multi-hour median in hours', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () =>
+        buildSampleMetrics({ time_to_first_deck_median_minutes_30d: 150 }),
+    });
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(screen.getByText('2.5 h')).toBeInTheDocument()
+    );
+  });
+
+  test('renders em-dash for null funnel metrics', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () =>
+        buildSampleMetrics({
+          time_to_first_deck_median_minutes_30d: null,
+          upload_to_download_rate_7d: null,
+        }),
+    });
+
+    renderTab();
+
+    await waitFor(() => expect(screen.getByText('824')).toBeInTheDocument());
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
   });
 
   test('renders failure panel titles', async () => {

--- a/web/src/pages/OpsPage/ConversionsTab.tsx
+++ b/web/src/pages/OpsPage/ConversionsTab.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import sharedStyles from '../../styles/shared.module.css';
 import {
+  formatDurationMinutes,
   formatInteger,
   formatPercentOneDecimal,
 } from './businessHelpers';
@@ -87,6 +88,35 @@ export default function ConversionsTab() {
               visible?.paid_conversion_success_rate_7d ?? null,
               formatPercentOneDecimal
             )}
+          />
+        </div>
+      </section>
+
+      <section className={styles.section} aria-labelledby="conv-section-funnel">
+        <header className={styles.sectionHeader}>
+          <h2 id="conv-section-funnel" className={styles.sectionTitle}>
+            Funnel
+          </h2>
+          <p className={styles.sectionHint}>
+            From signup or upload to a downloaded deck
+          </p>
+        </header>
+        <div className={styles.cardGrid}>
+          <MetricCard
+            title="Time to first deck"
+            value={formatNumberOrDash(
+              visible?.time_to_first_deck_median_minutes_30d ?? null,
+              formatDurationMinutes
+            )}
+            footnote="Median, accounts created in the last 30 days"
+          />
+          <MetricCard
+            title="Upload → download rate"
+            value={formatNumberOrDash(
+              visible?.upload_to_download_rate_7d ?? null,
+              formatPercentOneDecimal
+            )}
+            footnote="Distinct visitors, last 7 days"
           />
         </div>
       </section>

--- a/web/src/pages/OpsPage/businessHelpers.ts
+++ b/web/src/pages/OpsPage/businessHelpers.ts
@@ -44,6 +44,16 @@ export const formatInteger = (value: number): string =>
 export const formatPercentOneDecimal = (value: number): string =>
   `${value.toFixed(1)}%`;
 
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
+
+export const formatDurationMinutes = (value: number): string => {
+  if (value < MINUTES_PER_HOUR) return `${Math.round(value)} min`;
+  if (value < 2 * MINUTES_PER_DAY)
+    return `${(value / MINUTES_PER_HOUR).toFixed(1)} h`;
+  return `${(value / MINUTES_PER_DAY).toFixed(1)} d`;
+};
+
 const padTwo = (n: number): string => n.toString().padStart(2, '0');
 
 export const formatClockShort = (date: Date): string =>

--- a/web/src/pages/OpsPage/conversionTypes.test.ts
+++ b/web/src/pages/OpsPage/conversionTypes.test.ts
@@ -17,6 +17,8 @@ describe('conversionTypes', () => {
       paid_conversion_success_rate_7d: 95,
       conversion_errors_7d_top_reasons: [reason],
       failed_conversions_weekly: [week],
+      time_to_first_deck_median_minutes_30d: 42.5,
+      upload_to_download_rate_7d: 25,
     };
 
     expect(response.free_conversions_7d).toBe(10);
@@ -34,6 +36,8 @@ describe('conversionTypes', () => {
       paid_conversion_success_rate_7d: null,
       conversion_errors_7d_top_reasons: null,
       failed_conversions_weekly: null,
+      time_to_first_deck_median_minutes_30d: null,
+      upload_to_download_rate_7d: null,
     };
     expect(response.free_conversions_7d).toBeNull();
     expect(response.failed_conversions_weekly).toBeNull();

--- a/web/src/pages/OpsPage/conversionTypes.ts
+++ b/web/src/pages/OpsPage/conversionTypes.ts
@@ -15,4 +15,6 @@ export interface ConversionMetricsResponse {
   paid_conversion_success_rate_7d: number | null;
   conversion_errors_7d_top_reasons: ConversionErrorCount[] | null;
   failed_conversions_weekly: FailedConversionsWeekPoint[] | null;
+  time_to_first_deck_median_minutes_30d: number | null;
+  upload_to_download_rate_7d: number | null;
 }

--- a/web/src/pages/OpsPage/useConversionMetrics.test.ts
+++ b/web/src/pages/OpsPage/useConversionMetrics.test.ts
@@ -30,6 +30,8 @@ describe('useConversionMetrics', () => {
       paid_conversion_success_rate_7d: 95,
       conversion_errors_7d_top_reasons: [],
       failed_conversions_weekly: [],
+      time_to_first_deck_median_minutes_30d: 42.5,
+      upload_to_download_rate_7d: 25,
     };
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## What
Adds two funnel metrics to the /ops Conversions tab: **Time to first deck** (median minutes from `account_created` to that user's first `deck_downloaded`, 30-day signup cohort) and **Upload → download rate** (distinct actors with `deck_downloaded` ÷ distinct actors with `upload_started`, last 7 days). Both come from the `events` table — no migration.

## Why
Fixes #2535. Success rate says the pipeline didn't throw; it doesn't say the user got a deck they kept. Time-to-first-deck is the leading indicator for the "simplest, fastest" mission; the upload→download rate catches silent failures where conversion succeeded but the user bounced without a deck.

## How
- New `src/data_layer/EventsMetricsRepository.ts` — two read-only queries over `events`. The median joins per-user first `account_created` against first `deck_downloaded` and takes `percentile_cont(0.5)` over the minute delta; the rate counts `distinct COALESCE(user_id::text, anonymous_id)` per stage in one pass.
- `ConversionMetricsService` takes the new repository as a second constructor dependency and folds both metrics into the existing `Promise.allSettled` (a failing query degrades to `null`/“—”, never 500s the tab).
- `ConversionsTab` renders a new "Funnel" section with two `MetricCard`s; durations format as `42 min` / `2.5 h` / `1.3 d`.

## Decisions made overnight (please review)
- **Median, not mean** for time-to-first-deck — robust to outliers (one user taking a month would swamp a mean). Change `buildMedianMinutesToFirstDeckQuery` if wrong.
- **30-day cohort window** for the median — assumption; the issue said 7d but a 7-day cohort barely has time to convert. Window is `COHORT_WINDOW_DAYS` in `ConversionMetricsService`.
- **Actor identity = `COALESCE(user_id::text, anonymous_id)`** — matches the existing upload-funnel queries in `EventsRepository`; assumption that this is the identity we want for the rate.
- **Never-downloaders are excluded from the median** (inner join) rather than treated as infinity — the card answers "how fast do converters convert", the rate card answers "how many convert".
- **Field names** are `time_to_first_deck_median_minutes_30d` / `upload_to_download_rate_7d` rather than the issue's `*_p50_7d` names, since the implemented definitions (events-based, 30d cohort, minutes) differ from the issue's jobs/downloads sketch per the overnight brief.
- The issue's jobs↔downloads join approach was not used — the `events` table already carries both ends with consistent actor identity.

## Measuring success
The two cards render real numbers on https://2anki.net/ops → Conversions after deploy; `GET /api/ops/conversion/metrics` response carries `time_to_first_deck_median_minutes_30d` and `upload_to_download_rate_7d`. A query failure logs via the existing `[ops] getConversionMetrics failed` path and shows "—".

## Testing
- `src/data_layer/EventsMetricsRepository.sql.test.ts` — generated-SQL shape tests with `knex({ client: 'pg' })` (`toSQL()` text + bindings) for both queries, plus pure row-mapper tests (null row, string numerics, zero uploaders).
- `src/services/ops/ConversionMetricsService.test.ts` — pass-through, failure→null, and window-argument tests (fake timers).
- `src/routes/OpsRouter.test.ts` — response shape at the route boundary includes both new fields.
- `web/src/pages/OpsPage/ConversionsTab.test.tsx` — funnel cards render, hour formatting, null→"—".

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: overnight autonomous run — not browser-verified; /ops Conversions tab needs a look before merge.

## Changelog
No entry — internal-only ops dashboard change, no user-visible behavior.

## Risks
Read-only SQL on `events`; worst case is a slow query on a large table (both queries scan a bounded time window; the median's download subquery is unbounded by date but grouped by user). Rollback = revert. Sonar not run locally — `SONAR_TOKEN` unset on this machine; expect CI Sonar to be the first rule-engine pass.

## Goal alignment
Time-to-first-deck is the direct measurement of "simplest, fastest way to turn notes into flashcards"; the upload→download rate names the funnel leak between trying and succeeding — both feed prioritization toward 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783281448&installation_id=132681956&pr_number=3142&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3142&signature=42f772c345c16283f57d5755d5f60a63c06320ff22c31481df14ba34fa007927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander (standing waiver, overnight run 2026-06-05/06); automated suites green.
