### PR TITLE
fix: stop bouncing logged-out users off the password reset page

### DIFF
--- a/web/src/lib/backend/api.test.ts
+++ b/web/src/lib/backend/api.test.ts
@@ -129,6 +129,82 @@ describe('api.get error tagging', () => {
     expect(location.href).toBe('/login');
   });
 
+  it('a 401 on the password reset page does not bounce to /login', async () => {
+    const location = {
+      origin: 'http://localhost',
+      pathname: '/users/r/abc123resettoken',
+      href: '',
+    };
+    vi.stubGlobal('location', location);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Authentication required' }), {
+        status: 401,
+      })
+    );
+
+    await expect(get('http://localhost/api/users/me')).rejects.toBeInstanceOf(
+      UserNotice
+    );
+    expect(location.href).toBe('');
+  });
+
+  it('a 401 on the bare reset path does not bounce to /login', async () => {
+    const location = {
+      origin: 'http://localhost',
+      pathname: '/users/r',
+      href: '',
+    };
+    vi.stubGlobal('location', location);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Authentication required' }), {
+        status: 401,
+      })
+    );
+
+    await expect(get('http://localhost/api/users/me')).rejects.toBeInstanceOf(
+      UserNotice
+    );
+    expect(location.href).toBe('');
+  });
+
+  it('a 401 on an authed path that merely shares the reset prefix still bounces', async () => {
+    const location = {
+      origin: 'http://localhost',
+      pathname: '/users/recent',
+      href: '',
+    };
+    vi.stubGlobal('location', location);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Authentication required' }), {
+        status: 401,
+      })
+    );
+
+    await expect(get('http://localhost/api/users/me')).rejects.toBeInstanceOf(
+      UserNotice
+    );
+    expect(location.href).toBe('/login');
+  });
+
+  it('a 401 on the account page bounces to /login', async () => {
+    const location = {
+      origin: 'http://localhost',
+      pathname: '/account',
+      href: '',
+    };
+    vi.stubGlobal('location', location);
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Authentication required' }), {
+        status: 401,
+      })
+    );
+
+    await expect(get('http://localhost/api/users/me')).rejects.toBeInstanceOf(
+      UserNotice
+    );
+    expect(location.href).toBe('/login');
+  });
+
   it('throws UserNotice with code when present', async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(

--- a/web/src/lib/backend/api.ts
+++ b/web/src/lib/backend/api.ts
@@ -14,7 +14,7 @@ const NON_AUTH_PATHS = [
   '/login',
   '/register',
   '/forgot',
-  '/users/r/',
+  '/users/r',
   '/auth/magic',
   '/upload',
   '/card-options',

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-06-password-reset-logged-out.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-06-password-reset-logged-out.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-06-password-reset-logged-out",
+  "date": "2026-06-06",
+  "type": "fix",
+  "title": "Password reset links open correctly when you're signed out"
+}


### PR DESCRIPTION
## What
The client-side non-auth path allowlist entry `'/users/r/'` carried a trailing slash. `isNonAuthPath` checks `pathname === prefix || pathname.startsWith(\`\${prefix}/\`)`, so the trailing-slash prefix turned the second branch into `startsWith('/users/r//')` — a double slash a real reset URL never produces. A logged-out user opening `/users/r/<token>` fired a background API call, got a 401, and `redirectToLogin()` bounced them to `/login` before the reset form rendered. This drops the trailing slash so `startsWith('/users/r/')` matches the token URL.

## Why
Password reset is unusable for the exact users who need it — they're logged out by definition. The reset link opening to a `/login` redirect instead of the reset form is a hard block on account recovery, which costs us users at the worst moment. Discovered while adding auth e2e coverage in #3154.

## How
One-line change: `NON_AUTH_PATHS` entry `'/users/r/'` → `'/users/r'`. No change to `redirectToLogin`, the 401 handling, `isNonAuthPath`'s matching logic, or any auth/session/JWT code — purely a path-string correction. The `startsWith('/users/r/')` branch now matches the token URL, the `=== '/users/r'` branch covers the bare path, and `/users/recent` stays authed (it neither equals `/users/r` nor starts with `/users/r/`), so there's no over-match.

## Measuring success
The reset flow no longer redirects logged-out users to `/login`. In production, the signal is a drop in `/login` navigations immediately following a `/users/r/<token>` page load (and a corresponding rise in successful password-reset completions). The four added tests assert the `location.href` side-effect directly: reset paths stay (`''`), authed paths bounce (`'/login'`).

## Testing
- Unit tests added (web vitest, `api.test.ts`):
  - `/users/r/<token>` 401 → no `/login` bounce (the fix; failed before, passes after)
  - `/users/r` (bare) 401 → no `/login` bounce
  - `/users/recent` 401 → still bounces to `/login` (no over-match)
  - `/account` 401 → still bounces to `/login`
- Failing-then-passing evidence: before the fix the two reset-path cases failed with `expected '/login' to be ''`; after the one-line change all 12 cases in the file pass. Full web suite green (202 files, 1759 tests). Server tsc + web typecheck + oxlint + format:check all clean.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Alexander to verify — open a real password reset link (`/users/r/<token>`) while logged out and confirm the reset form renders instead of bouncing to `/login`. Boxes left unticked because the runtime effect (reset page loads) is user-visible and warrants a live check.

## Risks
Low. Single path-string correction, no auth-logic change. The over-match guard tests confirm sibling routes (`/users/recent`, `/account`) keep their existing redirect behavior. This is auth-adjacent (it governs the login-redirect guard), so **`/security-review` recommended before merge** — though the diff touches no authentication, session, or token code, only the client-side path allowlist.

Local test note: the worktree's freshly-resolved `node_modules` hit an unrelated jsdom/`@exodus/bytes` ESM-require breakage at vitest worker bootstrap (pre-existing on `main`, reproduces on an untouched test file). Ran the suite with `NODE_OPTIONS=--experimental-require-module` to work around it; the fix and tests are independent of that. Sonar not run locally (single-line string change).

## Goal alignment
Password reset is account-recovery infrastructure. A reset link that bounces logged-out users to `/login` silently locks people out of their own accounts — direct churn at the 300K-user scale goal. Restoring it keeps recoverable users from becoming lost users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783346358&installation_id=132681956&pr_number=3171&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3171&signature=993e7abfa22929af0146b61541042f59ad598024da7b2e549a39b36d3785bdf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->