### PR TITLE
fix: load saved per-page card options back into the form

### DIFF
--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -2,13 +2,16 @@ import { IServiceSettings } from '../../services/SettingsService';
 import CardOptionsController from './CardOptionsController';
 import { SettingsInitializer } from '../../data_layer/public/Settings';
 
-const FAKE_SAVED_PAYLOAD = {
+const FLAT_OPTIONS = {
   deckName: 'My Custom Deck',
   template: 'specialstyle',
 };
 
 class FakeSettingsService implements IServiceSettings {
+  public lastCreate: SettingsInitializer | null = null;
+
   create(settings: SettingsInitializer): Promise<number[]> {
+    this.lastCreate = settings;
     return Promise.resolve([]);
   }
   delete(owner: string, id: string): Promise<void> {
@@ -19,7 +22,7 @@ class FakeSettingsService implements IServiceSettings {
     return Promise.resolve({
       object_id: '1',
       owner: '1',
-      payload: FAKE_SAVED_PAYLOAD,
+      payload: FLAT_OPTIONS,
     });
   }
 
@@ -65,14 +68,37 @@ describe('CardOptionsController.findSetting', () => {
     } as unknown as import('express').Response;
   }
 
-  it('returns the inner payload object, not the full DB row', async () => {
+  it('returns the flat options for a new-shape row', async () => {
     const controller = new CardOptionsController(new FakeSettingsService());
     const req = {
       params: { id: 'page-123' },
     } as unknown as import('express').Request;
     const res = makeMockFindRes();
     await controller.findSetting(req, res);
-    expect(res.json).toHaveBeenCalledWith({ payload: FAKE_SAVED_PAYLOAD });
+    expect(res.json).toHaveBeenCalledWith({ payload: FLAT_OPTIONS });
+  });
+
+  it('unwraps a legacy wrapper row down to the flat options', async () => {
+    class LegacyWrapperService extends FakeSettingsService {
+      getById(_id: string): Promise<SettingsInitializer> {
+        return Promise.resolve({
+          object_id: '1',
+          owner: '1',
+          payload: {
+            object_id: 'page-123',
+            title: 'A',
+            payload: FLAT_OPTIONS,
+          },
+        } as unknown as SettingsInitializer);
+      }
+    }
+    const controller = new CardOptionsController(new LegacyWrapperService());
+    const req = {
+      params: { id: 'page-123' },
+    } as unknown as import('express').Request;
+    const res = makeMockFindRes();
+    await controller.findSetting(req, res);
+    expect(res.json).toHaveBeenCalledWith({ payload: FLAT_OPTIONS });
   });
 
   it('returns null payload when no settings are found', async () => {
@@ -88,6 +114,43 @@ describe('CardOptionsController.findSetting', () => {
     const res = makeMockFindRes();
     await controller.findSetting(req, res);
     expect(res.json).toHaveBeenCalledWith({ payload: null });
+  });
+});
+
+describe('CardOptionsController.createSetting', () => {
+  function makeMockCreateRes() {
+    const send = jest.fn();
+    const status = jest.fn().mockReturnValue({ send });
+    return {
+      locals: { owner: 'user-1' },
+      status,
+      send,
+    } as unknown as import('express').Response;
+  }
+
+  it('persists the flat options map, not the request wrapper', async () => {
+    const service = new FakeSettingsService();
+    const controller = new CardOptionsController(service);
+    const req = {
+      params: { id: 'page-123' },
+      body: {
+        settings: {
+          object_id: 'page-123',
+          title: 'Pharmacology',
+          payload: FLAT_OPTIONS,
+        },
+      },
+    } as unknown as import('express').Request;
+    const res = makeMockCreateRes();
+
+    await controller.createSetting(req, res);
+
+    expect(service.lastCreate).toEqual({
+      owner: 'user-1',
+      payload: FLAT_OPTIONS,
+      object_id: 'page-123',
+      title: 'Pharmacology',
+    });
   });
 });
 

--- a/src/controllers/CardOptionsController/CardOptionsController.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.ts
@@ -5,6 +5,7 @@ import { NotionService } from '../../services/NotionService/NotionService';
 import { getOwner } from '../../lib/User/getOwner';
 import supportedOptions from './supportedOptions';
 import CardOption from '../../lib/parser/Settings/CardOption';
+import { unwrapStoredSettingsPayload } from '../../lib/parser/Settings/unwrapStoredSettingsPayload';
 import { CardOptionDetail } from './CardOptionDetail';
 
 interface DeleteAllUseCase {
@@ -26,7 +27,7 @@ class CardOptionsController {
     try {
       await this.service.create({
         owner: owner,
-        payload: settings,
+        payload: settings.payload,
         object_id: settings.object_id,
         title: settings.title ?? null,
       });
@@ -62,7 +63,12 @@ class CardOptionsController {
 
     try {
       const storedSettings = await this.service.getById(id);
-      return res.json({ payload: storedSettings?.payload ?? null });
+      if (storedSettings?.payload == null) {
+        return res.json({ payload: null });
+      }
+      return res.json({
+        payload: unwrapStoredSettingsPayload(storedSettings.payload),
+      });
     } catch (error) {
       console.info('Get setting failed');
       console.error(error);

--- a/src/data_layer/SettingsRepository.test.ts
+++ b/src/data_layer/SettingsRepository.test.ts
@@ -233,3 +233,67 @@ describe('SettingsRepository.loadAnkifyTemplateOverrides', () => {
     expect(overrides).toBeNull();
   });
 });
+
+describe('SettingsRepository.loadIfExists', () => {
+  let db: Knex;
+  let repo: SettingsRepository;
+
+  beforeEach(async () => {
+    db = knexLib({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('settings', (t) => {
+      t.string('owner');
+      t.string('object_id');
+      t.string('title');
+      t.json('payload');
+      t.timestamp('updated_at').defaultTo(db.fn.now());
+    });
+    await db.schema.createTable('templates', (t) => {
+      t.string('owner');
+      t.json('payload');
+    });
+    repo = new SettingsRepository(db);
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test('reads the deck name from a legacy wrapper row', async () => {
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'page-a',
+      title: 'A',
+      payload: JSON.stringify({
+        object_id: 'page-a',
+        title: 'A',
+        payload: { deckName: 'Wrapped Deck' },
+      }),
+    });
+
+    const settings = await repo.loadIfExists('42', 'page-a');
+
+    expect(settings?.deckName).toBe('Wrapped Deck');
+  });
+
+  test('reads the deck name from a new flat row', async () => {
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'page-b',
+      title: 'B',
+      payload: JSON.stringify({ deckName: 'Flat Deck' }),
+    });
+
+    const settings = await repo.loadIfExists('42', 'page-b');
+
+    expect(settings?.deckName).toBe('Flat Deck');
+  });
+
+  test('returns null when no row exists for the owner and page', async () => {
+    const settings = await repo.loadIfExists('42', 'missing');
+    expect(settings).toBeNull();
+  });
+});

--- a/src/data_layer/SettingsRepository.ts
+++ b/src/data_layer/SettingsRepository.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex';
 import Settings, { SettingsInitializer } from './public/Settings';
 import CardOption from '../lib/parser/Settings/CardOption';
 import { getCustomTemplate } from '../lib/parser/Settings/helpers/getCustomTemplate';
+import { unwrapStoredSettingsPayload } from '../lib/parser/Settings/unwrapStoredSettingsPayload';
 import { AnkifyTemplateOverrides } from '../services/ankify/templateOverrides';
 
 export interface ISettingsRepository {
@@ -90,7 +91,9 @@ class SettingsRepository implements ISettingsRepository {
         return null;
       }
 
-      const settings = new CardOption(result.payload.payload);
+      const settings = new CardOption(
+        unwrapStoredSettingsPayload(result.payload)
+      );
       const templates = await this.database('templates')
         .where({ owner })
         .returning(['payload'])
@@ -125,10 +128,7 @@ class SettingsRepository implements ISettingsRepository {
     if (!row) {
       return null;
     }
-    const settingsPayload = parseJsonColumn(row.payload) as {
-      payload?: Record<string, string>;
-    } | null;
-    const cardOption = new CardOption(settingsPayload?.payload ?? {});
+    const cardOption = new CardOption(unwrapStoredSettingsPayload(row.payload));
     if (cardOption.template === 'custom') {
       return cardOption.basicModelName;
     }
@@ -152,11 +152,8 @@ class SettingsRepository implements ISettingsRepository {
       .select('card_options')
       .where({ id: owner })
       .first();
-    const globalOptions = parseJsonColumn(userRow?.card_options) as {
-      template?: string;
-      basic_model_name?: string;
-    } | null;
-    if (globalOptions?.template === 'custom') {
+    const globalOptions = unwrapStoredSettingsPayload(userRow?.card_options);
+    if (globalOptions.template === 'custom') {
       return new CardOption(globalOptions).basicModelName;
     }
     return null;

--- a/src/lib/parser/Settings/unwrapStoredSettingsPayload.test.ts
+++ b/src/lib/parser/Settings/unwrapStoredSettingsPayload.test.ts
@@ -1,0 +1,61 @@
+import { unwrapStoredSettingsPayload } from './unwrapStoredSettingsPayload';
+
+describe('unwrapStoredSettingsPayload', () => {
+  it('returns the inner options for a legacy wrapper row', () => {
+    const stored = {
+      object_id: 'page-a',
+      title: 'A',
+      payload: { deckName: 'My Deck', template: 'specialstyle' },
+    };
+
+    expect(unwrapStoredSettingsPayload(stored)).toEqual({
+      deckName: 'My Deck',
+      template: 'specialstyle',
+    });
+  });
+
+  it('returns the flat options unchanged for a new-shape row', () => {
+    const stored = { deckName: 'My Deck', template: 'specialstyle' };
+
+    expect(unwrapStoredSettingsPayload(stored)).toEqual({
+      deckName: 'My Deck',
+      template: 'specialstyle',
+    });
+  });
+
+  it('parses a JSON string column before unwrapping a legacy wrapper', () => {
+    const stored = JSON.stringify({
+      object_id: 'page-a',
+      payload: { deckName: 'My Deck' },
+    });
+
+    expect(unwrapStoredSettingsPayload(stored)).toEqual({
+      deckName: 'My Deck',
+    });
+  });
+
+  it('parses a JSON string column for a flat row', () => {
+    const stored = JSON.stringify({ deckName: 'My Deck' });
+
+    expect(unwrapStoredSettingsPayload(stored)).toEqual({
+      deckName: 'My Deck',
+    });
+  });
+
+  it('returns an empty object for null', () => {
+    expect(unwrapStoredSettingsPayload(null)).toEqual({});
+  });
+
+  it('returns an empty object for unparseable strings', () => {
+    expect(unwrapStoredSettingsPayload('not json')).toEqual({});
+  });
+
+  it('treats a nested non-object payload as flat options', () => {
+    const stored = { deckName: 'My Deck', payload: 'show-all' };
+
+    expect(unwrapStoredSettingsPayload(stored)).toEqual({
+      deckName: 'My Deck',
+      payload: 'show-all',
+    });
+  });
+});

--- a/src/lib/parser/Settings/unwrapStoredSettingsPayload.ts
+++ b/src/lib/parser/Settings/unwrapStoredSettingsPayload.ts
@@ -1,0 +1,27 @@
+function parseJsonColumn(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function unwrapStoredSettingsPayload(
+  stored: unknown
+): Record<string, string> {
+  const parsed = parseJsonColumn(stored);
+  if (!isPlainObject(parsed)) {
+    return {};
+  }
+  if (isPlainObject(parsed.payload)) {
+    return parsed.payload as Record<string, string>;
+  }
+  return parsed as Record<string, string>;
+}

--- a/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.test.tsx
@@ -449,6 +449,57 @@ describe('CardOptionsForm ai-comprehensive toggle (paid-only)', () => {
   });
 });
 
+describe('CardOptionsForm loads a saved per-page payload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setUserLocalsPaying(false);
+    localStorage.clear();
+    mockSaveSettings.mockResolvedValue(undefined);
+    mockGetSettingsCardOptions.mockResolvedValue([
+      new CardOptionModel(
+        'no-underline',
+        'Remove underlines',
+        'Strip underline formatting from card text.',
+        false
+      ),
+    ]);
+  });
+
+  it('shows the saved deck name and code theme from a flat payload', async () => {
+    mockGetSettings.mockResolvedValue({
+      deckName: 'Saved Pharmacology Deck',
+      'code-theme': 'dracula',
+    });
+
+    renderPageForm({ setError: vi.fn() });
+
+    const deckInput = (await screen.findByPlaceholderText(
+      'Enter deck name (optional)'
+    )) as HTMLInputElement;
+    await waitFor(() => {
+      expect(deckInput.value).toBe('Saved Pharmacology Deck');
+    });
+
+    const codeTheme = (await screen.findByLabelText(
+      'Code theme'
+    )) as HTMLSelectElement;
+    expect(codeTheme.value).toBe('dracula');
+  });
+
+  it('ticks a saved checkbox option from a flat payload', async () => {
+    mockGetSettings.mockResolvedValue({ 'no-underline': 'true' });
+
+    renderPageForm({ setError: vi.fn() });
+
+    const toggle = await screen.findByRole('checkbox', {
+      name: 'Remove underlines',
+    });
+    await waitFor(() => {
+      expect(toggle).toBeChecked();
+    });
+  });
+});
+
 describe('CardOptionsForm save defaults feedback', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-page-settings-load.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-page-settings-load.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-page-settings-load",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Saved per-page card options show up again when you reopen a page's settings"
+}


### PR DESCRIPTION
## What
Per-page card options now load back into the settings form after you save them. The form was double-nesting the payload on save and reading the wrong level on load, so saved customizations looked lost and a second save overwrote the real per-page row.

## Why
Fixes #3233 (HIGH, confirmed by two reviewers). User-visible outcome: open a Notion page's card options, save, reopen — your saved deck name, theme, toggles, and TTS settings are there.

## How
- The DB `payload` column held the wrapper `{object_id, title, payload: {options}}` because the controller stored the whole request `settings` object. `createSetting` now stores the flat options map (`settings.payload`); the `object_id`/`title` columns are unchanged.
- Reads unwrap tolerantly through one helper, `unwrapStoredSettingsPayload`: if the stored value has a nested `payload` object (legacy wrapper rows) it returns `payload.payload`, otherwise it returns the value directly. Centralized in `src/lib/parser/Settings/` and used by the controller's `findSetting`, the repository's `loadIfExists`, and `resolveCustomBasicModelName` — no duplicated conditional.
- The web `applyPayload` already expected a flat options map (it checks `Object.hasOwn(payload, 'deckName')` etc.), and `getLocalStorageValue` reads `key in theSettings` against the flat map — so once the server returns flat options, the form populates with no web source change. The form diff is test-only.

### Both-shape compatibility — no migration
Legacy wrapper rows written before this fix stay readable forever: the unwrap helper detects the nested `payload` object and digs one level in. New saves write flat. This is a deliberate decision — a backfill migration would touch every existing settings row for no behavioral gain, since the helper reads both shapes identically. Conversions already read the nested level correctly (`SettingsRepository` previously did `result.payload.payload`), and now route through the same helper, so legacy and new rows converge.

## Measuring success
No new metric. The bug is silent (no error log) — verification is the browser round-trip below and the new tests. If it regressed in prod, the symptom would be the original report: reopened per-page options showing global/default values.

## Testing
Unit tests added:
- `unwrapStoredSettingsPayload.test.ts` — legacy wrapper, new flat, JSON-string column, null, non-object nested `payload`.
- `CardOptionsController.test.ts` — `createSetting` persists the flat options map (not the wrapper); `findSetting` returns flat options for both a new-shape row and a legacy wrapper row.
- `SettingsRepository.test.ts` — `loadIfExists` reads the deck name from both a legacy wrapper row and a new flat row.
- `CardOptionsForm.test.tsx` — a saved flat payload populates the deck name, code theme, and a checkbox option.

Green: server `tsc -p .` + scoped Jest (26 passing), web `typecheck` + `CardOptionsForm` Vitest (23 passing).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: save per-page options on a Notion page, reload, reopen — values must persist.

## Changelog
`Saved per-page card options show up again when you reopen a page's settings`

## Risks
Low. The store-flat change only affects newly-saved rows; legacy rows are read via the tolerant unwrap, so nothing in the existing data set breaks. The conversion path was already reading the nested level and now reads through the shared helper that handles both shapes.

Rollback: revert the commit. New saves written while this is live are flat; after a revert the old code expects `payload.payload` and would read flat rows as empty options — so prefer rolling forward with a fix over reverting once any flat rows exist.

## Merge-order note
PR #3259 (`fix/card-options-reset`) also edits `CardOptionsForm.tsx` in the reset-handler region. This PR's `CardOptionsForm.tsx` change is test-only (no source edit to the component), so the overlap is minimal — whichever merges second should rebase cleanly.

## Sonar
Not run locally — no `SONAR_TOKEN` configured in this environment.

## Goal alignment
Retention/quality fix on the core conversion settings surface — per-page options are a power-user feature and silently losing them erodes trust in saved state. No direct funnel metric; reduces a confirmed HIGH friction point in the convert flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783778430&installation_id=132681956&pr_number=3264&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3264&signature=ccf0555454092cf7d099e3bc62366e922f4477db4f9d97da758b27808bf34292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->