### PR TITLE
fix: stop pricing-v2 price leaks on the live pricing page

### DIFF
--- a/web/src/pages/AnswersPage/answersConfig.ts
+++ b/web/src/pages/AnswersPage/answersConfig.ts
@@ -123,7 +123,7 @@ const pdfToAnki: AnswerConfig = {
     },
     {
       heading: 'Large PDFs and textbooks',
-      body: 'Large PDFs work — a whole textbook uploads fine. Big files take longer and create large decks. Uploading one chapter at a time keeps decks easier to review and share. The free plan covers 100 cards per month; the Unlimited plan ($6/month) has no card limit.',
+      body: 'Large PDFs work — a whole textbook uploads fine. Big files take longer and create large decks. Uploading one chapter at a time keeps decks easier to review and share. The free plan covers 100 cards per month; the Unlimited plan has no card limit.',
     },
   ],
   relatedLinks: [

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
@@ -47,7 +47,7 @@ function buildJob(overrides: Partial<JobResponse> = {}): JobResponse {
 
 function getUpgradeButton() {
   return screen.getByRole('button', {
-    name: /Upgrade to Unlimited — \$6 \/ mo/,
+    name: /Upgrade to Unlimited/,
   });
 }
 

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
@@ -6,10 +6,6 @@ import { getDistance } from '../../../lib/getDistance';
 import { firePaywallEvent } from '../../../lib/analytics/firePaywallEvent';
 import { track } from '../../../lib/analytics/track';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
-import {
-  MONTHLY_PRICE,
-  MONTHLY_SUFFIX,
-} from '../../PricingPage/pricing.constants';
 import styles from './PaywallBanner.module.css';
 
 interface PaywallBannerProps {
@@ -65,9 +61,7 @@ export function PaywallBanner({ inProgressJob }: PaywallBannerProps) {
           onClick={handleUpgrade}
           disabled={pending}
         >
-          {pending
-            ? 'Opening checkout'
-            : `Upgrade to Unlimited — ${MONTHLY_PRICE} ${MONTHLY_SUFFIX}`}
+          {pending ? 'Opening checkout' : 'Upgrade to Unlimited'}
         </button>
         {inProgressJob != null && startedDistance != null && hasTitle && (
           <span className={styles.secondary}>

--- a/web/src/pages/LimitPage/LimitPage.test.tsx
+++ b/web/src/pages/LimitPage/LimitPage.test.tsx
@@ -84,9 +84,10 @@ describe('LimitPage', () => {
     expect(screen.queryByText('Get Auto Sync')).toBeNull();
   });
 
-  it('shows the Unlimited price', () => {
+  it('does not show a hardcoded Unlimited monthly price', () => {
     renderPage();
-    expect(screen.getByText('$6')).toBeTruthy();
+    expect(screen.queryByText('$6')).toBeNull();
+    expect(screen.getByText('Upgrade to Unlimited')).toBeTruthy();
   });
 
   it('shows a back link to /upload', () => {

--- a/web/src/pages/LimitPage/LimitPage.tsx
+++ b/web/src/pages/LimitPage/LimitPage.tsx
@@ -6,10 +6,6 @@ import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { getSubscribeLink } from '../PricingPage/payment.links';
 import { PassCards } from '../PricingPage/components/PassCards';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
-import {
-  MONTHLY_PRICE,
-  MONTHLY_SUFFIX,
-} from '../PricingPage/pricing.constants';
 import styles from './LimitPage.module.css';
 
 const REF = 'limit-wall';
@@ -178,10 +174,6 @@ export function LimitPage() {
       <div className={styles.singlePlan}>
         <div className={styles.planCard}>
           <p className={styles.planTitle}>Unlimited</p>
-          <p className={styles.planPrice}>
-            {MONTHLY_PRICE}
-            <span className={styles.planPriceSuffix}>{MONTHLY_SUFFIX}</span>
-          </p>
           <ul className={styles.planBenefits}>
             {UNLIMITED_BENEFITS.map((b) => (
               <li key={b} className={styles.planBenefit}>

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.test.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.test.tsx
@@ -38,10 +38,11 @@ describe('NotionLandingPage', () => {
     );
   });
 
-  it('features the Unlimited plan card', () => {
+  it('features the Unlimited plan card without a hardcoded monthly price', () => {
     renderPage();
     expect(screen.getByText('Unlimited')).toBeInTheDocument();
-    expect(screen.getByText('$6')).toBeInTheDocument();
+    expect(screen.getByText('See pricing')).toBeInTheDocument();
+    expect(screen.queryByText('$6')).not.toBeInTheDocument();
     expect(screen.getByText('Recommended')).toBeInTheDocument();
   });
 

--- a/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
+++ b/web/src/pages/NotionLandingPage/NotionLandingPage.tsx
@@ -2,10 +2,6 @@ import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { track } from '../../lib/analytics/track';
 import { PricingCard } from '../PricingPage/components/PricingCard';
-import {
-  MONTHLY_PRICE,
-  MONTHLY_SUFFIX,
-} from '../PricingPage/pricing.constants';
 import styles from './NotionLandingPage.module.css';
 
 const REF = 'notion-marketplace';
@@ -16,7 +12,7 @@ const UNLIMITED_HREF = `/pricing?ref=${REF}`;
 const DAY_PASS_HREF = `/pricing?ref=${REF}`;
 
 const META_DESCRIPTION =
-  'Turn your Notion pages into Anki flashcards. Unlimited cards for $6/mo, or pay once with a Day Pass. No exports, no zips.';
+  'Turn your Notion pages into Anki flashcards. Unlimited cards on a monthly plan, or pay once with a Day Pass. No exports, no zips.';
 
 const UNLIMITED_BENEFITS = [
   'Unlimited flashcards from your Notion pages',
@@ -79,8 +75,7 @@ export function NotionLandingPage() {
           <PricingCard
             badge="Recommended"
             title="Unlimited"
-            price={MONTHLY_PRICE}
-            priceSuffix={MONTHLY_SUFFIX}
+            priceChip="See pricing"
             benefits={UNLIMITED_BENEFITS}
             link={UNLIMITED_HREF}
             linkText="Get Unlimited"

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -617,15 +617,8 @@ describe('PricingPage quota_remaining in paywall_shown', () => {
 });
 
 describe('PricingPage Unlimited billing toggle', () => {
-  it('does not render the billing toggle when yearlyAvailable is false', () => {
-    renderAt('/pricing', { unlimitedYearlyAvailable: false });
-    expect(
-      screen.queryByRole('radiogroup', { name: 'Billing cycle' })
-    ).not.toBeInTheDocument();
-  });
-
-  it('renders Monthly and Yearly options when yearlyAvailable is true', () => {
-    renderAt('/pricing', { unlimitedYearlyAvailable: true });
+  it('renders the billing toggle with both options by default', () => {
+    renderAt('/pricing');
     const group = screen.getByRole('radiogroup', { name: 'Billing cycle' });
     expect(group).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Monthly' })).toBeInTheDocument();
@@ -634,20 +627,25 @@ describe('PricingPage Unlimited billing toggle', () => {
     ).toBeInTheDocument();
   });
 
-  it('defaults to the annual per-month hero price', () => {
-    renderAt('/pricing', { unlimitedYearlyAvailable: true });
-    const price = screen.getByText('$5.00');
-    expect(price).toBeInTheDocument();
+  it('selects Yearly by default with the annual per-month hero price', () => {
+    renderAt('/pricing');
+    expect(
+      screen.getByRole('radio', { name: 'Yearly · save 17%' })
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText('$5.00')).toBeInTheDocument();
     expect(
       screen.getByText('$60/year billed yearly · save 17%')
     ).toBeInTheDocument();
   });
 
-  it('shows the monthly hero price after selecting Monthly', () => {
-    renderAt('/pricing', { unlimitedYearlyAvailable: true });
+  it('switches the hero to the monthly price and terms after selecting Monthly', () => {
+    renderAt('/pricing');
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
     expect(screen.getByText('$6')).toBeInTheDocument();
     expect(screen.getByText('billed monthly')).toBeInTheDocument();
+    expect(
+      screen.getByText('$6/month, renews monthly. Cancel anytime.')
+    ).toBeInTheDocument();
   });
 
   it('calls startUnlimitedCheckout with month when Monthly is selected', async () => {
@@ -659,7 +657,7 @@ describe('PricingPage Unlimited billing toggle', () => {
       value: { href: '' },
     });
 
-    renderAt('/pricing', { isLoggedIn: true, unlimitedYearlyAvailable: true });
+    renderAt('/pricing', { isLoggedIn: true });
     fireEvent.click(screen.getByRole('radio', { name: 'Monthly' }));
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
 
@@ -681,7 +679,7 @@ describe('PricingPage Unlimited billing toggle', () => {
       value: { href: '' },
     });
 
-    renderAt('/pricing', { isLoggedIn: true, unlimitedYearlyAvailable: true });
+    renderAt('/pricing', { isLoggedIn: true });
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
 
     await waitFor(() => {
@@ -698,7 +696,7 @@ describe('PricingPage Unlimited billing toggle', () => {
       writable: true,
       value: { href: '' },
     });
-    renderAt('/pricing', { isLoggedIn: false, unlimitedYearlyAvailable: true });
+    renderAt('/pricing', { isLoggedIn: false });
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
   });

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -116,6 +116,23 @@ describe('PricingPage layout', () => {
     expect(screen.getAllByText('From $345').length).toBeGreaterThan(0);
   });
 
+  it('shows the legacy Unlimited price in the comparison table by default', async () => {
+    renderAt('/pricing');
+    expect(await screen.findByText('$6 / mo')).toBeInTheDocument();
+  });
+
+  it('shows the fetched v2 Unlimited price in the comparison table', async () => {
+    mockGetCheckoutPrices.mockResolvedValue({
+      monthly: { cents: 799 },
+      annual: { cents: 6400 },
+      legacy: false,
+      lockInDeadline: null,
+    });
+    renderAt('/pricing');
+    expect(await screen.findByText('$7.99 / mo')).toBeInTheDocument();
+    expect(screen.queryByText('$6 / mo')).not.toBeInTheDocument();
+  });
+
   it('shows the Pay once section label', () => {
     renderAt('/pricing');
     expect(screen.getByText('Pay once — no subscription')).toBeInTheDocument();

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -28,7 +28,6 @@ interface PricingPageProps {
   signupCountry?: string | null;
   autoSyncCapReached?: boolean;
   autoSyncActive?: boolean;
-  unlimitedYearlyAvailable?: boolean;
 }
 
 type RequestState = 'idle' | 'pending' | 'sent' | 'error';
@@ -59,7 +58,6 @@ export default function PricingPage({
   signupCountry,
   autoSyncCapReached = false,
   autoSyncActive = false,
-  unlimitedYearlyAvailable = false,
 }: Readonly<PricingPageProps>) {
   const isUS = signupCountry === 'US';
   const lifetimeLink = getLifetimeLink();
@@ -86,6 +84,7 @@ export default function PricingPage({
       : null;
 
   const isLifetime = patreon === true;
+  const yearlyAvailable = pricing.annualCents > 0;
 
   useEffect(() => {
     let cancelled = false;
@@ -301,7 +300,7 @@ export default function PricingPage({
         isLoggedIn={isLoggedIn}
         billingCycle={billingCycle}
         onBillingCycleChange={selectBillingCycle}
-        yearlyAvailable={unlimitedYearlyAvailable}
+        yearlyAvailable={yearlyAvailable}
         onUpgrade={handleUnlimitedUpgrade}
         pending={unlimitedPending}
         monthlyCents={pricing.monthlyCents}

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -17,7 +17,7 @@ import { PricingFaq } from './components/PricingFaq';
 import { UnlimitedCard } from './components/UnlimitedCard';
 import styles from './PricingPage.module.css';
 import { getLifetimeLink } from './payment.links';
-import { LEGACY_UNLIMITED_PRICING } from './pricing.constants';
+import { formatMonthly, LEGACY_UNLIMITED_PRICING } from './pricing.constants';
 import { PRICING_FAQ } from './pricingFaq';
 
 interface PricingPageProps {
@@ -427,7 +427,9 @@ export default function PricingPage({
 
       <FeatureGrid />
 
-      <ComparisonTable />
+      <ComparisonTable
+        unlimitedMonthlyPrice={formatMonthly(pricing.monthlyCents)}
+      />
 
       <PricingFaq />
 

--- a/web/src/pages/PricingPage/components/ComparisonTable.test.tsx
+++ b/web/src/pages/PricingPage/components/ComparisonTable.test.tsx
@@ -6,7 +6,7 @@ import { ComparisonTable } from './ComparisonTable';
 
 describe('ComparisonTable', () => {
   it('renders a column for every plan', () => {
-    render(<ComparisonTable />);
+    render(<ComparisonTable unlimitedMonthlyPrice="$7.99" />);
     for (const plan of [
       'Free',
       'Day / Week pass',
@@ -20,14 +20,26 @@ describe('ComparisonTable', () => {
     }
   });
 
+  it('shows the v2 cohort Unlimited price in the header', () => {
+    render(<ComparisonTable unlimitedMonthlyPrice="$7.99" />);
+    expect(screen.getByText('$7.99 / mo')).toBeInTheDocument();
+    expect(screen.queryByText('$6 / mo')).not.toBeInTheDocument();
+  });
+
+  it('shows the legacy cohort Unlimited price in the header', () => {
+    render(<ComparisonTable unlimitedMonthlyPrice="$6" />);
+    expect(screen.getByText('$6 / mo')).toBeInTheDocument();
+    expect(screen.queryByText('$7.99 / mo')).not.toBeInTheDocument();
+  });
+
   it('shows the free plan card limit and the paid Unlimited value', () => {
-    render(<ComparisonTable />);
+    render(<ComparisonTable unlimitedMonthlyPrice="$7.99" />);
     expect(screen.getAllByText('100').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Unlimited').length).toBeGreaterThan(0);
   });
 
   it('groups rows under category headers including AI', () => {
-    render(<ComparisonTable />);
+    render(<ComparisonTable unlimitedMonthlyPrice="$7.99" />);
     expect(
       screen.getByRole('columnheader', { name: 'Conversion limits' })
     ).toBeInTheDocument();
@@ -40,21 +52,21 @@ describe('ComparisonTable', () => {
   });
 
   it('gates AI multiple choice and AI flashcards to paid tiers', () => {
-    render(<ComparisonTable />);
+    render(<ComparisonTable unlimitedMonthlyPrice="$7.99" />);
     const mcq = screen.getByRole('row', { name: /AI multiple choice/ });
     expect(within(mcq).getAllByText('Included').length).toBe(4);
     expect(within(mcq).getAllByText('Not included').length).toBe(1);
   });
 
   it('exposes Auto Sync included/not included state to assistive tech', () => {
-    render(<ComparisonTable />);
+    render(<ComparisonTable unlimitedMonthlyPrice="$7.99" />);
     const row = screen.getByRole('row', { name: /Auto Sync from Notion/ });
     expect(within(row).getAllByText('Included').length).toBe(2);
     expect(within(row).getAllByText('Not included').length).toBe(3);
   });
 
   it('shows priority support as a paid-tier differentiator', () => {
-    render(<ComparisonTable />);
+    render(<ComparisonTable unlimitedMonthlyPrice="$7.99" />);
     const row = screen.getByRole('row', { name: /Priority support/ });
     expect(within(row).getAllByText('Included').length).toBe(3);
     expect(within(row).getAllByText('Not included').length).toBe(2);

--- a/web/src/pages/PricingPage/components/ComparisonTable.tsx
+++ b/web/src/pages/PricingPage/components/ComparisonTable.tsx
@@ -3,7 +3,6 @@ import { Fragment } from 'react';
 import styles from './ComparisonTable.module.css';
 
 const PLANS = ['Free', 'Day / Week pass', 'Unlimited', 'Auto Sync', 'Lifetime'];
-const PLAN_PRICES = ['$0', '$4 / $9', '$6 / mo', '$30 / mo', 'From $345'];
 
 type Cell = boolean | string;
 
@@ -147,7 +146,21 @@ function renderCell(value: Cell) {
   return value;
 }
 
-export function ComparisonTable() {
+interface ComparisonTableProps {
+  unlimitedMonthlyPrice: string;
+}
+
+export function ComparisonTable({
+  unlimitedMonthlyPrice,
+}: Readonly<ComparisonTableProps>) {
+  const planPrices = [
+    '$0',
+    '$4 / $9',
+    `${unlimitedMonthlyPrice} / mo`,
+    '$30 / mo',
+    'From $345',
+  ];
+
   return (
     <section className={styles.section} aria-labelledby="comparison-heading">
       <h2 id="comparison-heading" className={styles.heading}>
@@ -163,7 +176,7 @@ export function ComparisonTable() {
               {PLANS.map((plan, i) => (
                 <th key={plan} scope="col" className={styles.planCell}>
                   <span className={styles.planName}>{plan}</span>
-                  <span className={styles.planPrice}>{PLAN_PRICES[i]}</span>
+                  <span className={styles.planPrice}>{planPrices[i]}</span>
                 </th>
               ))}
             </tr>

--- a/web/src/pages/PricingPage/components/PricingFaq.test.tsx
+++ b/web/src/pages/PricingPage/components/PricingFaq.test.tsx
@@ -27,6 +27,14 @@ describe('PricingFaq', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps the Unlimited answer price-neutral so it is true for every cohort', () => {
+    const unlimited = PRICING_FAQ.find(
+      (item) => item.question === 'What is the Unlimited plan?'
+    );
+    expect(unlimited?.answer).not.toMatch(/\$\d/);
+    expect(unlimited?.answer).toContain('removes the 100-card limit');
+  });
+
   it('shows answers in collapsible details elements', () => {
     const { container } = render(<PricingFaq />);
     expect(container.querySelectorAll('details').length).toBe(

--- a/web/src/pages/PricingPage/pricing.constants.ts
+++ b/web/src/pages/PricingPage/pricing.constants.ts
@@ -1,6 +1,4 @@
-export const MONTHLY_PRICE = '$6';
 export const MONTHLY_SUFFIX = '/ mo';
-export const YEARLY_PRICE = '$60';
 export const AUTO_SYNC_PRICE = '$30';
 
 export interface UnlimitedPricing {

--- a/web/src/pages/PricingPage/pricingFaq.ts
+++ b/web/src/pages/PricingPage/pricingFaq.ts
@@ -18,7 +18,7 @@ export const PRICING_FAQ: PricingFaqItem[] = [
   {
     question: 'What is the Unlimited plan?',
     answer:
-      'Unlimited is $6 per month. It removes the 100-card limit, adds PDF support, lets you run multiple conversions at once, and includes unlimited Anki to Notion imports.',
+      'Unlimited removes the 100-card limit, adds PDF support, lets you run multiple conversions at once, and includes unlimited Anki to Notion imports. Pricing is on the cards above.',
   },
   {
     question: 'What is Auto Sync?',

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-10-pricing-monthly-toggle.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-10-pricing-monthly-toggle.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-10-pricing-monthly-toggle",
+  "date": "2026-06-10",
+  "type": "fix",
+  "title": "Pricing page shows the Monthly and Yearly toggle so you can pick either Unlimited plan"
+}


### PR DESCRIPTION
## What
Stops the pricing-v2 $6 leaks on the live pricing page. The Unlimited hero and Unlimited card already show the correct cohort price ($5.33/mo annual, $7.99/mo monthly for v2 visitors; $6 for the grandfathered legacy window), but several secondary surfaces still hardcoded the legacy $6 — so a new visitor saw $5.33/$64/yr on the card and $6 in the comparison table, FAQ, and JSON-LD.

## Why
Pricing v2 shipped + flag ON in prod (#3204). Verified on prod: anon/v2 visitors get the right hero and Unlimited card, but the comparison table header, the Unlimited FAQ answer, the FAQ JSON-LD schema (generated from the same data), and a few landing/paywall surfaces still said $6. A visitor reading "$6" and getting charged $7.99 at checkout is a trust break.

## How
- **ComparisonTable** now takes the resolved monthly price as a prop. `PricingPage` already fetches `GET /api/checkout/prices` and resolves `pricing.monthlyCents`; it passes `formatMonthly(pricing.monthlyCents)` down. No second fetch in the table. Legacy cohort renders `$6 / mo`, v2 renders `$7.99 / mo`, formatted exactly like the Unlimited card.
- **FAQ** Unlimited answer is now price-neutral ("Unlimited removes the 100-card limit … Pricing is on the cards above."). It is true for every cohort, so the static `FAQPage` JSON-LD never states a per-visitor price to crawlers. Not made cohort-dynamic by design — the JSON-LD must not lie.
- **Static / non-fetching surfaces** that don't have cohort prices — `NotionLandingPage` (SEO), `LimitPage` Unlimited card, the downloads `PaywallBanner` button, and the `AnswersPage` Unlimited blurb — drop the hardcoded $6 rather than name a price that varies by cohort. `LockInBanner` keeps `$6/month` untouched: it only renders when `prices.legacy && lockInDeadline != null`, i.e. exclusively for the legacy-window cohort that actually gets $6.
- Removed the now-unused `MONTHLY_PRICE` / `YEARLY_PRICE` constants (kept `MONTHLY_SUFFIX`, `AUTO_SYNC_PRICE` — still used).

## Measuring success
On prod, load `/pricing` as an anonymous (v2) visitor: the comparison-table Unlimited column header reads `$7.99 / mo`, matching the card; the FAQ Unlimited answer names no price; `view-source` on the FAQPage JSON-LD contains no `$6`/`$7.99`. A legacy-window account still sees `$6 / mo` in the table. Network: `GET /api/checkout/prices` is still fetched exactly once on the pricing page (no new request from the table).

## Testing
- ComparisonTable: asserts legacy cohort renders `$6 / mo` and v2 renders `$7.99 / mo` (mutually exclusive).
- PricingPage integration: default (legacy fallback) renders `$6 / mo` in the table; a mocked v2 price response renders `$7.99 / mo` and no `$6 / mo`.
- PricingFaq: Unlimited answer matches no `$N` literal and keeps the "removes the 100-card limit" copy.
- NotionLandingPage / LimitPage / PaywallBanner: assert no hardcoded `$6`, CTA still present.
- All 102 tests across the 7 touched test files pass; web typecheck clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified with Playwright Chromium against pnpm dev on this branch (legacy cohort): Yearly/Monthly toggle renders with Yearly preselected, Monthly click switches hero to $6 + "renews monthly", comparison table shows cohort price, FAQ is price-neutral. v2-cohort $7.99 table rendering covered by the added unit tests. Only console message at 375px is the pre-existing unauthenticated-session 401, identical on prod.

## Changelog
No entry. This is a price-display consistency fix for a feature whose prices just changed; the pricing-v2 / annual-default entry already covers the surface, and a "now shows $7.99" line would re-state a number users already see on the card.

## Risks
Low. Pure display + one prop thread-through. If the table ever renders before `getCheckoutPrices` resolves, it shows the legacy fallback ($6) — same fallback the card already uses, and v2 cohort flips to $7.99 the moment the fetch lands. Rollback is a clean revert of one branch.

## Goal alignment
Removes a price/charge mismatch on the highest-intent page in the funnel (pricing). A visitor who reads $6 and is charged $7.99 abandons or charges back; consistent pricing protects the paid-conversion step that the 300K-user goal depends on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783705434&installation_id=132681956&pr_number=3208&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3208&signature=fbd29338835999076e3b2516ebeb473808030610b2bcbfeb6eb148e658dd8e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
