### PR TITLE
fix: quiet expired download-link 404s in the error log

### DIFF
--- a/src/controllers/DownloadController.test.ts
+++ b/src/controllers/DownloadController.test.ts
@@ -459,4 +459,53 @@ describe('DownloadController.getFile storage error handling', () => {
       .join('');
     expect(sent).not.toContain('weird internal detail');
   });
+
+  it('still logs an error for a genuinely unexpected failure', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const error = new Error('weird internal detail user must not see');
+    const service = makeServiceThatThrows(error);
+    const controller = new DownloadController(service as never);
+    const req = { params: { key: 'deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as never);
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe('DownloadController.getFile expired link logging', () => {
+  it('returns the 404 expire page when the file is absent', async () => {
+    const service = makeService({
+      getFileBody: jest.fn().mockResolvedValue(null),
+      isTransientStorageError: () => false,
+    });
+    const controller = new DownloadController(service as never);
+    const req = { params: { key: 'expired-deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as never);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith(
+      "Download link expire, try converting again <a href='/upload'>upload</a>"
+    );
+  });
+
+  it('does not log an error for an absent file (expected expired link)', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const service = makeService({
+      getFileBody: jest.fn().mockResolvedValue(null),
+      isTransientStorageError: () => false,
+    });
+    const controller = new DownloadController(service as never);
+    const req = { params: { key: 'expired-deck.apkg' } } as unknown as Request;
+    const res = mockResponse();
+
+    await controller.getFile(req, res, {} as never);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });

--- a/src/controllers/DownloadController.ts
+++ b/src/controllers/DownloadController.ts
@@ -79,9 +79,14 @@ class DownloadController {
         res.setHeader('Content-Type', 'application/octet-stream');
         res.setHeader('Content-Disposition', buildContentDisposition(filename));
         res.send(body);
-      } else {
-        throw new Error(`File not found: ${key}`);
+        return;
       }
+      console.info('Download link expired', { owner });
+      res
+        .status(404)
+        .send(
+          "Download link expire, try converting again <a href='/upload'>upload</a>"
+        );
     } catch (error) {
       if (this.service.isMissingDownloadError(error)) {
         this.service.deleteMissingFile(owner, key);


### PR DESCRIPTION
## What
`DownloadController.getFile` no longer logs an expired/cleaned-up download link as an error. The file-absent case (`body == null`) is now handled inline as the expected condition it is: return the existing 404 and log at `console.info` level instead of throwing into the catch block where it hit `console.error`.

## Why
An absent deck file is a normal, expected condition — the download link has expired or the file was cleaned up. The previous code did `throw new Error('File not found: ${key}')`, which the catch logged via `console.error` before returning the (already correct) 404. Result: the prod error log fills with `Error: File not found: <key>.apkg` for every normal expired-link hit (6× in recent logs). The 404 response and user-facing copy were already correct — only the error-level logging was wrong.

## How
Replace the `else { throw new Error(...) }` in `getFile` with an inline branch that returns the existing 404 + message and logs at `console.info`. The success path now `return`s early. The catch block is untouched — genuinely unexpected errors still `console.error` and fall back to the same 404, and the `isMissingDownloadError` redirect and `isTransientStorageError` 503 paths are unchanged. No status, copy, or VOICE.md string changed.

## Measuring success
Prod error log: `Error: File not found: <key>.apkg` lines from `DownloadController.getFile` stop appearing. Expired-link hits now surface as `info`-level `Download link expired` entries (no secret logged). The 404 + retry message rate at the download endpoint is unchanged.

## Testing
- Unit tests added (`DownloadController.test.ts`):
  - file-absent request returns the existing 404 + expire message
  - file-absent request does **not** call `console.error` (expected expired link)
  - a genuinely unexpected failure **still** calls `console.error`
- Watched the new "does not log error" test fail for the right reason (catch path → `console.error`) before implementing; all 19 tests green after.

## Browser check
Browser check: not applicable — server-side logging change, response unchanged

## Changelog
No entry — internal logging change. The 404 status and user-facing message are unchanged, so a real user notices no difference in behavior.

## Risks
Low. The only behavior change is log level for the file-absent path (error → info) and dropping the throw/catch round-trip for that case. The response body, status, redirect, and 503 paths are identical. Rollback: revert the single commit.

## Goal alignment
Cleaner prod error logs make real conversion/download failures visible instead of buried under expected expired-link noise — faster incident response keeps the download experience reliable as we scale toward 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783344769&installation_id=132681956&pr_number=3170&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3170&signature=0834606da09fa45f8dd2f046bc529ba7557db5f6bb8c79cc23c5e4158c15f742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->