### PR TITLE
feat: sync a Notion database in Ankify, not just a page

### DIFF
--- a/src/services/ankify/notionDatabasePagesFetcher.test.ts
+++ b/src/services/ankify/notionDatabasePagesFetcher.test.ts
@@ -1,0 +1,70 @@
+const retrieveMock = jest.fn();
+const queryMock = jest.fn();
+
+jest.mock('@notionhq/client', () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    databases: { retrieve: retrieveMock },
+    dataSources: { query: queryMock },
+  })),
+}));
+
+import { notionDatabasePagesFetcherFactory } from './notionDatabasePagesFetcher';
+
+describe('notionDatabasePagesFetcherFactory', () => {
+  beforeEach(() => {
+    retrieveMock.mockReset();
+    queryMock.mockReset();
+    retrieveMock.mockResolvedValue({ data_sources: [{ id: 'data-source-1' }] });
+  });
+
+  test('resolves the first data source and follows the cursor', async () => {
+    queryMock
+      .mockResolvedValueOnce({
+        results: [{ id: 'page-1' }, { id: 'page-2' }],
+        next_cursor: 'cursor-1',
+      })
+      .mockResolvedValueOnce({
+        results: [{ id: 'page-3' }],
+        next_cursor: null,
+      });
+
+    const fetch = notionDatabasePagesFetcherFactory('token');
+    const pages = await fetch('database-id');
+
+    expect(retrieveMock).toHaveBeenCalledWith({ database_id: 'database-id' });
+    expect(pages).toEqual([
+      { id: 'page-1' },
+      { id: 'page-2' },
+      { id: 'page-3' },
+    ]);
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(queryMock.mock.calls[0][0]).toMatchObject({
+      data_source_id: 'data-source-1',
+    });
+    expect(queryMock.mock.calls[1][0]).toMatchObject({
+      start_cursor: 'cursor-1',
+    });
+  });
+
+  test('returns no pages when the database has no data source', async () => {
+    retrieveMock.mockResolvedValue({ data_sources: [] });
+
+    const fetch = notionDatabasePagesFetcherFactory('token');
+    const pages = await fetch('database-id');
+
+    expect(pages).toEqual([]);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  test('skips rows that lack a string id', async () => {
+    queryMock.mockResolvedValueOnce({
+      results: [{ id: 'page-1' }, { id: 42 }, {}],
+      next_cursor: null,
+    });
+
+    const fetch = notionDatabasePagesFetcherFactory('token');
+    const pages = await fetch('database-id');
+
+    expect(pages).toEqual([{ id: 'page-1' }]);
+  });
+});

--- a/src/services/ankify/notionDatabasePagesFetcher.ts
+++ b/src/services/ankify/notionDatabasePagesFetcher.ts
@@ -1,0 +1,48 @@
+import { Client as NotionClient } from '@notionhq/client';
+import { NotionDatabasePageRef } from './notionPageWalker';
+
+export type NotionDatabasePagesFetcherFactory = (
+  token: string
+) => (databaseId: string) => Promise<NotionDatabasePageRef[]>;
+
+export const notionDatabasePagesFetcherFactory: NotionDatabasePagesFetcherFactory =
+  (token: string) => {
+    const notion = new NotionClient({ auth: token });
+
+    const findFirstDataSourceId = async (
+      databaseId: string
+    ): Promise<string | null> => {
+      const dbResp = await notion.databases.retrieve({
+        database_id: databaseId,
+      });
+      const dataSources =
+        'data_sources' in dbResp
+          ? (dbResp as { data_sources: { id: string }[] }).data_sources
+          : [];
+      return dataSources[0]?.id ?? null;
+    };
+
+    return async (databaseId: string): Promise<NotionDatabasePageRef[]> => {
+      const dataSourceId = await findFirstDataSourceId(databaseId);
+      if (dataSourceId == null) {
+        return [];
+      }
+      const aggregated: NotionDatabasePageRef[] = [];
+      let cursor: string | undefined;
+      do {
+        const response = await notion.dataSources.query({
+          data_source_id: dataSourceId,
+          page_size: 100,
+          ...(cursor == null ? {} : { start_cursor: cursor }),
+        });
+        for (const row of response.results) {
+          const id = (row as { id?: unknown }).id;
+          if (typeof id === 'string') {
+            aggregated.push({ id });
+          }
+        }
+        cursor = response.next_cursor ?? undefined;
+      } while (cursor != null);
+      return aggregated;
+    };
+  };

--- a/src/services/ankify/notionPageWalker.test.ts
+++ b/src/services/ankify/notionPageWalker.test.ts
@@ -1,4 +1,7 @@
-import { walkNotionPageForFlashcards } from './notionPageWalker';
+import {
+  walkNotionPageForFlashcards,
+  walkNotionDatabaseForFlashcards,
+} from './notionPageWalker';
 
 const toggleBlock = (overrides: Record<string, unknown> = {}) => ({
   id: 'toggle-1',
@@ -359,5 +362,71 @@ describe('walkNotionPageForFlashcards diagnostic', () => {
 
     expect(diagnostic.blocks_matched).toBe(0);
     expect(diagnostic.unmatched_samples).toEqual(['Introduction']);
+  });
+});
+
+describe('walkNotionDatabaseForFlashcards', () => {
+  const rowToggle = (id: string, front: string) => ({
+    id: `${id}-toggle`,
+    type: 'toggle',
+    has_children: true,
+    last_edited_time: '2026-05-09T12:00:00.000Z',
+    toggle: { rich_text: [{ plain_text: front }] },
+  });
+
+  test('walks every database row-page and aggregates the cards', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'row-1') return [rowToggle('row-1', 'Front 1')];
+      if (blockId === 'row-2') return [rowToggle('row-2', 'Front 2')];
+      if (blockId === 'row-1-toggle') return [paragraphChild('Back 1')];
+      if (blockId === 'row-2-toggle') return [paragraphChild('Back 2')];
+      return [];
+    });
+    const fetchDatabasePages = jest.fn(async () => [
+      { id: 'row-1' },
+      { id: 'row-2' },
+    ]);
+
+    const { cards, diagnostic } = await walkNotionDatabaseForFlashcards(
+      'database-id',
+      fetchChildren as never,
+      fetchDatabasePages
+    );
+
+    expect(fetchDatabasePages).toHaveBeenCalledWith('database-id');
+    expect(cards.map((c) => c.front)).toEqual(['Front 1', 'Front 2']);
+    expect(cards[0].back).toContain('Back 1');
+    expect(cards[1].back).toContain('Back 2');
+    expect(diagnostic.blocks_matched).toBe(2);
+    expect(diagnostic.pattern_hits).toEqual({ toggle: 2 });
+  });
+
+  test('caps the number of database rows walked at 250', async () => {
+    const pages = Array.from({ length: 300 }, (_v, i) => ({ id: `row-${i}` }));
+    const fetchChildren = jest.fn(async () => []);
+    const fetchDatabasePages = jest.fn(async () => pages);
+
+    await walkNotionDatabaseForFlashcards(
+      'database-id',
+      fetchChildren as never,
+      fetchDatabasePages
+    );
+
+    expect(fetchChildren).toHaveBeenCalledTimes(250);
+  });
+
+  test('returns zero cards for an empty database', async () => {
+    const fetchChildren = jest.fn(async () => []);
+    const fetchDatabasePages = jest.fn(async () => []);
+
+    const { cards, diagnostic } = await walkNotionDatabaseForFlashcards(
+      'database-id',
+      fetchChildren as never,
+      fetchDatabasePages
+    );
+
+    expect(cards).toEqual([]);
+    expect(diagnostic.blocks_scanned).toBe(0);
+    expect(diagnostic.blocks_matched).toBe(0);
   });
 });

--- a/src/services/ankify/notionPageWalker.ts
+++ b/src/services/ankify/notionPageWalker.ts
@@ -45,8 +45,17 @@ export type NotionBlockChildrenFetcher = (
   blockId: string
 ) => Promise<NotionRenderableBlock[]>;
 
+export interface NotionDatabasePageRef {
+  id: string;
+}
+
+export type NotionDatabasePagesFetcher = (
+  databaseId: string
+) => Promise<NotionDatabasePageRef[]>;
+
 const MAX_BLOCKS_SCANNED = 1000;
 const MAX_UNMATCHED_SAMPLES = 3;
+const MAX_DATABASE_PAGES = 250;
 
 const renderRichText = (items: RichTextItem[] | undefined): string => {
   if (items == null) return '';
@@ -122,6 +131,48 @@ export const walkNotionPageForFlashcards = async (
 
   const diagnostic: SyncDiagnostic = {
     blocks_scanned: limit,
+    blocks_matched: cards.length,
+    pattern_hits: patternHits,
+  };
+
+  if (unmatchedSamples.length > 0) {
+    diagnostic.unmatched_samples = unmatchedSamples;
+  }
+
+  return { cards, diagnostic };
+};
+
+export const walkNotionDatabaseForFlashcards = async (
+  databaseId: string,
+  fetchChildren: NotionBlockChildrenFetcher,
+  fetchDatabasePages: NotionDatabasePagesFetcher
+): Promise<WalkNotionPageResult> => {
+  const pages = await fetchDatabasePages(databaseId);
+  const limit = Math.min(pages.length, MAX_DATABASE_PAGES);
+
+  const cards: WalkedNotionFlashcard[] = [];
+  const patternHits: Record<string, number> = {};
+  const unmatchedSamples: string[] = [];
+  let blocksScanned = 0;
+
+  for (let i = 0; i < limit; i++) {
+    const page = await walkNotionPageForFlashcards(pages[i].id, fetchChildren);
+    cards.push(...page.cards);
+    blocksScanned += page.diagnostic.blocks_scanned;
+    for (const [pattern, count] of Object.entries(
+      page.diagnostic.pattern_hits
+    )) {
+      patternHits[pattern] = (patternHits[pattern] ?? 0) + count;
+    }
+    for (const sample of page.diagnostic.unmatched_samples ?? []) {
+      if (unmatchedSamples.length < MAX_UNMATCHED_SAMPLES) {
+        unmatchedSamples.push(sample);
+      }
+    }
+  }
+
+  const diagnostic: SyncDiagnostic = {
+    blocks_scanned: blocksScanned,
     blocks_matched: cards.length,
     pattern_hits: patternHits,
   };

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -196,7 +196,10 @@ describe('SyncNotionPageToRacUseCase', () => {
 
     const repos = makeRepos();
     const ac = makeAnkiConnectStub();
-    const databasePages = jest.fn(async () => [{ id: 'row-1' }, { id: 'row-2' }]);
+    const databasePages = jest.fn(async () => [
+      { id: 'row-1' },
+      { id: 'row-2' },
+    ]);
     const useCase = new SyncNotionPageToRacUseCase(
       repos.clients,
       repos.mappings,

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -12,6 +12,7 @@ import { WalkedNotionFlashcard } from '../../services/ankify/notionPageWalker';
 
 jest.mock('../../services/ankify/notionPageWalker', () => ({
   walkNotionPageForFlashcards: jest.fn(),
+  walkNotionDatabaseForFlashcards: jest.fn(),
 }));
 
 jest.mock('axios');
@@ -22,7 +23,10 @@ jest.mock('node:dns', () => ({
 
 import axios from 'axios';
 import dns from 'node:dns';
-import { walkNotionPageForFlashcards } from '../../services/ankify/notionPageWalker';
+import {
+  walkNotionPageForFlashcards,
+  walkNotionDatabaseForFlashcards,
+} from '../../services/ankify/notionPageWalker';
 
 const mockAxiosGet = axios.get as jest.Mock;
 const mockDnsLookup = dns.promises.lookup as jest.Mock;
@@ -165,6 +169,102 @@ describe('SyncNotionPageToRacUseCase', () => {
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue(
       emptyWalkResult()
     );
+    (walkNotionDatabaseForFlashcards as jest.Mock).mockReset();
+    (walkNotionDatabaseForFlashcards as jest.Mock).mockResolvedValue(
+      emptyWalkResult()
+    );
+  });
+
+  test('falls back to a database walk when the subscribed id is a Notion database', async () => {
+    const databaseNotPageError = Object.assign(
+      new Error(
+        'Provided ID 379cbac1 is a database, not a page. Use the retrieve database API instead.'
+      ),
+      { code: 'validation_error' }
+    );
+    (walkNotionPageForFlashcards as jest.Mock).mockRejectedValue(
+      databaseNotPageError
+    );
+    (walkNotionDatabaseForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [sampleCard()],
+      diagnostic: {
+        blocks_scanned: 4,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const databasePages = jest.fn(async () => [{ id: 'row-1' }, { id: 'row-2' }]);
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => databasePages
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      notionPageId: 'database-id',
+      trigger: 'polling',
+    });
+
+    expect(walkNotionDatabaseForFlashcards).toHaveBeenCalledWith(
+      'database-id',
+      expect.any(Function),
+      databasePages
+    );
+    expect(ac.addNote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fields: { Front: 'Front text', Back: 'Back text' },
+      })
+    );
+    expect(result.created).toBe(1);
+    expect(repos.subscriptions.setEnabled).not.toHaveBeenCalled();
+    expect(repos.subscriptions.recordPoll).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ synced: true })
+    );
+  });
+
+  test('propagates a non-database validation error without a database walk', async () => {
+    const otherError = Object.assign(new Error('Something else broke'), {
+      code: 'validation_error',
+    });
+    (walkNotionPageForFlashcards as jest.Mock).mockRejectedValue(otherError);
+
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => []
+    );
+
+    await expect(
+      useCase.execute({
+        owner: 42,
+        notionPageId: 'page-id',
+        trigger: 'polling',
+      })
+    ).rejects.toThrow('Something else broke');
+    expect(walkNotionDatabaseForFlashcards).not.toHaveBeenCalled();
   });
 
   test('persists icon returned by the page-meta fetcher on upsert', async () => {

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -28,11 +28,17 @@ import {
 } from '../../services/ankify/templateOverrides';
 import {
   walkNotionPageForFlashcards,
+  walkNotionDatabaseForFlashcards,
   NotionBlockChildrenFetcher,
+  WalkNotionPageResult,
   WalkedNotionFlashcard,
   WalkedNotionMediaRef,
   SyncDiagnostic,
 } from '../../services/ankify/notionPageWalker';
+import {
+  notionDatabasePagesFetcherFactory,
+  NotionDatabasePagesFetcherFactory,
+} from '../../services/ankify/notionDatabasePagesFetcher';
 import { NoActiveAnkifyClientError } from './SendUploadToRacUseCase';
 import { NotionNotConnectedError } from './ExportReviewDataToNotionUseCase';
 
@@ -160,6 +166,18 @@ function isNotionUnauthorizedError(error: unknown): boolean {
   );
 }
 
+function isNotionDatabaseNotPageError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+  const { code, message } = error as { code?: unknown; message?: unknown };
+  return (
+    code === 'validation_error' &&
+    typeof message === 'string' &&
+    message.includes('is a database, not a page')
+  );
+}
+
 export class SyncNotionPageToRacUseCase {
   private readonly modelCacheByClient = new Map<number, Set<string>>();
 
@@ -176,7 +194,8 @@ export class SyncNotionPageToRacUseCase {
     private readonly mediaFetcher: AnkifyMediaFetcher = guardedMediaFetcher,
     private readonly errorEvents?: IErrorEventRepository,
     private readonly onTokenInvalid?: OnTokenInvalidFn,
-    private readonly templateOverridesProvider?: AnkifyTemplateOverridesProvider
+    private readonly templateOverridesProvider?: AnkifyTemplateOverridesProvider,
+    private readonly databasePagesFetcher: NotionDatabasePagesFetcherFactory = notionDatabasePagesFetcherFactory
   ) {}
 
   private modelCache(clientId: number): Set<string> {
@@ -331,8 +350,9 @@ export class SyncNotionPageToRacUseCase {
   }): Promise<void> {
     const { input, token, client, subscription, result } = args;
     const fetchChildren = this.notionFetcher(token);
-    const { cards, diagnostic } = await walkNotionPageForFlashcards(
+    const { cards, diagnostic } = await this.walkSource(
       input.notionPageId,
+      token,
       fetchChildren
     );
     result.diagnostic = diagnostic;
@@ -367,6 +387,25 @@ export class SyncNotionPageToRacUseCase {
     }
 
     await this.runFinalAnkiWebSync(ac, result);
+  }
+
+  private async walkSource(
+    notionId: string,
+    token: string,
+    fetchChildren: NotionBlockChildrenFetcher
+  ): Promise<WalkNotionPageResult> {
+    try {
+      return await walkNotionPageForFlashcards(notionId, fetchChildren);
+    } catch (error) {
+      if (isNotionDatabaseNotPageError(error)) {
+        return walkNotionDatabaseForFlashcards(
+          notionId,
+          fetchChildren,
+          this.databasePagesFetcher(token)
+        );
+      }
+      throw error;
+    }
   }
 
   private async uploadCardMedia(

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-09-ankify-database-sync.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-09-ankify-database-sync.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-09-ankify-database-sync",
+  "date": "2026-06-09",
+  "type": "feature",
+  "title": "Auto-sync a Notion database — every row's toggles become cards, not just a single page"
+}


### PR DESCRIPTION
## What

Ankify auto-sync now works when the subscribed Notion id is a **database**, not only a page. Each row-page in the database is walked for toggle cards, same as a page subscription.

## Why

Prod log audit found 81× `validation_error: is a database, not a page` over ~6 hours, all from one enabled subscription (a user who subscribed a Notion database of study content). The old path:

- `walkNotionPageForFlashcards` → `blocks.children.list({block_id: <database>})` → Notion throws `is a database, not a page`
- `validation_error` isn't retryable and isn't in the disable list → the subscription stays enabled and **silently logs `success` with 0 cards every 5-minute poll**, spamming the error forever

The user saw "synced" but got nothing.

## Change

- `notionDatabasePagesFetcher.ts` — resolve the database's first data source (Notion SDK v5 `databases.retrieve` → `data_sources[0]`, then `dataSources.query`), paginate its row-pages
- `walkNotionDatabaseForFlashcards` — fan across rows, walk each page, aggregate cards + merge diagnostics; capped at 250 rows
- `SyncNotionPageToRacUseCase` — detect the exact `is a database, not a page` error and fall back to the database walk; non-database validation errors still propagate
- New ctor param defaults to the real factory → no wiring/test churn at existing call sites

Existing prod subscriptions on a database **self-heal on the next poll** after deploy — no manual DB fix needed.

## Tests

- `notionPageWalker.test.ts` — aggregation across rows, 250-row cap, empty database
- `notionDatabasePagesFetcher.test.ts` — data-source resolution, cursor pagination, no-data-source, non-string id skip
- `SyncNotionPageToRacUseCase.test.ts` — database fallback path (cards synced, sub not disabled, recordPoll synced), and non-database validation error still throws
- Full ankify sweep: 166/166 green; server `tsc -p .` clean

## Notes

Sonar not run locally (`SONAR_TOKEN` unset) — expect the CI gate to scan; new code is positive-first conditionals, no `any`/nested ternaries.

Browser check: not applicable — changelog-only web/src diff, no rendered behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)