### PR TITLE
fix: scope settings rows to their owner

### DIFF
--- a/migrations/20260911000001_settings_owner_object_id_unique.js
+++ b/migrations/20260911000001_settings_owner_object_id_unique.js
@@ -1,0 +1,26 @@
+module.exports.up = async function (knex) {
+  await knex.raw(`
+    DELETE FROM settings a
+    USING settings b
+    WHERE a.owner = b.owner
+      AND a.object_id = b.object_id
+      AND a.id < b.id
+  `);
+  await knex.schema.alterTable('settings', (table) => {
+    table.dropUnique(['object_id']);
+    table.unique(['owner', 'object_id']);
+  });
+};
+
+module.exports.down = async function (knex) {
+  await knex.raw(`
+    DELETE FROM settings a
+    USING settings b
+    WHERE a.object_id = b.object_id
+      AND a.id < b.id
+  `);
+  await knex.schema.alterTable('settings', (table) => {
+    table.dropUnique(['owner', 'object_id']);
+    table.unique(['object_id']);
+  });
+};

--- a/src/controllers/CardOptionsController/CardOptionsController.test.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.test.ts
@@ -18,10 +18,10 @@ class FakeSettingsService implements IServiceSettings {
     return Promise.resolve();
   }
 
-  getById(id: string): Promise<SettingsInitializer> {
+  getById(owner: string, id: string): Promise<SettingsInitializer> {
     return Promise.resolve({
-      object_id: '1',
-      owner: '1',
+      object_id: id,
+      owner,
       payload: FLAT_OPTIONS,
     });
   }
@@ -58,11 +58,11 @@ function testDefaultSettings(
 }
 
 describe('CardOptionsController.findSetting', () => {
-  function makeMockFindRes() {
+  function makeMockFindRes(owner = 'user-1') {
     const json = jest.fn();
     const status = jest.fn().mockReturnValue({ send: jest.fn() });
     return {
-      locals: {},
+      locals: { owner },
       json,
       status,
     } as unknown as import('express').Response;
@@ -101,9 +101,26 @@ describe('CardOptionsController.findSetting', () => {
     expect(res.json).toHaveBeenCalledWith({ payload: FLAT_OPTIONS });
   });
 
+  it('scopes the lookup to the authenticated owner', async () => {
+    const getById = jest.fn().mockResolvedValue({
+      object_id: 'page-123',
+      owner: 'user-7',
+      payload: FLAT_OPTIONS,
+    });
+    const service = new FakeSettingsService();
+    service.getById = getById;
+    const controller = new CardOptionsController(service);
+    const req = {
+      params: { id: 'page-123' },
+    } as unknown as import('express').Request;
+    const res = makeMockFindRes('user-7');
+    await controller.findSetting(req, res);
+    expect(getById).toHaveBeenCalledWith('user-7', 'page-123');
+  });
+
   it('returns null payload when no settings are found', async () => {
     class EmptySettingsService extends FakeSettingsService {
-      getById(_id: string): Promise<SettingsInitializer> {
+      getById(_owner: string, _id: string): Promise<SettingsInitializer> {
         return Promise.resolve(null as unknown as SettingsInitializer);
       }
     }

--- a/src/controllers/CardOptionsController/CardOptionsController.ts
+++ b/src/controllers/CardOptionsController/CardOptionsController.ts
@@ -56,13 +56,14 @@ class CardOptionsController {
   async findSetting(req: Request, res: Response) {
     console.debug(`find settings ${req.params.id}`);
     const { id } = req.params;
+    const owner = getOwner(res);
 
     if (!id) {
       return res.status(400).send();
     }
 
     try {
-      const storedSettings = await this.service.getById(id);
+      const storedSettings = await this.service.getById(owner, id);
       if (storedSettings?.payload == null) {
         return res.json({ payload: null });
       }

--- a/src/data_layer/SettingsRepository.test.ts
+++ b/src/data_layer/SettingsRepository.test.ts
@@ -234,7 +234,7 @@ describe('SettingsRepository.loadAnkifyTemplateOverrides', () => {
   });
 });
 
-describe('SettingsRepository.loadIfExists', () => {
+describe('SettingsRepository owner scoping and payload shapes', () => {
   let db: Knex;
   let repo: SettingsRepository;
 
@@ -245,11 +245,13 @@ describe('SettingsRepository.loadIfExists', () => {
       useNullAsDefault: true,
     });
     await db.schema.createTable('settings', (t) => {
-      t.string('owner');
-      t.string('object_id');
+      t.increments('id');
+      t.string('owner').notNullable();
+      t.string('object_id').notNullable();
       t.string('title');
-      t.json('payload');
+      t.json('payload').notNullable();
       t.timestamp('updated_at').defaultTo(db.fn.now());
+      t.unique(['owner', 'object_id']);
     });
     await db.schema.createTable('templates', (t) => {
       t.string('owner');
@@ -295,5 +297,102 @@ describe('SettingsRepository.loadIfExists', () => {
   test('returns null when no row exists for the owner and page', async () => {
     const settings = await repo.loadIfExists('42', 'missing');
     expect(settings).toBeNull();
+  });
+
+  test('two owners saving the same object_id keep separate rows', async () => {
+    await repo.create({
+      owner: 'owner-a',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Deck A' } }),
+      title: 'A',
+    });
+    await repo.create({
+      owner: 'owner-b',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Deck B' } }),
+      title: 'B',
+    });
+
+    const rows = await db('settings')
+      .where({ object_id: 'shared-page' })
+      .orderBy('owner');
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.owner)).toEqual(['owner-a', 'owner-b']);
+  });
+
+  test('re-saving the same owner + object_id updates that owner row in place', async () => {
+    await repo.create({
+      owner: 'owner-a',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'First' } }),
+      title: 'First',
+    });
+    await repo.create({
+      owner: 'owner-a',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Second' } }),
+      title: 'Second',
+    });
+
+    const rows = await db('settings').where({ owner: 'owner-a' });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe('Second');
+  });
+
+  test('one owner saving cannot overwrite another owner row', async () => {
+    await repo.create({
+      owner: 'owner-a',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Deck A' } }),
+      title: 'A',
+    });
+    await repo.create({
+      owner: 'owner-b',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Deck B' } }),
+      title: 'B',
+    });
+
+    const ownerARow = await db('settings')
+      .where({ owner: 'owner-a', object_id: 'shared-page' })
+      .first();
+
+    expect(ownerARow.title).toBe('A');
+  });
+
+  test('getById scoped by owner returns only that owner row', async () => {
+    await repo.create({
+      owner: 'owner-a',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Deck A' } }),
+      title: 'A',
+    });
+    await repo.create({
+      owner: 'owner-b',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Deck B' } }),
+      title: 'B',
+    });
+
+    const ownerBResult = await repo.getById('owner-b', 'shared-page');
+
+    expect(JSON.parse(ownerBResult.payload)).toEqual({
+      payload: { deck_name: 'Deck B' },
+    });
+  });
+
+  test('getById returns undefined when the page belongs to another owner', async () => {
+    await repo.create({
+      owner: 'owner-a',
+      object_id: 'shared-page',
+      payload: JSON.stringify({ payload: { deck_name: 'Deck A' } }),
+      title: 'A',
+    });
+
+    const result = await repo.getById('owner-b', 'shared-page');
+
+    expect(result).toBeUndefined();
   });
 });

--- a/src/data_layer/SettingsRepository.ts
+++ b/src/data_layer/SettingsRepository.ts
@@ -40,17 +40,17 @@ class SettingsRepository implements ISettingsRepository {
         payload,
         title,
       })
-      .onConflict('object_id')
-      .merge();
+      .onConflict(['owner', 'object_id'])
+      .merge(['payload', 'title']);
   }
 
   delete(owner: number | string, object_id: string) {
     return this.database(this.table).del().where({ owner, object_id });
   }
 
-  getById(object_id: string) {
+  getById(owner: string, object_id: string) {
     return this.database(this.table)
-      .where({ object_id })
+      .where({ owner, object_id })
       .returning(['payload'])
       .first();
   }

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -4,7 +4,7 @@ import { SettingsInitializer } from '../data_layer/public/Settings';
 export interface IServiceSettings {
   create: (settings: SettingsInitializer) => Promise<number[]>;
   delete: (owner: string, id: string) => Promise<void>;
-  getById: (id: string) => Promise<SettingsInitializer>;
+  getById: (owner: string, id: string) => Promise<SettingsInitializer>;
   getAllByOwner: (
     owner: string
   ) => Promise<
@@ -45,8 +45,8 @@ class SettingsService implements IServiceSettings {
     });
   }
 
-  getById(id: string) {
-    return this.repository.getById(id);
+  getById(owner: string, id: string) {
+    return this.repository.getById(owner, id);
   }
 
   getAllByOwner(owner: string) {


### PR DESCRIPTION
Fixes #3239.

Settings rows were keyed by `object_id` alone, so two users saving options for the same Notion page clobbered each other (`onConflict('object_id').merge()` rewrote `owner`), and `GET /settings/find/:id` served one user's saved payload — deck name, user-instructions — to any authenticated user who knew the page UUID.

## What

- Upsert now keys on the composite `(owner, object_id)` and no longer merges `owner`.
- `getById(owner, object_id)` and the controller's `findSetting` are owner-scoped via `res.locals.owner`; the read still routes through `unwrapStoredSettingsPayload` so legacy-wrapper and new-flat rows both decode.
- Migration `20260911000001_settings_owner_object_id_unique.js`: dedupe `(owner, object_id)` keeping the newest id, drop the single-column unique, add the composite unique. `down` reverses it.

## Migration review (migration-reviewer)

- **Dedupe is a no-op in prod** — the old `UNIQUE(object_id)` made `(owner, object_id)` duplicates impossible, so the up-dedupe matches zero rows. It's purely defensive and cannot over-reach (filter is `a.owner = b.owner`).
- **Locking** — `ALTER TABLE` drop+add unique takes ACCESS EXCLUSIVE on `settings`. The table is tiny (one row per user per page) so the DDL runs in milliseconds, but `settings` is read on every conversion via `loadIfExists`; if a long-running query holds a share lock at deploy time the request could queue briefly behind the DDL. Acceptable at current scale; building the index `CONCURRENTLY` is the escape hatch if that ever bites.
- **`down` is intentionally lossy** — restoring the global single-column unique collapses cross-owner rows for the same page to the newest. Documented; only relevant if rolling back after traffic under the new schema.
- **kanel** — no diff: a constraint change doesn't alter column types, and `src/data_layer/public/` is byte-identical to main. Verified.
- File timestamp sorts after the latest migration on main (`20260911000000`).

## Tests

`SettingsRepository` (better-sqlite3 in-memory with the composite unique): two owners keep separate rows, same-owner re-save updates in place, no cross-owner overwrite, `getById` owner-scoped + undefined for another owner's page — plus the carried-over legacy-wrapper / flat-row / null reads. Controller test asserts `findSetting` forwards the authenticated owner and unwraps. 27/27 green; server tsc clean.

Rebased on current main (resolved the overlap with #3264's `unwrapStoredSettingsPayload` refactor — both the owner-scoping and the both-shape reading are present).

Sonar: not run locally — no SONAR_TOKEN on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
