### PR TITLE
feat: ops commands for lock-in emails and inactive-user deletion

### DIFF
--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -7,8 +7,19 @@ import {
   createPricingV2Prices,
   CreatePricingV2PricesResponse,
 } from './createPricingV2Prices';
+import {
+  sendPriceLockInEmails,
+  SendPriceLockInEmailsResponse,
+} from './sendPriceLockInEmails';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
+
+function formatLockInResult(result: SendPriceLockInEmailsResponse): string {
+  if (result.dryRun) {
+    return `${result.count} recipient${result.count === 1 ? '' : 's'} in segment, sends nothing.`;
+  }
+  return `Sent ${result.count}; click again for the next batch.`;
+}
 
 function formatPricesResult(result: CreatePricingV2PricesResponse): string {
   const mode = result.livemode ? 'live' : 'test';
@@ -44,6 +55,8 @@ export default function CommandsTab() {
   const [syncMessage, setSyncMessage] = useState('');
   const [pricesStatus, setPricesStatus] = useState<Status>('idle');
   const [pricesMessage, setPricesMessage] = useState('');
+  const [lockInStatus, setLockInStatus] = useState<Status>('idle');
+  const [lockInMessage, setLockInMessage] = useState('');
 
   const run = async (dryRun: boolean) => {
     setStatus('loading');
@@ -84,6 +97,21 @@ export default function CommandsTab() {
     } catch (error) {
       setPricesStatus('error');
       setPricesMessage(
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  };
+
+  const runLockIn = async (dryRun: boolean) => {
+    setLockInStatus('loading');
+    setLockInMessage('');
+    try {
+      const result = await sendPriceLockInEmails(dryRun);
+      setLockInStatus('success');
+      setLockInMessage(formatLockInResult(result));
+    } catch (error) {
+      setLockInStatus('error');
+      setLockInMessage(
         error instanceof Error ? error.message : 'Unknown error'
       );
     }
@@ -191,6 +219,43 @@ export default function CommandsTab() {
       {pricesStatus === 'error' && pricesMessage && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {pricesMessage}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Price lock-in emails</h2>
+        <p className={styles.panelSubtitle}>
+          One-time price lock-in offer to free accounts older than 14 days.
+          Dry-run first; each send delivers up to 500.
+        </p>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runLockIn(true)}
+            disabled={lockInStatus === 'loading'}
+          >
+            {lockInStatus === 'loading' ? 'Working…' : 'Check segment'}
+          </button>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runLockIn(false)}
+            disabled={lockInStatus === 'loading'}
+          >
+            Send batch of 500
+          </button>
+        </div>
+      </section>
+
+      {lockInStatus === 'success' && lockInMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {lockInMessage}
+        </div>
+      )}
+      {lockInStatus === 'error' && lockInMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {lockInMessage}
         </div>
       )}
     </>

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -11,8 +11,19 @@ import {
   sendPriceLockInEmails,
   SendPriceLockInEmailsResponse,
 } from './sendPriceLockInEmails';
+import {
+  deleteInactiveUsers,
+  DeleteInactiveUsersResponse,
+} from './deleteInactiveUsers';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
+
+function formatDeleteResult(result: DeleteInactiveUsersResponse): string {
+  if (result.dryRun) {
+    return `${result.count} account${result.count === 1 ? '' : 's'} would be deleted.`;
+  }
+  return `Deleted ${result.count} account${result.count === 1 ? '' : 's'}.`;
+}
 
 function formatLockInResult(result: SendPriceLockInEmailsResponse): string {
   if (result.dryRun) {
@@ -57,6 +68,8 @@ export default function CommandsTab() {
   const [pricesMessage, setPricesMessage] = useState('');
   const [lockInStatus, setLockInStatus] = useState<Status>('idle');
   const [lockInMessage, setLockInMessage] = useState('');
+  const [deleteStatus, setDeleteStatus] = useState<Status>('idle');
+  const [deleteMessage, setDeleteMessage] = useState('');
 
   const run = async (dryRun: boolean) => {
     setStatus('loading');
@@ -112,6 +125,21 @@ export default function CommandsTab() {
     } catch (error) {
       setLockInStatus('error');
       setLockInMessage(
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  };
+
+  const runDelete = async (dryRun: boolean) => {
+    setDeleteStatus('loading');
+    setDeleteMessage('');
+    try {
+      const result = await deleteInactiveUsers(dryRun);
+      setDeleteStatus('success');
+      setDeleteMessage(formatDeleteResult(result));
+    } catch (error) {
+      setDeleteStatus('error');
+      setDeleteMessage(
         error instanceof Error ? error.message : 'Unknown error'
       );
     }
@@ -256,6 +284,45 @@ export default function CommandsTab() {
       {lockInStatus === 'error' && lockInMessage && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {lockInMessage}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Delete inactive accounts</h2>
+        <p className={styles.panelSubtitle}>
+          Permanently deletes free accounts that were warned 14+ days ago and
+          have not logged in since. Excludes lifetime and active subscribers.
+          Capped at 100 per run. Check candidates first — deletion cannot be
+          undone.
+        </p>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runDelete(true)}
+            disabled={deleteStatus === 'loading'}
+          >
+            {deleteStatus === 'loading' ? 'Working…' : 'Check candidates'}
+          </button>
+          <button
+            type="button"
+            className={sharedStyles.btnDanger}
+            onClick={() => runDelete(false)}
+            disabled={deleteStatus === 'loading'}
+          >
+            Delete inactive accounts
+          </button>
+        </div>
+      </section>
+
+      {deleteStatus === 'success' && deleteMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {deleteMessage}
+        </div>
+      )}
+      {deleteStatus === 'error' && deleteMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {deleteMessage}
         </div>
       )}
     </>

--- a/web/src/pages/OpsPage/deleteInactiveUsers.test.ts
+++ b/web/src/pages/OpsPage/deleteInactiveUsers.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { deleteInactiveUsers } from './deleteInactiveUsers';
+
+describe('deleteInactiveUsers', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs dryRun true and returns the candidate count', async () => {
+    const payload = { count: 42, dryRun: true };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await deleteInactiveUsers(true);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/delete-inactive-users?dryRun=true',
+      { method: 'POST', credentials: 'include' }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('POSTs dryRun false for a real delete and returns the deleted count', async () => {
+    const payload = { count: 42, dryRun: false };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await deleteInactiveUsers(false);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/delete-inactive-users?dryRun=false',
+      { method: 'POST', credentials: 'include' }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('throws the server message on a non-ok response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () =>
+        Promise.resolve({ message: 'Failed to run inactive user deletion' }),
+    });
+
+    await expect(deleteInactiveUsers(true)).rejects.toThrow(
+      'Failed to run inactive user deletion'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(deleteInactiveUsers(false)).rejects.toThrow('404 Not Found');
+  });
+});

--- a/web/src/pages/OpsPage/deleteInactiveUsers.ts
+++ b/web/src/pages/OpsPage/deleteInactiveUsers.ts
@@ -1,0 +1,20 @@
+export interface DeleteInactiveUsersResponse {
+  count: number;
+  dryRun: boolean;
+}
+
+export async function deleteInactiveUsers(
+  dryRun: boolean
+): Promise<DeleteInactiveUsersResponse> {
+  const response = await fetch(
+    `/api/ops/delete-inactive-users?dryRun=${dryRun}`,
+    { method: 'POST', credentials: 'include' }
+  );
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}

--- a/web/src/pages/OpsPage/sendPriceLockInEmails.test.ts
+++ b/web/src/pages/OpsPage/sendPriceLockInEmails.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { sendPriceLockInEmails } from './sendPriceLockInEmails';
+
+describe('sendPriceLockInEmails', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs dryRun true and returns the segment count', async () => {
+    const payload = { count: 18800, dryRun: true, variantA: 0, variantB: 0 };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await sendPriceLockInEmails(true);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/send-price-lock-in-emails',
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: true }),
+      }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('POSTs dryRun false for a real send and returns the sent count', async () => {
+    const payload = { count: 500, dryRun: false, variantA: 250, variantB: 250 };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await sendPriceLockInEmails(false);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/send-price-lock-in-emails',
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: false }),
+      }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('throws the server message on a non-ok response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () =>
+        Promise.resolve({ message: 'Failed to run price lock-in emails' }),
+    });
+
+    await expect(sendPriceLockInEmails(true)).rejects.toThrow(
+      'Failed to run price lock-in emails'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(sendPriceLockInEmails(false)).rejects.toThrow('404 Not Found');
+  });
+});

--- a/web/src/pages/OpsPage/sendPriceLockInEmails.ts
+++ b/web/src/pages/OpsPage/sendPriceLockInEmails.ts
@@ -1,0 +1,24 @@
+export interface SendPriceLockInEmailsResponse {
+  count: number;
+  dryRun: boolean;
+  variantA: number;
+  variantB: number;
+}
+
+export async function sendPriceLockInEmails(
+  dryRun: boolean
+): Promise<SendPriceLockInEmailsResponse> {
+  const response = await fetch('/api/ops/send-price-lock-in-emails', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dryRun }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## What
Adds two cards to the ops Commands tab (`/ops`, admin-gated), each wired to an already-shipped endpoint:

1. **Price lock-in emails** → `POST /api/ops/send-price-lock-in-emails` — check the segment, then send batches of 500 until the segment is drained.
2. **Delete inactive accounts** → `POST /api/ops/delete-inactive-users` — check candidates, then permanently delete free accounts that ignored the inactivity warning.

## Why
Both endpoints shipped without a UI — running them meant hand-crafting POST requests. This gives ops a two-button affordance per command: a preview action that counts, then the real action.

## How
- `sendPriceLockInEmails.ts` / `deleteInactiveUsers.ts` — client fns; throw the server message on a non-ok response.
- `CommandsTab.tsx` — two new cards.
  - Lock-in: "Check segment" posts `{dryRun:true}`; "Send batch of 500" posts `{dryRun:false}`.
  - Delete: "Check candidates" hits `?dryRun=true` (count only, no deletion); "Delete inactive accounts" hits `?dryRun=false`. The destructive button uses the shared `btnDanger` styling, not the primary `btnSmall`.
- The dry-run/candidate count is the natural confirm step before the real action.
- **Controller-default gotchas, both endpoints:** the lock-in controller defaults an empty body to dry-run (`req.body?.dryRun !== false`), so the real send posts `{dryRun:false}`. The delete controller reads `dryRun` from `req.query` (not body) and defaults to dry-run unless `dryRun=== 'false'`, so the client posts `dryRun` as a **query param**.
- No server change — the delete endpoint already supports `dryRun` server-side (counts candidates, deletes nothing on a dry run); both endpoints, repositories, and the `price-lock-in.html` template already shipped.

## Measuring success
- Lock-in: server emits `email_batch_sent` with `campaign: 'price_lock_in'` and per-variant counts on each real send. The dry-run path records nothing.
- Delete: the result banner shows the deleted count; the server logs each deletion via `[inactivity-delete]`. The dry-run path deletes nothing and returns the candidate count.

## Testing
- `sendPriceLockInEmails.test.ts` — 4 tests, all green.
- `deleteInactiveUsers.test.ts` — POSTs `?dryRun=true/false`, returns the payload, throws the server message on non-ok, falls back to status text. 4 tests, all green.
- No existing `CommandsTab.test.tsx` to mirror.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified with Playwright Chromium against pnpm dev on this branch, logged in as the ops owner: all four command cards render (Stripe sync, Create v2 prices, Price lock-in emails, Delete inactive accounts), both new dry-run buttons exercised live against the local API ("0 recipients in segment, sends nothing" / "0 accounts would be deleted" — empty local DB), delete button carries the shared danger styling, zero console errors.

## Changelog
No entry — admin-only ops surface, not user-visible.

## Risks
Low for the lock-in card (additive, dedupes across calls). The delete card is **destructive**: the real-delete button permanently removes accounts. Mitigations: capped at 100 per run server-side, dry-run candidate preview is the confirm step, the criteria exclude lifetime/active subscribers, and the button carries danger styling. Rollback: revert the PR; both endpoints stay reachable via direct POST.

## Goal alignment
Operational tooling for two retention/hygiene workflows — the price lock-in offer nudges aging free accounts toward paid, and inactive-account deletion keeps the user base honest. Both support the retention work called out in growth analysis.

