### PR TITLE
fix: enforce monthly card limit on async Claude upload path

### DIFF
--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -49,6 +49,14 @@ jest.mock('../lib/parser/WorkSpace', () => {
   };
 });
 
+jest.mock('../lib/parser/exporters/CustomExporter', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    configure: jest.fn(),
+    save: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 const mockStorageDelete = jest.fn().mockResolvedValue(true);
 const mockStorageUploadFile = jest.fn().mockResolvedValue(undefined);
 const mockStorageUniqify = jest.fn().mockReturnValue('test-key.apkg');
@@ -904,6 +912,7 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
 
     await service.handleUpload(req, res);
 
@@ -963,6 +972,7 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     });
     const { res } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
 
     await service.handleUpload(req, res);
     await updateCalled;
@@ -1024,6 +1034,7 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
 
     await service.handleUpload(req, res);
     await failedRecorded;
@@ -1099,6 +1110,7 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
     const { res } = buildResponse();
     (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
 
     await service.handleUpload(req, res);
     await failedRecorded;
@@ -1332,5 +1344,228 @@ describe('UploadService.restartClaudeJob — concurrent restart guard', () => {
 
     expect(mockGenerateDeckInfo).not.toHaveBeenCalled();
     expect(capturedStatus()).toBe(409);
+  });
+});
+
+describe('UploadService.handleUpload — claude flag does not bypass the card limit', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+
+  beforeAll(() => {
+    process.env.WORKSPACE_BASE = path.join(os.tmpdir(), 'upload-service-test');
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+  });
+
+  beforeEach(() => {
+    MockGeneratePackagesUseCase.mockClear();
+    trackMock.mockClear();
+    mockFirstApkg = Buffer.from('fake-apkg');
+    mockWorkspaceId = 'test-ws-id';
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [{ name: 'deck', cardCount: 30 }],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+  });
+
+  function buildJobRepo(): { repo: JobRepository; create: jest.Mock } {
+    const create = jest.fn().mockResolvedValue(undefined);
+    return {
+      repo: {
+        create,
+        updateJobStatus: jest.fn().mockResolvedValue(undefined),
+        findJobById: jest.fn().mockResolvedValue(null),
+        deleteJob: jest.fn().mockResolvedValue(undefined),
+      } as unknown as JobRepository,
+      create,
+    };
+  }
+
+  it('routes a free user with the claude flag through the sync path and enforces the limit', async () => {
+    const usersRepo = buildUsersRepo({
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 80, month_started_at: new Date() }),
+    });
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+    const { repo: jobRepo, create } = buildJobRepo();
+
+    const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+    const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
+    const built = buildResponse();
+    let redirectedTo: string | null = null;
+    (built.res.redirect as unknown as jest.Mock).mockImplementation(
+      (url: string) => {
+        redirectedTo = url;
+        return built.res;
+      }
+    );
+    (built.res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, built.res);
+
+    expect(create).not.toHaveBeenCalled();
+    expect(built.capturedStatus()).not.toBe(202);
+    expect(redirectedTo).toBe('/limit?kind=card_count');
+    expect(incrementSpy).not.toHaveBeenCalled();
+  });
+
+  it('serves a free user with the claude flag a sync deck when under the limit', async () => {
+    const usersRepo = buildUsersRepo({
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 10, month_started_at: new Date() }),
+    });
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+    const { repo: jobRepo, create } = buildJobRepo();
+
+    const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+    const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
+    const { res, capturedStatus, capturedSend } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.handleUpload(req, res);
+
+    expect(create).not.toHaveBeenCalled();
+    expect(capturedStatus()).toBe(200);
+    expect(capturedSend()).not.toBeNull();
+    expect(incrementSpy).toHaveBeenCalledWith(42, 30);
+  });
+
+  it('keeps the async path for a paying user with the claude flag', async () => {
+    const usersRepo = buildUsersRepo();
+    const { repo: jobRepo, create } = buildJobRepo();
+
+    const service = new UploadService(buildRepository(), jobRepo, usersRepo);
+    const req = buildRequest({ body: { 'claude-ai-flashcards': 'true' } });
+    const { res, capturedStatus, capturedJson } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
+
+    await service.handleUpload(req, res);
+
+    expect(create).toHaveBeenCalled();
+    expect(capturedStatus()).toBe(202);
+    expect(capturedJson()).toEqual({ jobId: 'test-ws-id' });
+  });
+});
+
+describe('UploadService.restartClaudeJob — card-limit enforcement', () => {
+  const originalWorkspaceBase = process.env.WORKSPACE_BASE;
+  let db: Knex;
+  let workspaceBase: string;
+
+  beforeAll(() => {
+    workspaceBase = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'restart-limit-base-')
+    );
+    process.env.WORKSPACE_BASE = workspaceBase;
+  });
+
+  afterAll(() => {
+    process.env.WORKSPACE_BASE = originalWorkspaceBase;
+    fs.rmSync(workspaceBase, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    mockGenerateDeckInfo.mockReset();
+    mockStorageUploadFile.mockClear();
+    db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('jobs', (t) => {
+      t.increments('id');
+      t.string('owner').notNullable();
+      t.string('object_id').notNullable();
+      t.string('title');
+      t.string('type');
+      t.string('status');
+      t.timestamp('created_at').defaultTo(db.fn.now());
+      t.timestamp('last_edited_time');
+      t.string('job_reason_failure');
+      t.integer('card_count');
+    });
+    const workspaceDir = path.join(workspaceBase, 'job-obj-limit');
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceDir, 'page.html'),
+      '<html><body>Q/A</body></html>'
+    );
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  async function waitForFailedJob(): Promise<{
+    status: string;
+    job_reason_failure: string;
+  }> {
+    for (let i = 0; i < 200; i++) {
+      const row = await db('jobs')
+        .where({ object_id: 'job-obj-limit' })
+        .first();
+      if (row?.status === 'failed') {
+        return row as { status: string; job_reason_failure: string };
+      }
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error('job never reached failed status');
+  }
+
+  it('fails a free user restart over the monthly limit with a monthly_limit reason and no delivery', async () => {
+    await db('jobs').insert({
+      owner: '42',
+      object_id: 'job-obj-limit',
+      title: 'Deck',
+      type: 'claude',
+      status: 'done',
+      last_edited_time: new Date(),
+    });
+    mockGenerateDeckInfo.mockResolvedValue([
+      {
+        name: 'Deck',
+        cards: new Array(150).fill({ front: 'q', back: 'a' }),
+      },
+    ]);
+    const usersRepo = buildUsersRepo({
+      getCardUsage: jest
+        .fn()
+        .mockResolvedValue({ cards_used: 80, month_started_at: new Date() }),
+    });
+    const incrementSpy = usersRepo.incrementCardUsage as jest.Mock;
+
+    const service = new UploadService(
+      buildRepository(),
+      new JobRepository(db),
+      usersRepo
+    );
+    const req = {
+      params: { jobId: 'job-obj-limit' },
+      body: {},
+    } as unknown as express.Request;
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+
+    await service.restartClaudeJob(req, res);
+
+    const failed = await waitForFailedJob();
+    const reason = JSON.parse(failed.job_reason_failure) as {
+      code: string;
+      cards_used: number;
+      limit: number;
+    };
+    expect(reason.code).toBe('monthly_limit');
+    expect(reason.cards_used).toBe(80);
+    expect(reason.limit).toBe(100);
+    expect(incrementSpy).not.toHaveBeenCalled();
+    expect(mockStorageUploadFile).not.toHaveBeenCalled();
   });
 });

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -138,6 +138,14 @@ function resolveAsyncFailureReason(
   message: string,
   jobId: string
 ): string {
+  if (err instanceof MonthlyLimitError) {
+    return JSON.stringify({
+      code: 'monthly_limit',
+      cards_used: err.cards_used,
+      limit: err.limit,
+      reset_on: err.reset_on,
+    });
+  }
   const isParserCrash =
     err instanceof Error &&
     (err as Error & { code?: string }).code === 'PARSER_CRASH';
@@ -211,14 +219,21 @@ class UploadService {
       return;
     }
 
-    this.runClaudeRestart(job.object_id, owner, workspaceDir, async (step) => {
-      await this.jobRepository.updateJobStatus(job.object_id, owner, step);
-    }).catch(async (err: Error) => {
+    const paying = isPaying(res.locals);
+    this.runClaudeRestart(
+      job.object_id,
+      owner,
+      workspaceDir,
+      paying,
+      async (step) => {
+        await this.jobRepository.updateJobStatus(job.object_id, owner, step);
+      }
+    ).catch(async (err: Error) => {
       await this.jobRepository.updateJobStatus(
         job.object_id,
         owner,
         'failed',
-        err.message
+        resolveAsyncFailureReason(err, err.message, job.object_id)
       );
     });
 
@@ -230,8 +245,14 @@ class UploadService {
     workspaceDir: string,
     owner: string,
     totalCards = 0,
-    source: UploadSource | null = null
+    source: UploadSource | null = null,
+    paying = false
   ): Promise<void> {
+    await new CheckMonthlyCardLimitUseCase(this.usersRepository).execute({
+      userId: owner,
+      candidateCardCount: totalCards,
+      isPaying: paying,
+    });
     const files = await fs.promises.readdir(workspaceDir);
     const apkgFilename = files.find((f) => f.endsWith('.apkg'));
     if (!apkgFilename) {
@@ -267,6 +288,7 @@ class UploadService {
     objectId: string,
     owner: string,
     workspaceDir: string,
+    paying: boolean,
     onProgress: (step: string) => Promise<void>
   ) {
     const htmlFiles = walkHtmlFiles(workspaceDir);
@@ -293,12 +315,20 @@ class UploadService {
       throw new Error('No packages produced');
     }
 
+    const totalCards = deckInfo.reduce((sum, d) => sum + d.cards.length, 0);
     const deckName = deckInfo[0].name;
     const exporter = new CustomExporter(deckName, workspaceDir);
     exporter.configure(deckInfo as unknown as Deck[]);
     await exporter.save();
 
-    await this.promoteClaudeJobToUpload(objectId, workspaceDir, owner);
+    await this.promoteClaudeJobToUpload(
+      objectId,
+      workspaceDir,
+      owner,
+      totalCards,
+      null,
+      paying
+    );
   }
 
   async deleteUpload(owner: number, key: string) {
@@ -338,7 +368,7 @@ class UploadService {
         },
       });
 
-      if (owner && settings.claudeAIFlashcards) {
+      if (owner != null && paying && settings.claudeAIFlashcards) {
         return await this.handleAsyncUpload(
           req,
           res,
@@ -478,7 +508,8 @@ class UploadService {
             ws.location,
             owner,
             totalCards,
-            source
+            source,
+            paying
           );
         } else {
           logNoPackageDiagnostics(req.files as UploadedFile[]);


### PR DESCRIPTION
Closes #3232.

## What

Free accounts could bypass the 100-card monthly limit by sending `claude-ai-flashcards=true` on `POST /api/upload/file`: the async path never ran `CheckMonthlyCardLimitUseCase`, and the worker's Claude branch is paying-gated anyway — so free users got a normal parse via a side door with no limit.

Two changes:

1. **Routing gate** (`handleUpload`): async path now requires `owner != null && paying && settings.claudeAIFlashcards`. Free users with the flag fall through to the sync path, which enforces the limit and redirects over-limit users to `/limit?kind=card_count` (existing UX — the upload page already tells free users "AI is off"). Also fixes the falsy-owner truthiness check.
2. **Sink guard** (`promoteClaudeJobToUpload`): re-checks the limit before any delivery, closing the restart path (`restartClaudeJob` preserves pre-fix Claude jobs across deploys). Restart jobs now count their real card total instead of 0, and `MonthlyLimitError` maps to the same `monthly_limit` failure payload `performConversion` already uses.

## Trio synthesis

- **pm**: option A (route gate) — protects the card-limit paywall, the free→paid conversion trigger on the upload surface.
- **designer**: behavior-only, no copy change — UI already paid-gates the AI toggle and shows the truthful "AI is off" badge to free users; existing limit states render unchanged.
- **engineer**: route gate alone insufficient — restart path independently bypasses; put the check in the shared sink. Done.
- **Conflict**: none; engineer extended pm's option.
- **Metric**: `paywall_shown` (kind=card_count) and limit-wall→checkout starts should tick up for the formerly-leaking cohort; read at `/api/ops/metrics`.

## Tests

- New: free user + claude flag over limit → sync routing, `/limit?kind=card_count` redirect, no job created, no usage increment.
- New: free user + claude flag under limit → sync 200 deck, usage incremented.
- New: paying user + claude flag → async 202 preserved.
- New: free-user restart over limit → job fails with `monthly_limit` payload, no storage upload, no increment.
- Existing async-path tests updated to paying (they exercise promote mechanics, not the gate).
- Full server suite green except two pre-existing `getPageCount` failures from a missing local `pdfinfo` binary (env, unrelated).

No changelog entry — limits-enforcement fix; no new user-facing capability, and the affected free-user flow already has the limit-wall UX. Stated per changelog policy.

Sonar: not run locally — no `SONAR_TOKEN` configured on this machine; expecting the SonarCloud Automatic Analysis on this PR to cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783762711&installation_id=132681956&pr_number=3248&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3248&signature=384679dd5c93279fdb80efa89d39ddb15cf1a8b17103aa4116caeaf02732d485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->