### PR TITLE
style: format CardOptionsForm test to unbreak main

### DIFF
--- a/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
@@ -69,10 +69,7 @@ function renderForm(
   );
 }
 
-function renderPageForm(spies: {
-  setError: () => void;
-  onSaved?: () => void;
-}) {
+function renderPageForm(spies: { setError: () => void; onSaved?: () => void }) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });


### PR DESCRIPTION
## What
Runs oxfmt on web/src/components/CardOptionsForm/CardOptionsForm.test.tsx.

## Why
#3175 (save-defaults feedback) merged with this test file unformatted, so `pnpm format:check` now fails on main and on every branch cut from it (already bounced #3179). This restores a green main.

## Testing
Formatting-only, one test file. `oxfmt --check` passes after.

Browser check: not applicable — whitespace/formatting only, no rendered change.

No changelog — internal formatting fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783418391&installation_id=132681956&pr_number=3181&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3181&signature=8155fbe06e0adfa70519dc5fb217f6cf661c73e6e63745de5773401f8c3eb607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->