### PR TITLE
fix: convert child pages when syncing a Notion database

### DIFF
--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -315,6 +315,122 @@ describe('SyncNotionPageToRacUseCase', () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  test('walks the database child pages when the page walk finds no blocks of its own', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue(
+      emptyWalkResult()
+    );
+    (walkNotionDatabaseForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [sampleCard()],
+      diagnostic: {
+        blocks_scanned: 8,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const insert = jest.fn().mockResolvedValue(undefined);
+    const errorEvents = {
+      insert,
+      existsWithinWindow: jest.fn().mockResolvedValue(false),
+      listGroups: jest.fn().mockResolvedValue([]),
+      countGroups: jest.fn().mockResolvedValue(0),
+      latestSamples: jest.fn().mockResolvedValue([]),
+      resolveGroup: jest.fn().mockResolvedValue(undefined),
+      reopenGroup: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IErrorEventRepository;
+    const databasePages = jest.fn(async () => [
+      { id: 'row-1' },
+      { id: 'row-2' },
+    ]);
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      undefined,
+      errorEvents,
+      undefined,
+      undefined,
+      () => databasePages
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      notionPageId: 'database-id',
+      trigger: 'polling',
+    });
+
+    expect(walkNotionDatabaseForFlashcards).toHaveBeenCalledWith(
+      'database-id',
+      expect.any(Function),
+      databasePages
+    );
+    expect(result.created).toBe(1);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  test('keeps the empty-page result when the database probe finds no child pages', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue(
+      emptyWalkResult()
+    );
+    (walkNotionDatabaseForFlashcards as jest.Mock).mockResolvedValue(
+      emptyWalkResult()
+    );
+
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    const insert = jest.fn().mockResolvedValue(undefined);
+    const errorEvents = {
+      insert,
+      existsWithinWindow: jest.fn().mockResolvedValue(false),
+      listGroups: jest.fn().mockResolvedValue([]),
+      countGroups: jest.fn().mockResolvedValue(0),
+      latestSamples: jest.fn().mockResolvedValue([]),
+      resolveGroup: jest.fn().mockResolvedValue(undefined),
+      reopenGroup: jest.fn().mockResolvedValue(undefined),
+    } as unknown as IErrorEventRepository;
+    const databasePages = jest.fn(async () => {
+      throw Object.assign(
+        new Error('page-id is not a database. Use the retrieve a page API.'),
+        { code: 'validation_error' }
+      );
+    });
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      undefined,
+      errorEvents,
+      undefined,
+      undefined,
+      () => databasePages
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'polling',
+    });
+
+    expect(result.created).toBe(0);
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'ankify.zero_cards' })
+    );
+  });
+
   test('propagates a non-database validation error without a database walk', async () => {
     const otherError = Object.assign(new Error('Something else broke'), {
       code: 'validation_error',

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -383,8 +383,9 @@ export class SyncNotionPageToRacUseCase {
     token: string,
     fetchChildren: NotionBlockChildrenFetcher
   ): Promise<WalkNotionPageResult> {
+    let pageResult: WalkNotionPageResult;
     try {
-      return await walkNotionPageForFlashcards(notionId, fetchChildren);
+      pageResult = await walkNotionPageForFlashcards(notionId, fetchChildren);
     } catch (error) {
       if (isNotionDatabaseNotPageError(error)) {
         return walkNotionDatabaseForFlashcards(
@@ -394,6 +395,36 @@ export class SyncNotionPageToRacUseCase {
         );
       }
       throw error;
+    }
+    if (pageResult.cards.length > 0) {
+      return pageResult;
+    }
+    return this.walkDatabaseOrFallback(
+      notionId,
+      token,
+      fetchChildren,
+      pageResult
+    );
+  }
+
+  private async walkDatabaseOrFallback(
+    notionId: string,
+    token: string,
+    fetchChildren: NotionBlockChildrenFetcher,
+    pageResult: WalkNotionPageResult
+  ): Promise<WalkNotionPageResult> {
+    try {
+      const databaseResult = await walkNotionDatabaseForFlashcards(
+        notionId,
+        fetchChildren,
+        this.databasePagesFetcher(token)
+      );
+      if (databaseResult.cards.length > 0) {
+        return databaseResult;
+      }
+      return pageResult;
+    } catch {
+      return pageResult;
     }
   }
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-database-pages-convert.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-database-pages-convert.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-database-pages-convert",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Notion databases convert the pages inside them — every page's toggles become cards"
+}


### PR DESCRIPTION
## What
Ankify databases (synced or added by pasted link) now convert the pages inside the database into cards. Previously they produced "0 new flashcards" and the deck showed "We couldn't read any content from this page."

## Why
A full-page or inline Notion database has no toggle blocks of its own — the toggle lists live in its child pages. This morning's commit 7a3c61d surfaced and registered databases in Ankify, but the content walk still read the database id's own blocks (`blocks.children.list`), found none, and emitted zero cards.

The existing database fallback only triggered when the page walk **threw** the `"is a database, not a page"` error — but that message comes from `pages.retrieve`, not from `blocks.children.list`. Listing a database's children returns an empty result rather than throwing, so the fallback never ran for the common shape.

Reported via support 2026-06-11.

## How
`walkSource` now also runs the database walk (`walkNotionDatabaseForFlashcards`, which paginates `dataSources.query` and walks each child page's toggles, aggregating under the database's deck) when the page walk yields **zero cards** — not only when it throws. When the id is a genuinely empty page (the database probe throws or returns no rows), it falls back to the original empty-page result so the `ankify.zero_cards` diagnostic still fires unchanged. The thrown-error path from 7a3c61d is preserved.

## Measuring success
Watch the `ankify.zero_cards` error-event rate for `source_type: notion_page` / `parser_path: ankify/notionPageWalker` (in the `error_events` table / `/api/ops/metrics`). A database sync that previously logged this event should now produce cards and stop emitting it. Confirm against the 2026-06-08 `ankify.zero_cards` telemetry referenced in 7a3c61d.

## Testing
- Unit tests added (`SyncNotionPageToRacUseCase.test.ts`):
  - Walks the database child pages when the page walk finds no blocks of its own (the reported bug — no thrown error).
  - Keeps the empty-page result + zero_cards event when the database probe throws (genuine empty page is not misclassified).
- Existing database/error-propagation tests still green (31/31 in the file). Walker suite green (16/16).
- `npx tsc -p . --noEmit` clean. Web suite green (changelog loader asserts the new entry's id uniqueness).

## Browser check
Browser check: not applicable — changelog-only `web/src/` change (one JSON file under `web/src/pages/WhatsNewPage/changelog/`); no rendered-component change.

## Changelog
`2026-06-12-database-pages-convert.json` — "Notion databases convert the pages inside them — every page's toggles become cards"

## Risks
- For genuinely empty Notion pages, the sync now makes one extra Notion API call (`databases.retrieve` via the database-pages fetcher) before falling back. This only happens on the zero-card path (already a failure path); the throw is caught and the empty result preserved. No change to the non-empty page path.
- Respects the existing poll cadence and the `MAX_DATABASE_PAGES = 250` cap in the walker.

## Merge coordination
Open PR #3260 also edits `SyncNotionPageToRacUseCase.ts` (media rehosting). Tight diff here — only `walkSource` is restructured. Rebase whichever of the two lands second.

## Goal alignment
Retention/activation for the paid Ankify ($30/mo Auto Sync) surface — a paying lifetime supporter hit this. Database-backed Notion workspaces are a common power-user shape; "0 cards, can't read content" on a paid surface is a churn trigger. Metric: `ankify.zero_cards` rate for notion_page sources should drop; read at `/api/ops/metrics`.

Sonar: not run locally — no SONAR_TOKEN configured in this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783783377&installation_id=132681956&pr_number=3269&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3269&signature=4fea958e40c163de085a42d3a6f6706b9780284a001d0f7dd5f2251006f2a598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->