### PR TITLE
fix: make interactive card previews work and match the app theme

### DIFF
--- a/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.test.tsx
@@ -6,7 +6,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
 import { CardFrame } from './CardFrame';
 
@@ -61,6 +61,10 @@ describe('CardFrame sandbox', () => {
 });
 
 describe('CardFrame srcDoc', () => {
+  beforeEach(() => {
+    localStorage.removeItem('2anki-theme');
+  });
+
   it('does not inject hardcoded background or foreground colors', async () => {
     const card = buildCard({ css: '' });
     const { container } = render(
@@ -71,7 +75,8 @@ describe('CardFrame srcDoc', () => {
     expect(srcDoc).not.toContain('color: #111');
   });
 
-  it('includes color-scheme meta tag', async () => {
+  it('drives color-scheme from the app theme (light by default)', async () => {
+    localStorage.setItem('2anki-theme', 'light');
     const { container } = render(
       <CardFrame
         card={buildCard()}
@@ -81,7 +86,52 @@ describe('CardFrame srcDoc', () => {
       />
     );
     const srcDoc = await waitForSrcDoc(container);
-    expect(srcDoc).toContain('<meta name="color-scheme" content="light dark">');
+    expect(srcDoc).toContain('<meta name="color-scheme" content="light">');
+    expect(srcDoc).not.toContain('class="nightMode"');
+  });
+
+  it('renders dark cards with nightMode + dark color-scheme when app theme is dark', async () => {
+    localStorage.setItem('2anki-theme', 'dark');
+    const { container } = render(
+      <CardFrame
+        card={buildCard()}
+        cardIndex={0}
+        onEdit={noop}
+        isEditable={false}
+      />
+    );
+    const srcDoc = await waitForSrcDoc(container);
+    expect(srcDoc).toContain('<meta name="color-scheme" content="dark">');
+    expect(srcDoc).toContain('<body class="nightMode">');
+  });
+
+  it('treats the light-background themes (gold) as light, not dark', async () => {
+    localStorage.setItem('2anki-theme', 'gold');
+    const { container } = render(
+      <CardFrame
+        card={buildCard()}
+        cardIndex={0}
+        onEdit={noop}
+        isEditable={false}
+      />
+    );
+    const srcDoc = await waitForSrcDoc(container);
+    expect(srcDoc).toContain('<meta name="color-scheme" content="light">');
+    expect(srcDoc).not.toContain('nightMode');
+  });
+
+  it('shims sessionStorage and localStorage so opaque-origin template scripts do not throw', async () => {
+    const { container } = render(
+      <CardFrame
+        card={buildCard()}
+        cardIndex={0}
+        onEdit={noop}
+        isEditable={false}
+      />
+    );
+    const srcDoc = await waitForSrcDoc(container);
+    expect(srcDoc).toContain("['sessionStorage', 'localStorage'].forEach");
+    expect(srcDoc).toContain('Object.defineProperty(window, name');
   });
 
   it('includes the resize-observer script', async () => {

--- a/web/src/pages/PreviewApkgPage/CardFrame.tsx
+++ b/web/src/pages/PreviewApkgPage/CardFrame.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ApkgPreviewCard } from '../../lib/backend/getApkgPreview';
 import { CardEditState } from './cardEditTypes';
 import { fetchMediaAsDataUrl, inlineApkgMedia } from './inlineMedia';
+import { useTheme } from '../../lib/hooks/useTheme';
 import styles from './PreviewApkgPage.module.css';
 
 interface CardFrameProps {
@@ -14,20 +15,68 @@ interface CardFrameProps {
 
 const mediaCache = new Map<string, string | null>();
 
-function buildSrcDoc(html: string, css: string, cardId: string): string {
+function buildSrcDoc(
+  html: string,
+  css: string,
+  cardId: string,
+  isDark: boolean
+): string {
+  const colorScheme = isDark ? 'dark' : 'light';
+  const bodyClass = isDark ? ' class="nightMode"' : '';
   return `<!doctype html>
 <html>
 <head>
 <meta charset="utf-8">
-<meta name="color-scheme" content="light dark">
+<meta name="color-scheme" content="${colorScheme}">
 <base target="_blank">
+<script>
+(function () {
+  // Preview iframes run with an opaque origin (sandbox="allow-scripts", no
+  // allow-same-origin), so sessionStorage/localStorage access throws
+  // SecurityError. Anki note templates — including the Anki Persistence library
+  // the MCQ card uses — read sessionStorage during init; an unhandled throw
+  // short-circuits the rest of the script and the click handlers never attach.
+  // Swap in an in-memory store so template scripts run to completion without
+  // weakening the sandbox to allow-same-origin.
+  function makeStore() {
+    var data = {};
+    return {
+      getItem: function (k) {
+        return Object.prototype.hasOwnProperty.call(data, k) ? data[k] : null;
+      },
+      setItem: function (k, v) { data[k] = String(v); },
+      removeItem: function (k) { delete data[k]; },
+      clear: function () { data = {}; },
+      key: function (i) { return Object.keys(data)[i] || null; },
+      get length() { return Object.keys(data).length; }
+    };
+  }
+  ['sessionStorage', 'localStorage'].forEach(function (name) {
+    var usable = false;
+    try {
+      window[name].getItem('__2anki_probe__');
+      usable = true;
+    } catch (e) {
+      usable = false;
+    }
+    if (!usable) {
+      try {
+        Object.defineProperty(window, name, {
+          value: makeStore(),
+          configurable: true
+        });
+      } catch (e) {}
+    }
+  });
+})();
+</script>
 <style>
   html, body { margin: 0; padding: 1rem; font-family: system-ui, sans-serif; }
   img, video { max-width: 100%; height: auto; }
 ${css}
 </style>
 </head>
-<body>
+<body${bodyClass}>
 <div class="card">${html}</div>
 <script>
 (function () {
@@ -75,6 +124,8 @@ export function CardFrame({
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const [srcDoc, setSrcDoc] = useState('');
+  const theme = useTheme();
+  const isDark = theme === 'dark';
   const deckSegments = useMemo(() => resolveDeckSegments(card), [card]);
 
   const isDeleted = editState?.deleted ?? false;
@@ -87,12 +138,12 @@ export function CardFrame({
     const cardId = String(card.id);
     const html = showBack ? effectiveBack : effectiveFront;
     inlineApkgMedia(html, fetchMediaAsDataUrl, mediaCache).then((inlined) => {
-      if (!cancelled) setSrcDoc(buildSrcDoc(inlined, card.css, cardId));
+      if (!cancelled) setSrcDoc(buildSrcDoc(inlined, card.css, cardId, isDark));
     });
     return () => {
       cancelled = true;
     };
-  }, [card, showBack, effectiveFront, effectiveBack]);
+  }, [card, showBack, effectiveFront, effectiveBack, isDark]);
 
   useEffect(() => {
     setFrameHeight(DEFAULT_FRAME_HEIGHT);

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-06-interactive-card-preview.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-06-interactive-card-preview.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-06-interactive-card-preview",
+  "date": "2026-06-06",
+  "type": "fix",
+  "title": "Card previews for multiple-choice and other interactive cards respond to taps and follow your theme"
+}


### PR DESCRIPTION
## What

Fixes the in-app card preview (`/preview/apkg/<key>`) for interactive cards (MCQ and any scripted note type), on two axes the issue diagnosed:

1. **Interactivity.** The preview iframe runs `sandbox="allow-scripts"` with no `allow-same-origin`, so it has an opaque origin where `sessionStorage`/`localStorage` access throws `SecurityError`. Anki templates (and the Anki Persistence library the MCQ card uses) read `sessionStorage` during init; the unhandled throw short-circuited the rest of the script, so option rows, the gear menu, and zoom never wired up. Fix: inject a tiny in-memory storage shim in the iframe `<head>`, before the card script runs.
2. **Theme.** The preview followed `<meta color-scheme="light dark">` (OS preference), not the 2anki theme, so a dark app could render a light preview. Fix: drive the iframe from the resolved app theme — dark → `color-scheme: dark` + `<body class="nightMode">`, every other theme → light.

## Decisions made overnight (please review)
- **Interactivity fix — in-memory storage shim, NOT `allow-same-origin`.** The issue floated `allow-same-origin` as an option; I rejected it. Giving a sandbox that already runs arbitrary user-supplied card HTML a same-origin context would let it reach the parent page — a real XSS/escalation risk. The shim restores the template's expected `sessionStorage` without weakening the sandbox. If you'd rather take a different approach, change `buildSrcDoc` in `CardFrame.tsx`.
- **Theme mapping — only `dark` is treated as dark.** Checked `base.css`: `dark` has a dark background (`#111827`); `gold`/`purple`/`hotpink`/`light` are all light backgrounds. So `isDark = theme === 'dark'`. If you intend any of the accent themes to render cards dark, change the `isDark` line.
- **Dark signal — `.nightMode` + `color-scheme`, not a new `data-theme` + per-template CSS.** The issue sketched adding `html[data-theme="dark"]` CSS into `n2a-mcq.json`. I drove the dark-mode signals Anki templates **already** support (`.nightMode` body class + forced `color-scheme`) so the fix covers every note type without editing each template JSON. Scope: deliberately did NOT touch any template file.

## Tests
`CardFrame.test.tsx` — added cases asserting the storage shim is present, dark theme → `nightMode` + dark color-scheme, light/accent themes → light, and updated the existing color-scheme assertion. 23/23 pass. Web tsc + lint + format clean.

`sonar-scanner` not run locally (no token in this environment).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

**Needs your in-browser verification** — this fix is specifically about iframe interactivity, which can't be confirmed by unit tests alone. To verify: convert a Notion page with MCQ blocks, open `/preview/apkg/<key>` from `/downloads`, and confirm the option rows / gear / zoom respond to clicks, then toggle the app between light and dark and confirm the preview follows. I could not run a browser in this session, so I've left the boxes unticked for you.

Fixes #2658

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783288360&installation_id=132681956&pr_number=3151&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3151&signature=56c1b25d322da0ec08f8666b60a325137e650b49bf786741ba479c2168014ae4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->