### PR TITLE
fix: read Ankify custom note type from global card options

### DIFF
--- a/src/data_layer/SettingsRepository.test.ts
+++ b/src/data_layer/SettingsRepository.test.ts
@@ -33,6 +33,10 @@ describe('SettingsRepository.loadAnkifyTemplateOverrides', () => {
       t.string('owner');
       t.json('payload');
     });
+    await db.schema.createTable('users', (t) => {
+      t.integer('id');
+      t.json('card_options');
+    });
     repo = new SettingsRepository(db);
   });
 
@@ -99,6 +103,70 @@ describe('SettingsRepository.loadAnkifyTemplateOverrides', () => {
 
   test('returns null when the owner has no settings rows at all', async () => {
     const overrides = await repo.loadAnkifyTemplateOverrides('99');
+    expect(overrides).toBeNull();
+  });
+
+  test('falls back to users.card_options when the owner has no settings row but set a custom template globally', async () => {
+    await db('users').insert({
+      id: 13574,
+      card_options: JSON.stringify({
+        template: 'custom',
+        basic_model_name: 'ATTI BASIC',
+      }),
+    });
+    await db('templates').insert({
+      owner: '13574',
+      payload: JSON.stringify(TEMPLATES_PAYLOAD),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides('13574');
+
+    expect(overrides).not.toBeNull();
+    expect(overrides?.basicModelName).toBe('ATTI BASIC');
+    expect(overrides?.basicTemplate.front).toContain('atti');
+  });
+
+  test('prefers a per-page settings row over global card_options', async () => {
+    await db('users').insert({
+      id: 13574,
+      card_options: JSON.stringify({
+        template: 'custom',
+        basic_model_name: 'GLOBAL NAME',
+      }),
+    });
+    await db('settings').insert({
+      owner: '13574',
+      object_id: 'page-a',
+      title: 'A',
+      payload: JSON.stringify({
+        payload: { template: 'custom', basic_model_name: 'PAGE NAME' },
+      }),
+    });
+    await db('templates').insert({
+      owner: '13574',
+      payload: JSON.stringify(TEMPLATES_PAYLOAD),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides('13574');
+
+    expect(overrides?.basicModelName).toBe('PAGE NAME');
+  });
+
+  test('returns null when global card_options template is not custom', async () => {
+    await db('users').insert({
+      id: 13574,
+      card_options: JSON.stringify({
+        template: 'specialstyle1',
+        basic_model_name: 'ATTI BASIC',
+      }),
+    });
+    await db('templates').insert({
+      owner: '13574',
+      payload: JSON.stringify(TEMPLATES_PAYLOAD),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides('13574');
+
     expect(overrides).toBeNull();
   });
 });

--- a/src/data_layer/SettingsRepository.ts
+++ b/src/data_layer/SettingsRepository.ts
@@ -118,23 +118,44 @@ class SettingsRepository implements ISettingsRepository {
     }
   }
 
-  async loadAnkifyTemplateOverrides(
+  private async resolveCustomBasicModelName(
     owner: string
-  ): Promise<AnkifyTemplateOverrides | null> {
-    try {
-      const settingsRow = await this.database(this.table)
-        .where({ owner })
-        .orderBy('updated_at', 'desc')
-        .first();
-      if (!settingsRow) {
-        return null;
-      }
-
+  ): Promise<string | null> {
+    const settingsRow = await this.database(this.table)
+      .where({ owner })
+      .orderBy('updated_at', 'desc')
+      .first();
+    if (settingsRow) {
       const settingsPayload = parseJsonColumn(settingsRow.payload) as {
         payload?: Record<string, string>;
       } | null;
       const cardOption = new CardOption(settingsPayload?.payload ?? {});
-      if (cardOption.template !== 'custom') {
+      if (cardOption.template === 'custom') {
+        return cardOption.basicModelName;
+      }
+    }
+
+    const userRow = await this.database('users')
+      .select('card_options')
+      .where({ id: owner })
+      .first();
+    const globalOptions = parseJsonColumn(userRow?.card_options) as {
+      template?: string;
+      basic_model_name?: string;
+    } | null;
+    if (globalOptions?.template === 'custom') {
+      return new CardOption(globalOptions).basicModelName;
+    }
+
+    return null;
+  }
+
+  async loadAnkifyTemplateOverrides(
+    owner: string
+  ): Promise<AnkifyTemplateOverrides | null> {
+    try {
+      const basicModelName = await this.resolveCustomBasicModelName(owner);
+      if (basicModelName == null) {
         return null;
       }
 
@@ -156,7 +177,7 @@ class SettingsRepository implements ISettingsRepository {
       }
 
       return {
-        basicModelName: cardOption.basicModelName,
+        basicModelName,
         basicTemplate,
       };
     } catch (error: unknown) {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-11-ankify-custom-note-type.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-11-ankify-custom-note-type.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-11-ankify-custom-note-type",
+  "date": "2026-06-11",
+  "type": "fix",
+  "title": "Ankify-synced cards use your custom note type when you set it in card options"
+}


### PR DESCRIPTION
## What
Ankify-synced cards now apply a user's custom Basic note type when that note type was set in the global card-options form, not just when it was saved per-page.

## Why
#3194 (f03b41b) made Ankify sync respect a custom Basic note type, but the override provider read the wrong store. A lifetime supporter (user 13574) reported media syncs but cards still land on stock Ankify basic instead of their custom note type (a clone of n2a-basic with an extra Media field).

Root cause — store mismatch, file:line:
- The override provider `SettingsRepository.loadAnkifyTemplateOverrides` (`src/data_layer/SettingsRepository.ts:125-131`) only read the **`settings`** table, keyed by `owner`. That table gets a row only when a user saves a *per-page* card-options config via `POST /api/settings/create/{id}`.
- The web card-options form's global `template` / `basic_model_name` are synced to **`users.card_options`** via `PATCH /api/users/me/preferences` (`web/src/lib/data_layer/userPreferencesSync.ts` → `UserPreferencesRepository.update`, `src/data_layer/UserPreferencesRepository.ts:112`) — a different store the provider never looked at.

A user who set their template once globally (never per-page) has zero `settings` rows, so the provider returned `null` (`SettingsRepository.ts:129`) → Ankify fell back to `ANKIFY_BASIC_MODEL` (`SyncNotionPageToRacUseCase.ts:487`).

Confirmed against prod (read-only) for user 13574: `users.card_options` → `template=custom`, `basic_model_name` = their custom model; `settings` → **0 rows**; `templates` → **1 row** (their custom note-type with the Media field). The user's save genuinely landed — in the store the provider wasn't reading.

## How
`loadAnkifyTemplateOverrides` now resolves the custom basic model name from the per-page `settings` row when present, otherwise falls back to `users.card_options`. The `templates`-table read for the note-type body is unchanged. Per-page settings still take precedence over the global preference.

No LLM calls, no Notion export processing touched. One extra single-row `users` read on the Ankify sync path only when no per-page settings row carries a custom template — negligible latency, no token/cost impact.

## Measuring success
After deploy, the next Ankify poll for user 13574 builds cards under their custom model name instead of `ANKIFY_BASIC_MODEL`. Confirm via the AnkiConnect `createModel`/`addNote` calls naming their model, and the user reporting the Media field renders. No new log line added — the existing sync result already names the model.

## Testing
- Unit tests added (`src/data_layer/SettingsRepository.test.ts`): fallback to `users.card_options` when no settings row exists but template is custom globally; per-page settings row wins over global card_options; global non-custom template yields no override. Existing settings-path tests unchanged and green. 7/7 pass; server tsc clean.

## Browser check
Browser check: not applicable — server-only behavior change; the only `web/src/` file is a changelog JSON entry.

## Changelog
"Ankify-synced cards use your custom note type when you set it in card options"

## Risks
Low. The fallback only fires when there is no per-page custom-template settings row; existing per-page behavior is preserved by precedence. The `users.card_options` read is one indexed single-row lookup. Rollback: revert the commit; behavior returns to settings-only resolution.

## Goal alignment
Retention/quality for paying members — a lifetime supporter's customized Ankify output now matches what they configured. No funnel metric; this is a correctness fix on a paid surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783750742&installation_id=132681956&pr_number=3226&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3226&signature=f2e9b5dcbbf421d207a736320418a9df6401a651271bc3f60291311b6537ad96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->