### PR TITLE
chore: regenerate kanel types after notion_object_type migration

### DIFF
--- a/src/data_layer/public/AnkifyNotionSubscriptions.ts
+++ b/src/data_layer/public/AnkifyNotionSubscriptions.ts
@@ -33,6 +33,8 @@ export default interface AnkifyNotionSubscriptions {
   notion_page_icon: string | null;
 
   target_deck: string | null;
+
+  notion_object_type: string | null;
 }
 
 /** Represents the initializer for the table public.ankify_notion_subscriptions */
@@ -68,6 +70,8 @@ export interface AnkifyNotionSubscriptionsInitializer {
   notion_page_icon?: string | null;
 
   target_deck?: string | null;
+
+  notion_object_type?: string | null;
 }
 
 /** Represents the mutator for the table public.ankify_notion_subscriptions */
@@ -99,4 +103,6 @@ export interface AnkifyNotionSubscriptionsMutator {
   notion_page_icon?: string | null;
 
   target_deck?: string | null;
+
+  notion_object_type?: string | null;
 }


### PR DESCRIPTION
## Why

PR #3284 added the `notion_object_type` column to `ankify_notion_subscriptions` but `pnpm kanel` could not run in the agent worktree (no kanel bin / DB connection). This regenerates `src/data_layer/public/AnkifyNotionSubscriptions.ts` against the migrated schema — flagged in #3284's review as the one post-merge action.

No changelog entry — internal generated-types sync, no user-visible behavior change.

Browser check: not applicable — no web/src/ change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783860677&installation_id=132681956&pr_number=3285&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3285&signature=b1016bc1075750e796c9ba94abdc64dbb09c241e9bdd49b8b22a406739855a9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->