### PR TITLE
fix: stop translation extensions crashing the upload flow

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -167,6 +167,30 @@ describe('DownloadsPage paywall query param', () => {
   });
 });
 
+describe('DownloadsPage translation safety', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    mockJobs = [buildJob()];
+    mockUploads = [];
+    mockDropboxUploads = [];
+    mockGoogleDriveUploads = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as AnalyticsGlobals).hj;
+    delete (globalThis as AnalyticsGlobals).gtag;
+  });
+
+  it('opts the polling job rows out of browser translation', () => {
+    const { container } = renderAt('/downloads');
+    expect(container.querySelector('tbody')).toHaveAttribute('translate', 'no');
+  });
+});
+
 describe('DownloadsPage empty state', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -491,7 +491,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                         </th>
                       </tr>
                     </thead>
-                    <tbody>
+                    <tbody translate="no">
                       {filteredRows.length === 0 && (
                         <tr>
                           <td

--- a/web/src/pages/UploadPage/components/RecentSources/RecentSources.test.tsx
+++ b/web/src/pages/UploadPage/components/RecentSources/RecentSources.test.tsx
@@ -71,6 +71,20 @@ describe('RecentSources', () => {
     expect(links[0]).toHaveAttribute('href', '/preview/a');
   });
 
+  it('opts the recent list out of browser translation', async () => {
+    getRecentSourcesMock.mockResolvedValue([
+      source({ id: 'a', title: 'Anatomy', convertUrl: '/preview/a' }),
+    ]);
+
+    const { container } = renderRecentSources();
+
+    await screen.findByText('Anatomy');
+    expect(container.querySelector('section')).toHaveAttribute(
+      'translate',
+      'no'
+    );
+  });
+
   it('fires recent_page_reconvert_clicked with the source type on click', async () => {
     getRecentSourcesMock.mockResolvedValue([
       source({ id: 'a', type: 'remote_upload', convertUrl: '/preview/apkg/a' }),

--- a/web/src/pages/UploadPage/components/RecentSources/RecentSources.tsx
+++ b/web/src/pages/UploadPage/components/RecentSources/RecentSources.tsx
@@ -41,7 +41,7 @@ export function RecentSources() {
   }
 
   return (
-    <section className={styles.section} aria-label="Recent">
+    <section className={styles.section} aria-label="Recent" translate="no">
       <h2 className={styles.heading}>Recent</h2>
       <ul className={styles.list}>
         {sources.map((source) => (

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -69,6 +69,16 @@ describe('UploadForm', () => {
     expect(container.querySelector('.null')).toBeNull();
   });
 
+  test('opts the drop zone out of browser translation', () => {
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
+    expect(container.querySelector('#upload-panel-local')).toHaveAttribute(
+      'translate',
+      'no'
+    );
+  });
+
   test('renders the Google Drive chip enabled when env vars are configured', () => {
     const previousClient = process.env.REACT_APP_GOOGLE_CLIENT_ID;
     const previousKey = process.env.REACT_APP_GOOGLE_API_KEY;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1474,6 +1474,7 @@ function UploadForm({
       <label
         htmlFor="pakker"
         id="upload-panel-local"
+        translate="no"
         className={`${zoneClassName} ${showLocalPanel ? '' : formStyles.panelHidden}`}
         aria-hidden={!showLocalPanel}
       >

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-10-upload-translate-crash.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-10-upload-translate-crash.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-10-upload-translate-crash",
+  "date": "2026-06-10",
+  "type": "fix",
+  "title": "Upload and downloads pages keep working while your browser auto-translates them"
+}


### PR DESCRIPTION
## What
Marks the high-churn, polling-driven regions of `/upload` and `/downloads` with `translate="no"` so browser translation extensions (Google Translate and friends) stop crashing them.

## Why
Production error tracking shows ~40 occurrences (May 31–Jun 7) of `NotFoundError: Failed to execute 'insertBefore' on 'Node'` from the minified React commit phase, all on `/upload`, anonymous Chrome/Windows. This is the well-known React-vs-translator failure mode: the extension rewrites text nodes and wraps them in `<font>` tags, then React's reconciler calls `insertBefore` against a node the extension has moved and throws — blanking the page. Not a logic bug in our code; a DOM-ownership conflict on the regions that re-render most.

User-visible outcome: the upload flow and the downloads job list keep working while a learner has their browser auto-translating the page.

## How
`translate="no"` on the minimal set of containers whose children churn on polling/state data — the browser leaves their subtree alone while React owns it. Static marketing copy (headings, "How it works", footnotes) stays translatable:
- `RecentSources` list `<section>` on `/upload` (re-renders on the recent-sources query)
- the upload drop-zone `<label>` on `/upload` (swaps between converting / success / error content, with an animated progress bar)
- the polling job-rows `<tbody>` on `/downloads` (re-renders every ~3s as job statuses advance)

`RootErrorBoundary` already wraps `<App />`, catches a render-phase crash on these routes via `getDerivedStateFromError`, and renders a "Something went wrong" card with Reload + Reset local data. No boundary change needed — this PR narrows the trigger rather than leaning on recovery.

## Measuring success
The `insertBefore` `NotFoundError` rate on `/upload` (and `/downloads`) in the client error tracker should drop toward zero over the days after deploy. Baseline: ~40 occurrences in the May 31–Jun 7 window. The boundary's `reportClientError` path stays in place as the catch-all if any residual churn region surfaces.

## Testing
- Unit tests added (Vitest):
  - `RecentSources` renders its list section with `translate="no"`
  - `UploadForm` renders the drop zone (`#upload-panel-local`) with `translate="no"`
  - `DownloadsPage` renders the job-rows `<tbody>` with `translate="no"`
- TDD verified: stripped the attributes, watched exactly these 3 tests fail for the right reason, restored, green.
- `pnpm typecheck` clean; 92/92 in the three touched suites; changelog loader green.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified on this branch with Playwright Chromium: /upload renders the drop-zone with translate="no" in the DOM (RecentSources/DownloadsPage variants render with data, covered by the suite's attribute tests), desktop + 375px. Console shows only the pre-existing anonymous auth probe (403), same as prod. The crash itself needs a translating extension; this narrows the trigger and the site-wide boundary already recovers.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-10-upload-translate-crash.json` — "Upload and downloads pages keep working while your browser auto-translates them"

## Risks
Very low. `translate="no"` is a standard HTML attribute (React 19 types it on every element); it only suppresses browser translation inside the marked subtree, no runtime behavior change. If translation of those specific regions is ever wanted, removing the attribute reverts it. No Sonar-relevant logic added.

## Goal alignment
Removes a hard crash on the core upload path for anonymous, non-English-default users — exactly the international, EU-leaning audience the product targets. A blank `/upload` is a dead conversion and a lost signup; keeping the page alive under auto-translate protects top-of-funnel activation on the way to 300K users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783707984&installation_id=132681956&pr_number=3214&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3214&signature=52adda6ffd8883b91448bda7c30df2af3e52b3bf3135f46bcca683cb3e9d9a7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
