### PR TITLE
fix: drop the Monday date from the lock-in email body

### DIFF
--- a/src/services/EmailService/PriceLockInEmail.test.ts
+++ b/src/services/EmailService/PriceLockInEmail.test.ts
@@ -89,8 +89,8 @@ describe('EmailService.sendPriceLockInEmail', () => {
     await service.sendPriceLockInEmail('user@example.com', 'tok', 'a');
 
     const msg = lastMessage();
-    expect(msg.html).toContain('Unlimited pricing goes up for new members');
+    expect(msg.html).toContain('Unlimited pricing has gone up for new members');
     expect(msg.html).toContain('The 2anki Team');
-    expect(msg.text).toContain('Unlimited pricing goes up for new members');
+    expect(msg.text).toContain('Unlimited pricing has gone up for new members');
   });
 });

--- a/src/services/EmailService/templates/price-lock-in.html
+++ b/src/services/EmailService/templates/price-lock-in.html
@@ -35,7 +35,7 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <p style="margin: 0 0 16px;">Unlimited pricing goes up for new members on Monday 15 June: $7.99/month and $64/year.</p>
+              <p style="margin: 0 0 16px;">Unlimited pricing has gone up for new members: $7.99/month and $64/year.</p>
               <p style="margin: 0 0 16px;">Your account locks in today's rate — $6/month or $60/year — if you upgrade before Sunday 21 June, 23:59 CEST. That rate stays as long as the subscription is active.</p>
               <p style="margin: 0 0 24px;">After Sunday, the $6 and $60 prices are retired and the new rates apply.</p>
               <div style="text-align: center; margin: 0 0 24px;" class="email-cta">

--- a/web/src/pages/Chat/ChatPage.test.tsx
+++ b/web/src/pages/Chat/ChatPage.test.tsx
@@ -452,7 +452,11 @@ describe('ChatPage — mobile conversation drawer', () => {
       if (url === '/api/chat/conversations') {
         return Promise.resolve({
           conversations: [
-            { id: 7, title: 'Krebs cycle', updatedAt: '2026-06-10T00:00:00.000Z' },
+            {
+              id: 7,
+              title: 'Krebs cycle',
+              updatedAt: '2026-06-10T00:00:00.000Z',
+            },
           ],
         });
       }

--- a/web/src/pages/Chat/ConversationsSidebar.test.tsx
+++ b/web/src/pages/Chat/ConversationsSidebar.test.tsx
@@ -10,7 +10,9 @@ const conversations: ConversationSummary[] = [
   { id: 2, title: 'French verbs', updatedAt: '2026-06-09T00:00:00.000Z' },
 ];
 
-function renderSidebar(overrides: Partial<Parameters<typeof ConversationsSidebar>[0]> = {}) {
+function renderSidebar(
+  overrides: Partial<Parameters<typeof ConversationsSidebar>[0]> = {}
+) {
   const props = {
     conversations,
     activeId: null,

--- a/web/src/pages/Chat/ConversationsSidebar.tsx
+++ b/web/src/pages/Chat/ConversationsSidebar.tsx
@@ -150,101 +150,103 @@ export default function ConversationsSidebar({
         aria-label="Conversations"
       >
         <button type="button" className={styles.newChatBtn} onClick={onNew}>
-        New chat
-      </button>
+          New chat
+        </button>
 
-      {conversations.length === 0 ? (
-        <p className={styles.empty}>No conversations yet. Start one below.</p>
-      ) : (
-        <ul className={styles.list}>
-          {conversations.map((c) => {
-            const isActive = c.id === activeId;
-            const isRenaming = c.id === renamingId;
-            return (
-              <li
-                key={c.id}
-                className={`${styles.item} ${isActive ? styles.itemActive : ''}`}
-              >
-                {isRenaming ? (
-                  <input
-                    ref={renameInputRef}
-                    type="text"
-                    className={styles.renameInput}
-                    value={renameDraft}
-                    onChange={(e) => setRenameDraft(e.target.value)}
-                    onBlur={() => commitRename(c.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault();
-                        commitRename(c.id);
-                      } else if (e.key === 'Escape') {
-                        e.preventDefault();
-                        cancelRename();
-                      }
-                    }}
-                    aria-label="Conversation title"
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    className={styles.itemMain}
-                    onClick={() => onSelect(c.id)}
-                    title={c.title}
-                  >
-                    <span className={styles.itemTitle}>{c.title}</span>
-                    <span className={styles.itemMeta}>
-                      {formatRelativeTime(c.updatedAt)}
-                    </span>
-                  </button>
-                )}
-
-                {!isRenaming && (
-                  <div
-                    className={styles.menuWrapper}
-                    ref={menuOpenFor === c.id ? menuRef : undefined}
-                  >
+        {conversations.length === 0 ? (
+          <p className={styles.empty}>No conversations yet. Start one below.</p>
+        ) : (
+          <ul className={styles.list}>
+            {conversations.map((c) => {
+              const isActive = c.id === activeId;
+              const isRenaming = c.id === renamingId;
+              return (
+                <li
+                  key={c.id}
+                  className={`${styles.item} ${isActive ? styles.itemActive : ''}`}
+                >
+                  {isRenaming ? (
+                    <input
+                      ref={renameInputRef}
+                      type="text"
+                      className={styles.renameInput}
+                      value={renameDraft}
+                      onChange={(e) => setRenameDraft(e.target.value)}
+                      onBlur={() => commitRename(c.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          commitRename(c.id);
+                        } else if (e.key === 'Escape') {
+                          e.preventDefault();
+                          cancelRename();
+                        }
+                      }}
+                      aria-label="Conversation title"
+                    />
+                  ) : (
                     <button
                       type="button"
-                      className={styles.menuTrigger}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setMenuOpenFor((prev) => (prev === c.id ? null : c.id));
-                      }}
-                      aria-label={`Options for ${c.title}`}
-                      aria-haspopup="menu"
-                      aria-expanded={menuOpenFor === c.id}
+                      className={styles.itemMain}
+                      onClick={() => onSelect(c.id)}
+                      title={c.title}
                     >
-                      <span aria-hidden="true">⋯</span>
+                      <span className={styles.itemTitle}>{c.title}</span>
+                      <span className={styles.itemMeta}>
+                        {formatRelativeTime(c.updatedAt)}
+                      </span>
                     </button>
+                  )}
 
-                    {menuOpenFor === c.id && (
-                      <div className={styles.menu} role="menu">
-                        <button
-                          type="button"
-                          role="menuitem"
-                          className={styles.menuItem}
-                          onClick={() => startRename(c.id, c.title)}
-                        >
-                          Rename
-                        </button>
-                        <button
-                          type="button"
-                          role="menuitem"
-                          className={`${styles.menuItem} ${styles.menuItemDanger}`}
-                          onClick={() => {
-                            setMenuOpenFor(null);
-                            onDelete(c.id);
-                          }}
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </li>
-            );
-          })}
+                  {!isRenaming && (
+                    <div
+                      className={styles.menuWrapper}
+                      ref={menuOpenFor === c.id ? menuRef : undefined}
+                    >
+                      <button
+                        type="button"
+                        className={styles.menuTrigger}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setMenuOpenFor((prev) =>
+                            prev === c.id ? null : c.id
+                          );
+                        }}
+                        aria-label={`Options for ${c.title}`}
+                        aria-haspopup="menu"
+                        aria-expanded={menuOpenFor === c.id}
+                      >
+                        <span aria-hidden="true">⋯</span>
+                      </button>
+
+                      {menuOpenFor === c.id && (
+                        <div className={styles.menu} role="menu">
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className={styles.menuItem}
+                            onClick={() => startRename(c.id, c.title)}
+                          >
+                            Rename
+                          </button>
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className={`${styles.menuItem} ${styles.menuItemDanger}`}
+                            onClick={() => {
+                              setMenuOpenFor(null);
+                              onDelete(c.id);
+                            }}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </aside>


### PR DESCRIPTION
The pricing-v2 ship moved up from the weekend plan, so the lock-in email body no longer names Monday 15 June. "Has gone up" is correct whenever the email sends, since the send runbook gates on the new prices being live first.

Follow-up to #3203 — that PR merged while this one-commit fix was in flight, so it lands separately. Also carries an oxfmt pass on three Chat page files that merged unformatted and turned main's format check red.

No changelog entry — copy fix in an email that has not been sent yet.

Browser check: not applicable — email template copy + whitespace-only formatting, no rendered output change

🤖 Generated with [Claude Code](https://claude.com/claude-code)