### PR TITLE
fix: cascade user deletion to email_preferences and favorites

### DIFF
--- a/migrations/20260911000000_user_delete_fk_cascade_gaps.js
+++ b/migrations/20260911000000_user_delete_fk_cascade_gaps.js
@@ -1,0 +1,35 @@
+exports.up = async (knex) => {
+  await knex.schema.table('email_preferences', (table) => {
+    table.dropForeign(['user_id']);
+  });
+  await knex.schema.table('email_preferences', (table) => {
+    table
+      .foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+  });
+
+  await knex.schema.table('favorites', (table) => {
+    table.dropForeign(['owner']);
+  });
+  await knex.schema.table('favorites', (table) => {
+    table.foreign('owner').references('id').inTable('users').onDelete('CASCADE');
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('email_preferences', (table) => {
+    table.dropForeign(['user_id']);
+  });
+  await knex.schema.table('email_preferences', (table) => {
+    table.foreign('user_id').references('id').inTable('users');
+  });
+
+  await knex.schema.table('favorites', (table) => {
+    table.dropForeign(['owner']);
+  });
+  await knex.schema.table('favorites', (table) => {
+    table.foreign('owner').references('id').inTable('users');
+  });
+};

--- a/migrations/20260911000000_user_delete_fk_cascade_gaps.js
+++ b/migrations/20260911000000_user_delete_fk_cascade_gaps.js
@@ -1,8 +1,6 @@
 exports.up = async (knex) => {
   await knex.schema.table('email_preferences', (table) => {
     table.dropForeign(['user_id']);
-  });
-  await knex.schema.table('email_preferences', (table) => {
     table
       .foreign('user_id')
       .references('id')
@@ -12,24 +10,28 @@ exports.up = async (knex) => {
 
   await knex.schema.table('favorites', (table) => {
     table.dropForeign(['owner']);
-  });
-  await knex.schema.table('favorites', (table) => {
     table.foreign('owner').references('id').inTable('users').onDelete('CASCADE');
   });
+
+  await knex.raw(
+    'CREATE INDEX IF NOT EXISTS favorites_owner_index ON favorites (owner)'
+  );
 };
 
 exports.down = async (knex) => {
+  await knex.raw('DROP INDEX IF EXISTS favorites_owner_index');
+
   await knex.schema.table('email_preferences', (table) => {
     table.dropForeign(['user_id']);
-  });
-  await knex.schema.table('email_preferences', (table) => {
-    table.foreign('user_id').references('id').inTable('users');
+    table
+      .foreign('user_id')
+      .references('id')
+      .inTable('users')
+      .onDelete('NO ACTION');
   });
 
   await knex.schema.table('favorites', (table) => {
     table.dropForeign(['owner']);
-  });
-  await knex.schema.table('favorites', (table) => {
-    table.foreign('owner').references('id').inTable('users');
+    table.foreign('owner').references('id').inTable('users').onDelete('NO ACTION');
   });
 };

--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -329,11 +329,24 @@ const RUN_INTEGRATION = process.env.DATABASE_URL != null;
         user_id: userId,
         token: `reengagement-tok-${userId}`,
       });
+
+      await db('email_preferences').insert({
+        user_id: userId,
+        marketing_opt_out: false,
+      });
+
+      await db('favorites').insert({
+        owner: userId,
+        object_id: `fav-obj-${userId}`,
+        type: 'page',
+      });
     });
 
     afterEach(async () => {
       await db('inactivity_emails').where({ user_id: userId }).del();
       await db('re_engagement_emails').where({ user_id: userId }).del();
+      await db('email_preferences').where({ user_id: userId }).del();
+      await db('favorites').where({ owner: userId }).del();
       await db('users').where({ id: userId }).del();
     });
 
@@ -355,6 +368,30 @@ const RUN_INTEGRATION = process.env.DATABASE_URL != null;
       expect(user).toBeUndefined();
       expect(inactivity).toBeUndefined();
       expect(reEngagement).toBeUndefined();
+    });
+
+    it('deletes a user that has an email_preferences row without an FK violation', async () => {
+      const repo = new UsersRepository(db);
+
+      await repo.deleteUser(String(userId));
+
+      const user = await db('users').where({ id: userId }).first();
+      const preferences = await db('email_preferences')
+        .where({ user_id: userId })
+        .first();
+
+      expect(user).toBeUndefined();
+      expect(preferences).toBeUndefined();
+    });
+
+    it('cascades to favorites when the user is deleted', async () => {
+      const repo = new UsersRepository(db);
+
+      await repo.deleteUser(String(userId));
+
+      const favorite = await db('favorites').where({ owner: userId }).first();
+
+      expect(favorite).toBeUndefined();
     });
   }
 );

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-11-account-deletion-fk.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-11-account-deletion-fk.json
@@ -2,5 +2,5 @@
   "id": "2026-06-11-account-deletion-fk",
   "date": "2026-06-11",
   "type": "fix",
-  "title": "Deleting your account works even when you have email preferences saved"
+  "title": "Deleting your account works even when you have saved favorites or email preferences"
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-11-account-deletion-fk.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-11-account-deletion-fk.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-11-account-deletion-fk",
+  "date": "2026-06-11",
+  "type": "fix",
+  "title": "Deleting your account works even when you have email preferences saved"
+}


### PR DESCRIPTION
## What
Adds `ON DELETE CASCADE` to the two foreign keys referencing `users(id)` that still had `NO ACTION`: `email_preferences.user_id` and `favorites.owner`. With this, deleting a user no longer 500s when the account has an email-preferences row.

## Why
Account deletion failed in production twice on 2026-06-10/11 with Postgres FK error 23503 on `email_preferences_user_id_foreign`:
- Admin **delete-inactive-users** ops command — user 1871.
- A **real user self-deleting** via `POST /api/users/delete-account` → 500 `"Delete account failed"` — user 10153.

Self-service deletion was broken for anyone with an `email_preferences` row (GDPR-adjacent). The prior `user_delete_fk_cascade` migration only covered `inactivity_emails` and `re_engagement_emails`.

## How
One migration drops and re-adds each gapped FK with `ON DELETE CASCADE` (down restores the prior `NO ACTION` shape). The FK constraint is the fix — no app-level cascade deletes were added. `UsersRepository.deleteUser` already clears `favorites` by `owner` in its manual loop, so the `favorites` cascade is a belt-and-braces safety net; `email_preferences` was never in that loop, which is exactly why the final `users` delete failed.

### FK audit — every FK referencing `users(id)` (from live schema)
| Child column | Delete rule before | Action |
| --- | --- | --- |
| `email_preferences.user_id` | **NO ACTION** | → CASCADE (this PR) |
| `favorites.owner` | **NO ACTION** | → CASCADE (this PR) |
| `inactivity_emails.user_id` | CASCADE | already covered |
| `re_engagement_emails.user_id` | CASCADE | already covered |
| `price_lock_in_emails.user_id` | CASCADE | already covered |
| `user_passes.user_id` | CASCADE | already covered |
| `user_surveys.user_id` | CASCADE | already covered |
| `subscription_claim_tokens.user_id` | CASCADE | already covered |
| `apple_transactions.user_id` | CASCADE | already covered |
| `chat_messages.user_id` | CASCADE | already covered |
| `conversations.user_id` | CASCADE | already covered |
| `deck_shares.owner` | CASCADE | already covered |
| `io_drafts.user_id` | CASCADE | already covered |
| `magic_tokens.owner` | CASCADE | already covered |
| `mindmaps.user_id` | CASCADE | already covered |
| `oauth_identities.user_id` | CASCADE | already covered |
| `pitch_dismissals.user_id` | CASCADE | already covered |
| `events.user_id` | SET NULL | retained — anonymized analytics |
| `error_events.user_id` | SET NULL | retained — diagnostics survive deletion |
| `error_resolutions.resolved_by` | SET NULL | retained — audit of who resolved |
| `feature_flags.updated_by` | SET NULL | retained — audit of who toggled |
| `user_visible_errors.user_id` | SET NULL | retained — error history |

`settings.owner` and `templates.owner` are `varchar` columns with **no FK constraint** (string owner, not an integer FK to `users.id`), so they never block deletion and are out of scope. `trial_ended_emails` / `subscription_claims` don't exist in the schema.

The `SET NULL` rows are left as-is: their `user_id` is nullable and the rows are intentionally retained after deletion (analytics, diagnostics, audit). No change needed.

## Measuring success
`POST /api/users/delete-account` returns 200 and the inactivity-delete ops command's `[inactivity-delete]` error log stops emitting `email_preferences_user_id_foreign`. Query to confirm zero remaining gaps: every FK to `users(id)` is `CASCADE` or `SET NULL` in `information_schema.referential_constraints`.

## Testing
- Verified migration up + rollback against local Postgres (client `pg`): up sets both FKs to CASCADE, down reverts both to NO ACTION.
- Extended the `DATABASE_URL`-gated integration test in `UsersRepository.test.ts`: inserts an `email_preferences` row (reproduces the 23503) and a `favorites` row, then asserts the user deletes cleanly with both children gone. Confirmed the new `email_preferences` test fails with the exact prod error (`email_preferences_user_id_foreign`) when the migration is reverted, and passes with it applied. Mocked-repo tests would not execute the FK, so the bug is covered at the SQL boundary per the testing rule.
- `npx tsc -p . --noEmit` clean; oxfmt/oxlint clean on touched files; changelog loader test green.

### Migration locking
`DROP CONSTRAINT` + `ADD CONSTRAINT ... ON DELETE CASCADE` takes `ACCESS EXCLUSIVE` on the child table for the swap moment. `email_preferences` and `favorites` are small relative to `users`, and re-adding the FK validates existing rows — but those rows already satisfy the reference (the constraint existed before), so validation is fast. Quick on these table sizes; no backfill.

### Kanel
Constraint-only change. Delete rules are not part of kanel's column-type or FK-target output, so the generated types in `src/data_layer/public/` are unchanged (kanel binary is not installed in this worktree; verified by inspection that `EmailPreferences.ts` and `Favorites.ts` already model the columns and FK relationships unchanged).

## Browser check
Browser check: not applicable — the only `web/src/` file is a changelog JSON entry (changelog-only diff, bypass-exempt).

## Changelog
`2026-06-11-account-deletion-fk.json` — "Deleting your account works even when you have email preferences saved"

## Risks
Cascading deletes now remove `email_preferences` and `favorites` rows with the user — this is the intended behavior (the data is user-owned with no retention value). Rollback: the migration `down` restores `NO ACTION` on both FKs, returning to the prior (broken) shape.

## Goal alignment
Unblocks self-service account deletion (GDPR-adjacent) for every account, not just those without saved preferences. Not a funnel-mover; it's a reliability/compliance fix on a path that was returning 500 to real users.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783750282&installation_id=132681956&pr_number=3225&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3225&signature=b1cbe55bd2ff02c6b7128f00ae69aa3e781ca9df036e73f7b0c89dd6be30bcb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->