### PR TITLE
fix: clear the low-severity audit batch

### DIFF
--- a/src/lib/parser/DeckParser.avocado.test.ts
+++ b/src/lib/parser/DeckParser.avocado.test.ts
@@ -1,0 +1,44 @@
+import { setupTests } from '../../test/configure-jest';
+import CardOption from './Settings/CardOption';
+import { DeckParser } from './DeckParser';
+import Note from './Note';
+import Workspace from './WorkSpace';
+
+beforeEach(() => setupTests());
+
+const makeParser = () => {
+  const html = `<html><head><title>x</title></head><body><article class="page"><div class="page-body"></div></article></body></html>`;
+  return new DeckParser({
+    name: 'x.html',
+    settings: new CardOption({}),
+    files: [{ name: 'x.html', contents: html }],
+    noLimits: true,
+    workspace: new Workspace(true, 'fs'),
+  });
+};
+
+describe('noteHasAvocado', () => {
+  it('detects the avocado emoji in the back like cherry does', () => {
+    const parser = makeParser();
+    const note = new Note('plain front', 'answer 🥑');
+    expect(parser.noteHasAvocado(note)).toBe(true);
+  });
+
+  it('detects the avocado HTML entity in the back', () => {
+    const parser = makeParser();
+    const note = new Note('plain front', 'answer &#x1F951;');
+    expect(parser.noteHasAvocado(note)).toBe(true);
+  });
+
+  it('detects the avocado in the front', () => {
+    const parser = makeParser();
+    const note = new Note('front 🥑', 'plain back');
+    expect(parser.noteHasAvocado(note)).toBe(true);
+  });
+
+  it('returns false when neither side has the avocado', () => {
+    const parser = makeParser();
+    const note = new Note('plain front', 'plain back');
+    expect(parser.noteHasAvocado(note)).toBe(false);
+  });
+});

--- a/src/lib/parser/DeckParser.emptyPayload.test.ts
+++ b/src/lib/parser/DeckParser.emptyPayload.test.ts
@@ -1,0 +1,24 @@
+import { setupTests } from '../../test/configure-jest';
+import CardOption from './Settings/CardOption';
+import { DeckParser } from './DeckParser';
+import Workspace from './WorkSpace';
+import { EmptyDeckError } from '../../usecases/jobs/EmptyDeckError';
+
+beforeEach(() => setupTests());
+
+describe('processPayload with an empty payload', () => {
+  it('throws EmptyDeckError instead of a TypeError', async () => {
+    const workspace = new Workspace(true, 'fs');
+    const parser = new DeckParser({
+      name: 'empty.html',
+      settings: new CardOption({}),
+      files: [{ name: 'empty.html', contents: '' }],
+      noLimits: true,
+      workspace,
+    });
+
+    await expect(parser.build(workspace)).rejects.toBeInstanceOf(
+      EmptyDeckError
+    );
+  });
+});

--- a/src/lib/parser/DeckParser.toggleEdgeCases.test.ts
+++ b/src/lib/parser/DeckParser.toggleEdgeCases.test.ts
@@ -1,0 +1,57 @@
+import { setupTests } from '../../test/configure-jest';
+import CardOption from './Settings/CardOption';
+import { DeckParser } from './DeckParser';
+import Workspace from './WorkSpace';
+
+beforeEach(() => setupTests());
+
+function buildParser(html: string, settings: CardOption): DeckParser {
+  const workspace = new Workspace(true, 'fs');
+  return new DeckParser({
+    name: 'toggle-edge.html',
+    settings,
+    files: [{ name: 'toggle-edge.html', contents: html }],
+    noLimits: true,
+    workspace,
+  });
+}
+
+const wrap = (body: string) =>
+  `<!DOCTYPE html><html><head><title>t</title></head><body><article class="page sans"><div class="page-body">${body}</div></article></body></html>`;
+
+describe('Toggle edge cases', () => {
+  it('keeps two identical toggles without ids as separate cards', () => {
+    const toggle = `<ul class="toggle"><li><details open=""><summary>Define osmosis</summary><p>Movement of water</p></details></li></ul>`;
+    const parser = buildParser(
+      wrap(toggle + toggle),
+      new CardOption({ cherry: 'false' })
+    );
+
+    const deck = parser.payload[0];
+    expect(deck.cards.length).toBe(2);
+  });
+
+  it('produces a card for a toggle whose header is an image only', () => {
+    const body = `<ul class="toggle"><li><details open=""><summary><img src="diagram.png" /></summary><p>The mitochondrion</p></details></li></ul>`;
+    const parser = buildParser(wrap(body), new CardOption({ cherry: 'false' }));
+
+    const deck = parser.payload[0];
+    expect(deck.cards.length).toBe(1);
+    expect(deck.cards[0].name).toContain('diagram.png');
+    expect(deck.cards[0].back).toContain('The mitochondrion');
+  });
+
+  it('does not smear classes from one toggle onto a differently-classed toggle', () => {
+    const body =
+      `<ul class="toggle red"><li><details open=""><summary>First</summary><p>A</p></details></li></ul>` +
+      `<ul class="toggle blue"><li><details open=""><summary>Second</summary><p>B</p></details></li></ul>`;
+    const parser = buildParser(wrap(body), new CardOption({ cherry: 'false' }));
+
+    const deck = parser.payload[0];
+    const first = deck.cards.find((c) => c.name.includes('First'));
+    const second = deck.cards.find((c) => c.name.includes('Second'));
+
+    expect(`${first?.name}${first?.back}`).not.toContain('blue');
+    expect(`${second?.name}${second?.back}`).not.toContain('red');
+  });
+});

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -198,8 +198,13 @@ export class DeckParser {
   }
 
   noteHasAvocado(note: Note) {
-    const avocado = '&#x1F951';
-    return note.name.includes(avocado) || note.name.includes('🥑');
+    const avocado = '&#x1F951;';
+    return (
+      note.name.includes(avocado) ||
+      note.back.includes(avocado) ||
+      note.name.includes('🥑') ||
+      note.back.includes('🥑')
+    );
   }
 
   findIndentedToggleLists(dom: cheerio.CheerioAPI): Element[] {
@@ -974,6 +979,13 @@ export class DeckParser {
   }
 
   private async processPayload(ws: Workspace): Promise<void> {
+    if (this.payload.length === 0) {
+      const markdownSourced =
+        isMarkdownFile(this.firstDeckName) ||
+        isMarkdownSourcedFiles(this.files);
+      throw new EmptyDeckError(markdownSourced ? 'markdown' : undefined);
+    }
+
     for (const d of this.payload) {
       const deck = d;
       deck.id = get16DigitRandomId();
@@ -1225,13 +1237,14 @@ export class DeckParser {
     // Remove duplicate toggles caused by merged ul.toggle
     const uniqueToggles: Element[] = [];
     const seen = new Set();
-    for (const t of foundToggleLists) {
-      const id = dom(t).attr('id') || dom(t).html();
-      if (!seen.has(id)) {
+    foundToggleLists.forEach((t, index) => {
+      const explicitId = dom(t).attr('id');
+      const key = explicitId ?? `${index}:${dom(t).html()}`;
+      if (!seen.has(key)) {
         uniqueToggles.push(t);
-        seen.add(id);
+        seen.add(key);
       }
-    }
+    });
 
     const convertedToggleLists =
       uniqueToggles.length === 0 && details.length > 0
@@ -1300,8 +1313,8 @@ export class DeckParser {
       }
 
       if (parentUL) {
-        dom('details').addClass(parentClass);
-        dom('summary').addClass(parentClass);
+        parentUL.find('details').addClass(parentClass);
+        parentUL.find('summary').addClass(parentClass);
         const summary = parentUL.find('summary').first();
         let toggle = parentUL.find('details').first();
 
@@ -1309,7 +1322,9 @@ export class DeckParser {
           toggle = parentUL.find('.indented');
         }
 
-        if (summary && summary.text()) {
+        const summaryHasMedia =
+          summary.find('img, figure, audio, video').length > 0;
+        if (summary && (summary.text() || summaryHasMedia)) {
           const validSummary = (() =>
             preserveNewlinesIfApplicable(
               summary.html() || '',

--- a/src/lib/parser/experimental/FallbackParser.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.test.ts
@@ -82,3 +82,14 @@ describe('FallbackParser tab-separated text', () => {
     expect(decks[0].cards[0].back).toBe('Back1');
   });
 });
+
+describe('FallbackParser nested lists', () => {
+  it('does not double-count items in a nested list', () => {
+    const parser = new FallbackParser([]);
+    const html = `<ul><li>Outer<ul><li>Inner</li></ul></li></ul>`;
+    const result = parser.htmlToTextWithNewlines(html);
+
+    const innerOccurrences = result.join('\n').split('Inner').length - 1;
+    expect(innerOccurrences).toBe(1);
+  });
+});

--- a/src/lib/parser/experimental/FallbackParser.ts
+++ b/src/lib/parser/experimental/FallbackParser.ts
@@ -38,10 +38,12 @@ class FallbackParser {
       return result;
     }
 
-    const elem = $('ul, ol');
+    const topLevelLists = $('ul, ol').filter(
+      (_, element) => $(element).parents('ul, ol').length === 0
+    );
     let items: string[] = [];
-    elem.each((_, element) => {
-      const listItems = $(element).find('li');
+    topLevelLists.each((_, element) => {
+      const listItems = $(element).children('li');
       const listText = processListItems(listItems);
       items.push(listText);
     });
@@ -193,7 +195,6 @@ class FallbackParser {
 
   run(settings: CardOption) {
     const decks = [];
-    let clean = true;
 
     for (const file of this.files) {
       const contents = file.contents?.toString();
@@ -216,9 +217,7 @@ class FallbackParser {
         continue;
       }
 
-      if (result.clean === false) {
-        clean = false;
-      }
+      const clean = result.clean !== false;
 
       decks.push(
         new Deck(

--- a/src/lib/parser/exporters/embedFile.test.ts
+++ b/src/lib/parser/exporters/embedFile.test.ts
@@ -85,4 +85,34 @@ describe('embedFile — filename-only fallback', () => {
 
     expect(result).toBeNull();
   });
+
+  it('does not append the literal "null" for extensionless files', () => {
+    const exporter = makeExporter();
+    const result = embedFile({
+      exporter,
+      files: [{ name: 'attachment', contents: 'binary-data' }],
+      filePath: 'attachment',
+      workspace: makeWorkspace(),
+    });
+
+    expect(result).not.toBeNull();
+    expect(result).not.toMatch(/null$/);
+    expect(exporter.addMedia).toHaveBeenCalledWith(
+      expect.any(String),
+      'binary-data'
+    );
+  });
+
+  it('returns null without referencing media when contents are empty', () => {
+    const exporter = makeExporter();
+    const result = embedFile({
+      exporter,
+      files: [{ name: 'image.png', contents: '' }],
+      filePath: 'image.png',
+      workspace: makeWorkspace(),
+    });
+
+    expect(result).toBeNull();
+    expect(exporter.addMedia).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/parser/exporters/embedFile.ts
+++ b/src/lib/parser/exporters/embedFile.ts
@@ -133,7 +133,7 @@ export const embedFile = (input: EmbedFileInput): string | null => {
   const { exporter, files, filePath, workspace, fallbackWorkspaceLocation } =
     input;
 
-  const suffix = SuffixFrom(filePath);
+  const suffix = SuffixFrom(filePath) ?? '';
   const file = getFile(
     exporter,
     files,
@@ -147,12 +147,10 @@ export const embedFile = (input: EmbedFileInput): string | null => {
    * The contents is used first to avoid name conflicts. URL can have conflicts but so far
    * no bug reports.
    */
-  if (file) {
+  if (file && file.contents) {
     const contents = file.contents as string;
-    const newName = getUniqueFileName(contents ?? filePath) + suffix;
-    if (contents) {
-      exporter.addMedia(newName, contents);
-    }
+    const newName = getUniqueFileName(contents) + suffix;
+    exporter.addMedia(newName, contents);
     return newName;
   }
 

--- a/src/lib/parser/guessMarkdownCards.test.ts
+++ b/src/lib/parser/guessMarkdownCards.test.ts
@@ -116,6 +116,20 @@ describe('guessMarkdownCards', () => {
       const md = `https://example.com::not a card`;
       expect(guessMarkdownCards(md)).toBeNull();
     });
+
+    it('does not split a line on a :: inside an Anki cloze marker', () => {
+      const md = `The {{c1::mitochondrion}} is the powerhouse of the cell`;
+      expect(guessMarkdownCards(md)).toBeNull();
+    });
+
+    it('keeps real :: pairs while ignoring cloze-only lines', () => {
+      const md = `Photosynthesis::Process by which plants convert light\nThe {{c1::nucleus}} stores DNA`;
+      const result = guessMarkdownCards(md);
+      expect(result).not.toBeNull();
+      expect(result!.formatDetected).toBe('inline-double-colon');
+      expect(result!.notes).toHaveLength(1);
+      expect(result!.notes[0].name).toContain('Photosynthesis');
+    });
   });
 
   describe('priority order', () => {

--- a/src/lib/parser/guessMarkdownCards.ts
+++ b/src/lib/parser/guessMarkdownCards.ts
@@ -106,11 +106,24 @@ function trySeparatorPattern(content: string): Note[] {
   return notes;
 }
 
+function indexOfSeparatorColon(line: string): number {
+  let idx = line.indexOf('::');
+  while (idx !== -1) {
+    const before = line.slice(0, idx);
+    const insideCloze = /\{\{c\d+$/.test(before);
+    if (!insideCloze) {
+      return idx;
+    }
+    idx = line.indexOf('::', idx + 2);
+  }
+  return -1;
+}
+
 function tryInlineDoubleColonPattern(content: string): Note[] {
   const lines = content.split('\n');
   const notes: Note[] = [];
   for (const line of lines) {
-    const idx = line.indexOf('::');
+    const idx = indexOfSeparatorColon(line);
     if (idx === -1) continue;
     const front = line.slice(0, idx).trim();
     const back = line.slice(idx + 2).trim();

--- a/web/src/lib/data_layer/getLocalStorageValue.test.ts
+++ b/web/src/lib/data_layer/getLocalStorageValue.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { getLocalStorageValue } from './getLocalStorageValue';
+import { SettingsPayload } from '../types';
+
+describe('getLocalStorageValue', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps a deliberately-saved empty string from settings', () => {
+    const settings: SettingsPayload = { 'tts-manual-lang': '' };
+    expect(getLocalStorageValue('tts-manual-lang', 'en-US', settings)).toBe('');
+  });
+
+  it('keeps a deliberately-saved empty string from localStorage', () => {
+    localStorage.setItem('deck-name', '');
+    expect(getLocalStorageValue('deck-name', 'My deck', {})).toBe('');
+  });
+
+  it('falls back to the default when the key is absent everywhere', () => {
+    expect(getLocalStorageValue('missing', 'fallback', {})).toBe('fallback');
+  });
+
+  it('returns the stored non-empty value over the default', () => {
+    const settings: SettingsPayload = { template: 'specialized' };
+    expect(getLocalStorageValue('template', 'default-template', settings)).toBe(
+      'specialized'
+    );
+  });
+});

--- a/web/src/lib/data_layer/getLocalStorageValue.tsx
+++ b/web/src/lib/data_layer/getLocalStorageValue.tsx
@@ -6,7 +6,9 @@ export const getLocalStorageValue = (
   theSettings: SettingsPayload
 ) => {
   if (theSettings && key in theSettings) {
-    return theSettings[key] || defaultValue;
+    const fromSettings = theSettings[key];
+    return fromSettings == null ? defaultValue : fromSettings;
   }
-  return localStorage.getItem(key) || defaultValue;
+  const fromStorage = localStorage.getItem(key);
+  return fromStorage == null ? defaultValue : fromStorage;
 };

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-toggle-edge-cases.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-toggle-edge-cases.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-toggle-edge-cases",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Toggles with image-only headers and repeated identical toggles convert to separate cards"
+}


### PR DESCRIPTION
## What
Clears the unclaimed mechanical findings from the 2026-06-11 card-options/parser audit (#3247). One PR for the batch; each item was verified against current `main` before changing.

## Why
`Fixes #3247`. Two of these are user-visible (image-only toggle headers and repeated identical toggles), the rest harden parser/web edge cases. User-visible outcome: Notion toggles whose header is an image now produce a card, identical toggles no longer collapse to one, and a deliberately-cleared setting (TTS "Don't speak", cleared deck name) now persists.

## Item-by-item

| # | Item | Status |
| --- | --- | --- |
| 1 | `embedFile.ts` — extensionless filename ending in literal `null`; falsy-contents path returned a name without `addMedia` | Fixed — `SuffixFrom(...) ?? ''`; guard on `file.contents` so no media is referenced unless written |
| 2 | `DeckParser.ts` toggle dedupe key `attr('id') || html()` collapsed identical id-less toggles | Fixed — key on element index when no id |
| 3 | `DeckParser.ts` empty payload → `TypeError` 500 | Fixed — `processPayload` throws `EmptyDeckError` |
| 4 | `DeckParser.ts` image-only toggle headers produced no card | Fixed — accept a summary whose only child is media (img/figure/audio/video) |
| 5 | `DeckParser.ts` per-toggle `addClass` smeared classes document-wide | Fixed — scope to the current toggle's `details`/`summary` |
| 6 | `noteHasAvocado` name-only + missing trailing `;` on the entity | Fixed — match name+back like cherry; `&#x1F951;` |
| 7 | `guessMarkdownCards.ts` inline-`::` split inside `{{c1::…}}` | Fixed — skip a `::` that sits inside a cloze marker |
| 8 | `FallbackParser.ts` sticky `clean` flag; nested-list double-count | Fixed — `clean` scoped per file; iterate top-level lists with direct-child `li` |
| 9 | web `getLocalStorageValue.tsx` `|| defaultValue` swallowed saved empty strings | Fixed — `== null` checks; TTS "Don't speak" and cleared deck name now persist |
| 10 | Stale compiled `.js`/`.js.map` debris under `src/` | No-op — `git ls-files` shows none are tracked (incl. `loadSettingsFromDatabase.js`); untracked local clutter left alone per the brief |

### Skipped (out of scope or owned elsewhere)
| Item | Reason |
| --- | --- |
| owner-truthiness gates (`UploadService.ts:341`, `handleDropbox.ts:40`) | Absorbed by the #3248-era pattern work |
| limit TOCTOU (`CheckMonthlyCardLimitUseCase` vs `incrementCardUsage`) | Cross-referenced in the quota-bypass fix (#3232) |
| `card-style` / `vertex-ai-pdf-questions` dead options | Product decisions, not mechanical fixes |
| whole-localStorage upload posting (`UploadForm.tsx`) | Needs design |
| `skip-defaults` sync question | Open question on #3262 |
| Dropbox un-awaited success log | Cosmetic, left for a focused pass |

## How
TDD per item — one focused failing test each, then the smallest fix. Toggle/avocado/empty-payload tests inspect `parser.payload` directly (no Python). The nested-list and embedFile fixes were confirmed to fail on unmodified `main` before the change.

## Measuring success
No metric to move — reliability/correctness batch. Confirmation is the new colocated tests staying green in CI and the absence of the empty-payload `TypeError` 500 and the toggle-collapse symptom in conversion logs.

## Testing
- Unit tests added: `embedFile` (null suffix + empty contents), `DeckParser.avocado`, `DeckParser.emptyPayload`, `DeckParser.toggleEdgeCases` (dupe toggles, image-only header, class smear), `guessMarkdownCards` (cloze `::`), `FallbackParser` (nested-list double-count), web `getLocalStorageValue` (saved empty strings).
- Server `tsc -p . --noEmit` and web `tsc --noEmit`: clean.
- `DeckParser.test.ts` MCQ cases fail locally with `PythonExitError` (worktree lacks the create_deck venv); verified the identical failures reproduce on unmodified `origin/main`, so they are environmental, not regressions. CI runs them with the venv.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: `getLocalStorageValue.tsx` is the only `web/src` runtime change — the TTS "Don't speak" setting and cleared deck names now persist. Spot-check the card options page (TTS language pickers, deck name).

## Sonar
Sonar: not run locally — no SONAR_TOKEN.

## Risks
Item 2 keys toggle dedupe on index, which disables html-based collapse for id-less toggles; `findNotionToggleLists` already returns instance-deduped elements, so distinct positions are distinct toggles — the only behavior change is keeping genuinely-distinct identical toggles. Rollback is per-item revert; each fix is independent.

## Goal alignment
None directly — internal reliability/correctness. Indirectly supports the "simplest, fastest way to turn notes into cards" mission by removing silent card-loss on image-only toggles and persisting deliberately-cleared settings, which reduces conversion frustration in the upload→download funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783794933&installation_id=132681956&pr_number=3276&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3276&signature=0c96937750fba776a13d56bdf9b0e4b93b8daa16f84c1c7e75460e0ddec8feb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->