### PR TITLE
fix: reassure lock-in email readers no charge happens without action

### DIFF
--- a/src/services/EmailService/templates/price-lock-in.html
+++ b/src/services/EmailService/templates/price-lock-in.html
@@ -37,7 +37,8 @@
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
               <p style="margin: 0 0 16px;">Unlimited pricing has gone up for new members: $7.99/month and $64/year.</p>
               <p style="margin: 0 0 16px;">Your account locks in today's rate — $6/month or $60/year — if you upgrade before Sunday 21 June, 23:59 CEST. That rate stays as long as the subscription is active.</p>
-              <p style="margin: 0 0 24px;">After Sunday, the $6 and $60 prices are retired and the new rates apply.</p>
+              <p style="margin: 0 0 16px;">After Sunday, the $6 and $60 prices are retired and the new rates apply.</p>
+              <p style="margin: 0 0 24px;">Nothing changes and you won't be charged unless you choose to upgrade.</p>
               <div style="text-align: center; margin: 0 0 24px;" class="email-cta">
                 <a href="{{ctaUrl}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Lock in $6/month</a>
               </div>
@@ -46,7 +47,7 @@
           </tr>
           <tr>
             <td class="email-footer" style="text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #9ca3af; padding: 16px 24px; border-top: 1px solid #e5e7eb;">
-              You're receiving this because you have a 2anki account.<br />
+              You're receiving this because you created an account at 2anki.net.<br />
               2anki.net — Turn what you study into Anki flashcards<br />
               <a href="{{unsubscribeUrl}}" style="color: #6b7280; text-decoration: underline;">Don't want emails like this? Unsubscribe</a>
             </td>


### PR DESCRIPTION
A dormant recipient parsed the lock-in campaign as a bill ("I did not subscribe! I do not want to pay this"). Campaign health is fine (0 spam reports, 0.85% opt-out across the first 5 063 sends) but the confusion is preventable with one sentence — and ~13.7k of the 18.8k segment is still unsent.

Two copy changes in `price-lock-in.html`:
- New line before the sign-off: "Nothing changes and you won't be charged unless you choose to upgrade."
- Footer origin made specific: "because you created an account at 2anki.net."

Template suite green (24/24). Send the next batch after this deploys.

No changelog entry — email copy, not an in-app surface.

Browser check: not applicable — email template only, no rendered web output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753400&installation_id=132681956&pr_number=3230&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3230&signature=5d9ec9a061c27ac282c35c101fa3bb103c5db7f55b5ba639bdc3f42a8fe7bf42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->