### PR TITLE
perf: skip re-uploading Ankify media already in the Anki collection

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -230,6 +230,24 @@ describe('AnkiConnectClient', () => {
     });
   });
 
+  test('getMediaFilesNames posts the action with the pattern and returns the names', async () => {
+    const fetchImpl = makeFetch({
+      result: ['ankify-a.png', 'ankify-b.jpg'],
+      error: null,
+    });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const names = await client.getMediaFilesNames('ankify-*');
+
+    expect(names).toEqual(['ankify-a.png', 'ankify-b.jpg']);
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'getMediaFilesNames',
+      version: 6,
+      params: { pattern: 'ankify-*' },
+    });
+  });
+
   test('getNumCardsReviewedToday posts the action and returns the count', async () => {
     const fetchImpl = makeFetch({ result: 42, error: null });
     const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -91,6 +91,10 @@ export class AnkiConnectClient {
     return this.invoke('modelFieldNames', { modelName });
   }
 
+  async getMediaFilesNames(pattern: string): Promise<string[]> {
+    return this.invoke('getMediaFilesNames', { pattern });
+  }
+
   async createModel(params: AnkiConnectCreateModelParams): Promise<unknown> {
     return this.invoke(
       'createModel',

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -164,6 +164,7 @@ const makeAnkiConnectStub = () =>
     updateNoteFields: jest.fn(async () => null),
     sync: jest.fn(async () => null),
     modelNames: jest.fn(async () => [] as string[]),
+    getMediaFilesNames: jest.fn(async () => [] as string[]),
     createModel: jest.fn(async (_p: unknown) => ({ id: 1 })),
     updateModelStyling: jest.fn(async () => null),
     updateModelTemplates: jest.fn(async () => null),
@@ -1521,6 +1522,184 @@ describe('SyncNotionPageToRacUseCase', () => {
       })
     );
     expect(ac.addNote).toHaveBeenCalled();
+  });
+
+  test('skips fetching and storing media already present in the Anki collection', async () => {
+    const sampleFetcher = jest.fn(async () => ({
+      status: 200,
+      data: Buffer.from('PNGDATA'),
+    }));
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [
+        sampleCard({
+          back: 'See <img src="ankify-already.png">',
+          media: [
+            {
+              block_id: 'already',
+              kind: 'image',
+              source: 'file',
+              url: 'https://prod-files.notion.so/already.png?signed=1',
+              filename: 'ankify-already.png',
+            },
+          ],
+        }),
+      ],
+      diagnostic: {
+        blocks_scanned: 1,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    (ac.getMediaFilesNames as jest.Mock).mockResolvedValue([
+      'ankify-already.png',
+    ]);
+
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      sampleFetcher
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'polling',
+    });
+
+    expect(ac.getMediaFilesNames).toHaveBeenCalledWith('ankify-*');
+    expect(sampleFetcher).not.toHaveBeenCalled();
+    expect(ac.storeMediaFile).not.toHaveBeenCalled();
+    expect(ac.addNote).toHaveBeenCalled();
+  });
+
+  test('fetches and stores media that is not yet in the Anki collection', async () => {
+    const sampleFetcher = jest.fn(async () => ({
+      status: 200,
+      data: Buffer.from('PNGDATA'),
+    }));
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [
+        sampleCard({
+          back: 'See <img src="ankify-new.png">',
+          media: [
+            {
+              block_id: 'new',
+              kind: 'image',
+              source: 'file',
+              url: 'https://prod-files.notion.so/new.png?signed=1',
+              filename: 'ankify-new.png',
+            },
+          ],
+        }),
+      ],
+      diagnostic: {
+        blocks_scanned: 1,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    (ac.getMediaFilesNames as jest.Mock).mockResolvedValue([
+      'ankify-something-else.png',
+    ]);
+
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      sampleFetcher
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'page-id',
+      trigger: 'polling',
+    });
+
+    expect(sampleFetcher).toHaveBeenCalledWith(
+      'https://prod-files.notion.so/new.png?signed=1'
+    );
+    expect(ac.storeMediaFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filename: 'ankify-new.png' })
+    );
+  });
+
+  test('falls back to fetching everything when getMediaFilesNames fails', async () => {
+    const sampleFetcher = jest.fn(async () => ({
+      status: 200,
+      data: Buffer.from('PNGDATA'),
+    }));
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [
+        sampleCard({
+          back: 'See <img src="ankify-fallback.png">',
+          media: [
+            {
+              block_id: 'fallback',
+              kind: 'image',
+              source: 'file',
+              url: 'https://prod-files.notion.so/fallback.png?signed=1',
+              filename: 'ankify-fallback.png',
+            },
+          ],
+        }),
+      ],
+      diagnostic: {
+        blocks_scanned: 1,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+    const repos = makeRepos();
+    const ac = makeAnkiConnectStub();
+    (ac.getMediaFilesNames as jest.Mock).mockRejectedValue(
+      new Error('unknown action getMediaFilesNames')
+    );
+
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      undefined,
+      sampleFetcher
+    );
+
+    const result = expectSyncResult(
+      await useCase.execute({
+        owner: 42,
+        notionPageId: 'page-id',
+        trigger: 'polling',
+      })
+    );
+
+    expect(sampleFetcher).toHaveBeenCalledWith(
+      'https://prod-files.notion.so/fallback.png?signed=1'
+    );
+    expect(ac.storeMediaFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filename: 'ankify-fallback.png' })
+    );
+    expect(result.created).toBe(1);
   });
 
   test('records sync_logs error but does not fail when image download fails', async () => {

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -120,6 +120,7 @@ export type NotionFetcherFactory = (
 
 const FRONT_FIELD_BASIC = 'Front';
 const BACK_FIELD_BASIC = 'Back';
+const ANKIFY_MEDIA_PATTERN = 'ankify-*';
 
 export interface AnkifyMediaResponse {
   status: number;
@@ -441,6 +442,8 @@ export class SyncNotionPageToRacUseCase {
     );
     await this.ensureModelsForOverrides(ac, client, overridesByPage);
 
+    const existingMediaNames = await this.loadExistingMediaNames(ac);
+
     for (const card of cards) {
       await this.processCard({
         card,
@@ -449,6 +452,7 @@ export class SyncNotionPageToRacUseCase {
         ac,
         input,
         result,
+        existingMediaNames,
         deckName: this.cardDeckName(parentDeckName, card),
         overrides: this.overridesForCard(
           overridesByPage,
@@ -709,16 +713,32 @@ export class SyncNotionPageToRacUseCase {
     }
   }
 
+  private async loadExistingMediaNames(
+    ac: AnkiConnectClient
+  ): Promise<Set<string>> {
+    try {
+      const names = await ac.getMediaFilesNames(ANKIFY_MEDIA_PATTERN);
+      return new Set(names);
+    } catch {
+      return new Set<string>();
+    }
+  }
+
   private async uploadCardMedia(
     ac: AnkiConnectClient,
     card: WalkedNotionFlashcard,
-    result: SyncNotionPageResult
+    result: SyncNotionPageResult,
+    existingMediaNames: Set<string>
   ): Promise<void> {
     for (const ref of card.media) {
       if (ref.filename == null) {
         continue;
       }
+      if (existingMediaNames.has(ref.filename)) {
+        continue;
+      }
       await this.uploadSingleMediaRef(ac, ref, result);
+      existingMediaNames.add(ref.filename);
     }
   }
 
@@ -809,6 +829,7 @@ export class SyncNotionPageToRacUseCase {
     ac: AnkiConnectClient;
     input: SyncNotionPageInput;
     result: SyncNotionPageResult;
+    existingMediaNames: Set<string>;
     deckName: string;
     overrides: AnkifyTemplateOverrides | null;
   }): Promise<void> {
@@ -819,11 +840,12 @@ export class SyncNotionPageToRacUseCase {
       ac,
       input,
       result,
+      existingMediaNames,
       deckName,
       overrides,
     } = args;
     try {
-      await this.uploadCardMedia(ac, card, result);
+      await this.uploadCardMedia(ac, card, result, existingMediaNames);
       const existing = await this.mappings.findBySourceId(
         client.id,
         card.notion_block_id


### PR DESCRIPTION
## What
Ankify's Notion→Anki sync previously re-fetched every media ref from Notion and re-ran `storeMediaFile` on every 5-minute poll tick, even when the file was already in the user's Anki media folder. This PR lists existing media once per sync run via AnkiConnect's `getMediaFilesNames` and skips the fetch + `storeMediaFile` for filenames already present.

## Why
Closes #3295. A lifetime Auto Sync user's prod logs showed the same ~17 images failing "AnkiConnect unreachable" on every tick for weeks — the loop re-uploaded unchanged media forever, and every redundant round-trip was another chance to hit an Anki-offline window and inflate the `ankify_sync_logs` error count. User-visible outcome: steady-state ticks stop re-uploading media that's already there, so the per-image error spam largely disappears.

## How
- Added `getMediaFilesNames(pattern)` to `AnkiConnectClient`, mirroring `modelNames` — invokes the `getMediaFilesNames` action with `{ pattern }` and returns `string[]`.
- `runSync` calls `loadExistingMediaNames(ac)` once (after model setup, before the per-card loop), building a `Set<string>` of present filenames, and threads it through `processCard` → `uploadCardMedia`.
- `uploadCardMedia` skips a ref whose filename is in the set; otherwise it fetches+stores as before and adds the filename to the set (so two cards referencing the same new image in one run only fetch once).
- If `getMediaFilesNames` throws (older AnkiConnect plugin without the action), `loadExistingMediaNames` returns an empty set and the sync falls back to fetching everything — the optimization never blocks a sync.

**Spec discrepancy worth flagging:** the issue says to match pattern `2anki-*` and asserts "our media filenames are content hashes, so present = identical; no staleness risk." In this code path the actual filenames are `ankify-<notionBlockId>.<ext>` (see `src/lib/notion-render/renderBlocks.ts` `buildMediaFilename`) — block-id-based, **not** content-addressed. So I used the pattern `ankify-*`, and the "present = identical" guarantee is per-block, not per-content. See Risks.

**Construction sites checked** (per first-time-fix rule): `new SyncNotionPageToRacUseCase` exists in `src/data_layer/index.ts` (the 5-min polling worker — the reporter's path), `src/routes/AnkifyRouter.ts` (manual sync), and `src/routes/AnkifyWebhookRouter.ts`. The change lives in the shared internal `runSync` path with no constructor-signature change, so all three sites get it without per-site wiring.

## Measuring success
Error-rate drop in `ankify_sync_logs` after deploy: the per-image AnkiConnect-unreachable / HTTP-error rows on steady-state polling ticks should fall sharply (the issue estimates ~90% fewer media round-trips on unchanged decks). Read via the `ankify_sync_logs` table / the Ankify ops view, comparing error rows per tick before vs after deploy for steady-state subscriptions.

## Testing
- Unit tests added:
  - `AnkiConnectClient.getMediaFilesNames posts the action with the pattern and returns the names`
  - `SyncNotionPageToRacUseCase`: skips fetching and storing media already present in the Anki collection
  - `SyncNotionPageToRacUseCase`: fetches and stores media that is not yet in the Anki collection
  - `SyncNotionPageToRacUseCase`: falls back to fetching everything when getMediaFilesNames fails
- AnkiConnect is mocked only at the external HTTP boundary (`fetch`) and as a client stub; internal collaborators run for real.
- `pnpm test` on both touched files: 61 passing. Server `tsc --noEmit`: clean. `oxlint` / `oxfmt --check` on changed files: clean (the one oxlint warning on line 280 is pre-existing, outside the diff).
- `sonar-scanner` not run locally — not installed on this machine. Expect a possible Sonar pass on CI; the change is small and adds no new HTTP/HTML/zip/path-from-input surface.

## Browser check
Browser check: not applicable — server-only change, no rendered output

## Changelog
No entry — internal sync optimization, no user-visible behavior change. The user perceives fewer transient sync errors, but there is no new capability or UI surface to announce.

## Risks
- **External-API integration** (AnkiConnect + Notion) — please run `/security-review` before merge. No new user-controlled URL or HTML sink is introduced; the pattern string is a fixed constant.
- **Staleness on re-edited images:** because filenames are `ankify-<blockId>.<ext>` (block-id-based, not content-hash-based), if a user *replaces* the image inside an existing Notion image block — same block id, new content — the new bytes will be skipped as "already present" and the card keeps the old image until that filename leaves the collection. The issue's "no staleness risk" claim rests on a content-hash assumption that doesn't hold for this path. The net win (killing the per-tick re-upload spam) is large and this edge is narrow; flagging so a reviewer can decide whether to scope a follow-up (e.g. content-hashed filenames) rather than silently accept it. Rollback: revert this PR — behavior returns to fetching every ref every tick.

## Goal alignment
Retention-side quality on the $30/mo Auto Sync surface — fewer phantom sync errors for a paying lifetime user who reported this. Metric: error-rate drop in `ankify_sync_logs` after deploy. No acquisition/funnel impact — internal reliability.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2anki/codesmith/server/pr/3306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783875498&installation_id=132681956&pr_number=3306&repository=2anki%2Fserver&return_to=https%3A%2F%2Fgithub.com%2F2anki%2Fserver%2Fpull%2F3306&signature=6829c572fb062e177052215425a37825499cd8095f8f01f42871660e70f362a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->