### PR TITLE
fix: stop tombstone restore from nulling NOT NULL month-start columns

### DIFF
--- a/src/data_layer/UsersRepository.test.ts
+++ b/src/data_layer/UsersRepository.test.ts
@@ -173,6 +173,33 @@ describe('UsersRepository.createUserAndSeedFromTombstone', () => {
       prints_month_started_at: seed.prints_month_started_at,
     });
   });
+
+  it('falls back to now for null month-start values so the NOT NULL columns never receive null', async () => {
+    const now = new Date('2026-05-24T00:00:00Z');
+    const seed = {
+      cards_used_this_month: 0,
+      cards_month_started_at: null,
+      pdf_prints_this_month: 0,
+      prints_month_started_at: null,
+    };
+    const { knex, tombstoneRepo, updateSpy } = buildTrxKnex(seed);
+    const repo = new UsersRepository(knex as any, tombstoneRepo as any);
+
+    await repo.createUserAndSeedFromTombstone(
+      'al',
+      SAMPLE_HASH,
+      'al@example.com',
+      null,
+      now
+    );
+
+    expect(updateSpy).toHaveBeenCalledWith({
+      cards_used_this_month: 0,
+      cards_month_started_at: now,
+      pdf_prints_this_month: 0,
+      prints_month_started_at: now,
+    });
+  });
 });
 
 describe('UsersRepository.deleteUser', () => {

--- a/src/data_layer/UsersRepository.ts
+++ b/src/data_layer/UsersRepository.ts
@@ -152,12 +152,14 @@ class UsersRepository {
       trx
     );
     if (!seed) return;
-    await trx(this.table).where({ id }).update({
-      cards_used_this_month: seed.cards_used_this_month,
-      cards_month_started_at: seed.cards_month_started_at,
-      pdf_prints_this_month: seed.pdf_prints_this_month,
-      prints_month_started_at: seed.prints_month_started_at,
-    });
+    await trx(this.table)
+      .where({ id })
+      .update({
+        cards_used_this_month: seed.cards_used_this_month,
+        cards_month_started_at: seed.cards_month_started_at ?? now,
+        pdf_prints_this_month: seed.pdf_prints_this_month,
+        prints_month_started_at: seed.prints_month_started_at ?? now,
+      });
   }
 
   async deleteUser(owner: string) {


### PR DESCRIPTION
**Prod incident — fixes broken account creation for re-registering users.**

## What broke

Prod log (server-green, 21:42 UTC) showed a Postgres NOT NULL violation (code 23502) on `users.prints_month_started_at` during a Google signup — the new account row failed to commit, so the signup silently failed.

## Root cause

When a deleted user re-registers, `createUserAndSeedFromTombstone` → `applyTombstoneSeed` (`UsersRepository.ts:155`) restores their saved usage counters onto the new row by writing the tombstone's month-start timestamps directly. Those timestamps are nullable in `deleted_user_usage`, but `cards_month_started_at` / `prints_month_started_at` on `users` were made **NOT NULL DEFAULT now()** by the `2026-06-09` migration. A tombstone with a null month-start makes the UPDATE write null into a NOT NULL column → 23502 → the whole signup transaction rolls back → no account created.

The inactive-free-account cleanup (`1a217c0`) mints exactly these tombstones in bulk, and many predate the counter columns (null month-start), so this hits a real and growing cohort of re-signups.

## Fix

Coalesce both month-start values to `now` when the seed is null, so the NOT NULL columns always receive a real timestamp. Restored usage counts (`cards_used_this_month`, `pdf_prints_this_month`) are unchanged — only the null start dates get a floor.

```ts
cards_month_started_at: seed.cards_month_started_at ?? now,
prints_month_started_at: seed.prints_month_started_at ?? now,
```

## Tests

TDD: added a `UsersRepository` case where the tombstone seed has null month-starts — asserts the UPDATE receives `now`, not null. Watched it fail (null passed through), then pass. Full UsersRepository suite green (13 passing), server tsc clean. No migration, no schema change.

No changelog entry — bug fix on an internal failure path; the user-visible effect is simply that signups stop failing.

Sonar: not run locally — no SONAR_TOKEN; two-line data-layer change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783800387&installation_id=132681956&pr_number=3277&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3277&signature=b4764ff5cfef131613285b67b4fbccce35ca1bf433126e66104cf3644520ea58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->