### PR TITLE
fix: let in-flight conversions drain on deploy swap

### DIFF
--- a/ecosystem.blue-green.config.js
+++ b/ecosystem.blue-green.config.js
@@ -14,8 +14,12 @@ const base = {
   max_restarts: 10,
   min_uptime: '60s',
   // Window for src/server.ts graceful shutdown to drain HTTP, Piscina,
-  // and Knex before pm2 escalates to SIGKILL.
-  kill_timeout: 30000,
+  // and Knex before pm2 escalates to SIGKILL. Must stay above
+  // SHUTDOWN_TIMEOUT_MS in src/lib/gracefulShutdown.ts (currently 85s) so a slow
+  // large-deck conversion finishes instead of being force-killed at the swap.
+  // Safe to be generous: blue-green serves users on the new color while the old
+  // color drains, so this only delays reaping the retired process.
+  kill_timeout: 90000,
   node_args: '--max-old-space-size=16384',
 };
 

--- a/src/lib/conversionPool.test.ts
+++ b/src/lib/conversionPool.test.ts
@@ -4,17 +4,26 @@ jest.mock('./storage/jobs/helpers/performConversion', () => ({
 }));
 
 const mockPoolRun = jest.fn();
-jest.mock('piscina', () => ({
-  __esModule: true,
-  default: jest.fn(() => ({
-    run: (...args: unknown[]) => mockPoolRun(...args),
-  })),
-}));
 
 jest.mock('../data_layer/NotionRespository');
 jest.mock('../data_layer/BlocksCacheRepository');
 jest.mock('../data_layer/JobRepository');
 jest.mock('../usecases/jobs/SetJobFailedUseCase');
+
+jest.mock('piscina', () => {
+  const construct = jest.fn();
+  const fakePiscina = jest.fn().mockImplementation((options) => {
+    construct(options);
+    return {
+      run: (...args: unknown[]) => mockPoolRun(...args),
+      close: jest.fn(),
+      destroy: jest.fn(),
+      queueSize: 0,
+    };
+  });
+  (fakePiscina as unknown as { construct: jest.Mock }).construct = construct;
+  return { __esModule: true, default: fakePiscina };
+});
 
 import performConversion from './storage/jobs/helpers/performConversion';
 import NotionRepository from '../data_layer/NotionRespository';
@@ -22,11 +31,15 @@ import BlocksCacheRepository from '../data_layer/BlocksCacheRepository';
 import JobRepository from '../data_layer/JobRepository';
 import { SetJobFailedUseCase } from '../usecases/jobs/SetJobFailedUseCase';
 import { NOTION_TOKEN_EXPIRED_REASON } from '../usecases/jobs/jobFailureReason';
+import Piscina from 'piscina';
 import {
   resolveConversionWorkers,
   runConversionInWorker,
   runUploadGeneration,
   shutdownConversionPool,
+  initConversionPool,
+  resetConversionPoolForTesting,
+  POOL_CLOSE_TIMEOUT_MS,
   ConversionWorkerRequest,
 } from './conversionPool';
 import { UploadGenerationTask } from '../usecases/uploads/uploadGenerationTypes';
@@ -249,5 +262,32 @@ describe('shutdownConversionPool', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('3 queued conversion(s)')
     );
+  });
+});
+
+describe('initConversionPool', () => {
+  const construct = (Piscina as unknown as { construct: jest.Mock }).construct;
+
+  beforeEach(() => {
+    resetConversionPoolForTesting();
+    construct.mockClear();
+    (Piscina as unknown as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    resetConversionPoolForTesting();
+  });
+
+  it('sets closeTimeout to the drain budget so close() waits for in-flight conversions', () => {
+    initConversionPool();
+
+    expect(construct).toHaveBeenCalledTimes(1);
+    expect(construct.mock.calls[0][0]).toMatchObject({
+      closeTimeout: POOL_CLOSE_TIMEOUT_MS,
+    });
+  });
+
+  it('keeps the drain budget well above piscina default so large decks finish', () => {
+    expect(POOL_CLOSE_TIMEOUT_MS).toBeGreaterThanOrEqual(60_000);
   });
 });

--- a/src/lib/conversionPool.ts
+++ b/src/lib/conversionPool.ts
@@ -30,6 +30,12 @@ export interface ConversionWorkerRequest {
 
 let pool: Piscina | null = null;
 
+export const POOL_CLOSE_TIMEOUT_MS = 80_000;
+
+export function resetConversionPoolForTesting(): void {
+  pool = null;
+}
+
 // CONVERSION_WORKERS caps concurrent Notion conversions (one per pool thread).
 // It composes with UPLOAD_BUILD_CONCURRENCY (per-conversion Python spawn cap)
 // — worst-case Python concurrency is the product. Defaults keep that at 16,
@@ -58,6 +64,7 @@ export function initConversionPool(): Piscina {
     maxThreads,
     minThreads: 1,
     resourceLimits: { maxOldGenerationSizeMb: 1024 },
+    closeTimeout: POOL_CLOSE_TIMEOUT_MS,
   });
   return pool;
 }

--- a/src/lib/gracefulShutdown.test.ts
+++ b/src/lib/gracefulShutdown.test.ts
@@ -1,6 +1,8 @@
 jest.mock('./conversionPool', () => ({
   __esModule: true,
   shutdownConversionPool: jest.fn(),
+  POOL_CLOSE_TIMEOUT_MS:
+    jest.requireActual('./conversionPool').POOL_CLOSE_TIMEOUT_MS,
 }));
 
 import type http from 'http';
@@ -10,6 +12,7 @@ import {
   gracefulShutdown,
   POOL_DRAIN_TIMEOUT_MS,
   SHUTDOWN_TIMEOUT_MS,
+  PM2_KILL_TIMEOUT_MS,
   resetGracefulShutdownStateForTesting,
 } from './gracefulShutdown';
 
@@ -134,7 +137,12 @@ describe('gracefulShutdown', () => {
     expect(drainMock).toHaveBeenCalledTimes(1);
   });
 
-  it('drains the pool with a budget below the hard shutdown ceiling', () => {
+  it('orders the timeouts so drain finishes before the hard exit and pm2 SIGKILL', () => {
     expect(POOL_DRAIN_TIMEOUT_MS).toBeLessThan(SHUTDOWN_TIMEOUT_MS);
+    expect(SHUTDOWN_TIMEOUT_MS).toBeLessThan(PM2_KILL_TIMEOUT_MS);
+  });
+
+  it('gives in-flight conversions room past the old 23s window that force-killed large decks', () => {
+    expect(POOL_DRAIN_TIMEOUT_MS).toBeGreaterThanOrEqual(60_000);
   });
 });

--- a/src/lib/gracefulShutdown.ts
+++ b/src/lib/gracefulShutdown.ts
@@ -1,16 +1,25 @@
 import type http from 'http';
 import type { Knex } from 'knex';
-import { shutdownConversionPool } from './conversionPool';
+import {
+  shutdownConversionPool,
+  POOL_CLOSE_TIMEOUT_MS,
+} from './conversionPool';
 
-// pm2 sends SIGINT then escalates to SIGKILL after kill_timeout (set to
-// 30s in ecosystem.blue-green.config.js). Reserve a safety margin so process.exit
-// fires before pm2's SIGKILL lands.
-export const SHUTDOWN_TIMEOUT_MS = 25_000;
-// The drain budget must stay just under SHUTDOWN_TIMEOUT_MS, not far below it:
-// an in-flight conversion that finishes between the old 20s ceiling and the 25s
-// hard exit was being force-destroyed with grace budget still on the clock.
-// 2s reserve covers the trailing database.destroy() before the hard exit fires.
-export const POOL_DRAIN_TIMEOUT_MS = 23_000;
+// pm2 sends SIGINT then escalates to SIGKILL after kill_timeout
+// (ecosystem.blue-green.config.js). Blue-green puts the new color live before
+// the old color drains, so a slow drain on the retiring process never delays a
+// user — the budget only needs to outlast the slowest legitimate conversion.
+export const PM2_KILL_TIMEOUT_MS = 90_000;
+// Reserve under PM2_KILL_TIMEOUT_MS so process.exit fires before pm2's SIGKILL.
+export const SHUTDOWN_TIMEOUT_MS = 85_000;
+// Sits just above piscina's own closeTimeout: close() races the pool flush
+// against that internal ceiling and self-destructs on timeout, so the outer
+// race here gives piscina its full window first, then force-destroys only if
+// close() itself hangs. A large Notion deck (pagination plus image/PDF
+// downloads plus the Python .apkg build) can run past the old 23s window; the
+// 80s pool budget lets it finish, and the 5s reserve below SHUTDOWN_TIMEOUT_MS
+// covers the trailing database.destroy() before the hard exit.
+export const POOL_DRAIN_TIMEOUT_MS = POOL_CLOSE_TIMEOUT_MS + 3_000;
 
 let shuttingDown = false;
 


### PR DESCRIPTION
## What

Widens the deploy-swap drain budget so an in-flight conversion finishes instead of being force-killed when the conversion pool shuts down, and pins piscina's own `closeTimeout` to the same budget so its internal race no longer fires first. The forced-destroy backstop stays so a stuck worker can never block a deploy.

## Why

On every blue-green swap, prod logs showed the conversion pool failing to drain and in-flight jobs being force-killed (`Conversion pool did not drain within …ms — forcing destroy`, then piscina `Error: Terminating worker thread`). With many deploys per day, users mid-conversion during a swap lost their job. User-visible outcome: a conversion running when a deploy lands now completes instead of dying.

## How

Diagnosis: large Notion decks (Notion pagination + image/PDF downloads + the Python `.apkg` build) legitimately run past the old 23s drain window. Two ceilings force-killed them:

1. piscina's internal `closeTimeout` (default **30 000ms**) — `close()` races the pool flush against it and self-destroys on timeout.
2. our outer `Promise.race` in `shutdownConversionPool` against `POOL_DRAIN_TIMEOUT_MS` (23s), which called `handle.destroy()` and terminated the worker.

Fix (widen the bound — blue-green makes it safe). The deploy script puts the new color live and verified *before* the old color drains, so a slower drain on the retiring process never delays a user; it only delays reaping the old process. New budget chain, ordering preserved (`pool-drain < shutdown ceiling < pm2 kill_timeout`):

- piscina `closeTimeout` = `POOL_CLOSE_TIMEOUT_MS` = 80 000ms (set at pool construction, replacing the 30s default)
- `POOL_DRAIN_TIMEOUT_MS` = 83 000ms (sits just above piscina's `closeTimeout` so piscina gets its full window first; the outer force-destroy fires only if `close()` itself hangs)
- `SHUTDOWN_TIMEOUT_MS` = 85 000ms (5s reserve for the trailing `database.destroy()`)
- pm2 `kill_timeout` = 90 000ms

**The forced-destroy backstop is unchanged:** if the pool genuinely hangs, `shutdownConversionPool` still force-destroys at the cap and logs the dropped queue size, so a deploy can never block indefinitely. No `process.env` flag introduced — the correct value is the default.

## Measuring success

In pm2 logs after a swap, the `Conversion pool did not drain within …ms — forcing destroy` and `Graceful shutdown exceeded …ms — forcing exit` lines should disappear for normal swaps, replaced by `… drain complete — exiting cleanly`. The force-destroy line remaining would now indicate a genuinely stuck worker (the backstop doing its job), not a swap killing a healthy conversion.

## Testing

- Unit tests added/extended (server, Jest):
  - `initConversionPool` constructs the pool with `closeTimeout === POOL_CLOSE_TIMEOUT_MS` so `close()` waits for in-flight conversions (piscina mocked at the module edge).
  - `POOL_CLOSE_TIMEOUT_MS` stays ≥ 60s so large decks finish.
  - `gracefulShutdown` timeout ordering: `POOL_DRAIN < SHUTDOWN < PM2_KILL`.
  - Drain budget ≥ 60s (regression guard against re-tightening to the old 23s window).
  - Existing backstop test retained: force-destroys and names the dropped queue when the budget is exceeded.
- `pnpm test src/lib/conversionPool.test.ts src/lib/gracefulShutdown.test.ts` — 16 passed.
- `tsc --noEmit` clean; oxlint + oxfmt clean on the changed files.
- `sonar-scanner` not run locally — not installed in this environment. Change is small and timing-constant only; expect no new Sonar findings, but flagging in case of a bounce.

## Browser check

Browser check: not applicable — server-only shutdown-lifecycle fix

## Changelog

No entry — internal deploy-lifecycle fix, no user-visible behavior change to the product surface.

## Risks

- The old (retired) process now lingers up to ~90s while draining instead of ~25s. This is off the user hot path in blue-green (new color already serving), and pm2 still SIGKILLs at `kill_timeout`, so a hung process can't accumulate. If a non-blue-green deploy path were ever used where the *only* process is being drained, the longer window would extend perceived downtime — but the live deploy script is blue-green.
- Rollback: revert the four timing constants and `kill_timeout` to their prior values.

## Goal alignment

Conversions are the core promise — drop something in, get a clean deck back. Silently losing a mid-flight conversion because of a routine deploy erodes trust exactly at the moment the product is doing its job. Protecting in-flight work across the many-deploys-per-day cadence keeps the experience reliable as we scale toward 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783284856&installation_id=132681956&pr_number=3149&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3149&signature=8ea3ee0efa5cca645efd91940cc6b451189e60e5507b04cd5b66fa0cba61da45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->