### PR TITLE
fix: resolve custom note type for existing Ankify schedules

### DIFF
--- a/src/data_layer/SettingsRepository.test.ts
+++ b/src/data_layer/SettingsRepository.test.ts
@@ -147,9 +147,72 @@ describe('SettingsRepository.loadAnkifyTemplateOverrides', () => {
       payload: JSON.stringify(TEMPLATES_PAYLOAD),
     });
 
-    const overrides = await repo.loadAnkifyTemplateOverrides('13574');
+    const overrides = await repo.loadAnkifyTemplateOverrides('13574', 'page-a');
 
     expect(overrides?.basicModelName).toBe('PAGE NAME');
+  });
+
+  test('honors the synced page row even when a newer non-custom row for another page exists', async () => {
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'synced-page',
+      title: 'Synced',
+      payload: JSON.stringify({
+        payload: { template: 'custom', basic_model_name: 'ATTI BASIC' },
+      }),
+      updated_at: '2026-06-01 00:00:00',
+    });
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'other-page',
+      title: 'Other',
+      payload: JSON.stringify({
+        payload: { template: 'specialstyle1' },
+      }),
+      updated_at: '2026-06-10 00:00:00',
+    });
+    await db('templates').insert({
+      owner: '42',
+      payload: JSON.stringify(TEMPLATES_PAYLOAD),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides(
+      '42',
+      'synced-page'
+    );
+
+    expect(overrides).not.toBeNull();
+    expect(overrides?.basicModelName).toBe('ATTI BASIC');
+  });
+
+  test('falls back to global card_options when the synced page has no custom row', async () => {
+    await db('users').insert({
+      id: 42,
+      card_options: JSON.stringify({
+        template: 'custom',
+        basic_model_name: 'GLOBAL NAME',
+      }),
+    });
+    await db('settings').insert({
+      owner: '42',
+      object_id: 'synced-page',
+      title: 'Synced',
+      payload: JSON.stringify({
+        payload: { template: 'specialstyle1' },
+      }),
+      updated_at: '2026-06-10 00:00:00',
+    });
+    await db('templates').insert({
+      owner: '42',
+      payload: JSON.stringify(TEMPLATES_PAYLOAD),
+    });
+
+    const overrides = await repo.loadAnkifyTemplateOverrides(
+      '42',
+      'synced-page'
+    );
+
+    expect(overrides?.basicModelName).toBe('GLOBAL NAME');
   });
 
   test('returns null when global card_options template is not custom', async () => {

--- a/src/data_layer/SettingsRepository.ts
+++ b/src/data_layer/SettingsRepository.ts
@@ -8,7 +8,8 @@ export interface ISettingsRepository {
   load(owner: string, id: string): Promise<CardOption>;
   loadIfExists(owner: string, id: string): Promise<CardOption | null>;
   loadAnkifyTemplateOverrides(
-    owner: string
+    owner: string,
+    pageId?: string
   ): Promise<AnkifyTemplateOverrides | null>;
 }
 
@@ -118,23 +119,35 @@ class SettingsRepository implements ISettingsRepository {
     }
   }
 
-  private async resolveCustomBasicModelName(
+  private customBasicModelNameFromSettingsRow(
+    row: { payload?: unknown } | undefined
+  ): string | null {
+    if (!row) {
+      return null;
+    }
+    const settingsPayload = parseJsonColumn(row.payload) as {
+      payload?: Record<string, string>;
+    } | null;
+    const cardOption = new CardOption(settingsPayload?.payload ?? {});
+    if (cardOption.template === 'custom') {
+      return cardOption.basicModelName;
+    }
+    return null;
+  }
+
+  private async customBasicModelNameForPage(
+    owner: string,
+    pageId: string
+  ): Promise<string | null> {
+    const pageRow = await this.database(this.table)
+      .where({ owner, object_id: pageId })
+      .first();
+    return this.customBasicModelNameFromSettingsRow(pageRow);
+  }
+
+  private async customBasicModelNameFromGlobal(
     owner: string
   ): Promise<string | null> {
-    const settingsRow = await this.database(this.table)
-      .where({ owner })
-      .orderBy('updated_at', 'desc')
-      .first();
-    if (settingsRow) {
-      const settingsPayload = parseJsonColumn(settingsRow.payload) as {
-        payload?: Record<string, string>;
-      } | null;
-      const cardOption = new CardOption(settingsPayload?.payload ?? {});
-      if (cardOption.template === 'custom') {
-        return cardOption.basicModelName;
-      }
-    }
-
     const userRow = await this.database('users')
       .select('card_options')
       .where({ id: owner })
@@ -146,15 +159,47 @@ class SettingsRepository implements ISettingsRepository {
     if (globalOptions?.template === 'custom') {
       return new CardOption(globalOptions).basicModelName;
     }
-
     return null;
   }
 
-  async loadAnkifyTemplateOverrides(
+  private async customBasicModelNameFromMostRecent(
     owner: string
+  ): Promise<string | null> {
+    const settingsRow = await this.database(this.table)
+      .where({ owner })
+      .orderBy('updated_at', 'desc')
+      .first();
+    return this.customBasicModelNameFromSettingsRow(settingsRow);
+  }
+
+  private async resolveCustomBasicModelName(
+    owner: string,
+    pageId?: string
+  ): Promise<string | null> {
+    if (pageId != null) {
+      const fromPage = await this.customBasicModelNameForPage(owner, pageId);
+      if (fromPage != null) {
+        return fromPage;
+      }
+    }
+
+    const fromGlobal = await this.customBasicModelNameFromGlobal(owner);
+    if (fromGlobal != null) {
+      return fromGlobal;
+    }
+
+    return this.customBasicModelNameFromMostRecent(owner);
+  }
+
+  async loadAnkifyTemplateOverrides(
+    owner: string,
+    pageId?: string
   ): Promise<AnkifyTemplateOverrides | null> {
     try {
-      const basicModelName = await this.resolveCustomBasicModelName(owner);
+      const basicModelName = await this.resolveCustomBasicModelName(
+        owner,
+        pageId
+      );
       if (basicModelName == null) {
         return null;
       }

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -289,8 +289,8 @@ const AnkifyRouter = () => {
 
   const ankifyNotionRepo = new NotionRepository(db);
   const settingsRepo = new SettingsRepository(db);
-  const templateOverridesProvider = (owner: number) =>
-    settingsRepo.loadAnkifyTemplateOverrides(String(owner));
+  const templateOverridesProvider = (owner: number, pageId?: string) =>
+    settingsRepo.loadAnkifyTemplateOverrides(String(owner), pageId);
   const syncNotionPageUseCase = new SyncNotionPageToRacUseCase(
     repo,
     mappings,

--- a/src/services/ankify/templateOverrides.ts
+++ b/src/services/ankify/templateOverrides.ts
@@ -8,7 +8,8 @@ export interface AnkifyTemplateOverrides {
 }
 
 export type AnkifyTemplateOverridesProvider = (
-  owner: number
+  owner: number,
+  pageId?: string
 ) => Promise<AnkifyTemplateOverrides | null>;
 
 const BASIC_FIELDS_FROM_TEMPLATE = ['Front', 'Back', 'MyMedia'];

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -517,6 +517,56 @@ describe('SyncNotionPageToRacUseCase', () => {
     expect(createdNames).not.toContain('Ankify Basic');
   });
 
+  test('resolves the template override for the synced page, not just the owner', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [sampleCard()],
+      diagnostic: {
+        blocks_scanned: 1,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const templateOverridesProvider = jest.fn(async () => ({
+      basicModelName: 'ATTI BASIC',
+      basicTemplate: {
+        parent: 'Basic',
+        name: 'ATTI BASIC',
+        storageKey: 'n2a-basic',
+        front: '{{Front}}',
+        back: '{{Back}}',
+        styling: '.card { color: tomato; }',
+      },
+    }));
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      templateOverridesProvider
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'synced-page-id',
+      trigger: 'polling',
+    });
+
+    expect(templateOverridesProvider).toHaveBeenCalledWith(
+      42,
+      'synced-page-id'
+    );
+  });
+
   test('seeds Ankify note types before the first addNote call', async () => {
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
       cards: [sampleCard()],

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -358,7 +358,10 @@ export class SyncNotionPageToRacUseCase {
     const deckName = buildDeckName(subscription.notion_page_title);
     await ac.createDeck(deckName);
     const overrides =
-      (await this.templateOverridesProvider?.(input.owner)) ?? null;
+      (await this.templateOverridesProvider?.(
+        input.owner,
+        input.notionPageId
+      )) ?? null;
     await ensureAnkifyModels(ac, this.modelCache(client.id), overrides);
     await this.refreshAnkifyModelStyling(ac, overrides);
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-synced-note-type.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-synced-note-type.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-synced-note-type",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Synced cards use your custom note type on existing decks too"
+}


### PR DESCRIPTION
## What
Ankify-synced cards now use the user's configured custom note type on existing schedules, not just newly created ones. The override resolver is now page-aware and resolves at note-creation time on the poll path.

## Why
A paying user reported (via support, 2026-06-11) that their synced cards still landed in "Ankify Basic" despite a configured custom note type with a Media field — even after the recent templates-everywhere fix (#3194). A card created today in `Notion Sync::<page>` still showed "Ankify Basic".

Root cause (b): the override resolver (`SettingsRepository.loadAnkifyTemplateOverrides`) picked the single most-recently-updated `settings` row for the owner, ignoring which page was being synced. A newer non-custom settings row for an unrelated page shadowed the synced page's own custom setting, so the resolver returned `null` and dispatch fell back to "Ankify Basic". It was never (a): the override is already resolved live each sync, not frozen at schedule creation.

## How
- `SyncNotionPageToRacUseCase` threads `input.notionPageId` into the override provider call (live, at note-creation time on the poll path).
- `AnkifyTemplateOverridesProvider` and `loadAnkifyTemplateOverrides` take an optional `pageId`.
- Resolution order: synced page's saved setting -> user's global `card_options` default -> most-recent custom row (back-compat) -> null fallback (Ankify Basic).
- The existing "prefers a per-page row over global" test asserted the old most-recent-row behavior without a page id; it now passes the page id so it tests the real per-page contract.

## Measuring success
Per-sync log line in `persistSyncLog` (`notion-page sync polling ...`) plus the addNote model name in AnkiConnect. After deploy, the reporter's next poll should create notes under their custom model name; "Ankify Basic" stops appearing in `Notion Sync::*` decks for users with a custom note type. No new metric added — this is a correctness fix on an existing paid surface.

## Testing
- Unit tests added: `SettingsRepository` page-scoped resolution (synced page row honored over a newer non-custom sibling row; falls back to global when the page has no custom row); `SyncNotionPageToRacUseCase` asserts the provider is called with `(owner, notionPageId)`.
- `npx tsc -p . --noEmit` clean.
- `pnpm test src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts src/data_layer/SettingsRepository.test.ts` 39/39 pass.
- web WhatsNewPage vitest 7/7 (changelog id uniqueness).

## Browser check
Browser check: not applicable — server-side dispatch change. The only `web/src/` file is the new changelog JSON, which is bypassed by the changelog-only gate.

## Changelog
`Synced cards use your custom note type on existing decks too` (type: fix).

## Risks
Resolution order change. Mitigated: a user with no per-page custom row and no global custom default still resolves via the most-recent custom row (back-compat) and otherwise falls back to Ankify Basic — same as before. Sonar: not run locally — no SONAR_TOKEN.

## Conflicts / merge order
- Open PR #3260 also touches `SyncNotionPageToRacUseCase`; this PR's change there is scoped to one provider call site (page id threading) — flag for rebase order.
- A sibling branch `fix/ankify-database-child-pages` works the database-child-page area of the same use case. No overlap with note-type resolution here. Suggested merge order: whichever of the database PRs lands first, this rebases on top (its change is a single line in `runSync` plus the provider signature).

## Goal alignment
Retention lever on a $30/mo paid surface (Auto Sync). 79% of churn is lifecycle; a paid user whose synced cards silently ignore their note-type config is a churn risk. None of the acquisition funnel — this is a paid-surface correctness fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783783345&installation_id=132681956&pr_number=3268&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3268&signature=0499f454f697cf80be6cd1fb9125473d9b43baaeb92296c56e8f80960ec7f6ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->