### PR TITLE
feat: delete inactive free accounts with dead email addresses

### DIFF
--- a/src/data_layer/InactivityEmailRepository.deadAddress.sql.test.ts
+++ b/src/data_layer/InactivityEmailRepository.deadAddress.sql.test.ts
@@ -1,0 +1,32 @@
+import knexFactory from 'knex';
+
+import { InactivityEmailRepository } from './InactivityEmailRepository';
+
+describe('InactivityEmailRepository dead-address candidate SQL', () => {
+  const pg = knexFactory({ client: 'pg' });
+  const repository = new InactivityEmailRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('selects free accounts inactive for the inactivity window without a warning requirement', () => {
+    const sql = repository.buildDeadAddressCandidatesQuery(100).toString();
+
+    expect(sql).toContain('select "u"."id", "u"."email" from "users" as "u"');
+    expect(sql).toContain("u.last_login_at < now() - interval '6 months'");
+    expect(sql).toContain(
+      "u.last_login_at IS NULL AND u.created_at < now() - interval '6 months'"
+    );
+    expect(sql).toContain('u.patreon IS NOT TRUE');
+    expect(sql).toContain('"subscriptions"');
+    expect(sql).toContain('"subscriptions"."active"');
+    expect(sql).toContain('limit 100');
+  });
+
+  it('does not gate the candidate query on inactivity_emails', () => {
+    const sql = repository.buildDeadAddressCandidatesQuery(100).toString();
+
+    expect(sql).not.toContain('inactivity_emails');
+  });
+});

--- a/src/data_layer/InactivityEmailRepository.ts
+++ b/src/data_layer/InactivityEmailRepository.ts
@@ -2,11 +2,16 @@ import type { Knex } from 'knex';
 
 export const INACTIVITY_DELETION_GRACE_DAYS = 14;
 
+export const INACTIVITY_WINDOW = '6 months';
+
 export interface IInactivityEmailRepository {
   getUsersToNotify(
     limit?: number
   ): Promise<Array<{ id: number; name: string; email: string }>>;
   getUsersToDelete(
+    limit?: number
+  ): Promise<Array<{ id: number; email: string }>>;
+  getDeadAddressCandidates(
     limit?: number
   ): Promise<Array<{ id: number; email: string }>>;
   recordSend(userId: number, token: string): Promise<void>;
@@ -36,9 +41,9 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
       .select('users.id', 'users.name', 'users.email')
       .where(function () {
         this.whereRaw(
-          "users.last_login_at < now() - interval '6 months'"
+          `users.last_login_at < now() - interval '${INACTIVITY_WINDOW}'`
         ).orWhereRaw(
-          "users.last_login_at IS NULL AND users.created_at < now() - interval '6 months'"
+          `users.last_login_at IS NULL AND users.created_at < now() - interval '${INACTIVITY_WINDOW}'`
         );
       })
       .whereRaw('users.patreon IS NOT TRUE')
@@ -99,6 +104,38 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
     return rows.map((row) => ({ id: row.id, email: row.email }));
   }
 
+  buildDeadAddressCandidatesQuery(
+    limit: number
+  ): Knex.QueryBuilder<UserRow, UserRow[]> {
+    return this.database<UserRow>('users as u')
+      .select('u.id', 'u.email')
+      .where(function () {
+        this.whereRaw(
+          `u.last_login_at < now() - interval '${INACTIVITY_WINDOW}'`
+        ).orWhereRaw(
+          `u.last_login_at IS NULL AND u.created_at < now() - interval '${INACTIVITY_WINDOW}'`
+        );
+      })
+      .whereRaw('u.patreon IS NOT TRUE')
+      .whereNotExists(
+        this.database('subscriptions')
+          .where('subscriptions.active', true)
+          .whereRaw(
+            '(subscriptions.email = u.email OR subscriptions.linked_email = u.email)'
+          )
+          .limit(1)
+      )
+      .orderBy('u.id', 'asc')
+      .limit(limit);
+  }
+
+  async getDeadAddressCandidates(
+    limit = 100
+  ): Promise<Array<{ id: number; email: string }>> {
+    const rows = await this.buildDeadAddressCandidatesQuery(limit);
+    return rows.map((row) => ({ id: row.id, email: row.email }));
+  }
+
   async recordSend(userId: number, token: string): Promise<void> {
     await this.database(this.table).insert({ user_id: userId, token });
   }
@@ -121,6 +158,7 @@ export class InMemoryInactivityEmailRepository implements IInactivityEmailReposi
   private usersToReturn: Array<{ id: number; name: string; email: string }> =
     [];
   private usersToDelete: Array<{ id: number; email: string }> = [];
+  private deadAddressCandidates: Array<{ id: number; email: string }> = [];
   private readonly sentUserIds = new Set<number>();
   private emails: Array<{ id: number; userId: number; token: string }> = [];
   private nextId = 1;
@@ -131,6 +169,10 @@ export class InMemoryInactivityEmailRepository implements IInactivityEmailReposi
 
   seedUsersToDelete(users: Array<{ id: number; email: string }>): void {
     this.usersToDelete = users;
+  }
+
+  seedDeadAddressCandidates(users: Array<{ id: number; email: string }>): void {
+    this.deadAddressCandidates = users;
   }
 
   async getUsersToNotify(
@@ -145,6 +187,12 @@ export class InMemoryInactivityEmailRepository implements IInactivityEmailReposi
     limit = 100
   ): Promise<Array<{ id: number; email: string }>> {
     return this.usersToDelete.slice(0, limit);
+  }
+
+  async getDeadAddressCandidates(
+    limit = 100
+  ): Promise<Array<{ id: number; email: string }>> {
+    return this.deadAddressCandidates.slice(0, limit);
   }
 
   async recordSend(userId: number, token: string): Promise<void> {
@@ -170,6 +218,7 @@ export class InMemoryInactivityEmailRepository implements IInactivityEmailReposi
   clear(): void {
     this.usersToReturn = [];
     this.usersToDelete = [];
+    this.deadAddressCandidates = [];
     this.sentUserIds.clear();
     this.emails = [];
     this.nextId = 1;

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -21,6 +21,7 @@ import { CancellationFeedbackRepository } from '../data_layer/CancellationFeedba
 import { EmojiFeedbackRepository } from '../data_layer/EmojiFeedbackRepository';
 import { ReEngagementFeedbackRepository } from '../data_layer/ReEngagementFeedbackRepository';
 import UsersRepository from '../data_layer/UsersRepository';
+import SuppressionEventsRepository from '../data_layer/SuppressionEventsRepository';
 import { ShowcaseRepository } from '../data_layer/ShowcaseRepository';
 import DownloadRepository from '../data_layer/DownloadRepository';
 import NotionRepository from '../data_layer/NotionRespository';
@@ -114,7 +115,8 @@ const OpsRouter = () => {
     new GetMindmapStorageMetricsUseCase(mindmapStorageService),
     new DeleteInactiveUsersUseCase(
       new InactivityEmailRepository(database),
-      new UsersRepository(database)
+      new UsersRepository(database),
+      new SuppressionEventsRepository(database)
     ),
     new SyncStripeSubscriptionsUseCase(() => updateStripeSubscriptions()),
     new GetPricingAbFunnelUseCase(

--- a/src/server.ts
+++ b/src/server.ts
@@ -94,6 +94,7 @@ import { getDefaultEmailService } from './services/EmailService/EmailService';
 import { SendInactivityWarningsUseCase } from './usecases/ops/SendInactivityWarningsUseCase';
 import { DeleteInactiveUsersUseCase } from './usecases/ops/DeleteInactiveUsersUseCase';
 import UsersRepository from './data_layer/UsersRepository';
+import SuppressionEventsRepository from './data_layer/SuppressionEventsRepository';
 import { initConversionPool } from './lib/conversionPool';
 import { gracefulShutdown } from './lib/gracefulShutdown';
 
@@ -303,7 +304,8 @@ const serve = async () => {
 
   const deleteInactiveUsersUseCase = new DeleteInactiveUsersUseCase(
     inactivityEmailRepo,
-    new UsersRepository(database)
+    new UsersRepository(database),
+    new SuppressionEventsRepository(database)
   );
   scheduleInactiveUserDeletions(deleteInactiveUsersUseCase, {
     eventsSink,

--- a/src/usecases/ops/DeleteInactiveUsersUseCase.test.ts
+++ b/src/usecases/ops/DeleteInactiveUsersUseCase.test.ts
@@ -3,6 +3,8 @@ import {
   IInactiveUserDeleter,
 } from './DeleteInactiveUsersUseCase';
 import { InMemoryInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
+import { InMemorySuppressionEventsRepository } from '../../data_layer/SuppressionEventsRepository';
+import { emailHash } from '../../lib/emailHash';
 
 function makeDeleter(
   overrides: Partial<IInactiveUserDeleter> = {}
@@ -13,12 +15,31 @@ function makeDeleter(
   } as jest.Mocked<IInactiveUserDeleter>;
 }
 
+async function seedSuppression(
+  suppression: InMemorySuppressionEventsRepository,
+  email: string,
+  eventType: 'bounce' | 'dropped' | 'deferred' = 'bounce'
+): Promise<void> {
+  await suppression.record({
+    emailHash: emailHash(email),
+    eventType,
+    sgEventId: `evt-${email}-${eventType}`,
+    eventAt: new Date('2026-06-06T10:00:00.000Z'),
+  });
+}
+
 describe('DeleteInactiveUsersUseCase', () => {
   let repo: InMemoryInactivityEmailRepository;
+  let suppression: InMemorySuppressionEventsRepository;
 
   beforeEach(() => {
     repo = new InMemoryInactivityEmailRepository();
+    suppression = new InMemorySuppressionEventsRepository();
   });
+
+  function makeUseCase(deleter: IInactiveUserDeleter) {
+    return new DeleteInactiveUsersUseCase(repo, deleter, suppression);
+  }
 
   describe('dry run', () => {
     it('returns candidate count without deleting anyone', async () => {
@@ -27,7 +48,7 @@ describe('DeleteInactiveUsersUseCase', () => {
         { id: 2, email: 'bob@example.com' },
       ]);
       const deleter = makeDeleter();
-      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+      const useCase = makeUseCase(deleter);
 
       const result = await useCase.execute(true);
 
@@ -41,7 +62,7 @@ describe('DeleteInactiveUsersUseCase', () => {
         { id: 2, email: 'bob@example.com' },
         { id: 3, email: 'carol@example.com' },
       ]);
-      const useCase = new DeleteInactiveUsersUseCase(repo, makeDeleter());
+      const useCase = makeUseCase(makeDeleter());
 
       const result = await useCase.execute(true, 1);
 
@@ -49,7 +70,7 @@ describe('DeleteInactiveUsersUseCase', () => {
     });
 
     it('returns zero when no candidates exist', async () => {
-      const useCase = new DeleteInactiveUsersUseCase(repo, makeDeleter());
+      const useCase = makeUseCase(makeDeleter());
 
       const result = await useCase.execute(true);
 
@@ -64,7 +85,7 @@ describe('DeleteInactiveUsersUseCase', () => {
         { id: 2, email: 'bob@example.com' },
       ]);
       const deleter = makeDeleter();
-      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+      const useCase = makeUseCase(deleter);
 
       const result = await useCase.execute(false);
 
@@ -85,7 +106,7 @@ describe('DeleteInactiveUsersUseCase', () => {
           .mockRejectedValueOnce(new Error('FK violation'))
           .mockResolvedValueOnce(undefined),
       });
-      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+      const useCase = makeUseCase(deleter);
 
       const result = await useCase.execute(false);
 
@@ -100,7 +121,7 @@ describe('DeleteInactiveUsersUseCase', () => {
         { id: 3, email: 'carol@example.com' },
       ]);
       const deleter = makeDeleter();
-      const useCase = new DeleteInactiveUsersUseCase(repo, deleter);
+      const useCase = makeUseCase(deleter);
 
       const result = await useCase.execute(false, 2);
 
@@ -109,11 +130,99 @@ describe('DeleteInactiveUsersUseCase', () => {
     });
 
     it('returns zero when no candidates exist', async () => {
-      const useCase = new DeleteInactiveUsersUseCase(repo, makeDeleter());
+      const useCase = makeUseCase(makeDeleter());
 
       const result = await useCase.execute(false);
 
       expect(result).toEqual({ count: 0, dryRun: false });
+    });
+  });
+
+  describe('dead-address segment', () => {
+    it('deletes an inactive free account whose address hard-bounced even without a warning', async () => {
+      repo.seedDeadAddressCandidates([{ id: 7, email: 'dead@example.com' }]);
+      await seedSuppression(suppression, 'dead@example.com', 'bounce');
+      const deleter = makeDeleter();
+      const useCase = makeUseCase(deleter);
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 1, dryRun: false });
+      expect(deleter.deleteUser).toHaveBeenCalledWith('7');
+    });
+
+    it('deletes an inactive free account whose address was dropped', async () => {
+      repo.seedDeadAddressCandidates([{ id: 8, email: 'gone@example.com' }]);
+      await seedSuppression(suppression, 'gone@example.com', 'dropped');
+      const deleter = makeDeleter();
+      const useCase = makeUseCase(deleter);
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 1, dryRun: false });
+      expect(deleter.deleteUser).toHaveBeenCalledWith('8');
+    });
+
+    it('counts dead-address candidates in a dry run without deleting', async () => {
+      repo.seedDeadAddressCandidates([{ id: 7, email: 'dead@example.com' }]);
+      await seedSuppression(suppression, 'dead@example.com', 'bounce');
+      const deleter = makeDeleter();
+      const useCase = makeUseCase(deleter);
+
+      const result = await useCase.execute(true);
+
+      expect(result).toEqual({ count: 1, dryRun: true });
+      expect(deleter.deleteUser).not.toHaveBeenCalled();
+    });
+
+    it('never deletes a candidate whose only suppression event is deferred', async () => {
+      repo.seedDeadAddressCandidates([{ id: 7, email: 'slow@example.com' }]);
+      await seedSuppression(suppression, 'slow@example.com', 'deferred');
+      const deleter = makeDeleter();
+      const useCase = makeUseCase(deleter);
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 0, dryRun: false });
+      expect(deleter.deleteUser).not.toHaveBeenCalled();
+    });
+
+    it('never deletes a candidate with no suppression event at all', async () => {
+      repo.seedDeadAddressCandidates([{ id: 7, email: 'fine@example.com' }]);
+      const useCase = makeUseCase(makeDeleter());
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 0, dryRun: false });
+    });
+
+    it('does not double-count a user present in both segments', async () => {
+      repo.seedUsersToDelete([{ id: 7, email: 'dead@example.com' }]);
+      repo.seedDeadAddressCandidates([{ id: 7, email: 'dead@example.com' }]);
+      await seedSuppression(suppression, 'dead@example.com', 'bounce');
+      const deleter = makeDeleter();
+      const useCase = makeUseCase(deleter);
+
+      const result = await useCase.execute(false);
+
+      expect(result).toEqual({ count: 1, dryRun: false });
+      expect(deleter.deleteUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('caps the combined segments at the batch limit', async () => {
+      repo.seedUsersToDelete([
+        { id: 1, email: 'a@example.com' },
+        { id: 2, email: 'b@example.com' },
+      ]);
+      repo.seedDeadAddressCandidates([{ id: 3, email: 'c@example.com' }]);
+      await seedSuppression(suppression, 'c@example.com', 'bounce');
+      const deleter = makeDeleter();
+      const useCase = makeUseCase(deleter);
+
+      const result = await useCase.execute(false, 2);
+
+      expect(result).toEqual({ count: 2, dryRun: false });
+      expect(deleter.deleteUser).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/usecases/ops/DeleteInactiveUsersUseCase.ts
+++ b/src/usecases/ops/DeleteInactiveUsersUseCase.ts
@@ -1,4 +1,6 @@
 import type { IInactivityEmailRepository } from '../../data_layer/InactivityEmailRepository';
+import type { ISuppressionEventsRepository } from '../../data_layer/SuppressionEventsRepository';
+import { emailHash } from '../../lib/emailHash';
 
 export interface IInactiveUserDeleter {
   deleteUser(owner: string): Promise<unknown>;
@@ -9,35 +11,74 @@ export interface DeleteInactiveUsersResult {
   dryRun: boolean;
 }
 
+interface DeletionCandidate {
+  id: number;
+  email: string;
+}
+
 export class DeleteInactiveUsersUseCase {
   constructor(
     private readonly repo: IInactivityEmailRepository,
-    private readonly userDeleter: IInactiveUserDeleter
+    private readonly userDeleter: IInactiveUserDeleter,
+    private readonly suppressionRepo: ISuppressionEventsRepository
   ) {}
 
   async execute(
     dryRun: boolean,
     limit = 100
   ): Promise<DeleteInactiveUsersResult> {
-    const users = await this.repo.getUsersToDelete(limit);
+    const candidates = await this.collectCandidates(limit);
 
     if (dryRun) {
-      return { count: users.length, dryRun: true };
+      return { count: candidates.length, dryRun: true };
     }
 
     let deleted = 0;
-    for (const user of users) {
+    for (const candidate of candidates) {
       try {
-        await this.userDeleter.deleteUser(String(user.id));
+        await this.userDeleter.deleteUser(String(candidate.id));
         deleted++;
       } catch (error) {
         console.error(
-          `[inactivity-delete] failed to delete user ${user.id}:`,
+          `[inactivity-delete] failed to delete user ${candidate.id}:`,
           error
         );
       }
     }
 
     return { count: deleted, dryRun: false };
+  }
+
+  private async collectCandidates(limit: number): Promise<DeletionCandidate[]> {
+    const warned = await this.repo.getUsersToDelete(limit);
+    const deadAddress = await this.collectDeadAddressCandidates(limit);
+
+    const merged: DeletionCandidate[] = [];
+    const seen = new Set<number>();
+    for (const candidate of [...warned, ...deadAddress]) {
+      if (seen.has(candidate.id)) {
+        continue;
+      }
+      seen.add(candidate.id);
+      merged.push(candidate);
+    }
+
+    return merged.slice(0, limit);
+  }
+
+  private async collectDeadAddressCandidates(
+    limit: number
+  ): Promise<DeletionCandidate[]> {
+    const candidates = await this.repo.getDeadAddressCandidates(limit);
+    const deadAddress: DeletionCandidate[] = [];
+    for (const candidate of candidates) {
+      const suppressed = await this.suppressionRepo.isSuppressed(
+        emailHash(candidate.email)
+      );
+      if (suppressed) {
+        deadAddress.push(candidate);
+      }
+    }
+    return deadAddress;
   }
 }

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -296,9 +296,10 @@ export default function CommandsTab() {
         <h2 className={styles.cardTitle}>Delete inactive accounts</h2>
         <p className={styles.panelSubtitle}>
           Permanently deletes free accounts that were warned 14+ days ago and
-          have not logged in since. Excludes lifetime and active subscribers.
-          Capped at 100 per run. Check candidates first — deletion cannot be
-          undone.
+          have not logged in since, plus inactive free accounts whose email
+          address hard-bounced or was dropped — the warning email can never
+          reach them. Excludes lifetime and active subscribers. Capped at 100
+          per run. Check candidates first — deletion cannot be undone.
         </p>
         <div className={styles.controls}>
           <button


### PR DESCRIPTION
## What
Extends the inactive-account deletion flow with a second segment: inactive, free accounts whose email address is dead (hard-bounced or dropped) are now deletable even though they were never warned. The warning email can never reach a dead address, so these accounts could never satisfy the existing "warned 14+ days ago" gate and accumulated as permanent zombies.

## Why
The price lock-in campaign surfaced ~214 hard-dead addresses (99 bounces + 115 dropped in `suppression_events`). Every one of those accounts is unreachable and un-deletable under the old rule. This closes the gap so the ops "Delete inactive accounts" action can clear them.

## Policy

A dead-address account is deletable only when **all three** hold; the warning-email requirement is waived because it is unsatisfiable by definition.

| # | Criterion | How it's enforced |
| --- | --- | --- |
| 1 | Address has a **current hard** suppression event (bounce / dropped / spamreport / blocked — never `deferred`, which is temporary) | `suppressionRepo.isSuppressed(emailHash(email))` — latest event wins, so a later `delivered` un-suppresses |
| 2 | Account **inactive** — no login within the inactivity window | reuses the inactivity flow's 6-month window (`INACTIVITY_WINDOW`) in `buildDeadAddressCandidatesQuery` |
| 3 | Account **free** — not patreon/lifetime, no active subscription | `u.patreon IS NOT TRUE` + `whereNotExists` active subscription, mirroring the warned-segment predicates |

**Waiver rationale:** the warning email is delivered to the same dead address that bounced, so requiring "warned 14+ days ago" makes the account immortal. Criterion 1 (a hard bounce/drop already on record) is itself stronger evidence the address is gone than a warning that would also bounce.

## How
- New `getDeadAddressCandidates` / `buildDeadAddressCandidatesQuery` on `InactivityEmailRepository` selects inactive + free users (no `inactivity_emails` gate).
- `DeleteInactiveUsersUseCase` now takes a `SuppressionEventsRepository`, filters dead-address candidates through `isSuppressed`, and merges them with the existing warned segment, deduped by user id and capped at the same 100/run batch limit. Dry-run still counts without deleting.
- Ops endpoint and card are unchanged in shape — the existing "Delete inactive accounts" card description now mentions dead-address accounts.
- FK cascades from the recent deletion-FK work mean removal does not 23503.

## Measuring success
The scheduled job logs `[inactivity-deletions] deleted N inactive account(s)` and records the `inactive_users_deleted` event with `count`. After the first ops dry-run, the candidate count should jump by up to ~214 (the dead-address backlog); after a live run, registered-user count drops and those addresses stop appearing in future `suppression_events`-driven segments.

## Dry-run instructions
Ops → Commands → **Delete inactive accounts** → **Check candidates** (dry run, deletes nothing). Confirm the count looks right before **Delete inactive accounts**. Capped at 100 per run; re-run to clear the rest of the backlog. Deletion cannot be undone.

## Testing
- Unit tests added (use case): dead-address + inactive + free → counted and deleted; deferred-only suppression → never deleted; no suppression event → never deleted; dropped → deleted; dry-run counts without deleting; dedup across both segments; combined batch cap. Paying/lifetime exclusion is enforced by the candidate query (free-only) and covered by the SQL-shape test.
- SQL-shape test added (`InactivityEmailRepository.deadAddress.sql.test.ts`): asserts the pg-dialect `toString()` of the candidate query — free + inactive predicates present, no `inactivity_emails` gate — so an invalid shape can't ship green where a mocked-repo test would lie.
- Scoped Jest green, server `tsc -p . --noEmit` clean, web typecheck clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified with Playwright Chromium on this branch, logged in as the ops owner: /ops/commands renders the updated Delete-inactive card (description covers dead-address accounts), Check candidates exercises the merged-segment dry-run live ("0 accounts would be deleted" — empty local DB), zero console errors.

## Changelog
No entry — admin/ops-only behavior behind the ops gate; no user-visible change for regular learners.

## Risks
Deletion is irreversible. Mitigated by: dry-run default, the 100/run cap, free-only + inactive + current-hard-suppression triple gate, and `deleteUser` continuing past individual failures rather than aborting the batch. The `isSuppressed` "latest event wins" semantics mean an address that later received a `delivered` is correctly excluded.

## Goal alignment
Internal — removes ~214 unreachable zombie accounts and keeps the registered-user count honest, which feeds the business-baseline metrics. No funnel or MRR metric moves directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753903&installation_id=132681956&pr_number=3231&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3231&signature=27c03c52350ff61ea3047a0188f91eed00a894b19f86eec366d9332317a5b790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
