### PR TITLE
fix: isolate deleted users in lock-in email batch

### DIFF
--- a/src/data_layer/PriceLockInEmailRepository.ts
+++ b/src/data_layer/PriceLockInEmailRepository.ts
@@ -126,9 +126,14 @@ export class InMemoryPriceLockInEmailRepository implements IPriceLockInEmailRepo
     variant: PriceLockInVariant;
   }> = [];
   private nextId = 1;
+  private readonly recordSendFailures = new Map<number, unknown>();
 
   seedUsers(users: PriceLockInRecipient[]): void {
     this.usersToReturn = users;
+  }
+
+  failRecordSendFor(userId: number, error: unknown): void {
+    this.recordSendFailures.set(userId, error);
   }
 
   async getUsersToNotify(limit = 500): Promise<PriceLockInRecipient[]> {
@@ -146,6 +151,10 @@ export class InMemoryPriceLockInEmailRepository implements IPriceLockInEmailRepo
     token: string,
     variant: PriceLockInVariant
   ): Promise<void> {
+    const failure = this.recordSendFailures.get(userId);
+    if (failure != null) {
+      throw failure;
+    }
     const id = this.nextId++;
     this.emails.push({ id, userId, token, variant });
     this.sentUserIds.add(userId);
@@ -170,6 +179,7 @@ export class InMemoryPriceLockInEmailRepository implements IPriceLockInEmailRepo
     this.sentUserIds.clear();
     this.emails = [];
     this.nextId = 1;
+    this.recordSendFailures.clear();
   }
 }
 

--- a/src/usecases/ops/SendPriceLockInEmailsUseCase.test.ts
+++ b/src/usecases/ops/SendPriceLockInEmailsUseCase.test.ts
@@ -42,6 +42,7 @@ describe('SendPriceLockInEmailsUseCase', () => {
 
     expect(result).toEqual({
       count: 2,
+      skipped: 0,
       dryRun: true,
       variantA: 0,
       variantB: 0,
@@ -141,7 +142,57 @@ describe('SendPriceLockInEmailsUseCase', () => {
     const result = await useCase.execute(false);
 
     expect(result.count).toBe(0);
+    expect(result.skipped).toBe(0);
     expect(repo.getSentEmails()).toHaveLength(1);
     expect(await repo.getUsersToNotify()).toHaveLength(0);
+  });
+
+  it('skips a user deleted mid-batch and finishes the rest', async () => {
+    const repo = new InMemoryPriceLockInEmailRepository();
+    repo.seedUsers([
+      { id: 2, email: 'a@example.com' },
+      { id: 643, email: 'gone@example.com' },
+      { id: 4, email: 'c@example.com' },
+    ]);
+    const fkError = Object.assign(
+      new Error('insert violates foreign key constraint'),
+      { code: '23503' }
+    );
+    repo.failRecordSendFor(643, fkError);
+    const { service, sent } = buildEmailService();
+    const { sink, events } = buildSink();
+    const useCase = new SendPriceLockInEmailsUseCase(repo, service, sink);
+
+    const result = await useCase.execute(false);
+
+    expect(result.count).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(sent.map((s) => s.to).sort()).toEqual([
+      'a@example.com',
+      'c@example.com',
+    ]);
+    expect(events[0]).toMatchObject({
+      props: { count: 2 },
+    });
+  });
+
+  it('rethrows when every user fails for a non-FK reason', async () => {
+    const repo = new InMemoryPriceLockInEmailRepository();
+    repo.seedUsers([
+      { id: 2, email: 'a@example.com' },
+      { id: 4, email: 'b@example.com' },
+    ]);
+    const dbDown = Object.assign(new Error('connection terminated'), {
+      code: '08006',
+    });
+    repo.failRecordSendFor(2, dbDown);
+    repo.failRecordSendFor(4, dbDown);
+    const { service } = buildEmailService();
+    const { sink } = buildSink();
+    const useCase = new SendPriceLockInEmailsUseCase(repo, service, sink);
+
+    await expect(useCase.execute(false)).rejects.toThrow(
+      'connection terminated'
+    );
   });
 });

--- a/src/usecases/ops/SendPriceLockInEmailsUseCase.ts
+++ b/src/usecases/ops/SendPriceLockInEmailsUseCase.ts
@@ -7,13 +7,20 @@ import type { EventsSink } from '../../services/events/EventsSink';
 
 export interface SendPriceLockInEmailsResult {
   count: number;
+  skipped: number;
   dryRun: boolean;
   variantA: number;
   variantB: number;
 }
 
+const FOREIGN_KEY_VIOLATION = '23503';
+
 function variantForUser(userId: number): PriceLockInVariant {
   return userId % 2 === 0 ? 'a' : 'b';
+}
+
+function isUserGoneError(error: unknown): boolean {
+  return (error as { code?: string })?.code === FOREIGN_KEY_VIOLATION;
 }
 
 export class SendPriceLockInEmailsUseCase {
@@ -29,17 +36,26 @@ export class SendPriceLockInEmailsUseCase {
   ): Promise<SendPriceLockInEmailsResult> {
     if (dryRun) {
       const count = await this.repo.countUsersToNotify();
-      return { count, dryRun: true, variantA: 0, variantB: 0 };
+      return { count, skipped: 0, dryRun: true, variantA: 0, variantB: 0 };
     }
 
     const users = await this.repo.getUsersToNotify(limit);
 
     let variantA = 0;
     let variantB = 0;
+    let skipped = 0;
+    let firstError: unknown;
     for (const user of users) {
       const variant = variantForUser(user.id);
       const token = crypto.randomUUID();
-      await this.repo.recordSend(user.id, token, variant);
+      try {
+        await this.repo.recordSend(user.id, token, variant);
+      } catch (error) {
+        firstError ??= error;
+        skipped++;
+        console.error(`[price-lock-in] skipped user ${user.id}:`, error);
+        continue;
+      }
       try {
         await this.emailService.sendPriceLockInEmail(
           user.email,
@@ -60,16 +76,21 @@ export class SendPriceLockInEmailsUseCase {
     }
 
     const count = variantA + variantB;
+    if (count === 0 && skipped > 0 && !isUserGoneError(firstError)) {
+      throw firstError;
+    }
+
     this.eventsSink?.record({
       name: 'email_batch_sent',
       props: {
         campaign: 'price_lock_in',
         count,
+        skipped,
         variant_a: variantA,
         variant_b: variantB,
       },
     });
 
-    return { count, dryRun: false, variantA, variantB };
+    return { count, skipped, dryRun: false, variantA, variantB };
   }
 }

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -29,6 +29,11 @@ function formatLockInResult(result: SendPriceLockInEmailsResponse): string {
   if (result.dryRun) {
     return `${result.count} recipient${result.count === 1 ? '' : 's'} in segment, sends nothing.`;
   }
+  if (result.skipped > 0) {
+    return `Sent ${result.count}, skipped ${result.skipped} deleted account${
+      result.skipped === 1 ? '' : 's'
+    }; click again for the next batch.`;
+  }
   return `Sent ${result.count}; click again for the next batch.`;
 }
 

--- a/web/src/pages/OpsPage/sendPriceLockInEmails.test.ts
+++ b/web/src/pages/OpsPage/sendPriceLockInEmails.test.ts
@@ -15,7 +15,13 @@ describe('sendPriceLockInEmails', () => {
   });
 
   test('POSTs dryRun true and returns the segment count', async () => {
-    const payload = { count: 18800, dryRun: true, variantA: 0, variantB: 0 };
+    const payload = {
+      count: 18800,
+      skipped: 0,
+      dryRun: true,
+      variantA: 0,
+      variantB: 0,
+    };
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,
@@ -38,7 +44,13 @@ describe('sendPriceLockInEmails', () => {
   });
 
   test('POSTs dryRun false for a real send and returns the sent count', async () => {
-    const payload = { count: 500, dryRun: false, variantA: 250, variantB: 250 };
+    const payload = {
+      count: 480,
+      skipped: 20,
+      dryRun: false,
+      variantA: 240,
+      variantB: 240,
+    };
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       status: 200,

--- a/web/src/pages/OpsPage/sendPriceLockInEmails.ts
+++ b/web/src/pages/OpsPage/sendPriceLockInEmails.ts
@@ -1,5 +1,6 @@
 export interface SendPriceLockInEmailsResponse {
   count: number;
+  skipped: number;
   dryRun: boolean;
   variantA: number;
   variantB: number;


### PR DESCRIPTION
## What
Per-recipient isolation in the price lock-in email batch so a recipient deleted mid-flight can no longer abort the whole batch.

## Why
Prod incident (today 18:19 UTC): an ops "Delete inactive accounts" run fired one second before a "Send batch of 500" lock-in batch that had already selected its recipients. `recordSend` for the just-deleted user hit the FK constraint `price_lock_in_emails_user_id_foreign` (`Key user_id=643 not present`) and the entire batch aborted with a 500, dropping the remaining ~hundreds of sends. No data damage — but one vanished user killed the batch.

## How
Each recipient's `recordSend` is now wrapped in its own try/catch. On a Postgres FK violation (`23503`) the user is skipped, counted, and the loop continues. The result shape gains `skipped: number`, threaded through the unchanged pass-through `OpsController` and rendered in the ops banner (`Sent 480, skipped 20 deleted accounts`). The email-send failure path stays non-fatal as before (logged, send still recorded). Systemic failures still abort: when `count === 0`, `skipped > 0`, and the first error is not an FK violation (e.g. DB down), the error is rethrown so the endpoint returns its 500 instead of silently reporting zero.

## Measuring success
- Log line `[price-lock-in] skipped user <id>:` fires once per vanished recipient instead of the batch 500ing.
- `email_batch_sent` event now carries `skipped` alongside `count`/`variant_a`/`variant_b` — query for non-zero `props.skipped` to see deleted-mid-batch occurrences.
- The ops banner shows the skipped count after a real send.

## Testing
- Jest (`SendPriceLockInEmailsUseCase.test.ts`): recipient deleted mid-batch (repo `recordSend` throws FK `23503` for one user) → batch continues, `{ count: 2, skipped: 1 }`, the two survivors emailed; all-fail-with-non-FK case rethrows; existing send-throws and dry-run tests updated for `skipped`.
- Vitest (`sendPriceLockInEmails.test.ts`): response payloads updated to the new shape including `skipped`.
- Server `tsc -p .`, web `typecheck`, web vitest (1820) all green; oxfmt + oxlint clean on touched files.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified on this branch with Playwright Chromium, logged in as the ops owner: /ops/commands renders, Check segment returns the dry-run banner ("0 recipients in segment, sends nothing" — empty local DB), zero console errors. Skip-mid-batch behavior covered by the 8 jest tests (FK-vanished user → sent n-1, skipped 1).

## Changelog
No entry — admin-only `/ops` tooling, not user-visible.

## Risks
Low. The only behavior change for a healthy batch is the added `skipped: 0` field. The rethrow heuristic could in theory mask a partial systemic failure where some recipients succeeded and others failed for a non-FK reason, but in that case the batch is making progress and a retry picks up the rest — the heuristic only rethrows when zero sends succeeded.

## Goal alignment
Keeps the price lock-in retention campaign reliable — a single deleted account no longer silently kills hundreds of conversion-protecting emails, supporting the paid-retention side of the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783708247&installation_id=132681956&pr_number=3215&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3215&signature=42d76bb5d0ea5acef02136e736aab7be927c3f69300f33bf4103917f6ec0425b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Sonar
Local sonar-scanner not run — no SONAR_TOKEN configured on this box. SonarCloud automatic analysis runs on the PR. Change is small; self-checked for the local-invisible smells (no nested ternary, positive-first `if`, narrowing matches the repo's `as { code?: string }` pg-error pattern).
