### PR TITLE
fix: scope strikethrough tag registry per conversion

### DIFF
--- a/src/lib/parser/TagRegistry.test.ts
+++ b/src/lib/parser/TagRegistry.test.ts
@@ -1,0 +1,33 @@
+import TagRegistry from './TagRegistry';
+
+describe('TagRegistry', () => {
+  it('collects strikethroughs into its own array', () => {
+    const registry = new TagRegistry();
+
+    registry.addStrikethrough('chapter-1');
+    registry.addStrikethrough('verb');
+
+    expect(registry.strikethroughs).toEqual(['chapter-1', 'verb']);
+  });
+
+  it('clear empties the strikethroughs', () => {
+    const registry = new TagRegistry();
+    registry.addStrikethrough('done');
+
+    registry.clear();
+
+    expect(registry.strikethroughs).toEqual([]);
+  });
+
+  it('isolates state across instances so interleaved conversions never share tags', () => {
+    const conversionA = new TagRegistry();
+    const conversionB = new TagRegistry();
+
+    conversionA.addStrikethrough('a-tag');
+    conversionB.addStrikethrough('b-tag');
+    conversionB.clear();
+
+    expect(conversionA.strikethroughs).toEqual(['a-tag']);
+    expect(conversionB.strikethroughs).toEqual([]);
+  });
+});

--- a/src/lib/parser/TagRegistry.ts
+++ b/src/lib/parser/TagRegistry.ts
@@ -1,18 +1,8 @@
 export default class TagRegistry {
   strikethroughs: string[];
 
-  // singleton instance
-  private static _instance: TagRegistry;
-
   constructor() {
     this.strikethroughs = [];
-  }
-
-  static getInstance(): TagRegistry {
-    if (!TagRegistry._instance) {
-      TagRegistry._instance = new TagRegistry();
-    }
-    return TagRegistry._instance;
   }
 
   addStrikethrough(strikethrough: string): void {

--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -160,6 +160,8 @@ class BlockHandler {
 
   owner?: string;
 
+  tagRegistry: TagRegistry;
+
   constructor(
     exporter: CustomExporter,
     api: NotionAPIWrapper,
@@ -173,6 +175,7 @@ class BlockHandler {
     this.settings = settings;
     this.settingsRepository = settingsRepository;
     this.owner = owner;
+    this.tagRegistry = new TagRegistry();
   }
 
   private buildDeckStyle(): string {
@@ -332,14 +335,14 @@ class BlockHandler {
           ankiNote.tags =
             rules.TAGS === 'heading'
               ? headingTagsFor(tableBlock.id, headingTagMap)
-              : TagRegistry.getInstance().strikethroughs;
+              : this.tagRegistry.strikethroughs;
           ankiNote.number = counter++;
           if (hierarchyEnabled) {
             applyHierarchyFields(ankiNote, tableBlock.id, headingContextMap);
           }
           cards.push(ankiNote);
         }
-        TagRegistry.getInstance().clear();
+        this.tagRegistry.clear();
         continue;
       }
 
@@ -352,10 +355,11 @@ class BlockHandler {
         : null;
       if (fullBlock && toggleSummary) {
         // Always preserve newlines in toggle summaries by converting \n to <br />
-        name = renderTextChildren(toggleSummary, this.settings).replaceAll(
-          '\n',
-          '<br />'
-        );
+        name = renderTextChildren(
+          toggleSummary,
+          this.settings,
+          this.tagRegistry
+        ).replaceAll('\n', '<br />');
         back = await this.getBackSide(fullBlock);
       } else {
         // For non-toggle blocks, use the existing logic
@@ -427,7 +431,7 @@ class BlockHandler {
       ankiNote.media = this.exporter.media;
       this.exporter.media = [];
 
-      const tr = TagRegistry.getInstance();
+      const tr = this.tagRegistry;
       ankiNote.tags =
         rules.TAGS === 'heading'
           ? headingTagsFor(block.id, headingTagMap)

--- a/src/services/NotionService/blocks/BlockCallout.tsx
+++ b/src/services/NotionService/blocks/BlockCallout.tsx
@@ -36,6 +36,7 @@ export const BlockCallout = (
           const { annotations } = t;
           return HandleBlockAnnotations(annotations, t, {
             noUnderline: handler.settings?.noUnderline,
+            tagRegistry: handler.tagRegistry,
           });
         })}
       </div>

--- a/src/services/NotionService/blocks/BlockCode.tsx
+++ b/src/services/NotionService/blocks/BlockCode.tsx
@@ -22,6 +22,7 @@ const BlockCode = (block: CodeBlockObjectResponse, handler: BlockHandler) => {
           const { annotations } = t;
           return HandleBlockAnnotations(annotations, t, {
             noUnderline: handler.settings?.noUnderline,
+            tagRegistry: handler.tagRegistry,
           });
         })}
       </code>

--- a/src/services/NotionService/blocks/BlockHeadings.tsx
+++ b/src/services/NotionService/blocks/BlockHeadings.tsx
@@ -66,7 +66,9 @@ export const BlockHeading = (
     >
       {headingText.map((t: RichTextItemResponse) => {
         const { annotations } = t;
-        return HandleBlockAnnotations(annotations, t);
+        return HandleBlockAnnotations(annotations, t, {
+          tagRegistry: handler.tagRegistry,
+        });
       })}
     </Heading>
   );

--- a/src/services/NotionService/blocks/BlockParagraph.tsx
+++ b/src/services/NotionService/blocks/BlockParagraph.tsx
@@ -18,7 +18,11 @@ const BlockParagraph = (
       className={styleWithColors(paragraph.color)}
       id={block.id}
       dangerouslySetInnerHTML={{
-        __html: renderTextChildren(richText, handler.settings),
+        __html: renderTextChildren(
+          richText,
+          handler.settings,
+          handler.tagRegistry
+        ),
       }}
     ></p>
   );

--- a/src/services/NotionService/blocks/BlockQuote.tsx
+++ b/src/services/NotionService/blocks/BlockQuote.tsx
@@ -20,7 +20,9 @@ export const BlockQuote = (
     <blockquote className={styleWithColors(quote.color)} id={block.id}>
       {richText.map((t) => {
         const { annotations } = t;
-        return HandleBlockAnnotations(annotations, t);
+        return HandleBlockAnnotations(annotations, t, {
+          tagRegistry: handler.tagRegistry,
+        });
       })}
     </blockquote>
   );

--- a/src/services/NotionService/blocks/HandleBlockAnnotations.tsx
+++ b/src/services/NotionService/blocks/HandleBlockAnnotations.tsx
@@ -14,6 +14,7 @@ interface Annotations {
 
 interface HandleBlockAnnotationsOptions {
   noUnderline?: boolean;
+  tagRegistry?: TagRegistry;
 }
 
 const HandleBlockAnnotations = (
@@ -26,13 +27,12 @@ const HandleBlockAnnotations = (
   }
   const content = text.plain_text;
   const color = annotations.color;
-  // Compose all styles, allowing background + bold/italic/etc
   let styledContent: React.ReactNode = content;
   if (annotations.code) {
     styledContent = <code>{styledContent}</code>;
   }
   if (annotations.strikethrough) {
-    TagRegistry.getInstance().addStrikethrough(content);
+    options.tagRegistry?.addStrikethrough(content);
     styledContent = <del>{styledContent}</del>;
   }
   if (annotations.italic) {

--- a/src/services/NotionService/blocks/lists/BlockTable.tsx
+++ b/src/services/NotionService/blocks/lists/BlockTable.tsx
@@ -37,7 +37,7 @@ function renderCell(
   cell: RichTextItemResponse[],
   handler: BlockHandler
 ): string {
-  return renderTextChildren(cell, handler.settings);
+  return renderTextChildren(cell, handler.settings, handler.tagRegistry);
 }
 
 function buildExtraColumnsTable(

--- a/src/services/NotionService/blocks/lists/BlockToggleList.tsx
+++ b/src/services/NotionService/blocks/lists/BlockToggleList.tsx
@@ -37,7 +37,11 @@ export async function BlockToggleList(
           <Details>
             <summary
               dangerouslySetInnerHTML={{
-                __html: renderTextChildren(richText, handler.settings),
+                __html: renderTextChildren(
+                  richText,
+                  handler.settings,
+                  handler.tagRegistry
+                ),
               }}
             ></summary>
             <div dangerouslySetInnerHTML={{ __html: backSide }} />

--- a/src/services/NotionService/helpers/getListItems.tsx
+++ b/src/services/NotionService/helpers/getListItems.tsx
@@ -47,7 +47,8 @@ export default function getListItems(
             dangerouslySetInnerHTML={{
               __html: renderTextChildren(
                 getRichTextFromBlock(list),
-                handler.settings
+                handler.settings,
+                handler.tagRegistry
               ),
             }}
           />

--- a/src/services/NotionService/helpers/renderTextChildren.test.tsx
+++ b/src/services/NotionService/helpers/renderTextChildren.test.tsx
@@ -1,6 +1,7 @@
 import { RichTextItemResponse } from '@notionhq/client/build/src/api-endpoints';
 import renderTextChildren from './renderTextChildren';
 import CardOption from '../../../lib/parser/Settings';
+import TagRegistry from '../../../lib/parser/TagRegistry';
 
 const baseAnnotations = {
   bold: false,
@@ -28,6 +29,59 @@ function makeMention(
     },
   } as unknown as RichTextItemResponse;
 }
+
+function makeText(
+  plainText: string,
+  annotations: Partial<typeof baseAnnotations> = {}
+): RichTextItemResponse {
+  return {
+    type: 'text',
+    plain_text: plainText,
+    href: null,
+    annotations: { ...baseAnnotations, ...annotations },
+    text: { content: plainText, link: null },
+  } as unknown as RichTextItemResponse;
+}
+
+describe('renderTextChildren — strikethrough tag collection', () => {
+  it('records strikethrough text into the registry it is handed', () => {
+    const registry = new TagRegistry();
+    const items: RichTextItemResponse[] = [
+      makeText('keep', { strikethrough: true }),
+    ];
+
+    renderTextChildren(items, defaultSettings, registry);
+
+    expect(registry.strikethroughs).toEqual(['keep']);
+  });
+
+  it('keeps two conversions strikethroughs apart when run interleaved', () => {
+    const conversionA = new TagRegistry();
+    const conversionB = new TagRegistry();
+
+    renderTextChildren(
+      [makeText('a-tag', { strikethrough: true })],
+      defaultSettings,
+      conversionA
+    );
+    renderTextChildren(
+      [makeText('b-tag', { strikethrough: true })],
+      defaultSettings,
+      conversionB
+    );
+
+    expect(conversionA.strikethroughs).toEqual(['a-tag']);
+    expect(conversionB.strikethroughs).toEqual(['b-tag']);
+  });
+
+  it('leaves the registry empty when no text is struck through', () => {
+    const registry = new TagRegistry();
+
+    renderTextChildren([makeText('plain')], defaultSettings, registry);
+
+    expect(registry.strikethroughs).toEqual([]);
+  });
+});
 
 describe('renderTextChildren — mention support', () => {
   it('renders the plain_text of an annotated mention', () => {

--- a/src/services/NotionService/helpers/renderTextChildren.tsx
+++ b/src/services/NotionService/helpers/renderTextChildren.tsx
@@ -4,6 +4,7 @@ import {
 } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
 import CardOption from '../../../lib/parser/Settings';
+import TagRegistry from '../../../lib/parser/TagRegistry';
 
 import { renderInlineEquation } from '../blocks/BlockEquation';
 import HandleBlockAnnotations from '../blocks/HandleBlockAnnotations';
@@ -14,7 +15,8 @@ import preserveNewlinesIfApplicable from './preserveNewlinesIfApplicable';
 
 export default function renderTextChildren(
   text: RichTextItemResponse[] | undefined,
-  settings: CardOption
+  settings: CardOption,
+  tagRegistry?: TagRegistry
 ): string {
   if (!text || text?.length === 0) {
     return '';
@@ -30,6 +32,7 @@ export default function renderTextChildren(
           <>
             {HandleBlockAnnotations(t.annotations, t, {
               noUnderline: settings.noUnderline,
+              tagRegistry,
             })}
           </>
         );

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-tags-isolated.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-tags-isolated.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-tags-isolated",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Strikethrough tags stay on the deck they came from when several conversions run at once"
+}


### PR DESCRIPTION
## What
Scopes the strikethrough tag registry to each conversion instead of a process-global singleton, so concurrent conversions never share or wipe each other's tags.

## Why
Fixes #3235. `TagRegistry` was a process-global singleton. `BlockHandler` collected strikethrough-derived tags into the shared instance, assigned the live array to a note, and cleared it per note — but `await`s (`getBackSide`, Notion API calls) sit between collection and assignment. The Ankify 5-minute poll runs conversions concurrently with interactive `/notion` conversions in the same process, so one user's strikethrough tags could land on another user's cards, or vanish when a concurrent request cleared the shared registry first. User-visible outcome: strikethrough tags stay on the deck they came from when several conversions run at once.

## How
- `TagRegistry`: removed the `getInstance` singleton; the class is now instantiable, API otherwise unchanged.
- `BlockHandler`: owns a `tagRegistry` instance per conversion (BlockHandler is already constructed per conversion) and uses it at the collect/assign/clear sites.
- Threaded the instance into the only writer (`HandleBlockAnnotations`) via `renderTextChildren` and the block renderers (`BlockHeadings`, `BlockCode`, `BlockQuote`, `BlockCallout`, `BlockParagraph`, `BlockTable`, `BlockToggleList`, `getListItems`) — all of which already receive the `handler`. The per-note collect → assign → clear semantics are preserved exactly.

## Measuring success
No new metric. Confirmation is the absence of the cross-deck-tag report in support; the regression tests below lock the behavior in CI.

## Testing
- Unit tests added: `src/lib/parser/TagRegistry.test.ts` (instance isolation + clear); `renderTextChildren` strikethrough-collection tests asserting an injected registry receives the struck-through text and that two interleaved conversions keep their tags apart. Verified these two fail against the old singleton (the injected registry stays empty) and pass with the fix.
- `npx tsc -p .` clean; full `src/services/NotionService` suite green (45 suites). The `src/lib/parser/DeckParser.test.ts` failures in this worktree are environmental (the Python `create_deck` venv isn't present in the agent worktree) and unrelated to this change — they fail in the `.apkg` packaging step this PR never touches.

Sonar: not run locally — no SONAR_TOKEN on this machine.

## Browser check
Changelog-only web change → attestation auto-bypass.

## Changelog
`Strikethrough tags stay on the deck they came from when several conversions run at once` (`web/src/pages/WhatsNewPage/changelog/2026-06-12-tags-isolated.json`).

## Risks
Low. The change is mechanical threading of an existing object plus removal of a singleton with a single consumer. If a writer path was missed, those strikethroughs would simply not become tags (the optional `tagRegistry` param no-ops when absent) — no crash, no cross-request leak. A grep confirmed all `HandleBlockAnnotations`/`renderTextChildren` call sites are threaded.

## Goal alignment
None — internal correctness/reliability fix on the conversion hot path. No funnel or revenue metric moves; it removes a data-integrity defect that produced wrong cards under concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783777351&installation_id=132681956&pr_number=3257&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3257&signature=ea1090573aa91877227e4e5a50f1ed06c8937979f6fd87826c4ff31e0488b81d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->