### PR TITLE
chore: regenerate EmojiFeedback type after email migration

### DIFF
--- a/src/data_layer/public/EmojiFeedback.ts
+++ b/src/data_layer/public/EmojiFeedback.ts
@@ -15,6 +15,8 @@ export default interface EmojiFeedback {
   page: string;
 
   created_at: Date;
+
+  email: string | null;
 }
 
 /** Represents the initializer for the table public.emoji_feedback */
@@ -30,6 +32,9 @@ export interface EmojiFeedbackInitializer {
 
   /** Default value: CURRENT_TIMESTAMP */
   created_at?: Date;
+
+  /** Default value: NULL::character varying */
+  email?: string | null;
 }
 
 /** Represents the mutator for the table public.emoji_feedback */
@@ -43,4 +48,6 @@ export interface EmojiFeedbackMutator {
   page?: string;
 
   created_at?: Date;
+
+  email?: string | null;
 }


### PR DESCRIPTION
## What

`pnpm kanel` regeneration for the nullable `email` column added to `emoji_feedback` in #3198. One generated file, 7 lines.

Server `tsc` clean.

No changelog entry — generated types, no user-visible change.
Browser check: not applicable — no web/src files in the diff.
Sonar not run — generated file, excluded from the scan anyway.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783686455&installation_id=132681956&pr_number=3202&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3202&signature=ac21d67875467f8f5fd83c1bdb0c759f59d14b6ccc1adb2ea8b7ff045b738c13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->