### PR TITLE
fix: drain Apache old-config workers before killing old color

### DIFF
--- a/Documentation/deploy/blue-green.md
+++ b/Documentation/deploy/blue-green.md
@@ -6,11 +6,12 @@ Apache. No application code is involved. Full rationale (and why not pm2 cluster
 mode) is in the original spec — recover it with
 `git log -p -- Documentation/specs/blue-green-deploys.md`.
 
-**Status: not wired into the automated deploy.** The live
-`.github/workflows/deploy.2anki.net.yml` still runs the single-color
-`pm2 startOrRestart ecosystem.config.js`. This page covers the manual validation
-that has to happen first. Flipping the workflow is a later PR — see
-[Rollout](#rollout).
+**Status: live.** `.github/workflows/deploy.2anki.net.yml` runs
+`scripts/deploy-blue-green.sh` on every deploy (wired in by #2800); prod
+alternates `server-blue` (:3000) and `server-green` (:3001). The
+[Rollout](#rollout) and bootstrap sections below are kept as the runbook for the
+manual cutovers that preceded the switch and for re-bootstrapping after an
+incident.
 
 ## Pieces
 
@@ -134,9 +135,19 @@ scripts/deploy-blue-green.sh
 What it does: reads `~/.deploy_color`, starts the other color, waits up to 30s
 for its `/api/version` to report `GIT_SHA`, rewrites both Apache includes (HTTP
 and WebSocket) to the new port, `apachectl graceful` once, verifies
-`https://2anki.net/api/version` reports the new sha, then drains and deletes the
-old color (SIGINT → the graceful-shutdown handler, bounded by `kill_timeout`),
-and writes the new color to `~/.deploy_color`.
+`https://2anki.net/api/version` reports the new sha, waits
+`OLD_COLOR_DRAIN_SECONDS` (default 15) for Apache's pre-reload worker children to
+turn over, then drains and deletes the old color (SIGINT → the graceful-shutdown
+handler, bounded by `kill_timeout`), and writes the new color to
+`~/.deploy_color`.
+
+The drain wait closes the only zero-downtime gap in the cutover: `apachectl
+graceful` does not switch every Apache worker at once — pre-reload children keep
+serving with the OLD config (still proxying to the old color's port) until they
+finish their current request. Killing the old color the instant the public
+health check passes left those children pointed at a dead port, so they returned
+503 with `(111)Connection refused: AH00957` in the Apache error log. Pausing
+before the kill lets them retire against a still-live backend.
 
 If the new color fails its health check, the script deletes it and exits non-zero
 — the current color never stopped serving. If the post-swap public check fails,
@@ -173,6 +184,7 @@ GIT_SHA=<sha> scripts/deploy-blue-green.sh
 | `WS_UPSTREAM_CONF` | `/etc/apache2/conf-2anki-ws-upstream.conf` | generated WebSocket (`/v/*`) include |
 | `ECOSYSTEM` | `$SERVER_DIR/ecosystem.blue-green.config.js` | pm2 app definitions |
 | `PUBLIC_HEALTH_URL` | `https://2anki.net/api/version` | post-swap verification URL |
+| `OLD_COLOR_DRAIN_SECONDS` | `15` | pause after the verified swap so Apache's pre-reload workers drain off the old color before it's killed |
 | `DEPLOY_LOCK_FILE` | `~/.2anki-deploy.lock` | flock target |
 | `DRY_RUN` | `0` | `1` prints actions instead of running them |
 

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -20,6 +20,12 @@ LOCK_FILE="${DEPLOY_LOCK_FILE:-$HOME/.2anki-deploy.lock}"
 ECOSYSTEM="${ECOSYSTEM:-$SERVER_DIR/ecosystem.blue-green.config.js}"
 PUBLIC_HEALTH_URL="${PUBLIC_HEALTH_URL:-https://2anki.net/api/version}"
 HEALTH_PATH="/api/version"
+# Seconds to let Apache's pre-reload worker children — which `apachectl graceful`
+# keeps alive on the OLD config until they finish their current request — drain
+# against the still-live old color before we kill it. Without this pause the old
+# color disappears while those children are still proxying to its port, and they
+# return 503 (AH00957 "Connection refused") to whoever they were serving.
+OLD_COLOR_DRAIN_SECONDS="${OLD_COLOR_DRAIN_SECONDS:-15}"
 DRY_RUN="${DRY_RUN:-0}"
 
 : "${GIT_SHA:?GIT_SHA must be exported to the sha being deployed}"
@@ -117,9 +123,21 @@ if ! wait_for_sha "$PUBLIC_HEALTH_URL"; then
   exit 1
 fi
 
-# New color is live and verified. Drain the old color via SIGINT -> the
-# graceful-shutdown handler (bounded by kill_timeout), then remove it. A missing
-# old color (first-run bootstrap leaves it named "server") is not fatal here.
+# New color is live and verified, but `apachectl graceful` keeps the pre-reload
+# worker children alive on the OLD config until they finish their current
+# request — those children still proxy to :$CURRENT_PORT. Wait for them to turn
+# over before killing the old color, or they hit a dead port and return 503
+# (the AH00957 "Connection refused" seen in the Apache error log at swap time).
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN: skip ${OLD_COLOR_DRAIN_SECONDS}s old-config drain"
+else
+  log "letting Apache's old-config workers drain for ${OLD_COLOR_DRAIN_SECONDS}s before retiring :$CURRENT_PORT"
+  sleep "$OLD_COLOR_DRAIN_SECONDS"
+fi
+
+# Drain the old color via SIGINT -> the graceful-shutdown handler (bounded by
+# kill_timeout), then remove it. A missing old color (first-run bootstrap leaves
+# it named "server") is not fatal here.
 run pm2 stop "server-$CURRENT" || log "could not stop server-$CURRENT (already gone?)"
 run pm2 delete "server-$CURRENT" || log "could not delete server-$CURRENT (already gone?)"
 run pm2 save


### PR DESCRIPTION
## What
Adds a short drain pause to the blue-green deploy cutover
(`scripts/deploy-blue-green.sh`): after the new color is verified live through
Apache, wait `OLD_COLOR_DRAIN_SECONDS` (default 15s) before stopping the old
color, so Apache's pre-reload worker children finish their in-flight requests
against a still-live backend instead of a port that's already been killed.

## Why
Despite blue-green deploys, prod served ~13 user-facing 503s during deploy swaps
over the last 48h.

Pinned root cause (evidence):
- Apache error log at swap moments: `(111)Connection refused: AH00957: http:
  attempt to connect to 127.0.0.1:3000 (127.0.0.1) failed` on real requests
  (referer + real UA), serving 503 on `/upload/`, `/api/upload/mine`, `GET /`.
- Access-log 503s cluster exactly at deploy times (Jun 11 07:06–18:15, Jun 12
  09:11–09:58).
- Prod confirms the design is sound: `server-blue` listens on :3000,
  `server-green` on :3001, Apache `conf-2anki-upstream.conf` proxies to the live
  color, `~/.deploy_color` tracks it, and green out-logs show real traffic — so
  colors **do** alternate and the per-color-port handoff works.

The gap is **not** the new-color health gate, the atomic upstream swap, or
startup timing. `src/server.ts` already binds `app.listen` *before* running
migrations, and `/api/version` answers as soon as the socket binds, so the
`wait_for_sha` gate correctly proves the new color is accepting before the swap.
No `wait_ready`/`process.send('ready')` change is needed — the health check
already does that job.

The gap is `apachectl graceful`: it does not switch every Apache worker child at
once. Pre-reload children keep serving with the OLD config — still proxying to
the old color's port — until they finish their current request and respawn. The
script killed the old color the instant the public health check passed (a *new*
child satisfied that check), leaving the lingering old-config children pointed at
a dead port → `Connection refused` → 503 to whoever they were serving.

## How
One pause between the verified swap and `pm2 stop server-$CURRENT`. The old color
keeps serving for the duration, so the wait has no user impact; it only delays
reaping the retired process. `DRY_RUN=1` skips the sleep. Verified the ordering
with a dry-run: gate → swap → graceful → public verify → **drain pause** → stop
old → delete old.

Also corrected the now-stale "not wired into the automated deploy" status in
`Documentation/deploy/blue-green.md` (the workflow has called this script since
#2800; prod is running it) and documented the new env var + the drain rationale.

## Construction-site / reachability check
The 503 path is the deploy script itself, not a multi-site class. Confirmed on
prod that the live workflow invokes `scripts/deploy-blue-green.sh`
(`.github/workflows/deploy.2anki.net.yml` line 81) and that prod is in steady
blue-green state (`server-blue` online on :3000, `~/.deploy_color=blue`,
`green` out-logs show served traffic).

## Measuring success
After this deploys and runs through at least one cutover, the Apache error log
should stop logging `AH00957 ... 127.0.0.1` at swap time:
`sudo grep AH00957 /var/log/apache2/error.log` — entries should cease appearing
in the minute around each deploy. The access log should show no 503s clustering
at deploy timestamps.

## Manual prod-side action
None. The fix ships entirely in the repo — `scripts/deploy-blue-green.sh` is
checked out and run on the box from `~/src/github.com/2anki/2anki.net`, so the
next deploy picks it up automatically. The Apache vhosts, upstream include files,
and `~/.deploy_color` are already bootstrapped and need no change.

Optional tuning: `OLD_COLOR_DRAIN_SECONDS` defaults to 15. If a future profile
shows Apache children turn over faster, it can be lowered via the deploy env
without a code change; the safe default is the unconditional behavior.

## Testing
- No automated test: this is a deploy shell script with no unit-testable seam
  (the change is a `sleep` between two pm2 calls). Verified the branch ordering
  and DRY_RUN guard via `bash -n` + a `DRY_RUN=1` dry-run; no `src/` code touched,
  so no tsc/Jest run applies.

## Changelog
No changelog entry — deploy infrastructure, no user-visible feature change.

Browser check: not applicable — no web/src/ change

## Risks
- The retired process lives ~15s longer per deploy; bounded and harmless (the
  pm2 `kill_timeout` window is unchanged at 90s, and the old color is idle by
  then). Rollback: revert this commit — the script returns to killing the old
  color immediately.

## Goal alignment
None — internal deploy reliability. Removes user-facing 503s during deploys,
which protects the upload/conversion path (the activation funnel) from
intermittent failures at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783858750&installation_id=132681956&pr_number=3281&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3281&signature=c04abd156b6ecb59cbfd635cd45334b843b251c537857d7f9ee2e9e61c855a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->