### PR TITLE
style: left-align docs layout so it sits next to app nav

### DIFF
--- a/web/src/pages/DocsPage/DocsPage.module.css
+++ b/web/src/pages/DocsPage/DocsPage.module.css
@@ -3,7 +3,7 @@
   grid-template-columns: 1fr;
   gap: 1rem;
   max-width: 1200px;
-  margin: 0 auto;
+  margin: 0;
   padding: 1.25rem 1rem 3rem;
   align-items: start;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-07-docs-layout-gap.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-07-docs-layout-gap.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-07-docs-layout-gap",
+  "date": "2026-06-07",
+  "type": "style",
+  "title": "Docs sidebar sits next to the main navigation instead of floating behind a wide empty gap"
+}


### PR DESCRIPTION
## What
On `/documentation`, the docs two-pane block (its own sidebar + article) is capped at `max-width: 1200px` and was centered with `margin: 0 auto` inside the app-shell content region. This left a large empty horizontal gap between the app-shell left nav and the docs page's own sidebar on desktop. This PR drops the auto margins so the docs block left-aligns against the content region, keeping the 1200px readable cap.

## Why
User reported (screenshot confirmed) a wide empty gutter between the two sidebars on `/docs`, growing wider on larger screens. The app shell (`SidebarLayout`) already provides a 240px left nav and a `1fr` content region with no max-width or centering of its own — so the docs block's `margin: 0 auto` was the sole source of the gap. User-visible outcome: docs sidebar sits adjacent to the app nav, content flows rightward, no wasted left gutter.

## How
Single CSS change in `web/src/pages/DocsPage/DocsPage.module.css`, the `.layout` rule: `margin: 0 auto` -> `margin: 0`. The `max-width: 1200px` cap is kept so content does not sprawl full-bleed on ultra-wide screens.

Verified the diagnosis before changing anything:
- `App.tsx` mounts `DocsPage` at `/documentation` inside `<AppShell>`.
- Logged-in users get `SidebarLayout`: `.shell` is a `240px 1fr` grid; the content region `.main` is a flex column with `min-width: 0`, `overflow-x: hidden`, and no max-width or centering of its own. `<main>` uses `flexGrow` (`flex: 1`, no max-width).
- So the docs `.layout` was the only thing imposing a width cap + centering. No double-correction risk.
- The `<901px` single-column layout and the `<600px` block use the same `.layout` base; left-aligning a column that already fills the (sub-1200px) viewport is a visual no-op there, so mobile/narrow is unaffected.

## Measuring success
Static CSS layout fix with no runtime instrumentation. Confirmation is visual: on `/documentation` at desktop width the docs sidebar sits flush against the app nav with no large left gutter; at 375px the stacked single-column layout is unchanged.

## Testing
- `pnpm --filter 2anki-web typecheck` — green.
- `pnpm --filter 2anki-web lint` — green from the main checkout (only pre-existing warnings, none in the changed files). In the isolated worktree, oxlint's native binding failed to resolve (`MODULE_NOT_FOUND` on `oxlint/dist/bindings.js`) — an install/platform-binary issue in the throwaway worktree, not a lint problem with this change. oxlint does not lint `.css` or `.json` anyway, and this diff is exactly one CSS property value + one changelog JSON file.
- No unit tests: pure presentational CSS value change with no logic.
- Sonar: skipped — pure CSS value + changelog JSON, no function/component/controller logic for the rule engine to evaluate.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: I cannot start the dev server from this environment (per web/CLAUDE.md) and have no browser/Playwright tool available here, so I have not personally verified in-browser. Boxes left unticked intentionally — needs your in-browser confirmation at desktop + 375px before merge: open `/documentation`, confirm the left gutter is gone and the docs sidebar sits next to the app nav, and that the narrow/stacked layout is unchanged with no console errors.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-07-docs-layout-gap.json` — "Docs sidebar sits next to the main navigation instead of floating behind a wide empty gap" (type: style). A visible layout fix a returning user could notice, so it warrants an entry; if you judge it too minor for What's New, drop the JSON file.

## Risks
Low. Single CSS value change scoped to the docs page. On ultra-wide screens the docs block now hugs the left of the content region (intended) rather than centering — the 1200px cap still prevents full-bleed line lengths. Rollback: revert the one-line change. No data, no API, no migration touched.

## Goal alignment
A tighter, cleaner docs layout with no wasted horizontal space — simpler and more beautiful, the bar every PR is held to in CLAUDE.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783416344&installation_id=132681956&pr_number=3173&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3173&signature=d8d437471a73735b3161de9f7619efbea41e8da5c2523c4d1b9507d25bb57d0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->