### PR TITLE
fix: raise paid .apkg import cap to 10 000 notes

### DIFF
--- a/src/controllers/ApkgController.test.ts
+++ b/src/controllers/ApkgController.test.ts
@@ -196,7 +196,7 @@ describe('ApkgController.importToNotion', () => {
     expect(executeCall[5]).toMatchObject({ isPaying: false, maxNotes: 1000 });
   });
 
-  it('gives a paying user maxNotes=5000', async () => {
+  it('gives a paying user maxNotes=10000', async () => {
     const controller = makeController();
     const req = makeReq() as Request;
     const res = makeRes({ patreon: true, subscriber: false }) as Response;
@@ -205,10 +205,10 @@ describe('ApkgController.importToNotion', () => {
 
     expect(res.status).toHaveBeenCalledWith(202);
     const executeCall = executeMock.mock.calls[0];
-    expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 5000 });
+    expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 10000 });
   });
 
-  it('gives a subscriber user maxNotes=5000', async () => {
+  it('gives a subscriber user maxNotes=10000', async () => {
     const controller = makeController();
     const req = makeReq() as Request;
     const res = makeRes({ patreon: false, subscriber: true }) as Response;
@@ -217,7 +217,7 @@ describe('ApkgController.importToNotion', () => {
 
     expect(res.status).toHaveBeenCalledWith(202);
     const executeCall = executeMock.mock.calls[0];
-    expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 5000 });
+    expect(executeCall[5]).toMatchObject({ isPaying: true, maxNotes: 10000 });
   });
 });
 

--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -342,7 +342,7 @@ class ApkgController {
 
       const userIsPaying =
         res.locals.patreon === true || res.locals.subscriber === true;
-      const maxNotes = userIsPaying ? 5000 : 1000;
+      const maxNotes = userIsPaying ? 10000 : 1000;
 
       const rawParentPageId = req.body?.parent_page_id;
       const hasExplicitParent =

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-09-apkg-import-10k.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-09-apkg-import-10k.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-09-apkg-import-10k",
+  "date": "2026-06-09",
+  "type": "feature",
+  "title": "Paid plans import .apkg decks up to 10 000 notes"
+}


### PR DESCRIPTION
## What

Paid users (`patreon` / `subscriber`) can now import `.apkg` decks up to **10 000 notes**, up from 5 000. Free tier unchanged at 1 000.

## Why

Prod 24h check surfaced a failed `apkg_import` job: a 7 445-note deck blocked at the cap. The import runs as a background job (`void useCase.execute`, returns `202 queued`), so it is **not** bound by the HTTP request timeout the cap was originally guarding — raising the ceiling is safe.

Free stays at 1 000 as the paywall lever (per the decision on this change). The 7 445-note user was free, so they're still gated — this lifts the ceiling for payers, not everyone.

## Changes

- `ApkgController.ts:345` — paid cap `5000 → 10000`
- `ApkgController.test.ts` — assertions updated to `maxNotes=10000`
- Changelog entry

Browser check: not applicable — changelog-only web/src diff, no rendered behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783623543&installation_id=132681956&pr_number=3195&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3195&signature=492bd579354e704dd938e0b35d0668bbb6bcd95db16a4ff8a897cb5678a41d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->