### PR TITLE
fix: reject zip entries that escape the conversion workspace

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -24,8 +24,8 @@ import { convertDocxToHTML } from './convertDocxToHTML';
 import { generateDeckInfo, DeckInfo } from '../../../lib/claude/ClaudeService';
 import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
 import Workspace from '../../../lib/parser/WorkSpace';
-import fs from 'fs';
 import path from 'path';
+import { writeWorkspaceFile } from './writeWorkspaceFile';
 
 const HTML_GENERATION_CONCURRENCY = 3;
 
@@ -351,16 +351,12 @@ export async function PrepareDeck(
     await Promise.all(
       allFiles
         .filter((file) => file.contents)
-        .map(async (file) => {
-          const dest = path.join(input.workspace.location, file.name);
-          await fs.promises.mkdir(path.dirname(dest), { recursive: true });
-          await fs.promises.writeFile(
-            dest,
-            Buffer.isBuffer(file.contents)
-              ? file.contents
-              : Buffer.from(file.contents as string)
-          );
-        })
+        .map((file) =>
+          writeWorkspaceFile(input.workspace.location, {
+            name: file.name,
+            contents: file.contents,
+          })
+        )
     );
     console.log('[PrepareDeck] Claude branch: files written', {
       durationMs: Date.now() - tWrite,

--- a/src/infrastracture/adapters/fileConversion/writeWorkspaceFile.test.ts
+++ b/src/infrastracture/adapters/fileConversion/writeWorkspaceFile.test.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { WorkspaceEscapeError, writeWorkspaceFile } from './writeWorkspaceFile';
+
+describe('writeWorkspaceFile', () => {
+  let workspace: string;
+  let outside: string;
+
+  beforeEach(() => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wsguard-'));
+    workspace = path.join(root, 'ws');
+    outside = path.join(root, 'outside');
+    fs.mkdirSync(workspace, { recursive: true });
+    fs.mkdirSync(outside, { recursive: true });
+  });
+
+  it('writes a legitimate nested file inside the workspace', async () => {
+    await writeWorkspaceFile(workspace, {
+      name: 'Private & Shared/SLE/page.html',
+      contents: '<p>real deck</p>',
+    });
+
+    const written = path.join(workspace, 'Private & Shared/SLE/page.html');
+    expect(fs.existsSync(written)).toBe(true);
+    expect(fs.readFileSync(written, 'utf8')).toBe('<p>real deck</p>');
+  });
+
+  it('throws and writes nothing outside the workspace for a traversal name', async () => {
+    const escapeTarget = path.join('..', 'outside', 'evil.html');
+
+    await expect(
+      writeWorkspaceFile(workspace, {
+        name: escapeTarget,
+        contents: '<p>evil</p>',
+      })
+    ).rejects.toBeInstanceOf(WorkspaceEscapeError);
+
+    expect(fs.readdirSync(outside)).toEqual([]);
+  });
+
+  it('throws for an absolute-path name', async () => {
+    const target = path.join(outside, 'abs-evil.html');
+
+    await expect(
+      writeWorkspaceFile(workspace, { name: target, contents: '<p>x</p>' })
+    ).rejects.toBeInstanceOf(WorkspaceEscapeError);
+
+    expect(fs.existsSync(target)).toBe(false);
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/writeWorkspaceFile.ts
+++ b/src/infrastracture/adapters/fileConversion/writeWorkspaceFile.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import path from 'path';
+
+export class WorkspaceEscapeError extends Error {
+  constructor() {
+    super('Refusing to write a file outside the conversion workspace');
+    this.name = 'WorkspaceEscapeError';
+  }
+}
+
+interface WorkspaceFile {
+  name: string;
+  contents?: Buffer | Uint8Array | string;
+}
+
+const toBuffer = (contents: Buffer | Uint8Array | string): Buffer =>
+  Buffer.isBuffer(contents) ? contents : Buffer.from(contents as string);
+
+export const writeWorkspaceFile = async (
+  workspaceLocation: string,
+  file: WorkspaceFile
+): Promise<void> => {
+  if (file.contents == null) {
+    return;
+  }
+
+  const base = path.resolve(workspaceLocation);
+  const dest = path.resolve(base, file.name);
+
+  if (dest !== base && !dest.startsWith(base + path.sep)) {
+    throw new WorkspaceEscapeError();
+  }
+
+  await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+  await fs.promises.writeFile(dest, toBuffer(file.contents));
+};

--- a/src/lib/zip/isSafeZipEntryName.test.ts
+++ b/src/lib/zip/isSafeZipEntryName.test.ts
@@ -1,0 +1,25 @@
+import { isSafeZipEntryName } from './isSafeZipEntryName';
+
+describe('isSafeZipEntryName', () => {
+  it.each([
+    'safe.html',
+    'notes.md',
+    'Private & Shared/SLE/page.html',
+    'Private & Shared/SLE/image.png',
+    'deck/sub/deeper/card.html',
+  ])('accepts legitimate entry %s', (name) => {
+    expect(isSafeZipEntryName(name)).toBe(true);
+  });
+
+  it.each([
+    '/etc/passwd.html',
+    '../escape.html',
+    '../../../../tmp/evil.html',
+    'a/../../escape.html',
+    'deck/../../escape.html',
+    'C:\\Windows\\evil.html',
+    '..\\..\\evil.html',
+  ])('rejects traversal or absolute entry %s', (name) => {
+    expect(isSafeZipEntryName(name)).toBe(false);
+  });
+});

--- a/src/lib/zip/isSafeZipEntryName.ts
+++ b/src/lib/zip/isSafeZipEntryName.ts
@@ -1,0 +1,18 @@
+import path from 'path';
+
+const isSafeZipEntryName = (entryName: string): boolean => {
+  const normalized = entryName.replaceAll('\\', '/');
+
+  if (path.posix.isAbsolute(normalized) || /^[A-Za-z]:\//.test(normalized)) {
+    return false;
+  }
+
+  const resolved = path.posix.normalize(normalized);
+  if (resolved.startsWith('..') || resolved.includes('/../')) {
+    return false;
+  }
+
+  return true;
+};
+
+export { isSafeZipEntryName };

--- a/src/lib/zip/zip.test.tsx
+++ b/src/lib/zip/zip.test.tsx
@@ -1,0 +1,71 @@
+import { strToU8, zipSync } from 'fflate';
+
+import { ZipHandler } from './zip';
+import CardOption from '../parser/Settings';
+
+function buildZip(files: Record<string, string>): Uint8Array {
+  const entries: Record<string, Uint8Array> = {};
+  for (const [name, contents] of Object.entries(files)) {
+    entries[name] = strToU8(contents);
+  }
+  return zipSync(entries);
+}
+
+describe('ZipHandler entry-name safety', () => {
+  it('drops absolute-path entries while keeping safe entries', async () => {
+    const zip = buildZip({
+      'safe.html': '<p>safe</p>',
+      '/etc/passwd.html': '<p>evil</p>',
+    });
+
+    const handler = new ZipHandler(10);
+    await handler.build(zip, false, new CardOption({}));
+
+    const names = handler.getFileNames();
+    expect(names).toContain('safe.html');
+    expect(names).not.toContain('/etc/passwd.html');
+  });
+
+  it('drops mid-path traversal entries that escape the destination', async () => {
+    const zip = buildZip({
+      'notes.md': '# notes',
+      'a/../../escape.html': '<p>evil</p>',
+    });
+
+    const handler = new ZipHandler(10);
+    await handler.build(zip, false, new CardOption({}));
+
+    const names = handler.getFileNames();
+    expect(names).toContain('notes.md');
+    expect(names).not.toContain('a/../../escape.html');
+    expect(names.some((n) => n.includes('..'))).toBe(false);
+  });
+
+  it('drops leading-dot-dot traversal entries', async () => {
+    const zip = buildZip({
+      'ok.html': '<p>ok</p>',
+      '../../../../tmp/evil.html': '<p>evil</p>',
+    });
+
+    const handler = new ZipHandler(10);
+    await handler.build(zip, false, new CardOption({}));
+
+    const names = handler.getFileNames();
+    expect(names).toContain('ok.html');
+    expect(names.some((n) => n.includes('..'))).toBe(false);
+  });
+
+  it('keeps legitimate nested names with spaces and ampersands', async () => {
+    const zip = buildZip({
+      'Private & Shared/SLE/page.html': '<p>real deck</p>',
+      'Private & Shared/SLE/notes.md': '# real',
+    });
+
+    const handler = new ZipHandler(10);
+    await handler.build(zip, false, new CardOption({}));
+
+    const names = handler.getFileNames();
+    expect(names).toContain('Private & Shared/SLE/page.html');
+    expect(names).toContain('Private & Shared/SLE/notes.md');
+  });
+});

--- a/src/lib/zip/zip.tsx
+++ b/src/lib/zip/zip.tsx
@@ -9,6 +9,7 @@ import {
   isPDFFile,
 } from '../storage/checks';
 import { processAndPrepareArchiveData } from './fallback/processAndPrepareArchiveData';
+import { isSafeZipEntryName } from './isSafeZipEntryName';
 import CardOption from '../parser/Settings';
 import { getRandomUUID } from '../../shared/helpers/getRandomUUID';
 import { convertImageToHTML } from '../../infrastracture/adapters/fileConversion/convertImageToHTML';
@@ -95,6 +96,11 @@ class ZipHandler {
     settings: CardOption
   ) {
     if (name.includes('__MACOSX/')) return;
+
+    if (!isSafeZipEntryName(name)) {
+      console.warn('Skipped zip entry with unsafe path of length', name.length);
+      return;
+    }
 
     if (name.endsWith('.zip')) {
       this.zipFileCount++;


### PR DESCRIPTION
## What
Validates zip entry names before extraction so an uploaded archive can no longer write files outside its per-conversion workspace.

## Why
Fixes #3238. Uploaded archives were extracted by raw entry name with no check that the resolved path stayed inside the workspace directory. An entry with a traversal segment or an absolute path resolved outside the workspace, so the converter could land bytes in an arbitrary on-disk location (CWE-22, path traversal). The download side already had this guard; the conversion/extract side did not.

## How
Two layers, defense in depth:
1. The zip handler runs each entry name through a new `isSafeZipEntryName` helper and skips anything that is absolute or contains a traversal segment, logging a warning that includes only the name length — no user content. Skipping (rather than failing) means one bad entry doesn't kill an otherwise legitimate deck.
2. The workspace write site now goes through `writeWorkspaceFile`, which resolves the destination and asserts it stays inside the workspace before writing, throwing a coded `WorkspaceEscapeError` otherwise.

Legitimate nested names with spaces and ampersands keep working; only resolved-escape and absolute paths are rejected.

## Measuring success
Server logs: `Skipped zip entry with unsafe path of length N` indicates a rejected entry. Absence of `WorkspaceEscapeError` in error logs confirms the first layer catches everything before the write site (the second layer is the backstop).

## Testing
- `isSafeZipEntryName`: accepts nested names with spaces/ampersands; rejects leading, mid-path, and Windows-style traversal plus absolute and drive-letter paths.
- `ZipHandler`: an archive containing an absolute-path and a mid-path-traversal entry drops only the bad entries and keeps the safe ones; legitimate nested names survive.
- `writeWorkspaceFile`: a traversal or absolute name throws `WorkspaceEscapeError` and writes nothing outside the workspace (verified against a real tmpdir); a legitimate nested name writes inside.

## Browser check
Browser check: not applicable — no `web/src/` files; server-side conversion path only.

## Changelog
No entry — security hardening with no behavior change for legitimate decks.

## Risks
Low. The only behavior change for real uploads is that entries which resolve outside the workspace are dropped instead of written; such entries are never part of a valid deck. Rollback is a straight revert.

## Goal alignment
None — internal security hardening. Protects the conversion host; no funnel or revenue metric.

Sonar: not run locally — no SONAR_TOKEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783777583&installation_id=132681956&pr_number=3258&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3258&signature=56fc9ad542bf4f6e92a71d49a1ebee94c7dff42c5ccb2c965555c6e06175545f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->