### PR TITLE
fix: confirm Save defaults with spinner, status, and inline error

### DIFF
--- a/web/src/components/CardOptionsForm/CardOptionsForm.module.css
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.module.css
@@ -98,6 +98,33 @@
   width: auto;
 }
 
+.actionButton[aria-busy='true'] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.actionButton[aria-busy='true'] > span {
+  width: 1rem;
+  height: 1rem;
+  border-width: 2px;
+}
+
+.savedStatus {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  margin-right: auto;
+}
+
+.saveError {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-danger);
+  margin-right: auto;
+}
+
 @media (max-width: 600px) {
   .saveBar {
     flex-direction: column;
@@ -105,6 +132,10 @@
   }
   .actionButton {
     width: 100%;
+  }
+  .savedStatus,
+  .saveError {
+    margin-right: 0;
   }
 }
 

--- a/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
@@ -10,13 +10,15 @@ import CardOptionModel from '../../lib/data_layer/model/CardOption';
 const mockResetUserCardOptions = vi.fn();
 const mockGetSettingsCardOptions = vi.fn();
 const mockUseUserLocals = vi.fn();
+const mockSaveSettings = vi.fn();
+const mockGetSettings = vi.fn();
 
 vi.mock('../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({
     resetUserCardOptions: mockResetUserCardOptions,
     deleteSettings: vi.fn().mockResolvedValue(undefined),
-    saveSettings: vi.fn().mockResolvedValue(undefined),
-    getSettings: vi.fn().mockResolvedValue({}),
+    saveSettings: (...args: unknown[]) => mockSaveSettings(...args),
+    getSettings: (...args: unknown[]) => mockGetSettings(...args),
   }),
 }));
 
@@ -65,6 +67,36 @@ function renderForm(
       </MemoryRouter>
     </QueryClientProvider>
   );
+}
+
+function renderPageForm(spies: {
+  setError: () => void;
+  onSaved?: () => void;
+}) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <CardOptionsForm
+          pageId="page-1"
+          pageTitle="Pharmacology"
+          isLoggedIn
+          onSaved={spies.onSaved}
+          setError={spies.setError}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+async function makeDirty() {
+  const deckInput = await screen.findByPlaceholderText(
+    'Enter deck name (optional)'
+  );
+  fireEvent.change(deckInput, { target: { value: 'Pharmacology II' } });
+  return screen.findByRole('button', { name: 'Save defaults' });
 }
 
 describe('CardOptionsForm reset for the account-default view', () => {
@@ -417,5 +449,103 @@ describe('CardOptionsForm ai-comprehensive toggle (paid-only)', () => {
       expect(localStorage.getItem('ai-comprehensive')).toBe('true');
     });
     expect(toggle).toBeChecked();
+  });
+});
+
+describe('CardOptionsForm save defaults feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUserLocalsPaying(false);
+    localStorage.clear();
+    mockGetSettingsCardOptions.mockResolvedValue([]);
+    mockGetSettings.mockResolvedValue({});
+    mockSaveSettings.mockResolvedValue(undefined);
+  });
+
+  it('disables the button and shows Saving while the save is in flight', async () => {
+    let resolveSave: () => void = () => {};
+    mockSaveSettings.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      })
+    );
+    renderPageForm({ setError: vi.fn() });
+    const saveButton = await makeDirty();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Saving' })).toBeDisabled();
+    });
+
+    resolveSave();
+  });
+
+  it('shows a Defaults saved status that survives the button unmounting', async () => {
+    renderPageForm({ setError: vi.fn() });
+    const saveButton = await makeDirty();
+
+    fireEvent.click(saveButton);
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent('Defaults saved');
+    expect(screen.queryByRole('button', { name: 'Save defaults' })).toBeNull();
+
+    await waitFor(
+      () => {
+        expect(screen.queryByRole('status')).toBeNull();
+      },
+      { timeout: 4000 }
+    );
+  });
+
+  it('shows an inline error and keeps the button enabled when the save fails', async () => {
+    const setError = vi.fn();
+    mockSaveSettings.mockRejectedValue(new Error('network down'));
+    renderPageForm({ setError });
+    const saveButton = await makeDirty();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        "Couldn't save your defaults. Try again."
+      );
+    });
+    expect(setError).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Save defaults' })).toBeEnabled();
+  });
+
+  it('saves once when the button is clicked twice in quick succession', async () => {
+    let resolveSave: () => void = () => {};
+    mockSaveSettings.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      })
+    );
+    renderPageForm({ setError: vi.fn() });
+    const saveButton = await makeDirty();
+
+    fireEvent.click(saveButton);
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    });
+
+    resolveSave();
+  });
+
+  it('does not show the saved status when onSaved navigates away', async () => {
+    const onSaved = vi.fn();
+    renderPageForm({ setError: vi.fn(), onSaved });
+    const saveButton = await makeDirty();
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(onSaved).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByRole('status')).toBeNull();
   });
 });

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { Link } from 'react-router-dom';
@@ -358,6 +359,10 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
       )
     );
     const [initialSnapshot, setInitialSnapshot] = useState<string | null>(null);
+    const [isSaving, setIsSaving] = useState(false);
+    const [justSaved, setJustSaved] = useState(false);
+    const [saveFailed, setSaveFailed] = useState(false);
+    const savingRef = useRef(false);
 
     useEffect(() => {
       if (!options) return;
@@ -566,6 +571,12 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
       currentSnapshot,
     ]);
 
+    useEffect(() => {
+      if (!justSaved) return;
+      const timer = setTimeout(() => setJustSaved(false), 2500);
+      return () => clearTimeout(timer);
+    }, [justSaved]);
+
     const toggleCheckbox = (key: string, checked: boolean) => {
       setCheckboxValues((prev) => ({ ...prev, [key]: checked }));
       saveValueInLocalStorage(key, checked.toString(), pageId);
@@ -618,6 +629,8 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
 
     const serverSave = async (): Promise<boolean> => {
       if (!pageId) return true;
+      if (savingRef.current) return false;
+      savingRef.current = true;
       const payload: { [key: string]: string } = {};
       Object.entries(checkboxValues).forEach(([key, value]) => {
         payload[key] = value.toString();
@@ -647,6 +660,8 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
         payload['field-mapping'] = JSON.stringify(fieldMapping);
       }
 
+      setIsSaving(true);
+      setSaveFailed(false);
       try {
         await get2ankiApi().saveSettings({
           object_id: pageId,
@@ -654,10 +669,15 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
           payload,
         });
         setInitialSnapshot(currentSnapshot);
+        if (onSaved == null) setJustSaved(true);
         return true;
       } catch (error) {
+        setSaveFailed(true);
         setError(error);
         return false;
+      } finally {
+        savingRef.current = false;
+        setIsSaving(false);
       }
     };
 
@@ -726,16 +746,36 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
 
     const showResetButton = !hideActions && pageId == null;
     const showSaveButton = !hideActions && isDirty;
+    const showSavedStatus = !hideActions && justSaved;
+    const showSaveError = !hideActions && saveFailed;
 
     return (
       <div className={fieldStyles.form}>
-        {(showResetButton || showSaveButton) && (
+        {(showResetButton ||
+          showSaveButton ||
+          showSavedStatus ||
+          showSaveError) && (
           <div className={fieldStyles.saveBar}>
+            {showSaveError && (
+              <span role="alert" className={fieldStyles.saveError}>
+                Couldn&apos;t save your defaults. Try again.
+              </span>
+            )}
+            {showSavedStatus && (
+              <span
+                role="status"
+                aria-live="polite"
+                className={fieldStyles.savedStatus}
+              >
+                Defaults saved
+              </span>
+            )}
             {showResetButton && (
               <button
                 type="button"
                 className={`${sharedStyles.btnSecondary} ${fieldStyles.actionButton}`}
                 onClick={resetStore}
+                disabled={isSaving}
               >
                 Reset to defaults
               </button>
@@ -745,8 +785,13 @@ export const CardOptionsForm = forwardRef<CardOptionsFormHandle, Props>(
                 type="button"
                 className={`${sharedStyles.btnPrimary} ${fieldStyles.actionButton}`}
                 onClick={onSubmit}
+                disabled={isSaving}
+                aria-busy={isSaving}
               >
-                Save defaults
+                {isSaving && (
+                  <span className={sharedStyles.spinnerSmall} aria-hidden />
+                )}
+                {isSaving ? 'Saving' : 'Save defaults'}
               </button>
             )}
           </div>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-07-save-defaults-confirmation.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-07-save-defaults-confirmation.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-07-save-defaults-confirmation",
+  "date": "2026-06-07",
+  "type": "fix",
+  "title": "Card options — saving your defaults shows a spinner, then confirms Defaults saved"
+}


### PR DESCRIPTION
## What
The "Save defaults" button on the card-options page now gives feedback while saving: a spinner with a "Saving" label and a disabled button during the request, an inline "Defaults saved" confirmation that survives the button unmounting, and an inline error if the save fails. A double-click only saves once.

## Why
On `/card-options`, clicking "Save defaults" did nothing visible: `serverSave()` flipped the form clean on success, so the button (rendered only while dirty) just vanished — no spinner, no confirmation. Errors only reached the global `ErrorPresenter`, invisible to modal users. Double-submit was unguarded. Users could not tell whether their defaults saved.

## How
Three local states in `CardOptionsForm` — `isSaving`, `justSaved`, `saveFailed` — plus a `savingRef` for the synchronous double-submit guard.
- `serverSave` returns early `false` when a save is already in flight (the guard is inside `serverSave` because `RulesPage` calls it via the imperative ref); sets `isSaving` true and clears `saveFailed` before the await; resets both in `finally`.
- The Save button shows a small spinner + "Saving", is `disabled` + `aria-busy` while saving; "Reset to defaults" is disabled while saving too.
- On success, when `onSaved == null`, set `justSaved`; an inline `role="status"` "Defaults saved" renders in the save bar (not on the button), so it survives the button unmounting once the form goes clean. A `useEffect` keyed on `justSaved` clears it after 2.5s and cleans up the timer.
- On failure, an inline `role="alert"` renders alongside the existing global `setError`; the button stays mounted and re-enabled for retry.
- The confirmation is gated on `onSaved == null`, so the navigating callers (settings modal `onSaved={onClickClose}`, save-and-return) are unaffected. `serverSave` still returns `Promise<boolean>`; the re-entrant `false` only fires on a genuine double-submit, which `RulesPage`'s single imperative save never triggers.

## Measuring success
Watch the card-options save path: the inline "Defaults saved" status renders on the full-page flow, and the existing `saveSettings` request volume should not grow (the double-submit guard caps it at one request per click burst). In the support inbox, the recurring "did my defaults save?" confusion should drop off.

## Testing
Unit tests added to `CardOptionsForm.test.tsx`:
- In-flight: deferred `saveSettings` → button disabled and labelled "Saving".
- Success: `role="status"` "Defaults saved" appears, survives the Save button unmounting, and clears after the timeout.
- Error: rejected `saveSettings` → `role="alert"` with the error copy, `setError` called once, button re-enabled.
- Double-submit: two rapid clicks during a deferred promise → `saveSettings` called once.
- Confirmation not rendered when `onSaved` is provided.

Verified red/green by stashing the source fix (4 of the 5 new tests fail without it, for the right reasons) then restoring. Full file plus the changelog loader test pass green (25 tests).

Note: the local vitest fork pool cannot start (`ERR_REQUIRE_ESM` from `@exodus/bytes`/jsdom, a known `node_modules` issue unrelated to this change); ran tests with `NODE_OPTIONS=--experimental-require-module` as a workaround. `pnpm --filter 2anki-web typecheck`, `lint`, and `build` are green. `sonar-scanner` is not installed locally — expect a Sonar pass on CI; the diff adds no nested ternaries or deep nesting.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: I did not start the dev server (CLAUDE.md says ask first), so I could not run the browser golden path or drive Playwright. Please verify on `/card-options`: edit a field, click Save defaults, confirm the spinner then "Defaults saved", and check no console errors at 375px before merging.

## Risks
Low. Scope is one component + one CSS class + colocated tests + a changelog entry. No new deps, no API changes, no toast system. The `onSaved`-gated confirmation keeps the modal and save-and-return flows behaving exactly as before. Rollback is a straight revert.

## Goal alignment
A core settings action the user can now trust — visible confirmation that defaults saved compounds confidence across every deck they configure, removing a small but repeated friction on the path to a clean deck.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783417144&installation_id=132681956&pr_number=3175&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3175&signature=5526bbfb60aa7b1feb63b71da7619a8214f6aa5b95a9df73e45143261623c565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->