### PR TITLE
feat: add native app coming-soon page with demand probe

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -63,6 +63,8 @@ export const KNOWN_EVENTS = new Set([
   'make_another_deck_clicked',
   'invite_link_copied',
   'recent_page_reconvert_clicked',
+  'native_app_page_viewed',
+  'native_app_interest_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -254,6 +254,10 @@ const TransformPage = lazyWithRetry(
   () => import('./pages/TransformPage'),
   './pages/TransformPage'
 );
+const NativeAppPage = lazyWithRetry(
+  () => import('./pages/NativeAppPage/NativeAppPage'),
+  './pages/NativeAppPage/NativeAppPage'
+);
 
 const queryClient = new QueryClient();
 
@@ -437,6 +441,7 @@ function AppContent({
           <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
           <Route path="/settings" element={requireAuth(<AccountPage />)} />
           <Route path="/about" element={<AboutPage />} />
+          <Route path="/app" element={<NativeAppPage />} />
           <Route path="/security" element={<SecurityPage />} />
           <Route path="/status" element={<StatusPage />} />
           <Route path="/whats-new" element={<WhatsNewPage />} />

--- a/web/src/components/Footer.test.tsx
+++ b/web/src/components/Footer.test.tsx
@@ -34,6 +34,9 @@ describe('Footer', () => {
       'href',
       '/contact'
     );
+    expect(
+      screen.getByRole('link', { name: 'iOS and macOS app' })
+    ).toHaveAttribute('href', '/app');
     expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute(
       'href',
       '/documentation/misc/terms-of-service'

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -15,6 +15,7 @@ function Footer() {
         <div className={styles.group}>
           <span className={styles.groupTitle}>Product</span>
           <a href="/about">{getVisibleText('navigation.legal.about')}</a>
+          <a href="/app">iOS and macOS app</a>
           <a href="/documentation">{getVisibleText('navigation.docs')}</a>
           <a href="/contact">{getVisibleText('navigation.contact')}</a>
         </div>

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -49,6 +49,8 @@ export const KNOWN_EVENTS = new Set([
   'make_another_deck_clicked',
   'invite_link_copied',
   'recent_page_reconvert_clicked',
+  'native_app_page_viewed',
+  'native_app_interest_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/NativeAppPage/NativeAppPage.module.css
+++ b/web/src/pages/NativeAppPage/NativeAppPage.module.css
@@ -1,0 +1,27 @@
+/* Local .page: shared.page has no flex/gap (see web/CLAUDE.md) */
+.page {
+  composes: pageNarrow from '../../styles/shared.module.css';
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.mascot {
+  display: block;
+  width: 96px;
+  height: 96px;
+}
+
+.body {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+.noted {
+  margin: 0;
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}

--- a/web/src/pages/NativeAppPage/NativeAppPage.test.tsx
+++ b/web/src/pages/NativeAppPage/NativeAppPage.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HelmetProvider } from 'react-helmet-async';
+import NativeAppPage from './NativeAppPage';
+
+const trackMock = vi.fn();
+vi.mock('../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+const renderPage = () =>
+  render(
+    <HelmetProvider>
+      <NativeAppPage />
+    </HelmetProvider>
+  );
+
+const callsFor = (name: string) =>
+  trackMock.mock.calls.filter(([eventName]) => eventName === name);
+
+describe('NativeAppPage', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+    trackMock.mockClear();
+  });
+
+  it('renders the hero title, body, and CTA', () => {
+    renderPage();
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: '2anki for iPhone, iPad, and Mac',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/A native app is in the works/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'I want this' })
+    ).toBeInTheDocument();
+  });
+
+  it('tracks native_app_page_viewed once on mount', () => {
+    renderPage();
+    expect(callsFor('native_app_page_viewed')).toHaveLength(1);
+  });
+
+  it('fires native_app_interest_clicked and swaps the CTA to a confirmation', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'I want this' }));
+    expect(callsFor('native_app_interest_clicked')).toHaveLength(1);
+    expect(
+      screen.queryByRole('button', { name: 'I want this' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Noted. Watch What's New for updates.")
+    ).toBeInTheDocument();
+  });
+
+  it('holds the guard across remounts — no second interest event, no button', () => {
+    const first = renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'I want this' }));
+    first.unmount();
+
+    renderPage();
+    expect(
+      screen.queryByRole('button', { name: 'I want this' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Noted. Watch What's New for updates.")
+    ).toBeInTheDocument();
+    expect(callsFor('native_app_interest_clicked')).toHaveLength(1);
+  });
+});

--- a/web/src/pages/NativeAppPage/NativeAppPage.tsx
+++ b/web/src/pages/NativeAppPage/NativeAppPage.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { track } from '../../lib/analytics/track';
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './NativeAppPage.module.css';
+
+const INTEREST_KEY = 'native_app_interest_clicked';
+
+function hasRegisteredInterest(): boolean {
+  return globalThis.localStorage?.getItem(INTEREST_KEY) != null;
+}
+
+export default function NativeAppPage() {
+  const pageViewTracked = useRef(false);
+  const [interestRegistered, setInterestRegistered] = useState(
+    hasRegisteredInterest
+  );
+
+  useEffect(() => {
+    if (pageViewTracked.current) return;
+    pageViewTracked.current = true;
+    track('native_app_page_viewed');
+  }, []);
+
+  const registerInterest = () => {
+    if (hasRegisteredInterest()) {
+      setInterestRegistered(true);
+      return;
+    }
+    track('native_app_interest_clicked');
+    globalThis.localStorage?.setItem(INTEREST_KEY, '1');
+    setInterestRegistered(true);
+  };
+
+  return (
+    <div className={styles.page}>
+      <Helmet>
+        <title>2anki for iPhone, iPad, and Mac</title>
+      </Helmet>
+      <img src="/mascot/Notion 1.png" alt="" className={styles.mascot} />
+      <h1 className={sharedStyles.title}>2anki for iPhone, iPad, and Mac</h1>
+      <p className={styles.body}>
+        A native app is in the works. Convert your notes to Anki decks on the
+        device you study with — no browser needed. Tap below and we'll count
+        you in when we decide what ships first.
+      </p>
+      {interestRegistered ? (
+        <p className={styles.noted}>Noted. Watch What's New for updates.</p>
+      ) : (
+        <button
+          type="button"
+          className={`${sharedStyles.btnPrimary} ${sharedStyles.btnInline}`}
+          onClick={registerInterest}
+        >
+          I want this
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds `/app` — a coming-soon page for the native iOS/macOS app that doubles as a demand probe. Hero (mascot, H1, one-paragraph body) plus a one-tap "I want this" CTA that fires `native_app_interest_clicked` once per visitor; `native_app_page_viewed` fires on mount. Linked from the footer Product group only.

## Why
Fixes #3105. Before investing further in the native app, we need a build/no-build signal. This page measures real interest with one tap instead of announcing a product that doesn't exist yet.

## How
Plain lazy React route in `web/src/App.tsx` (`lazyWithRetry`, same as every other page). Page composes `shared.module.css` tokens with its own local flex-gap `.page` (per the web/CLAUDE.md gotcha). Both event names registered in `web/src/lib/analytics/events.ts` and `src/types/AnalyticsEvents.ts` so EventsController doesn't flag them as unknown. No backend logic, no migration.

## Decisions made overnight (please review)
1. Route & placement: /app, plain lazy route, footer-only — prerender + sitemap deliberately skipped to keep the demand metric clean and avoid shared-file conflicts.
2. Demand capture = telemetry probe (one-tap, invite-link-probe pattern), not email — list storage/unsubscribe too heavy overnight, unnecessary for a build/no-build signal.
3. Not building: pricing display, screenshots, badges, TestFlight, countdown.
4. No changelog — instrument, not announcement; entry ships when the app does.
5. Goal alignment: probe rate by device class joins #3049's upload_started tagging to make the build/no-build call.

## Acceptance criteria
- [x] `/app` renders H1 `2anki for iPhone, iPad, and Mac`, body copy, and `I want this` CTA
- [x] CTA fires `native_app_interest_clicked` exactly once per visitor (localStorage guard), then swaps to `Noted. Watch What's New for updates.`
- [x] `native_app_page_viewed` fires on mount
- [x] Event names registered in both `web/src/lib/analytics/events.ts` and `src/types/AnalyticsEvents.ts`
- [x] Footer Product group links `iOS and macOS app` → /app; no nav link, no banner
- [x] Not in the prerender pipeline, not in sitemap.xml
- [x] No pricing, date, screenshots, App Store badges, TestFlight link, or email capture
- [x] No changelog entry (deliberate — see decision 4)

## Measuring success
`native_app_page_viewed` → `native_app_interest_clicked` conversion in the events table, segmented by device class via the #3049 `upload_started` tagging. A sustained probe rate is the build signal.

## Testing
- Unit tests added: `web/src/pages/NativeAppPage/NativeAppPage.test.tsx` (renders H1/body/CTA, viewed event once on mount, interest probe fires once then guard holds across remounts, CTA swaps to confirmation), `Footer.test.tsx` (link → /app)
- Server tsc, web typecheck, full web vitest (1726 passing), Biome lint all green
- Sonar not run locally — `SONAR_TOKEN` unset in this environment; change is one small component + two registry one-liners, expect CI analysis to cover it

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: overnight run — needs manual pass or waiver; page is mobile-first, check 375px

## Changelog
No entry — measurement instrument, not an announcement; a What's New entry would corrupt the demand signal. Entry ships when the app does.

## Risks
Tiny surface: a new lazy route and a footer link. Worst case the probe undercounts (localStorage cleared → re-fire is possible, ad blockers may drop `/api/events/track`) — acceptable noise for a directional signal. Rollback: revert the PR.

## Goal alignment
Gates native-app investment on measured demand instead of intuition — engineering time stays on what moves 2anki.net toward 300K users unless users say otherwise with a tap.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783281717&installation_id=132681956&pr_number=3143&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3143&signature=47beac3f045f0f0e90bbec3d7f68669b24314b1b0dfa82666a852e80f4f50dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


Browser check: not applicable — manual browser pass explicitly waived by Alexander (standing waiver, overnight run 2026-06-05/06); automated suites green.
