### PR TITLE
chore: regenerate kanel types after target_deck migration

### DIFF
--- a/src/data_layer/public/AnkifyNotionSubscriptions.ts
+++ b/src/data_layer/public/AnkifyNotionSubscriptions.ts
@@ -31,6 +31,8 @@ export default interface AnkifyNotionSubscriptions {
   notion_page_url: string | null;
 
   notion_page_icon: string | null;
+
+  target_deck: string | null;
 }
 
 /** Represents the initializer for the table public.ankify_notion_subscriptions */
@@ -64,6 +66,8 @@ export interface AnkifyNotionSubscriptionsInitializer {
   notion_page_url?: string | null;
 
   notion_page_icon?: string | null;
+
+  target_deck?: string | null;
 }
 
 /** Represents the mutator for the table public.ankify_notion_subscriptions */
@@ -93,4 +97,6 @@ export interface AnkifyNotionSubscriptionsMutator {
   notion_page_url?: string | null;
 
   notion_page_icon?: string | null;
+
+  target_deck?: string | null;
 }

--- a/src/data_layer/public/PriceLockInEmails.ts
+++ b/src/data_layer/public/PriceLockInEmails.ts
@@ -4,9 +4,7 @@
 import type { UsersId } from './Users';
 
 /** Identifier type for public.price_lock_in_emails */
-export type PriceLockInEmailsId = number & {
-  __brand: 'public.price_lock_in_emails';
-};
+export type PriceLockInEmailsId = number & { __brand: 'public.price_lock_in_emails' };
 
 /** Represents the table public.price_lock_in_emails */
 export default interface PriceLockInEmails {


### PR DESCRIPTION
Follow-up owed by #3266 and #3271 — both added migrations from worktrees with no live DB, so kanel regeneration was deferred.

Ran the two pending migrations (`settings_owner_object_id_unique`, `add_target_deck_to_ankify_subscriptions`) against the local dev DB, then `kanel -c ./.kanelrc.js`:

- `AnkifyNotionSubscriptions` gains `target_deck: string | null` (+ initializer/mutator) — matches the column #3271 added and the hand-written type in `src/entities/ankify.ts`.
- `PriceLockInEmails` picks up kanel's canonical one-line brand-type formatting. `src/data_layer/public/` is excluded from oxfmt, so the generator's output is the source of truth; `pnpm format:check` passes.

No source changes; server tsc clean.

No changelog entry — generated types, internal only.

Sonar: not run locally — no SONAR_TOKEN; trivial generated-code diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783794418&installation_id=132681956&pr_number=3273&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3273&signature=2a07a74b5312af283164c222a2c248dab3cc6982f4f7dc784009e8ecdb0281f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->