### PR TITLE
fix: tighten crawler hygiene and serve 404 for unknown routes

### DIFF
--- a/src/routes/DefaultRouter.test.ts
+++ b/src/routes/DefaultRouter.test.ts
@@ -1,0 +1,81 @@
+import express from 'express';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+
+import { isKnownAppRoute } from './knownRoutes';
+
+const SHELL_HTML =
+  '<!doctype html><html><body><div id="root"></div></body></html>';
+
+jest.mock('../controllers/IndexController/getIndexFileContents', () => ({
+  getIndexFileContents: jest.fn(() => SHELL_HTML),
+}));
+
+async function buildServer() {
+  const { default: DefaultRouter } = await import('./DefaultRouter');
+  const app = express();
+  app.use(DefaultRouter());
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+describe('DefaultRouter catch-all status', () => {
+  let server: http.Server;
+  let url: string;
+
+  beforeAll(async () => {
+    ({ server, url } = await buildServer());
+  });
+
+  afterAll(() => server.close());
+
+  it.each(['/wp-content/', '/wp-includes/l10n/', '/.env.backup'])(
+    'serves the shell with 404 for junk path %s',
+    async (junkPath) => {
+      const res = await fetch(`${url}${junkPath}`);
+      const body = await res.text();
+      expect(res.status).toBe(404);
+      expect(body).toBe(SHELL_HTML);
+    }
+  );
+
+  it.each(['/convert/not-a-real-thing', '/notion-to-ank', '/answers/nope'])(
+    'returns 404 for an unknown app-shaped path %s',
+    async (unknownPath) => {
+      const res = await fetch(`${url}${unknownPath}`);
+      expect(res.status).toBe(404);
+    }
+  );
+
+  it.each(['/pricing', '/pricing/', '/convert/csv-to-anki', '/account', '/'])(
+    'returns 200 for known route %s',
+    async (knownPath) => {
+      const res = await fetch(`${url}${knownPath}`);
+      const body = await res.text();
+      expect(res.status).toBe(200);
+      expect(body).toBe(SHELL_HTML);
+    }
+  );
+});
+
+describe('sitemap parity with isKnownAppRoute', () => {
+  const sitemap = fs.readFileSync(
+    path.resolve(__dirname, '../../web/public/sitemap.xml'),
+    'utf8'
+  );
+  const locPaths = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+    (match) => new URL(match[1]).pathname
+  );
+
+  it('extracts every sitemap loc', () => {
+    expect(locPaths.length).toBeGreaterThan(30);
+  });
+
+  it.each(locPaths)('sitemap path %s passes isKnownAppRoute', (loc) => {
+    expect(isKnownAppRoute(loc)).toBe(true);
+  });
+});

--- a/src/routes/DefaultRouter.ts
+++ b/src/routes/DefaultRouter.ts
@@ -3,6 +3,7 @@ import multer from 'multer';
 
 import IndexController from '../controllers/IndexController/IndexController';
 import { ensureIsLoggedIn } from './middleware/ensureIsLoggedIn';
+import { isKnownAppRoute } from './knownRoutes';
 
 const upload = multer({
   limits: { fileSize: 25 * 1024 * 1024 },
@@ -96,7 +97,12 @@ const DefaultRouter = () => {
    *               type: string
    *               description: HTML application page
    */
-  router.get(/^\/(?!api).*/, (req, res) => controller.getIndex(req, res));
+  router.get(/^\/(?!api).*/, (req, res) => {
+    if (!isKnownAppRoute(req.path)) {
+      res.status(404);
+    }
+    controller.getIndex(req, res);
+  });
 
   /**
    * @swagger

--- a/src/routes/knownRoutes.test.ts
+++ b/src/routes/knownRoutes.test.ts
@@ -1,0 +1,60 @@
+import { isKnownAppRoute } from './knownRoutes';
+
+describe('isKnownAppRoute', () => {
+  it.each([
+    '/',
+    '/upload',
+    '/pricing',
+    '/about',
+    '/convert',
+    '/notion-marketplace',
+    '/notion-to-anki',
+    '/quizlet-to-anki',
+    '/convert/csv-to-anki',
+    '/convert/enrich-anki-deck',
+    '/answers/fsrs-explained',
+    '/answers/pdf-to-anki',
+    '/answers/convert-notion-to-anki',
+    '/account',
+    '/account/claim',
+    '/ankify',
+    '/ankify/setup',
+    '/ops',
+    '/ops/pricing-ab',
+    '/documentation',
+    '/documentation/start-here/connect-notion',
+    '/security',
+    '/contact',
+    '/whats-new',
+    '/auth/magic',
+    '/s/abc123',
+    '/users/r/42',
+    '/rules/7',
+    '/preview/9',
+    '/mindmaps/4',
+    '/templates/edit/3',
+  ])('returns true for known route %s', (path) => {
+    expect(isKnownAppRoute(path)).toBe(true);
+  });
+
+  it.each([
+    '/wp-content/',
+    '/wp-includes/l10n/',
+    '/.env.backup',
+    '/convert/not-a-real-thing',
+    '/answers/not-a-real-answer',
+    '/notion-to-ank',
+    '/random-garbage',
+    '/rules/',
+    '/preview/',
+    '/s/',
+  ])('returns false for unknown route %s', (path) => {
+    expect(isKnownAppRoute(path)).toBe(false);
+  });
+
+  it('tolerates a trailing slash on a known route', () => {
+    expect(isKnownAppRoute('/pricing/')).toBe(true);
+    expect(isKnownAppRoute('/convert/csv-to-anki/')).toBe(true);
+    expect(isKnownAppRoute('/answers/fsrs-explained/')).toBe(true);
+  });
+});

--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -1,0 +1,161 @@
+const STATIC_PUBLIC_ROUTES = new Set<string>([
+  '/',
+  '/upload',
+  '/pricing',
+  '/about',
+  '/convert',
+  '/notion-marketplace',
+]);
+
+const APP_ROUTES = new Set<string>([
+  '/login',
+  '/register',
+  '/forgot',
+  '/account',
+  '/account/claim',
+  '/notion',
+  '/search',
+  '/downloads',
+  '/uploads',
+  '/favorites',
+  '/import',
+  '/ankify',
+  '/ankify/setup',
+  '/ankify/history',
+  '/feedback',
+  '/settings',
+  '/settings/card-options',
+  '/card-options',
+  '/transform',
+  '/mindmaps',
+  '/chat',
+  '/photo-to-deck',
+  '/image-occlusion',
+  '/print',
+  '/debug',
+  '/contact',
+  '/delete-account',
+  '/limit',
+  '/security',
+  '/status',
+  '/whats-new',
+  '/documentation',
+  '/successful-checkout',
+  '/auth/magic',
+  '/app',
+  '/templates',
+  '/templates/new',
+]);
+
+const OPS_ROUTES = new Set<string>([
+  '/ops',
+  '/ops/errors',
+  '/ops/performance',
+  '/ops/conversions',
+  '/ops/upload-funnel',
+  '/ops/business',
+  '/ops/showcase',
+  '/ops/interviews',
+  '/ops/messages',
+  '/ops/commands',
+  '/ops/flags',
+  '/ops/pricing-ab',
+]);
+
+const LANDING_SLUGS = new Set<string>([
+  'notion-to-anki',
+  'quizlet-to-anki',
+  'markdown-to-anki',
+  'pdf-to-anki',
+  'anki-to-notion',
+  'usmle-anki',
+  'nursing-flashcards',
+  'anki-from-medical-lecture-slides',
+  'powerpoint-to-anki',
+  'goodnotes-to-anki',
+  'ai-flashcard-generator',
+]);
+
+const CONVERT_SLUGS = new Set<string>([
+  'notion-to-anki',
+  'pdf-to-anki',
+  'markdown-to-anki',
+  'csv-to-anki',
+  'html-to-anki',
+  'apkg-to-csv',
+  'notion-tables-to-anki',
+  'brainscape-to-anki',
+  'lingvist-to-anki',
+  'studystack-to-anki',
+  'pleco-to-anki',
+  'zorbi-to-anki',
+  'language-reactor-to-anki',
+  'epub-to-anki',
+  'kindle-to-anki',
+  'enrich-anki-deck',
+]);
+
+const ANSWERS_SLUGS = new Set<string>([
+  'convert-notion-to-anki',
+  'notion-to-anki-sync',
+  'pdf-to-anki',
+  'quizlet-to-anki',
+  'fsrs-explained',
+]);
+
+const PARAM_PREFIXES = [
+  '/rules/',
+  '/preview/',
+  '/users/r/',
+  '/s/',
+  '/mindmaps/',
+  '/templates/edit/',
+];
+
+const normalizePathname = (pathname: string): string => {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+};
+
+const isLandingPath = (path: string): boolean => {
+  const slug = path.replace(/^\//, '');
+  return LANDING_SLUGS.has(slug);
+};
+
+const isConvertPath = (path: string): boolean => {
+  const slug = path.replace(/^\/convert\//, '');
+  return path.startsWith('/convert/') && CONVERT_SLUGS.has(slug);
+};
+
+const isAnswersPath = (path: string): boolean => {
+  const slug = path.replace(/^\/answers\//, '');
+  return path.startsWith('/answers/') && ANSWERS_SLUGS.has(slug);
+};
+
+const isParamPath = (path: string): boolean =>
+  PARAM_PREFIXES.some(
+    (prefix) => path.startsWith(prefix) && path.length > prefix.length
+  );
+
+const isDocumentationPath = (path: string): boolean =>
+  path === '/documentation' || path.startsWith('/documentation/');
+
+export const isKnownAppRoute = (pathname: string): boolean => {
+  const path = normalizePathname(pathname);
+
+  if (STATIC_PUBLIC_ROUTES.has(path)) {
+    return true;
+  }
+  if (APP_ROUTES.has(path) || OPS_ROUTES.has(path)) {
+    return true;
+  }
+  if (isDocumentationPath(path)) {
+    return true;
+  }
+  if (isLandingPath(path) || isConvertPath(path) || isAnswersPath(path)) {
+    return true;
+  }
+  return isParamPath(path);
+};

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,5 +1,6 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
+Disallow: /api/
 Disallow: /rules/
 Disallow: /notion
 Disallow: /favorites

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -2,188 +2,230 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://2anki.net/</loc>
-    <lastmod>2026-05-31</lastmod>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://2anki.net/upload</loc>
-    <lastmod>2026-05-31</lastmod>
+    <loc>https://2anki.net/upload/</loc>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/pricing</loc>
-    <lastmod>2026-05-31</lastmod>
+    <loc>https://2anki.net/pricing/</loc>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://2anki.net/about</loc>
-    <lastmod>2026-05-31</lastmod>
+    <loc>https://2anki.net/about/</loc>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert</loc>
-    <lastmod>2026-05-31</lastmod>
+    <loc>https://2anki.net/convert/</loc>
+    <lastmod>2026-06-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2anki.net/notion-to-anki</loc>
+    <loc>https://2anki.net/notion-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/quizlet-to-anki</loc>
+    <loc>https://2anki.net/quizlet-to-anki/</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/markdown-to-anki</loc>
+    <loc>https://2anki.net/markdown-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/pdf-to-anki</loc>
+    <loc>https://2anki.net/pdf-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/anki-to-notion</loc>
+    <loc>https://2anki.net/anki-to-notion/</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/usmle-anki</loc>
+    <loc>https://2anki.net/usmle-anki/</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/nursing-flashcards</loc>
+    <loc>https://2anki.net/nursing-flashcards/</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/anki-from-medical-lecture-slides</loc>
+    <loc>https://2anki.net/anki-from-medical-lecture-slides/</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/powerpoint-to-anki</loc>
+    <loc>https://2anki.net/powerpoint-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/goodnotes-to-anki</loc>
+    <loc>https://2anki.net/goodnotes-to-anki/</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/ai-flashcard-generator</loc>
+    <loc>https://2anki.net/ai-flashcard-generator/</loc>
     <lastmod>2026-05-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/notion-marketplace</loc>
+    <loc>https://2anki.net/notion-marketplace/</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/csv-to-anki</loc>
+    <loc>https://2anki.net/convert/csv-to-anki/</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/html-to-anki</loc>
+    <loc>https://2anki.net/convert/html-to-anki/</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/apkg-to-csv</loc>
+    <loc>https://2anki.net/convert/apkg-to-csv/</loc>
     <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/notion-tables-to-anki</loc>
+    <loc>https://2anki.net/convert/notion-tables-to-anki/</loc>
     <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/lingvist-to-anki</loc>
+    <loc>https://2anki.net/convert/lingvist-to-anki/</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/studystack-to-anki</loc>
+    <loc>https://2anki.net/convert/studystack-to-anki/</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/zorbi-to-anki</loc>
+    <loc>https://2anki.net/convert/zorbi-to-anki/</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/pleco-to-anki</loc>
+    <loc>https://2anki.net/convert/pleco-to-anki/</loc>
     <lastmod>2026-05-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/brainscape-to-anki</loc>
+    <loc>https://2anki.net/convert/brainscape-to-anki/</loc>
     <lastmod>2026-05-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/language-reactor-to-anki</loc>
+    <loc>https://2anki.net/convert/language-reactor-to-anki/</loc>
     <lastmod>2026-05-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/epub-to-anki</loc>
+    <loc>https://2anki.net/convert/epub-to-anki/</loc>
     <lastmod>2026-05-31</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/kindle-to-anki</loc>
+    <loc>https://2anki.net/convert/kindle-to-anki/</loc>
     <lastmod>2026-05-31</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/convert/enrich-anki-deck</loc>
+    <loc>https://2anki.net/convert/enrich-anki-deck/</loc>
     <lastmod>2026-06-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://2anki.net/answers/fsrs-explained</loc>
+    <loc>https://2anki.net/answers/fsrs-explained/</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/answers/convert-notion-to-anki/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/answers/notion-to-anki-sync/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/answers/pdf-to-anki/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/answers/quizlet-to-anki/</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/security</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/contact</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/documentation/start-here/connect-notion</loc>
+    <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -65,20 +65,20 @@ describe('emitLandingPages', () => {
       true
     );
     expect(files.some((p) => p.endsWith('usmle-anki/index.html'))).toBe(true);
-    expect(
-      files.some((p) => p.endsWith('nursing-flashcards/index.html'))
-    ).toBe(true);
+    expect(files.some((p) => p.endsWith('nursing-flashcards/index.html'))).toBe(
+      true
+    );
     expect(
       files.some((p) =>
         p.endsWith('anki-from-medical-lecture-slides/index.html')
       )
     ).toBe(true);
-    expect(
-      files.some((p) => p.endsWith('powerpoint-to-anki/index.html'))
-    ).toBe(true);
-    expect(
-      files.some((p) => p.endsWith('goodnotes-to-anki/index.html'))
-    ).toBe(true);
+    expect(files.some((p) => p.endsWith('powerpoint-to-anki/index.html'))).toBe(
+      true
+    );
+    expect(files.some((p) => p.endsWith('goodnotes-to-anki/index.html'))).toBe(
+      true
+    );
     expect(
       files.some((p) => p.endsWith('ai-flashcard-generator/index.html'))
     ).toBe(true);
@@ -152,7 +152,7 @@ describe('emitLandingPages', () => {
       'utf8'
     );
     expect(html).toContain(
-      '<link rel="canonical" href="https://2anki.net/pdf-to-anki">'
+      '<link rel="canonical" href="https://2anki.net/pdf-to-anki/">'
     );
   });
 
@@ -213,17 +213,28 @@ describe('emitMetaOnlyPages', () => {
   it('sets a unique title per route', () => {
     emitMetaOnlyPages(buildDir);
     const upload = readFileSync(join(buildDir, 'upload', 'index.html'), 'utf8');
-    const pricing = readFileSync(join(buildDir, 'pricing', 'index.html'), 'utf8');
+    const pricing = readFileSync(
+      join(buildDir, 'pricing', 'index.html'),
+      'utf8'
+    );
     const about = readFileSync(join(buildDir, 'about', 'index.html'), 'utf8');
-    expect(upload).toContain('<title>Upload notes and get an Anki deck — 2anki</title>');
-    expect(pricing).toContain('<title>Pricing — Free, Day Pass, Unlimited, Auto Sync | 2anki</title>');
-    expect(about).toContain('<title>About 2anki — open-source Notion to Anki converter</title>');
+    expect(upload).toContain(
+      '<title>Upload notes and get an Anki deck — 2anki</title>'
+    );
+    expect(pricing).toContain(
+      '<title>Pricing — Free, Day Pass, Unlimited, Auto Sync | 2anki</title>'
+    );
+    expect(about).toContain(
+      '<title>About 2anki — open-source Notion to Anki converter</title>'
+    );
   });
 
   it('points the canonical link at the route URL', () => {
     emitMetaOnlyPages(buildDir);
     const html = readFileSync(join(buildDir, 'pricing', 'index.html'), 'utf8');
-    expect(html).toContain('<link rel="canonical" href="https://2anki.net/pricing">');
+    expect(html).toContain(
+      '<link rel="canonical" href="https://2anki.net/pricing/">'
+    );
   });
 
   it('leaves the root div empty so React mounts without a flash', () => {
@@ -248,8 +259,12 @@ describe('emitNotionMarketplacePage', () => {
       join(buildDir, 'notion-marketplace', 'index.html'),
       'utf8'
     );
-    expect(html).toContain('<title>Notion to Anki — automatic sync | 2anki</title>');
-    expect(html).toContain('<link rel="canonical" href="https://2anki.net/notion-marketplace">');
+    expect(html).toContain(
+      '<title>Notion to Anki — automatic sync | 2anki</title>'
+    );
+    expect(html).toContain(
+      '<link rel="canonical" href="https://2anki.net/notion-marketplace/">'
+    );
     expect(html).toContain('Your Notion notes become Anki cards');
   });
 });
@@ -289,7 +304,7 @@ describe('emitAnswersPages', () => {
       'utf8'
     );
     expect(html).toContain(
-      '<link rel="canonical" href="https://2anki.net/answers/pdf-to-anki">'
+      '<link rel="canonical" href="https://2anki.net/answers/pdf-to-anki/">'
     );
   });
 

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -38,6 +38,11 @@ const escapeHtml = (value: string): string =>
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
 
+const canonicalUrl = (pathname: string): string => {
+  const withTrailingSlash = pathname.endsWith('/') ? pathname : `${pathname}/`;
+  return `https://2anki.net${withTrailingSlash}`;
+};
+
 function buildHeroFragment(copy: LandingCopy): string {
   return [
     '<section id="upload" style="background:var(--color-bg-secondary);padding:4rem 1.5rem 3rem;">',
@@ -53,7 +58,12 @@ function buildHeroFragment(copy: LandingCopy): string {
   ].join('');
 }
 
-const REPLACED_OG_PROPERTIES = ['og:title', 'og:description', 'og:url', 'og:type'];
+const REPLACED_OG_PROPERTIES = [
+  'og:title',
+  'og:description',
+  'og:url',
+  'og:type',
+];
 const REPLACED_TWITTER_NAMES = ['twitter:title', 'twitter:description'];
 
 function stripExistingMeta(html: string): string {
@@ -73,7 +83,7 @@ function stripExistingMeta(html: string): string {
 }
 
 function rewriteHead(html: string, copy: LandingCopy): string {
-  const canonical = `https://2anki.net${copy.pathname}`;
+  const canonical = canonicalUrl(copy.pathname);
   const titleTag = `<title>${escapeHtml(copy.title)}</title>`;
   const descriptionTag = `<meta name="description" content="${escapeHtml(
     copy.description
@@ -92,28 +102,19 @@ function rewriteHead(html: string, copy: LandingCopy): string {
   ].join('\n  ');
 
   let next = html.replace(/<title>[\s\S]*?<\/title>/, titleTag);
-  next = next.replace(
-    /<meta\s+name="description"[^>]*>/,
-    descriptionTag
-  );
+  next = next.replace(/<meta\s+name="description"[^>]*>/, descriptionTag);
   next = next.replace(
     /<link\s+rel="canonical"[^>]*>/,
     `<link rel="canonical" href="${canonical}">`
   );
   next = stripExistingMeta(next);
-  next = next.replace(
-    /<\/head>/,
-    `  ${ogTags}\n</head>`
-  );
+  next = next.replace(/<\/head>/, `  ${ogTags}\n</head>`);
   return next;
 }
 
 function rewriteRoot(html: string, copy: LandingCopy): string {
   const hero = buildHeroFragment(copy);
-  return html.replace(
-    /<div id="root"><\/div>/,
-    `<div id="root">${hero}</div>`
-  );
+  return html.replace(/<div id="root"><\/div>/, `<div id="root">${hero}</div>`);
 }
 
 const NOTION_MARKETPLACE_META = {
@@ -122,7 +123,8 @@ const NOTION_MARKETPLACE_META = {
   description:
     'Connect your Notion workspace and your notes become Anki flashcards automatically. No exports, no zips. Auto Sync $30/mo, Unlimited $6/mo.',
   h1: 'Your Notion notes become Anki cards — automatically',
-  subhead: 'Connect your workspace in 5 minutes. No exports, no zips, no manual steps.',
+  subhead:
+    'Connect your workspace in 5 minutes. No exports, no zips, no manual steps.',
 };
 
 function buildNotionMarketplaceFragment(): string {
@@ -140,7 +142,7 @@ export function emitNotionMarketplacePage(buildDir: string): string {
   const meta = NOTION_MARKETPLACE_META;
   const indexPath = join(buildDir, 'index.html');
   const source = readFileSync(indexPath, 'utf8');
-  const canonical = `https://2anki.net${meta.pathname}`;
+  const canonical = canonicalUrl(meta.pathname);
   const slug = meta.pathname.replace(/^\//, '');
   const outDir = join(buildDir, slug);
   const outPath = join(outDir, 'index.html');
@@ -157,7 +159,10 @@ export function emitNotionMarketplacePage(buildDir: string): string {
 
   let html = source.replace(/<title>[\s\S]*?<\/title>/, titleTag);
   html = html.replace(/<meta\s+name="description"[^>]*>/, descriptionTag);
-  html = html.replace(/<link\s+rel="canonical"[^>]*>/, `<link rel="canonical" href="${canonical}">`);
+  html = html.replace(
+    /<link\s+rel="canonical"[^>]*>/,
+    `<link rel="canonical" href="${canonical}">`
+  );
   html = stripExistingMeta(html);
   html = html.replace(/<\/head>/, `  ${ogTags}\n</head>`);
   html = html.replace(
@@ -250,7 +255,7 @@ export function emitMetaOnlyPages(buildDir: string): string[] {
   const emitted: string[] = [];
 
   for (const meta of META_ONLY_PAGES) {
-    const canonical = `https://2anki.net${meta.pathname}`;
+    const canonical = canonicalUrl(meta.pathname);
     const slug = meta.pathname.replace(/^\//, '');
     const outDir = join(buildDir, slug);
     const outPath = join(outDir, 'index.html');
@@ -269,7 +274,10 @@ export function emitMetaOnlyPages(buildDir: string): string[] {
 
     let html = source.replace(/<title>[\s\S]*?<\/title>/, titleTag);
     html = html.replace(/<meta\s+name="description"[^>]*>/, descriptionTag);
-    html = html.replace(/<link\s+rel="canonical"[^>]*>/, `<link rel="canonical" href="${canonical}">`);
+    html = html.replace(
+      /<link\s+rel="canonical"[^>]*>/,
+      `<link rel="canonical" href="${canonical}">`
+    );
     html = stripExistingMeta(html);
     html = html.replace(/<\/head>/, `  ${ogTags}\n</head>`);
 

--- a/web/src/pages/NotFoundPage.test.tsx
+++ b/web/src/pages/NotFoundPage.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { HelmetProvider } from 'react-helmet-async';
+import { describe, expect, it } from 'vitest';
+
+import NotFoundPage from './NotFoundPage';
+
+function renderPage() {
+  return render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={['/no-such-page']}>
+        <NotFoundPage />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+}
+
+describe('NotFoundPage', () => {
+  it('renders the page-not-found heading', () => {
+    renderPage();
+    expect(
+      screen.getByRole('heading', { name: 'Page not found' })
+    ).toBeInTheDocument();
+  });
+
+  it('sets a noindex robots meta so search engines skip 404s', async () => {
+    renderPage();
+    await waitFor(() => {
+      const meta = document.querySelector('meta[name="robots"]');
+      expect(meta?.getAttribute('content')).toBe('noindex, nofollow');
+    });
+  });
+
+  it('sets the page title', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(document.title).toBe('Page not found — 2anki');
+    });
+  });
+});

--- a/web/src/pages/NotFoundPage.tsx
+++ b/web/src/pages/NotFoundPage.tsx
@@ -1,8 +1,13 @@
+import { Helmet } from 'react-helmet-async';
 import styles from '../styles/shared.module.css';
 
 function NotFoundPage() {
   return (
     <div className={`${styles.pageNarrow} ${styles.textCenter}`}>
+      <Helmet>
+        <title>Page not found — 2anki</title>
+        <meta name="robots" content="noindex, nofollow" />
+      </Helmet>
       <div className={styles.emptyState}>
         <img src="/mascot/Notion 1.png" alt="" className={styles.mascot404} />
         <h1 className={styles.title}>Page not found</h1>


### PR DESCRIPTION
## What
Four crawl-hygiene fixes from the SEO crawl-log analysis, shipped as one PR: a trailing-slash canonical fix, sitemap additions for the answers pages and a few public pages, a robots.txt `/api/` disallow, and a soft-404 fix so unknown routes return a real 404 instead of a 200 shell.

## Why
The crawl logs showed wasted and misdirected crawl budget:
- 74% of Googlebot crawl was spent on 301 hops — every prerendered landing URL in the sitemap is slash-less but prod 301s it to the trailing-slash form.
- ChatGPT-User repeatedly fetched `/answers/pdf-to-anki`, `/answers/notion-to-anki-sync`, `/answers/convert-notion-to-anki` — none were in the sitemap (only `/answers/fsrs-explained` was).
- Googlebot hit `/api/*` 51 times in 4 days with no `Disallow`.
- Junk probes like `/.env.backup` and `/wp-content/` returned a soft-200 (the SPA shell with a 200 status), which search engines treat as thin/duplicate content rather than 404s.

## How
**Canonical form — chosen: trailing-slash for prerendered paths.** The redirect origin is structural, not in-repo logic: prerendered pages are written as `<slug>/index.html` directories, and `express.static` (`redirect: true`) plus Apache on prod both 301 the slash-less request to the directory's trailing-slash form. We can't edit Apache from this repo, so per the decision rule this is the low-blast-radius path: flip the sitemap to trailing-slash for prerendered paths and emit a self-referencing trailing-slash `<link rel="canonical">` from the prerender (`canonicalUrl()` helper). Pure-SPA routes (`/security`, `/contact`, `/documentation/...`) serve 200 slash-less via the catch-all with no 301, so they stay slash-less in the sitemap. React Router internal `<Link>`s are unchanged — client-side nav never hits the server, so they generate no crawl-wasting 301s.

**Soft-404.** New `src/routes/knownRoutes.ts` exports `isKnownAppRoute(pathname)`, a trailing-slash-tolerant allowlist of every real route (static public, landing slugs, `/convert/:slug`, `/answers/:slug`, app/auth/ops routes, documentation, and param prefixes like `/s/:token`, `/preview/:id`). The `DefaultRouter` catch-all sets `res.status(404)` when the path is not on the allowlist, then serves the same `index.html` shell — `res.send()` honors the pre-set status, so `sendIndex` needed no change. Auth-gated routes still resolve (they're on the allowlist); nothing redirects to `/404`; no junk-pattern blocklist. `NotFoundPage` gets a `noindex, nofollow` robots meta and a "Page not found — 2anki" title.

The server cannot import the web workspace (`tsconfig` excludes `web`), so `knownRoutes.ts` is the server-side source of truth for the slug lists; a parity test guards drift against the sitemap.

## Measuring success
- **GSC Crawl Stats (1–2 wk):** "Pages with redirect" share drops well below the current ~74%; total crawl requests per indexed page falls.
- **GSC Coverage (2–6 wk):** `/answers/*` pages move from Discovered/Crawled to Indexed; `/api/*` and junk paths leave the "Crawled — not indexed" / "Soft 404" buckets.
- **Server logs:** unknown paths now log a 404 status (grep the access log for `/.env`, `/wp-` → 404).

## Testing
- Unit tests added:
  - `src/routes/knownRoutes.test.ts` — known routes pass, junk/unknown fail, trailing-slash tolerance.
  - `src/routes/DefaultRouter.test.ts` — `/wp-content/`, `/wp-includes/l10n/`, `/.env.backup` → 404 + shell; `/convert/not-a-real-thing`, `/notion-to-ank` → 404; `/pricing`, `/pricing/`, `/convert/csv-to-anki`, `/account`, `/` → 200 + shell; **parity:** every sitemap `<loc>` path passes `isKnownAppRoute`.
  - `web/src/pages/NotFoundPage.test.tsx` — asserts the `noindex, nofollow` robots meta and the title.
- Server tsc, web typecheck, and the scoped Jest/Vitest runs are green locally.
- `sonar-scanner` not run locally (no `SONAR_TOKEN` configured here) — expect the SonarCloud Automatic Analysis on the PR. New code is low-complexity (flat positive-lead `if` chains, small pure predicates).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified on this branch: Express (with built web) serves 404 + app shell for /wp-content/ and /notion-to-ank, 200 for /pricing/ /account /convert slugs (301 hop on slash-less per the structural redirect); unknown route renders the not-found page at 375px with title "Page not found — 2anki" and meta robots noindex,nofollow; only console message is the pre-existing anonymous 403 probe.

## Changelog
No entry — the only user-visible behavior change is junk URLs now returning a 404 instead of a soft-200, which real users don't hit. Everything else is crawler-facing (sitemap, robots, canonical form). Internal/crawler-only, no entry warranted.

## Risks
- If a real route was omitted from `knownRoutes.ts`, that page would start returning a 404 status while still rendering the shell (React still routes it client-side, so users see the page; only the HTTP status is wrong for crawlers). The sitemap-parity test covers every advertised URL; the allowlist was built directly from `App.tsx`, the prerender config, and the answers/convert configs. Rollback is a one-line revert of the catch-all change.
- Trailing-slash sitemap assumes prod keeps 301ing slash-less → trailing-slash for prerendered dirs. If that ever changes, the canonical and sitemap stay internally consistent (both trailing-slash), so no loop.

## Goal alignment
Acquisition lane. Wasted crawl budget and soft-404s suppress indexation and rankings for the landing/answers pages, which are the top of the organic-signup funnel. Freeing crawl budget and getting the answers pages indexed should lift impressions/clicks in GSC (read in Search Console), feeding the landing → signup → first-conversion funnel toward the 300K-user goal.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783752849&installation_id=132681956&pr_number=3229&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3229&signature=666dad6ec0ee4039e971125d34d0f29080abf46120b75b418e207060ac142f65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
