### PR TITLE
fix: send media to Anki when dispatching uploaded apkgs via Ankify

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -44,7 +44,7 @@ import { Client as NotionClient } from '@notionhq/client';
 import NotionRepository from '../data_layer/NotionRespository';
 import StorageHandler from '../lib/storage/StorageHandler';
 import { parseCollection } from '../services/ApkgPreviewService/parseCollection';
-import { extractApkg } from '../services/ApkgPreviewService/extractApkg';
+import { extractApkg, parseMediaManifest } from '../services/ApkgPreviewService/extractApkg';
 import RequireAnkifyAccess from './middleware/RequireAnkifyAccess';
 
 const buildNotionExportClient = (token: string) => {
@@ -353,7 +353,11 @@ const AnkifyRouter = () => {
       fetchApkgBytes,
       async (bytes) => {
         const archive = await extractApkg(bytes);
-        return parseCollection(archive.collectionBuffer);
+        return {
+          collection: parseCollection(archive.collectionBuffer),
+          mediaMap: parseMediaManifest(archive.mediaManifestRaw),
+          mediaEntries: archive.mediaEntries,
+        };
       },
       ankiConnectFactory,
       logsRepo

--- a/src/usecases/ankify/SendUploadToRacUseCase.test.ts
+++ b/src/usecases/ankify/SendUploadToRacUseCase.test.ts
@@ -1,5 +1,6 @@
 import {
   NoActiveAnkifyClientError,
+  ParsedApkgForSend,
   SendUploadToRacUseCase,
   UploadNotFoundError,
 } from './SendUploadToRacUseCase';
@@ -64,6 +65,18 @@ const buildCollection = (overrides: {
   cards: overrides.cards ?? [{ id: 1, nid: 100, did: 10, ord: 0 }],
 });
 
+const buildParsed = (
+  overrides: Parameters<typeof buildCollection>[0] = {},
+  media: {
+    mediaMap?: Map<string, string>;
+    mediaEntries?: Map<string, Buffer>;
+  } = {}
+): ParsedApkgForSend => ({
+  collection: buildCollection(overrides),
+  mediaMap: media.mediaMap ?? new Map(),
+  mediaEntries: media.mediaEntries ?? new Map(),
+});
+
 const makeAnkiConnectStub = () => {
   const stub = {
     createDeck: jest.fn(async (_d: string) => 1),
@@ -72,6 +85,7 @@ const makeAnkiConnectStub = () => {
     sync: jest.fn(async () => null),
     modelNames: jest.fn(async () => [] as string[]),
     createModel: jest.fn(async (_p: unknown) => ({ id: 1 })),
+    storeMediaFile: jest.fn(async (_p: unknown) => 'ok'),
   };
   return stub as unknown as AnkiConnectClient & typeof stub;
 };
@@ -132,7 +146,7 @@ describe('SendUploadToRacUseCase', () => {
       mappings,
       uploads,
       async () => Buffer.from('fake'),
-      async () => buildCollection({}),
+      async () => buildParsed({}),
       () => ac
     );
 
@@ -174,7 +188,7 @@ describe('SendUploadToRacUseCase', () => {
       mappings,
       uploads,
       async () => Buffer.from('fake'),
-      async () => buildCollection({}),
+      async () => buildParsed({}),
       () => ac
     );
 
@@ -194,7 +208,7 @@ describe('SendUploadToRacUseCase', () => {
       uploads,
       async () => Buffer.from('fake'),
       async () =>
-        buildCollection({
+        buildParsed({
           notes: new Map(),
           cards: [],
         }),
@@ -226,7 +240,7 @@ describe('SendUploadToRacUseCase', () => {
       mappings,
       uploads,
       async () => Buffer.from('fake'),
-      async () => buildCollection({}),
+      async () => buildParsed({}),
       () => ac
     );
 
@@ -265,7 +279,7 @@ describe('SendUploadToRacUseCase', () => {
       mappings,
       uploads,
       async () => Buffer.from('fake'),
-      async () => buildCollection({}),
+      async () => buildParsed({}),
       () => ac
     );
 
@@ -290,7 +304,7 @@ describe('SendUploadToRacUseCase', () => {
       uploads,
       async () => Buffer.from('fake'),
       async () =>
-        buildCollection({
+        buildParsed({
           notes: new Map([
             [
               100,
@@ -329,7 +343,7 @@ describe('SendUploadToRacUseCase', () => {
       uploads,
       async () => Buffer.from('fake'),
       async () =>
-        buildCollection({
+        buildParsed({
           notes: new Map([
             [
               100,
@@ -384,7 +398,7 @@ describe('SendUploadToRacUseCase', () => {
       mappings,
       uploads,
       async () => Buffer.from(''),
-      async () => buildCollection({}),
+      async () => buildParsed({}),
       () => ac
     );
 
@@ -401,7 +415,7 @@ describe('SendUploadToRacUseCase', () => {
       mappings,
       uploads,
       async () => Buffer.from(''),
-      async () => buildCollection({}),
+      async () => buildParsed({}),
       () => ac
     );
 
@@ -422,7 +436,7 @@ describe('SendUploadToRacUseCase', () => {
       uploads,
       async () => Buffer.from('fake'),
       async () =>
-        buildCollection({
+        buildParsed({
           notes: new Map([
             [
               100,
@@ -458,5 +472,93 @@ describe('SendUploadToRacUseCase', () => {
     expect(result.created).toBe(1);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toContain('first failed');
+  });
+
+  test('uploads each media file via storeMediaFile before adding notes', async () => {
+    const { clients, mappings, uploads } = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const callOrder: string[] = [];
+    (ac.storeMediaFile as jest.Mock).mockImplementation(async (params) => {
+      callOrder.push(`store:${(params as { filename: string }).filename}`);
+      return 'ok';
+    });
+    (ac.addNote as jest.Mock).mockImplementation(async () => {
+      callOrder.push('addNote');
+      return 9_876_543_210;
+    });
+
+    const useCase = new SendUploadToRacUseCase(
+      clients,
+      mappings,
+      uploads,
+      async () => Buffer.from('fake'),
+      async () =>
+        buildParsed(
+          {},
+          {
+            mediaMap: new Map([
+              ['image.png', '0'],
+              ['audio.mp3', '1'],
+            ]),
+            mediaEntries: new Map([
+              ['0', Buffer.from('img-bytes')],
+              ['1', Buffer.from('audio-bytes')],
+            ]),
+          }
+        ),
+      () => ac
+    );
+
+    const result = await useCase.execute({ uploadId: 7, owner: 42 });
+
+    expect(ac.storeMediaFile).toHaveBeenCalledTimes(2);
+    expect(ac.storeMediaFile).toHaveBeenCalledWith({
+      filename: 'image.png',
+      data: Buffer.from('img-bytes').toString('base64'),
+    });
+    expect(ac.storeMediaFile).toHaveBeenCalledWith({
+      filename: 'audio.mp3',
+      data: Buffer.from('audio-bytes').toString('base64'),
+    });
+    expect(callOrder).toEqual(['store:image.png', 'store:audio.mp3', 'addNote']);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('per-file storeMediaFile failure is recorded but does not abort dispatch', async () => {
+    const { clients, mappings, uploads } = makeRepos();
+    const ac = makeAnkiConnectStub();
+    (ac.storeMediaFile as jest.Mock)
+      .mockRejectedValueOnce(new Error('disk full'))
+      .mockResolvedValueOnce('ok');
+
+    const useCase = new SendUploadToRacUseCase(
+      clients,
+      mappings,
+      uploads,
+      async () => Buffer.from('fake'),
+      async () =>
+        buildParsed(
+          {},
+          {
+            mediaMap: new Map([
+              ['broken.png', '0'],
+              ['ok.png', '1'],
+            ]),
+            mediaEntries: new Map([
+              ['0', Buffer.from('a')],
+              ['1', Buffer.from('b')],
+            ]),
+          }
+        ),
+      () => ac
+    );
+
+    const result = await useCase.execute({ uploadId: 7, owner: 42 });
+
+    expect(result.created).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Media broken.png');
+    expect(result.errors[0]).toContain('disk full');
+    expect(ac.addNote).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/usecases/ankify/SendUploadToRacUseCase.ts
+++ b/src/usecases/ankify/SendUploadToRacUseCase.ts
@@ -57,7 +57,13 @@ export type AnkiConnectFactory = (
 
 export type ApkgFetcher = (key: string) => Promise<Buffer>;
 
-export type ApkgParser = (buffer: Buffer) => Promise<NormalizedCollection>;
+export interface ParsedApkgForSend {
+  collection: NormalizedCollection;
+  mediaMap: Map<string, string>;
+  mediaEntries: Map<string, Buffer>;
+}
+
+export type ApkgParser = (buffer: Buffer) => Promise<ParsedApkgForSend>;
 
 const CLOZE_PATTERN = /\{\{c\d+::/;
 
@@ -154,7 +160,8 @@ export class SendUploadToRacUseCase {
     await this.clients.touchLastActiveAt(client.id);
 
     const buffer = await this.fetchApkgBytes(upload.key);
-    const collection = await this.parseApkg(buffer);
+    const parsed = await this.parseApkg(buffer);
+    const collection = parsed.collection;
 
     const host = input.ankiConnectHost ?? 'localhost';
     const ac = this.ankiConnect(host, client.anki_port, client.anki_connect_api_key);
@@ -173,6 +180,7 @@ export class SendUploadToRacUseCase {
     };
 
     await ensureAnkifyModels(ac, this.modelCache(client.id));
+    await this.uploadAllMedia(ac, parsed, result);
 
     for (const [noteId, note] of collection.notes) {
       await this.processNote({
@@ -288,6 +296,29 @@ export class SendUploadToRacUseCase {
         result.errors.push(`Note ${noteId}: ${error.message}`);
       } else {
         result.errors.push(`Note ${noteId}: ${(error as Error).message}`);
+      }
+    }
+  }
+
+  private async uploadAllMedia(
+    ac: AnkiConnectClient,
+    parsed: ParsedApkgForSend,
+    result: SendUploadToRacResult
+  ): Promise<void> {
+    for (const [originalName, archiveName] of parsed.mediaMap) {
+      const bytes = parsed.mediaEntries.get(archiveName);
+      if (bytes == null) {
+        continue;
+      }
+      try {
+        await ac.storeMediaFile({
+          filename: originalName,
+          data: bytes.toString('base64'),
+        });
+      } catch (error) {
+        result.errors.push(
+          `Media ${originalName}: ${(error as Error).message}`
+        );
       }
     }
   }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-09-ankify-apkg-media.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-09-ankify-apkg-media.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-09-ankify-apkg-media",
+  "date": "2026-06-09",
+  "type": "fix",
+  "title": "Ankify .apkg uploads carry their images and audio to Anki, so synced cards render media instead of broken links"
+}


### PR DESCRIPTION
## Summary
- `SendUploadToRacUseCase` shipped notes via `addNote`/`updateNoteFields` but never called `storeMediaFile`. Any image or audio referenced in note fields landed as a broken ref in the user's Anki — every card, every time, on this path.
- Widen the `ApkgParser` callback to return `{ collection, mediaMap, mediaEntries }`. `extractApkg` already produces those; we were discarding them at the router wiring (`AnkifyRouter.ts:354-357`).
- Add `uploadAllMedia` between `ensureAnkifyModels` and the notes loop. Iterates `mediaMap`, calls `ac.storeMediaFile({ filename, data: base64 })` per file, pushes per-file errors to `result.errors` without aborting the dispatch — matches the working pattern in `SyncNotionPageToRacUseCase`.
- Two new tests: ordering (media uploaded before `addNote`) and per-file failure isolation.

## Why this is the right scope
Originally surfaced by a paying Ankify user (numeric ID withheld; details in the support inbox) reporting broken images on every synced card. Two underlying bugs were found; per PM scope this PR ships the higher-severity / narrower one. The companion bug — external Notion image URLs leaking into card HTML, breaking offline or after signed URLs expire — is deferred to a follow-up issue and affects both Ankify polling and one-shot conversion.

## Browser check
Browser check: not applicable — server-side fix in the Ankify AnkiConnect dispatch path. The only `web/src/` file in the diff is a new changelog JSON entry under `web/src/pages/WhatsNewPage/changelog/`, which is bypassed by the merge gate.

## Test plan
- [x] `pnpm test src/usecases/ankify src/routes/AnkifyRouter` — 49/49 pass (10 in this use case, including 2 new)
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm --filter 2anki-web typecheck` clean
- [x] `pnpm --filter 2anki-web test src/pages/WhatsNewPage` — 9/9 pass (asserts the new changelog id is unique and valid)
- [ ] `/security-review` before flipping ready — touches external-API integration per CLAUDE.md rule
- [ ] `sonar-scanner` not run locally — small fix, no token configured here; expect Sonar to report cleanly on the new code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783590695&installation_id=132681956&pr_number=3192&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3192&signature=d8759a654e798197db95394828db2ac7863fa9b358360e5f7909ba84658370ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->