### PR TITLE
fix: reach card settings from upload page without AI on

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -228,6 +228,79 @@ describe('UploadPage AI toggle', () => {
     ).toBeInTheDocument();
     expect(callsFor('upload_ai_turned_off')).toHaveLength(1);
   });
+
+  it('turns AI on from the inline "Turn on Claude cards" button in the off state', async () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: true, subscriber: false };
+    renderPage();
+    const turnOn = screen.getByRole('button', {
+      name: /turn on claude cards/i,
+    });
+    turnOn.click();
+    await waitFor(() => {
+      expect(globalThis.localStorage.getItem('claude-ai-flashcards')).toBe(
+        'true'
+      );
+    });
+    expect(
+      screen.getByRole('button', { name: /turn ai off/i })
+    ).toBeInTheDocument();
+    expect(callsFor('upload_ai_turned_on')).toHaveLength(1);
+  });
+});
+
+describe('UploadPage AI badge settings link', () => {
+  beforeEach(() => {
+    trackMock.mockClear();
+    fakeUser = null;
+    fakeLocals = undefined;
+    globalThis.localStorage.clear();
+    globalThis.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    fakeUser = null;
+    fakeLocals = undefined;
+    globalThis.localStorage.clear();
+  });
+
+  it('shows a Manage in Settings link in the off state pointing at card-options without the pdf-ai anchor', () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: true, subscriber: false };
+    renderPage();
+    const settings = screen.getByRole('link', { name: /manage in settings/i });
+    expect(settings).toHaveAttribute('href', '/card-options?returnTo=/upload');
+  });
+
+  it('shows both the upgrade link and a Manage in Settings link in the free state', () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: false, subscriber: false };
+    renderPage();
+    expect(
+      screen.getByRole('link', { name: /upgrade to write cards with claude/i })
+    ).toHaveAttribute('href', '/pricing');
+    expect(
+      screen.getByRole('link', { name: /manage in settings/i })
+    ).toHaveAttribute('href', '/card-options?returnTo=/upload');
+  });
+
+  it('keeps the on state Manage in Settings link anchored at pdf-ai', () => {
+    fakeUser = { id: 42 };
+    fakeLocals = { patreon: true, subscriber: false };
+    globalThis.localStorage.setItem('claude-ai-flashcards', 'true');
+    renderPage();
+    expect(
+      screen.getByRole('link', { name: /manage in settings/i })
+    ).toHaveAttribute('href', '/card-options?returnTo=/upload#pdf-ai');
+  });
+
+  it('does not add a settings link in the anon state', () => {
+    fakeUser = null;
+    renderPage();
+    expect(
+      screen.queryByRole('link', { name: /manage in settings/i })
+    ).not.toBeInTheDocument();
+  });
 });
 
 const SIGNUP_FLAG_KEY = 'signup_completed_tracked';

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -192,8 +192,20 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
               <span>
                 {' '}
                 You&apos;ll get rule-based cards from your file&apos;s
-                structure. Turn on Claude cards.
+                structure.{' '}
               </span>
+              <button
+                type="button"
+                className={styles.aiInlineLink}
+                onClick={toggleAi}
+              >
+                Turn on Claude cards
+              </button>
+              <span>. </span>
+              <Link to="/card-options?returnTo=/upload">
+                Manage in Settings
+              </Link>
+              <span>.</span>
             </span>
           </>
         )}
@@ -211,6 +223,10 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
                 onClick={() => track('upload_ai_free_badge_clicked')}
               >
                 Upgrade to write cards with Claude
+              </Link>
+              <span>. </span>
+              <Link to="/card-options?returnTo=/upload">
+                Manage in Settings
               </Link>
               <span>.</span>
             </span>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-07-upload-settings-link.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-07-upload-settings-link.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-07-upload-settings-link",
+  "date": "2026-06-07",
+  "type": "fix",
+  "title": "Upload page — reach card settings whether or not Claude cards are on, and turn Claude cards on with one click"
+}

--- a/web/src/styles/shared.module.css
+++ b/web/src/styles/shared.module.css
@@ -273,6 +273,25 @@
   text-decoration: underline;
 }
 
+.aiInlineLink {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+  color: var(--color-text-link);
+}
+
+.aiInlineLink:hover {
+  color: var(--color-text-link-hover);
+  text-decoration: underline;
+}
+
+.aiInlineLink:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .notification {
   padding: 1rem 1.25rem;
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## What
Fixes the AI-mode badge banner above the upload dropzone so non-AI users can reach their conversion settings, and gives the "off" state a real toggle control.

## Why
The badge above the dropzone rendered four states. Two of them left rule-based users stranded:
- **off** (paid, AI off): "Turn on Claude cards" was plain text, not a control, and there was no link to settings at all.
- **free**: an upgrade link but no path to card-options.

Rule-based users still configure templates, deck name, and tags on the general card-options page — they had no one-click route to it from the upload surface that AI users already get.

## How
- **off + free** states now render a `Link` to `/card-options?returnTo=/upload` with the established "Manage in Settings" copy. No `#pdf-ai` anchor — that anchor is AI-specific; the general page applies to rule-based users too.
- **off** state's "Turn on Claude cards" is now a real `<button type="button">` styled as an inline link (new `aiInlineLink` class mirroring the existing badge-body link styles), calling the same `toggleAi` handler — keyboard-accessible, a second obvious affordance alongside the badge toggle.
- **on** and **anon** states unchanged: `on` keeps its `#pdf-ai` link; `anon` gets no settings link (no account = no settings, "Sign in to turn it on" already covers it).
- Change is confined to the badge block in `UploadPage.tsx` plus one class in `shared.module.css`; the 4-state conditional structure is untouched.

## Measuring success
Existing `upload_ai_turned_on` analytics event fires from the new inline button as well as the badge toggle — a rise in `upload_ai_turned_on` events whose source is the off-state body confirms the affordance is being used. Card-options visits with `returnTo=/upload` from non-AI users confirm the settings link is reached.

## Testing
- Unit tests added (extend `UploadPage.test.tsx`):
  - off state renders "Manage in Settings" → `/card-options?returnTo=/upload` (no `#pdf-ai`)
  - off state "Turn on Claude cards" is a button; clicking it flips AI on and fires `upload_ai_turned_on`
  - free state renders both the upgrade link and the settings link
  - on state still links with `#pdf-ai`; anon state has no settings link
- Local vitest could not start (`ERR_REQUIRE_ESM` from `@exodus/bytes`/jsdom in this checkout's node_modules — known local issue, not this change). Relying on CI for the vitest run. Typecheck and lint are green locally.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Playwright MCP not available in this run and the dev server is not started by the agent. Boxes left unticked for a human to verify: load /upload as a paid user with AI off, confirm the "Manage in Settings" link and the clickable "Turn on Claude cards" button appear and work, and check the free state shows both links.

## Changelog
`Upload page — reach card settings whether or not Claude cards are on, and turn Claude cards on with one click` (`web/src/pages/WhatsNewPage/changelog/2026-06-07-upload-settings-link.json`)

## Risks
Low. Pure UI/markup change in one banner block plus one additive CSS class. No data, no API, no routing changes — `/card-options` already exists. Rollback is reverting the single commit.

## Goal alignment
Rule-based users get the same one-click path to their conversion settings that AI users already had, and the off-state's "turn on" is finally clickable — a simpler, more consistent upload surface that reduces dead ends on the core conversion flow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783419147&installation_id=132681956&pr_number=3182&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3182&signature=4b7aedccf2da1d336a6765b1a636d2a838d830a88b2072a020da11e3c0f1ab55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->