### PR TITLE
fix: align anon click-tracking tests with the minimal default

### DIFF
--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -579,7 +579,7 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
     expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
       surface: 'pricing_page',
       plan: 'auto_sync',
-      variant: 'passes-first',
+      variant: 'minimal',
     });
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
     expect(mockStartAutoSyncCheckout).not.toHaveBeenCalled();
@@ -601,7 +601,7 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
     expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
       surface: 'pricing_page',
       plan: 'day_pass',
-      variant: 'passes-first',
+      variant: 'minimal',
     });
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
     expect(mockStartPassCheckout).not.toHaveBeenCalled();
@@ -623,7 +623,7 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
     expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
       surface: 'pricing_page',
       plan: 'week_pass',
-      variant: 'passes-first',
+      variant: 'minimal',
     });
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
     expect(mockStartPassCheckout).not.toHaveBeenCalled();
@@ -645,7 +645,7 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
     expect(trackMock).toHaveBeenCalledWith('paywall_upgrade_clicked', {
       surface: 'pricing_page',
       plan: 'unlimited',
-      variant: 'passes-first',
+      variant: 'minimal',
     });
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
     expect(mockStartUnlimitedCheckout).not.toHaveBeenCalled();


### PR DESCRIPTION
Main's web test job is red after #3217 and #3218 merged: both touched PricingPage.test.tsx and were green in isolation, but #3217 flipped the variant mock default to `minimal` while #3218's four new anonymous-click tests still asserted `variant: 'passes-first'`. Combined on main, the assertions mismatch.

Four assertion updates, no source change. Full PricingPage suite green locally (56/56).

No changelog entry — test-only.

Browser check: not applicable — test-only change, no rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783713843&installation_id=132681956&pr_number=3219&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3219&signature=09905b3d6b82a47cdc153a1100f591e3a43c7af74994494a56504c5f53f8946b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->