### PR TITLE
fix: show the legacy-rate cancel note to all grandfathered subscribers

### DIFF
--- a/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
@@ -21,7 +21,11 @@ function withQueryClient(ui: ReactNode) {
   return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
 }
 
-function stubStripeActive() {
+function stubStripeActive(plan?: {
+  amount: number | null;
+  currency: string | null;
+  interval: string | null;
+}) {
   mockUseStripeSubscriptions.mockReturnValue({
     subscriptions: [],
     view: {
@@ -33,12 +37,25 @@ function stubStripeActive() {
         current_period_end: 1893456000,
         cancel_at: null,
         canceled_at: null,
-        plan: { amount: 1000, currency: 'usd', interval: 'month' },
+        plan: plan ?? { amount: 1000, currency: 'usd', interval: 'month' },
       },
     },
     isLoading: false,
     refetch: vi.fn().mockResolvedValue(undefined),
   } as unknown as StripeSubscriptionsState);
+}
+
+function renderStripeManagement() {
+  return render(
+    withQueryClient(
+      <SubscriptionManagement
+        user={user}
+        locals={{ subscriber: true, planSource: 'stripe' }}
+        hasActivePlan
+        onRefetch={vi.fn().mockResolvedValue(undefined)}
+      />
+    )
+  );
 }
 
 describe('SubscriptionManagement', () => {
@@ -121,6 +138,33 @@ describe('SubscriptionManagement', () => {
       screen.getByRole('button', { name: 'Cancel at period end' })
     ).toBeTruthy();
     expect(mockUseStripeSubscriptions).toHaveBeenCalledWith(true);
+  });
+
+  it.each([
+    ['legacy monthly $6', { amount: 600, interval: 'month' }],
+    ['legacy yearly $60', { amount: 6000, interval: 'year' }],
+    ['unknown interval below monthly v2', { amount: 600, interval: null }],
+  ])('shows the legacy-rate note for %s', (_label, plan) => {
+    stubStripeActive({ currency: 'usd', ...plan });
+
+    renderStripeManagement();
+
+    expect(
+      screen.getByText('Cancelling forfeits this legacy rate.')
+    ).toBeTruthy();
+  });
+
+  it.each([
+    ['v2 monthly $7.99', { amount: 799, interval: 'month' }],
+    ['v2 yearly $64', { amount: 6400, interval: 'year' }],
+  ])('hides the legacy-rate note for %s', (_label, plan) => {
+    stubStripeActive({ currency: 'usd', ...plan });
+
+    renderStripeManagement();
+
+    expect(
+      screen.queryByText('Cancelling forfeits this legacy rate.')
+    ).toBeNull();
   });
 
   it('renders nothing when the user is not a subscriber', () => {

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -37,6 +37,17 @@ const formatDate = (seconds: number | null): string => {
   });
 };
 
+const V2_MONTHLY_AMOUNT = 799;
+const V2_YEARLY_AMOUNT = 6400;
+
+const isLegacyRate = (sub: StripeSubscriptionSummary): boolean => {
+  const plan = sub.plan;
+  if (plan?.amount == null) return false;
+  const v2Amount =
+    plan.interval === 'year' ? V2_YEARLY_AMOUNT : V2_MONTHLY_AMOUNT;
+  return plan.amount < v2Amount;
+};
+
 const formatPlan = (sub: StripeSubscriptionSummary): string | null => {
   const plan = sub.plan;
   if (plan?.amount == null || !plan?.currency) return null;
@@ -154,12 +165,11 @@ function StripeSubscriptionManagement({
                   {formatDate(view.subscription.current_period_end)}
                 </strong>
               </p>
-              {view.subscription.plan?.amount != null &&
-                view.subscription.plan.amount < 600 && (
-                  <p className={styles.legacyNote}>
-                    Cancelling forfeits this legacy rate.
-                  </p>
-                )}
+              {isLegacyRate(view.subscription) && (
+                <p className={styles.legacyNote}>
+                  Cancelling forfeits this legacy rate.
+                </p>
+              )}
               <div className={styles.actions}>
                 <button
                   type="button"

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-legacy-rate-note.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-legacy-rate-note.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-legacy-rate-note",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "The cancel flow now reminds everyone on a legacy price what they would give up"
+}


### PR DESCRIPTION
Fixes #3209.

The cancel-flow note "Cancelling forfeits this legacy rate." was gated on `plan.amount < 600`, so post-reprice it fired for almost nobody — the $6/mo (600) and $60/yr (6000) grandfathered cohorts cancelled with no reminder that resubscribing after 21 June means v2 prices. The gate is now interval-aware (`monthly < 799`, `yearly < 6400`, unknown interval falls back to monthly) via an `isLegacyRate` helper.

## Decisions made overnight (please review)

- Threshold: interval-aware `year ? < 6400 : < 799` (pm's call, data shape verified — `plan.interval` is Stripe's `'month' | 'year'`). Assumption: no sub-$7.99 v2 price exists; if one ever does, switch the comparison to an explicit legacy-price allowlist.
- Fallback: null/unknown interval uses the monthly threshold so a missing field never hides the warning.
- Copy: unchanged — kept the existing "Cancelling forfeits this legacy rate." (pm: the proposed rewrite was wordier, no copy change in a gate fix). Swap if you'd word it differently.
- Scope: deliberately did NOT add a pause/downgrade/retention offer — that's a separate spec; this surfaces the existing note to the right cohort before the 21 Jun lock-in closes.
- Metric: protects monthly paid churn % (read at `/api/ops/business/metrics`); leading proxy is cancel-flow completion among legacy subs in `/api/ops/metrics`.

## Tests

Vitest: legacy monthly $6 shows the note, legacy yearly $60 shows it (previously hidden), unknown interval + $6 shows it, v2 $7.99/$64 hide it. Full SubscriptionManagement suite green (10/10), web typecheck clean.

Sonar: not run locally — no SONAR_TOKEN on this machine.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: account page → active Stripe subscription → cancel section; the note's visibility is the only change. Boxes left for your morning run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783776941&installation_id=132681956&pr_number=3255&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3255&signature=fd0c014b7bfe1cb5b8e52c920f1d704eb1b4f75a09dc37c0306d2d5c48b43746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->