### PR TITLE
fix: keep embedded markdown media through batch deck builds

### DIFF
--- a/src/lib/parser/DeckParser.batchImageMedia.test.ts
+++ b/src/lib/parser/DeckParser.batchImageMedia.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+import { setupTests } from '../../test/configure-jest';
+import CardOption from './Settings/CardOption';
+import { DeckParser } from './DeckParser';
+import Workspace from './WorkSpace';
+
+beforeEach(() => setupTests());
+
+function buildMarkdownParser(constructorWorkspace: Workspace) {
+  const markdown = [
+    '- What is shown here?',
+    '    ![image.png](image.png)',
+    '',
+  ].join('\n');
+  return new DeckParser({
+    name: 'notes.md',
+    settings: new CardOption({ 'markdown-nested-bullet-points': 'true' }),
+    files: [
+      { name: 'notes.md', contents: markdown },
+      { name: 'image.png', contents: Buffer.from('fake-png-bytes') },
+    ] as unknown as DeckParser['files'],
+    noLimits: true,
+    workspace: constructorWorkspace,
+  });
+}
+
+test('batch build keeps the embedded markdown image in card media and the exporter', async () => {
+  process.env.SKIP_CREATE_DECK = 'true';
+
+  const constructorWorkspace = new Workspace(true, 'fs');
+  const batchWorkspace = Workspace.subdir(constructorWorkspace.location);
+
+  const parser = buildMarkdownParser(constructorWorkspace);
+
+  await parser.writeDeckInfo(batchWorkspace);
+
+  const card = parser.payload[0].cards[0];
+  const embeddedSrc = /<img[^>]+src="([^"]+)"/.exec(card.back)?.[1];
+
+  expect(embeddedSrc).toBeDefined();
+  expect(card.media).toContain(embeddedSrc);
+  expect(
+    parser.customExporter.media.some((m) => path.basename(m) === embeddedSrc)
+  ).toBe(true);
+  expect(fs.existsSync(path.join(batchWorkspace.location, embeddedSrc!))).toBe(
+    true
+  );
+});

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -614,6 +614,7 @@ export class DeckParser {
         files: this.files,
         filePath: decodedPath,
         workspace: ws,
+        fallbackWorkspaceLocation: this.workspace.location,
       });
       if (newName) {
         dom(elem).attr('src', newName);
@@ -631,6 +632,7 @@ export class DeckParser {
         files: this.files,
         filePath: zipFile.name,
         workspace: ws,
+        fallbackWorkspaceLocation: this.workspace.location,
       });
       if (newName) {
         dom(elem).attr('src', newName);
@@ -719,6 +721,7 @@ export class DeckParser {
       files: this.files,
       filePath: global.decodeURIComponent(audiofile),
       workspace: ws,
+      fallbackWorkspaceLocation: this.workspace.location,
     });
     if (newFileName) {
       card.back += `[sound:${newFileName}]`;

--- a/src/lib/parser/exporters/embedFile.ts
+++ b/src/lib/parser/exporters/embedFile.ts
@@ -7,19 +7,44 @@ import getUniqueFileName from '../../misc/getUniqueFileName';
 import CustomExporter from './CustomExporter';
 import Workspace from '../WorkSpace';
 
-const getFile = (
-  exporter: CustomExporter,
-  files: File[],
-  filePath: string,
-  workspace: Workspace
+const readFromWorkspaceLocation = (
+  location: string,
+  filePath: string
 ): File | undefined => {
-  const fullPath = path.resolve(workspace.location, filePath);
-  if (fullPath.startsWith(workspace.location) && existsSync(fullPath)) {
+  const fullPath = path.resolve(location, filePath);
+  if (fullPath.startsWith(location) && existsSync(fullPath)) {
     const buffer = fs.readFileSync(fullPath);
     return {
       name: fullPath,
       contents: buffer,
     } as File;
+  }
+  return undefined;
+};
+
+const getFile = (
+  exporter: CustomExporter,
+  files: File[],
+  filePath: string,
+  workspace: Workspace,
+  fallbackWorkspaceLocation?: string
+): File | undefined => {
+  const fromWorkspace = readFromWorkspaceLocation(workspace.location, filePath);
+  if (fromWorkspace) {
+    return fromWorkspace;
+  }
+
+  if (
+    fallbackWorkspaceLocation &&
+    fallbackWorkspaceLocation !== workspace.location
+  ) {
+    const fromFallback = readFromWorkspaceLocation(
+      fallbackWorkspaceLocation,
+      filePath
+    );
+    if (fromFallback) {
+      return fromFallback;
+    }
   }
 
   const asRootFile = files.find((f) => f.name === filePath);
@@ -101,13 +126,21 @@ interface EmbedFileInput {
   files: File[];
   filePath: string;
   workspace: Workspace;
+  fallbackWorkspaceLocation?: string;
 }
 
 export const embedFile = (input: EmbedFileInput): string | null => {
-  const { exporter, files, filePath, workspace } = input;
+  const { exporter, files, filePath, workspace, fallbackWorkspaceLocation } =
+    input;
 
   const suffix = SuffixFrom(filePath);
-  const file = getFile(exporter, files, filePath, workspace);
+  const file = getFile(
+    exporter,
+    files,
+    filePath,
+    workspace,
+    fallbackWorkspaceLocation
+  );
 
   /**
    * The found file can be a file path in the workspace or a file in the zip or url.

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-batch-markdown-images.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-batch-markdown-images.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-batch-markdown-images",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Images in markdown files survive multi-deck conversions"
+}


### PR DESCRIPTION
> **⚠️ MERGE ORDER — conflicts expected with #3260.** PR #3260 (`fix/rehost-external-images`) makes the embed phase async (`build`/`writeDeckInfo` return Promises, `embedImagesInCardContent` gains a remote-fetch fallback). This branch is off `origin/main` **without** those changes, so the two PRs will conflict in `DeckParser.ts`. **Merge #3260 first; I'll rebase this one on top** (or whichever order you prefer — say the word).

## What
Batch-built markdown decks silently lost their embedded images. This restores them by letting the batch re-embed find the already-embedded bytes.

## Why
Fixes #3236 (HIGH). Markdown image bytes are embedded at `DeckParser` construction time — written into the constructor workspace under a content-hashed filename, with the `<img src>` rewritten to that hash. The batch build path (`writeDeckInfo`) can run against a **different** sub-workspace; `transformCard` then wipes `card.media = []` and re-embeds via `embedFile`. But `getFile` only looked in the batch workspace and the zip — neither holds the hashed file — so it returned `null`, the card kept the hashed `src` with an **empty** media array, and per the `create_deck.py` contract (`src/lib/ankify/FEATURE.md` media-passthrough note) a file absent from `card["media"]` is dropped from the `.apkg`. Result: broken images on every batch-built markdown deck whose sub-workspace differs from the constructor workspace.

The single-deck `build(input.workspace)` path survived only because the same workspace let `getFile`'s disk-read branch re-find the bytes.

## How
`getFile` now falls back to reading the already-embedded bytes from the **constructor workspace** when the file isn't in the batch workspace. The fallback location is threaded through `embedFile` (`fallbackWorkspaceLocation?`) and passed only by the three batch-path callers in `DeckParser` (`embedImagesInCardContent` image + zip-image, `embedCardAudio`). Because the embedded name is a SHA-512 of the file contents, the re-embed re-hashes to the same name, re-adds the bytes to the new exporter, and re-attaches the filename to `card.media`. Single-deck (same-workspace) behaviour is unchanged.

## Measuring success
No new event needed — this is a correctness fix. Confirmable in prod via the absence of `{"hint":"Missing relative path", ...}` debug lines (from `embedFile`'s null return) on batch markdown conversions, and by the regression test that drives `writeDeckInfo` with a distinct sub-workspace.

## Testing
- Unit test added: `src/lib/parser/DeckParser.batchImageMedia.test.ts` — drives the batch path (`writeDeckInfo` with a `Workspace.subdir`) and asserts the hashed filename lands in **both** `card.media` and the exporter's media list, and that the bytes physically exist in the batch workspace. Verified it fails on unmodified `main` (`Received array: []`) and passes with the fix.
- Full `src/lib/parser/` suite (46 files), `getPackagesFromZip`, and `PrepareDeck` suites green. `tsc -p . --noEmit` clean.

## Browser check
Browser check: not applicable — the only `web/src` file is a changelog JSON entry (auto-bypassed by the attestation gate).

## Changelog
`2026-06-12-batch-markdown-images.json` — "Images in markdown files survive multi-deck conversions"

## Sonar
Sonar: not run locally — no `SONAR_TOKEN` in this environment. Diff is small (one extracted helper + an optional param), so a Sonar bounce is unlikely; flagging per policy.

## Risks
Low. The fallback only activates when (a) the primary workspace read misses and (b) a distinct fallback location is supplied — i.e. exactly the broken batch case. SSRF/path-traversal posture is preserved: the fallback uses the same `resolve` + `startsWith(location)` containment check as the primary read. No new external calls, no behaviour change for the single-deck path.

## Goal alignment
Quality/correctness fix on the core conversion path (markdown → deck). Broken images on a delivered deck is a trust-and-retention hit on the simplest/fastest promise in CLAUDE.md; restoring them protects activation → retention rather than moving a specific acquisition metric. None — correctness, not a funnel lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783778407&installation_id=132681956&pr_number=3263&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3263&signature=d5293be3d27911df32acc873edb4bfb7104ecb2274f2b26efccd231119507601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->