### PR TITLE
docs: warn against lint:fix in local pre-push hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Pricing v2 shipped 2026-06-10: $7.99/mo + $64/yr for new members, legacy $6/$60 
 ## Gotchas
 
 - **Stripe sync is manual only** — never put `updateStripeSubscriptions` on a cron or `setInterval`.
+- **The local git `pre-push` hook must NOT run `npm run lint:fix`.** `.git/hooks/` is untracked (never cloned), so this is per-machine. A `lint:fix` line there whole-tree-autofixes on every push, dirtying unrelated files (`DeckParser.ts`, `extractApkg.ts`, `UploadService.ts` recurred all session) whose fixes aren't staged and never ship — pure pollution that forces a `git checkout --` dance before each rebase/commit. Lint/format are already enforced non-destructively by CI (`pnpm lint` + `format:check`) and the Claude pre-push hooks (`oxfmt --check` / `oxlint` on changed files). If a fresh clone or teammate re-adds the `lint:fix` line, strip it.
 - **Never edit `src/data_layer/public/`** — Kanel-generated; rerun `pnpm kanel` instead.
 - Lead with the positive in `if/else` (`if (ready)` not `if (!ready)`) — Sonar S7735.
 - Use `value == null` to test "is the ID present?" — `!value` rejects falsy IDs like `0`.


### PR DESCRIPTION
## What

Document that the local git `pre-push` hook must not run `npm run lint:fix`.

## Why

The hook had a `npm run lint:fix` line that whole-tree-autofixed on every push. Its fixes weren't staged, so they never shipped — they just dirtied unrelated files (`DeckParser.ts`, `extractApkg.ts`, `UploadService.ts` recurred across a full session), forcing a `git checkout --` cleanup before every rebase/commit. It also violated the pnpm-only rule.

Lint/format are already enforced **non-destructively** elsewhere:
- CI: `pnpm lint` + `format:check`
- Claude pre-push hooks: `oxfmt --check` / `oxlint` on changed files only

`.git/hooks/` is untracked (git never clones hooks), so the actual line was removed on the local machine; this PR adds the durable rule to `CLAUDE.md` so a fresh clone or teammate knows to strip the line if it reappears.

## Scope

Docs only — one bullet in CLAUDE.md Gotchas. No code, no user-facing change, no changelog entry.

Browser check: not applicable — docs-only change, no rendered output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783874540&installation_id=132681956&pr_number=3303&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3303&signature=ead06a5bf3af8749cfe77b768f71b7fce71770ed07d253a090f3a3d80bd45e74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->