### PR TITLE
fix: import oversized Anki decks up to the cap instead of failing

### DIFF
--- a/src/controllers/ApkgController.ts
+++ b/src/controllers/ApkgController.ts
@@ -26,6 +26,7 @@ import { NotionService } from '../services/NotionService/NotionService';
 import JobRepository from '../data_layer/JobRepository';
 import sendErrorResponse from '../lib/sendErrorResponse';
 import { isPaying } from '../lib/isPaying';
+import { getApkgImportNoteCap } from '../lib/apkg/importLimits';
 import { buildContentDisposition } from '../lib/buildContentDisposition';
 import { getSafeFilename } from '../lib/getSafeFilename';
 import { track } from '../services/events/track';
@@ -342,7 +343,7 @@ class ApkgController {
 
       const userIsPaying =
         res.locals.patreon === true || res.locals.subscriber === true;
-      const maxNotes = userIsPaying ? 10000 : 1000;
+      const maxNotes = getApkgImportNoteCap(userIsPaying);
 
       const rawParentPageId = req.body?.parent_page_id;
       const hasExplicitParent =
@@ -474,6 +475,7 @@ class ApkgController {
       let progress = { total_notes: 0, imported: 0 };
       let notionPageUrl: string | null = null;
       let errorMessage: string | null = null;
+      let truncated = false;
 
       if (job.status === 'done' && job.job_reason_failure) {
         try {
@@ -483,6 +485,7 @@ class ApkgController {
             imported: parsed.imported ?? 0,
           };
           notionPageUrl = parsed.notion_page_url ?? null;
+          truncated = parsed.truncated === true;
         } catch {
           // job_reason_failure is not JSON, ignore
         }
@@ -510,6 +513,7 @@ class ApkgController {
         status_text: statusText,
         notion_page_url: notionPageUrl,
         error: errorMessage,
+        truncated,
       });
     } catch (error) {
       console.error(error);

--- a/src/lib/apkg/importLimits.test.ts
+++ b/src/lib/apkg/importLimits.test.ts
@@ -1,0 +1,17 @@
+import {
+  APKG_IMPORT_NOTE_CAP_FREE,
+  APKG_IMPORT_NOTE_CAP_PAID,
+  getApkgImportNoteCap,
+} from './importLimits';
+
+describe('getApkgImportNoteCap', () => {
+  it('returns the paid cap for paying users', () => {
+    expect(getApkgImportNoteCap(true)).toBe(APKG_IMPORT_NOTE_CAP_PAID);
+    expect(getApkgImportNoteCap(true)).toBe(10000);
+  });
+
+  it('returns the free cap for free users', () => {
+    expect(getApkgImportNoteCap(false)).toBe(APKG_IMPORT_NOTE_CAP_FREE);
+    expect(getApkgImportNoteCap(false)).toBe(1000);
+  });
+});

--- a/src/lib/apkg/importLimits.ts
+++ b/src/lib/apkg/importLimits.ts
@@ -1,0 +1,6 @@
+export const APKG_IMPORT_NOTE_CAP_PAID = 10000;
+export const APKG_IMPORT_NOTE_CAP_FREE = 1000;
+
+export function getApkgImportNoteCap(isPaying: boolean): number {
+  return isPaying ? APKG_IMPORT_NOTE_CAP_PAID : APKG_IMPORT_NOTE_CAP_FREE;
+}

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -1,4 +1,6 @@
-import ApkgToNotionBlocksService from './ApkgToNotionBlocksService';
+import ApkgToNotionBlocksService, {
+  buildTruncationNoticeBlocks,
+} from './ApkgToNotionBlocksService';
 import {
   NormalizedCollection,
   Note,
@@ -62,7 +64,7 @@ describe('ApkgToNotionBlocksService', () => {
   describe('transform', () => {
     it('creates a deck page with toggle blocks for each note', () => {
       const collection = buildCollection();
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       expect(result.deckPages).toHaveLength(1);
       expect(result.deckPages[0].title).toBe('Math');
@@ -92,7 +94,7 @@ describe('ApkgToNotionBlocksService', () => {
         ],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const toggle = getToggle(result.deckPages[0].children);
       expect(toggle.heading_3.rich_text[0].plain_text).toBe('Bold text');
@@ -111,7 +113,7 @@ describe('ApkgToNotionBlocksService', () => {
         ],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const backChildren = getToggle(result.deckPages[0].children).heading_3
         .children;
@@ -139,7 +141,7 @@ describe('ApkgToNotionBlocksService', () => {
         ],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const backChildren = getToggle(result.deckPages[0].children).heading_3
         .children;
@@ -161,7 +163,7 @@ describe('ApkgToNotionBlocksService', () => {
       ]);
       const cards: Card[] = [{ id: 1000, nid: 100, did: 11, ord: 0 }];
       const collection = buildCollection({ decks, cards });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       expect(result.deckPages).toHaveLength(1);
       expect(result.deckPages[0].title).toBe('Bio');
@@ -174,7 +176,7 @@ describe('ApkgToNotionBlocksService', () => {
         [100, { id: 100, mid: 1, tags: ' math algebra ', fields: ['Q', 'A'] }],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const toggleChildren = getToggle(result.deckPages[0].children).heading_3
         .children;
@@ -218,7 +220,7 @@ describe('ApkgToNotionBlocksService', () => {
       ]);
       const noteTypes = new Map<number, NoteType>([[2, clozeNoteType]]);
       const collection = buildCollection({ noteTypes, notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const toggle = getToggle(result.deckPages[0].children);
       expect(toggle.heading_3.rich_text[0].plain_text).toBe(
@@ -231,7 +233,7 @@ describe('ApkgToNotionBlocksService', () => {
         [100, { id: 100, mid: 1, tags: '', fields: ['3 x 4 =&nbsp;', '12'] }],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const toggle = getToggle(result.deckPages[0].children);
       expect(toggle.heading_3.rich_text[0].plain_text).toBe('3 x 4 = ');
@@ -251,7 +253,7 @@ describe('ApkgToNotionBlocksService', () => {
         ],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const backChildren = getToggle(result.deckPages[0].children).heading_3
         .children;
@@ -280,7 +282,7 @@ describe('ApkgToNotionBlocksService', () => {
         ],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const toggle = result.deckPages[0].children[0];
       expect(toggle.type).toBe('heading_3');
@@ -324,7 +326,7 @@ describe('ApkgToNotionBlocksService', () => {
         notes,
         cards: [{ id: 1000, nid: 100, did: 10, ord: 0 }],
       });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const blocks = result.deckPages[0].children;
       expect(blocks[0].type).toBe('divider');
@@ -377,7 +379,7 @@ describe('ApkgToNotionBlocksService', () => {
         notes,
         cards: [{ id: 1000, nid: 100, did: 10, ord: 0 }],
       });
-      const result = service.transform(collection, mediaUrlMap);
+      const result = service.transform(collection, mediaUrlMap, 10000);
 
       const blocks = result.deckPages[0].children;
       expect(blocks[0].type).toBe('divider');
@@ -438,7 +440,8 @@ describe('ApkgToNotionBlocksService', () => {
       });
       const result = service.transform(
         collection,
-        new Map([['flag.png', 'https://cdn.example.com/flag.png']])
+        new Map([['flag.png', 'https://cdn.example.com/flag.png']]),
+        10000
       );
 
       const toggleBlock = result.deckPages[0].children[2];
@@ -466,7 +469,8 @@ describe('ApkgToNotionBlocksService', () => {
       const collection = buildCollection({ notes });
       const result = service.transform(
         collection,
-        new Map([['hint.jpg', 'https://cdn.example.com/hint.jpg']])
+        new Map([['hint.jpg', 'https://cdn.example.com/hint.jpg']]),
+        10000
       );
 
       const block = result.deckPages[0].children[0];
@@ -494,7 +498,7 @@ describe('ApkgToNotionBlocksService', () => {
         ['bollard.jpg', 'https://cdn.example.com/imports/job-1/bollard.jpg'],
       ]);
       const collection = buildCollection({ notes });
-      const result = service.transform(collection, mediaUrlMap);
+      const result = service.transform(collection, mediaUrlMap, 10000);
 
       const blocks = result.deckPages[0].children;
       const imageBlock = blocks.find((b) => b.type === 'image');
@@ -519,63 +523,65 @@ describe('ApkgToNotionBlocksService', () => {
         { id: 1001, nid: 101, did: 10, ord: 0 },
       ];
       const collection = buildCollection({ notes, cards });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       expect(result.totalNotes).toBe(2);
     });
 
-    it('limits to MAX_NOTES and signals truncation', () => {
+    function buildLargeCollection(noteCount: number) {
       const notes = new Map<number, Note>();
       const cards: Card[] = [];
-      for (let i = 0; i < 5001; i++) {
+      for (let i = 0; i < noteCount; i++) {
         notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
         cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
       }
-      const collection = buildCollection({ notes, cards });
+      return buildCollection({ notes, cards });
+    }
 
-      expect(() => service.transform(collection)).toThrow(/too large/i);
-    });
+    interface PageShape {
+      children: unknown[];
+      subDecks: PageShape[];
+    }
 
-    it('throws NoteTooLargeError with paid cap (5000) when deck exceeds it', () => {
-      const notes = new Map<number, Note>();
-      const cards: Card[] = [];
-      for (let i = 0; i < 5001; i++) {
-        notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
-        cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
-      }
-      const collection = buildCollection({ notes, cards });
-
-      expect(() => service.transform(collection, new Map(), 5000)).toThrow(
-        /too large/i
+    function countNotesInPage(page: PageShape): number {
+      return (
+        page.children.length +
+        page.subDecks.reduce((sum, sub) => sum + countNotesInPage(sub), 0)
       );
+    }
+
+    it('truncates to the first maxNotes notes instead of failing', () => {
+      const collection = buildLargeCollection(1005);
+
+      const result = service.transform(collection, new Map(), 1000);
+
+      expect(result.truncated).toBe(true);
+      expect(result.totalNotes).toBe(1005);
+      expect(result.importedNotes).toBe(1000);
+      expect(countNotesInPage(result.deckPages[0])).toBe(1000);
+      const firstToggle = getToggle(result.deckPages[0].children, 0);
+      expect(firstToggle.heading_3.rich_text[0].plain_text).toBe('Q0');
+      const lastToggle = getToggle(result.deckPages[0].children, 999);
+      expect(lastToggle.heading_3.rich_text[0].plain_text).toBe('Q999');
     });
 
-    it('throws NoteTooLargeError with free-tier cap (1000) when deck exceeds it', () => {
-      const notes = new Map<number, Note>();
-      const cards: Card[] = [];
-      for (let i = 0; i < 1001; i++) {
-        notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
-        cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
-      }
-      const collection = buildCollection({ notes, cards });
+    it('truncates identically across repeated calls', () => {
+      const collection = buildLargeCollection(1003);
 
-      expect(() => service.transform(collection, new Map(), 1000)).toThrow(
-        /too large/i
-      );
+      const first = service.transform(collection, new Map(), 1000);
+      const second = service.transform(collection, new Map(), 1000);
+
+      expect(second.deckPages).toEqual(first.deckPages);
     });
 
-    it('allows exactly 1000 notes when maxNotes is 1000', () => {
-      const notes = new Map<number, Note>();
-      const cards: Card[] = [];
-      for (let i = 0; i < 1000; i++) {
-        notes.set(i, { id: i, mid: 1, tags: '', fields: [`Q${i}`, `A${i}`] });
-        cards.push({ id: 10000 + i, nid: i, did: 10, ord: 0 });
-      }
-      const collection = buildCollection({ notes, cards });
+    it('does not truncate exactly at the cap', () => {
+      const collection = buildLargeCollection(1000);
 
-      expect(() =>
-        service.transform(collection, new Map(), 1000)
-      ).not.toThrow();
+      const result = service.transform(collection, new Map(), 1000);
+
+      expect(result.truncated).toBe(false);
+      expect(result.importedNotes).toBe(1000);
+      expect(result.totalNotes).toBe(1000);
     });
 
     it('skips empty decks like Default', () => {
@@ -588,7 +594,7 @@ describe('ApkgToNotionBlocksService', () => {
       ]);
       const cards: Card[] = [{ id: 1000, nid: 100, did: 10, ord: 0 }];
       const collection = buildCollection({ decks, notes, cards });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       expect(result.deckPages).toHaveLength(1);
       expect(result.deckPages[0].title).toBe('Spanish');
@@ -608,7 +614,7 @@ describe('ApkgToNotionBlocksService', () => {
         { id: 1001, nid: 101, did: 20, ord: 0 },
       ];
       const collection = buildCollection({ decks, notes, cards });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       expect(result.deckPages).toHaveLength(2);
       const deckNames = result.deckPages.map((d) => d.title);
@@ -651,7 +657,7 @@ describe('ApkgToNotionBlocksService', () => {
         notes,
         cards: [{ id: 1000, nid: 100, did: 10, ord: 0 }],
       });
-      const result = service.transform(collection);
+      const result = service.transform(collection, new Map(), 10000);
 
       const blocks = result.deckPages[0].children;
       expect(blocks[0].type).toBe('divider');
@@ -673,5 +679,57 @@ describe('ApkgToNotionBlocksService', () => {
         expect(texts).toContain('note: Snowpole on right found in Andorra');
       }
     });
+  });
+});
+
+describe('buildTruncationNoticeBlocks', () => {
+  function plainText(blocks: ReturnType<typeof buildTruncationNoticeBlocks>) {
+    return blocks
+      .filter((b) => b.type === 'paragraph')
+      .map((b) =>
+        b.type === 'paragraph'
+          ? b.paragraph.rich_text.map((s) => s.plain_text).join('')
+          : ''
+      );
+  }
+
+  it('tells free users the cap and where to upgrade, ending with a divider', () => {
+    const blocks = buildTruncationNoticeBlocks({
+      importedNotes: 1000,
+      totalNotes: 5864,
+      isPaying: false,
+      paidCap: 10000,
+    });
+
+    const [headline, upsell] = plainText(blocks);
+    expect(headline).toBe(
+      'Imported the first 1000 of 5864 notes. The free plan stops at 1000 notes per import.'
+    );
+    expect(upsell).toBe(
+      'Paid plans import up to 10 000 notes. Upgrade at 2anki.net/pricing'
+    );
+    const first = blocks[0];
+    expect(first.type).toBe('paragraph');
+    if (first.type === 'paragraph') {
+      expect(first.paragraph.rich_text[0].annotations.bold).toBe(true);
+    }
+    expect(blocks[blocks.length - 1].type).toBe('divider');
+  });
+
+  it('tells paying users the remaining count with no upgrade pitch', () => {
+    const blocks = buildTruncationNoticeBlocks({
+      importedNotes: 10000,
+      totalNotes: 12000,
+      isPaying: true,
+      paidCap: 10000,
+    });
+
+    const [headline] = plainText(blocks);
+    expect(headline).toBe(
+      'Imported the first 10 000 of 12 000 notes. 10 000 notes is the largest import 2anki supports — the remaining 2000 notes were not imported.'
+    );
+    expect(plainText(blocks)).toHaveLength(1);
+    expect(headline).not.toContain('pricing');
+    expect(blocks[blocks.length - 1].type).toBe('divider');
   });
 });

--- a/src/services/ApkgToNotionBlocksService.test.ts
+++ b/src/services/ApkgToNotionBlocksService.test.ts
@@ -724,11 +724,13 @@ describe('buildTruncationNoticeBlocks', () => {
       paidCap: 10000,
     });
 
-    const [headline] = plainText(blocks);
+    const [headline, contact] = plainText(blocks);
     expect(headline).toBe(
-      'Imported the first 10 000 of 12 000 notes. 10 000 notes is the largest import 2anki supports — the remaining 2000 notes were not imported.'
+      'Imported the first 10 000 of 12 000 notes. The remaining 2000 notes were not imported — your plan imports up to 10 000 notes at a time.'
     );
-    expect(plainText(blocks)).toHaveLength(1);
+    expect(contact).toBe(
+      'Need a higher limit? Email support@2anki.net and we will raise it for you.'
+    );
     expect(headline).not.toContain('pricing');
     expect(blocks[blocks.length - 1].type).toBe('divider');
   });

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -663,9 +663,17 @@ export function buildTruncationNoticeBlocks(
           rich_text: [
             ...headline,
             ...makeRichText(
-              ` ${imported} notes is the largest import 2anki supports — the remaining ${remaining} notes were not imported.`
+              ` The remaining ${remaining} notes were not imported — your plan imports up to ${imported} notes at a time.`
             ),
           ],
+        },
+      },
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: makeRichText(
+            'Need a higher limit? Email support@2anki.net and we will raise it for you.'
+          ),
         },
       },
       { type: 'divider', divider: {} },

--- a/src/services/ApkgToNotionBlocksService.ts
+++ b/src/services/ApkgToNotionBlocksService.ts
@@ -4,7 +4,6 @@ import {
   NoteType,
 } from './ApkgPreviewService/types';
 
-const MAX_NOTES = 5000;
 const CLOZE_REGEX = /\{\{c\d+::([^}]*?)(?:::[^}]*)?\}\}/g;
 const SOUND_TAG_REGEX = /\[sound:([^\]]+)\]/g;
 const IMG_SRC_REGEX = /<img\s[^>]*?\bsrc=["']([^"']+)["'][^>]*>/gi;
@@ -95,15 +94,15 @@ export interface DeckPage {
 export interface TransformResult {
   deckPages: DeckPage[];
   totalNotes: number;
+  importedNotes: number;
+  truncated: boolean;
 }
 
-export class NoteTooLargeError extends Error {
-  constructor(count: number, limit: number) {
-    super(
-      `This deck has ${count} notes. Import supports up to ${limit} notes — it is too large to import.`
-    );
-    this.name = 'NoteTooLargeError';
-  }
+export interface TruncationNoticeInput {
+  importedNotes: number;
+  totalNotes: number;
+  isPaying: boolean;
+  paidCap: number;
 }
 
 const HTML_ENTITY_REGEX = /&(#(\d+)|#x([0-9a-fA-F]+)|(\w+));/g;
@@ -637,23 +636,94 @@ function deckNodeToDeckPage(
   };
 }
 
+function formatNoteCount(count: number): string {
+  if (count < 10000) {
+    return String(count);
+  }
+  return count.toLocaleString('en-US').replaceAll(',', ' ');
+}
+
+export function buildTruncationNoticeBlocks(
+  input: TruncationNoticeInput
+): NoteBlock[] {
+  const imported = formatNoteCount(input.importedNotes);
+  const total = formatNoteCount(input.totalNotes);
+  const paidCap = formatNoteCount(input.paidCap);
+  const headline = makeRichText(
+    `Imported the first ${imported} of ${total} notes.`,
+    true
+  );
+
+  if (input.isPaying) {
+    const remaining = formatNoteCount(input.totalNotes - input.importedNotes);
+    return [
+      {
+        type: 'paragraph',
+        paragraph: {
+          rich_text: [
+            ...headline,
+            ...makeRichText(
+              ` ${imported} notes is the largest import 2anki supports — the remaining ${remaining} notes were not imported.`
+            ),
+          ],
+        },
+      },
+      { type: 'divider', divider: {} },
+    ];
+  }
+
+  return [
+    {
+      type: 'paragraph',
+      paragraph: {
+        rich_text: [
+          ...headline,
+          ...makeRichText(
+            ` The free plan stops at ${imported} notes per import.`
+          ),
+        ],
+      },
+    },
+    {
+      type: 'paragraph',
+      paragraph: {
+        rich_text: makeRichText(
+          `Paid plans import up to ${paidCap} notes. Upgrade at 2anki.net/pricing`
+        ),
+      },
+    },
+    { type: 'divider', divider: {} },
+  ];
+}
+
 export default class ApkgToNotionBlocksService {
   transform(
     collection: NormalizedCollection,
-    mediaUrlMap: Map<string, string> = new Map(),
-    maxNotes: number = MAX_NOTES
+    mediaUrlMap: Map<string, string>,
+    maxNotes: number
   ): TransformResult {
     const seenNotes = new Set<number>();
     for (const card of collection.cards) {
       seenNotes.add(card.nid);
     }
     const totalNotes = seenNotes.size;
+    const truncated = totalNotes > maxNotes;
 
-    if (totalNotes > maxNotes) {
-      throw new NoteTooLargeError(totalNotes, maxNotes);
+    let workingCollection = collection;
+    if (truncated) {
+      const keptNids = new Set<number>();
+      for (const card of collection.cards) {
+        if (keptNids.has(card.nid)) continue;
+        if (keptNids.size === maxNotes) continue;
+        keptNids.add(card.nid);
+      }
+      workingCollection = {
+        ...collection,
+        cards: collection.cards.filter((card) => keptNids.has(card.nid)),
+      };
     }
 
-    const tree = buildDeckTree(collection);
+    const tree = buildDeckTree(workingCollection);
     const deckPages: DeckPage[] = [];
 
     for (const [, node] of tree) {
@@ -662,6 +732,11 @@ export default class ApkgToNotionBlocksService {
       }
     }
 
-    return { deckPages, totalNotes };
+    return {
+      deckPages,
+      totalNotes,
+      importedNotes: Math.min(totalNotes, maxNotes),
+      truncated,
+    };
   }
 }

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -188,10 +188,14 @@ describe('ImportApkgToNotionUseCase', () => {
       .paragraph!.rich_text.map((s) => s.plain_text)
       .join('');
     expect(noticeText).toBe(
-      'Imported the first 3 of 4 notes. 3 notes is the largest import 2anki supports — the remaining 1 notes were not imported.'
+      'Imported the first 3 of 4 notes. The remaining 1 notes were not imported — your plan imports up to 3 notes at a time.'
     );
     expect(noticeText).not.toContain('pricing');
-    expect(firstBatch[1].type).toBe('divider');
+    const contactText = firstBatch[1].paragraph!.rich_text[0].plain_text;
+    expect(contactText).toBe(
+      'Need a higher limit? Email support@2anki.net and we will raise it for you.'
+    );
+    expect(firstBatch[2].type).toBe('divider');
   });
 
   it('adds no notice when the deck is under the cap', async () => {

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.test.ts
@@ -1,8 +1,6 @@
 import ImportApkgToNotionUseCase from './ImportApkgToNotionUseCase';
 import ApkgPreviewService from '../../services/ApkgPreviewService/ApkgPreviewService';
-import ApkgToNotionBlocksService, {
-  NoteTooLargeError,
-} from '../../services/ApkgToNotionBlocksService';
+import ApkgToNotionBlocksService from '../../services/ApkgToNotionBlocksService';
 import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
 import JobRepository from '../../data_layer/JobRepository';
 import { NormalizedCollection } from '../../services/ApkgPreviewService/types';
@@ -108,7 +106,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     expect(notionApi.createPage).toHaveBeenCalledWith(
@@ -128,34 +127,95 @@ describe('ImportApkgToNotionUseCase', () => {
     expect(result.notion_page_url).toBe('https://notion.so/page-123');
   });
 
-  it('marks the job as failed when transform throws NoteTooLargeError', async () => {
-    previewService.parse.mockResolvedValue(makeParsed(2));
+  it('imports up to the cap and prepends a truncation notice for free users', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(5));
 
-    const throwingBlocksService = {
-      transform: () => {
-        throw new NoteTooLargeError(5001, 5000);
-      },
-    } as unknown as ApkgToNotionBlocksService;
-
-    const useCaseWithLimit = new ImportApkgToNotionUseCase(
-      previewService,
-      throwingBlocksService,
-      jobRepository
-    );
-
-    await useCaseWithLimit.execute(
+    await useCase.execute(
       Buffer.from('fake'),
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { isPaying: false, maxNotes: 2 }
     );
 
-    const failCall = jobRepository.updateJobStatus.mock.calls.find(
-      (c) => c[2] === 'failed'
+    const firstBatch = notionApi.appendBlocks.mock
+      .calls[0][1] as unknown as Array<{
+      type: string;
+      paragraph?: { rich_text: Array<{ plain_text: string }> };
+    }>;
+    expect(firstBatch[0].type).toBe('paragraph');
+    expect(firstBatch[0].paragraph!.rich_text[0].plain_text).toBe(
+      'Imported the first 2 of 5 notes.'
     );
-    expect(failCall).toBeDefined();
-    expect(failCall![3]).toContain('5001');
+    const upsell = firstBatch[1].paragraph!.rich_text[0].plain_text;
+    expect(upsell).toContain('Upgrade at 2anki.net/pricing');
+    expect(firstBatch[2].type).toBe('divider');
+
+    const noteToggles = firstBatch.filter((b) => b.type === 'heading_3');
+    expect(noteToggles).toHaveLength(2);
+
+    const finalUpdate =
+      jobRepository.updateJobStatus.mock.calls[
+        jobRepository.updateJobStatus.mock.calls.length - 1
+      ];
+    expect(finalUpdate[2]).toBe('done');
+    const result = JSON.parse(finalUpdate[3] as string);
+    expect(result.imported).toBe(2);
+    expect(result.total_notes).toBe(5);
+    expect(result.truncated).toBe(true);
+    expect(result.note_cap).toBe(2);
+  });
+
+  it('writes no truncation notice for paying users without an upgrade pitch', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(4));
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1',
+      { isPaying: true, maxNotes: 3 }
+    );
+
+    const firstBatch = notionApi.appendBlocks.mock
+      .calls[0][1] as unknown as Array<{
+      type: string;
+      paragraph?: { rich_text: Array<{ plain_text: string }> };
+    }>;
+    const noticeText = firstBatch[0]
+      .paragraph!.rich_text.map((s) => s.plain_text)
+      .join('');
+    expect(noticeText).toBe(
+      'Imported the first 3 of 4 notes. 3 notes is the largest import 2anki supports — the remaining 1 notes were not imported.'
+    );
+    expect(noticeText).not.toContain('pricing');
+    expect(firstBatch[1].type).toBe('divider');
+  });
+
+  it('adds no notice when the deck is under the cap', async () => {
+    previewService.parse.mockResolvedValue(makeParsed(2));
+
+    await useCase.execute(
+      Buffer.from('fake'),
+      'parent-page',
+      'user-1',
+      notionApi,
+      'job-1',
+      { maxNotes: 10000 }
+    );
+
+    const firstBatch = notionApi.appendBlocks.mock
+      .calls[0][1] as unknown as Array<{ type: string }>;
+    expect(firstBatch.every((b) => b.type === 'heading_3')).toBe(true);
+
+    const finalUpdate =
+      jobRepository.updateJobStatus.mock.calls[
+        jobRepository.updateJobStatus.mock.calls.length - 1
+      ];
+    const result = JSON.parse(finalUpdate[3] as string);
+    expect(result.truncated).toBe(false);
   });
 
   it('tracks progress during batch writes', async () => {
@@ -166,7 +226,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const progressCalls = jobRepository.updateJobStatus.mock.calls.filter(
@@ -185,7 +246,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -220,7 +282,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -242,7 +305,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -264,7 +328,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -286,7 +351,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -310,7 +376,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -332,7 +399,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -355,7 +423,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     const failCall = jobRepository.updateJobStatus.mock.calls.find(
@@ -390,7 +459,8 @@ describe('ImportApkgToNotionUseCase', () => {
       'parent-page',
       'user-1',
       notionApi,
-      'job-1'
+      'job-1',
+      { maxNotes: 10000 }
     );
 
     expect(notionApi.createPage).toHaveBeenCalledTimes(3);

--- a/src/usecases/apkg/ImportApkgToNotionUseCase.ts
+++ b/src/usecases/apkg/ImportApkgToNotionUseCase.ts
@@ -2,8 +2,9 @@ import path from 'path';
 import ApkgPreviewService from '../../services/ApkgPreviewService/ApkgPreviewService';
 import ApkgToNotionBlocksService, {
   DeckPage,
-  NoteTooLargeError,
+  buildTruncationNoticeBlocks,
 } from '../../services/ApkgToNotionBlocksService';
+import { APKG_IMPORT_NOTE_CAP_PAID } from '../../lib/apkg/importLimits';
 import NotionAPIWrapper from '../../services/NotionService/NotionAPIWrapper';
 import JobRepository from '../../data_layer/JobRepository';
 import { BlockObjectRequest } from '@notionhq/client/build/src/api-endpoints';
@@ -11,7 +12,6 @@ import { APIErrorCode, APIResponseError } from '@notionhq/client';
 
 const BATCH_SIZE = 50;
 const THROTTLE_MS = 350;
-const MAX_NOTES = 5000;
 
 const IMAGE_EXTENSIONS = new Set([
   '.jpg',
@@ -44,9 +44,6 @@ const SQLITE_ERROR_CODES = new Set([
 ]);
 
 function resolveFailureMessage(error: unknown): string {
-  if (error instanceof NoteTooLargeError) {
-    return error.message;
-  }
   if (error instanceof Error && error.message.includes('Upgrade')) {
     return error.message;
   }
@@ -91,9 +88,9 @@ export default class ImportApkgToNotionUseCase {
     owner: string,
     notionApi: NotionAPIWrapper,
     jobId: string,
-    options: { isPaying?: boolean; maxNotes?: number } = {}
+    options: { isPaying?: boolean; maxNotes: number }
   ): Promise<void> {
-    const maxNotes = options.maxNotes ?? MAX_NOTES;
+    const maxNotes = options.maxNotes;
     try {
       const cacheKey = `import:${owner}:${Date.now()}`;
       const parsed = await this.previewService.parse(cacheKey, fileBuffer);
@@ -103,7 +100,6 @@ export default class ImportApkgToNotionUseCase {
         new Map(),
         maxNotes
       );
-      const totalNotes = result.totalNotes;
 
       let mediaUrlMap = new Map<string, string>();
       if (parsed.mediaMap.size > 0) {
@@ -134,11 +130,22 @@ export default class ImportApkgToNotionUseCase {
         }
       }
 
+      if (result.truncated && result.deckPages.length > 0) {
+        result.deckPages[0].children.unshift(
+          ...buildTruncationNoticeBlocks({
+            importedNotes: result.importedNotes,
+            totalNotes: result.totalNotes,
+            isPaying: options.isPaying ?? false,
+            paidCap: APKG_IMPORT_NOTE_CAP_PAID,
+          })
+        );
+      }
+
       await this.jobRepository.updateJobStatus(
         jobId,
         owner,
         'processing',
-        `0/${totalNotes} notes`
+        `0/${result.importedNotes} notes`
       );
 
       let imported = 0;
@@ -151,7 +158,7 @@ export default class ImportApkgToNotionUseCase {
           jobId,
           owner,
           imported,
-          result.totalNotes
+          result.importedNotes
         );
       }
 
@@ -166,8 +173,10 @@ export default class ImportApkgToNotionUseCase {
         owner,
         'done',
         JSON.stringify({
-          imported,
+          imported: result.importedNotes,
           total_notes: result.totalNotes,
+          truncated: result.truncated,
+          note_cap: maxNotes,
           notion_page_url: notionUrl,
         })
       );

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -926,6 +926,7 @@ export class Backend {
     status_text?: string;
     notion_page_url?: string;
     error?: string;
+    truncated?: boolean;
   }> {
     return get(`${this.baseURL}apkg/import/${jobId}/status`);
   }

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -115,11 +115,21 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
           <h1 className={sharedStyles.title}>Import to Notion</h1>
         </div>
         <div className={sharedStyles.notificationSuccess}>
-          {job.progress.imported} cards added
-          {selectedPageTitle ? (
-            <> to &ldquo;{selectedPageTitle}&rdquo;</>
+          {job.truncated ? (
+            <>
+              Imported {job.progress.imported} of {job.progress.total_notes}{' '}
+              notes — import limit reached. See the note at the top of your
+              Notion page.
+            </>
           ) : (
-            <> to your &ldquo;2anki Imports&rdquo; page</>
+            <>
+              {job.progress.imported} notes added
+              {selectedPageTitle ? (
+                <> to &ldquo;{selectedPageTitle}&rdquo;</>
+              ) : (
+                <> to your &ldquo;2anki Imports&rdquo; page</>
+              )}
+            </>
           )}
         </div>
         <div className={styles.completeActions}>
@@ -161,7 +171,7 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
         <div className={sharedStyles.notificationDanger}>
           {isUpgradeError && job.errorMessage}
           {partialProgress &&
-            `Imported ${job.progress.imported} of ${job.progress.total_notes} cards before something went wrong. The cards already created are still in your Notion page.`}
+            `Imported ${job.progress.imported} of ${job.progress.total_notes} notes before something went wrong. The notes already created are still in your Notion page.`}
           {!isUpgradeError &&
             !partialProgress &&
             (job.errorMessage ?? 'Something went wrong.')}

--- a/web/src/pages/ImportPage/ImportPage.tsx
+++ b/web/src/pages/ImportPage/ImportPage.tsx
@@ -16,6 +16,39 @@ interface ImportPageProps {
   setError: (error: unknown) => void;
 }
 
+interface CompletedNoticeProps {
+  truncated: boolean;
+  imported: number;
+  totalNotes: number;
+  pageTitle: string;
+}
+
+function CompletedNotice({
+  truncated,
+  imported,
+  totalNotes,
+  pageTitle,
+}: Readonly<CompletedNoticeProps>) {
+  if (truncated) {
+    return (
+      <>
+        Imported {imported} of {totalNotes} notes — import limit reached. See
+        the note at the top of your Notion page.
+      </>
+    );
+  }
+  return (
+    <>
+      {imported} notes added
+      {pageTitle ? (
+        <> to &ldquo;{pageTitle}&rdquo;</>
+      ) : (
+        <> to your &ldquo;2anki Imports&rdquo; page</>
+      )}
+    </>
+  );
+}
+
 export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
   const [file, setFile] = useState<File | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
@@ -115,22 +148,12 @@ export default function ImportPage({ setError }: Readonly<ImportPageProps>) {
           <h1 className={sharedStyles.title}>Import to Notion</h1>
         </div>
         <div className={sharedStyles.notificationSuccess}>
-          {job.truncated ? (
-            <>
-              Imported {job.progress.imported} of {job.progress.total_notes}{' '}
-              notes — import limit reached. See the note at the top of your
-              Notion page.
-            </>
-          ) : (
-            <>
-              {job.progress.imported} notes added
-              {selectedPageTitle ? (
-                <> to &ldquo;{selectedPageTitle}&rdquo;</>
-              ) : (
-                <> to your &ldquo;2anki Imports&rdquo; page</>
-              )}
-            </>
-          )}
+          <CompletedNotice
+            truncated={job.truncated}
+            imported={job.progress.imported}
+            totalNotes={job.progress.total_notes}
+            pageTitle={selectedPageTitle}
+          />
         </div>
         <div className={styles.completeActions}>
           {job.notionPageUrl && (

--- a/web/src/pages/ImportPage/components/ImportProgress.tsx
+++ b/web/src/pages/ImportPage/components/ImportProgress.tsx
@@ -41,7 +41,7 @@ export default function ImportProgress({
               'uploading images ',
               'Uploading images: '
             )
-          : `${imported} of ${total} cards`}
+          : `${imported} of ${total} notes`}
       </p>
       <p className={styles.progressReassurance}>
         {isUploadingImages

--- a/web/src/pages/ImportPage/hooks/useImportJob.ts
+++ b/web/src/pages/ImportPage/hooks/useImportJob.ts
@@ -14,6 +14,7 @@ interface ImportJobState {
   statusText: string | null;
   notionPageUrl: string | null;
   errorMessage: string | null;
+  truncated: boolean;
 }
 
 const POLL_INTERVAL_MS = 2000;
@@ -25,6 +26,7 @@ export default function useImportJob() {
     statusText: null,
     notionPageUrl: null,
     errorMessage: null,
+    truncated: false,
   });
 
   const jobIdRef = useRef<string | null>(null);
@@ -52,6 +54,7 @@ export default function useImportJob() {
           statusText: null,
           notionPageUrl: result.notion_page_url ?? null,
           errorMessage: null,
+          truncated: result.truncated === true,
         });
       } else if (result.status === 'failed') {
         stopPolling();
@@ -61,6 +64,7 @@ export default function useImportJob() {
           statusText: null,
           notionPageUrl: null,
           errorMessage: result.error ?? 'Import failed',
+          truncated: false,
         });
       } else {
         setState((prev) => ({
@@ -97,6 +101,7 @@ export default function useImportJob() {
         statusText: null,
         notionPageUrl: null,
         errorMessage: null,
+        truncated: false,
       });
 
       try {
@@ -114,6 +119,7 @@ export default function useImportJob() {
           notionPageUrl: null,
           errorMessage:
             err instanceof Error ? err.message : 'Failed to start import',
+          truncated: false,
         });
       }
     },
@@ -129,6 +135,7 @@ export default function useImportJob() {
       statusText: null,
       notionPageUrl: null,
       errorMessage: null,
+      truncated: false,
     });
   }, [stopPolling]);
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-11-apkg-import-truncate.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-11-apkg-import-truncate.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-11-apkg-import-truncate",
+  "date": "2026-06-11",
+  "type": "fix",
+  "title": "Anki decks over the Notion import limit now import up to the limit instead of failing"
+}


### PR DESCRIPTION
Closes #3186.

## What

Anki→Notion imports over the note cap (free 1 000, paid 10 000) no longer fail outright. The import brings in the first cap-many notes and writes a notice at the top of the created Notion page:

- **Free users** — "Imported the first 1000 of 5864 notes. The free plan stops at 1000 notes per import." followed by "Paid plans import up to 10 000 notes. Upgrade at 2anki.net/pricing", then a divider. (Bold paragraph, not a callout — a callout forces an icon, and emoji are banned in product UI per VOICE.md.)
- **Paying users** — "Imported the first 10 000 of 12 000 notes. The remaining 2000 notes were not imported — your plan imports up to 10 000 notes at a time." followed by "Need a higher limit? Email support@2anki.net and we will raise it for you." Oversized paid imports become a support conversation instead of a dead end.

Also per the issue: the three drifting cap constants (controller ternary + two stale `MAX_NOTES = 5000` defaults) collapse into `src/lib/apkg/importLimits.ts`, and `maxNotes` is now a required argument so a silent default can't drift back.

Plumbing: progress denominators use the capped count so the bar reaches 100% instead of stalling; the done payload carries `truncated` + `note_cap`; the status endpoint surfaces `truncated`; the import UI shows "Imported X of Y notes — import limit reached. See the note at the top of your Notion page." on truncated completions and counts "notes" instead of "cards" throughout (the import works in notes).

## Trio synthesis

- **pm**: truncate for all tiers (consistent), truncated = success in the job UI, the in-page note is the only in-Notion upgrade touchpoint on this surface. Not built: chunked continuation, resume jobs, new tiers, per-user caps.
- **designer**: bold paragraphs + divider over callout; exact copy both tiers; URL stays in the note (the page lives in Notion, no in-app link to click); job-completion line needs an explicit `truncated` flag, not `imported < total` inference.
- **engineer**: notice prepended to the root page's children so it rides batch 0 (no extra Notion call); deterministic truncation means the media second-pass transform truncates identically; `NoteTooLargeError` deleted wholesale; additive payload fields verified safe for existing web consumers.
- **Conflicts**: engineer raised "should free users still hard-fail as the upgrade prompt?" — overruled by Alexander's decision on the issue (truncate + in-page note). Callout vs paragraph resolved to designer's paragraph.
- **Metric**: free→paid conversions originating from the import surface (the in-page upgrade note is the new touchpoint); funnel at `/api/ops/metrics` via the weekly pull.

## Tests

- `importLimits.test.ts` — cap values per tier.
- Blocks service: truncates to first `maxNotes` notes (order preserved, deterministic across calls), exact-at-cap not truncated, notice copy for free (upgrade + divider, bold headline) and paying (remaining count, no pitch).
- Use case: notice prepended for free users with correct done payload (`truncated`, `note_cap`), paying notice without pitch, no notice under cap, progress denominator uses capped count.
- Controller tests (existing) still assert 1 000/10 000 per tier, now via the shared module.
- Full server suite green except two pre-existing `getPageCount` failures (missing local `pdfinfo` binary, unrelated). Web: 1 834 vitest tests green, typecheck + lint clean.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs a local run before merge — the truncated completed-state banner and the "notes" unit change are the visible bits (`/import`).

Sonar: not run locally — no `SONAR_TOKEN` on this machine; expecting SonarCloud Automatic Analysis on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783763748&installation_id=132681956&pr_number=3249&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3249&signature=79d6bd3e5093f3431f606a909c44371bca0f7ef563f2e6abc1a1c952f3477237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
