### PR TITLE
docs: add SECURITY.md mirroring the published policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+The canonical version of this policy lives at <https://2anki.net/security>.
+
+## Report a vulnerability
+
+Email **support@2anki.net** with details of what you found.
+
+## What to include
+
+A clear write-up of the issue, steps to reproduce it, what you were able to
+access or affect, and how severe you think it is. A working proof of concept is
+helpful but not required.
+
+## Scope
+
+**In scope:** 2anki.net and its subdomains, the API, authentication flows, file
+upload and conversion, user data, and the `2anki/server` GitHub repository.
+
+**Out of scope:** third-party services we integrate with (Notion, Stripe,
+Anthropic, AnkiWeb), social engineering, physical attacks, denial of service
+without a working amplification proof of concept, automated scanner output
+without a reproducible exploit, missing security headers or version disclosure
+without demonstrated impact, and findings on forks or preview deploys.
+
+## Response time
+
+We acknowledge reports within 5 business days. We aim to resolve critical issues
+within 30 days. This is best-effort — 2anki is a small team. If you have not
+heard back in a week, follow up at the same address.
+
+## Rewards
+
+No monetary bounty. If you would like to be credited, say so in your report and
+we will add your name to the acknowledgements once the issue is resolved.
+
+## Acknowledgements
+
+- [endscene665](https://github.com/endscene665) — server-side request forgery in
+  the Notion bookmark and media fetch. Fixed May 2026.


### PR DESCRIPTION
## What
Adds a repo-root `SECURITY.md` mirroring the policy published at https://2anki.net/security (report address, what to include, in/out scope, response time, rewards, acknowledgements).

## Why
GitHub surfaces a repo-level SECURITY.md as the "Report a vulnerability" link and the Security tab. The policy only existed on the website, so researchers landing on the repo had no in-repo path to it. The live page stays the source of truth; this points to it.

## Testing
Doc-only. No code, no behavior change.

Browser check: not applicable — adds a Markdown doc, no web/src change.

No changelog entry — repository documentation, not user-facing product.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783417716&installation_id=132681956&pr_number=3176&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3176&signature=00674efe079db6d3cbf5762ec4ebc5316083cfc7a076e0e17bddcddc844d06bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->