### PR TITLE
fix: classify encrypted and zero-page PDFs as readable failures

### DIFF
--- a/src/lib/pdf/getPageCount.test.ts
+++ b/src/lib/pdf/getPageCount.test.ts
@@ -1,8 +1,17 @@
-import { execSync } from 'child_process';
-import { getPageCount } from './getPageCount';
+import { EventEmitter } from 'events';
+import { execSync, spawn as realSpawn, type ChildProcess } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
+import { getPageCount } from './getPageCount';
+import { jobFailureReasonCode } from '../../usecases/jobs/jobFailureReason';
+
+jest.mock('child_process', () => {
+  const actual = jest.requireActual('child_process');
+  return { ...actual, spawn: jest.fn(actual.spawn) };
+});
+
+const spawnMock = realSpawn as jest.MockedFunction<typeof realSpawn>;
 
 const hasPdfinfo = (() => {
   try {
@@ -15,11 +24,44 @@ const hasPdfinfo = (() => {
 
 const itIfPdfinfo = hasPdfinfo ? it : it.skip;
 
+interface FakePdfinfoRun {
+  stdout?: string;
+  stderr?: string;
+  code?: number | null;
+  signal?: NodeJS.Signals | null;
+}
+
+function fakePdfinfo(run: FakePdfinfoRun) {
+  spawnMock.mockImplementationOnce((): ChildProcess => {
+    const proc = new EventEmitter() as ChildProcess;
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    (proc as unknown as { stdout: EventEmitter }).stdout = stdout;
+    (proc as unknown as { stderr: EventEmitter }).stderr = stderr;
+
+    setImmediate(() => {
+      if (run.stdout != null) {
+        stdout.emit('data', Buffer.from(run.stdout));
+      }
+      if (run.stderr != null) {
+        stderr.emit('data', Buffer.from(run.stderr));
+      }
+      proc.emit('close', run.code ?? 0, run.signal ?? null);
+    });
+
+    return proc;
+  });
+}
+
 describe('getPageCount', () => {
   let tmpDir: string;
+  let pdfPath: string;
 
   beforeEach(async () => {
+    spawnMock.mockClear();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'getPageCount-test-'));
+    pdfPath = path.join(tmpDir, 'sample.pdf');
+    await fs.writeFile(pdfPath, '%PDF-1.4 placeholder');
   });
 
   afterEach(async () => {
@@ -56,4 +98,38 @@ describe('getPageCount', () => {
       expect(caught!.message).toContain('path=not-a-pdf.txt');
     }
   );
+
+  it('rejects encrypted PDFs with a message the failure classifier reads as pdf_password', async () => {
+    fakePdfinfo({
+      stderr: 'Command Line Error: Incorrect password\nEncrypted',
+      code: 1,
+    });
+
+    let caught: unknown = null;
+    try {
+      await getPageCount(pdfPath);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(jobFailureReasonCode(caught)).toBe('pdf_password');
+  });
+
+  it('rejects zero-page PDFs with a message the failure classifier reads as pdf_unreadable', async () => {
+    fakePdfinfo({
+      stdout: 'Title:          Broken\nPages:          0\n',
+      code: 0,
+    });
+
+    let caught: unknown = null;
+    try {
+      await getPageCount(pdfPath);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).not.toBeNull();
+    expect(jobFailureReasonCode(caught)).toBe('pdf_unreadable');
+  });
 });

--- a/src/lib/pdf/getPageCount.ts
+++ b/src/lib/pdf/getPageCount.ts
@@ -53,7 +53,7 @@ export function getPageCount(
 
       if (code !== 0) {
         if (stderr.includes('Encrypted') || stderr.includes('password')) {
-          reject(new Error('PDF_NEEDS_PASSWORD'));
+          reject(new Error(`pdfinfo_password path=${basename}`));
           return;
         }
         const trimmed = stderr.trim();
@@ -73,7 +73,11 @@ export function getPageCount(
       );
 
       if (!pageCount) {
-        reject(new Error('Failed to get page count'));
+        reject(
+          new Error(
+            `pdfinfo_failed code=${code ?? 'null'} signal=${signal ?? 'none'} path=${basename} stderr=no_page_count`
+          )
+        );
         return;
       }
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-06-pdf-error-messages.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-06-pdf-error-messages.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-06-pdf-error-messages",
+  "date": "2026-06-06",
+  "type": "fix",
+  "title": "Password-protected and unreadable PDFs say what to do next instead of a generic error"
+}


### PR DESCRIPTION
## What

Prod logs showed a recurring `Failed to execute pdfinfo` surfacing from the conversion worker (4× today, no open PR). Some PDFs convert fine, so poppler-utils is installed — `pdfinfo` fails on specific PDFs (encrypted or zero-page/malformed) and the resulting error aborted the whole conversion with the generic "Something went wrong on our end" crash message instead of telling the user what to do.

Root cause: `src/lib/pdf/getPageCount.ts` rejected two of its failure paths with messages that `jobFailureReason.ts` does not recognize, so they fell through to the generic crash reason. The fix aligns those two reject messages with the classifier contract that already exists. No behavior change for the paths that were already classified correctly.

## Symptom (sanitized)

```
Error: Failed to execute pdfinfo
    at GeneratePackagesUseCase (src/usecases/uploads/GeneratePackagesUseCase.ts)
    ← src/lib/pdf/getPageCount.ts (pdfinfo close handler)
```

No reporter data present — log-derived, file path carries no user content.

## Why it broke

`jobFailureReason.ts` already classifies PDF errors by message prefix: `pdfinfo_password*` → password-protected guidance, `pdfinfo_(failed|spawn_failed)*` → unreadable guidance. But `getPageCount` rejected:

- encrypted PDFs with the literal `PDF_NEEDS_PASSWORD` (no `pdfinfo_password` prefix), and
- a zero/unparseable page count with `Failed to get page count` (no prefix at all).

Both missed the classifier and dropped to the generic `unknown` crash reason that aborts the conversion.

## How the fix works

Two-line message change in `getPageCount.ts` — no control-flow change:

- encrypted → `pdfinfo_password path=<name>` (classifier reads it as `pdf_password`)
- zero/unparseable page count → `pdfinfo_failed code=… path=<name> stderr=no_page_count` (classifier reads it as `pdf_unreadable`)

Users now get "This PDF is password-protected. Remove the password and try again." or "We could not read this PDF. It may be corrupted, password-protected, or an unsupported variant…" instead of the generic crash. The `pdfinfo_failed` / `pdfinfo_spawn_failed` paths were already correct and are unchanged. The separate `PrepareDeck` password sentinel path (`buildPdfPasswordSentinel`) is untouched.

## Regression test

`src/lib/pdf/getPageCount.test.ts` — adds two cases that mock the `pdfinfo` spawn (encrypted stderr; zero-page stdout) and assert `jobFailureReasonCode` classifies them as `pdf_password` and `pdf_unreadable`. Both fail on `main` (classified as `unknown`) and pass with the fix. The existing real-`pdfinfo` integration cases are retained.

## Goal alignment

A PDF that previously failed the whole conversion with an opaque crash now degrades to a clear, actionable message — fewer dead-end uploads, fewer support emails, better retention on the PDF path.

## Notes

- `/check`: server `tsc --noEmit` clean; pdf + jobFailureReason + PrepareDeck suites green (64 passing). The web changelog change is JSON-only. The web vitest suite could not run in this environment (pre-existing `html-encoding-sniffer` ESM resolution failure in node_modules, unrelated to this change); changelog JSON validated by hand for id-uniqueness and shape.
- `sonar-scanner` not installed locally — expect CI to run it. Change is security-neutral (no new HTTP sink, no user-URL, no zip/file-path handling).

Browser check: not applicable — server-only conversion fix; the only web change is a changelog JSON entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783284500&installation_id=132681956&pr_number=3148&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3148&signature=5435b2631a6051909c520c7120d14230fabd2338466c3f3cd7c6b2c04a14b598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->