### PR TITLE
ci: cut CI job count to ease Blacksmith queue starvation

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -15,8 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  typecheck:
-    name: typecheck (22.20.0)
+  static:
+    name: static (22.20.0)
     runs-on: blacksmith
     steps:
       - uses: actions/checkout@v6
@@ -25,13 +25,6 @@ jobs:
         run: pnpm typecheck
         env:
           CI: true
-
-  lint:
-    name: lint (22.20.0)
-    runs-on: blacksmith
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
       - name: Lint
         run: pnpm lint
         env:
@@ -42,18 +35,14 @@ jobs:
           CI: true
 
   test:
-    name: test (${{ matrix.shard }})
+    name: test (22.20.0)
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: blacksmith
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: ['1/3', '2/3', '3/3']
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - name: Test
-        run: pnpm test --shard=${{ matrix.shard }}
+        run: pnpm test
         env:
           CI: true
           NOTION_KEY: ${{ secrets.NOTION_KEY }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: lint (22.20.0)
+  build:
+    name: build (22.20.0)
     runs-on: blacksmith
     steps:
       - uses: actions/checkout@v6
@@ -27,13 +27,6 @@ jobs:
         run: pnpm --filter 2anki-web lint
         env:
           CI: true
-
-  build:
-    name: build (22.20.0)
-    runs-on: blacksmith
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/actions/setup
       - name: Typecheck
         run: pnpm --filter 2anki-web typecheck
         env:


### PR DESCRIPTION
## Problem

CI jobs sit **queued for 4–5 minutes** before a Blacksmith runner picks them up, even though the actual work finishes in 40–55s. Evidence from a recent server run:

| job | queued | started | wait |
| --- | --- | --- | --- |
| test (2/3) | 19:15:48 | 19:17:05 | 1.3 min |
| typecheck | 19:15:48 | — | 4.5 min, never started |
| test (1/3) | 19:15:48 | 19:19:52 | 4 min |
| test (3/3) | 19:15:48 | — | still queued |

It's **runner pickup latency**, not a hang. Every job re-runs the composite setup (checkout + `pnpm install`) before its real work, so a full push fans out **9 jobs** (server 5 + web 3 + playwright 1) all competing for a small runner pool. Sharding 456 test files 3 ways triples runner demand to save ~80s — a bad trade when the pain is queue time.

## Change

Reduce job count so fewer slots compete:

- **Server 5 → 2**: merge `typecheck` + `lint` + `format:check` into one `static` job (one install); collapse the 3-way `test` shard into a single `test` job.
- **Web 3 → 2**: fold the standalone `lint` job into `build` (which already runs typecheck).
- Playwright unchanged (1 job).

**Net: 9 → 5 jobs per full push, 4 fewer redundant `pnpm install`.** On a starved pool, one test slot running ~2.5 min beats three slots each waiting ~4 min to start.

## Notes

- No required status checks / rulesets reference the old job names (`required_status_checks.contexts` is empty), so renaming `typecheck`/`lint`/`test (1/3)` → `static`/`test` doesn't break merge gating.
- Caching is already good (pnpm store, node_modules, dist, playwright browsers keyed on lockfile) — untouched.
- Reversible: if the server suite later outgrows a single job, re-shard `test` to 2.
- No changelog entry — internal CI, no user-visible change.

Browser check: not applicable — CI workflow change, no web/src/ files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783625170&installation_id=132681956&pr_number=3197&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3197&signature=a0c56f1d71c6d691794a20a2db18a6b66e0dcc6895aa31a49f49c5eeb73e603d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->