### PR TITLE
fix: make Chat conversation history reachable on mobile

### DIFF
--- a/web/src/pages/Chat/ChatPage.module.css
+++ b/web/src/pages/Chat/ChatPage.module.css
@@ -13,3 +13,48 @@
   min-width: 0;
   height: 100%;
 }
+
+.mobileBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-light);
+  background: var(--color-bg-secondary);
+  flex-shrink: 0;
+}
+
+@media (min-width: 769px) {
+  .mobileBar {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .mobileBarBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.375rem 0.625rem;
+    background: transparent;
+    border: none;
+    color: var(--color-text-primary);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    cursor: pointer;
+    border-radius: var(--radius-md);
+  }
+
+  .mobileBarNew {
+    appearance: none;
+    border: 1px solid var(--color-primary);
+    background: var(--color-primary-light);
+    color: var(--color-primary);
+    padding: 0.375rem 0.75rem;
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    font-weight: var(--font-medium);
+    cursor: pointer;
+  }
+}

--- a/web/src/pages/Chat/ChatPage.test.tsx
+++ b/web/src/pages/Chat/ChatPage.test.tsx
@@ -408,3 +408,84 @@ describe('ChatPage — query-param handling', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('ChatPage — mobile conversation drawer', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+    mockGet.mockResolvedValue({ used: 0, limit: 20 });
+  });
+
+  it('exposes Past chats and New chat in the mobile bar', () => {
+    renderChatPage();
+    expect(
+      screen.getByRole('button', { name: 'Past chats' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: 'New chat' }).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it('opens the conversation drawer when Past chats is tapped', () => {
+    renderChatPage();
+    expect(
+      screen.queryByRole('button', { name: 'Close conversations' })
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Past chats' }));
+    expect(
+      screen.getByRole('button', { name: 'Close conversations' })
+    ).toBeInTheDocument();
+  });
+
+  it('closes the drawer when the scrim is tapped', () => {
+    renderChatPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Past chats' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Close conversations' })
+    );
+    expect(
+      screen.queryByRole('button', { name: 'Close conversations' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('closes the drawer after selecting a conversation', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/api/chat/conversations') {
+        return Promise.resolve({
+          conversations: [
+            { id: 7, title: 'Krebs cycle', updatedAt: '2026-06-10T00:00:00.000Z' },
+          ],
+        });
+      }
+      if (url === '/api/chat/conversations/7') {
+        return Promise.resolve({
+          id: 7,
+          title: 'Krebs cycle',
+          draft: null,
+          templateSlug: null,
+          createdAt: '2026-06-10T00:00:00.000Z',
+          updatedAt: '2026-06-10T00:00:00.000Z',
+          messages: [],
+        });
+      }
+      return Promise.resolve({ used: 0, limit: 20 });
+    });
+
+    renderChatPage();
+    await waitFor(() => {
+      expect(screen.getByText('Krebs cycle')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Past chats' }));
+    expect(
+      screen.getByRole('button', { name: 'Close conversations' })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Krebs cycle'));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Close conversations' })
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/pages/Chat/ChatPage.tsx
+++ b/web/src/pages/Chat/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import ChatPanel, { type Message } from '../../components/ChatPanel/ChatPanel';
 import { del, get, patch } from '../../lib/backend/api';
@@ -61,6 +61,8 @@ export default function ChatPage() {
     templateSlug: null,
   });
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const closeSidebar = useCallback(() => setSidebarOpen(false), []);
 
   useEffect(() => {
     get('/api/chat/conversations', { redirect: false })
@@ -87,6 +89,7 @@ export default function ChatPage() {
   }
 
   async function handleSelectConversation(id: number) {
+    setSidebarOpen(false);
     if (id === activeConversationId) return;
     setLoadError(null);
     setActiveConversationId(id);
@@ -119,6 +122,7 @@ export default function ChatPage() {
   }
 
   function handleNewConversation() {
+    setSidebarOpen(false);
     setActiveConversationId(null);
     setPanelSeed({
       key: `new-${Date.now()}`,
@@ -177,8 +181,44 @@ export default function ChatPage() {
         onNew={handleNewConversation}
         onRename={handleRenameConversation}
         onDelete={handleDeleteConversation}
+        isOpen={sidebarOpen}
+        onClose={closeSidebar}
       />
       <div className={styles.container}>
+        <div className={styles.mobileBar}>
+          <button
+            type="button"
+            className={styles.mobileBarBtn}
+            onClick={() => setSidebarOpen(true)}
+            aria-haspopup="dialog"
+            aria-expanded={sidebarOpen}
+            aria-controls="conversations-sidebar"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+            Past chats
+          </button>
+          <button
+            type="button"
+            className={styles.mobileBarNew}
+            onClick={handleNewConversation}
+          >
+            New chat
+          </button>
+        </div>
         {loadError != null && (
           <p
             style={{

--- a/web/src/pages/Chat/ConversationsSidebar.module.css
+++ b/web/src/pages/Chat/ConversationsSidebar.module.css
@@ -181,8 +181,37 @@
   color: var(--color-danger);
 }
 
+.scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  border: none;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+}
+
 @media (max-width: 768px) {
   .sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 30;
+    width: 280px;
+    max-width: 85vw;
+    transform: translateX(-100%);
+    transition: transform var(--transition-base);
+    box-shadow: var(--shadow-md);
+  }
+
+  .sidebarOpen {
+    transform: translateX(0);
+  }
+}
+
+@media (min-width: 769px) {
+  .scrim {
     display: none;
   }
 }

--- a/web/src/pages/Chat/ConversationsSidebar.test.tsx
+++ b/web/src/pages/Chat/ConversationsSidebar.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import ConversationsSidebar, {
+  ConversationSummary,
+} from './ConversationsSidebar';
+
+const conversations: ConversationSummary[] = [
+  { id: 1, title: 'Photosynthesis', updatedAt: '2026-06-10T00:00:00.000Z' },
+  { id: 2, title: 'French verbs', updatedAt: '2026-06-09T00:00:00.000Z' },
+];
+
+function renderSidebar(overrides: Partial<Parameters<typeof ConversationsSidebar>[0]> = {}) {
+  const props = {
+    conversations,
+    activeId: null,
+    onSelect: vi.fn(),
+    onNew: vi.fn(),
+    onRename: vi.fn(),
+    onDelete: vi.fn(),
+    isOpen: false,
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  render(<ConversationsSidebar {...props} />);
+  return props;
+}
+
+describe('ConversationsSidebar', () => {
+  it('renders the conversation list', () => {
+    renderSidebar();
+    expect(screen.getByText('Photosynthesis')).toBeInTheDocument();
+    expect(screen.getByText('French verbs')).toBeInTheDocument();
+  });
+
+  it('does not render the scrim when closed', () => {
+    renderSidebar({ isOpen: false });
+    expect(
+      screen.queryByRole('button', { name: 'Close conversations' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the scrim when open', () => {
+    renderSidebar({ isOpen: true });
+    expect(
+      screen.getByRole('button', { name: 'Close conversations' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClose when the scrim is clicked', () => {
+    const props = renderSidebar({ isOpen: true });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Close conversations' })
+    );
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape is pressed while open', () => {
+    const props = renderSidebar({ isOpen: true });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not react to Escape when closed', () => {
+    const props = renderSidebar({ isOpen: false });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onSelect with the conversation id', () => {
+    const props = renderSidebar();
+    fireEvent.click(screen.getByText('Photosynthesis'));
+    expect(props.onSelect).toHaveBeenCalledWith(1);
+  });
+});

--- a/web/src/pages/Chat/ConversationsSidebar.tsx
+++ b/web/src/pages/Chat/ConversationsSidebar.tsx
@@ -14,6 +14,16 @@ interface Props {
   onNew: () => void;
   onRename: (id: number, title: string) => void;
   onDelete: (id: number) => void;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function focusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button, [href], input, [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter((el) => !el.hasAttribute('disabled'));
 }
 
 function formatRelativeTime(iso: string): string {
@@ -40,12 +50,47 @@ export default function ConversationsSidebar({
   onNew,
   onRename,
   onDelete,
+  isOpen,
+  onClose,
 }: Props) {
   const [menuOpenFor, setMenuOpenFor] = useState<number | null>(null);
   const [renamingId, setRenamingId] = useState<number | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
   const menuRef = useRef<HTMLDivElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const asideRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const aside = asideRef.current;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    focusableElements(aside ?? document.body)[0]?.focus();
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab' || aside == null) return;
+      const focusables = focusableElements(aside);
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [isOpen, onClose]);
 
   useEffect(() => {
     if (menuOpenFor == null) return;
@@ -89,8 +134,22 @@ export default function ConversationsSidebar({
   }
 
   return (
-    <aside className={styles.sidebar} aria-label="Conversations">
-      <button type="button" className={styles.newChatBtn} onClick={onNew}>
+    <>
+      {isOpen && (
+        <button
+          type="button"
+          className={styles.scrim}
+          aria-label="Close conversations"
+          onClick={onClose}
+        />
+      )}
+      <aside
+        ref={asideRef}
+        id="conversations-sidebar"
+        className={`${styles.sidebar} ${isOpen ? styles.sidebarOpen : ''}`}
+        aria-label="Conversations"
+      >
+        <button type="button" className={styles.newChatBtn} onClick={onNew}>
         New chat
       </button>
 
@@ -186,8 +245,9 @@ export default function ConversationsSidebar({
               </li>
             );
           })}
-        </ul>
-      )}
-    </aside>
+          </ul>
+        )}
+      </aside>
+    </>
   );
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-10-chat-history-mobile.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-10-chat-history-mobile.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-10-chat-history-mobile",
+  "date": "2026-06-10",
+  "type": "fix",
+  "title": "Reach your past chats on mobile — tap Past chats to open the conversation list, or New chat to start fresh"
+}


### PR DESCRIPTION
## What

On 2anki Chat, the conversation-history sidebar was `display:none` below 768px with **no** replacement entry point. On phones a user who opened any conversation was trapped: no past chats, no switching, no rename/delete, and no New chat (that button lived only in the hidden sidebar). Desktop was fine.

## Fix

- New Chat-local mobile bar (shown only ≤768px) with two controls: **Past chats** (opens history) and **New chat** (direct, one tap).
- **Past chats** opens the existing `ConversationsSidebar` as a left slide-in drawer over a scrim. The drawer reuses the component verbatim, so the list, per-item rename/delete menu, and its own New chat button all come along — nothing rebuilt.
- Drawer dismisses on scrim tap, Escape, or selecting a conversation. Focus trap while open; focus restored to the trigger on close.
- Desktop (≥769px) layout and behavior unchanged — the sidebar stays a static 260px column; the mobile bar and scrim are hidden.

Trio (pm + designer + engineer) reviewed before implementation; they agreed on the drawer approach. Designer's two-control bar won over a single trigger so New chat stays one tap rather than two.

## Tests

- New `ConversationsSidebar.test.tsx`: scrim renders only when open, scrim click and Escape call `onClose`, no Escape reaction when closed, list + select still work.
- `ChatPage.test.tsx`: mobile bar exposes Past chats + New chat, Past chats opens the drawer, scrim tap closes it, selecting a conversation closes it.
- Full suite: 1786 web tests pass; server `tsc`, web typecheck, and oxlint clean (oxlint warnings present are all pre-existing, in unrelated files).

Sonar: not run locally — no `SONAR_TOKEN` on this machine. Expect the CI Sonar pass; change is small and uses native `<button>` elements throughout.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: verified via the test suite and type/lint, but the manual 375px browser pass is NOT done yet (dev server not started). Needs a visual check at 375px before merge — happy to run it if you want me to start the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783695227&installation_id=132681956&pr_number=3205&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3205&signature=97a3b77e645868fc0e6a95b90ddc1f52f108044a227caf74cfb828bc8ef87b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->