### PR TITLE
fix: suppress upload filenames from Hotjar recordings

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -791,7 +791,7 @@ function UploadForm({
     const remoteSource = remoteSourceLabel();
     return (
       <div className={formStyles.stateContent}>
-        <p className={formStyles.filename}>
+        <p className={formStyles.filename} data-hj-suppress>
           {remoteFilename ?? displayFilename(fileInputRef.current)}
         </p>
         <div className={formStyles.progressTrack}>
@@ -1100,7 +1100,11 @@ function UploadForm({
         <p className={formStyles.limitTitle}>{title}</p>
         <p className={formStyles.limitDescription}>{description}</p>
         {displayedFilename && (
-          <span className={formStyles.limitFilename} title={displayedFilename}>
+          <span
+            className={formStyles.limitFilename}
+            title={displayedFilename}
+            data-hj-suppress
+          >
             {displayedFilename}
             {isFileSize && limitInfo?.fileSizeBytes != null && (
               <> &mdash; {formatFileSize(limitInfo.fileSizeBytes)}</>
@@ -1312,7 +1316,9 @@ function UploadForm({
         </svg>
       </span>
       <div className={formStyles.lockedBadge}>Locked</div>
-      <p className={formStyles.lockedFilename}>{lockedPdfInfo?.filename}</p>
+      <p className={formStyles.lockedFilename} data-hj-suppress>
+        {lockedPdfInfo?.filename}
+      </p>
       <p className={formStyles.lockedHeadline}>
         This PDF is password-protected
       </p>


### PR DESCRIPTION
## What
Adds `data-hj-suppress` to the three UploadForm states that render a user's filename without it:
- the "This conversion is over your free limit…" card (and its `title` tooltip)
- the in-progress upload filename
- the locked-PDF badge filename

The deck-list filename was already suppressed.

## Why
User filenames routinely contain PII — the person's name, course, employer, or study material. Hotjar records the DOM, so these were leaking into session recordings. Reported from a Hotjar observation on the free-limit card.

## How
`data-hj-suppress` on each element rendering a filename, matching the existing pattern (deck list, account profile, search results). Hotjar masks suppressed elements' text in recordings.

## Testing
`pnpm --filter 2anki-web typecheck` green. No rendered output changes — purely a recording-privacy attribute.

## Risks
None — invisible to users; only changes what Hotjar captures.

Browser check: not applicable — adds data-hj-suppress attributes, no rendered output change.

No changelog entry — privacy hardening, not user-visible.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783416847&installation_id=132681956&pr_number=3174&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3174&signature=20d88f096f846f496133fed23940f902d7d9c555e064939ac9d944bc531e523a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->