### PR TITLE
fix: put page emoji first on default-path conversions

### DIFF
--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -221,7 +221,7 @@ describe('SettingsController', () => {
       'process-pdfs': 'true',
       'pdf-extract-text': 'false',
       'download-pdfs': 'false',
-      'page-emoji': 'first-emoji',
+      'page-emoji': 'first_emoji',
       'image-quiz-html-to-anki': 'false',
       'embed-images': 'true',
       'markdown-nested-bullet-points': 'true',

--- a/src/lib/extractDeckName.test.ts
+++ b/src/lib/extractDeckName.test.ts
@@ -1,4 +1,5 @@
 import { extractName } from './extractDeckName';
+import CardOption from './parser/Settings/CardOption';
 
 const createInput = (
   name: string,
@@ -66,5 +67,16 @@ describe('extractDeckName', () => {
     it(description, () => {
       expect(extractName(input)).toBe(expected);
     });
+  });
+
+  it('puts the page emoji first on the default options path', () => {
+    const settings = new CardOption(CardOption.LoadDefaultOptions());
+    const name = extractName({
+      name: 'My Deck',
+      pageIcon: '📘',
+      decksCount: 0,
+      settings,
+    });
+    expect(name).toBe('📘 My Deck');
   });
 });

--- a/src/lib/parser/Settings/CardOption.ts
+++ b/src/lib/parser/Settings/CardOption.ts
@@ -231,7 +231,7 @@ class CardOption {
       'process-pdfs': 'true',
       'pdf-extract-text': 'false',
       'download-pdfs': 'false',
-      'page-emoji': 'first-emoji',
+      'page-emoji': 'first_emoji',
       'image-quiz-html-to-anki': 'false',
       'embed-images': 'true',
       'markdown-nested-bullet-points': 'true',

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-page-emoji-first.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-page-emoji-first.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-page-emoji-first",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Deck names show the page emoji at the front again"
+}


### PR DESCRIPTION
## What
The default conversion options set `page-emoji` to the value `first-emoji` (hyphen), but every consumer — `extractDeckName` and the `CardOption` constructor fallback — compares against `first_emoji` (underscore). The hyphenated string is truthy yet never matches, so on the default path the page emoji rendered at the **end** of the deck name instead of the front. This aligns the default to `first_emoji`.

## Why
Fixes #3237. Default-path Notion conversions now show the page emoji at the front of the deck name, matching the intended (and documented `first_emoji`) behaviour.

## How
One-character-class fix to `LoadDefaultOptions()` in `CardOption.ts` (`first-emoji` → `first_emoji`). The default-path test constructs a `CardOption` from `LoadDefaultOptions()` and feeds its `pageEmoji` through `extractName`, asserting the emoji lands first — this is the true regression and fails before the fix.

## Measuring success
Default-path conversions emit deck names of the shape `📘 My Deck` (emoji first) rather than `My Deck 📘`. The new test `extractDeckName › puts the page emoji first on the default options path` guards it.

## Testing
- `extractDeckName › puts the page emoji first on the default options path` — failing before the fix (`Received: "My Deck 📘"`), passing after.
- Existing `extractDeckName` and `CardOption` suites stay green (17 tests).
- `npx tsc -p . --noEmit` clean.

Sonar: not run locally — no SONAR_TOKEN on this machine. The change is a single string-literal correction, so a Sonar bounce is not expected.

The only `web/src` change is a new changelog JSON file, so the browser-attestation gate auto-bypasses (changelog-only diff).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-12-page-emoji-first.json` — "Deck names show the page emoji at the front again"

## Risks
Low. Users who relied on the accidental emoji-last default will see it move to the front — which is the documented and intended behaviour. The explicit `last_emoji` option is unaffected.

## Goal alignment
Cleaner, more correct deck names on the core Notion conversion path — the "beautiful deck back" half of the mission. No funnel metric; quality fix on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783776713&installation_id=132681956&pr_number=3251&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3251&signature=70ba0b7b00369cbff328e76753fa0136f428878ed3eb090d8cc85a0c095f4a4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->