### PR TITLE
fix: contain upload-page crash from extension DOM mutation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-router-dom';
 import { AppShell } from './components/AppShell/AppShell';
 import { ChunkReloadOverlay } from './components/ChunkReloadOverlay/ChunkReloadOverlay';
+import { DomRecoveryBoundary } from './components/DomRecoveryBoundary/DomRecoveryBoundary';
 import { getErrorMessage } from './components/errors/helpers/getErrorMessage';
 import { SkeletonPage } from './components/Skeleton/Skeleton';
 import PostLoginSurvey from './components/PostLoginSurvey/PostLoginSurvey';
@@ -376,7 +377,24 @@ function AppContent({
           />
           <Route
             path="/upload"
-            element={<UploadPage setErrorMessage={setErrorMessage} />}
+            element={
+              <DomRecoveryBoundary
+                onError={(error, errorInfo) =>
+                  reportClientError(error, {
+                    surface: 'upload',
+                    componentStack: errorInfo.componentStack,
+                  })
+                }
+                onRecover={(error) =>
+                  reportClientError(error, {
+                    surface: 'upload',
+                    recovered: true,
+                  })
+                }
+              >
+                <UploadPage setErrorMessage={setErrorMessage} />
+              </DomRecoveryBoundary>
+            }
           />
           <Route path="/print" element={<PrintPage />} />
           <Route path="/image-occlusion" element={<ImageOcclusionPage />} />

--- a/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.test.tsx
+++ b/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.test.tsx
@@ -1,0 +1,143 @@
+import { act, render, screen } from '@testing-library/react';
+import React, { type ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DomRecoveryBoundary,
+  MAX_REMOUNTS,
+  shouldRemount,
+} from './DomRecoveryBoundary';
+
+function makeNotFoundError(): DOMException {
+  return new DOMException(
+    "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+    'NotFoundError'
+  );
+}
+
+function Healthy(): ReactElement {
+  return <p>Upload page</p>;
+}
+
+function AlwaysThrows(): ReactElement {
+  throw new Error('boom');
+}
+
+describe('shouldRemount', () => {
+  it('remounts on a DOM NotFoundError under the cap', () => {
+    expect(shouldRemount(makeNotFoundError(), 0)).toBe(true);
+  });
+
+  it('stops remounting once the cap is reached', () => {
+    expect(shouldRemount(makeNotFoundError(), MAX_REMOUNTS)).toBe(false);
+  });
+
+  it('does not remount a non-DOM error', () => {
+    expect(shouldRemount(new Error('boom'), 0)).toBe(false);
+  });
+});
+
+describe('DomRecoveryBoundary', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('renders children untouched while healthy', () => {
+    render(
+      <DomRecoveryBoundary>
+        <Healthy />
+      </DomRecoveryBoundary>
+    );
+
+    expect(screen.getByText('Upload page')).toBeInTheDocument();
+  });
+
+  it('shows the recovery fallback and reports a persisting error', () => {
+    const onError = vi.fn();
+
+    render(
+      <DomRecoveryBoundary onError={onError}>
+        <AlwaysThrows />
+      </DomRecoveryBoundary>
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /something went wrong/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^reload$/i })
+    ).toBeInTheDocument();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('remounts once on a commit-phase DOM error, then keeps the subtree alive', () => {
+    const onRecover = vi.fn();
+    const ref = React.createRef<DomRecoveryBoundary>();
+
+    render(
+      <DomRecoveryBoundary ref={ref} onRecover={onRecover}>
+        <Healthy />
+      </DomRecoveryBoundary>
+    );
+
+    act(() => {
+      ref.current!.componentDidCatch(makeNotFoundError(), {
+        componentStack: '',
+      });
+    });
+
+    expect(onRecover).toHaveBeenCalledOnce();
+    expect(screen.getByText('Upload page')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /something went wrong/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the fallback after a second commit-phase DOM error', () => {
+    const onRecover = vi.fn();
+    const ref = React.createRef<DomRecoveryBoundary>();
+
+    render(
+      <DomRecoveryBoundary ref={ref} onRecover={onRecover}>
+        <Healthy />
+      </DomRecoveryBoundary>
+    );
+
+    act(() => {
+      ref.current!.componentDidCatch(makeNotFoundError(), {
+        componentStack: '',
+      });
+    });
+    act(() => {
+      ref.current!.setState({ error: makeNotFoundError() });
+      ref.current!.componentDidCatch(makeNotFoundError(), {
+        componentStack: '',
+      });
+    });
+
+    expect(onRecover).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole('heading', { name: /something went wrong/i })
+    ).toBeInTheDocument();
+  });
+
+  it('reloads the page when the user clicks Reload on the fallback', () => {
+    const reloadPage = vi.fn();
+
+    render(
+      <DomRecoveryBoundary reloadPage={reloadPage}>
+        <AlwaysThrows />
+      </DomRecoveryBoundary>
+    );
+
+    screen.getByRole('button', { name: /^reload$/i }).click();
+
+    expect(reloadPage).toHaveBeenCalledOnce();
+  });
+});

--- a/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.tsx
+++ b/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.tsx
@@ -1,0 +1,90 @@
+import React, { type ErrorInfo, type ReactNode } from 'react';
+
+import styles from '../../styles/shared.module.css';
+import { isDomManipulationError } from '../../lib/isDomManipulationError';
+
+type DomRecoveryBoundaryProps = Readonly<{
+  children: ReactNode;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  onRecover?: (error: Error) => void;
+  reloadPage?: () => void;
+}>;
+
+type DomRecoveryBoundaryState = {
+  error: Error | null;
+  remountCount: number;
+};
+
+export const MAX_REMOUNTS = 1;
+
+export function shouldRemount(error: Error, remountCount: number): boolean {
+  return isDomManipulationError(error) && remountCount < MAX_REMOUNTS;
+}
+
+export class DomRecoveryBoundary extends React.Component<
+  DomRecoveryBoundaryProps,
+  DomRecoveryBoundaryState
+> {
+  state: DomRecoveryBoundaryState = {
+    error: null,
+    remountCount: 0,
+  };
+
+  static getDerivedStateFromError(
+    error: Error
+  ): Partial<DomRecoveryBoundaryState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    this.props.onError?.(error, errorInfo);
+
+    if (shouldRemount(error, this.state.remountCount)) {
+      this.props.onRecover?.(error);
+      this.setState((prev) => ({
+        error: null,
+        remountCount: prev.remountCount + 1,
+      }));
+    }
+  }
+
+  private readonly defaultReload = () => window.location.reload();
+
+  private readonly reloadPage = () => {
+    (this.props.reloadPage ?? this.defaultReload)();
+  };
+
+  render() {
+    if (this.state.error) {
+      return (
+        <main className={styles.pageNarrow}>
+          <section className={styles.card} role="alert" aria-live="assertive">
+            <header className={styles.pageHeader}>
+              <h1 className={styles.title}>Something went wrong</h1>
+              <p className={styles.subtitle}>
+                A browser extension may be interfering with this page. Reload to
+                start over.
+              </p>
+            </header>
+
+            <div className={styles.modalFooter}>
+              <button
+                type="button"
+                className={`${styles.btnPrimary} ${styles.btnInline}`}
+                onClick={this.reloadPage}
+              >
+                Reload
+              </button>
+            </div>
+          </section>
+        </main>
+      );
+    }
+
+    return (
+      <React.Fragment key={this.state.remountCount}>
+        {this.props.children}
+      </React.Fragment>
+    );
+  }
+}

--- a/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.tsx
+++ b/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.tsx
@@ -48,7 +48,7 @@ export class DomRecoveryBoundary extends React.Component<
     }
   }
 
-  private readonly defaultReload = () => window.location.reload();
+  private readonly defaultReload = () => globalThis.location.reload();
 
   private readonly reloadPage = () => {
     (this.props.reloadPage ?? this.defaultReload)();

--- a/web/src/lib/isDomManipulationError.test.ts
+++ b/web/src/lib/isDomManipulationError.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { isDomManipulationError } from './isDomManipulationError';
+
+describe('isDomManipulationError', () => {
+  it('matches a NotFoundError DOMException', () => {
+    const error = new DOMException(
+      "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+      'NotFoundError'
+    );
+
+    expect(isDomManipulationError(error)).toBe(true);
+  });
+
+  it('matches a removeChild message even when the name differs', () => {
+    const error = new Error(
+      "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node."
+    );
+
+    expect(isDomManipulationError(error)).toBe(true);
+  });
+
+  it('does not match an ordinary render error', () => {
+    expect(isDomManipulationError(new Error('boom'))).toBe(false);
+  });
+
+  it('does not match non-error values', () => {
+    expect(isDomManipulationError(null)).toBe(false);
+    expect(isDomManipulationError('insertBefore')).toBe(false);
+    expect(isDomManipulationError(undefined)).toBe(false);
+  });
+});

--- a/web/src/lib/isDomManipulationError.ts
+++ b/web/src/lib/isDomManipulationError.ts
@@ -1,0 +1,26 @@
+const DOM_ERROR_MESSAGE_FRAGMENTS = [
+  "insertBefore' on 'Node'",
+  "removeChild' on 'Node'",
+  "appendChild' on 'Node'",
+  'is not a child of this node',
+];
+
+export function isDomManipulationError(error: unknown): boolean {
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+
+  const name = (error as { name?: unknown }).name;
+  if (name === 'NotFoundError' || name === 'HierarchyRequestError') {
+    return true;
+  }
+
+  const message = (error as { message?: unknown }).message;
+  if (typeof message !== 'string') {
+    return false;
+  }
+
+  return DOM_ERROR_MESSAGE_FRAGMENTS.some((fragment) =>
+    message.includes(fragment)
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-upload-page-stability.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-upload-page-stability.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-upload-page-stability",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Upload page recovers automatically when a browser extension interferes with it"
+}


### PR DESCRIPTION
## What
Wraps the `/upload` route in a `DomRecoveryBoundary` that contains the React white-screen crash caused by browser extensions mutating DOM nodes React owns. On a DOM-manipulation error (`NotFoundError` / `insertBefore` / `removeChild`), the boundary remounts the upload subtree once so the extension's stale nodes get rebuilt and the user never sees a crash. A second DOM failure or any non-DOM error falls back to a graceful reload prompt instead of a blank page.

## Why
Top prod error group by volume: `NotFoundError: Failed to execute 'insertBefore' on 'Node'` — 40 events (31 May–7 Jun), all anonymous Chrome/Windows, all on `/upload`, plus a sibling `removeChild` group (4 events). This is the classic React reconciliation crash when an extension (Google Translate, ad blockers, grammar tools) reorders DOM nodes between React's render and commit. We can't stop extensions; we can stop the white screen. The page is conversion-critical — anonymous visitors who hit a blank screen bounce before they ever upload.

No PII: the evidence is aggregate counts and an error class, no reporter identity.

## How
- `lib/isDomManipulationError.ts` — pure discriminator for `NotFoundError`/`HierarchyRequestError` and `insertBefore`/`removeChild`/`appendChild` messages.
- `components/DomRecoveryBoundary/` — class error boundary. `componentDidCatch` bumps a remount key (cap 1) on a DOM error and reports as recovered; otherwise renders the reload fallback and reports the error.
- `App.tsx` — the `/upload` element is wrapped, wiring `onError`/`onRecover` to the existing `reportClientError` (`/api/events/errors`) with `surface: 'upload'` context.

Note on React 19: transient render-phase errors are auto-recovered by React itself before any boundary lifecycle fires. The remount-once mechanism is for the production scenario — a commit-phase DOM-mutation error — which reliably triggers `componentDidCatch`. That commit-phase path is not faithfully reproducible in jsdom, so the recovery/cap logic is unit-tested via `shouldRemount` and by driving `componentDidCatch` directly; the persisting-error fallback and reporting are tested through React rendering.

No span-wrap shipped: the upload page's badge copy is already `<span>`-wrapped; the only residual triggers are whitespace `{' '}` text nodes across conditional branches, and rewrapping those is a broad refactor the boundary makes unnecessary.

## Measuring success
- Client error endpoint `/api/events/errors`: the `insertBefore`/`removeChild` `NotFoundError` group on `/upload` should drop, replaced by `recovered: true` events (`context.surface = 'upload'`, `context.recovered = true`) where the user silently continued.
- Funnel: upload-page bounce on the landing→upload step (read in `/api/ops/metrics`) should improve as anonymous Chrome/Windows visitors stop hitting the white screen.

## Testing
- Unit tests added: `isDomManipulationError` (4 cases — name match, message match, ordinary error, non-error input); `DomRecoveryBoundary` (`shouldRemount` cap/discrimination, healthy render, persisting-error fallback + `onError`, commit-phase remount-once + `onRecover`, fallback after second error, Reload button).
- Full web suite green: 1882 tests passed. Typecheck clean. Build succeeds.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: needs manual browser check before merge — no dev server was running on :3000 and the agent does not start one.

## Sonar
sonar-scanner not run locally — `SONAR_TOKEN` is unset in this environment. Expect the PR analysis to post via Automatic Analysis; resolve any new-code smells on the bounce.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-12-upload-page-stability.json` — "Upload page recovers automatically when a browser extension interferes with it"

## Risks
- The boundary only wraps `/upload`; other routes still crash on the same class. Scoped intentionally to the top error group; widen later if other pages show the same signal.
- If a real (non-extension) bug throws a DOM-manipulation error on `/upload`, the one remount may briefly hide it before the fallback shows — but it's still reported via `onError`, so visibility is preserved.
- Rollback: revert the PR; the boundary is additive and self-contained.

## Goal alignment
Acquisition/conversion. The white screen lands on anonymous visitors at the upload step — the exact moment a first-time user decides whether 2anki works. Removing it should lift the landing→upload conversion and reduce bounce, feeding the 300K-user goal. Metric: upload-page bounce (read in `/api/ops/metrics`), checked once the error group decays in the client error feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783862969&installation_id=132681956&pr_number=3287&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3287&signature=c017e9b48150804d0d3acb24ae631fa94ad1eb89dc37784ce738bbdfc43b22b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->