### PR TITLE
chore: add pre-push oxfmt gate + changelog reminder

### DIFF
--- a/.claude/hooks/pre-push-format.py
+++ b/.claude/hooks/pre-push-format.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+PreToolUse hook: run oxfmt --check on the files this branch changed before
+`git push`, plus a warn-only changelog-presence reminder.
+
+Why: CI runs `pnpm format:check` (oxfmt --check over src + web/src) and rejects
+the push on any format diff — costing a full push + CI cycle each time. A large
+share of recent commits are pure "fix oxfmt" appeasement. This catches the same
+diff locally in milliseconds.
+
+Scope: changed files vs origin/main only — never the full tree. A full-tree
+check would block every push whenever main itself carries a pre-existing format
+violation (a merged PR can leave main red), which has nothing to do with the
+branch being pushed.
+
+Two gates:
+1. Format (BLOCKS): oxfmt --check on changed .ts/.tsx/.js/.jsx under src/ and
+   web/src/. On failure, prints the offending files and the exact fix command.
+2. Changelog (WARNS only, never blocks): if the branch adds a feat:/fix: commit
+   touching src/ or web/src/ (excluding tests) and no new changelog JSON file,
+   prints a one-line reminder. The CLAUDE.md no-entry out-clause is legitimate,
+   so this can never block.
+
+Skips pushes to main/master (safety.py owns those). oxfmt applies its own
+ignorePatterns from .oxfmtrc.json (templates, fixtures, generated, etc.), so we
+don't re-implement that filter here.
+
+Bypass: CLAUDE_SKIP_FORMAT_CHECK=1 git push ...   (env var, or inline in the
+        command string — both honored, mirroring the typecheck hook).
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+
+OXFMT_TIMEOUT_SECONDS = 30
+
+FORMATTABLE_EXTS = (".ts", ".tsx", ".js", ".jsx")
+FORMATTABLE_ROOTS = ("src/", "web/src/")
+CHANGELOG_DIR = "web/src/pages/WhatsNewPage/changelog/"
+
+GIT_PUSH = re.compile(r"\bgit\s+push\b")
+PROTECTED_BRANCH = re.compile(r"\b(main|master)\b")
+SKIP_IN_COMMAND = re.compile(r"\bCLAUDE_SKIP_FORMAT_CHECK=1\b")
+NOT_INSTALLED = re.compile(
+    r"command not found|ENOENT|not found|No such file|not be found",
+    re.IGNORECASE,
+)
+
+
+def allow():
+    print(json.dumps({"continue": True}))
+    sys.exit(0)
+
+
+def deny(reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def is_git_push(cmd):
+    return bool(GIT_PUSH.search(cmd))
+
+
+def push_targets_protected(cmd):
+    after = GIT_PUSH.split(cmd, 1)[1]
+    after = re.split(r"[;&|]", after, 1)[0]
+    return bool(PROTECTED_BRANCH.search(after))
+
+
+def git_lines(args, project_dir):
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            cwd=project_dir, capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.splitlines()
+
+
+def changed_paths(project_dir):
+    """All paths that differ from origin/main or are uncommitted on the branch.
+    None means git couldn't tell us — caller errs toward running the check."""
+    committed = git_lines(
+        ["diff", "--name-only", "origin/main...HEAD"], project_dir
+    )
+    working = git_lines(["diff", "--name-only", "HEAD"], project_dir)
+    if committed is None and working is None:
+        return None
+    return list(dict.fromkeys((committed or []) + (working or [])))
+
+
+def formattable(paths):
+    return [
+        p for p in paths
+        if p.endswith(FORMATTABLE_EXTS) and p.startswith(FORMATTABLE_ROOTS)
+    ]
+
+
+def run_oxfmt_check(files, project_dir):
+    """True = clean, str = offending output, None = couldn't run (fail open)."""
+    try:
+        result = subprocess.run(
+            ["pnpm", "exec", "oxfmt", "-c", ".oxfmtrc.json",
+             "--threads", "1", "--check"] + files,
+            cwd=project_dir, capture_output=True, text=True,
+            timeout=OXFMT_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"[pre-push-format] oxfmt exceeded {OXFMT_TIMEOUT_SECONDS}s; "
+            "allowing push.\n"
+        )
+        return None
+    except FileNotFoundError:
+        sys.stderr.write("[pre-push-format] pnpm not on PATH; allowing push.\n")
+        return None
+    if result.returncode == 0:
+        return True
+    output = result.stdout or result.stderr or "(no output)"
+    if NOT_INSTALLED.search(output):
+        sys.stderr.write(
+            "[pre-push-format] oxfmt isn't installed in this checkout "
+            "(common in agent worktrees). Run `pnpm install`, then push again "
+            "to get the format gate. Allowing this push.\n"
+        )
+        return None
+    return output
+
+
+def offending_files(output, candidates):
+    named = [f for f in candidates if f in output]
+    return named or candidates
+
+
+def deny_for_format(output, files):
+    offenders = offending_files(output, files)
+    listing = "\n".join(f"  {f}" for f in offenders[:20])
+    fix_cmd = "pnpm exec oxfmt -c .oxfmtrc.json --threads 1 --write " + " ".join(
+        offenders
+    )
+    deny(
+        "Refusing `git push` — oxfmt found format issues in changed files "
+        "(CI's `pnpm format:check` would reject this push):\n\n"
+        f"{listing}\n\n"
+        "Fix them with:\n"
+        f"  {fix_cmd}\n\n"
+        "Then re-stage and push. Bypass with CLAUDE_SKIP_FORMAT_CHECK=1 if "
+        "you're pushing a WIP branch."
+    )
+
+
+def commit_subjects(project_dir):
+    lines = git_lines(
+        ["log", "--format=%s", "origin/main..HEAD"], project_dir
+    )
+    return lines or []
+
+
+def branch_adds_changelog(paths):
+    return any(
+        p.startswith(CHANGELOG_DIR) and p.endswith(".json") for p in paths
+    )
+
+
+def is_test_path(path):
+    return ".test." in path or ".spec." in path or "/__tests__/" in path
+
+
+def touches_user_facing_source(paths):
+    return any(
+        p.startswith(FORMATTABLE_ROOTS)
+        and not is_test_path(p)
+        and not p.startswith(CHANGELOG_DIR)
+        for p in paths
+    )
+
+
+FEAT_FIX_SUBJECT = re.compile(r"^(feat|fix)(\([^)]*\))?!?:", re.IGNORECASE)
+
+
+def warn_changelog_if_missing(paths, project_dir):
+    if branch_adds_changelog(paths):
+        return
+    if not touches_user_facing_source(paths):
+        return
+    subjects = commit_subjects(project_dir)
+    if not any(FEAT_FIX_SUBJECT.match(s) for s in subjects):
+        return
+    sys.stderr.write(
+        "[pre-push-format] reminder: this branch has a feat:/fix: commit "
+        "touching src/ or web/src/ but adds no changelog entry under "
+        f"{CHANGELOG_DIR}. CLAUDE.md's changelog table expects one for "
+        "user-visible feat:/fix: changes. If this change isn't user-visible, "
+        "state the no-entry out-clause in the PR body "
+        "(\"no changelog entry — internal-only ...\"). Not blocking.\n"
+    )
+
+
+def main():
+    if os.environ.get("CLAUDE_SKIP_FORMAT_CHECK"):
+        allow()
+
+    try:
+        data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError:
+        allow()
+
+    if data.get("tool_name") != "Bash":
+        allow()
+
+    cmd = data.get("tool_input", {}).get("command", "")
+    if not is_git_push(cmd):
+        allow()
+
+    if SKIP_IN_COMMAND.search(cmd):
+        allow()
+
+    if push_targets_protected(cmd):
+        allow()
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+    paths = changed_paths(project_dir)
+    if paths is None:
+        allow()
+
+    warn_changelog_if_missing(paths, project_dir)
+
+    files = formattable(paths)
+    if not files:
+        allow()
+
+    sys.stderr.write(
+        f"[pre-push-format] running oxfmt --check on {len(files)} changed "
+        "file(s)...\n"
+    )
+    result = run_oxfmt_check(files, project_dir)
+    if isinstance(result, str):
+        deny_for_format(result, files)
+
+    allow()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/pre-push-format.test.py
+++ b/.claude/hooks/pre-push-format.test.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "pre_push_format",
+    os.path.join(HOOKS_DIR, "pre-push-format.py"),
+)
+hook = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hook)
+
+
+def run_hook(
+    command,
+    tool_name="Bash",
+    env=None,
+    paths=None,
+    oxfmt_result=True,
+    subjects=None,
+):
+    """paths: changed paths (or None = couldn't tell).
+    oxfmt_result: True (clean) | str (offending output) | None (couldn't run).
+    subjects: commit subjects vs origin/main."""
+    subjects = subjects or []
+    stdin_data = json.dumps(
+        {"tool_name": tool_name, "tool_input": {"command": command}}
+    )
+    captured = {"oxfmt_called": False}
+
+    def fake_allow():
+        captured["result"] = "allow"
+        sys.exit(0)
+
+    def fake_deny(reason):
+        captured["result"] = "deny"
+        captured["reason"] = reason
+        sys.exit(0)
+
+    def fake_changed_paths(project_dir):
+        return paths
+
+    def fake_run_oxfmt(files, project_dir):
+        captured["oxfmt_called"] = True
+        captured["oxfmt_files"] = files
+        return oxfmt_result
+
+    def fake_subjects(project_dir):
+        return subjects
+
+    with patch.object(hook, "allow", side_effect=fake_allow), \
+         patch.object(hook, "deny", side_effect=fake_deny), \
+         patch.object(hook, "changed_paths", side_effect=fake_changed_paths), \
+         patch.object(hook, "run_oxfmt_check", side_effect=fake_run_oxfmt), \
+         patch.object(hook, "commit_subjects", side_effect=fake_subjects), \
+         patch("sys.stdin") as mock_stdin, \
+         patch.dict(os.environ, env or {}, clear=False):
+        mock_stdin.read.return_value = stdin_data
+        try:
+            hook.main()
+        except SystemExit:
+            pass
+
+    return captured
+
+
+class TestPassThrough(unittest.TestCase):
+    def test_non_bash_tool_allows(self):
+        result = run_hook("git push", tool_name="Write")
+        self.assertEqual(result["result"], "allow")
+        self.assertFalse(result["oxfmt_called"])
+
+    def test_non_push_command_allows(self):
+        result = run_hook("git status")
+        self.assertEqual(result["result"], "allow")
+        self.assertFalse(result["oxfmt_called"])
+
+    def test_push_to_main_allows_without_check(self):
+        result = run_hook(
+            "git push origin main", paths=["src/server.ts"]
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertFalse(result["oxfmt_called"])
+
+    def test_env_bypass_allows(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            env={"CLAUDE_SKIP_FORMAT_CHECK": "1"},
+            paths=["web/src/App.tsx"],
+            oxfmt_result="web/src/App.tsx has issues",
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertFalse(result["oxfmt_called"])
+
+    def test_inline_skip_in_command_allows(self):
+        result = run_hook(
+            "CLAUDE_SKIP_FORMAT_CHECK=1 git push -u origin feat/x",
+            paths=["web/src/App.tsx"],
+            oxfmt_result="web/src/App.tsx has issues",
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertFalse(result["oxfmt_called"])
+
+    def test_no_formattable_changes_allows(self):
+        result = run_hook(
+            "git push -u origin docs/x", paths=["README.md"]
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertFalse(result["oxfmt_called"])
+
+    def test_couldnt_tell_diff_allows(self):
+        result = run_hook("git push -u origin feat/x", paths=None)
+        self.assertEqual(result["result"], "allow")
+        self.assertFalse(result["oxfmt_called"])
+
+
+class TestFormatGate(unittest.TestCase):
+    def test_clean_changed_files_allow(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            paths=["src/usecases/Convert.ts"],
+            oxfmt_result=True,
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertTrue(result["oxfmt_called"])
+        self.assertEqual(result["oxfmt_files"], ["src/usecases/Convert.ts"])
+
+    def test_format_issue_denies_with_fix_command(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            paths=["web/src/App.tsx"],
+            oxfmt_result="web/src/App.tsx (1ms)\nFormat issues found",
+        )
+        self.assertEqual(result["result"], "deny")
+        self.assertIn("web/src/App.tsx", result["reason"])
+        self.assertIn("oxfmt", result["reason"])
+        self.assertIn("--write", result["reason"])
+        self.assertIn("CLAUDE_SKIP_FORMAT_CHECK=1", result["reason"])
+
+    def test_only_formattable_paths_passed_to_oxfmt(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            paths=[
+                "src/server.ts",
+                "README.md",
+                "web/src/App.tsx",
+                "migrations/x.js",
+                "src/templates/note.html",
+            ],
+            oxfmt_result=True,
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertEqual(
+            result["oxfmt_files"], ["src/server.ts", "web/src/App.tsx"]
+        )
+
+    def test_oxfmt_not_runnable_allows_fail_open(self):
+        result = run_hook(
+            "git push -u origin feat/x",
+            paths=["src/server.ts"],
+            oxfmt_result=None,
+        )
+        self.assertEqual(result["result"], "allow")
+        self.assertTrue(result["oxfmt_called"])
+
+
+class TestFormattableFilter(unittest.TestCase):
+    def test_filters_extension_and_root(self):
+        kept = hook.formattable([
+            "src/a.ts",
+            "web/src/b.tsx",
+            "src/c.js",
+            "web/src/d.jsx",
+            "src/e.json",
+            "docs/f.ts",
+            "web/public/g.ts",
+        ])
+        self.assertEqual(
+            kept,
+            ["src/a.ts", "web/src/b.tsx", "src/c.js", "web/src/d.jsx"],
+        )
+
+
+class TestChangelogWarning(unittest.TestCase):
+    def test_feat_touching_src_without_changelog_warns(self):
+        with patch.object(hook.sys.stderr, "write") as werr:
+            with patch.object(hook, "commit_subjects",
+                              return_value=["feat: add thing"]):
+                hook.warn_changelog_if_missing(["src/usecases/Convert.ts"], ".")
+        joined = "".join(c.args[0] for c in werr.call_args_list)
+        self.assertIn("no changelog entry", joined)
+
+    def test_changelog_present_does_not_warn(self):
+        with patch.object(hook.sys.stderr, "write") as werr:
+            with patch.object(hook, "commit_subjects",
+                              return_value=["feat: add thing"]):
+                hook.warn_changelog_if_missing(
+                    [
+                        "src/usecases/Convert.ts",
+                        "web/src/pages/WhatsNewPage/changelog/2026-06-10-x.json",
+                    ],
+                    ".",
+                )
+        self.assertEqual(werr.call_count, 0)
+
+    def test_chore_only_does_not_warn(self):
+        with patch.object(hook.sys.stderr, "write") as werr:
+            with patch.object(hook, "commit_subjects",
+                              return_value=["chore: tooling"]):
+                hook.warn_changelog_if_missing(["src/server.ts"], ".")
+        self.assertEqual(werr.call_count, 0)
+
+    def test_test_only_source_does_not_warn(self):
+        with patch.object(hook.sys.stderr, "write") as werr:
+            with patch.object(hook, "commit_subjects",
+                              return_value=["fix: bug"]):
+                hook.warn_changelog_if_missing(
+                    ["src/usecases/Convert.test.ts"], "."
+                )
+        self.assertEqual(werr.call_count, 0)
+
+    def test_fix_scoped_subject_warns(self):
+        with patch.object(hook.sys.stderr, "write") as werr:
+            with patch.object(hook, "commit_subjects",
+                              return_value=["fix(notion): broken table"]):
+                hook.warn_changelog_if_missing(["web/src/App.tsx"], ".")
+        joined = "".join(c.args[0] for c in werr.call_args_list)
+        self.assertIn("no changelog entry", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -110,6 +110,10 @@
           {
             "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/pre-push-typecheck.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/pre-push-format.py"
           }
         ]
       },


### PR DESCRIPTION
## What
Adds a `pre-push-format.py` PreToolUse hook that runs `oxfmt --check` on the
files a branch changed before `git push`, plus a warn-only changelog-presence
reminder. Wires it into `.claude/settings.json` after the existing
`pre-push-typecheck.py`. Does not touch the tsc check, `safety.py`, or the merge
hooks.

## Why
~20% of recent commits are post-push CI-gate appeasement. The biggest source is
formatting: CI runs `pnpm format:check` (oxfmt `--check` over `src` + `web/src`)
and rejects the push on any format diff, costing a full push + CI round-trip each
time (4 separate format-fix commits in one day recently). Catching the same diff
locally costs milliseconds.

## How
Two gates in one PreToolUse hook that intercepts `git push`:

1. **Format (blocks).** Computes the `.ts/.tsx/.js/.jsx` files changed vs
   `origin/main` (committed + working tree) under `src/` and `web/src/`, then runs
   `pnpm exec oxfmt -c .oxfmtrc.json --threads 1 --check <files>`. On a format
   issue it lists the offending files and prints the exact `oxfmt --write` fix
   command, then denies the push.

   **Changed-files-only by design.** A full-tree check would block every push
   whenever `main` itself carries a pre-existing format violation (a merged PR can
   leave `main` format-broken — exactly the recent Chat-page incident), which has
   nothing to do with the branch being pushed. oxfmt applies its own
   `.oxfmtrc.json` `ignorePatterns` (templates, fixtures, generated), so that
   filter isn't re-implemented here.

2. **Changelog (warns only, never blocks).** If the branch has a `feat:`/`fix:`
   commit touching `src/` or `web/src/` (excluding test files) and adds no JSON
   file under `web/src/pages/WhatsNewPage/changelog/`, it prints a one-line stderr
   reminder citing CLAUDE.md's changelog table and the valid no-entry out-clause.
   The out-clause is legitimate, so this can never block.

**Bypass:** `CLAUDE_SKIP_FORMAT_CHECK=1` — honored as an env var or inline in the
push command string, mirroring the `CLAUDE_SKIP_TYPECHECK` pattern. Fail-open when
oxfmt isn't installed (common in agent worktrees) or when git can't compute the
diff, so it never blocks a push for tooling reasons.

## Measuring success
Fewer standalone `chore: format`/`style: oxfmt` follow-up commits on `main`, and
fewer Server-workflow "Format check" CI failures on first push. Confirm in the
commit log: format-only fixup commits in a trailing window should drop after this
lands.

## Testing
- Unit tests added: `pre-push-format.test.py`, 17 tests — pass-through (non-Bash,
  non-push, push-to-main, env bypass, inline skip, no-formattable-changes,
  couldn't-tell-diff), the format gate (clean allow, issue denies with fix command,
  only-formattable-paths passed to oxfmt, fail-open when oxfmt can't run), the
  `formattable` filter, and the changelog warning (feat/fix warns, changelog
  present silences, chore silences, test-only source silences, scoped fix warns).
- Manual end-to-end against the real hook + real oxfmt 0.53.0 (main checkout's
  node_modules symlinked in for the run, then removed):
  - Mis-formatted scratch commit -> **deny**, names `src/__scratch_badfmt__.ts` and
    prints the exact `oxfmt --write` fix command.
  - `CLAUDE_SKIP_FORMAT_CHECK=1` (env and inline) -> **allow**, oxfmt not run.
  - Auto-fixed file -> **allow**.
  - `feat:` commit touching `src/` with no changelog -> stderr **warning**, still
    **allow** (`{"continue": true}`).
  - Scratch commit + node_modules symlink dropped before commit; only the three
    intended files (`pre-push-format.py`, `pre-push-format.test.py`,
    `settings.json`) are in the PR.

## Browser check
Browser check: not applicable — git hook change, no rendered output.

## Changelog
No changelog entry — developer tooling.

## Risks
Fail-open everywhere (oxfmt missing, git diff unavailable, timeout), so the worst
case is the gate silently does nothing — never a blocked push for tooling reasons.
The format gate can only block on a genuine oxfmt format diff in a changed file,
which CI would have blocked anyway. The `CLAUDE_SKIP_FORMAT_CHECK=1` bypass is the
escape hatch for WIP pushes. Rollback: remove the one hook line from
`.claude/settings.json`.

## Goal alignment
None — internal developer tooling. Reduces wasted push + CI cycles on formatting
bounces, freeing engineering time for revenue/funnel work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783719562&installation_id=132681956&pr_number=3224&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3224&signature=8adfbe54fcca53fdbc4dc985c1fdaca72d6365fb2e0a04b40afb035651db9239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->