### PR TITLE
fix: wire template overrides into the Ankify polling sync

### DIFF
--- a/src/data_layer/index.ts
+++ b/src/data_layer/index.ts
@@ -22,6 +22,8 @@ import { AnkifySyncConflictsRepository } from './ankify/AnkifySyncConflictsRepos
 import { AnkifySyncLogsRepository } from './ankify/AnkifySyncLogsRepository';
 import { ankiConnectFactory } from '../services/ankify/buildAnkiConnectClient';
 import { notionBlockChildrenFetcherFactory } from '../services/ankify/notionBlockChildrenFetcher';
+import { makeAnkifyTemplateOverridesProvider } from '../services/ankify/templateOverrides';
+import SettingsRepository from './SettingsRepository';
 import NotionRepository from './NotionRespository';
 import NotionTopLevelPagesRepository from './NotionTopLevelPagesRepository';
 import BlocksCacheRepository from './BlocksCacheRepository';
@@ -244,7 +246,8 @@ export const setupDatabase = async (database: Knex) => {
             notionRepo,
             new UsersRepository(database),
             getDefaultEmailService()
-          ).execute(owner)
+          ).execute(owner),
+        makeAnkifyTemplateOverridesProvider(new SettingsRepository(database))
       );
       const topLevelPagesRepo = new NotionTopLevelPagesRepository(database);
       const blocksCacheRepo = new BlocksCacheRepository(database);

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -54,6 +54,7 @@ import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { MarkNotionTokenInvalidUseCase } from '../usecases/notion/MarkNotionTokenInvalidUseCase';
 import { buildNotionPageMetaFetcher } from '../services/ankify/buildNotionPageMetaFetcher';
+import { makeAnkifyTemplateOverridesProvider } from '../services/ankify/templateOverrides';
 
 const buildNotionExportClient = (token: string) => {
   const notion = new NotionClient({ auth: token });
@@ -289,8 +290,8 @@ const AnkifyRouter = () => {
 
   const ankifyNotionRepo = new NotionRepository(db);
   const settingsRepo = new SettingsRepository(db);
-  const templateOverridesProvider = (owner: number, pageId?: string) =>
-    settingsRepo.loadAnkifyTemplateOverrides(String(owner), pageId);
+  const templateOverridesProvider =
+    makeAnkifyTemplateOverridesProvider(settingsRepo);
   const syncNotionPageUseCase = new SyncNotionPageToRacUseCase(
     repo,
     mappings,

--- a/src/routes/AnkifyWebhookRouter.ts
+++ b/src/routes/AnkifyWebhookRouter.ts
@@ -17,6 +17,8 @@ import SubscriptionService from '../services/SubscriptionService';
 import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { MarkNotionTokenInvalidUseCase } from '../usecases/notion/MarkNotionTokenInvalidUseCase';
+import { makeAnkifyTemplateOverridesProvider } from '../services/ankify/templateOverrides';
+import SettingsRepository from '../data_layer/SettingsRepository';
 
 const AnkifyWebhookRouter = () => {
   const router = express.Router();
@@ -46,7 +48,8 @@ const AnkifyWebhookRouter = () => {
         notionRepo,
         usersRepo,
         getDefaultEmailService()
-      ).execute(owner)
+      ).execute(owner),
+    makeAnkifyTemplateOverridesProvider(new SettingsRepository(db))
   );
 
   router.post(

--- a/src/services/ankify/templateOverrides.test.ts
+++ b/src/services/ankify/templateOverrides.test.ts
@@ -1,0 +1,74 @@
+import {
+  AnkifyTemplateOverrides,
+  buildBasicModelFromTemplate,
+  makeAnkifyTemplateOverridesProvider,
+} from './templateOverrides';
+
+const sampleOverrides = (): AnkifyTemplateOverrides => ({
+  basicModelName: 'CUSTOM BASIC',
+  basicTemplate: {
+    parent: 'Basic',
+    name: 'CUSTOM BASIC',
+    storageKey: 'n2a-basic',
+    front: '{{Front}}',
+    back: '{{Back}}',
+    styling: '.card { color: teal; }',
+  },
+});
+
+describe('makeAnkifyTemplateOverridesProvider', () => {
+  it('forwards the owner as a string with both page id candidates', async () => {
+    const loadAnkifyTemplateOverrides = jest
+      .fn()
+      .mockResolvedValue(sampleOverrides());
+
+    const provider = makeAnkifyTemplateOverridesProvider({
+      loadAnkifyTemplateOverrides,
+    });
+    const result = await provider(13574, 'child-page', 'database-id');
+
+    expect(loadAnkifyTemplateOverrides).toHaveBeenCalledWith(
+      '13574',
+      'child-page',
+      'database-id'
+    );
+    expect(result?.basicModelName).toBe('CUSTOM BASIC');
+  });
+
+  it('forwards a call without page ids unchanged', async () => {
+    const loadAnkifyTemplateOverrides = jest.fn().mockResolvedValue(null);
+
+    const provider = makeAnkifyTemplateOverridesProvider({
+      loadAnkifyTemplateOverrides,
+    });
+    const result = await provider(42);
+
+    expect(loadAnkifyTemplateOverrides).toHaveBeenCalledWith(
+      '42',
+      undefined,
+      undefined
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe('buildBasicModelFromTemplate', () => {
+  it('builds the model from the template fields and styling', () => {
+    const overrides = sampleOverrides();
+
+    const model = buildBasicModelFromTemplate(
+      overrides.basicTemplate,
+      overrides.basicModelName
+    );
+
+    expect(model).toMatchObject({
+      modelName: 'CUSTOM BASIC',
+      css: '.card { color: teal; }',
+      isCloze: false,
+      inOrderFields: ['Front', 'Back', 'MyMedia'],
+    });
+    expect(model.cardTemplates).toEqual([
+      { Name: 'Card 1', Front: '{{Front}}', Back: '{{Back}}' },
+    ]);
+  });
+});

--- a/src/services/ankify/templateOverrides.ts
+++ b/src/services/ankify/templateOverrides.ts
@@ -13,6 +13,19 @@ export type AnkifyTemplateOverridesProvider = (
   fallbackPageId?: string
 ) => Promise<AnkifyTemplateOverrides | null>;
 
+export interface AnkifyTemplateOverridesSource {
+  loadAnkifyTemplateOverrides(
+    owner: string,
+    pageId?: string,
+    fallbackPageId?: string
+  ): Promise<AnkifyTemplateOverrides | null>;
+}
+
+export const makeAnkifyTemplateOverridesProvider =
+  (settings: AnkifyTemplateOverridesSource): AnkifyTemplateOverridesProvider =>
+  (owner, pageId, fallbackPageId) =>
+    settings.loadAnkifyTemplateOverrides(String(owner), pageId, fallbackPageId);
+
 const BASIC_FIELDS_FROM_TEMPLATE = ['Front', 'Back', 'MyMedia'];
 
 export const buildBasicModelFromTemplate = (

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-polling-note-type.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-polling-note-type.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-polling-note-type",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Cards created by the automatic 5-minute Notion sync use your custom note type"
+}


### PR DESCRIPTION
Follow-up to #3278 — found while verifying that PR against production data, before replying to the reporter.

## The actual root cause of "note type still not working"

The 5-minute polling worker (`src/data_layer/index.ts`) constructed `SyncNotionPageToRacUseCase` **without the `templateOverridesProvider` argument**. Every card created by the poll therefore ran with `overrides = null` and fell back to Ankify Basic — regardless of how correct the resolution chain in `SettingsRepository` was. This is why two earlier fixes (#3268 and #3278) tested green yet the user kept producing screenshots of fresh Ankify Basic cards: their cards are created by the poll, and the poll never asked for overrides. Only the manual-sync route had the provider wired.

Verified against the reporter's production rows: global card options are `template: custom` with their custom basic model name, and their templates row carries the full note type with styling. With the provider wired, the existing chain (page row → fallback row → global → most recent) resolves their custom model.

## Second gap: dropped argument on manual syncs

`AnkifyRouter`'s inline adapter forwarded only `(owner, pageId)`, silently discarding the `fallbackPageId` argument added in #3278 — the database-row fallback would have been dead on manual syncs too.

## Change

New `makeAnkifyTemplateOverridesProvider(settingsRepo)` factory in `services/ankify/templateOverrides.ts`, used by all three construction sites: the polling worker, `AnkifyRouter`, and `AnkifyWebhookRouter` (inactive, wired for consistency). Tests cover the factory's argument forwarding; full ankify suites pass (144 tests), server tsc clean.

Sonar: local scanner not run — no `SONAR_TOKEN` in this shell (small wiring diff; Automatic Analysis runs on the PR).

`web/src` diff is changelog-only (one entry).

Metric: retention/churn — same as #3278; this is the missing piece that makes the note-type fix actually reach poll-created cards. Verify via the reporter's next polling sync in prod logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783847913&installation_id=132681956&pr_number=3279&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3279&signature=1d839939e80fe555aa767393e65c284c98d0c18d8e240bf3fe51de088d03513a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->