### PR TITLE
chore: point CLAUDE.md and the funnel analyst at MRR

### DIFF
--- a/.claude/agents/conversion-funnel-analyst.md
+++ b/.claude/agents/conversion-funnel-analyst.md
@@ -1,6 +1,6 @@
 ---
 name: conversion-funnel-analyst
-description: Read-only analyst that pulls funnel metrics (signups → first upload → first download → paid) week-over-week and names the biggest leak. Use weekly or before any prioritization decision.
+description: Read-only analyst that pulls funnel metrics (signups → first upload → first download → paid) week-over-week and names the biggest leak, plus churn cohorts and the cancel-flow funnel. Use weekly or before any prioritization decision.
 tools: Read, Bash, Grep, Glob
 model: sonnet
 ---
@@ -20,6 +20,16 @@ The five stages that matter, in order:
 5. **Paid** — `subscriptions` row with active status, or `users.patreon = true`.
 
 A leak is the largest absolute drop-off between two adjacent stages — the gap PM should prioritize next.
+
+## Churn (the back door)
+
+Acquisition is only half the job: 79% of churn is lifecycle ("finished what I needed"), and at ~19% monthly churn the paying base fully turns over in ~5 months. Alongside the funnel, report:
+
+1. **30d churn rate** — cancelled or lapsed paying users ÷ paying users at period start (`subscriptions` rows flipping inactive; `users.patreon` excluded).
+2. **Cancel-flow funnel** — account page visits → cancel clicks → completed cancellations (events + `cancellation-feedback` rows where present).
+3. **Cohort note** — are recent cancellations new subscribers (<60d, activation failure) or old ones (lifecycle exit)? One line.
+
+If churn moved more than the worst funnel transition, the churn line IS the recommendation.
 
 ## Workflow
 
@@ -45,6 +55,8 @@ A leak is the largest absolute drop-off between two adjacent stages — the gap 
 **Biggest leak:** Landing → Signup (88% drop).
 **Biggest mover:** Landing → Signup widened by 2pp this week.
 **Recommendation:** Spec a landing-page conversion experiment — that's the biggest hole and it just got bigger.
+
+**Churn:** 30d churn X% (prior Y%); cancellations skew <new|old> subscribers. <One-line read.>
 ```
 
 One row per transition. No commentary outside the three single-line statements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,13 @@ Express/TypeScript server that converts Notion pages and uploaded files (HTML, m
 
 Mission: give people the simplest, fastest way to turn what they're studying into beautiful Anki flashcards. Drop something in, get a clean deck back.
 Scale: grow 2anki.net past 300K users.
-Every PR is checked against both — does it make the experience simpler/faster/more beautiful, and does it move us toward scale?
+Revenue: grow MRR past $5K — ARPU and retention are the levers; user count follows. The system sat at its mathematical ceiling (adds ÷ churn) at $2.24 ARPU until the June 2026 reprice; never again let user-count work crowd out revenue work.
+Every PR is checked against all three — does it make the experience simpler/faster/more beautiful, does it move us toward scale, and does it (for user-facing changes) state which funnel or revenue metric it should move?
+
+### Business baseline (as of 2026-06-10 — weekly-retro updates this block)
+
+MRR $1,710 · 763 paying subs · ARPU $2.24 · 18.9%/mo churn (79% lifecycle, not price) · 34 new paid/wk trailing · ~19,580 registered. Read live at `/api/ops/business/metrics` (ops-gated) and Stripe; funnel events at `/api/ops/metrics`.
+Pricing v2 shipped 2026-06-10: $7.99/mo + $64/yr for new members, legacy $6/$60 lock-in until 21 Jun, annual default. Scheduled reads: v2 funnel week of 15 Jun (targets: ≥70 new paid/wk, page→checkout ≥10%, checkout→paid ≥50%); minimal-layout CTR guardrail 24 Jun.
 
 ## Tech stack
 
@@ -108,7 +114,7 @@ Default: `pm` produces a spec → `designer` validates UX (only if user-facing) 
 
 **Supporting cast** (specialists, invoke by name):
 
-- **conversion-funnel-analyst** (sonnet) — weekly funnel pull; names the biggest drop-off between landing → signup → upload → download → paid. Use before prioritization.
+- **conversion-funnel-analyst** (sonnet) — weekly funnel pull; names the biggest drop-off between landing → signup → upload → download → paid, plus churn cohorts and the cancel-flow funnel. Use before prioritization.
 - **seo-content** (opus) — landing-page content, topical clusters, internal linking, sitemap proposals. Designer owns in-product voice; this owns search-driven copy.
 - **seo-specialist** (opus) — technical SEO: crawlability, Core Web Vitals, structured data, SERP/AI-overview features, Search Console analysis. seo-content owns the words; this owns the search infrastructure under them.
 - **prod-incident-responder** (opus, worktree) — turns a recurring prod error into a single fix PR with a regression test. Use when logs show a repeat crash with no open PR.
@@ -129,6 +135,7 @@ For any task that changes user-facing behavior, invoke `pm`, `designer`, and `en
 - UI/UX changes, copy that users see
 - Pricing, limits, quotas, or API surface changes
 - Onboarding, signup, payment, or core conversion flows
+- Cancellation and churn surfaces — any cancel-flow change must weigh a retention offer (pause, downgrade, legacy-rate reminder); 79% of churn is lifecycle, and this surface owns it
 - Refactors that change user-visible behavior
 
 **Trio optional (proceed unless you sense a product question):**
@@ -142,6 +149,7 @@ For any task that changes user-facing behavior, invoke `pm`, `designer`, and `en
 - Where they agree
 - Where they conflict, and how the conflict was resolved
 - The resulting plan
+- Expected MRR/funnel impact — which metric should move, where it is read, and when (one line; "none — internal" is a valid answer, silence is not)
 
 **When the trio disagrees on a visual direction, don't pick silently — ship a preview.** Build a `/dev/<surface>-preview` route that renders each candidate side by side with prefilled state for every variant the surface supports (free / paid / lifetime user, loading / error / empty, etc.). Use direct prop injection on the existing components — don't re-mock the data hooks. No auth gate, no nav link, no analytics. Push it as part of the draft PR so the user can open it locally with `pnpm dev` and choose from visuals. The preview route stays in the repo after merge as a regression check; remove only if the surface is deleted. Example: `/dev/account-preview` and `/dev/notion-preview` shipped with `style/account-redesign`.
 


### PR DESCRIPTION
The agent setup was excellent at shipping safely and silent on shipping what makes money: the goal section optimized user count while the binding constraint was ARPU (the paying base sat at its adds ÷ churn ceiling at $2.24 until this week's reprice). Five changes, all process/docs:

1. **Goal section gains a revenue axis** — "grow MRR past $5K; ARPU and retention are the levers; user count follows." Every user-facing PR now answers a third question: which funnel or revenue metric should it move?
2. **Dated business-baseline block in CLAUDE.md** — MRR, paying subs, ARPU, churn, weekly paid, where each is read, plus the scheduled v2/lock-in and A/B-guardrail read dates. `weekly-retro` owns keeping it current; the date stamp makes staleness visible.
3. **Trio synthesis format gains a required line** — expected MRR/funnel impact, where it's read, when. "None — internal" is a valid answer; silence is not.
4. **Cancel-flow changes are now trio-required with a retention-offer rule** — 79% of churn is lifecycle and no rule owned that surface; any cancel-flow change must weigh pause/downgrade/legacy-rate alternatives.
5. **conversion-funnel-analyst gains churn scope** — 30d churn rate, cancel-flow funnel, new-vs-old cancellation cohorts; if churn moved more than the worst funnel transition, churn is the recommendation.

Deliberately NOT changed: no new growth agents, Stripe-sync-manual and no-cron-send rules untouched, revenue experiments still gated on Alexander's sign-off.

No changelog entry — internal process docs.

Browser check: not applicable — docs and agent definitions only, no rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783716934&installation_id=132681956&pr_number=3221&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3221&signature=c1a8197ddcc3b1e6b15ccfbd578ef6aa05781d80c44c02238f18422f95967f69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->