### PR TITLE
fix: sniff image MIME from bytes for vision conversion

### DIFF
--- a/src/infrastracture/adapters/fileConversion/convertImageToHTML.test.ts
+++ b/src/infrastracture/adapters/fileConversion/convertImageToHTML.test.ts
@@ -1,0 +1,33 @@
+import { detectImageMediaType } from './convertImageToHTML';
+
+const toBase64 = (bytes: number[]): string =>
+  Buffer.from(bytes).toString('base64');
+
+describe('detectImageMediaType', () => {
+  it('returns image/jpeg for JPEG bytes even when the source was labeled png', () => {
+    const jpeg = toBase64([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    expect(detectImageMediaType(jpeg)).toBe('image/jpeg');
+  });
+
+  it('returns image/png for PNG bytes', () => {
+    const png = toBase64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    expect(detectImageMediaType(png)).toBe('image/png');
+  });
+
+  it('returns image/gif for GIF bytes', () => {
+    const gif = toBase64([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    expect(detectImageMediaType(gif)).toBe('image/gif');
+  });
+
+  it('returns image/webp for WEBP bytes', () => {
+    const webp = toBase64([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]);
+    expect(detectImageMediaType(webp)).toBe('image/webp');
+  });
+
+  it('falls back to image/png when the bytes are not a recognized image', () => {
+    const unknown = toBase64([0x00, 0x01, 0x02, 0x03]);
+    expect(detectImageMediaType(unknown)).toBe('image/png');
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/convertImageToHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/convertImageToHTML.ts
@@ -1,5 +1,28 @@
 import { getAnthropicClient } from '../../../lib/claude/ClaudeService';
+import { detectFileMime } from '../../../lib/detectFileMime';
 import { convertWithClaude } from './claudeFileConversion';
+
+type ImageMediaType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+
+const SUPPORTED_IMAGE_MEDIA_TYPES = new Set<ImageMediaType>([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+function isSupportedImageMediaType(value: string): value is ImageMediaType {
+  return SUPPORTED_IMAGE_MEDIA_TYPES.has(value as ImageMediaType);
+}
+
+export function detectImageMediaType(imageData: string): ImageMediaType {
+  const header = Buffer.from(imageData.slice(0, 24), 'base64');
+  const sniffed = detectFileMime(header);
+  if (sniffed != null && isSupportedImageMediaType(sniffed)) {
+    return sniffed;
+  }
+  return 'image/png';
+}
 
 const IMAGE_TO_HTML_SYSTEM_PROMPT = `Convert the text in this image to the following format for (every question is their own ul):
 
@@ -39,7 +62,7 @@ export const convertImageToHTML = async (
         type: 'image',
         source: {
           type: 'base64',
-          media_type: 'image/png',
+          media_type: detectImageMediaType(imageData),
           data: imageData,
         },
       },

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-08-vision-image-mime-sniff.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-08-vision-image-mime-sniff.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-08-vision-image-mime-sniff",
+  "date": "2026-06-08",
+  "type": "fix",
+  "title": "Uploaded images with mismatched formats convert instead of failing"
+}


### PR DESCRIPTION
## What
The Claude vision upload-conversion path now detects the real image format from the file's bytes before building the Anthropic image content block, instead of always declaring it as PNG.

## Why
Conversion jobs died with an Anthropic 400 — \"image was specified using the image/png media type, but the image appears to be a image/jpeg image\". The image content block in `convertImageToHTML.ts` hardcoded `media_type: 'image/png'` for every upload (plain image uploads via `PrepareDeck` and images inside an uploaded zip via `lib/zip`). Any non-PNG image — a JPEG, GIF, or WebP — was base64-encoded and shipped declared as PNG; Anthropic's server detected the true signature and rejected the request, failing the whole conversion. User-visible outcome: their conversion failed when an uploaded image's bytes didn't match the assumed format.

## How
Added a small pure helper `detectImageMediaType` that decodes the base64 header and runs the existing `detectFileMime` magic-byte sniffer (PNG / JPEG / GIF / WebP), returning the detected image media type and falling back to `image/png` only when no image signature matches. The Anthropic block now uses the sniffed type. Trust bytes over the declared extension — the same approach the photo-to-flashcards path already uses. No new dependency.

## Measuring success
The Anthropic 400 with message containing \"media type, but the image appears to be\" should stop appearing in the conversion-worker logs for upload jobs. A drop in `FileConversionError`-wrapped failures from `GeneratePackagesUseCase` on image uploads confirms it.

## Testing
- Unit tests added: `convertImageToHTML.test.ts` — JPEG/GIF/WebP bytes return the matching media type (JPEG labeled as PNG returns `image/jpeg`), PNG returns `image/png`, and unrecognized bytes fall back to `image/png`.
- Server `tsc -p . --noEmit` passes.
- Sonar not run locally — `SONAR_TOKEN` unset; change is a single typed pure helper with no new security surface, so expect a clean gate.

Browser check: not applicable — server-only conversion fix; the sole web/src change is a What's New changelog entry.

## Changelog
\"Uploaded images with mismatched formats convert instead of failing\" (`web/src/pages/WhatsNewPage/changelog/2026-06-08-vision-image-mime-sniff.json`).

## Risks
Low. The fallback preserves the previous behavior (`image/png`) when bytes aren't a recognized image, so nothing that worked before regresses; correctly-tagged PNGs are unaffected. Rollback is a revert.

## Goal alignment
Removes a hard failure on the core conversion path — uploads that silently failed now produce a deck, directly improving activation and retention on the way to 300K users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783534303&installation_id=132681956&pr_number=3191&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3191&signature=136139520def585d66251e346c74b07caec4f9a0d3f6e5c35ea645a8cb3f303d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->