### PR TITLE
fix: convert cloze deletions on attributed inline code

### DIFF
--- a/src/lib/parser/helpers/handleClozeDeletions.test.ts
+++ b/src/lib/parser/helpers/handleClozeDeletions.test.ts
@@ -199,6 +199,27 @@ describe('#1094 — code tags become cloze deletions', () => {
   });
 });
 
+describe('#3245 — cloze on attributed inline code', () => {
+  it('inline code carrying a class attribute still becomes a cloze', () => {
+    const input =
+      '<p>The capital is <code class="language-js">Paris</code></p>';
+    const result = handleClozeDeletions(input);
+    expect(result).toBe('<p>The capital is {{c1::Paris}}</p>');
+  });
+
+  it('explicit cloze on attributed code wraps the right element, not an earlier empty code', () => {
+    const input = '<p>a <code></code> b <code>c1::answer</code> c</p>';
+    const result = handleClozeDeletions(input);
+    expect(result).toBe('<p>a <code></code> b {{c1::answer}} c</p>');
+  });
+
+  it('explicit cloze on a class-attributed code element gets the braces', () => {
+    const input = '<p><code class="hl">c1::answer</code></p>';
+    const result = handleClozeDeletions(input);
+    expect(result).toBe('<p>{{c1::answer}}</p>');
+  });
+});
+
 describe('#2501 — group cloze blanks per toggle', () => {
   const threeBlanks =
     '<p><code>alpha</code> and <code>beta</code> and <code>gamma</code></p>';

--- a/src/lib/parser/helpers/handleClozeDeletions.ts
+++ b/src/lib/parser/helpers/handleClozeDeletions.ts
@@ -30,6 +30,12 @@ function handleRegularCloze(content: string, num: number): string {
   return content.match(/c\d::/) ? `{{${content}}}` : `{{c${num}::${content}}}`;
 }
 
+function handleExplicitCloze(content: string): string {
+  const prefix = content.includes('{{') ? '' : '{{';
+  const suffix = content.endsWith('}}') ? '' : '}}';
+  return `${prefix}${content}${suffix}`;
+}
+
 export default function handleClozeDeletions(
   input: string,
   groupClozePerToggle = false
@@ -46,7 +52,7 @@ export default function handleClozeDeletions(
     const v = dom(elem).html();
     if (!v) return;
 
-    const old = `<code>${v}</code>`;
+    const old = dom.html(elem);
 
     if (v.includes('KaTex')) {
       const isStandalone = totalCodeBlocks === 1;
@@ -64,8 +70,7 @@ export default function handleClozeDeletions(
     }
 
     if (v.match(/c\d::/)) {
-      mangle = mangle.replace('<code>', v.includes('{{') ? '' : '{{');
-      mangle = mangle.replace('</code>', v.endsWith('}}') ? '' : '}}');
+      mangle = replaceAll(mangle, old, handleExplicitCloze(v));
       return;
     }
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-cloze-code-styles.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-cloze-code-styles.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-cloze-code-styles",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Cloze deletions work on inline code that carries styling"
+}


### PR DESCRIPTION
## What
Cloze deletions on inline `<code>` that carries an attribute (e.g. `<code class="language-js">`) now convert to `{{c1::...}}` tokens. Before this, the card was flagged as a cloze but no token was produced, so users saw raw `<code>` text.

## Why
Fixes #3245. `handleClozeDeletions` reconstructed each element's markup as the literal string `<code>${inner}</code>` and string-matched that against the input. Any class attribute (Notion emits these for syntax-highlighted inline code) or entity-serialization difference made the `replaceAll` a silent no-op. Separately, the explicit `cN::` branch ran a blind `replace('<code>', ...)` against the first `<code>` in the whole string, so an earlier empty `<code></code>` could absorb the `{{` and corrupt placement.

## How
Match on the element's actual outer HTML via cheerio's `dom.html(elem)` instead of a reconstructed string, and route the explicit-`cN::` branch through the same `replaceAll` path with a small `handleExplicitCloze` helper. For code elements without attributes, `dom.html(elem)` serializes back to `<code>${inner}</code>`, so output is byte-identical for every previously passing case — the existing suite is unchanged.

## Measuring success
No raw `<code class="...">` text left in cloze-card `Text` fields for converted Notion exports. The three new unit tests in `handleClozeDeletions.test.ts` (#3245 block) pin the behavior; a regression would flip them red.

## Testing
- Unit tests added: attributed-class code becomes a cloze; explicit `cN::` cloze on attributed code gets the braces; an empty `<code></code>` preceding a typed cloze no longer steals the `{{`.
- Full `handleClozeDeletions` / `handleOverlappingCloze` / `hasInlineClozeCode` suites green (44 tests).
- `tsc -p . --noEmit` clean. The `DeckParser.test.ts` Python-bridge failures are pre-existing (no venv in this worktree) and unrelated.

## Browser check
Changelog-only `web/src/` change — attestation auto-bypass (every `web/src/` file in the diff is under `WhatsNewPage/changelog/`).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-12-cloze-code-styles.json` — "Cloze deletions work on inline code that carries styling"

## Sonar
Not run locally — no SONAR_TOKEN on this machine.

## Risks
Low. The fix narrows matching to the exact element markup; the only behavior that could shift is for code with attributes, which previously produced broken output. Rollback is a single revert.

## Goal alignment
Conversion-quality fix on the core Notion→Anki path — broken cloze cards are a silent reason a first deck looks wrong, which hurts upload→download→paid activation. Not directly attributed to a single funnel metric; quality on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783776846&installation_id=132681956&pr_number=3253&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3253&signature=8c0dc0502acbd477fd1779f6d86740b8b273321787941fa44e380cdf75afe493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->