### PR TITLE
fix: respect the Templates setting on Ankify-synced cards

### DIFF
--- a/src/data_layer/SettingsRepository.test.ts
+++ b/src/data_layer/SettingsRepository.test.ts
@@ -1,0 +1,104 @@
+import knexLib, { Knex } from 'knex';
+import SettingsRepository from './SettingsRepository';
+
+const TEMPLATES_PAYLOAD = [
+  {
+    parent: 'Basic',
+    name: 'ATTI BASIC',
+    storageKey: 'n2a-basic',
+    front: '<div class="atti">{{Front}}</div>',
+    back: '<div class="atti-back">{{Back}}</div>',
+    styling: '.atti { color: tomato; }',
+  },
+];
+
+describe('SettingsRepository.loadAnkifyTemplateOverrides', () => {
+  let db: Knex;
+  let repo: SettingsRepository;
+
+  beforeEach(async () => {
+    db = knexLib({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('settings', (t) => {
+      t.string('owner');
+      t.string('object_id');
+      t.string('title');
+      t.json('payload');
+      t.timestamp('updated_at').defaultTo(db.fn.now());
+    });
+    await db.schema.createTable('templates', (t) => {
+      t.string('owner');
+      t.json('payload');
+    });
+    repo = new SettingsRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test('returns the override when settings.template is "custom" and a basic template is saved', async () => {
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'page-a',
+      title: 'A',
+      payload: JSON.stringify({
+        payload: { template: 'custom', basic_model_name: 'ATTI BASIC' },
+      }),
+      updated_at: db.fn.now(),
+    });
+    await db('templates').insert({
+      owner: '42',
+      payload: JSON.stringify(TEMPLATES_PAYLOAD),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides('42');
+
+    expect(overrides).not.toBeNull();
+    expect(overrides?.basicModelName).toBe('ATTI BASIC');
+    expect(overrides?.basicTemplate.front).toContain('atti');
+    expect(overrides?.basicTemplate.styling).toContain('tomato');
+  });
+
+  test('returns null when template is not "custom"', async () => {
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'page-a',
+      title: 'A',
+      payload: JSON.stringify({
+        payload: { template: 'specialstyle1', basic_model_name: 'ATTI BASIC' },
+      }),
+    });
+    await db('templates').insert({
+      owner: '42',
+      payload: JSON.stringify(TEMPLATES_PAYLOAD),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides('42');
+
+    expect(overrides).toBeNull();
+  });
+
+  test('returns null when there is no templates row even though template === custom', async () => {
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'page-a',
+      title: 'A',
+      payload: JSON.stringify({
+        payload: { template: 'custom', basic_model_name: 'ATTI BASIC' },
+      }),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides('42');
+
+    expect(overrides).toBeNull();
+  });
+
+  test('returns null when the owner has no settings rows at all', async () => {
+    const overrides = await repo.loadAnkifyTemplateOverrides('99');
+    expect(overrides).toBeNull();
+  });
+});

--- a/src/data_layer/SettingsRepository.ts
+++ b/src/data_layer/SettingsRepository.ts
@@ -130,9 +130,9 @@ class SettingsRepository implements ISettingsRepository {
         return null;
       }
 
-      const settingsPayload = parseJsonColumn(settingsRow.payload) as
-        | { payload?: Record<string, string> }
-        | null;
+      const settingsPayload = parseJsonColumn(settingsRow.payload) as {
+        payload?: Record<string, string>;
+      } | null;
       const cardOption = new CardOption(settingsPayload?.payload ?? {});
       if (cardOption.template !== 'custom') {
         return null;

--- a/src/data_layer/SettingsRepository.ts
+++ b/src/data_layer/SettingsRepository.ts
@@ -2,10 +2,25 @@ import { Knex } from 'knex';
 import Settings, { SettingsInitializer } from './public/Settings';
 import CardOption from '../lib/parser/Settings/CardOption';
 import { getCustomTemplate } from '../lib/parser/Settings/helpers/getCustomTemplate';
+import { AnkifyTemplateOverrides } from '../services/ankify/templateOverrides';
 
 export interface ISettingsRepository {
   load(owner: string, id: string): Promise<CardOption>;
   loadIfExists(owner: string, id: string): Promise<CardOption | null>;
+  loadAnkifyTemplateOverrides(
+    owner: string
+  ): Promise<AnkifyTemplateOverrides | null>;
+}
+
+function parseJsonColumn(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  return value;
 }
 
 class SettingsRepository implements ISettingsRepository {
@@ -98,6 +113,54 @@ class SettingsRepository implements ISettingsRepository {
       return settings;
     } catch (error: unknown) {
       console.info('Load settings from database failed');
+      console.error(error);
+      return null;
+    }
+  }
+
+  async loadAnkifyTemplateOverrides(
+    owner: string
+  ): Promise<AnkifyTemplateOverrides | null> {
+    try {
+      const settingsRow = await this.database(this.table)
+        .where({ owner })
+        .orderBy('updated_at', 'desc')
+        .first();
+      if (!settingsRow) {
+        return null;
+      }
+
+      const settingsPayload = parseJsonColumn(settingsRow.payload) as
+        | { payload?: Record<string, string> }
+        | null;
+      const cardOption = new CardOption(settingsPayload?.payload ?? {});
+      if (cardOption.template !== 'custom') {
+        return null;
+      }
+
+      const templatesRow = await this.database('templates')
+        .where({ owner })
+        .first();
+      if (!templatesRow) {
+        return null;
+      }
+
+      const templatesPayload = parseJsonColumn(templatesRow.payload);
+      if (!Array.isArray(templatesPayload)) {
+        return null;
+      }
+
+      const basicTemplate = getCustomTemplate('n2a-basic', templatesPayload);
+      if (!basicTemplate) {
+        return null;
+      }
+
+      return {
+        basicModelName: cardOption.basicModelName,
+        basicTemplate,
+      };
+    } catch (error: unknown) {
+      console.info('Load Ankify template overrides failed');
       console.error(error);
       return null;
     }

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -45,6 +45,7 @@ import NotionRepository from '../data_layer/NotionRespository';
 import StorageHandler from '../lib/storage/StorageHandler';
 import { parseCollection } from '../services/ApkgPreviewService/parseCollection';
 import { extractApkg, parseMediaManifest } from '../services/ApkgPreviewService/extractApkg';
+import SettingsRepository from '../data_layer/SettingsRepository';
 import RequireAnkifyAccess from './middleware/RequireAnkifyAccess';
 import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
@@ -337,6 +338,9 @@ const AnkifyRouter = () => {
   };
 
   const ankifyNotionRepo = new NotionRepository(db);
+  const settingsRepo = new SettingsRepository(db);
+  const templateOverridesProvider = (owner: number) =>
+    settingsRepo.loadAnkifyTemplateOverrides(String(owner));
   const syncNotionPageUseCase = new SyncNotionPageToRacUseCase(
     repo,
     mappings,
@@ -354,7 +358,8 @@ const AnkifyRouter = () => {
         ankifyNotionRepo,
         new UsersRepository(db),
         getDefaultEmailService()
-      ).execute(owner)
+      ).execute(owner),
+    templateOverridesProvider
   );
 
   const controller = new AnkifyController(
@@ -375,7 +380,8 @@ const AnkifyRouter = () => {
         };
       },
       ankiConnectFactory,
-      logsRepo
+      logsRepo,
+      templateOverridesProvider
     ),
     new RespinAnkifyClientUseCase(rac),
     new ExportReviewDataToNotionUseCase(

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -44,7 +44,10 @@ import { Client as NotionClient } from '@notionhq/client';
 import NotionRepository from '../data_layer/NotionRespository';
 import StorageHandler from '../lib/storage/StorageHandler';
 import { parseCollection } from '../services/ApkgPreviewService/parseCollection';
-import { extractApkg, parseMediaManifest } from '../services/ApkgPreviewService/extractApkg';
+import {
+  extractApkg,
+  parseMediaManifest,
+} from '../services/ApkgPreviewService/extractApkg';
 import SettingsRepository from '../data_layer/SettingsRepository';
 import RequireAnkifyAccess from './middleware/RequireAnkifyAccess';
 import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';

--- a/src/services/NotionService/BlockHandler/__tests__/findFlashcardsFromPage.test.ts
+++ b/src/services/NotionService/BlockHandler/__tests__/findFlashcardsFromPage.test.ts
@@ -66,6 +66,7 @@ function buildSettingsRepository(
     loadIfExists: jest.fn(
       async (_owner: string, id: string) => rows[id] ?? null
     ),
+    loadAnkifyTemplateOverrides: jest.fn(async () => null),
   };
 }
 

--- a/src/services/ankify/ensureAnkifyModels.test.ts
+++ b/src/services/ankify/ensureAnkifyModels.test.ts
@@ -87,7 +87,8 @@ describe('ensureAnkifyModels', () => {
     await ensureAnkifyModels(ac, cache, overrides);
 
     const created = (ac.createModel as jest.Mock).mock.calls.map(
-      (args) => args[0] as { modelName: string; inOrderFields: string[]; css: string }
+      (args) =>
+        args[0] as { modelName: string; inOrderFields: string[]; css: string }
     );
     const basic = created.find((c) => c.modelName === 'ATTI BASIC');
     expect(basic).toBeDefined();

--- a/src/services/ankify/ensureAnkifyModels.test.ts
+++ b/src/services/ankify/ensureAnkifyModels.test.ts
@@ -1,6 +1,8 @@
 import { ensureAnkifyModels } from './ensureAnkifyModels';
 import { ANKIFY_BASIC_MODEL, ANKIFY_CLOZE_MODEL } from './ankifyModels';
 import { AnkiConnectClient } from './AnkiConnectClient';
+import { AnkifyTemplateOverrides } from './templateOverrides';
+import { TemplateFile } from '../../lib/parser/Settings/types';
 
 const makeStub = (modelNames: string[]) => {
   const stub = {
@@ -64,5 +66,34 @@ describe('ensureAnkifyModels', () => {
 
     expect(cache.has(ANKIFY_BASIC_MODEL)).toBe(true);
     expect(cache.has(ANKIFY_CLOZE_MODEL)).toBe(true);
+  });
+
+  test('creates the basic model from the user template when overrides are present', async () => {
+    const ac = makeStub([]);
+    const cache = new Set<string>();
+    const customTemplate: TemplateFile = {
+      parent: 'Basic',
+      name: 'ATTI BASIC',
+      storageKey: 'n2a-basic',
+      front: '<div class="atti-front">{{Front}}</div>',
+      back: '<div class="atti-back">{{Back}}</div>',
+      styling: '.atti-front { color: tomato; }',
+    };
+    const overrides: AnkifyTemplateOverrides = {
+      basicModelName: 'ATTI BASIC',
+      basicTemplate: customTemplate,
+    };
+
+    await ensureAnkifyModels(ac, cache, overrides);
+
+    const created = (ac.createModel as jest.Mock).mock.calls.map(
+      (args) => args[0] as { modelName: string; inOrderFields: string[]; css: string }
+    );
+    const basic = created.find((c) => c.modelName === 'ATTI BASIC');
+    expect(basic).toBeDefined();
+    expect(basic?.inOrderFields).toEqual(['Front', 'Back', 'MyMedia']);
+    expect(basic?.css).toContain('tomato');
+    expect(cache.has('ATTI BASIC')).toBe(true);
+    expect(created.some((c) => c.modelName === ANKIFY_BASIC_MODEL)).toBe(false);
   });
 });

--- a/src/services/ankify/ensureAnkifyModels.ts
+++ b/src/services/ankify/ensureAnkifyModels.ts
@@ -1,4 +1,7 @@
-import { AnkiConnectClient, AnkiConnectCreateModelParams } from './AnkiConnectClient';
+import {
+  AnkiConnectClient,
+  AnkiConnectCreateModelParams,
+} from './AnkiConnectClient';
 import {
   ankifyBasicCreateModelParams,
   ankifyClozeCreateModelParams,
@@ -35,7 +38,10 @@ const resolveBasicParams = (
   overrides: AnkifyTemplateOverrides | null
 ): AnkiConnectCreateModelParams =>
   overrides
-    ? buildBasicModelFromTemplate(overrides.basicTemplate, overrides.basicModelName)
+    ? buildBasicModelFromTemplate(
+        overrides.basicTemplate,
+        overrides.basicModelName
+      )
     : ankifyBasicCreateModelParams();
 
 export const ensureAnkifyModels = async (

--- a/src/services/ankify/ensureAnkifyModels.ts
+++ b/src/services/ankify/ensureAnkifyModels.ts
@@ -1,10 +1,12 @@
-import { AnkiConnectClient } from './AnkiConnectClient';
+import { AnkiConnectClient, AnkiConnectCreateModelParams } from './AnkiConnectClient';
 import {
-  ANKIFY_BASIC_MODEL,
-  ANKIFY_CLOZE_MODEL,
   ankifyBasicCreateModelParams,
   ankifyClozeCreateModelParams,
 } from './ankifyModels';
+import {
+  AnkifyTemplateOverrides,
+  buildBasicModelFromTemplate,
+} from './templateOverrides';
 
 const ALREADY_EXISTS_PATTERN = /already\s+exists/i;
 
@@ -14,7 +16,7 @@ const isAlreadyExistsError = (error: unknown): boolean =>
 const ensureSingleModel = async (
   ac: AnkiConnectClient,
   cache: Set<string>,
-  params: ReturnType<typeof ankifyBasicCreateModelParams>
+  params: AnkiConnectCreateModelParams
 ): Promise<void> => {
   if (cache.has(params.modelName)) {
     return;
@@ -29,21 +31,32 @@ const ensureSingleModel = async (
   cache.add(params.modelName);
 };
 
+const resolveBasicParams = (
+  overrides: AnkifyTemplateOverrides | null
+): AnkiConnectCreateModelParams =>
+  overrides
+    ? buildBasicModelFromTemplate(overrides.basicTemplate, overrides.basicModelName)
+    : ankifyBasicCreateModelParams();
+
 export const ensureAnkifyModels = async (
   ac: AnkiConnectClient,
-  cache: Set<string>
+  cache: Set<string>,
+  overrides: AnkifyTemplateOverrides | null = null
 ): Promise<void> => {
-  if (cache.has(ANKIFY_BASIC_MODEL) && cache.has(ANKIFY_CLOZE_MODEL)) {
+  const basicParams = resolveBasicParams(overrides);
+  const clozeParams = ankifyClozeCreateModelParams();
+
+  if (cache.has(basicParams.modelName) && cache.has(clozeParams.modelName)) {
     return;
   }
 
   const existing = new Set(await ac.modelNames());
   for (const name of existing) {
-    if (name === ANKIFY_BASIC_MODEL || name === ANKIFY_CLOZE_MODEL) {
+    if (name === basicParams.modelName || name === clozeParams.modelName) {
       cache.add(name);
     }
   }
 
-  await ensureSingleModel(ac, cache, ankifyBasicCreateModelParams());
-  await ensureSingleModel(ac, cache, ankifyClozeCreateModelParams());
+  await ensureSingleModel(ac, cache, basicParams);
+  await ensureSingleModel(ac, cache, clozeParams);
 };

--- a/src/services/ankify/templateOverrides.ts
+++ b/src/services/ankify/templateOverrides.ts
@@ -1,0 +1,31 @@
+import { TemplateFile } from '../../lib/parser/Settings/types';
+import { NOTION_STYLE } from '../../templates/helper';
+import { AnkiConnectCreateModelParams } from './AnkiConnectClient';
+
+export interface AnkifyTemplateOverrides {
+  basicModelName: string;
+  basicTemplate: TemplateFile;
+}
+
+export type AnkifyTemplateOverridesProvider = (
+  owner: number
+) => Promise<AnkifyTemplateOverrides | null>;
+
+const BASIC_FIELDS_FROM_TEMPLATE = ['Front', 'Back', 'MyMedia'];
+
+export const buildBasicModelFromTemplate = (
+  template: TemplateFile,
+  modelName: string
+): AnkiConnectCreateModelParams => ({
+  modelName,
+  inOrderFields: BASIC_FIELDS_FROM_TEMPLATE,
+  css: template.styling || NOTION_STYLE,
+  isCloze: false,
+  cardTemplates: [
+    {
+      Name: 'Card 1',
+      Front: template.front,
+      Back: template.back,
+    },
+  ],
+});

--- a/src/usecases/ankify/SendUploadToRacUseCase.test.ts
+++ b/src/usecases/ankify/SendUploadToRacUseCase.test.ts
@@ -527,7 +527,11 @@ describe('SendUploadToRacUseCase', () => {
       filename: 'audio.mp3',
       data: Buffer.from('audio-bytes').toString('base64'),
     });
-    expect(callOrder).toEqual(['store:image.png', 'store:audio.mp3', 'addNote']);
+    expect(callOrder).toEqual([
+      'store:image.png',
+      'store:audio.mp3',
+      'addNote',
+    ]);
     expect(result.errors).toEqual([]);
   });
 

--- a/src/usecases/ankify/SendUploadToRacUseCase.test.ts
+++ b/src/usecases/ankify/SendUploadToRacUseCase.test.ts
@@ -568,4 +568,63 @@ describe('SendUploadToRacUseCase', () => {
     expect(result.errors[0]).toContain('disk full');
     expect(ac.addNote).toHaveBeenCalledTimes(1);
   });
+
+  test('uses the user’s custom basic model name when templateOverridesProvider returns an override', async () => {
+    const { clients, mappings, uploads } = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SendUploadToRacUseCase(
+      clients,
+      mappings,
+      uploads,
+      async () => Buffer.from('fake'),
+      async () => buildParsed({}),
+      () => ac,
+      undefined,
+      async () => ({
+        basicModelName: 'ATTI BASIC',
+        basicTemplate: {
+          parent: 'Basic',
+          name: 'ATTI BASIC',
+          storageKey: 'n2a-basic',
+          front: '{{Front}}',
+          back: '{{Back}}',
+          styling: '.card {}',
+        },
+      })
+    );
+
+    const result = await useCase.execute({ uploadId: 7, owner: 42 });
+
+    expect(result.created).toBe(1);
+    expect(ac.addNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelName: 'ATTI BASIC',
+        fields: { Front: 'front text', Back: 'back text', MyMedia: '' },
+      })
+    );
+  });
+
+  test('falls back to Ankify Basic when templateOverridesProvider returns null', async () => {
+    const { clients, mappings, uploads } = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SendUploadToRacUseCase(
+      clients,
+      mappings,
+      uploads,
+      async () => Buffer.from('fake'),
+      async () => buildParsed({}),
+      () => ac,
+      undefined,
+      async () => null
+    );
+
+    await useCase.execute({ uploadId: 7, owner: 42 });
+
+    expect(ac.addNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelName: 'Ankify Basic',
+        fields: { Front: 'front text', Back: 'back text' },
+      })
+    );
+  });
 });

--- a/src/usecases/ankify/SendUploadToRacUseCase.ts
+++ b/src/usecases/ankify/SendUploadToRacUseCase.ts
@@ -19,6 +19,10 @@ import {
 } from '../../services/ankify/ankifyModels';
 import { ensureAnkifyModels } from '../../services/ankify/ensureAnkifyModels';
 import {
+  AnkifyTemplateOverrides,
+  AnkifyTemplateOverridesProvider,
+} from '../../services/ankify/templateOverrides';
+import {
   NormalizedCollection,
   Note,
 } from '../../services/ApkgPreviewService/types';
@@ -74,6 +78,7 @@ const buildAnkiConnectNoteFromApkgNote = (input: {
   fields: string[];
   tags: string;
   deckName: string;
+  overrides: AnkifyTemplateOverrides | null;
 }): AnkiConnectNote => {
   const trimmedTags = input.tags
     .split(/\s+/)
@@ -91,13 +96,18 @@ const buildAnkiConnectNoteFromApkgNote = (input: {
       options: { allowDuplicate: true },
     };
   }
+  const basicModelName = input.overrides?.basicModelName ?? ANKIFY_BASIC_MODEL;
+  const basicFields: Record<string, string> = {
+    Front: input.fields[0] ?? '',
+    Back: input.fields[1] ?? '',
+  };
+  if (input.overrides) {
+    basicFields.MyMedia = '';
+  }
   return {
     deckName: input.deckName,
-    modelName: ANKIFY_BASIC_MODEL,
-    fields: {
-      Front: input.fields[0] ?? '',
-      Back: input.fields[1] ?? '',
-    },
+    modelName: basicModelName,
+    fields: basicFields,
     tags: trimmedTags,
     options: { allowDuplicate: true },
   };
@@ -132,7 +142,8 @@ export class SendUploadToRacUseCase {
     private readonly fetchApkgBytes: ApkgFetcher,
     private readonly parseApkg: ApkgParser,
     private readonly ankiConnect: AnkiConnectFactory,
-    private readonly logs?: AnkifySyncLogsRepositoryInterface
+    private readonly logs?: AnkifySyncLogsRepositoryInterface,
+    private readonly templateOverridesProvider?: AnkifyTemplateOverridesProvider
   ) {}
 
   private modelCache(clientId: number): Set<string> {
@@ -183,7 +194,9 @@ export class SendUploadToRacUseCase {
       ankiWebSyncError: null,
     };
 
-    await ensureAnkifyModels(ac, this.modelCache(client.id));
+    const overrides =
+      (await this.templateOverridesProvider?.(input.owner)) ?? null;
+    await ensureAnkifyModels(ac, this.modelCache(client.id), overrides);
     await this.uploadAllMedia(ac, parsed, result);
 
     for (const [noteId, note] of collection.notes) {
@@ -196,6 +209,7 @@ export class SendUploadToRacUseCase {
         fallbackDeckName,
         seenDeckNames,
         result,
+        overrides,
       });
     }
 
@@ -216,6 +230,7 @@ export class SendUploadToRacUseCase {
     fallbackDeckName: string;
     seenDeckNames: Set<string>;
     result: SendUploadToRacResult;
+    overrides: AnkifyTemplateOverrides | null;
   }): Promise<void> {
     const {
       noteId,
@@ -226,6 +241,7 @@ export class SendUploadToRacUseCase {
       fallbackDeckName,
       seenDeckNames,
       result,
+      overrides,
     } = args;
     try {
       const deckName = resolveDeckNameForNote(
@@ -244,6 +260,7 @@ export class SendUploadToRacUseCase {
         fields: note.fields,
         tags: note.tags,
         deckName,
+        overrides,
       });
 
       const existing = await this.mappings.findBySourceId(client.id, sourceId);

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -284,6 +284,62 @@ describe('SyncNotionPageToRacUseCase', () => {
     );
   });
 
+  test('addNote uses the user’s custom basic model name when templateOverridesProvider returns an override', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [sampleCard()],
+      diagnostic: {
+        blocks_scanned: 1,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      async () => ({
+        basicModelName: 'ATTI BASIC',
+        basicTemplate: {
+          parent: 'Basic',
+          name: 'ATTI BASIC',
+          storageKey: 'n2a-basic',
+          front: '{{Front}}',
+          back: '{{Back}}',
+          styling: '.card { color: tomato; }',
+        },
+      })
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'manual',
+    });
+
+    expect(ac.addNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelName: 'ATTI BASIC',
+        fields: { Front: 'Front text', Back: 'Back text', MyMedia: '' },
+      })
+    );
+    const createdNames = (ac.createModel as jest.Mock).mock.calls.map(
+      (args) => (args[0] as { modelName: string }).modelName
+    );
+    expect(createdNames).toContain('ATTI BASIC');
+    expect(createdNames).not.toContain('Ankify Basic');
+  });
+
   test('seeds Ankify note types before the first addNote call', async () => {
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
       cards: [sampleCard()],

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -22,6 +22,11 @@ import {
 } from '../../services/ankify/ankifyModels';
 import { ensureAnkifyModels } from '../../services/ankify/ensureAnkifyModels';
 import {
+  AnkifyTemplateOverrides,
+  AnkifyTemplateOverridesProvider,
+  buildBasicModelFromTemplate,
+} from '../../services/ankify/templateOverrides';
+import {
   walkNotionPageForFlashcards,
   NotionBlockChildrenFetcher,
   WalkedNotionFlashcard,
@@ -170,7 +175,8 @@ export class SyncNotionPageToRacUseCase {
     private readonly notionPageMeta?: NotionPageMetaFetcher,
     private readonly mediaFetcher: AnkifyMediaFetcher = guardedMediaFetcher,
     private readonly errorEvents?: IErrorEventRepository,
-    private readonly onTokenInvalid?: OnTokenInvalidFn
+    private readonly onTokenInvalid?: OnTokenInvalidFn,
+    private readonly templateOverridesProvider?: AnkifyTemplateOverridesProvider
   ) {}
 
   private modelCache(clientId: number): Set<string> {
@@ -342,8 +348,10 @@ export class SyncNotionPageToRacUseCase {
     );
     const deckName = buildDeckName(subscription.notion_page_title);
     await ac.createDeck(deckName);
-    await ensureAnkifyModels(ac, this.modelCache(client.id));
-    await this.refreshAnkifyModelStyling(ac);
+    const overrides =
+      (await this.templateOverridesProvider?.(input.owner)) ?? null;
+    await ensureAnkifyModels(ac, this.modelCache(client.id), overrides);
+    await this.refreshAnkifyModelStyling(ac, overrides);
 
     for (const card of cards) {
       await this.processCard({
@@ -354,6 +362,7 @@ export class SyncNotionPageToRacUseCase {
         input,
         result,
         deckName,
+        overrides,
       });
     }
 
@@ -398,9 +407,15 @@ export class SyncNotionPageToRacUseCase {
   }
 
   private async refreshAnkifyModelStyling(
-    ac: AnkiConnectClient
+    ac: AnkiConnectClient,
+    overrides: AnkifyTemplateOverrides | null
   ): Promise<void> {
-    const basic = ankifyBasicCreateModelParams();
+    const basic = overrides
+      ? buildBasicModelFromTemplate(
+          overrides.basicTemplate,
+          overrides.basicModelName
+        )
+      : ankifyBasicCreateModelParams();
     const cloze = ankifyClozeCreateModelParams();
     await ac.updateModelStyling({ name: basic.modelName, css: basic.css });
     await ac.updateModelStyling({ name: cloze.modelName, css: cloze.css });
@@ -424,6 +439,30 @@ export class SyncNotionPageToRacUseCase {
     });
   }
 
+  private buildBasicNote(args: {
+    deckName: string;
+    front: string;
+    back: string;
+    overrides: AnkifyTemplateOverrides | null;
+  }) {
+    const modelName =
+      args.overrides?.basicModelName ?? ANKIFY_BASIC_MODEL;
+    const fields: Record<string, string> = {
+      [FRONT_FIELD_BASIC]: args.front,
+      [BACK_FIELD_BASIC]: args.back,
+    };
+    if (args.overrides) {
+      fields.MyMedia = '';
+    }
+    return {
+      deckName: args.deckName,
+      modelName,
+      fields,
+      tags: ['ankify-notion-sync'],
+      options: { allowDuplicate: true },
+    };
+  }
+
   private async processCard(args: {
     card: WalkedNotionFlashcard;
     client: AnkifyClient;
@@ -432,8 +471,18 @@ export class SyncNotionPageToRacUseCase {
     input: SyncNotionPageInput;
     result: SyncNotionPageResult;
     deckName: string;
+    overrides: AnkifyTemplateOverrides | null;
   }): Promise<void> {
-    const { card, client, subscription, ac, input, result, deckName } = args;
+    const {
+      card,
+      client,
+      subscription,
+      ac,
+      input,
+      result,
+      deckName,
+      overrides,
+    } = args;
     try {
       await this.uploadCardMedia(ac, card, result);
       const existing = await this.mappings.findBySourceId(
@@ -441,16 +490,14 @@ export class SyncNotionPageToRacUseCase {
         card.notion_block_id
       );
       if (existing == null) {
-        const ankiNoteId = await ac.addNote({
-          deckName,
-          modelName: ANKIFY_BASIC_MODEL,
-          fields: {
-            [FRONT_FIELD_BASIC]: card.front,
-            [BACK_FIELD_BASIC]: card.back,
-          },
-          tags: ['ankify-notion-sync'],
-          options: { allowDuplicate: true },
-        });
+        const ankiNoteId = await ac.addNote(
+          this.buildBasicNote({
+            deckName,
+            front: card.front,
+            back: card.back,
+            overrides,
+          })
+        );
         await this.mappings.upsert({
           ankify_client_id: client.id,
           source_id: card.notion_block_id,
@@ -480,6 +527,7 @@ export class SyncNotionPageToRacUseCase {
         input,
         result,
         deckName,
+        overrides,
       });
     } catch (error) {
       result.errors.push(
@@ -497,24 +545,23 @@ export class SyncNotionPageToRacUseCase {
     input: SyncNotionPageInput;
     result: SyncNotionPageResult;
     deckName: string;
+    overrides: AnkifyTemplateOverrides | null;
   }): Promise<void> {
-    const { card, existing, client, ac, result, deckName } = args;
+    const { card, existing, client, ac, result, deckName, overrides } = args;
     const lastSyncedAt = existing.last_synced_at;
     const ankiInfo = await ac.notesInfo([existing.anki_note_id]);
     const ankiNote = ankiInfo[0];
 
     if (ankiNote?.noteId == null) {
       await this.mappings.deleteByAnkiNoteId(client.id, existing.anki_note_id);
-      const ankiNoteId = await ac.addNote({
-        deckName,
-        modelName: ANKIFY_BASIC_MODEL,
-        fields: {
-          [FRONT_FIELD_BASIC]: card.front,
-          [BACK_FIELD_BASIC]: card.back,
-        },
-        tags: ['ankify-notion-sync'],
-        options: { allowDuplicate: true },
-      });
+      const ankiNoteId = await ac.addNote(
+        this.buildBasicNote({
+          deckName,
+          front: card.front,
+          back: card.back,
+          overrides,
+        })
+      );
       await this.mappings.upsert({
         ankify_client_id: client.id,
         source_id: card.notion_block_id,

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -445,8 +445,7 @@ export class SyncNotionPageToRacUseCase {
     back: string;
     overrides: AnkifyTemplateOverrides | null;
   }) {
-    const modelName =
-      args.overrides?.basicModelName ?? ANKIFY_BASIC_MODEL;
+    const modelName = args.overrides?.basicModelName ?? ANKIFY_BASIC_MODEL;
     const fields: Record<string, string> = {
       [FRONT_FIELD_BASIC]: args.front,
       [BACK_FIELD_BASIC]: args.back,

--- a/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
+++ b/src/usecases/jobs/CreateJobWorkSpaceUseCase.test.ts
@@ -21,6 +21,7 @@ describe('CreateJobWorkSpaceUseCase', () => {
     loadIfExists: jest
       .fn()
       .mockResolvedValue(new CardOption(CardOption.LoadDefaultOptions())),
+    loadAnkifyTemplateOverrides: jest.fn().mockResolvedValue(null),
   };
 
   const parserRulesRepository: IParserRulesRepository = {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-09-templates-everywhere.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-09-templates-everywhere.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-09-templates-everywhere",
+  "date": "2026-06-09",
+  "type": "fix",
+  "title": "Custom note types you save in Templates settings now apply to synced cards too, not just decks you download"
+}


### PR DESCRIPTION
## Summary
- Atticus reported his custom \"ATTI BASIC\" note type from Settings → Templates → \"My note types\" had no effect on his Ankify-synced cards. Reason: Ankify's dispatch hardcoded `Ankify Basic` / `Ankify Cloze` and ignored the user's `CardOption` entirely. Templates was a one-shot-only setting masquerading as a global one.
- This PR makes the Templates setting apply across both products. When `cardOption.template === 'custom'` and the user has a saved `n2a-basic` template, Ankify dispatch creates/uses the user's named model (`basicModelName`) with their HTML/CSS instead of `Ankify Basic`. Otherwise the existing defaults apply — zero behavior change for users who never set a custom template.
- Scope this round: **Basic only**. Cloze and Input continue to use Ankify defaults — separable follow-up.

## What changed
- `SettingsRepository.loadAnkifyTemplateOverrides(owner)` resolves a user's most-recent settings row + their templates row into an `AnkifyTemplateOverrides | null`.
- `services/ankify/templateOverrides.ts` — new shared type + `buildBasicModelFromTemplate` that converts a `TemplateFile` into an `AnkiConnectCreateModelParams` with fields `[Front, Back, MyMedia]`.
- `ensureAnkifyModels` accepts optional overrides and creates the user's named model instead of `Ankify Basic` when present.
- `SendUploadToRacUseCase` and `SyncNotionPageToRacUseCase` accept an optional `AnkifyTemplateOverridesProvider` (injected at the router). Both pass the resolved override through every model-create + add-note + style-refresh site.
- Both use cases default to the existing behavior when the provider is absent or returns `null`. Existing wired-up tests stay green without modification beyond mock-method additions.

## Migration
- No data migration. Users who already have `Ankify Basic` notes in their Anki keep them — new syncs land in their custom-named model alongside. No forced rename, no review-history risk.
- Cloze + Input + MCQ unaffected; deferred to a follow-up.

## Browser check
Browser check: not applicable — server-side dispatch change. The only `web/src/` file in this diff is the new `web/src/pages/WhatsNewPage/changelog/2026-06-09-templates-everywhere.json`, which is bypassed by the changelog-only gate.

## Test plan
- [x] `pnpm test src/services/ankify src/usecases/ankify src/data_layer/SettingsRepository` — 162/162 pass (8 new across Send/Sync/ensureAnkifyModels/SettingsRepository).
- [x] `pnpm tsc --noEmit` clean.
- [x] `pnpm --filter 2anki-web typecheck` clean.
- [x] `pnpm --filter 2anki-web test src/pages/WhatsNewPage` — 7/7 pass (asserts changelog id uniqueness).
- [ ] `/security-review` before flipping ready — touches external-API integration per CLAUDE.md.
- [ ] `sonar-scanner` not run locally — no token configured here; expect Sonar to report cleanly on the new code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783596822&installation_id=132681956&pr_number=3194&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3194&signature=172cd6bb0e88c3f4aa1db9d6af2f9153e0b1fce5a4871c31a97256e212a7cf27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->