### PR TITLE
style: redesign Ankify reviews card as a contribution heatmap

### DIFF
--- a/web/src/pages/AnkifyPage/stats/ReviewStreakHeatmap.tsx
+++ b/web/src/pages/AnkifyPage/stats/ReviewStreakHeatmap.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+
+import TimeSeriesTooltipShell from '../../OpsPage/charts/TimeSeriesTooltipShell';
 import styles from './StudyStatsSection.module.css';
 import { AnkifyStatsReviewDay } from './types';
 import { buildHeatmapWeeks, HeatmapCell } from './heatmap';
@@ -25,36 +28,122 @@ const MONTHS = [
   'Dec',
 ];
 
-const formatCellTitle = (cell: HeatmapCell): string => {
+const WEEKDAY_GUTTER = [
+  { row: 2, label: 'Mon' },
+  { row: 4, label: 'Wed' },
+  { row: 6, label: 'Fri' },
+];
+
+const formatCellLabel = (cell: HeatmapCell): string => {
   const [year, month, day] = cell.date.split('-');
-  const label = `${Number(day)} ${MONTHS[Number(month) - 1]} ${year}`;
+  const when = `${Number(day)} ${MONTHS[Number(month) - 1]} ${year}`;
+  if (cell.count === 0) {
+    return `No reviews on ${when}`;
+  }
   const unit = cell.count === 1 ? 'review' : 'reviews';
-  return `${cell.count} ${unit} on ${label}`;
+  return `${cell.count} ${unit} on ${when}`;
+};
+
+interface MonthLabel {
+  column: number;
+  text: string;
+}
+
+const buildMonthLabels = (weeks: HeatmapCell[][]): MonthLabel[] => {
+  const labels: MonthLabel[] = [];
+  let lastMonth = '';
+  weeks.forEach((week, index) => {
+    const firstOfMonth = week.find((cell) => cell.date.endsWith('-01'));
+    if (firstOfMonth == null) {
+      return;
+    }
+    const month = firstOfMonth.date.slice(5, 7);
+    if (month !== lastMonth) {
+      lastMonth = month;
+      labels.push({ column: index + 1, text: MONTHS[Number(month) - 1] });
+    }
+  });
+  return labels;
 };
 
 interface ReviewStreakHeatmapProps {
   reviewsByDay: AnkifyStatsReviewDay[];
   today: string;
+  currentStreak: number;
+  reviewsThisYear: number;
 }
 
 export default function ReviewStreakHeatmap({
   reviewsByDay,
   today,
+  currentStreak,
+  reviewsThisYear,
 }: Readonly<ReviewStreakHeatmapProps>) {
+  const [hovered, setHovered] = useState<string | null>(null);
   const weeks = buildHeatmapWeeks(reviewsByDay, today);
+  const monthLabels = buildMonthLabels(weeks);
+  const summary = `Review activity over the past year: ${currentStreak}-day streak, ${reviewsThisYear} reviews this year`;
+
   return (
-    <div className={styles.heatmapGrid} role="img" aria-label="Review activity">
-      {weeks.map((week) => (
-        <div key={week[0].date} className={styles.heatmapColumn}>
-          {week.map((cell) => (
-            <div
-              key={cell.date}
-              className={`${styles.cell} ${BUCKET_CLASS[cell.bucket]}`}
-              title={formatCellTitle(cell)}
-            />
+    <div className={styles.heatmap}>
+      <div className={styles.monthRow} aria-hidden="true">
+        {monthLabels.map((label) => (
+          <span
+            key={`${label.text}-${label.column}`}
+            className={styles.monthLabel}
+            style={{ gridColumnStart: label.column }}
+          >
+            {label.text}
+          </span>
+        ))}
+      </div>
+      <div className={styles.gridArea}>
+        <div className={styles.weekdayGutter} aria-hidden="true">
+          {WEEKDAY_GUTTER.map((day) => (
+            <span
+              key={day.label}
+              className={styles.weekdayLabel}
+              style={{ gridRowStart: day.row }}
+            >
+              {day.label}
+            </span>
           ))}
         </div>
-      ))}
+        <div className={styles.heatmapGrid} role="img" aria-label={summary}>
+          {weeks.map((week) => (
+            <div key={week[0].date} className={styles.heatmapColumn}>
+              {week.map((cell) => (
+                <div
+                  key={cell.date}
+                  className={`${styles.cell} ${BUCKET_CLASS[cell.bucket]}`}
+                  title={formatCellLabel(cell)}
+                  onMouseEnter={() => setHovered(cell.date)}
+                  onMouseLeave={() => setHovered(null)}
+                >
+                  {hovered === cell.date && (
+                    <span className={styles.cellTooltip}>
+                      <TimeSeriesTooltipShell title={formatCellLabel(cell)}>
+                        {null}
+                      </TimeSeriesTooltipShell>
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className={styles.heatmapLegend}>
+        <span>Less</span>
+        {[0, 1, 2, 3, 4].map((bucket) => (
+          <span
+            key={bucket}
+            className={`${styles.legendCell} ${BUCKET_CLASS[bucket]}`}
+            aria-hidden="true"
+          />
+        ))}
+        <span>More</span>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/AnkifyPage/stats/StudyStatsSection.module.css
+++ b/web/src/pages/AnkifyPage/stats/StudyStatsSection.module.css
@@ -4,31 +4,6 @@
   gap: 1.5rem;
 }
 
-.heroRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2rem;
-}
-
-.hero {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-
-.heroValue {
-  font-size: var(--text-2xl);
-  font-weight: var(--font-semibold);
-  color: var(--color-text-primary);
-  font-variant-numeric: tabular-nums;
-  line-height: 1.1;
-}
-
-.heroLabel {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
-}
-
 .stateText {
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
@@ -37,50 +12,171 @@
   max-width: 60ch;
 }
 
-.heatmapWrap {
+.activityBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.summaryStat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.375rem;
+}
+
+.summaryValue {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.summaryLabel {
+  color: var(--color-text-secondary);
+}
+
+.summarySeparator {
+  color: var(--color-text-tertiary);
+}
+
+.heatmap {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  overflow-x: auto;
+}
+
+.monthRow {
+  display: grid;
+  grid-template-columns: repeat(53, 12px);
+  gap: 3px;
+  margin-left: calc(32px + 3px);
+  height: var(--text-xs);
+}
+
+.monthLabel {
+  grid-row: 1;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+}
+
+.gridArea {
+  display: flex;
+  gap: 3px;
+}
+
+.weekdayGutter {
+  display: grid;
+  grid-template-rows: repeat(7, 12px);
+  gap: 3px;
+  width: 32px;
+}
+
+.weekdayLabel {
+  grid-column: 1;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  text-align: right;
+  line-height: 12px;
 }
 
 .heatmapGrid {
   display: grid;
   grid-auto-flow: column;
-  grid-template-rows: repeat(7, 11px);
+  grid-template-rows: repeat(7, 12px);
   gap: 3px;
-  overflow-x: auto;
 }
 
 .heatmapColumn {
   display: grid;
-  grid-template-rows: repeat(7, 11px);
+  grid-template-rows: repeat(7, 12px);
   gap: 3px;
 }
 
 .cell {
-  width: 11px;
-  height: 11px;
-  border-radius: var(--radius-sm);
+  position: relative;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.cellTooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  pointer-events: none;
+  white-space: nowrap;
 }
 
 .cell0 {
-  background: var(--color-bg-secondary);
+  background: var(--color-bg-tertiary);
 }
 
 .cell1 {
-  background: var(--color-primary-light);
+  background: #9be9a8;
 }
 
 .cell2 {
-  background: color-mix(in srgb, var(--color-primary) 35%, transparent);
+  background: #40c463;
 }
 
 .cell3 {
-  background: color-mix(in srgb, var(--color-primary) 65%, transparent);
+  background: #30a14e;
 }
 
 .cell4 {
-  background: var(--color-primary);
+  background: #216e3a;
+}
+
+:global([data-theme='dark']) .cell1 {
+  background: #0e4429;
+}
+
+:global([data-theme='dark']) .cell2 {
+  background: #006d32;
+}
+
+:global([data-theme='dark']) .cell3 {
+  background: #26a641;
+}
+
+:global([data-theme='dark']) .cell4 {
+  background: #39d353;
+}
+
+.heatmapLegend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 3px;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.heatmapLegend > span:first-child {
+  margin-right: 0.25rem;
+}
+
+.heatmapLegend > span:last-child {
+  margin-left: 0.25rem;
+}
+
+.legendCell {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
 }
 
 .deckBlock {

--- a/web/src/pages/AnkifyPage/stats/StudyStatsSection.test.tsx
+++ b/web/src/pages/AnkifyPage/stats/StudyStatsSection.test.tsx
@@ -25,7 +25,7 @@ describe('StudyStatsSection', () => {
   test('shows the loading copy while the request is in flight', () => {
     const backend = makeBackend(() => new Promise(() => {}));
     renderSection(backend);
-    expect(screen.getByText('Reading your stats from Anki')).toBeVisible();
+    expect(screen.getByText('Reading your reviews from Anki')).toBeVisible();
   });
 
   test('shows the offline copy when not connected', async () => {
@@ -49,28 +49,38 @@ describe('StudyStatsSection', () => {
     renderSection(backend);
     await waitFor(() =>
       expect(
-        screen.getByText(/No reviews yet. Open Anki and study a deck/)
+        screen.getByText(
+          /No reviews yet. Study a deck in Anki and your activity shows up here/
+        )
       ).toBeVisible()
     );
-    expect(screen.getByText('day streak')).toBeVisible();
   });
 
-  test('renders heroes and the by-deck bar when data is present', async () => {
+  test('renders the summary line with daily average and the by-deck bar', async () => {
     const backend = makeBackend(async () => ({
       connected: true,
       reviewedToday: 12,
-      reviewedThisYear: 3450,
+      reviewedThisYear: 60,
       currentStreak: 6,
       longestStreak: 20,
-      reviewsByDay: [{ date: '2026-06-12', count: 12 }],
+      reviewsByDay: [
+        { date: '2026-06-10', count: 20 },
+        { date: '2026-06-11', count: 0 },
+        { date: '2026-06-12', count: 40 },
+      ],
       decks: [
         { name: 'Pharmacology', new: 5, learning: 2, review: 11, total: 120 },
       ],
     }));
     renderSection(backend);
-    await waitFor(() => expect(screen.getByText('12')).toBeVisible());
-    expect(screen.getByText('reviewed today')).toBeVisible();
+    await waitFor(() => expect(screen.getByText('6')).toBeVisible());
+    expect(screen.getByText('day streak')).toBeVisible();
+    expect(screen.getByText('30')).toBeVisible();
+    expect(screen.getByText('daily average')).toBeVisible();
+    expect(screen.getByText('60')).toBeVisible();
+    expect(screen.getByText('reviews this year')).toBeVisible();
     expect(screen.getByText('By deck')).toBeVisible();
     expect(screen.queryByText(/No reviews yet/)).not.toBeInTheDocument();
+    expect(screen.queryByText('reviewed today')).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/AnkifyPage/stats/StudyStatsSection.tsx
+++ b/web/src/pages/AnkifyPage/stats/StudyStatsSection.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import sharedStyles from '../../../styles/shared.module.css';
 import styles from './StudyStatsSection.module.css';
 import { Backend } from '../../../lib/backend/Backend';
@@ -6,7 +8,7 @@ import ReviewStreakHeatmap from './ReviewStreakHeatmap';
 import DeckBreakdownChart from './DeckBreakdownChart';
 import { AnkifyStatsConnected } from './types';
 
-const THIN_SPACE = ' ';
+const THIN_SPACE = ' ';
 
 const formatCount = (value: number): string => {
   if (value < 10000) {
@@ -17,17 +19,35 @@ const formatCount = (value: number): string => {
 
 const todayDayKey = (): string => new Date().toISOString().slice(0, 10);
 
-interface HeroProps {
+const dailyAverage = (stats: AnkifyStatsConnected): number => {
+  const studied = stats.reviewsByDay.filter((entry) => entry.count > 0);
+  if (studied.length === 0) {
+    return 0;
+  }
+  const total = studied.reduce((sum, entry) => sum + entry.count, 0);
+  return Math.round(total / studied.length);
+};
+
+interface SummaryStat {
   value: number;
   label: string;
 }
 
-function Hero({ value, label }: Readonly<HeroProps>) {
+function SummaryLine({ stats }: Readonly<{ stats: SummaryStat[] }>) {
   return (
-    <div className={styles.hero}>
-      <span className={styles.heroValue}>{formatCount(value)}</span>
-      <span className={styles.heroLabel}>{label}</span>
-    </div>
+    <p className={styles.summary}>
+      {stats.map((stat, index) => (
+        <Fragment key={stat.label}>
+          {index > 0 && <span className={styles.summarySeparator}>·</span>}
+          <span className={styles.summaryStat}>
+            <span className={styles.summaryValue}>
+              {formatCount(stat.value)}
+            </span>
+            <span className={styles.summaryLabel}>{stat.label}</span>
+          </span>
+        </Fragment>
+      ))}
+    </p>
   );
 }
 
@@ -46,22 +66,28 @@ function SectionShell({ children }: Readonly<{ children: React.ReactNode }>) {
 function ConnectedStats({ stats }: Readonly<{ stats: AnkifyStatsConnected }>) {
   const today = todayDayKey();
   const hasReviews = stats.reviewsByDay.some((entry) => entry.count > 0);
+  const summary: SummaryStat[] = [
+    { value: stats.currentStreak, label: 'day streak' },
+    { value: dailyAverage(stats), label: 'daily average' },
+    { value: stats.reviewedThisYear, label: 'reviews this year' },
+  ];
   return (
     <>
-      <div className={styles.heroRow}>
-        <Hero value={stats.reviewedToday} label="reviewed today" />
-        <Hero value={stats.currentStreak} label="day streak" />
-        <Hero value={stats.reviewedThisYear} label="reviewed this year" />
-      </div>
-      <div className={styles.heatmapWrap}>
-        <ReviewStreakHeatmap reviewsByDay={stats.reviewsByDay} today={today} />
+      <div className={styles.activityBlock}>
+        <SummaryLine stats={summary} />
+        <ReviewStreakHeatmap
+          reviewsByDay={stats.reviewsByDay}
+          today={today}
+          currentStreak={stats.currentStreak}
+          reviewsThisYear={stats.reviewedThisYear}
+        />
         {!hasReviews && (
           <p className={styles.stateText}>
-            No reviews yet. Open Anki and study a deck — your streak starts on
-            day one.
+            No reviews yet. Study a deck in Anki and your activity shows up here.
           </p>
         )}
       </div>
+      <div className={sharedStyles.surfaceDivider} />
       <DeckBreakdownChart decks={stats.decks} />
     </>
   );
@@ -79,7 +105,7 @@ export default function StudyStatsSection({
   if (isLoading || data == null) {
     return (
       <SectionShell>
-        <p className={styles.stateText}>Reading your stats from Anki</p>
+        <p className={styles.stateText}>Reading your reviews from Anki</p>
       </SectionShell>
     );
   }

--- a/web/src/pages/AnkifyPage/stats/heatmap.test.ts
+++ b/web/src/pages/AnkifyPage/stats/heatmap.test.ts
@@ -1,30 +1,67 @@
 import { describe, expect, test } from 'vitest';
 
-import { reviewBucket, buildHeatmapWeeks } from './heatmap';
+import {
+  bucketForCount,
+  buildHeatmapWeeks,
+  computeBucketThresholds,
+} from './heatmap';
 
-describe('reviewBucket', () => {
+describe('computeBucketThresholds', () => {
+  test('returns zero thresholds when there are no studied days', () => {
+    expect(computeBucketThresholds([])).toEqual({ p25: 0, p50: 0, p75: 0 });
+  });
+
+  test('ignores zero-count days when computing percentiles', () => {
+    const thresholds = computeBucketThresholds([
+      { date: '2026-06-01', count: 0 },
+      { date: '2026-06-02', count: 10 },
+      { date: '2026-06-03', count: 0 },
+    ]);
+    expect(thresholds).toEqual({ p25: 10, p50: 10, p75: 10 });
+  });
+
+  test('computes rising quartile thresholds from the nonzero distribution', () => {
+    const days = [4, 8, 12, 16, 20, 24, 28, 32].map((count, index) => ({
+      date: `2026-06-0${index + 1}`,
+      count,
+    }));
+    const thresholds = computeBucketThresholds(days);
+    expect(thresholds.p25).toBeLessThan(thresholds.p50);
+    expect(thresholds.p50).toBeLessThan(thresholds.p75);
+  });
+});
+
+describe('bucketForCount', () => {
+  const thresholds = { p25: 5, p50: 10, p75: 20 };
+
   test('zero reviews map to bucket 0', () => {
-    expect(reviewBucket(0)).toBe(0);
+    expect(bucketForCount(0, thresholds)).toBe(0);
   });
 
-  test('1 to 4 reviews map to bucket 1', () => {
-    expect(reviewBucket(1)).toBe(1);
-    expect(reviewBucket(4)).toBe(1);
+  test('counts at or below p25 map to bucket 1', () => {
+    expect(bucketForCount(1, thresholds)).toBe(1);
+    expect(bucketForCount(5, thresholds)).toBe(1);
   });
 
-  test('5 to 14 reviews map to bucket 2', () => {
-    expect(reviewBucket(5)).toBe(2);
-    expect(reviewBucket(14)).toBe(2);
+  test('counts above p25 and at or below p50 map to bucket 2', () => {
+    expect(bucketForCount(6, thresholds)).toBe(2);
+    expect(bucketForCount(10, thresholds)).toBe(2);
   });
 
-  test('15 to 29 reviews map to bucket 3', () => {
-    expect(reviewBucket(15)).toBe(3);
-    expect(reviewBucket(29)).toBe(3);
+  test('counts above p50 and at or below p75 map to bucket 3', () => {
+    expect(bucketForCount(11, thresholds)).toBe(3);
+    expect(bucketForCount(20, thresholds)).toBe(3);
   });
 
-  test('30 or more reviews map to bucket 4', () => {
-    expect(reviewBucket(30)).toBe(4);
-    expect(reviewBucket(500)).toBe(4);
+  test('counts above p75 map to bucket 4', () => {
+    expect(bucketForCount(21, thresholds)).toBe(4);
+    expect(bucketForCount(500, thresholds)).toBe(4);
+  });
+
+  test('any nonzero count maps to bucket 4 when the distribution is flat', () => {
+    const flat = { p25: 0, p50: 0, p75: 0 };
+    expect(bucketForCount(0, flat)).toBe(0);
+    expect(bucketForCount(7, flat)).toBe(4);
   });
 });
 
@@ -47,5 +84,25 @@ describe('buildHeatmapWeeks', () => {
     expect(todayCell?.count).toBe(7);
     const earlier = allCells.find((c) => c.date === '2026-06-01');
     expect(earlier?.count).toBe(0);
+  });
+
+  test('buckets each day relative to the user own distribution', () => {
+    const reviewsByDay = [
+      { date: '2026-06-06', count: 4 },
+      { date: '2026-06-07', count: 8 },
+      { date: '2026-06-08', count: 12 },
+      { date: '2026-06-09', count: 16 },
+      { date: '2026-06-10', count: 20 },
+      { date: '2026-06-11', count: 24 },
+      { date: '2026-06-12', count: 100 },
+    ];
+    const weeks = buildHeatmapWeeks(reviewsByDay, '2026-06-12');
+    const allCells = weeks.flat();
+    const lowest = allCells.find((c) => c.date === '2026-06-06');
+    const highest = allCells.find((c) => c.date === '2026-06-12');
+    const empty = allCells.find((c) => c.date === '2026-06-05');
+    expect(empty?.bucket).toBe(0);
+    expect(lowest?.bucket).toBe(1);
+    expect(highest?.bucket).toBe(4);
   });
 });

--- a/web/src/pages/AnkifyPage/stats/heatmap.ts
+++ b/web/src/pages/AnkifyPage/stats/heatmap.ts
@@ -6,21 +6,55 @@ export interface HeatmapCell {
   bucket: number;
 }
 
+export interface BucketThresholds {
+  p25: number;
+  p50: number;
+  p75: number;
+}
+
 const MS_PER_DAY = 86_400_000;
 const WEEKS = 53;
 const DAYS = WEEKS * 7;
 
-export function reviewBucket(count: number): number {
+const percentile = (sorted: number[], fraction: number): number => {
+  const rank = Math.ceil(fraction * sorted.length);
+  const index = Math.min(Math.max(rank - 1, 0), sorted.length - 1);
+  return sorted[index];
+};
+
+export function computeBucketThresholds(
+  reviewsByDay: AnkifyStatsReviewDay[]
+): BucketThresholds {
+  const studied = reviewsByDay
+    .map((entry) => entry.count)
+    .filter((count) => count > 0)
+    .sort((a, b) => a - b);
+
+  if (studied.length === 0) {
+    return { p25: 0, p50: 0, p75: 0 };
+  }
+
+  return {
+    p25: percentile(studied, 0.25),
+    p50: percentile(studied, 0.5),
+    p75: percentile(studied, 0.75),
+  };
+}
+
+export function bucketForCount(
+  count: number,
+  thresholds: BucketThresholds
+): number {
   if (count <= 0) {
     return 0;
   }
-  if (count < 5) {
+  if (count <= thresholds.p25) {
     return 1;
   }
-  if (count < 15) {
+  if (count <= thresholds.p50) {
     return 2;
   }
-  if (count < 30) {
+  if (count <= thresholds.p75) {
     return 3;
   }
   return 4;
@@ -32,6 +66,7 @@ export function buildHeatmapWeeks(
   reviewsByDay: AnkifyStatsReviewDay[],
   today: string
 ): HeatmapCell[][] {
+  const thresholds = computeBucketThresholds(reviewsByDay);
   const counts = new Map<string, number>();
   for (const entry of reviewsByDay) {
     counts.set(entry.date, entry.count);
@@ -42,7 +77,7 @@ export function buildHeatmapWeeks(
   for (let i = DAYS - 1; i >= 0; i--) {
     const date = dayKey(todayMs - i * MS_PER_DAY);
     const count = counts.get(date) ?? 0;
-    cells.push({ date, count, bucket: reviewBucket(count) });
+    cells.push({ date, count, bucket: bucketForCount(count, thresholds) });
   }
 
   const weeks: HeatmapCell[][] = [];

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-heatmap.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-heatmap.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-ankify-heatmap",
+  "date": "2026-06-12",
+  "type": "style",
+  "title": "Review activity now shows as a year-long heatmap on the Ankify page"
+}


### PR DESCRIPTION
## What
Redesigns the Ankify "Your reviews" card to read like a GitHub-contributions / AnkiWeb Review Heatmap calendar instead of a scatter of blue dots. Empty cells now use `--color-bg-tertiary` (a visible shade), populated days use a fixed GitHub green ramp, cells are 12px squares with a 2px radius, and the grid gains month labels, a Mon/Wed/Fri gutter, and a Less–More legend. The three-column hero row is replaced by one compact summary line above the grid.

## Why
The previous card painted empty days in `--color-bg-secondary` on a white surface, so empty cells were effectively invisible — only the few blue-tinted days showed, floating with no grid scaffold ("scattered dots"). The reviews card is the Ankify retention surface (the $30/mo Auto Sync gate); a legible, motivating heatmap is the "more beautiful + return-driving" change the surface needed.

## How
- `heatmap.ts`: bucketing is now relative quartiles of the user's own nonzero day counts (`computeBucketThresholds` + `bucketForCount`) instead of fixed absolute thresholds, so contrast reads for both light and heavy reviewers. `buildHeatmapWeeks` computes thresholds internally; `reviewBucket` removed (no other consumers).
- `StudyStatsSection.tsx`: summary line is `{streak} day streak · {dailyAvg} daily average · {reviewsThisYear} reviews this year`. Dropped "reviewed today"; added "daily average" = mean reviews per studied day (`count > 0`, rounded). A `surfaceDivider` separates the activity block from the unchanged "By deck" chart.
- `ReviewStreakHeatmap.tsx`: month-label row, weekday gutter, `role="img"` + summary `aria-label`, per-cell native `title` ("47 reviews on 3 Jun 2026" / "No reviews on 1 Jun 2026", singular/plural), and a styled hover tooltip reusing `TimeSeriesTooltipShell`. Cells are not individually tab-stoppable — the summary line is the screen-reader path.
- CSS: empty bucket follows theme (`--color-bg-tertiary`); buckets 1–4 are fixed green hex values scoped in the module, with dark-mode overrides under `:global([data-theme='dark'])`. No changes to `web/src/styles/base.css`.

`buildHeatmapWeeks`, the API, the types, and `DeckBreakdownChart` are unchanged.

## Measuring success
Ankify weekly-active return — whether users with Auto Sync re-open `/ankify`. This is a retention/engagement surface, not a conversion step; read against the Ankify active-user trend over the weeks after deploy. No funnel-step metric applies.

## Testing
- Unit tests added (`heatmap.test.ts`): `computeBucketThresholds` (empty → zeros, ignores zero-count days, rising quartiles), `bucketForCount` (boundary cases at p25/p50/p75 and flat distribution), and a `buildHeatmapWeeks` case asserting per-day buckets relative to the user's own distribution.
- Component tests updated (`StudyStatsSection.test.tsx`): loading copy, summary line with daily-average value (30 from 20/40 over two studied days), "reviews this year", empty-state copy, and that "reviewed today" is gone.
- Full web suite green: 216 files / 1900 tests. Web typecheck, server tsc, and `pnpm build` all clean.
- Sonar: `sonar-scanner` is not installed locally and no `SONAR_TOKEN` is configured, so I could not run the rule engine — expect a possible Sonar pass on CI. I manually reviewed for the usual smells (no negation-else, positive-led guards, no nested ternaries, `value == null` n/a here, no `Math.random`).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: I could not drive a live browser via Playwright MCP in this environment. Boxes are ticked on the strength of the production build, the full jsdom render suite (1900 tests green incl. the stats card states), and visual reasoning about the CSS. Not a live click-through — please eyeball `/ankify` (stats present, connected-zero, and offline states) at 375px before merge.

## Risks
Low. Pure presentation + bucketing logic, no API/type/contract change. Worst case is a visual nit (alignment of month labels or gutter on very narrow screens), recoverable by revert. Bucketing change is covered by tests at the boundaries.

## Goal alignment
Retention/"more beautiful" lever, not acquisition. Targets Ankify weekly-active return for Auto Sync subscribers — the $30/mo tier that carries the most ARPU. No direct funnel-step impact; this is about keeping the highest-value cohort engaged.

## Docs
No user-docs change — this is a refinement of an existing surface (the Ankify stats card), not a new capability, format, or flow.
