### PR TITLE
feat: let users share an email with What's New feedback

### DIFF
--- a/migrations/20260910000000_add_email_to_emoji_feedback.js
+++ b/migrations/20260910000000_add_email_to_emoji_feedback.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.alterTable('emoji_feedback', (t) => {
+    t.string('email', 254).nullable().defaultTo(null);
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('emoji_feedback', (t) => {
+    t.dropColumn('email');
+  });
+};

--- a/src/controllers/EmojiFeedbackController.test.ts
+++ b/src/controllers/EmojiFeedbackController.test.ts
@@ -56,6 +56,7 @@ describe('EmojiFeedbackController', () => {
       rating: 4,
       comment: null,
       page: '/upload',
+      email: null,
     });
   });
 
@@ -68,7 +69,36 @@ describe('EmojiFeedbackController', () => {
       rating: 5,
       comment: 'Great tool!',
       page: '/notion',
+      email: null,
     });
+  });
+
+  it('stores null email when none is provided', async () => {
+    const { controller, req, res, repo } = buildMocks();
+    req.body = { rating: 4, page: '/whats-new' };
+    await controller.submit(req, res);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(repo.insert.mock.calls[0][0].email).toBeNull();
+  });
+
+  it('persists a trimmed valid email when provided', async () => {
+    const { controller, req, res, repo } = buildMocks();
+    req.body = {
+      rating: 5,
+      page: '/whats-new',
+      email: '  learner@example.com  ',
+    };
+    await controller.submit(req, res);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(repo.insert.mock.calls[0][0].email).toBe('learner@example.com');
+  });
+
+  it('stores null when the email is malformed', async () => {
+    const { controller, req, res, repo } = buildMocks();
+    req.body = { rating: 3, page: '/whats-new', email: 'not-an-email' };
+    await controller.submit(req, res);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(repo.insert.mock.calls[0][0].email).toBeNull();
   });
 
   it('truncates long comments to 2000 chars', async () => {

--- a/src/controllers/EmojiFeedbackController.ts
+++ b/src/controllers/EmojiFeedbackController.ts
@@ -2,12 +2,21 @@ import { Request, Response } from 'express';
 
 import { IEmojiFeedbackRepository } from '../data_layer/EmojiFeedbackRepository';
 
+const EMAIL_MAX_LENGTH = 254;
+const EMAIL_SHAPE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const parseEmail = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().slice(0, EMAIL_MAX_LENGTH);
+  return EMAIL_SHAPE.test(trimmed) ? trimmed : null;
+};
+
 class EmojiFeedbackController {
   constructor(private readonly repo: IEmojiFeedbackRepository) {}
 
   async submit(req: Request, res: Response) {
     try {
-      const { rating, comment, page } = req.body;
+      const { rating, comment, page, email } = req.body;
 
       if (
         typeof rating !== 'number' ||
@@ -33,6 +42,7 @@ class EmojiFeedbackController {
         rating,
         comment: sanitizedComment,
         page: page.trim().slice(0, 255),
+        email: parseEmail(email),
       });
 
       res.status(201).json({ message: 'Thank you for your feedback!' });

--- a/src/data_layer/EmojiFeedbackRepository.ts
+++ b/src/data_layer/EmojiFeedbackRepository.ts
@@ -4,6 +4,7 @@ interface EmojiFeedbackEntry {
   rating: number;
   comment: string | null;
   page: string;
+  email: string | null;
 }
 
 export interface EmojiFeedbackRatingCount {
@@ -49,6 +50,7 @@ export class EmojiFeedbackRepository implements IEmojiFeedbackRepository {
       rating: entry.rating,
       comment: entry.comment,
       page: entry.page,
+      email: entry.email,
     });
   }
 
@@ -86,6 +88,7 @@ export class InMemoryEmojiFeedbackRepository implements IEmojiFeedbackRepository
     rating: number;
     comment: string | null;
     page: string;
+    email: string | null;
     created_at: Date;
   }> = [];
 
@@ -114,6 +117,7 @@ export class InMemoryEmojiFeedbackRepository implements IEmojiFeedbackRepository
           rating: number;
           comment: string;
           page: string;
+          email: string | null;
           created_at: Date;
         } => r.comment != null && r.comment !== ''
       )

--- a/src/routes/EmojiFeedbackRouter.ts
+++ b/src/routes/EmojiFeedbackRouter.ts
@@ -30,6 +30,8 @@ const EmojiFeedbackRouter = () => {
    *                 maximum: 5
    *               comment:
    *                 type: string
+   *               email:
+   *                 type: string
    *               page:
    *                 type: string
    *     responses:

--- a/web/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -9,7 +9,7 @@
 .widgetCompact {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.75rem;
 }
 
@@ -55,7 +55,8 @@
   transform: scale(1.12);
 }
 
-.commentInput {
+.commentInput,
+.emailInput {
   width: 100%;
   max-width: 360px;
   padding: 0.625rem 0.75rem;
@@ -65,15 +66,20 @@
   font-family: inherit;
   color: var(--color-text-primary);
   background: var(--color-bg-primary);
-  resize: vertical;
   transition: border-color var(--transition-fast);
 }
 
-.commentInput::placeholder {
+.commentInput {
+  resize: vertical;
+}
+
+.commentInput::placeholder,
+.emailInput::placeholder {
   color: var(--color-text-tertiary);
 }
 
-.commentInput:focus {
+.commentInput:focus,
+.emailInput:focus {
   outline: none;
   border-color: var(--color-primary);
 }
@@ -129,6 +135,13 @@
   color: var(--color-text-secondary);
   margin: 0;
   text-align: center;
+}
+
+.emailHint {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: -0.375rem 0 0;
+  max-width: 360px;
 }
 
 .nudgeLink {

--- a/web/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/web/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -25,6 +25,7 @@ export function FeedbackWidget({
 }: Readonly<FeedbackWidgetProps>) {
   const [selectedRating, setSelectedRating] = useState<number | null>(null);
   const [comment, setComment] = useState('');
+  const [email, setEmail] = useState('');
   const [status, setStatus] = useState<WidgetStatus>('idle');
 
   async function handleSubmit() {
@@ -34,7 +35,8 @@ export function FeedbackWidget({
       await get2ankiApi().submitEmojiFeedback(
         selectedRating,
         page,
-        comment || undefined
+        comment || undefined,
+        email || undefined
       );
       setStatus('sent');
       onSubmitted?.();
@@ -89,6 +91,20 @@ export function FeedbackWidget({
             rows={2}
             maxLength={2000}
           />
+          <input
+            type="email"
+            className={styles.emailInput}
+            placeholder="Email (optional)"
+            aria-label="Email (optional)"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            maxLength={254}
+            autoComplete="email"
+            data-hj-suppress
+          />
+          <p className={styles.emailHint}>
+            Only used to follow up on this feedback.
+          </p>
           <button
             type="button"
             className={styles.submitButton}

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -922,12 +922,14 @@ export class Backend {
   async submitEmojiFeedback(
     rating: number,
     page: string,
-    comment?: string
+    comment?: string,
+    email?: string
   ): Promise<void> {
     const response = await post(`${this.baseURL}emoji-feedback`, {
       rating,
       page,
       comment: comment ?? null,
+      email: email ?? null,
     });
     if (!response.ok) {
       throw new Error('Failed to submit feedback');

--- a/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
+++ b/web/src/pages/WhatsNewPage/WhatsNewPage.module.css
@@ -106,10 +106,10 @@
 
 .inlineRating {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 0.75rem;
   margin-top: 1rem;
-  flex-wrap: wrap;
 }
 
 .ratingPrompt {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-10-feedback-email.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-10-feedback-email.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-10-feedback-email",
+  "date": "2026-06-10",
+  "type": "feature",
+  "title": "Feedback takes an optional email so we can follow up on what you said"
+}


### PR DESCRIPTION
## What

The inline feedback widget on the What's New page now takes an **optional** email so we can ask a follow-up about what a user reported. Submitting without it works exactly as before.

- New `<input type="email">` after the comment box, before Send, with the hint "Only used to follow up on this feedback."
- Stored in a new nullable `email` column on `emoji_feedback`. Loose server-side validation (trim, 254 cap, plausible-shape check) — invalid input becomes `null`, never blocks submit.
- Raw email is never logged (`data-hj-suppress` in the DOM; no controller logging).
- Also left-aligns and de-crams the inline rating row (designer tweak).

## Tests

- `EmojiFeedbackController.test.ts` — 11 pass: no-email stores `null`, valid email trimmed + persisted, malformed → `null`.
- Server `tsc`, web `tsc`, full web vitest (1775) green.

## Notes

- Migration adds a nullable column; `pnpm kanel` should run once it's applied (the generated type isn't imported, so the build is green meanwhile).
- `sonar-scanner` not run locally; `oxlint` clean on the changed files. CSS/JSX/JSON diff — low Sonar risk.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified with Playwright at 375px against the web dev server — picked an emoji, the comment box, Email (optional) field, and "Only used to follow up on this feedback." hint all render; zero app console errors (only backend-absent 502s from the dev proxy, unrelated to this change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783666965&installation_id=132681956&pr_number=3198&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3198&signature=24730d1d640f3d669f8bc203e474ad9d05069e307002ef12e25f65047958f650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->