### PR TITLE
fix: surface zero-card uploads instead of a silent empty deck

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -712,6 +712,55 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     expect(capturedSend()).not.toBeNull();
     expect(incrementSpy).not.toHaveBeenCalled();
   });
+
+  it('returns 400 empty_export instead of a silent empty deck when the single package has 0 cards', async () => {
+    mockPackages([{ name: 'deck', cardCount: 0 }]);
+    const usersRepo = buildUsersRepo();
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      usersRepo
+    );
+    const req = buildRequest();
+    const { res, capturedStatus, capturedSend, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    expect(capturedSend()).toBeNull();
+    const body = capturedJson() as { code: string };
+    expect(body.code).toBe('empty_export');
+    expect(incrementSpy).not.toHaveBeenCalled();
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_failed',
+      expect.objectContaining({
+        props: expect.objectContaining({ reason: 'empty_deck' }),
+      })
+    );
+  });
+
+  it('returns 400 empty_export when every package across a batch has 0 cards', async () => {
+    mockPackages([
+      { name: 'deck-a', cardCount: 0 },
+      { name: 'deck-b', cardCount: 0 },
+    ]);
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res, capturedStatus, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(400);
+    const body = capturedJson() as { code: string };
+    expect(body.code).toBe('empty_export');
+  });
 });
 
 describe('UploadService.deleteUpload — cascade', () => {
@@ -1003,6 +1052,63 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     );
     expect(failedCall).toBeDefined();
     expect(failedCall?.[3]).toMatch(/^No cards in this deck yet\./);
+  });
+
+  it('marks a Claude job failed with the empty-deck reason when the only package has 0 cards', async () => {
+    let resolveFailed!: () => void;
+    const failedRecorded = new Promise<void>((r) => {
+      resolveFailed = r;
+    });
+    const updateJobStatusMock = jest
+      .fn()
+      .mockImplementation((_id: string, _owner: string, status: string) => {
+        if (status === 'failed') {
+          resolveFailed();
+        }
+        return Promise.resolve(undefined);
+      });
+    const jobRepository = {
+      create: jest.fn().mockResolvedValue(undefined),
+      updateJobStatus: updateJobStatusMock,
+      findJobById: jest.fn().mockResolvedValue(null),
+      deleteJob: jest.fn().mockResolvedValue(undefined),
+    } as unknown as JobRepository;
+    const updateSpy = jest.fn().mockResolvedValue([]);
+    const repo: IUploadRepository = {
+      ...buildRepository(),
+      update: updateSpy,
+    };
+
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [
+              {
+                name: 'my-deck',
+                cardCount: 0,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+              },
+            ],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+    await failedRecorded;
+
+    const failedCall = updateJobStatusMock.mock.calls.find(
+      (call) => call[2] === 'failed'
+    );
+    expect(failedCall).toBeDefined();
+    expect(failedCall?.[3]).toMatch(/^No cards in this deck yet\./);
+    expect(updateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -471,11 +471,8 @@ class UploadService {
         ownerId
       )
       .then(async ({ packages }) => {
-        if (packages.length > 0) {
-          const totalCards = packages.reduce(
-            (s, p) => s + (p.cardCount ?? 0),
-            0
-          );
+        const totalCards = packages.reduce((s, p) => s + (p.cardCount ?? 0), 0);
+        if (totalCards > 0) {
           await this.promoteClaudeJobToUpload(
             ws.id,
             ws.location,
@@ -489,7 +486,7 @@ class UploadService {
             ws.id,
             owner,
             'failed',
-            'No packages produced'
+            jobFailureReasonFromError(new EmptyDeckError(), ws.id)
           );
         }
       })
@@ -542,6 +539,16 @@ class UploadService {
     const totalCards = packages.reduce((s, p) => s + (p.cardCount ?? 0), 0);
     const owner = getOwner(res);
     const authenticated = hasSessionToken(req);
+
+    if (totalCards === 0) {
+      logNoPackageDiagnostics(req.files as UploadedFile[]);
+      track('conversion_failed', {
+        userId: owner != null ? Number(owner) : null,
+        anonymousId: this.resolveAnonId(req),
+        props: { source: this.resolveUploadSource(req), reason: 'empty_deck' },
+      });
+      throw new EmptyDeckError();
+    }
 
     if (owner != null) {
       await new CheckMonthlyCardLimitUseCase(this.usersRepository).execute({
@@ -613,32 +620,22 @@ class UploadService {
         await this.usersRepository.incrementCardUsage(owner, totalCards);
       }
       return res.status(200).send(apkg);
-    } else if (packages.length > 1) {
-      track('conversion_succeeded', {
-        userId: owner != null ? Number(owner) : null,
-        anonymousId: this.resolveAnonId(req),
-        props: {
-          source: this.resolveUploadSource(req),
-          card_count_bucket: this.toCardCountBucket(totalCards),
-        },
-      });
-      if (owner != null) {
-        await this.usersRepository.incrementCardUsage(owner, totalCards);
-      }
-      return res
-        .status(200)
-        .json(
-          await this.buildBatchResponse(ws, resolveUploadWarning(warnings))
-        );
-    } else {
-      logNoPackageDiagnostics(req.files as UploadedFile[]);
-      track('conversion_failed', {
-        userId: getOwner(res) != null ? Number(getOwner(res)) : null,
-        anonymousId: this.resolveAnonId(req),
-        props: { source: this.resolveUploadSource(req), reason: 'empty_deck' },
-      });
-      throw new EmptyDeckError();
     }
+
+    track('conversion_succeeded', {
+      userId: owner != null ? Number(owner) : null,
+      anonymousId: this.resolveAnonId(req),
+      props: {
+        source: this.resolveUploadSource(req),
+        card_count_bucket: this.toCardCountBucket(totalCards),
+      },
+    });
+    if (owner != null) {
+      await this.usersRepository.incrementCardUsage(owner, totalCards);
+    }
+    return res
+      .status(200)
+      .json(await this.buildBatchResponse(ws, resolveUploadWarning(warnings)));
   }
 
   private async buildBatchResponse(

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-07-empty-deck-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-07-empty-deck-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-07-empty-deck-message",
+  "date": "2026-06-07",
+  "type": "fix",
+  "title": "Uploads that produce no cards tell you why and what to change instead of returning an empty deck"
+}


### PR DESCRIPTION
## What
An upload that produces no cards now returns a clear, actionable error at the upload boundary instead of a silent 0-card `.apkg`. Both the synchronous upload path and the asynchronous Claude path are covered.

## Why
Fixes #3184. When a Notion HTML export yielded zero convertible cards (commonly: toggles nested inside a column/text block, so the parser finds zero top-level toggles), the converter completed "successfully", the user downloaded a deck, and Anki showed "no cards added" with no explanation. Confirmed live in prod (`[PrepareDeck] file conversions done { convertedCount: 0 }` then `New Deck with 0 cards`), reported repeatedly over years. A med student converting image-heavy notes is the core ICP hitting this as a hard activation drop.

## How
The boundary previously gated on **package count**, but a zero-card conversion still returns a `Package` (with `cardCount: 0`) from `PrepareDeck` — so `packages.length === 1` fell into the success branch and emitted an empty deck. Both paths now gate on **total card count across all packages**:

- `handleSyncUpload`: when `totalCards === 0`, throw `EmptyDeckError` (the existing catch maps it to 400 `empty_export` with the actionable copy). The now-unreachable `packages.length === 0` else branch is removed.
- `handleAsyncUpload`: when `totalCards === 0`, mark the job failed with the existing empty-deck reason via `jobFailureReasonFromError(new EmptyDeckError())` instead of promoting a 0-card job.

Reuses the existing structured upload-error mechanism — `EmptyDeckError` maps to the `empty_deck`/`empty_export` code and the actionable `EMPTY_DECK_FAILURE_REASON` copy. No new error code needed. Paths producing N>0 cards are unchanged.

## Measuring success
- Conversion analytics: the `conversion_failed` event with `props.reason = empty_deck` now fires for zero-card uploads on the sync path (it previously mis-fired `conversion_succeeded` with a `card_count_bucket` for a 0-card deck). Watch the `empty_deck` rate vs. the drop in 0-card `conversion_succeeded` events.
- Async jobs: the `jobs` row for a zero-card Claude upload lands in `failed` with the "No cards in this deck yet…" reason rather than completing with 0 cards.
- Prod log: the `[PrepareDeck] … convertedCount: 0` / `New Deck with 0 cards` line now ends in a surfaced 400 / failed job, not a 200 download.

## Testing
- Unit tests added (`UploadService.test.ts`):
  - Sync path: a single package with `cardCount: 0` returns 400 `empty_export` (not a 200 send), increments no usage, and tracks `conversion_failed` reason `empty_deck`.
  - Sync path: a batch where every package has 0 cards returns 400 `empty_export`.
  - Async path: a Claude job whose only package has 0 cards is marked `failed` with the actionable empty-deck reason and is never promoted to an upload.
- Existing regression coverage (single package with N>0 cards returns a 200 send; multi-deck batch returns 200 JSON) stays green. Full `UploadService.test.ts` (29 tests) plus `jobFailureReason` and `worker` suites pass. `tsc --noEmit` clean. oxfmt applied to touched files. SonarCloud not run locally (scanner not installed in this worktree) — expect a possible Sonar pass on the small, branch-only change.

## Browser check
Browser check: not applicable — the only `web/src/` file is a changelog JSON entry (covered by the changelog-only bypass); the behavior change is server-side error handling with no new rendered surface.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-07-empty-deck-message.json` — "Uploads that produce no cards tell you why and what to change instead of returning an empty deck"

## Risks
- **Default-unchanged guarantee:** only the zero-total-card path changes (silent empty deck becomes a 400 / failed job with an actionable message). Every path that produces N>0 cards keeps byte-identical output — the success branches are untouched except for the dead-branch removal. Image-only exports that genuinely have no question/answer content correctly get the clear message, not a fabricated card.
- **Column-descent root-cause fix is DEFERRED, not included.** Diagnosed: `findNotionToggleLists`' default selector `dom('.page-body > ul')` only matches toggle lists that are direct children of `.page-body`, so toggles wrapped in a Notion column layout (`.page-body` then a column wrapper then `.column` then `ul.toggle`) yield zero top-level toggles — the exact reported cause. The `isCherry`/`isAll` modes use a global `.toggle` selector and would catch them, but broadening the default selector to descend into column wrappers is a change to the conversion hot path that could alter nesting behavior for pages that convert today, and we have no real Notion column-export HTML fixture to prove a default-unchanged guarantee. Per the task rails, that ships separately with its own fixture and regression test. This PR is the must-have messaging fix.
- Rollback: revert the single commit; no migration, no schema, no config.

## Goal alignment
Removes a silent activation drop for the core ICP. A med student converting image-heavy notes who currently gets a mysterious empty deck now gets a specific, actionable message (what happened plus what to change), turning a dead-end into a recoverable step — directly supporting the simpler/faster experience and the 300K-user growth goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783455120&installation_id=132681956&pr_number=3190&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3190&signature=58b6ae8b343065f0a8c87156cee53b3468782342630e2c1abf9594fdbd42d002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->