### PR TITLE
fix: wrap Monaco workers in same-origin blob shim

### DIFF
--- a/web/src/pages/TemplatesPage/components/CodeEditor/CodeEditor.tsx
+++ b/web/src/pages/TemplatesPage/components/CodeEditor/CodeEditor.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import styles from './CodeEditor.module.css';
+import { crossOriginWorker } from './crossOriginWorker';
 
 const MonacoEditor = lazy(async () => {
   const [{ default: Editor, loader }, monaco] = await Promise.all([
@@ -7,25 +8,25 @@ const MonacoEditor = lazy(async () => {
     import('monaco-editor'),
   ]);
 
-  const editorWorker = (
-    await import('monaco-editor/esm/vs/editor/editor.worker?worker&inline')
+  const editorWorkerUrl = (
+    await import('monaco-editor/esm/vs/editor/editor.worker?worker&url')
   ).default;
-  const cssWorker = (
-    await import('monaco-editor/esm/vs/language/css/css.worker?worker&inline')
+  const cssWorkerUrl = (
+    await import('monaco-editor/esm/vs/language/css/css.worker?worker&url')
   ).default;
-  const htmlWorker = (
-    await import('monaco-editor/esm/vs/language/html/html.worker?worker&inline')
+  const htmlWorkerUrl = (
+    await import('monaco-editor/esm/vs/language/html/html.worker?worker&url')
   ).default;
 
   (globalThis as unknown as { MonacoEnvironment: object }).MonacoEnvironment = {
     getWorker(_workerId: string, label: string) {
       if (label === 'css' || label === 'scss' || label === 'less') {
-        return new cssWorker();
+        return crossOriginWorker(cssWorkerUrl);
       }
       if (label === 'html' || label === 'handlebars' || label === 'razor') {
-        return new htmlWorker();
+        return crossOriginWorker(htmlWorkerUrl);
       }
-      return new editorWorker();
+      return crossOriginWorker(editorWorkerUrl);
     },
   };
 

--- a/web/src/pages/TemplatesPage/components/CodeEditor/crossOriginWorker.test.ts
+++ b/web/src/pages/TemplatesPage/components/CodeEditor/crossOriginWorker.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { crossOriginWorker } from './crossOriginWorker';
+
+const workerUrls: string[] = [];
+
+class FakeWorker {
+  constructor(url: string) {
+    workerUrls.push(url);
+  }
+}
+
+function stubWorker() {
+  workerUrls.length = 0;
+  vi.stubGlobal('Worker', FakeWorker);
+}
+
+describe('crossOriginWorker', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('builds a same-origin blob worker that importScripts the cross-origin url', async () => {
+    const blobs: Blob[] = [];
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(
+      (blob: Blob | MediaSource) => {
+        blobs.push(blob as Blob);
+        return 'blob:mock';
+      }
+    );
+    stubWorker();
+
+    crossOriginWorker(
+      'https://2anki-assets.fra1.cdn.digitaloceanspaces.com/assets/css.worker-CvXBzhp8.js'
+    );
+
+    expect(blobs).toHaveLength(1);
+    expect(blobs[0].type).toBe('application/javascript');
+    expect(workerUrls).toEqual(['blob:mock']);
+
+    const source = await blobs[0].text();
+    expect(source).toBe(
+      'importScripts("https://2anki-assets.fra1.cdn.digitaloceanspaces.com/assets/css.worker-CvXBzhp8.js");'
+    );
+  });
+
+  it('falls back to a direct worker when blob construction throws', () => {
+    vi.spyOn(URL, 'createObjectURL').mockImplementation(() => {
+      throw new Error('blob unsupported');
+    });
+    stubWorker();
+
+    crossOriginWorker('/assets/editor.worker-abc.js');
+
+    expect(workerUrls).toEqual(['/assets/editor.worker-abc.js']);
+  });
+});

--- a/web/src/pages/TemplatesPage/components/CodeEditor/crossOriginWorker.ts
+++ b/web/src/pages/TemplatesPage/components/CodeEditor/crossOriginWorker.ts
@@ -1,0 +1,10 @@
+export function crossOriginWorker(url: string): Worker {
+  try {
+    const blob = new Blob([`importScripts(${JSON.stringify(url)});`], {
+      type: 'application/javascript',
+    });
+    return new Worker(URL.createObjectURL(blob));
+  } catch {
+    return new Worker(url);
+  }
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-template-editor-load.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-template-editor-load.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-template-editor-load",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Template editor syntax highlighting and code hints load reliably"
+}


### PR DESCRIPTION
## What
Routes every Monaco editor worker on `/templates` through a same-origin blob shim so the language workers (CSS, HTML) construct without a cross-origin `SecurityError`.

## Why
Prod error tracker, 4 events Jun 10 on `/templates`: anonymous users hit `SecurityError: Failed to construct 'Worker'` because built assets are served from a CDN origin (`2anki-assets.fra1.cdn.digitaloceanspaces.com`) while the app runs on `https://2anki.net`. The Worker spec forbids constructing a worker from a cross-origin script URL, so syntax highlighting, hover, and completion were dead while plain typing still worked.

The Jun 10 `?worker&inline` attempt was logically reasonable but did not hold: Vite's inline blob trampoline still resolved sibling worker chunks against the CDN base — the mixed-hash `css.worker-CvX…` requested from inside `css.worker-Cg…` in the prod stack is that exact failure.

## How
Monaco's worker factory consults `globalThis.MonacoEnvironment.getWorker` **first**, ahead of each language mode's own `createWorker` (which Vite emits as `new Worker(new URL("<cdn>…", import.meta.url), {type:"module"})`). I switched the three worker imports from `?worker&inline` to `?worker&url` and route every label through a `crossOriginWorker(url)` shim. `getWorker` now returns a same-origin **classic** blob worker that `importScripts` the CDN URL:

```ts
const blob = new Blob([`importScripts(${JSON.stringify(url)});`], { type: 'application/javascript' });
return new Worker(URL.createObjectURL(blob));
```

DigitalOcean Spaces serves CORS headers on `/assets` (verified: `vary: Origin, Access-Control-Request-*`), so `importScripts` of the cross-origin IIFE worker chunk succeeds. The worker chunks are IIFE/classic (verified in the build output — zero top-level `import`/`export`), so `importScripts` is the correct mechanism. A `try/catch` falls back to `new Worker(url)` so local dev (same-origin URL) is untouched.

Because the shim sits at the single `getWorker` entry point — which monaco reaches before any per-mode `createWorker` — it covers **all** Monaco workers (editor, css, html, and any future json/ts) regardless of which internal path monaco uses.

**First-time-fix checks:** runtime entry point is the lazy-loaded `MonacoEditor` in `CodeEditor.tsx` (the only Monaco wiring in the app — `grep` for `getWorker`/`MonacoEnvironment` returns this file alone). `getWorker` is the single, monaco-precedence-confirmed construction site for all workers; the prior fix's failure was build-mechanism reachability, not logic, which this shim removes by being independent of Vite's inline heuristics.

## Measuring success
The prod error tracker should show zero new `SecurityError: Failed to construct 'Worker'` events on `/templates` after deploy (was 4 on Jun 10). Confirm the page renders syntax-highlighted CSS/HTML with hover and completion working.

## Testing
- Unit tests added: `crossOriginWorker.test.ts` — asserts the shim builds an `application/javascript` blob whose body is `importScripts("<url>")` and constructs the worker from the blob URL; and that it falls back to a direct `new Worker(url)` when blob construction throws.
- Full web suite green: 1872 passed.
- `pnpm --filter 2anki-web build` (with `ASSET_BASE_URL` set to the CDN to mirror prod) passes; verified the emitted `getWorker` calls the shim and the worker chunks are classic IIFE.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs manual browser check before merge — no dev server was running on :3000 and the agent did not start one. Open `/templates` locally, confirm the CSS/HTML editors show syntax highlighting with no `SecurityError` in the console at 375px.

## Changelog
`2026-06-12-template-editor-load.json` — "Template editor syntax highlighting and code hints load reliably"

## Sonar
sonar-scanner is installed but `SONAR_TOKEN` is unset in this environment, so a local scan was not run — expect the analysis on the PR. The change is small (a 10-line helper + three import swaps); no user-controlled URLs, no HTML rendering, no zip handling.

## Risks
If a browser blocks `importScripts` of a cross-origin script despite CORS headers, the worker would fail — but DO Spaces sends the headers and the `try/catch` falls back to a direct worker. Worst case matches today's behavior (no language features), never worse. Rollback is a single-commit revert.

## Goal alignment
`/templates` is a paid-adjacent surface (custom card styling drives perceived quality and retention). Metric to move: zero `SecurityError` events on `/templates` in the prod error tracker, read after deploy. Restores syntax highlighting and code hints for everyone editing templates — supports retention, not a direct funnel step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783862697&installation_id=132681956&pr_number=3286&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3286&signature=b9205004773c64366d02688f78a7bb6340ec51797c60df8b9fd880b7deff76f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->