### PR TITLE
fix: track anonymous upgrade clicks on pricing page

### DIFF
--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -536,6 +536,146 @@ describe('PricingPage internal event tracking', () => {
       });
     });
   });
+
+  it('fires paywall_upgrade_clicked exactly once for a logged-in Auto Sync click', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    mockStartAutoSyncCheckout.mockResolvedValue({
+      url: 'https://checkout.stripe.com/session',
+    });
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+
+    renderAt('/pricing', { isLoggedIn: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Get Auto Sync' }));
+
+    await waitFor(() => {
+      expect(globalThis.location.href).toBe(
+        'https://checkout.stripe.com/session'
+      );
+    });
+    expect(
+      trackMock.mock.calls.filter(
+        ([event]) => event === 'paywall_upgrade_clicked'
+      )
+    ).toHaveLength(1);
+  });
+});
+
+describe('PricingPage anonymous upgrade-click tracking', () => {
+  beforeEach(() => {
+    mockUseCardUsage.mockReturnValue(null);
+  });
+
+  it('tracks paywall_upgrade_clicked then redirects to login for an anonymous Auto Sync click', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    mockStartAutoSyncCheckout.mockClear();
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+
+    renderAt('/pricing', { isLoggedIn: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Get Auto Sync' }));
+
+    expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+      surface: 'pricing_page',
+      plan: 'auto_sync',
+      variant: 'passes-first',
+    });
+    expect(globalThis.location.href).toBe('/login?redirect=/pricing');
+    expect(mockStartAutoSyncCheckout).not.toHaveBeenCalled();
+  });
+
+  it('tracks paywall_upgrade_clicked then redirects to login for an anonymous Day Pass click', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    mockStartPassCheckout.mockClear();
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+
+    renderAt('/pricing', { isLoggedIn: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Get Day Pass' }));
+
+    expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+      surface: 'pricing_page',
+      plan: 'day_pass',
+      variant: 'passes-first',
+    });
+    expect(globalThis.location.href).toBe('/login?redirect=/pricing');
+    expect(mockStartPassCheckout).not.toHaveBeenCalled();
+  });
+
+  it('tracks paywall_upgrade_clicked then redirects to login for an anonymous Week Pass click', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    mockStartPassCheckout.mockClear();
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+
+    renderAt('/pricing', { isLoggedIn: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Get Week Pass' }));
+
+    expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+      surface: 'pricing_page',
+      plan: 'week_pass',
+      variant: 'passes-first',
+    });
+    expect(globalThis.location.href).toBe('/login?redirect=/pricing');
+    expect(mockStartPassCheckout).not.toHaveBeenCalled();
+  });
+
+  it('tracks paywall_upgrade_clicked then redirects to login for an anonymous Unlimited click', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    mockStartUnlimitedCheckout.mockClear();
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+
+    renderAt('/pricing', { isLoggedIn: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
+
+    expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+      surface: 'pricing_page',
+      plan: 'unlimited',
+      variant: 'passes-first',
+    });
+    expect(globalThis.location.href).toBe('/login?redirect=/pricing');
+    expect(mockStartUnlimitedCheckout).not.toHaveBeenCalled();
+  });
+
+  it('fires paywall_upgrade_clicked exactly once for an anonymous Auto Sync click', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    Object.defineProperty(globalThis, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+
+    renderAt('/pricing', { isLoggedIn: false });
+    fireEvent.click(screen.getByRole('button', { name: 'Get Auto Sync' }));
+
+    expect(
+      trackMock.mock.calls.filter(
+        ([event]) => event === 'paywall_upgrade_clicked'
+      )
+    ).toHaveLength(1);
+  });
 });
 
 describe('PricingPage pricing_left telemetry', () => {

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -164,15 +164,15 @@ export default function PricingPage({
   };
 
   const handleAutoSyncSubscribe = async () => {
-    if (!isLoggedIn) {
-      globalThis.location.href = '/login?redirect=/pricing';
-      return;
-    }
     track('paywall_upgrade_clicked', {
       surface: 'pricing_page',
       plan: 'auto_sync',
       variant: pricingOrder,
     });
+    if (!isLoggedIn) {
+      globalThis.location.href = '/login?redirect=/pricing';
+      return;
+    }
     setSubscribeError(null);
     const result = await get2ankiApi().startAutoSyncCheckout(
       pricingOrder,
@@ -196,15 +196,15 @@ export default function PricingPage({
   };
 
   const handlePassCheckout = async (kind: '24h' | '7d') => {
-    if (!isLoggedIn) {
-      globalThis.location.href = '/login?redirect=/pricing';
-      return;
-    }
     track('paywall_upgrade_clicked', {
       surface: 'pricing_page',
       plan: kind === '24h' ? 'day_pass' : 'week_pass',
       variant: pricingOrder,
     });
+    if (!isLoggedIn) {
+      globalThis.location.href = '/login?redirect=/pricing';
+      return;
+    }
     if (kind === '24h') {
       setDayPassState('pending');
     } else {
@@ -227,15 +227,15 @@ export default function PricingPage({
   };
 
   const handleUnlimitedUpgrade = async () => {
-    if (!isLoggedIn) {
-      globalThis.location.href = '/login?redirect=/pricing';
-      return;
-    }
     track('paywall_upgrade_clicked', {
       surface: 'pricing_page',
       plan: 'unlimited',
       variant: pricingOrder,
     });
+    if (!isLoggedIn) {
+      globalThis.location.href = '/login?redirect=/pricing';
+      return;
+    }
     setUnlimitedError(false);
     setUnlimitedPending(true);
     const result = await get2ankiApi().startUnlimitedCheckout(


### PR DESCRIPTION
## What
Fires `track('paywall_upgrade_clicked', …)` before the login gate in all three pricing-page upgrade handlers (Auto Sync, Day/Week Pass, Unlimited), so clicks from logged-out visitors are recorded.

## Why
All three handlers gated on `isLoggedIn` and redirected to `/login` *before* calling `track()`, so anonymous upgrade clicks never reached the events table. The Pricing A/B dashboard counted anonymous paywall *views* but showed anonymous *clicks* as a flat zero — a false zero that hid the top-of-funnel intent signal for over a thousand logged-out visitors.

## How
Moved the `track('paywall_upgrade_clicked')` call above the `if (!isLoggedIn)` gate in `handleAutoSyncSubscribe`, `handlePassCheckout`, and `handleUnlimitedUpgrade`. The events table already keys anonymous events on `anonymous_id` via cookie, so the move is enough to record them. Each handler fires the event exactly once per click for both cohorts; the logged-in checkout path is otherwise unchanged. Touched only the three handlers and their tests — kept clear of the header/variant region that `refactor/conclude-pricing-ab-minimal` is changing.

## Measuring success
In the Pricing A/B dashboard / events table, `paywall_upgrade_clicked` rows now appear with an `anonymous_id` and no `user_id`. Confirm the anon-click count for `surface = 'pricing_page'` moves off zero within a day of deploy, and that the anon click/view ratio becomes non-null.

## Testing
- Unit tests added (vitest, `PricingPage.test.tsx`):
  - anon Auto Sync / Day Pass / Week Pass / Unlimited click each fires `paywall_upgrade_clicked` with the right `plan`, then redirects to `/login`, and does NOT call the checkout API
  - `paywall_upgrade_clicked` fires exactly once per click for both the anon cohort and the logged-in cohort (no double-fire)
- Full `PricingPage.test.tsx` suite green (57 passed).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified live on this branch with Playwright Chromium: anonymous click on Get Unlimited fires exactly one paywall_upgrade_clicked POST (props: surface=pricing_page, plan=unlimited, variant=minimal) and then redirects to /login?redirect=/pricing. Only console messages are the pre-existing anonymous auth probes (401/403), identical on prod.

## Changelog
No entry — telemetry-only fix. Users see no change in behavior; only the internal Pricing A/B analytics gain the previously-missing anonymous click data.

## Risks
Low. The only behavioral change is one extra analytics call on the logged-out path before the existing redirect; the redirect and checkout flows are unchanged. Rollback is reverting the single commit.

## Goal alignment
Restores the anonymous top-of-funnel click signal on `/pricing`, which the Pricing A/B test relies on to pick the variant that converts logged-out visitors to signups and paid plans — directly informing the conversion work toward the 300K-user goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783711395&installation_id=132681956&pr_number=3218&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3218&signature=6fc70ed2a0524ce0eab1d94b90698371368e5f5dbaf51719e69fc3b0dbf1b9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
