### PR TITLE
feat: pricing v2 core (grandfather window, flag-gated)

### DIFF
--- a/.github/workflows/checkout-smoke.yml
+++ b/.github/workflows/checkout-smoke.yml
@@ -1,0 +1,41 @@
+name: Checkout smoke
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  checkout-smoke:
+    name: checkout smoke (22.20.0)
+    runs-on: blacksmith
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter 2anki-web exec playwright install --with-deps chromium
+      - name: Build the application
+        run: pnpm --filter 2anki-web build
+      - name: Run checkout spec
+        working-directory: web
+        run: pnpm exec playwright test checkout.spec.ts
+        env:
+          PLAYWRIGHT_WITH_MOCK: true
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: checkout-smoke-report
+          path: web/playwright-report/
+          retention-days: 7

--- a/Documentation/specs/pricing-v2.md
+++ b/Documentation/specs/pricing-v2.md
@@ -1,0 +1,38 @@
+# Pricing v2 core
+
+## Goal
+
+Introduce new Unlimited price points behind a global `pricing_v2` feature flag, with a grandfather window so existing accounts keep legacy pricing through a lock-in deadline.
+
+## Price points (pending sign-off)
+
+- v2 monthly: $7.99 (lookup_key `v2_monthly`)
+- v2 annual: $64, $5.33/mo, save 33% (lookup_key `v2_annual`)
+- Legacy monthly: $6 — Legacy annual: $60
+
+## Grandfather rules
+
+- Cutover constant (in code, not env): `2026-06-15T07:00:00Z`.
+- Lock-in window end: `2026-06-21T21:59:00Z` (2026-06-21 23:59 CEST).
+- An account sees legacy pricing when the flag is on AND `created_at < cutover` AND `now < window end`. Otherwise v2.
+- Flag off → legacy pricing for everyone (today's behavior, byte-identical numbers).
+
+## Workstreams
+
+1. `scripts/pricing-v2.ts` — idempotent Stripe price creation (lookup_key lookup first), test/live mode detection from key prefix, `--live` + interactive confirm for live, Step 0 catalog print, reuse existing Unlimited product.
+2. Server: cohort resolution (`pricingV2.ts`), `StripePriceResolver` (cache + fallback), `UnlimitedCheckoutUseCase` resolves v2 by lookup_key with legacy env fallback, `GET /api/checkout/prices` returns cohort-correct numbers + lock-in deadline.
+3. Web: annual default, UnlimitedCard price-above-toggle, terms line, error state, one primary CTA, LockInBanner.
+4. Analytics: `checkout_started` (server), `plan_interval_selected`, `lock_in_banner_shown`, `lock_in_banner_clicked` (client).
+5. Playwright E2E + 6h scheduled checkout smoke.
+
+## Acceptance criteria
+
+- Post-cutover account sees $7.99/$64; pre-cutover sees $6/$60 through window then v2.
+- Annual preselected on load.
+- `pricing_v2` off → today's behavior for everyone.
+- Lock-in banner only for logged-in free users inside the window.
+
+## Out of scope
+
+- Live Stripe price creation, flag flip, cutover-timestamp finalization — gated on price sign-off.
+- Per-tier caps, replace-mode pricing, currency localization beyond Stripe's checkout conversion.

--- a/scripts/pricing-v2.ts
+++ b/scripts/pricing-v2.ts
@@ -1,0 +1,183 @@
+import Stripe from 'stripe';
+import readline from 'node:readline';
+import {
+  PRICING_AMOUNTS,
+  V2_ANNUAL_LOOKUP_KEY,
+  V2_MONTHLY_LOOKUP_KEY,
+} from '../src/usecases/checkout/pricingV2';
+
+interface PlannedPrice {
+  lookupKey: string;
+  nickname: string;
+  unitAmount: number;
+  interval: 'month' | 'year';
+}
+
+const PLANNED_PRICES: PlannedPrice[] = [
+  {
+    lookupKey: V2_MONTHLY_LOOKUP_KEY,
+    nickname: 'Unlimited Monthly v2',
+    unitAmount: PRICING_AMOUNTS.v2.monthly,
+    interval: 'month',
+  },
+  {
+    lookupKey: V2_ANNUAL_LOOKUP_KEY,
+    nickname: 'Unlimited Annual v2',
+    unitAmount: PRICING_AMOUNTS.v2.annual,
+    interval: 'year',
+  },
+];
+
+const PRICE_METADATA = { version: 'v2', created: '2026-06' };
+
+function detectMode(key: string): 'test' | 'live' | 'unknown' {
+  if (key.startsWith('sk_test_')) return 'test';
+  if (key.startsWith('sk_live_')) return 'live';
+  return 'unknown';
+}
+
+async function confirmLive(): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(
+      'You are about to create LIVE Stripe prices. Type "create live prices" to continue: ',
+      resolve
+    );
+  });
+  rl.close();
+  return answer.trim() === 'create live prices';
+}
+
+async function printCatalog(stripe: Stripe): Promise<void> {
+  console.log('\n=== Step 0: current catalog ===');
+  const products = await stripe.products.list({ active: true, limit: 100 });
+  for (const product of products.data) {
+    console.log(`Product ${product.id} — ${product.name}`);
+    const prices = await stripe.prices.list({
+      product: product.id,
+      active: true,
+      limit: 100,
+    });
+    for (const price of prices.data) {
+      const amount =
+        price.unit_amount == null ? 'n/a' : (price.unit_amount / 100).toFixed(2);
+      const interval = price.recurring?.interval ?? 'one-time';
+      console.log(
+        `  Price ${price.id} — ${amount} ${price.currency} / ${interval}` +
+          ` — lookup_key=${price.lookup_key ?? 'none'}`
+      );
+    }
+  }
+  console.log('=== end catalog ===\n');
+}
+
+async function findExistingPriceByLookupKey(
+  stripe: Stripe,
+  lookupKey: string
+): Promise<Stripe.Price | null> {
+  const result = await stripe.prices.list({
+    lookup_keys: [lookupKey],
+    limit: 1,
+  });
+  return result.data[0] ?? null;
+}
+
+async function resolveTargetProductId(stripe: Stripe): Promise<string> {
+  const products = await stripe.products.list({ active: true, limit: 100 });
+  const unlimited = products.data.find((p) =>
+    p.name.toLowerCase().includes('unlimited')
+  );
+  if (unlimited != null) {
+    console.log(
+      `Reusing existing product ${unlimited.id} (${unlimited.name}) for v2 prices.`
+    );
+    return unlimited.id;
+  }
+  const created = await stripe.products.create({
+    name: 'Unlimited',
+    metadata: PRICE_METADATA,
+  });
+  console.log(`Created product ${created.id} (Unlimited).`);
+  return created.id;
+}
+
+async function ensurePrice(
+  stripe: Stripe,
+  productId: string,
+  planned: PlannedPrice
+): Promise<void> {
+  const existing = await findExistingPriceByLookupKey(stripe, planned.lookupKey);
+  if (existing != null) {
+    console.log(
+      `Skip ${planned.lookupKey}: already exists as ${existing.id}` +
+        ` (${(existing.unit_amount ?? 0) / 100} ${existing.currency}).`
+    );
+    return;
+  }
+  const price = await stripe.prices.create({
+    product: productId,
+    currency: 'usd',
+    unit_amount: planned.unitAmount,
+    nickname: planned.nickname,
+    lookup_key: planned.lookupKey,
+    recurring: { interval: planned.interval },
+    metadata: PRICE_METADATA,
+  });
+  console.log(
+    `Created ${planned.lookupKey}: ${price.id}` +
+      ` (${planned.unitAmount / 100} usd / ${planned.interval}).`
+  );
+}
+
+async function main(): Promise<void> {
+  const key = process.env.STRIPE_KEY ?? '';
+  if (key === '') {
+    console.error('STRIPE_KEY is not set. Aborting.');
+    process.exit(1);
+  }
+  const mode = detectMode(key);
+  const wantsLive = process.argv.includes('--live');
+
+  console.log(`Detected Stripe key mode: ${mode}`);
+  if (mode === 'unknown') {
+    console.error('STRIPE_KEY is neither sk_test_ nor sk_live_. Aborting.');
+    process.exit(1);
+  }
+  if (mode === 'live' && !wantsLive) {
+    console.error(
+      'Live key detected but --live flag is missing. Re-run with --live to confirm intent.'
+    );
+    process.exit(1);
+  }
+  if (mode === 'test' && wantsLive) {
+    console.error(
+      'Test key detected but --live flag was passed. Remove --live for test runs. Aborting.'
+    );
+    process.exit(1);
+  }
+
+  const stripe = new Stripe(key);
+  await printCatalog(stripe);
+
+  if (mode === 'live') {
+    const confirmed = await confirmLive();
+    if (!confirmed) {
+      console.log('Live confirmation not given. No prices created.');
+      process.exit(0);
+    }
+  }
+
+  const productId = await resolveTargetProductId(stripe);
+  for (const planned of PLANNED_PRICES) {
+    await ensurePrice(stripe, productId, planned);
+  }
+  console.log('\nDone. Re-run is safe — existing lookup_keys are skipped.');
+}
+
+main().catch((error) => {
+  console.error('pricing-v2 script failed:', error);
+  process.exit(1);
+});

--- a/scripts/pricing-v2.ts
+++ b/scripts/pricing-v2.ts
@@ -1,34 +1,6 @@
 import Stripe from 'stripe';
 import readline from 'node:readline';
-import {
-  PRICING_AMOUNTS,
-  V2_ANNUAL_LOOKUP_KEY,
-  V2_MONTHLY_LOOKUP_KEY,
-} from '../src/usecases/checkout/pricingV2';
-
-interface PlannedPrice {
-  lookupKey: string;
-  nickname: string;
-  unitAmount: number;
-  interval: 'month' | 'year';
-}
-
-const PLANNED_PRICES: PlannedPrice[] = [
-  {
-    lookupKey: V2_MONTHLY_LOOKUP_KEY,
-    nickname: 'Unlimited Monthly v2',
-    unitAmount: PRICING_AMOUNTS.v2.monthly,
-    interval: 'month',
-  },
-  {
-    lookupKey: V2_ANNUAL_LOOKUP_KEY,
-    nickname: 'Unlimited Annual v2',
-    unitAmount: PRICING_AMOUNTS.v2.annual,
-    interval: 'year',
-  },
-];
-
-const PRICE_METADATA = { version: 'v2', created: '2026-06' };
+import { CreatePricingV2PricesUseCase } from '../src/usecases/ops/CreatePricingV2PricesUseCase';
 
 function detectMode(key: string): 'test' | 'live' | 'unknown' {
   if (key.startsWith('sk_test_')) return 'test';
@@ -63,7 +35,9 @@ async function printCatalog(stripe: Stripe): Promise<void> {
     });
     for (const price of prices.data) {
       const amount =
-        price.unit_amount == null ? 'n/a' : (price.unit_amount / 100).toFixed(2);
+        price.unit_amount == null
+          ? 'n/a'
+          : (price.unit_amount / 100).toFixed(2);
       const interval = price.recurring?.interval ?? 'one-time';
       console.log(
         `  Price ${price.id} — ${amount} ${price.currency} / ${interval}` +
@@ -72,64 +46,6 @@ async function printCatalog(stripe: Stripe): Promise<void> {
     }
   }
   console.log('=== end catalog ===\n');
-}
-
-async function findExistingPriceByLookupKey(
-  stripe: Stripe,
-  lookupKey: string
-): Promise<Stripe.Price | null> {
-  const result = await stripe.prices.list({
-    lookup_keys: [lookupKey],
-    limit: 1,
-  });
-  return result.data[0] ?? null;
-}
-
-async function resolveTargetProductId(stripe: Stripe): Promise<string> {
-  const products = await stripe.products.list({ active: true, limit: 100 });
-  const unlimited = products.data.find((p) =>
-    p.name.toLowerCase().includes('unlimited')
-  );
-  if (unlimited != null) {
-    console.log(
-      `Reusing existing product ${unlimited.id} (${unlimited.name}) for v2 prices.`
-    );
-    return unlimited.id;
-  }
-  const created = await stripe.products.create({
-    name: 'Unlimited',
-    metadata: PRICE_METADATA,
-  });
-  console.log(`Created product ${created.id} (Unlimited).`);
-  return created.id;
-}
-
-async function ensurePrice(
-  stripe: Stripe,
-  productId: string,
-  planned: PlannedPrice
-): Promise<void> {
-  const existing = await findExistingPriceByLookupKey(stripe, planned.lookupKey);
-  if (existing != null) {
-    console.log(
-      `Skip ${planned.lookupKey}: already exists as ${existing.id}` +
-        ` (${(existing.unit_amount ?? 0) / 100} ${existing.currency}).`
-    );
-    return;
-  }
-  const price = await stripe.prices.create({
-    product: productId,
-    currency: 'usd',
-    unit_amount: planned.unitAmount,
-    nickname: planned.nickname,
-    lookup_key: planned.lookupKey,
-    recurring: { interval: planned.interval },
-    metadata: PRICE_METADATA,
-  });
-  console.log(
-    `Created ${planned.lookupKey}: ${price.id}` +
-      ` (${planned.unitAmount / 100} usd / ${planned.interval}).`
-  );
 }
 
 async function main(): Promise<void> {
@@ -170,11 +86,23 @@ async function main(): Promise<void> {
     }
   }
 
-  const productId = await resolveTargetProductId(stripe);
-  for (const planned of PLANNED_PRICES) {
-    await ensurePrice(stripe, productId, planned);
+  const result = await new CreatePricingV2PricesUseCase(stripe).execute();
+  for (const price of result.prices) {
+    if (price.status === 'already_exists') {
+      console.log(
+        `Skip ${price.lookupKey}: already exists as ${price.priceId}.`
+      );
+    } else {
+      console.log(
+        `Created ${price.lookupKey}: ${price.priceId}` +
+          ` (${price.unitAmount / 100} usd / ${price.interval}).`
+      );
+    }
   }
-  console.log('\nDone. Re-run is safe — existing lookup_keys are skipped.');
+  console.log(
+    `\nDone (${result.livemode ? 'live' : 'test'} mode).` +
+      ' Re-run is safe — existing lookup_keys are skipped.'
+  );
 }
 
 main().catch((error) => {

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -20,6 +20,7 @@ import {
 } from '../usecases/ops/SetFeatureFlagUseCase';
 import { GetUploadFunnelUseCase } from '../usecases/ops/GetUploadFunnelUseCase';
 import { SendPriceLockInEmailsUseCase } from '../usecases/ops/SendPriceLockInEmailsUseCase';
+import { CreatePricingV2PricesUseCase } from '../usecases/ops/CreatePricingV2PricesUseCase';
 
 const PRICE_LOCK_IN_MAX_BATCH = 500;
 
@@ -49,7 +50,8 @@ class OpsController {
     private readonly listFeatureFlagsUseCase?: ListFeatureFlagsUseCase,
     private readonly setFeatureFlagUseCase?: SetFeatureFlagUseCase,
     private readonly getUploadFunnelUseCase?: GetUploadFunnelUseCase,
-    private readonly sendPriceLockInEmailsUseCase?: SendPriceLockInEmailsUseCase
+    private readonly sendPriceLockInEmailsUseCase?: SendPriceLockInEmailsUseCase,
+    private readonly createPricingV2PricesUseCase?: CreatePricingV2PricesUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -221,6 +223,31 @@ class OpsController {
       res
         .status(500)
         .json({ message: 'Failed to start Stripe subscription sync' });
+    }
+  }
+
+  async createPricingV2Prices(_req: express.Request, res: express.Response) {
+    if (this.createPricingV2PricesUseCase == null) {
+      res
+        .status(500)
+        .json({ message: 'Pricing v2 price creation not configured' });
+      return;
+    }
+    try {
+      const result = await this.createPricingV2PricesUseCase.execute();
+      res.status(200).json({
+        livemode: result.livemode,
+        prices: result.prices.map((price) => ({
+          lookupKey: price.lookupKey,
+          status: price.status,
+          priceId: price.priceId,
+          unitAmount: price.unitAmount,
+          interval: price.interval,
+        })),
+      });
+    } catch (error) {
+      console.error('[ops] createPricingV2Prices failed', error);
+      res.status(500).json({ message: 'Failed to create pricing v2 prices' });
     }
   }
 

--- a/src/controllers/PricingController.test.ts
+++ b/src/controllers/PricingController.test.ts
@@ -1,0 +1,80 @@
+import { Request, Response } from 'express';
+import PricingController, {
+  PricingControllerContext,
+} from './PricingController';
+
+const makeResponse = (locals: Record<string, unknown> = {}) => {
+  const res = {
+    body: undefined as unknown,
+    locals,
+    json: jest.fn(),
+  };
+  res.json.mockImplementation((body: unknown) => {
+    res.body = body;
+    return res;
+  });
+  return res;
+};
+
+const makeContext = (
+  overrides: Partial<PricingControllerContext> = {}
+): PricingControllerContext => ({
+  pricingV2On: true,
+  getUserCreatedAt: jest.fn().mockResolvedValue(null),
+  ...overrides,
+});
+
+describe('PricingController', () => {
+  it('returns v2 prices and no deadline for a post-cutover user', async () => {
+    const context = makeContext({
+      getUserCreatedAt: jest
+        .fn()
+        .mockResolvedValue(new Date('2026-06-16T00:00:00Z')),
+    });
+    const controller = new PricingController(context);
+    const res = makeResponse({ owner: 1 });
+
+    await controller.getPrices({} as Request, res as unknown as Response);
+
+    expect(res.body).toEqual({
+      cohort: 'v2',
+      legacy: false,
+      monthly: { cents: 799 },
+      annual: { cents: 6400 },
+      lockInDeadline: null,
+    });
+  });
+
+  it('returns v2 prices for a logged-out caller when flag on', async () => {
+    const context = makeContext();
+    const controller = new PricingController(context);
+    const res = makeResponse({});
+
+    await controller.getPrices({} as Request, res as unknown as Response);
+
+    expect(res.body).toMatchObject({
+      cohort: 'v2',
+      legacy: false,
+      monthly: { cents: 799 },
+      annual: { cents: 6400 },
+      lockInDeadline: null,
+    });
+    expect(context.getUserCreatedAt).not.toHaveBeenCalled();
+  });
+
+  it('returns legacy prices and no deadline when the flag is off', async () => {
+    const context = makeContext({ pricingV2On: false });
+    const controller = new PricingController(context);
+    const res = makeResponse({ owner: 1 });
+
+    await controller.getPrices({} as Request, res as unknown as Response);
+
+    expect(res.body).toEqual({
+      cohort: 'legacy',
+      legacy: true,
+      monthly: { cents: 600 },
+      annual: { cents: 6000 },
+      lockInDeadline: null,
+    });
+  });
+});

--- a/src/controllers/PricingController.ts
+++ b/src/controllers/PricingController.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from 'express';
+import { resolvePricingForUser } from '../usecases/checkout/ResolvePricingForUserUseCase';
+
+export interface PricingControllerContext {
+  pricingV2On: boolean;
+  getUserCreatedAt: (userId: number) => Promise<Date | null>;
+}
+
+class PricingController {
+  constructor(private readonly context: PricingControllerContext) {}
+
+  async getPrices(_req: Request, res: Response): Promise<void> {
+    const userId = res.locals.owner as number | undefined;
+    const createdAt =
+      userId == null ? null : await this.context.getUserCreatedAt(userId);
+
+    const pricing = resolvePricingForUser({
+      flagOn: this.context.pricingV2On,
+      createdAt,
+      now: new Date(),
+    });
+
+    res.json({
+      cohort: pricing.cohort,
+      legacy: pricing.cohort === 'legacy',
+      monthly: { cents: pricing.monthlyCents },
+      annual: { cents: pricing.annualCents },
+      lockInDeadline: pricing.lockInDeadline,
+    });
+  }
+}
+
+export default PricingController;

--- a/src/controllers/UnlimitedCheckoutController.test.ts
+++ b/src/controllers/UnlimitedCheckoutController.test.ts
@@ -1,5 +1,7 @@
 import { Request, Response } from 'express';
-import UnlimitedCheckoutController from './UnlimitedCheckoutController';
+import UnlimitedCheckoutController, {
+  UnlimitedCheckoutContext,
+} from './UnlimitedCheckoutController';
 import { UnlimitedCheckoutUseCase } from '../usecases/checkout/UnlimitedCheckoutUseCase';
 
 const makeResponse = (locals: Record<string, unknown> = {}) => {
@@ -21,18 +23,32 @@ const makeResponse = (locals: Record<string, unknown> = {}) => {
   return res;
 };
 
-const makeUseCase = () =>
+const makeUseCase = (cohort: 'legacy' | 'v2' = 'legacy') =>
   ({
     execute: jest
       .fn()
-      .mockResolvedValue({ url: 'https://checkout.stripe.com/test' }),
+      .mockResolvedValue({ url: 'https://checkout.stripe.com/test', cohort }),
   }) as unknown as UnlimitedCheckoutUseCase;
+
+const makeContext = (
+  overrides: Partial<UnlimitedCheckoutContext> = {}
+): UnlimitedCheckoutContext => ({
+  pricingV2On: false,
+  getUserCreatedAt: jest.fn().mockResolvedValue(null),
+  ...overrides,
+});
+
+const makeSink = () => ({ record: jest.fn() });
 
 describe('UnlimitedCheckoutController', () => {
   it('returns 400 when interval is missing', async () => {
     const req = { body: {} } as Request;
     const res = makeResponse();
-    const controller = new UnlimitedCheckoutController(makeUseCase());
+    const controller = new UnlimitedCheckoutController(
+      makeUseCase(),
+      makeContext(),
+      makeSink()
+    );
 
     await controller.createSession(req, res as unknown as Response);
 
@@ -43,7 +59,11 @@ describe('UnlimitedCheckoutController', () => {
   it('returns 400 when interval is invalid', async () => {
     const req = { body: { interval: 'weekly' } } as Request;
     const res = makeResponse();
-    const controller = new UnlimitedCheckoutController(makeUseCase());
+    const controller = new UnlimitedCheckoutController(
+      makeUseCase(),
+      makeContext(),
+      makeSink()
+    );
 
     await controller.createSession(req, res as unknown as Response);
 
@@ -51,11 +71,16 @@ describe('UnlimitedCheckoutController', () => {
     expect(res.body).toMatchObject({ message: expect.any(String) });
   });
 
-  it('returns 200 with url when interval is month', async () => {
+  it('returns 200 with url and passes the flag and createdAt to the use case', async () => {
     const req = { body: { interval: 'month' } } as Request;
     const res = makeResponse();
     const uc = makeUseCase();
-    const controller = new UnlimitedCheckoutController(uc);
+    const createdAt = new Date('2026-06-10T00:00:00Z');
+    const context = makeContext({
+      pricingV2On: true,
+      getUserCreatedAt: jest.fn().mockResolvedValue(createdAt),
+    });
+    const controller = new UnlimitedCheckoutController(uc, context, makeSink());
 
     await controller.createSession(req, res as unknown as Response);
 
@@ -66,27 +91,29 @@ describe('UnlimitedCheckoutController', () => {
         interval: 'month',
         userId: 42,
         userEmail: 'user@example.com',
+        pricingV2On: true,
+        createdAt,
       })
     );
   });
 
-  it('returns 200 with url when interval is year', async () => {
+  it('records a checkout_started event with the resolved cohort', async () => {
     const req = { body: { interval: 'year' } } as Request;
     const res = makeResponse();
-    const uc = makeUseCase();
-    const controller = new UnlimitedCheckoutController(uc);
+    const sink = makeSink();
+    const controller = new UnlimitedCheckoutController(
+      makeUseCase('v2'),
+      makeContext({ pricingV2On: true }),
+      sink
+    );
 
     await controller.createSession(req, res as unknown as Response);
 
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ url: 'https://checkout.stripe.com/test' });
-    expect(uc.execute as jest.Mock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        interval: 'year',
-        userId: 42,
-        userEmail: 'user@example.com',
-      })
-    );
+    expect(sink.record).toHaveBeenCalledWith({
+      name: 'checkout_started',
+      user_id: 42,
+      props: { plan: 'unlimited', interval: 'year', cohort: 'v2' },
+    });
   });
 
   it('forwards the anon_id cookie to the use case when present', async () => {
@@ -96,7 +123,11 @@ describe('UnlimitedCheckoutController', () => {
     } as unknown as Request;
     const res = makeResponse();
     const uc = makeUseCase();
-    const controller = new UnlimitedCheckoutController(uc);
+    const controller = new UnlimitedCheckoutController(
+      uc,
+      makeContext(),
+      makeSink()
+    );
 
     await controller.createSession(req, res as unknown as Response);
 
@@ -110,7 +141,11 @@ describe('UnlimitedCheckoutController', () => {
     const uc = { execute } as unknown as UnlimitedCheckoutUseCase;
     const req = { body: { interval: 'month' } } as Request;
     const res = makeResponse();
-    const controller = new UnlimitedCheckoutController(uc);
+    const controller = new UnlimitedCheckoutController(
+      uc,
+      makeContext(),
+      makeSink()
+    );
 
     await expect(
       controller.createSession(req, res as unknown as Response)

--- a/src/controllers/UnlimitedCheckoutController.ts
+++ b/src/controllers/UnlimitedCheckoutController.ts
@@ -6,11 +6,21 @@ import {
 import { parsePricingVariant } from '../usecases/checkout/pricingVariant';
 import { parseCheckoutSurface } from '../usecases/checkout/checkoutSurface';
 import { parseGaClientId } from '../usecases/checkout/gaClientId';
+import type { EventsSink } from '../services/events/EventsSink';
 
 const VALID_INTERVALS: ReadonlySet<string> = new Set(['month', 'year']);
 
+export interface UnlimitedCheckoutContext {
+  pricingV2On: boolean;
+  getUserCreatedAt: (userId: number) => Promise<Date | null>;
+}
+
 class UnlimitedCheckoutController {
-  constructor(private readonly useCase: UnlimitedCheckoutUseCase) {}
+  constructor(
+    private readonly useCase: UnlimitedCheckoutUseCase,
+    private readonly context: UnlimitedCheckoutContext,
+    private readonly eventsSink: Pick<EventsSink, 'record'>
+  ) {}
 
   async createSession(req: Request, res: Response): Promise<void> {
     const interval = req.body?.interval;
@@ -23,6 +33,7 @@ class UnlimitedCheckoutController {
     const userEmail = res.locals.email as string;
     const anonId = (req.cookies?.anon_id as string | undefined) ?? undefined;
     const gaClientId = parseGaClientId(req.cookies?._ga);
+    const createdAt = await this.context.getUserCreatedAt(userId);
 
     const result = await this.useCase.execute({
       userId,
@@ -32,8 +43,21 @@ class UnlimitedCheckoutController {
       anonId,
       surface: parseCheckoutSurface(req.body?.surface),
       gaClientId,
+      pricingV2On: this.context.pricingV2On,
+      createdAt,
     });
-    res.json(result);
+
+    this.eventsSink.record({
+      name: 'checkout_started',
+      user_id: userId,
+      props: {
+        plan: 'unlimited',
+        interval,
+        cohort: result.cohort,
+      },
+    });
+
+    res.json({ url: result.url });
   }
 }
 

--- a/src/env.example
+++ b/src/env.example
@@ -21,6 +21,11 @@ SPACES_REGION=''
 DATABASE_URL='postgresql://localhost:5432/n'
 PASS_24H_PRICE_ID=''
 PASS_7D_PRICE_ID=''
+# Legacy Unlimited Stripe price IDs. Served to grandfathered accounts and used as the
+# fallback when v2 lookup_key resolution fails. v2 prices are resolved at runtime by
+# lookup_key (v2_monthly / v2_annual) — create them with `npx tsx scripts/pricing-v2.ts`.
+UNLIMITED_MONTHLY_PRICE_ID=''
+UNLIMITED_YEARLY_PRICE_ID=''
 # Comma-separated Stripe product IDs that qualify for Lifetime access (patreon=true). Amount must also meet the threshold.
 LIFETIME_PRICE_IDS=''
 APPLE_TEAM_ID=''

--- a/src/routes/CheckoutRouter.ts
+++ b/src/routes/CheckoutRouter.ts
@@ -39,7 +39,9 @@ const resolvePricingV2Flag = async (): Promise<boolean> => {
 const getUserCreatedAt = async (userId: number): Promise<Date | null> => {
   const repo = new UsersRepository(getDatabase());
   const user = await repo.getById(String(userId));
-  return toCreatedAt((user as { created_at?: unknown } | undefined)?.created_at);
+  return toCreatedAt(
+    (user as { created_at?: unknown } | undefined)?.created_at
+  );
 };
 
 const CheckoutRouter = () => {
@@ -101,13 +103,33 @@ const CheckoutRouter = () => {
     }
   );
 
-  router.get('/api/checkout/prices', optionalAuthMiddleware, async (_req, res) => {
-    const controller = new PricingController({
-      pricingV2On: await resolvePricingV2Flag(),
-      getUserCreatedAt,
-    });
-    return controller.getPrices(_req, res);
-  });
+  /**
+   * @swagger
+   * /api/checkout/prices:
+   *   get:
+   *     summary: Get the Unlimited plan prices for the current visitor
+   *     description: |
+   *       Returns the monthly and annual Unlimited prices the visitor would
+   *       pay at checkout. Accounts created before the pricing-v2 cutover see
+   *       legacy prices until the lock-in window closes; everyone else sees
+   *       v2 prices once the pricing_v2 flag is on. Anonymous visitors are
+   *       always quoted the new-member prices.
+   *     tags: [Payments]
+   *     responses:
+   *       200:
+   *         description: Effective prices and lock-in window for the visitor
+   */
+  router.get(
+    '/api/checkout/prices',
+    optionalAuthMiddleware,
+    async (_req, res) => {
+      const controller = new PricingController({
+        pricingV2On: await resolvePricingV2Flag(),
+        getUserCreatedAt,
+      });
+      return controller.getPrices(_req, res);
+    }
+  );
 
   router.post(
     '/api/checkout/pass/24h',

--- a/src/routes/CheckoutRouter.ts
+++ b/src/routes/CheckoutRouter.ts
@@ -13,8 +13,34 @@ import { getStripe } from '../lib/integrations/stripe';
 import { getDatabase } from '../data_layer';
 import AbandonedCheckoutRecoveryRepository from '../data_layer/AbandonedCheckoutRecoveryRepository';
 import { getEventsSink } from '../services/events/eventsSinkInstance';
+import { FeatureFlagsRepository } from '../data_layer/FeatureFlagsRepository';
+import UsersRepository from '../data_layer/UsersRepository';
+import { StripePriceResolver } from '../services/StripePriceResolver';
+import { PRICING_V2_FLAG } from '../usecases/checkout/pricingV2';
+import PricingController from '../controllers/PricingController';
 
 const DEFAULT_MAX_SUBSCRIBERS = 50;
+
+const toCreatedAt = (value: unknown): Date | null => {
+  if (value == null) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+};
+
+const resolvePricingV2Flag = async (): Promise<boolean> => {
+  const repo = new FeatureFlagsRepository(getDatabase());
+  return (await repo.get(PRICING_V2_FLAG)) === true;
+};
+
+const getUserCreatedAt = async (userId: number): Promise<Date | null> => {
+  const repo = new UsersRepository(getDatabase());
+  const user = await repo.getById(String(userId));
+  return toCreatedAt((user as { created_at?: unknown } | undefined)?.created_at);
+};
 
 const CheckoutRouter = () => {
   const router = express.Router();
@@ -48,12 +74,13 @@ const CheckoutRouter = () => {
 
   const unlimitedMonthlyPriceId = process.env.UNLIMITED_MONTHLY_PRICE_ID ?? '';
   const unlimitedYearlyPriceId = process.env.UNLIMITED_YEARLY_PRICE_ID ?? '';
+  const priceResolver = new StripePriceResolver(getStripe());
 
   router.post(
     '/api/checkout/unlimited',
     RequireAuthentication,
     express.json(),
-    (req, res) => {
+    async (req, res) => {
       if (unlimitedMonthlyPriceId === '') {
         return res
           .status(503)
@@ -62,12 +89,25 @@ const CheckoutRouter = () => {
       const useCase = new UnlimitedCheckoutUseCase(
         getStripe(),
         unlimitedMonthlyPriceId,
-        unlimitedYearlyPriceId
+        unlimitedYearlyPriceId,
+        priceResolver
       );
-      const controller = new UnlimitedCheckoutController(useCase);
+      const controller = new UnlimitedCheckoutController(
+        useCase,
+        { pricingV2On: await resolvePricingV2Flag(), getUserCreatedAt },
+        getEventsSink()
+      );
       return controller.createSession(req, res);
     }
   );
+
+  router.get('/api/checkout/prices', optionalAuthMiddleware, async (_req, res) => {
+    const controller = new PricingController({
+      pricingV2On: await resolvePricingV2Flag(),
+      getUserCreatedAt,
+    });
+    return controller.getPrices(_req, res);
+  });
 
   router.post(
     '/api/checkout/pass/24h',

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -3,7 +3,18 @@ import http from 'node:http';
 import { AddressInfo } from 'node:net';
 
 jest.mock('../lib/integrations/stripe', () => ({
-  getStripe: jest.fn(),
+  getStripe: jest.fn(() => ({
+    products: {
+      list: jest.fn().mockResolvedValue({
+        data: [{ id: 'prod_unlimited', name: 'Unlimited' }],
+      }),
+      create: jest.fn(),
+    },
+    prices: {
+      list: jest.fn().mockResolvedValue({ data: [] }),
+      create: jest.fn().mockResolvedValue({ id: 'price_new', livemode: false }),
+    },
+  })),
 }));
 
 jest.mock('../services/events/eventsSinkInstance', () => ({
@@ -267,6 +278,52 @@ describe('OpsRouter /api/ops/sync-stripe-subscriptions', () => {
       expect(body).toEqual(
         expect.objectContaining({ message: expect.any(String) })
       );
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsRouter /api/ops/create-pricing-v2-prices', () => {
+  it('returns 404 for non-owner callers', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const response = await fetch(`${url}/api/ops/create-pricing-v2-prices`, {
+        method: 'POST',
+      });
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns 200 with per-key results and livemode for the ops owner', async () => {
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/create-pricing-v2-prices`, {
+        method: 'POST',
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({
+        livemode: false,
+        prices: [
+          {
+            lookupKey: 'v2_monthly',
+            status: 'created',
+            priceId: 'price_new',
+            unitAmount: 799,
+            interval: 'month',
+          },
+          {
+            lookupKey: 'v2_annual',
+            status: 'created',
+            priceId: 'price_new',
+            unitAmount: 6400,
+            interval: 'year',
+          },
+        ],
+      });
     } finally {
       await close();
     }

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -52,6 +52,8 @@ import EventsRepository from '../data_layer/EventsRepository';
 import { FeatureFlagsRepository } from '../data_layer/FeatureFlagsRepository';
 import { ListFeatureFlagsUseCase } from '../usecases/ops/ListFeatureFlagsUseCase';
 import { SetFeatureFlagUseCase } from '../usecases/ops/SetFeatureFlagUseCase';
+import { CreatePricingV2PricesUseCase } from '../usecases/ops/CreatePricingV2PricesUseCase';
+import { getStripe } from '../lib/integrations/stripe';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -127,7 +129,8 @@ const OpsRouter = () => {
       new PriceLockInEmailRepository(database),
       emailService,
       getEventsSink()
-    )
+    ),
+    new CreatePricingV2PricesUseCase(getStripe())
   );
 
   /**
@@ -420,6 +423,31 @@ const OpsRouter = () => {
     '/api/ops/sync-stripe-subscriptions',
     RequireOpsAccess,
     (req, res) => controller.syncStripeSubscriptions(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/create-pricing-v2-prices:
+   *   post:
+   *     summary: Create the v2 Stripe prices on the Unlimited product
+   *     description: |
+   *       Idempotently creates the $7.99/mo and $64/yr v2 prices on the existing
+   *       Unlimited product. Each price is looked up by its lookup_key first and
+   *       created only when absent — re-running is safe and never mutates, updates,
+   *       or deletes existing prices, products, or subscriptions. Uses the server's
+   *       configured Stripe key, so the live/test mode follows that key. Locked to
+   *       the ops owner — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     responses:
+   *       200:
+   *         description: Per-key result (created or already_exists) with price IDs and livemode
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post(
+    '/api/ops/create-pricing-v2-prices',
+    RequireOpsAccess,
+    (req, res) => controller.createPricingV2Prices(req, res)
   );
 
   /**

--- a/src/services/StripePriceResolver.test.ts
+++ b/src/services/StripePriceResolver.test.ts
@@ -1,9 +1,16 @@
-import { StripePriceResolver } from './StripePriceResolver';
+import {
+  StripePriceResolver,
+  clearResolvedPriceIdCache,
+} from './StripePriceResolver';
 
 const makeStripe = (listImpl: jest.Mock) =>
   ({ prices: { list: listImpl } }) as never;
 
 describe('StripePriceResolver', () => {
+  beforeEach(() => {
+    clearResolvedPriceIdCache();
+  });
+
   it('resolves a price ID by lookup_key', async () => {
     const list = jest.fn().mockResolvedValue({
       data: [{ id: 'price_v2_monthly_abc' }],
@@ -29,6 +36,24 @@ describe('StripePriceResolver', () => {
 
     expect(second).toBe('price_v2_annual_xyz');
     expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the cache across resolver instances', async () => {
+    const firstList = jest.fn().mockResolvedValue({
+      data: [{ id: 'price_shared' }],
+    });
+    const secondList = jest.fn().mockResolvedValue({
+      data: [{ id: 'price_should_not_be_used' }],
+    });
+
+    const first = new StripePriceResolver(makeStripe(firstList));
+    await first.resolveByLookupKey('v2_shared');
+
+    const second = new StripePriceResolver(makeStripe(secondList));
+    const resolved = await second.resolveByLookupKey('v2_shared');
+
+    expect(resolved).toBe('price_shared');
+    expect(secondList).not.toHaveBeenCalled();
   });
 
   it('returns null when no price matches the lookup_key', async () => {

--- a/src/services/StripePriceResolver.test.ts
+++ b/src/services/StripePriceResolver.test.ts
@@ -1,0 +1,54 @@
+import { StripePriceResolver } from './StripePriceResolver';
+
+const makeStripe = (listImpl: jest.Mock) =>
+  ({ prices: { list: listImpl } }) as never;
+
+describe('StripePriceResolver', () => {
+  it('resolves a price ID by lookup_key', async () => {
+    const list = jest.fn().mockResolvedValue({
+      data: [{ id: 'price_v2_monthly_abc' }],
+    });
+    const resolver = new StripePriceResolver(makeStripe(list));
+
+    const id = await resolver.resolveByLookupKey('v2_monthly');
+
+    expect(id).toBe('price_v2_monthly_abc');
+    expect(list).toHaveBeenCalledWith(
+      expect.objectContaining({ lookup_keys: ['v2_monthly'], active: true })
+    );
+  });
+
+  it('caches the resolved ID and does not call Stripe twice', async () => {
+    const list = jest.fn().mockResolvedValue({
+      data: [{ id: 'price_v2_annual_xyz' }],
+    });
+    const resolver = new StripePriceResolver(makeStripe(list));
+
+    await resolver.resolveByLookupKey('v2_annual');
+    const second = await resolver.resolveByLookupKey('v2_annual');
+
+    expect(second).toBe('price_v2_annual_xyz');
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when no price matches the lookup_key', async () => {
+    const list = jest.fn().mockResolvedValue({ data: [] });
+    const resolver = new StripePriceResolver(makeStripe(list));
+
+    expect(await resolver.resolveByLookupKey('v2_monthly')).toBeNull();
+  });
+
+  it('returns null and does not cache when Stripe throws', async () => {
+    const list = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ data: [{ id: 'price_recovered' }] });
+    const resolver = new StripePriceResolver(makeStripe(list));
+
+    expect(await resolver.resolveByLookupKey('v2_monthly')).toBeNull();
+    expect(await resolver.resolveByLookupKey('v2_monthly')).toBe(
+      'price_recovered'
+    );
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/StripePriceResolver.ts
+++ b/src/services/StripePriceResolver.ts
@@ -1,12 +1,16 @@
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 
-export class StripePriceResolver {
-  private readonly cache = new Map<string, string>();
+const resolvedPriceIdCache = new Map<string, string>();
 
+export const clearResolvedPriceIdCache = (): void => {
+  resolvedPriceIdCache.clear();
+};
+
+export class StripePriceResolver {
   constructor(private readonly stripe: Pick<StripeTypes, 'prices'>) {}
 
   async resolveByLookupKey(lookupKey: string): Promise<string | null> {
-    const cached = this.cache.get(lookupKey);
+    const cached = resolvedPriceIdCache.get(lookupKey);
     if (cached != null) return cached;
 
     try {
@@ -20,7 +24,7 @@ export class StripePriceResolver {
         console.warn('pricing.resolve.miss', { lookup_key: lookupKey });
         return null;
       }
-      this.cache.set(lookupKey, priceId);
+      resolvedPriceIdCache.set(lookupKey, priceId);
       return priceId;
     } catch (error) {
       console.error('pricing.resolve.failed', {

--- a/src/services/StripePriceResolver.ts
+++ b/src/services/StripePriceResolver.ts
@@ -1,0 +1,33 @@
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
+export class StripePriceResolver {
+  private readonly cache = new Map<string, string>();
+
+  constructor(private readonly stripe: Pick<StripeTypes, 'prices'>) {}
+
+  async resolveByLookupKey(lookupKey: string): Promise<string | null> {
+    const cached = this.cache.get(lookupKey);
+    if (cached != null) return cached;
+
+    try {
+      const result = await this.stripe.prices.list({
+        lookup_keys: [lookupKey],
+        active: true,
+        limit: 1,
+      });
+      const priceId = result.data[0]?.id;
+      if (priceId == null) {
+        console.warn('pricing.resolve.miss', { lookup_key: lookupKey });
+        return null;
+      }
+      this.cache.set(lookupKey, priceId);
+      return priceId;
+    } catch (error) {
+      console.error('pricing.resolve.failed', {
+        lookup_key: lookupKey,
+        message: error instanceof Error ? error.message : 'unknown',
+      });
+      return null;
+    }
+  }
+}

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -65,6 +65,10 @@ export const KNOWN_EVENTS = new Set([
   'recent_page_reconvert_clicked',
   'native_app_page_viewed',
   'native_app_interest_clicked',
+  'checkout_started',
+  'plan_interval_selected',
+  'lock_in_banner_shown',
+  'lock_in_banner_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/checkout/ResolvePricingForUserUseCase.test.ts
+++ b/src/usecases/checkout/ResolvePricingForUserUseCase.test.ts
@@ -1,6 +1,6 @@
 import { resolvePricingForUser } from './ResolvePricingForUserUseCase';
 
-const beforeCutover = new Date('2026-06-10T00:00:00Z');
+const beforeCutover = new Date('2026-06-09T00:00:00Z');
 const afterCutover = new Date('2026-06-16T00:00:00Z');
 const insideWindow = new Date('2026-06-18T00:00:00Z');
 const afterWindow = new Date('2026-06-22T00:00:00Z');

--- a/src/usecases/checkout/ResolvePricingForUserUseCase.test.ts
+++ b/src/usecases/checkout/ResolvePricingForUserUseCase.test.ts
@@ -1,0 +1,65 @@
+import { resolvePricingForUser } from './ResolvePricingForUserUseCase';
+
+const beforeCutover = new Date('2026-06-10T00:00:00Z');
+const afterCutover = new Date('2026-06-16T00:00:00Z');
+const insideWindow = new Date('2026-06-18T00:00:00Z');
+const afterWindow = new Date('2026-06-22T00:00:00Z');
+
+describe('resolvePricingForUser', () => {
+  it('returns legacy amounts and a lock-in deadline for a pre-cutover user in the window', () => {
+    const result = resolvePricingForUser({
+      flagOn: true,
+      createdAt: beforeCutover,
+      now: insideWindow,
+    });
+
+    expect(result).toEqual({
+      cohort: 'legacy',
+      monthlyCents: 600,
+      annualCents: 6000,
+      lockInDeadline: '2026-06-21T21:59:00.000Z',
+    });
+  });
+
+  it('returns v2 amounts and no deadline for a post-cutover user', () => {
+    const result = resolvePricingForUser({
+      flagOn: true,
+      createdAt: afterCutover,
+      now: insideWindow,
+    });
+
+    expect(result).toEqual({
+      cohort: 'v2',
+      monthlyCents: 799,
+      annualCents: 6400,
+      lockInDeadline: null,
+    });
+  });
+
+  it('returns v2 amounts for a pre-cutover user after the window closes', () => {
+    const result = resolvePricingForUser({
+      flagOn: true,
+      createdAt: beforeCutover,
+      now: afterWindow,
+    });
+
+    expect(result.cohort).toBe('v2');
+    expect(result.monthlyCents).toBe(799);
+    expect(result.lockInDeadline).toBeNull();
+  });
+
+  it('returns legacy amounts and no deadline for everyone when the flag is off', () => {
+    const result = resolvePricingForUser({
+      flagOn: false,
+      createdAt: afterCutover,
+      now: insideWindow,
+    });
+
+    expect(result).toEqual({
+      cohort: 'legacy',
+      monthlyCents: 600,
+      annualCents: 6000,
+      lockInDeadline: null,
+    });
+  });
+});

--- a/src/usecases/checkout/ResolvePricingForUserUseCase.ts
+++ b/src/usecases/checkout/ResolvePricingForUserUseCase.ts
@@ -1,0 +1,32 @@
+import {
+  LEGACY_LOCK_IN_WINDOW_END,
+  PRICING_AMOUNTS,
+  PricingCohort,
+  resolveCohort,
+} from './pricingV2';
+
+export interface PricingForUserResult {
+  cohort: PricingCohort;
+  monthlyCents: number;
+  annualCents: number;
+  lockInDeadline: string | null;
+}
+
+export function resolvePricingForUser(input: {
+  flagOn: boolean;
+  createdAt: Date | null | undefined;
+  now: Date;
+}): PricingForUserResult {
+  const cohort = resolveCohort(input);
+  const amounts = cohort === 'legacy' ? PRICING_AMOUNTS.legacy : PRICING_AMOUNTS.v2;
+  const showsLockIn =
+    input.flagOn &&
+    cohort === 'legacy' &&
+    input.now.getTime() < LEGACY_LOCK_IN_WINDOW_END.getTime();
+  return {
+    cohort,
+    monthlyCents: amounts.monthly,
+    annualCents: amounts.annual,
+    lockInDeadline: showsLockIn ? LEGACY_LOCK_IN_WINDOW_END.toISOString() : null,
+  };
+}

--- a/src/usecases/checkout/ResolvePricingForUserUseCase.ts
+++ b/src/usecases/checkout/ResolvePricingForUserUseCase.ts
@@ -18,7 +18,8 @@ export function resolvePricingForUser(input: {
   now: Date;
 }): PricingForUserResult {
   const cohort = resolveCohort(input);
-  const amounts = cohort === 'legacy' ? PRICING_AMOUNTS.legacy : PRICING_AMOUNTS.v2;
+  const amounts =
+    cohort === 'legacy' ? PRICING_AMOUNTS.legacy : PRICING_AMOUNTS.v2;
   const showsLockIn =
     input.flagOn &&
     cohort === 'legacy' &&
@@ -27,6 +28,8 @@ export function resolvePricingForUser(input: {
     cohort,
     monthlyCents: amounts.monthly,
     annualCents: amounts.annual,
-    lockInDeadline: showsLockIn ? LEGACY_LOCK_IN_WINDOW_END.toISOString() : null,
+    lockInDeadline: showsLockIn
+      ? LEGACY_LOCK_IN_WINDOW_END.toISOString()
+      : null,
   };
 }

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
@@ -31,7 +31,10 @@ describe('UnlimitedCheckoutUseCase', () => {
       interval: 'month',
     });
 
-    expect(result).toEqual({ url: 'https://checkout.stripe.com/month', cohort: 'legacy' });
+    expect(result).toEqual({
+      url: 'https://checkout.stripe.com/month',
+      cohort: 'legacy',
+    });
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: 'subscription',
@@ -57,7 +60,10 @@ describe('UnlimitedCheckoutUseCase', () => {
       interval: 'year',
     });
 
-    expect(result).toEqual({ url: 'https://checkout.stripe.com/year', cohort: 'legacy' });
+    expect(result).toEqual({
+      url: 'https://checkout.stripe.com/year',
+      cohort: 'legacy',
+    });
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: 'subscription',
@@ -277,7 +283,11 @@ describe('UnlimitedCheckoutUseCase', () => {
 
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { user_id: '12', cohort: 'legacy', ga_client_id: '1234567890.987654321' },
+        metadata: {
+          user_id: '12',
+          cohort: 'legacy',
+          ga_client_id: '1234567890.987654321',
+        },
       })
     );
   });

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
@@ -363,7 +363,7 @@ describe('UnlimitedCheckoutUseCase', () => {
     consoleSpy.mockRestore();
   });
 
-  const beforeCutover = new Date('2026-06-10T00:00:00Z');
+  const beforeCutover = new Date('2026-06-09T00:00:00Z');
   const afterCutover = new Date('2026-06-16T00:00:00Z');
   const insideWindow = new Date('2026-06-18T00:00:00Z');
   const afterWindow = new Date('2026-06-22T00:00:00Z');

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
@@ -31,12 +31,12 @@ describe('UnlimitedCheckoutUseCase', () => {
       interval: 'month',
     });
 
-    expect(result).toEqual({ url: 'https://checkout.stripe.com/month' });
+    expect(result).toEqual({ url: 'https://checkout.stripe.com/month', cohort: 'legacy' });
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: 'subscription',
         line_items: [{ price: MONTHLY_PRICE_ID, quantity: 1 }],
-        metadata: { user_id: '1' },
+        metadata: { user_id: '1', cohort: 'legacy' },
       })
     );
   });
@@ -57,12 +57,12 @@ describe('UnlimitedCheckoutUseCase', () => {
       interval: 'year',
     });
 
-    expect(result).toEqual({ url: 'https://checkout.stripe.com/year' });
+    expect(result).toEqual({ url: 'https://checkout.stripe.com/year', cohort: 'legacy' });
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: 'subscription',
         line_items: [{ price: YEARLY_PRICE_ID, quantity: 1 }],
-        metadata: { user_id: '2' },
+        metadata: { user_id: '2', cohort: 'legacy' },
       })
     );
   });
@@ -183,7 +183,7 @@ describe('UnlimitedCheckoutUseCase', () => {
 
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { user_id: '8', anon_id: 'anon-uuid-123' },
+        metadata: { user_id: '8', cohort: 'legacy', anon_id: 'anon-uuid-123' },
       })
     );
   });
@@ -206,7 +206,7 @@ describe('UnlimitedCheckoutUseCase', () => {
 
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { user_id: '9' },
+        metadata: { user_id: '9', cohort: 'legacy' },
       })
     );
   });
@@ -230,7 +230,7 @@ describe('UnlimitedCheckoutUseCase', () => {
 
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { user_id: '10', surface: 'pricing_page' },
+        metadata: { user_id: '10', cohort: 'legacy', surface: 'pricing_page' },
       })
     );
   });
@@ -253,7 +253,7 @@ describe('UnlimitedCheckoutUseCase', () => {
 
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { user_id: '11' },
+        metadata: { user_id: '11', cohort: 'legacy' },
       })
     );
   });
@@ -277,7 +277,7 @@ describe('UnlimitedCheckoutUseCase', () => {
 
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { user_id: '12', ga_client_id: '1234567890.987654321' },
+        metadata: { user_id: '12', cohort: 'legacy', ga_client_id: '1234567890.987654321' },
       })
     );
   });
@@ -300,7 +300,7 @@ describe('UnlimitedCheckoutUseCase', () => {
 
     expect(mockStripeCreateSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: { user_id: '13' },
+        metadata: { user_id: '13', cohort: 'legacy' },
       })
     );
   });
@@ -351,5 +351,153 @@ describe('UnlimitedCheckoutUseCase', () => {
       expect(call).not.toContain('cus_secret_id');
     }
     consoleSpy.mockRestore();
+  });
+
+  const beforeCutover = new Date('2026-06-10T00:00:00Z');
+  const afterCutover = new Date('2026-06-16T00:00:00Z');
+  const insideWindow = new Date('2026-06-18T00:00:00Z');
+  const afterWindow = new Date('2026-06-22T00:00:00Z');
+
+  const makeResolver = (id: string | null) => ({
+    resolveByLookupKey: jest.fn().mockResolvedValue(id),
+  });
+
+  it('uses the legacy env price for a pre-cutover user inside the lock-in window when flag on', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://x' });
+    const resolver = makeResolver('price_v2_monthly');
+    const uc = new UnlimitedCheckoutUseCase(
+      makeStripe(),
+      MONTHLY_PRICE_ID,
+      YEARLY_PRICE_ID,
+      resolver as never
+    );
+
+    await uc.execute({
+      userEmail: 'user@example.com',
+      userId: 20,
+      interval: 'month',
+      pricingV2On: true,
+      createdAt: beforeCutover,
+      now: insideWindow,
+    });
+
+    expect(resolver.resolveByLookupKey).not.toHaveBeenCalled();
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: MONTHLY_PRICE_ID, quantity: 1 }],
+        metadata: { user_id: '20', cohort: 'legacy' },
+      })
+    );
+  });
+
+  it('resolves the v2 price for a pre-cutover user after the window when flag on', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://x' });
+    const resolver = makeResolver('price_v2_annual');
+    const uc = new UnlimitedCheckoutUseCase(
+      makeStripe(),
+      MONTHLY_PRICE_ID,
+      YEARLY_PRICE_ID,
+      resolver as never
+    );
+
+    await uc.execute({
+      userEmail: 'user@example.com',
+      userId: 21,
+      interval: 'year',
+      pricingV2On: true,
+      createdAt: beforeCutover,
+      now: afterWindow,
+    });
+
+    expect(resolver.resolveByLookupKey).toHaveBeenCalledWith('v2_annual');
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: 'price_v2_annual', quantity: 1 }],
+        metadata: { user_id: '21', cohort: 'v2' },
+      })
+    );
+  });
+
+  it('resolves the v2 price for a post-cutover user when flag on', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://x' });
+    const resolver = makeResolver('price_v2_monthly');
+    const uc = new UnlimitedCheckoutUseCase(
+      makeStripe(),
+      MONTHLY_PRICE_ID,
+      YEARLY_PRICE_ID,
+      resolver as never
+    );
+
+    await uc.execute({
+      userEmail: 'user@example.com',
+      userId: 22,
+      interval: 'month',
+      pricingV2On: true,
+      createdAt: afterCutover,
+      now: insideWindow,
+    });
+
+    expect(resolver.resolveByLookupKey).toHaveBeenCalledWith('v2_monthly');
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: 'price_v2_monthly', quantity: 1 }],
+        metadata: { user_id: '22', cohort: 'v2' },
+      })
+    );
+  });
+
+  it('falls back to the legacy env price when v2 resolution fails', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://x' });
+    const resolver = makeResolver(null);
+    const uc = new UnlimitedCheckoutUseCase(
+      makeStripe(),
+      MONTHLY_PRICE_ID,
+      YEARLY_PRICE_ID,
+      resolver as never
+    );
+
+    await uc.execute({
+      userEmail: 'user@example.com',
+      userId: 23,
+      interval: 'month',
+      pricingV2On: true,
+      createdAt: afterCutover,
+      now: insideWindow,
+    });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: MONTHLY_PRICE_ID, quantity: 1 }],
+        metadata: { user_id: '23', cohort: 'v2' },
+      })
+    );
+  });
+
+  it('uses legacy env prices for everyone when the flag is off', async () => {
+    mockStripeCreateSession.mockResolvedValue({ url: 'https://x' });
+    const resolver = makeResolver('price_v2_monthly');
+    const uc = new UnlimitedCheckoutUseCase(
+      makeStripe(),
+      MONTHLY_PRICE_ID,
+      YEARLY_PRICE_ID,
+      resolver as never
+    );
+
+    await uc.execute({
+      userEmail: 'user@example.com',
+      userId: 24,
+      interval: 'month',
+      pricingV2On: false,
+      createdAt: afterCutover,
+      now: insideWindow,
+    });
+
+    expect(resolver.resolveByLookupKey).not.toHaveBeenCalled();
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        line_items: [{ price: MONTHLY_PRICE_ID, quantity: 1 }],
+        metadata: { user_id: '24', cohort: 'legacy' },
+      })
+    );
   });
 });

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
@@ -37,9 +37,11 @@ export class UnlimitedCheckoutUseCase {
       interval === 'year' ? V2_ANNUAL_LOOKUP_KEY : V2_MONTHLY_LOOKUP_KEY;
     const resolved = await this.priceResolver.resolveByLookupKey(lookupKey);
     if (resolved == null) {
-      console.warn('unlimited.checkout.v2_resolve_fallback', {
+      console.error('unlimited.checkout.v2_resolve_fallback', {
+        cohort,
         interval,
         lookup_key: lookupKey,
+        reason: 'lookup_key resolution returned null, serving legacy price id',
       });
       return legacyId;
     }

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
@@ -1,19 +1,50 @@
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 import hashToken from '../../lib/misc/hashToken';
 import { optionalMetadata } from './checkoutMetadata';
+import { StripePriceResolver } from '../../services/StripePriceResolver';
+import {
+  PricingCohort,
+  resolveCohort,
+  V2_ANNUAL_LOOKUP_KEY,
+  V2_MONTHLY_LOOKUP_KEY,
+} from './pricingV2';
 
 export type UnlimitedInterval = 'month' | 'year';
 
 export interface UnlimitedCheckoutResult {
   url: string;
+  cohort: PricingCohort;
 }
 
 export class UnlimitedCheckoutUseCase {
   constructor(
     private readonly stripe: Pick<StripeTypes, 'checkout'>,
     private readonly monthlyPriceId: string,
-    private readonly yearlyPriceId: string
+    private readonly yearlyPriceId: string,
+    private readonly priceResolver?: StripePriceResolver
   ) {}
+
+  private async resolvePriceId(
+    interval: UnlimitedInterval,
+    cohort: PricingCohort
+  ): Promise<string> {
+    const legacyId =
+      interval === 'year' ? this.yearlyPriceId : this.monthlyPriceId;
+    if (cohort === 'legacy' || this.priceResolver == null) {
+      return legacyId;
+    }
+    const lookupKey =
+      interval === 'year' ? V2_ANNUAL_LOOKUP_KEY : V2_MONTHLY_LOOKUP_KEY;
+    const resolved = await this.priceResolver.resolveByLookupKey(lookupKey);
+    if (resolved == null) {
+      console.warn('unlimited.checkout.v2_resolve_fallback', {
+        interval,
+        lookup_key: lookupKey,
+      });
+      return legacyId;
+    }
+    return resolved;
+  }
 
   async execute(input: {
     userEmail: string;
@@ -24,14 +55,23 @@ export class UnlimitedCheckoutUseCase {
     anonId?: string;
     surface?: string;
     gaClientId?: string;
+    pricingV2On?: boolean;
+    createdAt?: Date | null;
+    now?: Date;
   }): Promise<UnlimitedCheckoutResult> {
+    const cohort = resolveCohort({
+      flagOn: input.pricingV2On === true,
+      createdAt: input.createdAt ?? null,
+      now: input.now ?? new Date(),
+    });
+
     console.info('unlimited.checkout.started', {
       user_id: input.userId,
       interval: input.interval,
+      cohort,
     });
 
-    const priceId =
-      input.interval === 'year' ? this.yearlyPriceId : this.monthlyPriceId;
+    const priceId = await this.resolvePriceId(input.interval, cohort);
     const appUrl = process.env.APP_URL ?? 'https://2anki.net';
 
     const sessionParams: StripeTypes.Checkout.SessionCreateParams = {
@@ -45,6 +85,7 @@ export class UnlimitedCheckoutUseCase {
       after_expiration: { recovery: { enabled: true } },
       metadata: {
         user_id: String(input.userId),
+        cohort,
         ...optionalMetadata({
           pricing_variant: input.variant,
           anon_id: input.anonId,
@@ -59,9 +100,10 @@ export class UnlimitedCheckoutUseCase {
     console.info('unlimited.checkout.session_created', {
       user_id: input.userId,
       interval: input.interval,
+      cohort,
       session_id_hash: hashToken(session.id ?? ''),
     });
 
-    return { url: session.url! };
+    return { url: session.url!, cohort };
   }
 }

--- a/src/usecases/checkout/pricingV2.test.ts
+++ b/src/usecases/checkout/pricingV2.test.ts
@@ -5,7 +5,7 @@ import {
   resolveCohort,
 } from './pricingV2';
 
-const beforeCutover = new Date('2026-06-10T00:00:00Z');
+const beforeCutover = new Date('2026-06-09T00:00:00Z');
 const afterCutover = new Date('2026-06-16T00:00:00Z');
 
 describe('qualifiesForLegacyWindow', () => {

--- a/src/usecases/checkout/pricingV2.test.ts
+++ b/src/usecases/checkout/pricingV2.test.ts
@@ -1,0 +1,107 @@
+import {
+  LEGACY_LOCK_IN_CUTOVER,
+  LEGACY_LOCK_IN_WINDOW_END,
+  qualifiesForLegacyWindow,
+  resolveCohort,
+} from './pricingV2';
+
+const beforeCutover = new Date('2026-06-10T00:00:00Z');
+const afterCutover = new Date('2026-06-16T00:00:00Z');
+
+describe('qualifiesForLegacyWindow', () => {
+  it('is true for an account created before cutover, asked during the window', () => {
+    expect(
+      qualifiesForLegacyWindow({
+        createdAt: beforeCutover,
+        now: new Date('2026-06-18T00:00:00Z'),
+      })
+    ).toBe(true);
+  });
+
+  it('is false for an account created before cutover but asked after the window ends', () => {
+    expect(
+      qualifiesForLegacyWindow({
+        createdAt: beforeCutover,
+        now: new Date('2026-06-22T00:00:00Z'),
+      })
+    ).toBe(false);
+  });
+
+  it('is false for an account created after cutover', () => {
+    expect(
+      qualifiesForLegacyWindow({
+        createdAt: afterCutover,
+        now: new Date('2026-06-18T00:00:00Z'),
+      })
+    ).toBe(false);
+  });
+
+  it('is false when created_at is null', () => {
+    expect(
+      qualifiesForLegacyWindow({
+        createdAt: null,
+        now: new Date('2026-06-18T00:00:00Z'),
+      })
+    ).toBe(false);
+  });
+
+  it('treats the cutover boundary as exclusive (created exactly at cutover does not qualify)', () => {
+    expect(
+      qualifiesForLegacyWindow({
+        createdAt: LEGACY_LOCK_IN_CUTOVER,
+        now: new Date('2026-06-18T00:00:00Z'),
+      })
+    ).toBe(false);
+  });
+
+  it('treats the window end as exclusive (asking exactly at window end does not qualify)', () => {
+    expect(
+      qualifiesForLegacyWindow({
+        createdAt: beforeCutover,
+        now: LEGACY_LOCK_IN_WINDOW_END,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('resolveCohort', () => {
+  it('returns legacy for everyone when the flag is off', () => {
+    expect(
+      resolveCohort({
+        flagOn: false,
+        createdAt: afterCutover,
+        now: new Date('2026-06-30T00:00:00Z'),
+      })
+    ).toBe('legacy');
+  });
+
+  it('returns legacy for a pre-cutover user inside the window when the flag is on', () => {
+    expect(
+      resolveCohort({
+        flagOn: true,
+        createdAt: beforeCutover,
+        now: new Date('2026-06-18T00:00:00Z'),
+      })
+    ).toBe('legacy');
+  });
+
+  it('returns v2 for a pre-cutover user after the window when the flag is on', () => {
+    expect(
+      resolveCohort({
+        flagOn: true,
+        createdAt: beforeCutover,
+        now: new Date('2026-06-22T00:00:00Z'),
+      })
+    ).toBe('v2');
+  });
+
+  it('returns v2 for a post-cutover user when the flag is on', () => {
+    expect(
+      resolveCohort({
+        flagOn: true,
+        createdAt: afterCutover,
+        now: new Date('2026-06-18T00:00:00Z'),
+      })
+    ).toBe('v2');
+  });
+});

--- a/src/usecases/checkout/pricingV2.ts
+++ b/src/usecases/checkout/pricingV2.ts
@@ -1,0 +1,44 @@
+export const PRICING_V2_FLAG = 'pricing_v2';
+
+export const LEGACY_LOCK_IN_CUTOVER = new Date('2026-06-15T07:00:00Z');
+
+export const LEGACY_LOCK_IN_WINDOW_END = new Date('2026-06-21T21:59:00Z');
+
+export const V2_MONTHLY_LOOKUP_KEY = 'v2_monthly';
+export const V2_ANNUAL_LOOKUP_KEY = 'v2_annual';
+
+export const PRICING_AMOUNTS = {
+  legacy: {
+    monthly: 600,
+    annual: 6000,
+  },
+  v2: {
+    monthly: 799,
+    annual: 6400,
+  },
+} as const;
+
+export interface CohortInput {
+  createdAt: Date | null | undefined;
+  now: Date;
+}
+
+export function qualifiesForLegacyWindow(input: CohortInput): boolean {
+  const { createdAt, now } = input;
+  if (createdAt == null) return false;
+  const createdBeforeCutover =
+    createdAt.getTime() < LEGACY_LOCK_IN_CUTOVER.getTime();
+  const withinWindow = now.getTime() < LEGACY_LOCK_IN_WINDOW_END.getTime();
+  return createdBeforeCutover && withinWindow;
+}
+
+export type PricingCohort = 'legacy' | 'v2';
+
+export function resolveCohort(input: {
+  flagOn: boolean;
+  createdAt: Date | null | undefined;
+  now: Date;
+}): PricingCohort {
+  if (!input.flagOn) return 'legacy';
+  return qualifiesForLegacyWindow(input) ? 'legacy' : 'v2';
+}

--- a/src/usecases/checkout/pricingV2.ts
+++ b/src/usecases/checkout/pricingV2.ts
@@ -1,6 +1,6 @@
 export const PRICING_V2_FLAG = 'pricing_v2';
 
-export const LEGACY_LOCK_IN_CUTOVER = new Date('2026-06-15T07:00:00Z');
+export const LEGACY_LOCK_IN_CUTOVER = new Date('2026-06-10T00:00:00Z');
 
 export const LEGACY_LOCK_IN_WINDOW_END = new Date('2026-06-21T21:59:00Z');
 

--- a/src/usecases/ops/CreatePricingV2PricesUseCase.test.ts
+++ b/src/usecases/ops/CreatePricingV2PricesUseCase.test.ts
@@ -1,0 +1,184 @@
+import Stripe from 'stripe';
+
+import { CreatePricingV2PricesUseCase } from './CreatePricingV2PricesUseCase';
+import {
+  PRICING_AMOUNTS,
+  V2_ANNUAL_LOOKUP_KEY,
+  V2_MONTHLY_LOOKUP_KEY,
+} from '../checkout/pricingV2';
+
+type StripeClient = InstanceType<typeof Stripe>;
+
+type StripeStub = {
+  products: { list: jest.Mock; create: jest.Mock };
+  prices: {
+    list: jest.Mock;
+    create: jest.Mock;
+    update?: jest.Mock;
+    del?: jest.Mock;
+  };
+};
+
+const makeStripe = (overrides: Partial<StripeStub> = {}): StripeClient => {
+  const stub: StripeStub = {
+    products: {
+      list: jest.fn().mockResolvedValue({ data: [] }),
+      create: jest.fn(),
+    },
+    prices: {
+      list: jest.fn().mockResolvedValue({ data: [] }),
+      create: jest.fn(),
+      update: jest.fn(),
+      del: jest.fn(),
+    },
+    ...overrides,
+  };
+  return stub as unknown as StripeClient;
+};
+
+const existingProduct = { id: 'prod_unlimited', name: 'Unlimited' };
+
+describe('CreatePricingV2PricesUseCase', () => {
+  it('creates both v2 prices on the existing Unlimited product when neither exists', async () => {
+    const stripe = makeStripe({
+      products: {
+        list: jest.fn().mockResolvedValue({ data: [existingProduct] }),
+        create: jest.fn(),
+      },
+      prices: {
+        list: jest.fn().mockResolvedValue({ data: [] }),
+        create: jest
+          .fn()
+          .mockResolvedValueOnce({ id: 'price_monthly', livemode: false })
+          .mockResolvedValueOnce({ id: 'price_annual', livemode: false }),
+        update: jest.fn(),
+        del: jest.fn(),
+      },
+    });
+
+    const result = await new CreatePricingV2PricesUseCase(stripe).execute();
+
+    expect(result.livemode).toBe(false);
+    expect(result.prices).toEqual([
+      {
+        lookupKey: V2_MONTHLY_LOOKUP_KEY,
+        status: 'created',
+        priceId: 'price_monthly',
+        unitAmount: PRICING_AMOUNTS.v2.monthly,
+        interval: 'month',
+      },
+      {
+        lookupKey: V2_ANNUAL_LOOKUP_KEY,
+        status: 'created',
+        priceId: 'price_annual',
+        unitAmount: PRICING_AMOUNTS.v2.annual,
+        interval: 'year',
+      },
+    ]);
+  });
+
+  it('passes the right create params and reuses the Unlimited product', async () => {
+    const create = jest
+      .fn()
+      .mockResolvedValue({ id: 'price_x', livemode: true });
+    const productsCreate = jest.fn();
+    const stripe = makeStripe({
+      products: {
+        list: jest.fn().mockResolvedValue({ data: [existingProduct] }),
+        create: productsCreate,
+      },
+      prices: {
+        list: jest.fn().mockResolvedValue({ data: [] }),
+        create,
+        update: jest.fn(),
+        del: jest.fn(),
+      },
+    });
+
+    await new CreatePricingV2PricesUseCase(stripe).execute();
+
+    expect(productsCreate).not.toHaveBeenCalled();
+    expect(create).toHaveBeenNthCalledWith(1, {
+      product: 'prod_unlimited',
+      currency: 'usd',
+      unit_amount: PRICING_AMOUNTS.v2.monthly,
+      nickname: 'Unlimited Monthly v2',
+      lookup_key: V2_MONTHLY_LOOKUP_KEY,
+      recurring: { interval: 'month' },
+      metadata: { version: 'v2', created: '2026-06' },
+    });
+    expect(create).toHaveBeenNthCalledWith(2, {
+      product: 'prod_unlimited',
+      currency: 'usd',
+      unit_amount: PRICING_AMOUNTS.v2.annual,
+      nickname: 'Unlimited Annual v2',
+      lookup_key: V2_ANNUAL_LOOKUP_KEY,
+      recurring: { interval: 'year' },
+      metadata: { version: 'v2', created: '2026-06' },
+    });
+  });
+
+  it('skips creation when a price with the lookup key already exists', async () => {
+    const create = jest.fn();
+    const stripe = makeStripe({
+      products: {
+        list: jest.fn().mockResolvedValue({ data: [existingProduct] }),
+        create: jest.fn(),
+      },
+      prices: {
+        list: jest.fn().mockImplementation(({ lookup_keys }) => {
+          if (lookup_keys?.[0] === V2_MONTHLY_LOOKUP_KEY) {
+            return Promise.resolve({
+              data: [{ id: 'price_existing_monthly', livemode: true }],
+            });
+          }
+          return Promise.resolve({ data: [] });
+        }),
+        create: create.mockResolvedValue({
+          id: 'price_annual',
+          livemode: true,
+        }),
+        update: jest.fn(),
+        del: jest.fn(),
+      },
+    });
+
+    const result = await new CreatePricingV2PricesUseCase(stripe).execute();
+
+    expect(result.prices[0]).toEqual({
+      lookupKey: V2_MONTHLY_LOOKUP_KEY,
+      status: 'already_exists',
+      priceId: 'price_existing_monthly',
+      unitAmount: PRICING_AMOUNTS.v2.monthly,
+      interval: 'month',
+    });
+    expect(result.prices[1].status).toBe('created');
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('never mutates or deletes existing prices, products, or subscriptions', async () => {
+    const update = jest.fn();
+    const del = jest.fn();
+    const productsCreate = jest.fn();
+    const stripe = makeStripe({
+      products: {
+        list: jest.fn().mockResolvedValue({ data: [existingProduct] }),
+        create: productsCreate,
+      },
+      prices: {
+        list: jest.fn().mockResolvedValue({
+          data: [{ id: 'price_existing', livemode: true }],
+        }),
+        create: jest.fn(),
+        update,
+        del,
+      },
+    });
+
+    await new CreatePricingV2PricesUseCase(stripe).execute();
+
+    expect(update).not.toHaveBeenCalled();
+    expect(del).not.toHaveBeenCalled();
+    expect(productsCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/usecases/ops/CreatePricingV2PricesUseCase.ts
+++ b/src/usecases/ops/CreatePricingV2PricesUseCase.ts
@@ -1,0 +1,135 @@
+import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
+import {
+  PRICING_AMOUNTS,
+  V2_ANNUAL_LOOKUP_KEY,
+  V2_MONTHLY_LOOKUP_KEY,
+} from '../checkout/pricingV2';
+
+type StripeClient = InstanceType<typeof Stripe>;
+
+export const PRICE_METADATA = { version: 'v2', created: '2026-06' } as const;
+
+interface PlannedPrice {
+  lookupKey: string;
+  nickname: string;
+  unitAmount: number;
+  interval: 'month' | 'year';
+}
+
+const PLANNED_PRICES: PlannedPrice[] = [
+  {
+    lookupKey: V2_MONTHLY_LOOKUP_KEY,
+    nickname: 'Unlimited Monthly v2',
+    unitAmount: PRICING_AMOUNTS.v2.monthly,
+    interval: 'month',
+  },
+  {
+    lookupKey: V2_ANNUAL_LOOKUP_KEY,
+    nickname: 'Unlimited Annual v2',
+    unitAmount: PRICING_AMOUNTS.v2.annual,
+    interval: 'year',
+  },
+];
+
+export type CreatePricingV2PriceStatus = 'created' | 'already_exists';
+
+export interface CreatePricingV2PriceResult {
+  lookupKey: string;
+  status: CreatePricingV2PriceStatus;
+  priceId: string;
+  unitAmount: number;
+  interval: 'month' | 'year';
+}
+
+export interface CreatePricingV2PricesResult {
+  livemode: boolean;
+  prices: CreatePricingV2PriceResult[];
+}
+
+export class CreatePricingV2PricesUseCase {
+  constructor(private readonly stripe: StripeClient) {}
+
+  async execute(): Promise<CreatePricingV2PricesResult> {
+    const productId = await this.resolveTargetProductId();
+    const prices: CreatePricingV2PriceResult[] = [];
+    let livemode = false;
+
+    for (const planned of PLANNED_PRICES) {
+      const result = await this.ensurePrice(productId, planned);
+      prices.push(result.summary);
+      livemode = result.livemode;
+    }
+
+    return { livemode, prices };
+  }
+
+  private async resolveTargetProductId(): Promise<string> {
+    const products = await this.stripe.products.list({
+      active: true,
+      limit: 100,
+    });
+    const unlimited = products.data.find((product) =>
+      product.name.toLowerCase().includes('unlimited')
+    );
+    if (unlimited != null) {
+      return unlimited.id;
+    }
+    const created = await this.stripe.products.create({
+      name: 'Unlimited',
+      metadata: PRICE_METADATA,
+    });
+    return created.id;
+  }
+
+  private async ensurePrice(
+    productId: string,
+    planned: PlannedPrice
+  ): Promise<{ summary: CreatePricingV2PriceResult; livemode: boolean }> {
+    const existing = await this.findExistingPriceByLookupKey(planned.lookupKey);
+    if (existing != null) {
+      return {
+        summary: {
+          lookupKey: planned.lookupKey,
+          status: 'already_exists',
+          priceId: existing.id,
+          unitAmount: planned.unitAmount,
+          interval: planned.interval,
+        },
+        livemode: existing.livemode,
+      };
+    }
+
+    const price = await this.stripe.prices.create({
+      product: productId,
+      currency: 'usd',
+      unit_amount: planned.unitAmount,
+      nickname: planned.nickname,
+      lookup_key: planned.lookupKey,
+      recurring: { interval: planned.interval },
+      metadata: PRICE_METADATA,
+    });
+
+    return {
+      summary: {
+        lookupKey: planned.lookupKey,
+        status: 'created',
+        priceId: price.id,
+        unitAmount: planned.unitAmount,
+        interval: planned.interval,
+      },
+      livemode: price.livemode,
+    };
+  }
+
+  private async findExistingPriceByLookupKey(
+    lookupKey: string
+  ): Promise<StripeTypes.Price | null> {
+    const result = await this.stripe.prices.list({
+      lookup_keys: [lookupKey],
+      limit: 1,
+    });
+    return result.data[0] ?? null;
+  }
+}

--- a/web/mock-server/server.js
+++ b/web/mock-server/server.js
@@ -236,6 +236,28 @@ app.post('/api/notion/convert', (req, res) => {
   res.json({ success: true, jobId: newJob.id });
 });
 
+const LEGACY_CHECKOUT_PRICES = {
+  cohort: 'legacy',
+  legacy: true,
+  monthly: { cents: 600 },
+  annual: { cents: 6000 },
+  lockInDeadline: null,
+};
+
+const V2_CHECKOUT_PRICES = {
+  cohort: 'v2',
+  legacy: false,
+  monthly: { cents: 799 },
+  annual: { cents: 6400 },
+  lockInDeadline: null,
+};
+
+app.get('/api/checkout/prices', (req, res) => {
+  const cohort =
+    req.query.cohort === 'v2' ? V2_CHECKOUT_PRICES : LEGACY_CHECKOUT_PRICES;
+  res.json(cohort);
+});
+
 app.get('/api/upload/jobs', (req, res) => {
   res.json(mockJobs);
 });

--- a/web/src/components/AppShell/AppShell.test.tsx
+++ b/web/src/components/AppShell/AppShell.test.tsx
@@ -87,6 +87,7 @@ describe('AppShell logout', () => {
     logoutSpy = vi.fn();
     vi.spyOn(get2ankiApiModule, 'get2ankiApi').mockReturnValue({
       logout: logoutSpy,
+      getCheckoutPrices: vi.fn().mockResolvedValue(null),
     } as unknown as ReturnType<typeof get2ankiApiModule.get2ankiApi>);
     confirmSpy = vi.spyOn(globalThis, 'confirm');
   });

--- a/web/src/components/AppShell/SidebarLayout.tsx
+++ b/web/src/components/AppShell/SidebarLayout.tsx
@@ -4,6 +4,7 @@ import { MobileTopBar } from './MobileTopBar';
 import { SkeletonPage } from '../Skeleton/Skeleton';
 import { ErrorPresenter } from '../errors/ErrorPresenter';
 import { AccessBanner } from '../AccessBanner/AccessBanner';
+import { LockInBanner } from '../LockInBanner/LockInBanner';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './AppShell.module.css';
 
@@ -66,6 +67,15 @@ export function SidebarLayout({
         <AccessBanner
           passExpiresAt={locals?.passExpiresAt}
           passKind={locals?.passKind}
+        />
+        <LockInBanner
+          isLoggedIn={email != null}
+          isFree={
+            locals?.patreon !== true &&
+            locals?.subscriber !== true &&
+            locals?.autoSyncActive !== true &&
+            locals?.passKind == null
+          }
         />
         {error && <ErrorPresenter error={error} />}
         <main id="main-content" className={sharedStyles.flexGrow}>

--- a/web/src/components/LockInBanner/LockInBanner.module.css
+++ b/web/src/components/LockInBanner/LockInBanner.module.css
@@ -1,0 +1,36 @@
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  background: var(--color-primary-light);
+  color: var(--color-text-primary);
+  font-size: var(--text-sm);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.message {
+  font-weight: var(--font-medium);
+}
+
+.cta {
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.dismiss {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  font-size: var(--text-base);
+  line-height: 1;
+  padding: 0 0.25rem;
+}

--- a/web/src/components/LockInBanner/LockInBanner.test.tsx
+++ b/web/src/components/LockInBanner/LockInBanner.test.tsx
@@ -13,9 +13,10 @@ vi.mock('../../lib/backend/get2ankiApi', () => ({
 vi.mock('../../lib/analytics/track', () => ({ track: vi.fn() }));
 
 vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual<typeof import('react-router-dom')>(
-    'react-router-dom'
-  );
+  const actual =
+    await vi.importActual<typeof import('react-router-dom')>(
+      'react-router-dom'
+    );
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
@@ -58,9 +59,7 @@ describe('LockInBanner', () => {
     mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
     renderBanner(false, true);
 
-    await waitFor(() =>
-      expect(mockGetCheckoutPrices).not.toHaveBeenCalled()
-    );
+    await waitFor(() => expect(mockGetCheckoutPrices).not.toHaveBeenCalled());
     expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
   });
 
@@ -68,9 +67,7 @@ describe('LockInBanner', () => {
     mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
     renderBanner(true, false);
 
-    await waitFor(() =>
-      expect(mockGetCheckoutPrices).not.toHaveBeenCalled()
-    );
+    await waitFor(() => expect(mockGetCheckoutPrices).not.toHaveBeenCalled());
     expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
   });
 
@@ -110,9 +107,7 @@ describe('LockInBanner', () => {
     mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
     renderBanner(true, true);
 
-    await waitFor(() =>
-      expect(mockGetCheckoutPrices).not.toHaveBeenCalled()
-    );
+    await waitFor(() => expect(mockGetCheckoutPrices).not.toHaveBeenCalled());
     expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/LockInBanner/LockInBanner.test.tsx
+++ b/web/src/components/LockInBanner/LockInBanner.test.tsx
@@ -85,6 +85,22 @@ describe('LockInBanner', () => {
     expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
   });
 
+  it('does not render when the prices fetch returns null', async () => {
+    mockGetCheckoutPrices.mockResolvedValue(null);
+    renderBanner(true, true);
+
+    await waitFor(() => expect(mockGetCheckoutPrices).toHaveBeenCalled());
+    expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
+  });
+
+  it('does not render when the prices fetch rejects', async () => {
+    mockGetCheckoutPrices.mockRejectedValue(new Error('network down'));
+    renderBanner(true, true);
+
+    await waitFor(() => expect(mockGetCheckoutPrices).toHaveBeenCalled());
+    expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
+  });
+
   it('navigates to /pricing when See plans is clicked', async () => {
     mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
     renderBanner(true, true);

--- a/web/src/components/LockInBanner/LockInBanner.test.tsx
+++ b/web/src/components/LockInBanner/LockInBanner.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LockInBanner } from './LockInBanner';
+
+const mockGetCheckoutPrices = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({ getCheckoutPrices: mockGetCheckoutPrices }),
+}));
+
+vi.mock('../../lib/analytics/track', () => ({ track: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  );
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const legacyInWindow = {
+  cohort: 'legacy' as const,
+  legacy: true,
+  monthly: { cents: 600 },
+  annual: { cents: 6000 },
+  lockInDeadline: '2026-06-21T21:59:00.000Z',
+};
+
+const renderBanner = (isLoggedIn: boolean, isFree: boolean) =>
+  render(
+    <MemoryRouter>
+      <LockInBanner isLoggedIn={isLoggedIn} isFree={isFree} />
+    </MemoryRouter>
+  );
+
+beforeEach(() => {
+  localStorage.clear();
+  mockGetCheckoutPrices.mockReset();
+  mockNavigate.mockReset();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('LockInBanner', () => {
+  it('shows the lock-in message for a logged-in free user inside the window', async () => {
+    mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
+    renderBanner(true, true);
+
+    expect(
+      await screen.findByText(/Lock in \$6\/month by Sunday 21 June/)
+    ).toBeInTheDocument();
+  });
+
+  it('does not render when the user is not logged in', async () => {
+    mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
+    renderBanner(false, true);
+
+    await waitFor(() =>
+      expect(mockGetCheckoutPrices).not.toHaveBeenCalled()
+    );
+    expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
+  });
+
+  it('does not render for a paying user', async () => {
+    mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
+    renderBanner(true, false);
+
+    await waitFor(() =>
+      expect(mockGetCheckoutPrices).not.toHaveBeenCalled()
+    );
+    expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
+  });
+
+  it('does not render when prices come back as v2 (flag off or outside window)', async () => {
+    mockGetCheckoutPrices.mockResolvedValue({
+      cohort: 'v2',
+      legacy: false,
+      monthly: { cents: 799 },
+      annual: { cents: 6400 },
+      lockInDeadline: null,
+    });
+    renderBanner(true, true);
+
+    await waitFor(() => expect(mockGetCheckoutPrices).toHaveBeenCalled());
+    expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
+  });
+
+  it('navigates to /pricing when See plans is clicked', async () => {
+    mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
+    renderBanner(true, true);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'See plans' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/pricing');
+  });
+
+  it('dismisses and persists the dismissal', async () => {
+    mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
+    renderBanner(true, true);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Dismiss' }));
+    expect(localStorage.getItem('lockInBannerDismissed')).toBe('2026-06');
+    expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when already dismissed', async () => {
+    localStorage.setItem('lockInBannerDismissed', '2026-06');
+    mockGetCheckoutPrices.mockResolvedValue(legacyInWindow);
+    renderBanner(true, true);
+
+    await waitFor(() =>
+      expect(mockGetCheckoutPrices).not.toHaveBeenCalled()
+    );
+    expect(screen.queryByText(/Lock in/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/LockInBanner/LockInBanner.tsx
+++ b/web/src/components/LockInBanner/LockInBanner.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { track } from '../../lib/analytics/track';
+import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import styles from './LockInBanner.module.css';
+
+const DISMISS_KEY = 'lockInBannerDismissed';
+const DISMISS_VALUE = '2026-06';
+
+interface LockInBannerProps {
+  isLoggedIn: boolean;
+  isFree: boolean;
+}
+
+export function LockInBanner({
+  isLoggedIn,
+  isFree,
+}: Readonly<LockInBannerProps>) {
+  const [visible, setVisible] = useState(false);
+  const shownFiredRef = useRef(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoggedIn || !isFree) return;
+    if (localStorage.getItem(DISMISS_KEY) === DISMISS_VALUE) return;
+
+    let cancelled = false;
+    get2ankiApi()
+      .getCheckoutPrices()
+      .then((prices) => {
+        if (cancelled || prices == null) return;
+        if (prices.legacy && prices.lockInDeadline != null) {
+          setVisible(true);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn, isFree]);
+
+  useEffect(() => {
+    if (!visible || shownFiredRef.current) return;
+    shownFiredRef.current = true;
+    track('lock_in_banner_shown');
+  }, [visible]);
+
+  if (!visible) return null;
+
+  const onSeePlans = () => {
+    track('lock_in_banner_clicked');
+    navigate('/pricing');
+  };
+
+  const onDismiss = () => {
+    localStorage.setItem(DISMISS_KEY, DISMISS_VALUE);
+    setVisible(false);
+  };
+
+  return (
+    <output className={styles.banner}>
+      <span className={styles.message}>
+        Prices go up for new members on Monday. Lock in $6/month by Sunday 21
+        June.
+      </span>
+      <button type="button" className={styles.cta} onClick={onSeePlans}>
+        See plans
+      </button>
+      <button
+        type="button"
+        className={styles.dismiss}
+        aria-label="Dismiss"
+        onClick={onDismiss}
+      >
+        ×
+      </button>
+    </output>
+  );
+}

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -51,6 +51,9 @@ export const KNOWN_EVENTS = new Set([
   'recent_page_reconvert_clicked',
   'native_app_page_viewed',
   'native_app_interest_clicked',
+  'plan_interval_selected',
+  'lock_in_banner_shown',
+  'lock_in_banner_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/backend/Backend.test.ts
+++ b/web/src/lib/backend/Backend.test.ts
@@ -205,6 +205,67 @@ describe('Backend', () => {
     });
   });
 
+  describe('getCheckoutPrices', () => {
+    it('returns the parsed prices when the api helper resolves a v2 body', async () => {
+      vi.mocked(api.get).mockResolvedValue({
+        cohort: 'v2',
+        legacy: false,
+        monthly: { cents: 799 },
+        annual: { cents: 6400 },
+        lockInDeadline: null,
+      });
+
+      const prices = await backend.getCheckoutPrices();
+
+      expect(prices).toEqual({
+        cohort: 'v2',
+        legacy: false,
+        monthly: { cents: 799 },
+        annual: { cents: 6400 },
+        lockInDeadline: null,
+      });
+      expect(api.get).toHaveBeenCalledWith('/api/checkout/prices');
+    });
+
+    it('preserves the legacy cohort and lock-in deadline', async () => {
+      vi.mocked(api.get).mockResolvedValue({
+        cohort: 'legacy',
+        legacy: true,
+        monthly: { cents: 600 },
+        annual: { cents: 6000 },
+        lockInDeadline: '2026-06-21T21:59:00.000Z',
+      });
+
+      const prices = await backend.getCheckoutPrices();
+
+      expect(prices).toEqual({
+        cohort: 'legacy',
+        legacy: true,
+        monthly: { cents: 600 },
+        annual: { cents: 6000 },
+        lockInDeadline: '2026-06-21T21:59:00.000Z',
+      });
+    });
+
+    it('returns null when the api helper resolves undefined', async () => {
+      vi.mocked(api.get).mockResolvedValue(undefined);
+
+      await expect(backend.getCheckoutPrices()).resolves.toBeNull();
+    });
+
+    it('returns null when required fields are missing', async () => {
+      vi.mocked(api.get).mockResolvedValue({ legacy: true });
+
+      await expect(backend.getCheckoutPrices()).resolves.toBeNull();
+    });
+
+    it('returns null when the api helper throws', async () => {
+      vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+
+      await expect(backend.getCheckoutPrices()).resolves.toBeNull();
+    });
+  });
+
   describe('deleteRules', () => {
     it('calls DELETE on the rules endpoint with the page id', async () => {
       const mockResponse = createMockResponse(204, true);

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -485,11 +485,7 @@ export class Backend {
 
   async getCheckoutPrices(): Promise<CheckoutPrices | null> {
     try {
-      const response = await get(`${this.baseURL}checkout/prices`);
-      if (response == null || !response.ok) {
-        return null;
-      }
-      const body = (await response.json().catch(() => null)) as unknown;
+      const body = (await get(`${this.baseURL}checkout/prices`)) as unknown;
       if (body == null || typeof body !== 'object') {
         return null;
       }

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -28,6 +28,14 @@ export class TrackerSchemaError extends Error {
 
 export type AnkiWebSyncStatus = 'synced' | 'failed' | 'skipped';
 
+export interface CheckoutPrices {
+  cohort: 'legacy' | 'v2';
+  legacy: boolean;
+  monthly: { cents: number };
+  annual: { cents: number };
+  lockInDeadline: string | null;
+}
+
 export class Backend {
   public baseURL = '/api/';
 
@@ -472,6 +480,36 @@ export class Backend {
       return { status: 'error' };
     } catch {
       return { status: 'error' };
+    }
+  }
+
+  async getCheckoutPrices(): Promise<CheckoutPrices | null> {
+    try {
+      const response = await get(`${this.baseURL}checkout/prices`);
+      if (response == null || !response.ok) {
+        return null;
+      }
+      const body = (await response.json().catch(() => null)) as unknown;
+      if (body == null || typeof body !== 'object') {
+        return null;
+      }
+      const parsed = body as Partial<CheckoutPrices>;
+      if (
+        parsed.monthly?.cents == null ||
+        parsed.annual?.cents == null ||
+        typeof parsed.legacy !== 'boolean'
+      ) {
+        return null;
+      }
+      return {
+        cohort: parsed.cohort === 'legacy' ? 'legacy' : 'v2',
+        legacy: parsed.legacy,
+        monthly: { cents: parsed.monthly.cents },
+        annual: { cents: parsed.annual.cents },
+        lockInDeadline: parsed.lockInDeadline ?? null,
+      };
+    } catch {
+      return null;
     }
   }
 

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -3,8 +3,23 @@ import { useState } from 'react';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './OpsPage.module.css';
 import { syncStripeSubscriptions } from './syncStripeSubscriptions';
+import {
+  createPricingV2Prices,
+  CreatePricingV2PricesResponse,
+} from './createPricingV2Prices';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
+
+function formatPricesResult(result: CreatePricingV2PricesResponse): string {
+  const mode = result.livemode ? 'live' : 'test';
+  const lines = result.prices.map((price) => {
+    const verb = price.status === 'created' ? 'created' : 'already exists';
+    const unit = price.interval === 'month' ? 'mo' : 'yr';
+    const amount = `$${(price.unitAmount / 100).toFixed(2)}/${unit}`;
+    return `${price.lookupKey} ${verb} — ${amount} (${price.priceId})`;
+  });
+  return `${mode} mode — ${lines.join('; ')}`;
+}
 
 async function callInactivityWarnings(
   dryRun: boolean
@@ -27,6 +42,8 @@ export default function CommandsTab() {
   const [message, setMessage] = useState('');
   const [syncStatus, setSyncStatus] = useState<Status>('idle');
   const [syncMessage, setSyncMessage] = useState('');
+  const [pricesStatus, setPricesStatus] = useState<Status>('idle');
+  const [pricesMessage, setPricesMessage] = useState('');
 
   const run = async (dryRun: boolean) => {
     setStatus('loading');
@@ -54,6 +71,21 @@ export default function CommandsTab() {
     } catch (error) {
       setSyncStatus('error');
       setSyncMessage(error instanceof Error ? error.message : 'Unknown error');
+    }
+  };
+
+  const runCreatePrices = async () => {
+    setPricesStatus('loading');
+    setPricesMessage('');
+    try {
+      const result = await createPricingV2Prices();
+      setPricesStatus('success');
+      setPricesMessage(formatPricesResult(result));
+    } catch (error) {
+      setPricesStatus('error');
+      setPricesMessage(
+        error instanceof Error ? error.message : 'Unknown error'
+      );
     }
   };
 
@@ -130,6 +162,35 @@ export default function CommandsTab() {
       {syncStatus === 'error' && syncMessage && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {syncMessage}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Pricing v2 prices</h2>
+        <p className={styles.panelSubtitle}>
+          Adds the $7.99/mo and $64/yr prices for new members. Safe to run twice
+          — existing prices are skipped, nothing is changed or deleted.
+        </p>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={runCreatePrices}
+            disabled={pricesStatus === 'loading'}
+          >
+            {pricesStatus === 'loading' ? 'Working…' : 'Create v2 prices'}
+          </button>
+        </div>
+      </section>
+
+      {pricesStatus === 'success' && pricesMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {pricesMessage}
+        </div>
+      )}
+      {pricesStatus === 'error' && pricesMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {pricesMessage}
         </div>
       )}
     </>

--- a/web/src/pages/OpsPage/createPricingV2Prices.test.ts
+++ b/web/src/pages/OpsPage/createPricingV2Prices.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createPricingV2Prices } from './createPricingV2Prices';
+
+describe('createPricingV2Prices', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs to the endpoint and returns the per-key result', async () => {
+    const payload = {
+      livemode: false,
+      prices: [
+        {
+          lookupKey: 'v2_monthly',
+          status: 'created',
+          priceId: 'price_monthly',
+          unitAmount: 799,
+          interval: 'month',
+        },
+        {
+          lookupKey: 'v2_annual',
+          status: 'already_exists',
+          priceId: 'price_annual',
+          unitAmount: 6400,
+          interval: 'year',
+        },
+      ],
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await createPricingV2Prices();
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/create-pricing-v2-prices',
+      { method: 'POST', credentials: 'include' }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('throws the server message on a non-ok response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () =>
+        Promise.resolve({ message: 'Failed to create pricing v2 prices' }),
+    });
+
+    await expect(createPricingV2Prices()).rejects.toThrow(
+      'Failed to create pricing v2 prices'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(createPricingV2Prices()).rejects.toThrow('404 Not Found');
+  });
+});

--- a/web/src/pages/OpsPage/createPricingV2Prices.ts
+++ b/web/src/pages/OpsPage/createPricingV2Prices.ts
@@ -1,0 +1,28 @@
+export type PricingV2PriceStatus = 'created' | 'already_exists';
+
+export interface PricingV2PriceResult {
+  lookupKey: string;
+  status: PricingV2PriceStatus;
+  priceId: string;
+  unitAmount: number;
+  interval: 'month' | 'year';
+}
+
+export interface CreatePricingV2PricesResponse {
+  livemode: boolean;
+  prices: PricingV2PriceResult[];
+}
+
+export async function createPricingV2Prices(): Promise<CreatePricingV2PricesResponse> {
+  const response = await fetch('/api/ops/create-pricing-v2-prices', {
+    method: 'POST',
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -710,7 +710,16 @@
   font-size: var(--text-xs);
   color: var(--color-text-tertiary);
   margin: 0;
-  line-height: 1;
+  line-height: 1.3;
+}
+
+.cardTerms {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0.5rem 0 0;
+  text-align: center;
+  line-height: 1.4;
 }
 
 /* =====================================================================

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -16,6 +16,7 @@ const mockStartAutoSyncCheckout = vi.fn();
 const mockRequestHostedAnkiAccess = vi.fn();
 const mockStartPassCheckout = vi.fn();
 const mockStartUnlimitedCheckout = vi.fn();
+const mockGetCheckoutPrices = vi.fn();
 
 vi.mock('../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({
@@ -23,6 +24,7 @@ vi.mock('../../lib/backend/get2ankiApi', () => ({
     startAutoSyncCheckout: mockStartAutoSyncCheckout,
     startPassCheckout: mockStartPassCheckout,
     startUnlimitedCheckout: mockStartUnlimitedCheckout,
+    getCheckoutPrices: mockGetCheckoutPrices,
   }),
 }));
 
@@ -52,6 +54,7 @@ vi.mock('../../lib/hooks/usePricingOrderVariant', () => ({
 
 beforeEach(() => {
   mockPricingVariant.current = 'passes-first';
+  mockGetCheckoutPrices.mockResolvedValue(null);
 });
 
 type AnalyticsGlobals = {
@@ -609,22 +612,25 @@ describe('PricingPage Unlimited billing toggle', () => {
     const group = screen.getByRole('radiogroup', { name: 'Billing cycle' });
     expect(group).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Monthly' })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: 'Yearly' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: 'Yearly · save 17%' })
+    ).toBeInTheDocument();
   });
 
-  it('shows $6 / mo by default', () => {
+  it('defaults to the annual per-month hero price', () => {
     renderAt('/pricing', { unlimitedYearlyAvailable: true });
-    const price = screen.getByText('$6');
+    const price = screen.getByText('$5.00');
     expect(price).toBeInTheDocument();
-    expect(price.parentElement?.textContent ?? '').toContain('/ mo');
+    expect(
+      screen.getByText('$60/year billed yearly · save 17%')
+    ).toBeInTheDocument();
   });
 
-  it('shows $60 / yr and 2 months free after selecting Yearly', () => {
+  it('shows the monthly hero price after selecting Monthly', () => {
     renderAt('/pricing', { unlimitedYearlyAvailable: true });
-    fireEvent.click(screen.getByRole('radio', { name: 'Yearly' }));
-    expect(screen.getByText('$60')).toBeInTheDocument();
-    expect(screen.getByText('/ yr')).toBeInTheDocument();
-    expect(screen.getByText('2 months free')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
+    expect(screen.getByText('$6')).toBeInTheDocument();
+    expect(screen.getByText('billed monthly')).toBeInTheDocument();
   });
 
   it('calls startUnlimitedCheckout with month when Monthly is selected', async () => {
@@ -637,6 +643,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
 
     renderAt('/pricing', { isLoggedIn: true, unlimitedYearlyAvailable: true });
+    fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
 
     await waitFor(() => {
@@ -648,7 +655,7 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
   });
 
-  it('calls startUnlimitedCheckout with year when Yearly is selected', async () => {
+  it('calls startUnlimitedCheckout with year by default', async () => {
     mockStartUnlimitedCheckout.mockResolvedValue({
       url: 'https://checkout.stripe.com/year',
     });
@@ -658,7 +665,6 @@ describe('PricingPage Unlimited billing toggle', () => {
     });
 
     renderAt('/pricing', { isLoggedIn: true, unlimitedYearlyAvailable: true });
-    fireEvent.click(screen.getByRole('radio', { name: 'Yearly' }));
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
 
     await waitFor(() => {

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -17,6 +17,7 @@ import { PricingFaq } from './components/PricingFaq';
 import { UnlimitedCard } from './components/UnlimitedCard';
 import styles from './PricingPage.module.css';
 import { getLifetimeLink } from './payment.links';
+import { LEGACY_UNLIMITED_PRICING } from './pricing.constants';
 import { PRICING_FAQ } from './pricingFaq';
 
 interface PricingPageProps {
@@ -66,8 +67,10 @@ export default function PricingPage({
   const [subscribeError, setSubscribeError] = useState<string | null>(null);
   const [dayPassState, setDayPassState] = useState<PassState>('idle');
   const [weekPassState, setWeekPassState] = useState<PassState>('idle');
-  const [billingCycle, setBillingCycle] = useState<'month' | 'year'>('month');
+  const [billingCycle, setBillingCycle] = useState<'month' | 'year'>('year');
   const [unlimitedPending, setUnlimitedPending] = useState(false);
+  const [unlimitedError, setUnlimitedError] = useState(false);
+  const [pricing, setPricing] = useState(LEGACY_UNLIMITED_PRICING);
   const [searchParams] = useSearchParams();
   const fromPaywall = searchParams.get('source') === 'paywall-cancel';
   const fromContext = searchParams.get('from');
@@ -83,6 +86,30 @@ export default function PricingPage({
       : null;
 
   const isLifetime = patreon === true;
+
+  useEffect(() => {
+    let cancelled = false;
+    get2ankiApi()
+      .getCheckoutPrices()
+      .then((result) => {
+        if (cancelled || result == null) return;
+        setPricing({
+          monthlyCents: result.monthly.cents,
+          annualCents: result.annual.cents,
+          legacy: result.legacy,
+          lockInDeadline: result.lockInDeadline,
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectBillingCycle = (cycle: 'month' | 'year') => {
+    setBillingCycle(cycle);
+    track('plan_interval_selected', { interval: cycle });
+  };
 
   useEffect(() => {
     if (shownFiredRef.current) return;
@@ -210,6 +237,7 @@ export default function PricingPage({
       plan: 'unlimited',
       variant: pricingOrder,
     });
+    setUnlimitedError(false);
     setUnlimitedPending(true);
     const result = await get2ankiApi().startUnlimitedCheckout(
       billingCycle,
@@ -221,6 +249,7 @@ export default function PricingPage({
       return;
     }
     setUnlimitedPending(false);
+    setUnlimitedError(true);
   };
 
   const autoSyncCaptionText =
@@ -262,7 +291,7 @@ export default function PricingPage({
       onWeekPass={() => handlePassCheckout('7d')}
       dayPassPending={dayPassState === 'pending'}
       weekPassPending={weekPassState === 'pending'}
-      featureDayPass={!unlimitedFirst}
+      featureDayPass={false}
     />
   );
 
@@ -271,11 +300,13 @@ export default function PricingPage({
       <UnlimitedCard
         isLoggedIn={isLoggedIn}
         billingCycle={billingCycle}
-        onBillingCycleChange={setBillingCycle}
+        onBillingCycleChange={selectBillingCycle}
         yearlyAvailable={unlimitedYearlyAvailable}
         onUpgrade={handleUnlimitedUpgrade}
         pending={unlimitedPending}
-        featured={unlimitedFirst}
+        monthlyCents={pricing.monthlyCents}
+        annualCents={pricing.annualCents}
+        error={unlimitedError}
       />
 
       <div id="auto-sync">

--- a/web/src/pages/PricingPage/components/UnlimitedCard.tsx
+++ b/web/src/pages/PricingPage/components/UnlimitedCard.tsx
@@ -68,7 +68,7 @@ export function UnlimitedCard({
   const monthlyTotal = formatMonthly(monthlyCents);
 
   const terms = isYearly
-    ? `${annualTotal}/year, renews annually. Cancel anytime.`
+    ? `${annualTotal}/year, renews yearly. Cancel anytime — keeps access through the year you paid for.`
     : `${monthlyTotal}/month, renews monthly. Cancel anytime.`;
 
   function getButtonLabel(): string {

--- a/web/src/pages/PricingPage/components/UnlimitedCard.tsx
+++ b/web/src/pages/PricingPage/components/UnlimitedCard.tsx
@@ -1,4 +1,10 @@
 import styles from '../PricingPage.module.css';
+import {
+  annualSavingsPercent,
+  formatAnnual,
+  formatAnnualPerMonth,
+  formatMonthly,
+} from '../pricing.constants';
 
 interface UnlimitedCardProps {
   isLoggedIn: boolean;
@@ -7,7 +13,9 @@ interface UnlimitedCardProps {
   yearlyAvailable: boolean;
   onUpgrade: () => void;
   pending: boolean;
-  featured?: boolean;
+  monthlyCents: number;
+  annualCents: number;
+  error?: boolean;
 }
 
 function CheckIcon() {
@@ -47,25 +55,63 @@ export function UnlimitedCard({
   yearlyAvailable,
   onUpgrade,
   pending,
-  featured = false,
+  monthlyCents,
+  annualCents,
+  error = false,
 }: Readonly<UnlimitedCardProps>) {
   const isYearly = billingCycle === 'year';
-  const price = isYearly ? '$60' : '$6';
-  const priceSuffix = isYearly ? '/ yr' : '/ mo';
+  const savings = annualSavingsPercent(monthlyCents, annualCents);
+  const heroPrice = isYearly
+    ? formatAnnualPerMonth(annualCents)
+    : formatMonthly(monthlyCents);
+  const annualTotal = formatAnnual(annualCents);
+  const monthlyTotal = formatMonthly(monthlyCents);
+
+  const terms = isYearly
+    ? `${annualTotal}/year, renews annually. Cancel anytime.`
+    : `${monthlyTotal}/month, renews monthly. Cancel anytime.`;
+
+  function getButtonLabel(): string {
+    if (error) return 'Try again';
+    if (pending) return 'Starting checkout';
+    return 'Get Unlimited';
+  }
 
   return (
-    <div
-      className={featured ? `${styles.card} ${styles.cardPro}` : styles.card}
-    >
-      {featured && <span className={styles.cardBadge}>Most popular</span>}
+    <div className={`${styles.card} ${styles.cardPro}`}>
+      <span className={styles.cardBadge}>Most popular</span>
       <div className={styles.cardHeader}>
         <p className={styles.cardTitle}>Unlimited</p>
+        <span className={styles.cardPriceLine}>
+          <span className={styles.cardPrice}>{heroPrice}</span>
+          <span className={styles.cardPriceSuffix}>/ mo</span>
+        </span>
+        {isYearly ? (
+          <p className={styles.yearlyHint}>
+            {annualTotal}/year billed yearly · save {savings}%
+          </p>
+        ) : (
+          <p className={styles.yearlyHint}>billed monthly</p>
+        )}
         {yearlyAvailable && (
           <div
             role="radiogroup"
             aria-label="Billing cycle"
             className={styles.billingToggle}
           >
+            <button
+              type="button"
+              role="radio"
+              aria-checked={isYearly}
+              className={
+                isYearly
+                  ? styles.billingToggleOptionActive
+                  : styles.billingToggleOption
+              }
+              onClick={() => onBillingCycleChange('year')}
+            >
+              Yearly · save {savings}%
+            </button>
             <button
               type="button"
               role="radio"
@@ -79,26 +125,8 @@ export function UnlimitedCard({
             >
               Monthly
             </button>
-            <button
-              type="button"
-              role="radio"
-              aria-checked={isYearly}
-              className={
-                isYearly
-                  ? styles.billingToggleOptionActive
-                  : styles.billingToggleOption
-              }
-              onClick={() => onBillingCycleChange('year')}
-            >
-              Yearly
-            </button>
           </div>
         )}
-        <span className={styles.cardPriceLine}>
-          <span className={styles.cardPrice}>{price}</span>
-          <span className={styles.cardPriceSuffix}>{priceSuffix}</span>
-        </span>
-        {isYearly && <p className={styles.yearlyHint}>2 months free</p>}
       </div>
       <div className={styles.cardBody}>
         {BENEFITS.map((benefit) => (
@@ -115,8 +143,15 @@ export function UnlimitedCard({
           onClick={onUpgrade}
           disabled={pending}
         >
-          {pending ? 'Starting checkout' : 'Get Unlimited'}
+          {getButtonLabel()}
         </button>
+        {error ? (
+          <p className={styles.cardCaption}>
+            Couldn't start checkout. Try again, or email support@2anki.net.
+          </p>
+        ) : (
+          <p className={styles.cardTerms}>{terms}</p>
+        )}
       </div>
     </div>
   );

--- a/web/src/pages/PricingPage/pricing.constants.test.ts
+++ b/web/src/pages/PricingPage/pricing.constants.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  annualSavingsPercent,
+  formatAnnual,
+  formatAnnualPerMonth,
+  formatMonthly,
+} from './pricing.constants';
+
+describe('pricing formatters', () => {
+  it('formats whole-dollar monthly amounts without decimals', () => {
+    expect(formatMonthly(600)).toBe('$6');
+  });
+
+  it('formats fractional monthly amounts with two decimals', () => {
+    expect(formatMonthly(799)).toBe('$7.99');
+  });
+
+  it('formats annual amounts', () => {
+    expect(formatAnnual(6400)).toBe('$64');
+    expect(formatAnnual(6000)).toBe('$60');
+  });
+
+  it('formats the annual per-month figure', () => {
+    expect(formatAnnualPerMonth(6400)).toBe('$5.33');
+    expect(formatAnnualPerMonth(6000)).toBe('$5.00');
+  });
+
+  it('computes the savings percent of annual over monthly', () => {
+    expect(annualSavingsPercent(799, 6400)).toBe(33);
+    expect(annualSavingsPercent(600, 6000)).toBe(17);
+  });
+});

--- a/web/src/pages/PricingPage/pricing.constants.ts
+++ b/web/src/pages/PricingPage/pricing.constants.ts
@@ -19,9 +19,7 @@ export const LEGACY_UNLIMITED_PRICING: UnlimitedPricing = {
 
 function formatDollars(cents: number): string {
   const dollars = cents / 100;
-  return Number.isInteger(dollars)
-    ? `$${dollars}`
-    : `$${dollars.toFixed(2)}`;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
 }
 
 export function formatMonthly(cents: number): string {

--- a/web/src/pages/PricingPage/pricing.constants.ts
+++ b/web/src/pages/PricingPage/pricing.constants.ts
@@ -2,3 +2,46 @@ export const MONTHLY_PRICE = '$6';
 export const MONTHLY_SUFFIX = '/ mo';
 export const YEARLY_PRICE = '$60';
 export const AUTO_SYNC_PRICE = '$30';
+
+export interface UnlimitedPricing {
+  monthlyCents: number;
+  annualCents: number;
+  legacy: boolean;
+  lockInDeadline: string | null;
+}
+
+export const LEGACY_UNLIMITED_PRICING: UnlimitedPricing = {
+  monthlyCents: 600,
+  annualCents: 6000,
+  legacy: true,
+  lockInDeadline: null,
+};
+
+function formatDollars(cents: number): string {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars)
+    ? `$${dollars}`
+    : `$${dollars.toFixed(2)}`;
+}
+
+export function formatMonthly(cents: number): string {
+  return formatDollars(cents);
+}
+
+export function formatAnnual(cents: number): string {
+  return formatDollars(cents);
+}
+
+export function formatAnnualPerMonth(annualCents: number): string {
+  const perMonth = annualCents / 12 / 100;
+  return `$${perMonth.toFixed(2)}`;
+}
+
+export function annualSavingsPercent(
+  monthlyCents: number,
+  annualCents: number
+): number {
+  if (monthlyCents <= 0) return 0;
+  const fullYear = monthlyCents * 12;
+  return Math.round(((fullYear - annualCents) / fullYear) * 100);
+}

--- a/web/src/pages/PricingPage/pricingFaq.ts
+++ b/web/src/pages/PricingPage/pricingFaq.ts
@@ -33,7 +33,7 @@ export const PRICING_FAQ: PricingFaqItem[] = [
   {
     question: 'Can I cancel anytime?',
     answer:
-      'Subscriptions cancel in one click from your account — no need to email support. Passes are one-time, so there is nothing to cancel.',
+      'Cancel in one click from your account — no need to email support. On a yearly plan, cancelling stops the next renewal and your access stays through the year you already paid for; unused time is not refunded. Passes are one-time, so there is nothing to cancel.',
   },
   {
     question: 'What happens to my decks if I stop paying?',

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-15-annual-default.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-15-annual-default.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-15-annual-default",
+  "date": "2026-06-15",
+  "type": "feature",
+  "title": "Unlimited now leads with the annual plan — two months free over paying monthly"
+}

--- a/web/tests/checkout.spec.ts
+++ b/web/tests/checkout.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+const loggedInFreeLocals = {
+  user: {
+    id: 1,
+    email: 'free@example.com',
+    patreon: false,
+    created_at: '2026-06-16T00:00:00Z',
+  },
+  locals: { owner: 1, patreon: false, subscriber: false },
+  features: {},
+  autoSyncCapReached: false,
+  autoSyncActive: false,
+};
+
+const v2Prices = {
+  cohort: 'v2',
+  legacy: false,
+  monthly: { cents: 799 },
+  annual: { cents: 6400 },
+  lockInDeadline: null,
+};
+
+test.describe('Unlimited checkout', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/users/debug/locals**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(loggedInFreeLocals),
+      })
+    );
+    await page.route('**/api/checkout/prices', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(v2Prices),
+      })
+    );
+  });
+
+  test('annual is selected by default with the v2 per-month hero price', async ({
+    page,
+  }) => {
+    await page.goto('/pricing');
+
+    await expect(page.getByText('$5.33')).toBeVisible();
+    await expect(
+      page.getByText('$64/year billed yearly · save 33%')
+    ).toBeVisible();
+  });
+
+  test('Get Unlimited starts an annual checkout and redirects to Stripe', async ({
+    page,
+  }) => {
+    let checkoutBody: { interval?: string } = {};
+    await page.route('**/api/checkout/unlimited', async (route) => {
+      checkoutBody = JSON.parse(route.request().postData() ?? '{}');
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ url: 'https://checkout.stripe.com/c/pay/test' }),
+      });
+    });
+
+    await page.goto('/pricing');
+    await page.getByRole('button', { name: 'Get Unlimited' }).click();
+
+    await expect.poll(() => checkoutBody.interval).toBe('year');
+  });
+});

--- a/web/tests/checkout.spec.ts
+++ b/web/tests/checkout.spec.ts
@@ -13,6 +13,14 @@ const loggedInFreeLocals = {
   autoSyncActive: false,
 };
 
+const legacyPrices = {
+  cohort: 'legacy',
+  legacy: true,
+  monthly: { cents: 600 },
+  annual: { cents: 6000 },
+  lockInDeadline: null,
+};
+
 const v2Prices = {
   cohort: 'v2',
   legacy: false,
@@ -20,6 +28,18 @@ const v2Prices = {
   annual: { cents: 6400 },
   lockInDeadline: null,
 };
+
+const routePrices = (
+  page: import('@playwright/test').Page,
+  prices: typeof legacyPrices | typeof v2Prices
+) =>
+  page.route('**/api/checkout/prices', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(prices),
+    })
+  );
 
 test.describe('Unlimited checkout', () => {
   test.beforeEach(async ({ page }) => {
@@ -30,18 +50,25 @@ test.describe('Unlimited checkout', () => {
         body: JSON.stringify(loggedInFreeLocals),
       })
     );
-    await page.route('**/api/checkout/prices', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(v2Prices),
-      })
-    );
+  });
+
+  test('flag-off prices show the legacy per-month hero and no v2 numbers', async ({
+    page,
+  }) => {
+    await routePrices(page, legacyPrices);
+    await page.goto('/pricing');
+
+    await expect(page.getByText('$5.00').first()).toBeVisible();
+    await expect(
+      page.getByText('$60/year billed yearly · save 17%')
+    ).toBeVisible();
+    await expect(page.getByText('$5.33')).toBeHidden();
   });
 
   test('annual is selected by default with the v2 per-month hero price', async ({
     page,
   }) => {
+    await routePrices(page, v2Prices);
     await page.goto('/pricing');
 
     await expect(page.getByText('$5.33')).toBeVisible();
@@ -53,6 +80,7 @@ test.describe('Unlimited checkout', () => {
   test('Get Unlimited starts an annual checkout and redirects to Stripe', async ({
     page,
   }) => {
+    await routePrices(page, v2Prices);
     let checkoutBody: { interval?: string } = {};
     await page.route('**/api/checkout/unlimited', async (route) => {
       checkoutBody = JSON.parse(route.request().postData() ?? '{}');


### PR DESCRIPTION
## What
Introduces pricing v2 for Unlimited ($7.99/mo, $64/yr) behind the global `pricing_v2` feature flag, with a grandfather window that serves legacy ($6/$60) pricing to accounts created before a code-constant cutover until the lock-in deadline (`2026-06-21T21:59:00Z`). Flag defaults **off** — behavior is unchanged for everyone until flipped.

## Why
Raise Unlimited revenue per subscriber while protecting existing users from a surprise increase, and steer new signups toward the annual plan (the second-deck retention lever from the growth analysis). Prices are PM-recommended and **pending Alexander's sign-off** ($7.99/$64).

## How
- **Cohort logic** (`src/usecases/checkout/pricingV2.ts`) — pure `resolveCohort` / `qualifiesForLegacyWindow`. Cutover (`2026-06-15T07:00:00Z` placeholder) and window-end are code constants, not env flags.
- **Price resolution** (`src/services/StripePriceResolver.ts`) — resolves v2 prices by `lookup_key`, caches the ID, falls back (logged) when resolution fails.
- **Checkout** — `UnlimitedCheckoutUseCase` resolves the correct price per cohort, stamps `cohort` into Stripe metadata, never trusts client price/interval beyond the existing `month|year` validation. Falls back to legacy env IDs on resolution failure.
- **Cohort endpoint** — `GET /api/checkout/prices` (optional auth) returns cohort-correct cents + `lockInDeadline`. The page renders legacy numbers for legacy-window users.
- **Web** — annual preselected; Unlimited card leads with per-month hero price above the toggle, cycle-dependent terms line, checkout error state, single primary CTA; `LockInBanner` for logged-in free users inside the window.
- **Stripe script** — `scripts/pricing-v2.ts` (idempotent, lookup_key-first, Step-0 catalog print, `--live`+confirm for live, reuses existing Unlimited product).

## Step 0 inventory (current state)
- **Env price vars:** `UNLIMITED_MONTHLY_PRICE_ID` / `UNLIMITED_YEARLY_PRICE_ID` were referenced by `CheckoutRouter` but missing from `src/env.example` — added them with a note. Legacy IDs stay the fallback; v2 prices resolve at runtime by lookup_key.
- **Checkout flow:** `CheckoutRouter` → `UnlimitedCheckoutController` → `UnlimitedCheckoutUseCase` → Stripe `checkout.sessions.create`. Unchanged shape; now threads flag + `created_at`.
- **Webhook entitlements:** unchanged — `StripeController` handles `customer.subscription.*`; v2 prices attach to the same Unlimited product so existing entitlement matching keeps working.
- **Email capability:** untouched (parallel PR owns templates).
- **Analytics:** added `checkout_started` (server), `plan_interval_selected`, `lock_in_banner_shown`, `lock_in_banner_clicked` (client). `checkout_completed`/`paywall_shown` reused.

## Measuring success
- `checkout_started` events grouped by `props.cohort` (legacy vs v2) confirm the grandfather split is firing in prod.
- Server log `unlimited.checkout.session_created` carries `cohort`; `pricing.resolve.failed` / `unlimited.checkout.v2_resolve_fallback` flag any lookup_key resolution misses.
- `GET /api/checkout/prices` response per cohort is the single source the page renders from.

## Testing
- Server unit tests: cohort boundaries (pre-cutover in/after window, post-cutover, flag off), price resolver (resolve/cache/miss/error), use-case v2-resolution + legacy fallback + flag-off, controller flag/createdAt threading + `checkout_started` emit, prices endpoint per cohort. 120 server tests green across touched paths; full server `tsc` clean.
- Web: PricingPage (50), LockInBanner (7), pricing formatters (5) — all green; web `typecheck` + `lint` clean (no new warnings in touched files).
- Playwright `web/tests/checkout.spec.ts` (mock-based): annual-default + correct hero price + checkout starts with `interval: year`.
- **Stripe script rehearsed in test mode** — created `v2_monthly` ($7.99/mo) and `v2_annual` ($64/yr); idempotent re-run verified (both skipped). Live run still gated on price sign-off.
- **Sonar not run locally** — `sonar-scanner` is installed but `SONAR_TOKEN` is unset here. Expect the CI Sonar pass to be the first rule-engine run.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified with Playwright Chromium against `pnpm dev` on the PR branch, desktop + 375px. Flag-off state confirmed: legacy $6 pricing renders, no v2 numbers leak, Get Unlimited CTA and the new cancel-terms line present. The only console message is a 401 from the unauthenticated session probe, reproduced identically on production /pricing — pre-existing, not introduced here.

## Changelog
`2026-06-15-annual-default.json` — "Unlimited now leads with the annual plan — two months free over paying monthly"

## Risks
- The Unlimited card layout (price-above-toggle, terms line, single CTA) renders for **all** users once merged, not only flag-on cohorts — this is the designer-approved redesign ("ship it"). Only the price **numbers** and the lock-in banner are flag/cohort-gated, so "flag off = byte-identical" holds for the numbers and banner but not the card structure. Called out so it's a conscious decision, not a silent deviation.
- If v2 lookup_keys don't exist in Stripe when the flag flips, checkout falls back to legacy env IDs (logged) — no user-facing failure, but v2 pricing silently won't apply until the script runs.

### Rollback
1. Flip `pricing_v2` off in `feature_flags` (Ops panel). 
2. Verify: `GET /api/checkout/prices` returns `cohort: legacy`, `$6/$60`, `lockInDeadline: null` for every caller; the LockInBanner disappears; new `checkout_started` events show `cohort: legacy`. No Stripe objects are mutated by the flag, so rollback is instantaneous.

## Gated on sign-off (do NOT do until prices are approved)
- Live-mode `scripts/pricing-v2.ts` run (`--live`).
- `pricing_v2` flag flip.
- Finalizing the cutover timestamp constant (currently `2026-06-15T07:00:00Z` placeholder).

## Goal alignment
Annual-default + grandfather lock-in targets the retention/revenue leak named in the growth analysis (second-deck conversion, monthly→annual mix) while keeping the free 100-cards tier untouched — supports the 300K-user + sustainable-revenue goal without raising the signup barrier.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783689009&installation_id=132681956&pr_number=3204&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3204&signature=2e7b94ef2ca7116dcb16468bce39b88a9725421b81dd8ff09decbe852d23a0e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
