### PR TITLE
fix: keep removed Ankify decks from re-registering

### DIFF
--- a/src/data_layer/ankify/AnkifyNotionSubscriptionsRepository.ts
+++ b/src/data_layer/ankify/AnkifyNotionSubscriptionsRepository.ts
@@ -14,6 +14,10 @@ export interface AnkifyNotionSubscriptionsRepositoryInterface {
   listByOwner(owner: number): Promise<AnkifyNotionSubscription[]>;
   listEnabled(): Promise<AnkifyNotionSubscription[]>;
   findByPageId(notionPageId: string): Promise<AnkifyNotionSubscription[]>;
+  findByOwnerAndPageId(
+    owner: number,
+    notionPageId: string
+  ): Promise<AnkifyNotionSubscription | null>;
   findById(id: number, owner: number): Promise<AnkifyNotionSubscription | null>;
   setEnabled(id: number, enabled: boolean): Promise<void>;
   deleteById(id: number, owner: number): Promise<void>;
@@ -78,6 +82,17 @@ export class AnkifyNotionSubscriptionsRepository implements AnkifyNotionSubscrip
     return this.database<AnkifyNotionSubscription>(TABLE)
       .select('*')
       .where({ notion_page_id: notionPageId, enabled: true });
+  }
+
+  async findByOwnerAndPageId(
+    owner: number,
+    notionPageId: string
+  ): Promise<AnkifyNotionSubscription | null> {
+    const row = await this.database<AnkifyNotionSubscription>(TABLE)
+      .select('*')
+      .where({ owner, notion_page_id: notionPageId })
+      .first();
+    return row ?? null;
   }
 
   async findById(

--- a/src/lib/ankify/FEATURE.md
+++ b/src/lib/ankify/FEATURE.md
@@ -4,7 +4,7 @@ Background-job factories and pure helpers for the Ankify product (separate from 
 
 ## What's here
 
-- `jobs/scheduleAnkifyPolling.ts` — schedules the Notion poll loop (5-min cadence; webhook story is deferred per `Documentation/ankify/notion-webhooks-deferred.md`).
+- `jobs/scheduleAnkifyPolling.ts` — schedules the Notion poll loop (5-min cadence; webhook story is deferred per `Documentation/ankify/notion-webhooks-deferred.md`). Before syncing each subscription from the enabled snapshot, the tick re-checks the row still exists via `findByOwnerAndPageId`; a deck the user deleted between the snapshot and its turn is skipped, so deletion sticks instead of being re-registered by `SyncNotionPageToRacUseCase`'s upsert.
 - `jobs/scheduleAnkifyReaper.ts` — cleans up dead/expired sessions and tokens.
 - `scheduler/instance.ts` — singleton scheduler; survives one process lifetime.
 - `nextDailyRunAt.ts` — pure cron-ish next-run calculation. Heavily tested.

--- a/src/lib/ankify/jobs/scheduleAnkifyPolling.test.ts
+++ b/src/lib/ankify/jobs/scheduleAnkifyPolling.test.ts
@@ -1,0 +1,98 @@
+import { scheduleAnkifyPolling } from './scheduleAnkifyPolling';
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import { SyncNotionPageToRacUseCase } from '../../../usecases/ankify/SyncNotionPageToRacUseCase';
+import { AnkifyNotionSubscription } from '../../../entities/ankify';
+
+const sampleSubscription = (
+  overrides: Partial<AnkifyNotionSubscription> = {}
+): AnkifyNotionSubscription => ({
+  id: 1,
+  owner: 42,
+  ankify_client_id: 1,
+  notion_page_id: 'page-id',
+  notion_page_title: null,
+  notion_page_url: null,
+  notion_page_icon: null,
+  enabled: true,
+  last_polled_at: null,
+  last_synced_at: null,
+  last_error: null,
+  created_at: new Date(),
+  updated_at: new Date(),
+  ...overrides,
+});
+
+const makeSubscriptions =
+  (): jest.Mocked<AnkifyNotionSubscriptionsRepositoryInterface> =>
+    ({
+      upsert: jest.fn(),
+      listByOwner: jest.fn(),
+      listEnabled: jest.fn(),
+      findByPageId: jest.fn(),
+      findByOwnerAndPageId: jest.fn(),
+      findById: jest.fn(),
+      setEnabled: jest.fn(),
+      deleteById: jest.fn(),
+      recordPoll: jest.fn(),
+    }) as unknown as jest.Mocked<AnkifyNotionSubscriptionsRepositoryInterface>;
+
+const makeUseCase = (): jest.Mocked<
+  Pick<SyncNotionPageToRacUseCase, 'execute'>
+> =>
+  ({
+    execute: jest.fn(async () => undefined),
+  }) as unknown as jest.Mocked<Pick<SyncNotionPageToRacUseCase, 'execute'>>;
+
+const waitForTick = () => new Promise((resolve) => setTimeout(resolve, 30));
+
+describe('scheduleAnkifyPolling', () => {
+  test('skips a subscription deleted after the enabled snapshot was taken', async () => {
+    const subscriptions = makeSubscriptions();
+    const useCase = makeUseCase();
+
+    const sub = sampleSubscription({ id: 7, notion_page_id: 'deleted-page' });
+    subscriptions.listEnabled.mockResolvedValue([sub]);
+    subscriptions.findByOwnerAndPageId.mockResolvedValue(null);
+
+    const timer = scheduleAnkifyPolling(
+      subscriptions,
+      useCase as unknown as SyncNotionPageToRacUseCase,
+      { intervalMs: 5 }
+    );
+
+    await waitForTick();
+
+    expect(subscriptions.findByOwnerAndPageId).toHaveBeenCalledWith(
+      42,
+      'deleted-page'
+    );
+    expect(useCase.execute).not.toHaveBeenCalled();
+
+    clearInterval(timer);
+  });
+
+  test('syncs a subscription that still exists when the tick runs', async () => {
+    const subscriptions = makeSubscriptions();
+    const useCase = makeUseCase();
+
+    const sub = sampleSubscription({ id: 8, notion_page_id: 'live-page' });
+    subscriptions.listEnabled.mockResolvedValue([sub]);
+    subscriptions.findByOwnerAndPageId.mockResolvedValue(sub);
+
+    const timer = scheduleAnkifyPolling(
+      subscriptions,
+      useCase as unknown as SyncNotionPageToRacUseCase,
+      { intervalMs: 5 }
+    );
+
+    await waitForTick();
+
+    expect(useCase.execute).toHaveBeenCalledWith({
+      owner: 42,
+      notionPageId: 'live-page',
+      trigger: 'polling',
+    });
+
+    clearInterval(timer);
+  });
+});

--- a/src/lib/ankify/jobs/scheduleAnkifyPolling.ts
+++ b/src/lib/ankify/jobs/scheduleAnkifyPolling.ts
@@ -25,6 +25,13 @@ export const scheduleAnkifyPolling = (
     const seenOwners = new Set<number>();
     for (const sub of active) {
       try {
+        const current = await subscriptions.findByOwnerAndPageId(
+          sub.owner,
+          sub.notion_page_id
+        );
+        if (current == null) {
+          continue;
+        }
         await useCase.execute({
           owner: sub.owner,
           notionPageId: sub.notion_page_id,

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-deleted-decks-stay.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-deleted-decks-stay.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-deleted-decks-stay",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Decks you stop syncing in Ankify stay removed instead of reappearing on the next poll"
+}


### PR DESCRIPTION
## What
Ankify decks the user stops syncing (deletes in the deck list) no longer reappear on their own. The 5-minute poll now re-checks that each subscription still exists right before syncing it, and skips any the user removed since the tick's snapshot was taken.

## Why
Reported via support on 2026-06-11: a paying user deleted two synced page-decks, added nothing back, and within minutes both reappeared with fresh "Last sync" times. User-visible outcome: deletion sticks.

Resurrection path: `scheduleAnkifyPolling` captures an enabled-subscription snapshot at tick start, then iterates it. `SyncNotionPageToRacUseCase.execute` upserts the subscription with `enabled: true` *before* syncing. A page the user deleted after the snapshot was taken but before its turn in the loop gets re-inserted by that upsert, with a fresh `last_synced_at`. The whole pre-deletion snapshot resurrects, so both decks come back.

## How
The poll re-checks each subscription via a new `findByOwnerAndPageId(owner, notionPageId)` repository read immediately before calling `execute`, and `continue`s past any row that no longer exists. No schema change — the existing hard-delete of the row is now respected by the discovery pass. No change to the manual subscribe/refresh paths.

## Measuring success
Prod log: the absence of `[ankify-polling] sync failed` re-creation churn for deleted pages; positively, a deleted subscription's `ankify_notion_subscriptions` row stays absent (no new row with a `created_at` after the delete for the same `(owner, notion_page_id)`). Support: no repeat of the "deleted decks come back" report.

## Testing
- Unit tests added: `src/lib/ankify/jobs/scheduleAnkifyPolling.test.ts` — (1) a subscription deleted after the enabled snapshot is skipped (no `execute` call), proven red without the guard; (2) a still-present subscription still syncs.

## Browser check
Browser check: not applicable — the only `web/src/` file is a changelog JSON entry; the fix is server-side polling logic.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-12-deleted-decks-stay.json` — "Decks you stop syncing in Ankify stay removed instead of reappearing on the next poll"

## Risks
Low. The added read is one indexed lookup per subscription per 5-min tick (small N). If `findByOwnerAndPageId` failed, it's inside the per-sub try/catch, so a transient error skips that sub for one tick rather than crashing the loop. Rollback is reverting this commit. No migration.

## Sonar
Sonar: not run locally — no SONAR_TOKEN.

## Goal alignment
Retention lever: Ankify is a paid surface ($30/mo Auto Sync / lifetime). A sync product that resurrects decks the user deliberately removed is a trust break that drives churn — 79% of churn is lifecycle, and a broken-feeling core loop accelerates it. Metric: Ankify-cohort retention; read via the paid-cohort churn in `/api/ops/business/metrics`. No direct funnel target — this is a correctness fix on an existing paid surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783783941&installation_id=132681956&pr_number=3270&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3270&signature=b817c43cd5c8f924abaf6cebf7ac2511732af95d715f845f29cacc1ce3d91fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->