### PR TITLE
fix: inline Monaco workers to fix /templates cross-origin error

### DIFF
--- a/web/src/pages/TemplatesPage/components/CodeEditor/CodeEditor.tsx
+++ b/web/src/pages/TemplatesPage/components/CodeEditor/CodeEditor.tsx
@@ -8,13 +8,13 @@ const MonacoEditor = lazy(async () => {
   ]);
 
   const editorWorker = (
-    await import('monaco-editor/esm/vs/editor/editor.worker?worker')
+    await import('monaco-editor/esm/vs/editor/editor.worker?worker&inline')
   ).default;
   const cssWorker = (
-    await import('monaco-editor/esm/vs/language/css/css.worker?worker')
+    await import('monaco-editor/esm/vs/language/css/css.worker?worker&inline')
   ).default;
   const htmlWorker = (
-    await import('monaco-editor/esm/vs/language/html/html.worker?worker')
+    await import('monaco-editor/esm/vs/language/html/html.worker?worker&inline')
   ).default;
 
   (globalThis as unknown as { MonacoEnvironment: object }).MonacoEnvironment = {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-10-template-editor-syntax.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-10-template-editor-syntax.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-10-template-editor-syntax",
+  "date": "2026-06-10",
+  "type": "fix",
+  "title": "Template editor code hints and syntax highlighting work again"
+}


### PR DESCRIPTION
## What
Switches the three Monaco worker imports in the template editor (`CodeEditor.tsx`) from Vite `?worker` to `?worker&inline`, so each worker is constructed from a same-origin Blob URL instead of a CDN-origin script URL.

## Why
Prod (3 occurrences, all `/templates`): `SecurityError: Failed to construct 'Worker': Script at 'https://2anki-assets.fra1.cdn.digitaloceanspaces.com/assets/css.worker-….js' cannot be accessed from origin 'https://2anki.net'`. Built assets are served from a CDN origin; browsers forbid constructing a classic Worker from a cross-origin script. Typing in the editor worked, but every Monaco language feature (hover, highlight, completion) silently died for every `/templates` user as soon as it tried to spawn a worker.

## How
`?worker&inline` makes Vite emit each worker chunk as a same-origin Blob-URL trampoline — the emitted module builds a `Blob` from the worker source and constructs `new Worker(URL.createObjectURL(blob))` (with a `data:text/javascript` fallback), instead of `new Worker(new URL("…cdn…/css.worker.js"))`. The Worker is now always same-origin regardless of where the JS is hosted.

Lazy-load confirmed intact: the entry chunk (`index-*.js`) references neither Monaco nor any worker; the workers live inside the dynamically imported Monaco chunk loaded only when `/templates` mounts the editor.

## Measuring success
The `SecurityError: Failed to construct 'Worker'` events on `/templates` in error tracking should drop to zero after deploy. No new log line added — absence of the existing error is the signal.

## Testing
- Existing `EditorPage.test.tsx` (mocks `CodeEditor`) — 14 pass.
- `WhatsNewPage` suite — 7 pass (changelog loader asserts id uniqueness).
- Web typecheck clean.
- `pnpm --filter 2anki-web build`: verified the emitted `css.worker` / `html.worker` / `editor.worker` chunks now wrap the source in a `Blob` + `createObjectURL` constructor (inline shape) rather than a `new URL(...worker.js)` file reference. No unit test added — the change is bundler behavior; a query-string assertion would test Vite, not the product. Build inspection is the real proof.

Chunk-size delta (inline wrapper only): css.worker +1.74 kB, html.worker +2.96 kB, editor.worker unchanged — ~7 kB total across the three worker chunks. No chunk approaches the 5 MB inline-fallback threshold; the 6.9 MB `ts.worker` is Monaco's own loader bundle, untouched and not on the `/templates` path.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified /templates loads cleanly on this branch at desktop + 375px (Playwright Chromium). Console shows only the pre-existing anonymous auth probes (401/403), identical in kind to prod. The CORS bug itself cannot reproduce on localhost (same-origin); the fix is verified at the build level — emitted worker chunk constructs a same-origin Blob worker.

## Risks
Low. `?worker&inline` is the standard Vite answer for this exact CDN/cross-origin worker problem. The blob path has a `data:` URL fallback built in. Rollback = revert the one-line-per-import query change. Build verified the inline shape is emitted.

## Goal alignment
Templates are part of the "beautiful Anki flashcards" promise — broken syntax highlighting and code hints make the template editor feel unfinished for every `/templates` user. Restoring language smarts keeps a paid-adjacent power feature working, supporting retention toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783707826&installation_id=132681956&pr_number=3213&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3213&signature=ce24ea0159d000a1c4f603b3e958b6d67adf16e2fc429a1ff6f0875ed1c70b12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
