### PR TITLE
fix: isolate concurrent PDF-to-image conversions per call

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -1,4 +1,4 @@
-import { PrepareDeck } from './PrepareDeck';
+import { PrepareDeck, prepareDeckInfoOnly } from './PrepareDeck';
 import CardOption from '../../../lib/parser/Settings/CardOption';
 
 jest.mock('../../../lib/claude/ClaudeService', () => ({
@@ -398,14 +398,7 @@ describe('PrepareDeck — duplicate-name dedup', () => {
       workspace: makeWorkspace(),
     }).catch(() => undefined);
 
-    const startCalls = infoSpy.mock.calls.filter(
-      (args) => args[0] === '[PrepareDeck] convertFile start'
-    );
-    expect(startCalls).toHaveLength(1);
-    expect(startCalls[0][1]).toMatchObject({
-      name: 'anatomy.pdf',
-      workspaceLocation: '/tmp/test-workspace',
-    });
+    expect(convertPDFToImages).toHaveBeenCalledTimes(1);
   });
 
   it('keeps distinct-named PDFs as separate conversions', async () => {
@@ -421,13 +414,52 @@ describe('PrepareDeck — duplicate-name dedup', () => {
       workspace: makeWorkspace(),
     }).catch(() => undefined);
 
-    const startCalls = infoSpy.mock.calls.filter(
-      (args) => args[0] === '[PrepareDeck] convertFile start'
-    );
-    expect(startCalls).toHaveLength(2);
-    expect(startCalls.map((c) => c[1].name)).toEqual([
-      'anatomy.pdf',
-      'histology.pdf',
-    ]);
+    expect(convertPDFToImages).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('prepareDeckInfoOnly — duplicate-name dedup', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('converts a same-named PDF once instead of fanning out two conversions', async () => {
+    const settings = makeSettings();
+    await prepareDeckInfoOnly(
+      {
+        name: 'anatomy.pdf',
+        files: [
+          { name: 'anatomy.pdf', contents: Buffer.from('%PDF-1.4 a') },
+          { name: 'anatomy.pdf', contents: Buffer.from('%PDF-1.4 b') },
+        ],
+        settings,
+        noLimits: true,
+        workspace: makeWorkspace(),
+      },
+      makeWorkspace(),
+      makeWorkspace()
+    ).catch(() => undefined);
+
+    expect(convertPDFToImages).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps distinct-named PDFs as separate conversions', async () => {
+    const settings = makeSettings();
+    await prepareDeckInfoOnly(
+      {
+        name: 'export.zip',
+        files: [
+          { name: 'anatomy.pdf', contents: Buffer.from('%PDF-1.4 a') },
+          { name: 'histology.pdf', contents: Buffer.from('%PDF-1.4 b') },
+        ],
+        settings,
+        noLimits: true,
+        workspace: makeWorkspace(),
+      },
+      makeWorkspace(),
+      makeWorkspace()
+    ).catch(() => undefined);
+
+    expect(convertPDFToImages).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -350,7 +350,7 @@ describe('PrepareDeck — PDF text-vs-image gate', () => {
   });
 });
 
-describe('PrepareDeck — diagnostic logging', () => {
+describe('PrepareDeck — duplicate-name dedup', () => {
   let infoSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -362,7 +362,7 @@ describe('PrepareDeck — diagnostic logging', () => {
     infoSpy.mockRestore();
   });
 
-  it('logs received file list with count, names, and sources when two same-named entries are present', async () => {
+  it('collapses two same-named entries to a single received file', async () => {
     const settings = makeSettings();
     await PrepareDeck({
       name: 'anatomy.pdf',
@@ -378,14 +378,14 @@ describe('PrepareDeck — diagnostic logging', () => {
     expect(infoSpy).toHaveBeenCalledWith(
       '[PrepareDeck] received',
       expect.objectContaining({
-        count: 2,
-        names: ['anatomy.pdf', 'anatomy.pdf'],
-        sources: expect.arrayContaining(['anatomy.pdf']),
+        count: 1,
+        names: ['anatomy.pdf'],
+        sources: ['anatomy.pdf'],
       })
     );
   });
 
-  it('logs a convertFile start line for each same-named entry', async () => {
+  it('converts a same-named PDF once instead of fanning out two conversions', async () => {
     const settings = makeSettings();
     await PrepareDeck({
       name: 'anatomy.pdf',
@@ -401,14 +401,33 @@ describe('PrepareDeck — diagnostic logging', () => {
     const startCalls = infoSpy.mock.calls.filter(
       (args) => args[0] === '[PrepareDeck] convertFile start'
     );
-    expect(startCalls).toHaveLength(2);
+    expect(startCalls).toHaveLength(1);
     expect(startCalls[0][1]).toMatchObject({
       name: 'anatomy.pdf',
       workspaceLocation: '/tmp/test-workspace',
     });
-    expect(startCalls[1][1]).toMatchObject({
-      name: 'anatomy.pdf',
-      workspaceLocation: '/tmp/test-workspace',
-    });
+  });
+
+  it('keeps distinct-named PDFs as separate conversions', async () => {
+    const settings = makeSettings();
+    await PrepareDeck({
+      name: 'export.zip',
+      files: [
+        { name: 'anatomy.pdf', contents: Buffer.from('%PDF-1.4 a') },
+        { name: 'histology.pdf', contents: Buffer.from('%PDF-1.4 b') },
+      ],
+      settings,
+      noLimits: true,
+      workspace: makeWorkspace(),
+    }).catch(() => undefined);
+
+    const startCalls = infoSpy.mock.calls.filter(
+      (args) => args[0] === '[PrepareDeck] convertFile start'
+    );
+    expect(startCalls).toHaveLength(2);
+    expect(startCalls.map((c) => c[1].name)).toEqual([
+      'anatomy.pdf',
+      'histology.pdf',
+    ]);
   });
 });

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -496,11 +496,12 @@ export async function prepareDeckInfoOnly(
   deckSubWorkspace: Workspace,
   outputWorkspace: Workspace
 ): Promise<DeckInfoOnlyResult> {
+  const files = dedupeFilesByName(input.files);
   const results = await Promise.all(
-    input.files.map((file) => convertFile(file, input))
+    files.map((file) => convertFile(file, input))
   );
   const convertedFiles = results.flatMap((r) => (r ? [r] : []));
-  const allFiles = [...input.files, ...convertedFiles];
+  const allFiles = [...files, ...convertedFiles];
 
   const parser = new DeckParser({ ...input, files: allFiles });
 

--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -48,6 +48,17 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
+function dedupeFilesByName(
+  files: DeckParserInput['files']
+): DeckParserInput['files'] {
+  const seen = new Set<string>();
+  return files.filter((file) => {
+    if (seen.has(file.name)) return false;
+    seen.add(file.name);
+    return true;
+  });
+}
+
 interface PrepareDeckResult {
   name: string;
   apkg: Buffer;
@@ -298,23 +309,25 @@ export async function PrepareDeck(
 ): Promise<PrepareDeckResult> {
   const tTotal = Date.now();
 
+  const files = dedupeFilesByName(input.files);
+
   console.info('[PrepareDeck] received', {
-    count: input.files.length,
-    names: input.files.map((f) => f.name),
-    sources: input.files.map((f) => f.name.slice(0, 60)),
+    count: files.length,
+    names: files.map((f) => f.name),
+    sources: files.map((f) => f.name.slice(0, 60)),
   });
 
   console.log('[PrepareDeck] start', {
     name: input.name,
-    fileCount: input.files.length,
-    fileNames: input.files.map((f) => f.name),
+    fileCount: files.length,
+    fileNames: files.map((f) => f.name),
     claudeEnabled: input.settings.claudeAIFlashcards,
     noLimits: input.noLimits,
   });
 
   const tConvert = Date.now();
   const results = await Promise.all(
-    input.files.map((file) => convertFile(file, input))
+    files.map((file) => convertFile(file, input))
   );
   const convertedFiles = results.flatMap((r) => (r ? [r] : []));
   console.log('[PrepareDeck] file conversions done', {
@@ -322,7 +335,7 @@ export async function PrepareDeck(
     durationMs: Date.now() - tConvert,
   });
 
-  const allFiles = [...input.files, ...convertedFiles];
+  const allFiles = [...files, ...convertedFiles];
 
   if (input.settings.claudeAIFlashcards && input.noLimits) {
     console.log('[PrepareDeck] Claude branch: collecting HTML content');

--- a/src/infrastracture/adapters/fileConversion/convertPDFToImages.test.ts
+++ b/src/infrastracture/adapters/fileConversion/convertPDFToImages.test.ts
@@ -1,0 +1,135 @@
+import path from 'path';
+import { convertPDFToImages } from './convertPDFToImages';
+import CardOption from '../../../lib/parser/Settings/CardOption';
+
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  writeFile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('fs', () => ({
+  __esModule: true,
+  ...jest.requireActual('fs'),
+  promises: {
+    mkdir: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../../../lib/pdf/getPageCount', () => ({
+  getPageCount: jest.fn().mockResolvedValue(2),
+}));
+
+jest.mock('../../../lib/pdf/convertPage', () => ({
+  convertPage: jest
+    .fn()
+    .mockImplementation((pdfPath: string, pageNumber: number) =>
+      Promise.resolve(`${pdfPath}-page${pageNumber}-${pageNumber}.png`)
+    ),
+}));
+
+const { writeFile } = require('fs/promises');
+const fs = require('fs');
+const { getPageCount } = require('../../../lib/pdf/getPageCount');
+const { convertPage } = require('../../../lib/pdf/convertPage');
+
+function makeSettings(overrides: Record<string, string> = {}): CardOption {
+  return new CardOption({ ...CardOption.LoadDefaultOptions(), ...overrides });
+}
+
+const WORKSPACE_LOCATION = '/tmp/race-workspace';
+
+function makeWorkspace(location = WORKSPACE_LOCATION) {
+  return { location } as never;
+}
+
+describe('convertPDFToImages — concurrent-run isolation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('gives two concurrent calls with the same name distinct pdf write paths', async () => {
+    const workspace = makeWorkspace();
+
+    await Promise.all([
+      convertPDFToImages({
+        name: 'anatomy.pdf',
+        workspace,
+        noLimits: true,
+        contents: Buffer.from('%PDF-1.4 a'),
+        settings: makeSettings(),
+      }),
+      convertPDFToImages({
+        name: 'anatomy.pdf',
+        workspace,
+        noLimits: true,
+        contents: Buffer.from('%PDF-1.4 b'),
+        settings: makeSettings(),
+      }),
+    ]);
+
+    const writePaths = (writeFile as jest.Mock).mock.calls.map(
+      (call) => call[0] as string
+    );
+    expect(writePaths).toHaveLength(2);
+    expect(writePaths[0]).not.toEqual(writePaths[1]);
+
+    const pageCountPaths = (getPageCount as jest.Mock).mock.calls.map(
+      (call) => call[0] as string
+    );
+    expect(pageCountPaths).toHaveLength(2);
+    expect(pageCountPaths[0]).not.toEqual(pageCountPaths[1]);
+
+    for (const writtenPath of writePaths) {
+      expect(path.dirname(writtenPath)).not.toEqual(WORKSPACE_LOCATION);
+      expect(path.dirname(writtenPath).startsWith(WORKSPACE_LOCATION)).toBe(
+        true
+      );
+    }
+  });
+
+  it('creates a unique subdirectory inside the workspace for each call', async () => {
+    const workspace = makeWorkspace();
+
+    await convertPDFToImages({
+      name: 'notes.pdf',
+      workspace,
+      noLimits: true,
+      contents: Buffer.from('%PDF-1.4'),
+      settings: makeSettings(),
+    });
+
+    const mkdirCalls = (fs.promises.mkdir as jest.Mock).mock.calls;
+    expect(mkdirCalls).toHaveLength(1);
+    const createdDir = mkdirCalls[0][0] as string;
+    expect(path.dirname(createdDir)).toEqual(WORKSPACE_LOCATION);
+    expect(path.basename(createdDir).startsWith('pdf-')).toBe(true);
+  });
+
+  it('emits img src paths resolvable from the workspace location', async () => {
+    const workspace = makeWorkspace();
+
+    const html = await convertPDFToImages({
+      name: 'notes.pdf',
+      workspace,
+      noLimits: true,
+      contents: Buffer.from('%PDF-1.4'),
+      settings: makeSettings(),
+    });
+
+    const srcMatches = [...html.matchAll(/<img src="([^"]+)"/g)].map(
+      (m) => m[1]
+    );
+    expect(srcMatches.length).toBeGreaterThan(0);
+    const pageImagePath = (convertPage as jest.Mock).mock.results[0]
+      .value as Promise<string>;
+    const resolvedPageImage = await pageImagePath;
+    for (const src of srcMatches) {
+      expect(src.includes('..')).toBe(false);
+      const resolved = path.resolve(WORKSPACE_LOCATION, src);
+      expect(resolved.startsWith(WORKSPACE_LOCATION)).toBe(true);
+    }
+    expect(path.resolve(WORKSPACE_LOCATION, srcMatches[0])).toEqual(
+      resolvedPageImage
+    );
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/convertPDFToImages.test.ts
+++ b/src/infrastracture/adapters/fileConversion/convertPDFToImages.test.ts
@@ -5,14 +5,7 @@ import CardOption from '../../../lib/parser/Settings/CardOption';
 jest.mock('fs/promises', () => ({
   __esModule: true,
   writeFile: jest.fn().mockResolvedValue(undefined),
-}));
-
-jest.mock('fs', () => ({
-  __esModule: true,
-  ...jest.requireActual('fs'),
-  promises: {
-    mkdir: jest.fn().mockResolvedValue(undefined),
-  },
+  mkdir: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../../../lib/pdf/getPageCount', () => ({
@@ -27,8 +20,7 @@ jest.mock('../../../lib/pdf/convertPage', () => ({
     ),
 }));
 
-const { writeFile } = require('fs/promises');
-const fs = require('fs');
+const { writeFile, mkdir } = require('fs/promises');
 const { getPageCount } = require('../../../lib/pdf/getPageCount');
 const { convertPage } = require('../../../lib/pdf/convertPage');
 
@@ -98,7 +90,7 @@ describe('convertPDFToImages — concurrent-run isolation', () => {
       settings: makeSettings(),
     });
 
-    const mkdirCalls = (fs.promises.mkdir as jest.Mock).mock.calls;
+    const mkdirCalls = (mkdir as jest.Mock).mock.calls;
     expect(mkdirCalls).toHaveLength(1);
     const createdDir = mkdirCalls[0][0] as string;
     expect(path.dirname(createdDir)).toEqual(WORKSPACE_LOCATION);

--- a/src/infrastracture/adapters/fileConversion/convertPDFToImages.ts
+++ b/src/infrastracture/adapters/fileConversion/convertPDFToImages.ts
@@ -1,7 +1,6 @@
-import { writeFile } from 'fs/promises';
+import { writeFile, mkdir } from 'fs/promises';
 import path from 'path';
 import crypto from 'crypto';
-import { promises as fs } from 'fs';
 import Workspace from '../../../lib/parser/WorkSpace';
 import { getPageCount } from '../../../lib/pdf/getPageCount';
 import { convertPage } from '../../../lib/pdf/convertPage';
@@ -33,7 +32,7 @@ export async function convertPDFToImages(
     : 'Default.pdf';
 
   const callDir = path.join(workspace.location, `pdf-${crypto.randomUUID()}`);
-  await fs.mkdir(callDir, { recursive: true });
+  await mkdir(callDir, { recursive: true });
   const pdfPath = path.join(callDir, fileName);
 
   await writeFile(pdfPath, Buffer.from(contents as Buffer));

--- a/src/infrastracture/adapters/fileConversion/convertPDFToImages.ts
+++ b/src/infrastracture/adapters/fileConversion/convertPDFToImages.ts
@@ -1,10 +1,11 @@
 import { writeFile } from 'fs/promises';
 import path from 'path';
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
 import Workspace from '../../../lib/parser/WorkSpace';
 import { getPageCount } from '../../../lib/pdf/getPageCount';
 import { convertPage } from '../../../lib/pdf/convertPage';
 import { combineIntoHTML } from '../../../lib/pdf/combineIntoHTML';
-import { existsSync } from 'fs';
 import CardOption from '../../../lib/parser/Settings/CardOption';
 
 interface ConvertPDFToImagesInput {
@@ -30,11 +31,12 @@ export async function convertPDFToImages(
   const fileName = name
     ? path.basename(name).replace(/\.pptx?$/i, '.pdf')
     : 'Default.pdf';
-  const pdfPath = path.join(workspace.location, fileName);
 
-  if (!existsSync(pdfPath)) {
-    await writeFile(pdfPath, Buffer.from(contents as Buffer));
-  }
+  const callDir = path.join(workspace.location, `pdf-${crypto.randomUUID()}`);
+  await fs.mkdir(callDir, { recursive: true });
+  const pdfPath = path.join(callDir, fileName);
+
+  await writeFile(pdfPath, Buffer.from(contents as Buffer));
 
   const pageCount = await getPageCount(pdfPath);
   const title = path.basename(pdfPath);
@@ -48,5 +50,5 @@ export async function convertPDFToImages(
     )
   );
 
-  return combineIntoHTML(imagePaths, title);
+  return combineIntoHTML(imagePaths, title, workspace.location);
 }

--- a/src/lib/pdf/combineIntoHTML.ts
+++ b/src/lib/pdf/combineIntoHTML.ts
@@ -1,13 +1,22 @@
 import path from 'path';
 
-export function combineIntoHTML(imagePaths: string[], title: string): string {
+export function combineIntoHTML(
+  imagePaths: string[],
+  title: string,
+  workspaceLocation?: string
+): string {
+  const toSrc = (imagePath: string) =>
+    workspaceLocation
+      ? path.relative(workspaceLocation, imagePath).replaceAll('\\', '/')
+      : path.basename(imagePath);
+
   const html = `<!DOCTYPE html>
 <html>
 <head><title>${title}</title></head>
 <body>
   ${Array.from({ length: imagePaths.length / 2 }, (_, i) => {
-    const front = path.basename(imagePaths[i * 2]);
-    const back = path.basename(imagePaths[i * 2 + 1]);
+    const front = toSrc(imagePaths[i * 2]);
+    const back = toSrc(imagePaths[i * 2 + 1]);
     return `<ul class="toggle">
     <li>
       <details>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-06-pdf-concurrent-convert.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-06-pdf-concurrent-convert.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-06-pdf-concurrent-convert",
+  "date": "2026-06-06",
+  "type": "fix",
+  "title": "Uploading the same PDF more than once in a batch converts reliably instead of intermittently failing"
+}


### PR DESCRIPTION
## What
Concurrent `convertPDFToImages` calls against the same workspace now write into a unique `pdf-<uuid>` subdirectory, so the PDF, its `pdfinfo` stdout/stderr logs, and its per-page images never share a path. `PrepareDeck` also dedupes `input.files` by name before the convert fan-out.

## Why
Fixes #2862. Two concurrent calls with the same PDF name — duplicate entries in `input.files` (the `Promise.all` fans out two conversions against one workspace), or a retry re-entering before the first finishes — all derived the same `pdfPath = path.join(workspace.location, fileName)`. They then raced on the file write, the `pdfinfo` read (reading a half-written / concurrently-overwritten file), the shared `<basename>_stdout.log` / `<basename>_stderr.log`, and the `${pdfPath}-pageN` image paths. The symptom users hit was an intermittent `Failed to execute pdfinfo` failure on PDFs that pdfinfo parses fine in isolation.

## How
- `convertPDFToImages.ts`: build `callDir = path.join(workspace.location, 'pdf-' + crypto.randomUUID())`, `mkdir` it, and put `pdfPath` inside. Because the dir is fresh per call, the file cannot pre-exist — dropped the `existsSync` guard and always write. `getPageCount` writes its logs into `dirname(pdfPath)` (now the unique dir) and `convertPage` writes images as `${pdfPath}-pageN` (also in the unique dir), so all four collision points are isolated by construction. Used `crypto.randomUUID()` (not `Math.random` — Sonar S2245).
- `combineIntoHTML.ts`: emit `<img src>` relative to `workspace.location` (e.g. `pdf-<uuid>/notes.pdf-page1-1.png`) so the page images still resolve through `embedFile` (`path.resolve(workspace.location, src)`). Falls back to basename when no base dir is passed, preserving the old contract for any other caller.
- `PrepareDeck.ts`: `dedupeFilesByName` keeps the first occurrence per name, applied once before the convert `Promise.all` and reused for `allFiles`. Cheap defense for the duplicate-entry case.

pdfinfo invocation, the page-limit check, and the error classification from #3148 are unchanged. No LLM / Vertex / Notion-export paths touched — no latency or token-cost delta.

## Measuring success
Per the issue acceptance criterion: no new `Failed to execute pdfinfo` errors in pm2 logs for unencrypted PDFs that pdfinfo parses manually. The diagnostic log lines from #2858 stay in place — `[PrepareDeck] received` now reports the deduped count, and a duplicate-named upload emits a single `[PrepareDeck] convertFile start` line instead of two. Grep pm2 for `pdfinfo_failed` against multi-PDF / retried jobs to confirm the race is gone.

## Testing
- `convertPDFToImages.test.ts` (new): two concurrent same-name calls get distinct pdf write paths and distinct `getPageCount` paths, each inside a unique workspace subdir; each call creates one `pdf-<uuid>` dir; emitted `img src` paths contain no `..` and resolve back to the on-disk page image under the workspace. Verified failing on the pre-fix source (shared `/tmp/.../anatomy.pdf`, no mkdir) before implementing.
- `PrepareDeck.test.ts` (updated): duplicate-named entries collapse to one received file and one conversion; distinct-named PDFs still convert separately. Replaces the two #2858 diagnostic-logging tests that asserted the now-fixed double-fan-out.
- `pnpm test src/lib/pdf src/infrastracture/adapters/fileConversion` → 11 suites / 75 tests green. Server `tsc --noEmit`, `pnpm format:check`, and `pnpm lint` clean (no warnings on changed files).
- `sonar-scanner` not run — scanner not installed and `SONAR_TOKEN` unset on this box. Change is small and adds no HTTP sinks or user-controlled-path writes; expect no new Sonar findings.
- Web vitest could not run in this worktree — a global `ERR_REQUIRE_ESM` from `html-encoding-sniffer` / `@exodus/bytes` in the shared `node_modules` breaks the jsdom environment for every web test, unrelated to this change. Web `tsc --noEmit` passes; the only web file here is a static changelog JSON.

## Browser check
Browser check: not applicable — server-side conversion fix; only web change is a changelog entry

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-06-pdf-concurrent-convert.json` — "Uploading the same PDF more than once in a batch converts reliably instead of intermittently failing"

## Risks
- Page images moved from the workspace root into a per-call subdir. Mitigated by emitting workspace-relative `img src` so `embedFile` `path.resolve(workspace.location, src)` still finds them inside the traversal-guarded base dir; covered by the new resolvability test.
- Dropping the `existsSync` guard means we always write — safe because the target dir is freshly created per call and cannot contain a prior file.
- Rollback: revert the single commit; no migration, no data, no config.

## Goal alignment
PDF-to-image is a core conversion path. Intermittent `pdfinfo` failures turn an upload into a dead end — the user gets nothing back. Removing a class of "drop something in, get an error" failures directly serves the simplest-fastest-deck mission and protects the conversion step of the funnel as we scale toward 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783340663&installation_id=132681956&pr_number=3168&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3168&signature=39158112cf26be8b3ccda6de3f650ae3c1f3bcae3d2d961ac1d3766ecad016ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->