### PR TITLE
fix: quote ankify stats swagger description so the YAML parses

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -772,7 +772,7 @@ const AnkifyRouter = () => {
    * /api/ankify/stats:
    *   get:
    *     summary: Live study stats from the user's hosted Anki
-   *     description: Allowlisted endpoint. Pings AnkiConnect, then returns reviewed-today, the per-day review history, computed streaks, and per-deck backlog for the user's synced decks. Always 200 — returns { connected: false } when no active client exists or AnkiConnect is unreachable.
+   *     description: "Allowlisted endpoint. Pings AnkiConnect, then returns reviewed-today, the per-day review history, computed streaks, and per-deck backlog for the user's synced decks. Always 200 — returns connected: false when no active client exists or AnkiConnect is unreachable."
    *     tags: [Ankify]
    *     responses:
    *       200:


### PR DESCRIPTION
## What

Quotes the `description:` line in the `/api/ankify/stats` swagger JSDoc (`src/routes/AnkifyRouter.ts`).

## Why

Since #3301, every prod boot logs `YAMLSemanticError: Nested mappings are not allowed in compact mappings` — the unquoted description contains `connected: false`, which YAML parses as a nested mapping. The endpoint works; its swagger entry fails to parse. Spotted in the post-merge `/deploy-status` error log.

## Testing

Quoted string verified parseable with the project's `yaml` package; server tsc clean. Comment-only change — no behavior, no tests, no changelog entry (internal), Sonar skipped per the doc/typo exemption.

Browser check: not applicable — server-side comment-only change, no rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783874701&installation_id=132681956&pr_number=3304&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3304&signature=ff5177109f8485b6ee149e31885896711aee731399f03289b22820fa4c2b8bef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->