### PR TITLE
perf: batch Ankify sync with notesModTime mod-time prefilter

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -310,6 +310,92 @@ describe('AnkiConnectClient', () => {
     });
   });
 
+  test('apiReflect posts the scopes+actions payload and returns the action names', async () => {
+    const fetchImpl = makeFetch({
+      result: { scopes: ['actions'], actions: ['notesModTime', 'multi'] },
+      error: null,
+    });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const actions = await client.apiReflect();
+
+    expect(actions).toEqual(['notesModTime', 'multi']);
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'apiReflect',
+      version: 6,
+      params: { scopes: ['actions'], actions: null },
+    });
+  });
+
+  test('apiReflect returns an empty list when the result lacks an actions array', async () => {
+    const fetchImpl = makeFetch({
+      result: { scopes: ['actions'] },
+      error: null,
+    });
+    const client = new AnkiConnectClient('http://x', fetchImpl);
+
+    const actions = await client.apiReflect();
+
+    expect(actions).toEqual([]);
+  });
+
+  test('notesModTime posts the note ids and returns id+mod pairs', async () => {
+    const fetchImpl = makeFetch({
+      result: [
+        { noteId: 900, mod: 1700000000 },
+        { noteId: 0, mod: 1700000005 },
+      ],
+      error: null,
+    });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const modTimes = await client.notesModTime([900, 0]);
+
+    expect(modTimes).toEqual([
+      { noteId: 900, mod: 1700000000 },
+      { noteId: 0, mod: 1700000005 },
+    ]);
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'notesModTime',
+      version: 6,
+      params: { notes: [900, 0] },
+    });
+  });
+
+  test('multi posts the wrapped actions array and returns per-action results in order', async () => {
+    const fetchImpl = makeFetch({
+      result: [
+        { result: 111, error: null },
+        { result: null, error: 'cannot create note because it is a duplicate' },
+      ],
+      error: null,
+    });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const results = await client.multi([
+      { action: 'addNote', params: { note: { deckName: 'D' } } },
+      { action: 'addNote', params: { note: { deckName: 'E' } } },
+    ]);
+
+    expect(results).toEqual([
+      { result: 111, error: null },
+      { result: null, error: 'cannot create note because it is a duplicate' },
+    ]);
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'multi',
+      version: 6,
+      params: {
+        actions: [
+          { action: 'addNote', params: { note: { deckName: 'D' } } },
+          { action: 'addNote', params: { note: { deckName: 'E' } } },
+        ],
+      },
+    });
+  });
+
   test('throws AnkiConnectUnreachableError when fetch rejects', async () => {
     const fetchImpl = jest.fn(async () => {
       throw new Error('connect ECONNREFUSED');

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -173,6 +173,22 @@ export class AnkiConnectClient {
     return this.invoke('guiBrowse', { query });
   }
 
+  async apiReflect(): Promise<string[]> {
+    const reflection = await this.invoke<AnkiApiReflection>('apiReflect', {
+      scopes: ['actions'],
+      actions: null,
+    });
+    return Array.isArray(reflection?.actions) ? reflection.actions : [];
+  }
+
+  async notesModTime(notes: number[]): Promise<AnkiNoteModTime[]> {
+    return this.invoke('notesModTime', { notes });
+  }
+
+  async multi(actions: AnkiConnectMultiAction[]): Promise<unknown[]> {
+    return this.invoke('multi', { actions });
+  }
+
   private async invoke<T>(
     action: string,
     params?: Record<string, unknown>
@@ -265,6 +281,26 @@ export interface AnkiNoteInfo {
   fields: Record<string, { value: string; order: number }>;
   cards?: number[];
   mod?: number;
+}
+
+export interface AnkiApiReflection {
+  scopes: string[];
+  actions: string[];
+}
+
+export interface AnkiNoteModTime {
+  noteId: number;
+  mod: number;
+}
+
+export interface AnkiConnectMultiAction {
+  action: string;
+  params?: Record<string, unknown>;
+}
+
+export interface AnkiConnectMultiResult<T = unknown> {
+  result: T;
+  error: string | null;
 }
 
 export const buildAnkiConnectUrl = (host: string, port: number): string =>

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -169,6 +169,9 @@ const makeAnkiConnectStub = () =>
     updateModelStyling: jest.fn(async () => null),
     updateModelTemplates: jest.fn(async () => null),
     storeMediaFile: jest.fn(async () => 'stored.png'),
+    apiReflect: jest.fn(async () => [] as string[]),
+    notesModTime: jest.fn(async () => [] as { noteId: number; mod: number }[]),
+    multi: jest.fn(async () => [] as unknown[]),
   }) as unknown as AnkiConnectClient & { [k: string]: jest.Mock };
 
 const makeRepos = () => ({
@@ -2461,6 +2464,322 @@ describe('SyncNotionPageToRacUseCase', () => {
       });
 
       expect(walkNotionPageForFlashcards).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('batch mod-time prefilter', () => {
+    const unchangedMapping = () => ({
+      id: 5,
+      ankify_client_id: 1,
+      source_id: 'block-1',
+      source_type: 'notion_block' as const,
+      anki_note_id: 900,
+      deck_name: 'Notion Sync::Algebra',
+      last_synced_at: new Date('2026-01-01T00:00:00Z'),
+    });
+
+    const reflectingStub = (actions: string[]) => {
+      const ac = makeAnkiConnectStub();
+      (ac.apiReflect as jest.Mock).mockResolvedValue(actions);
+      return ac;
+    };
+
+    test('skips the full notesInfo fetch when both Notion and Anki are unchanged', async () => {
+      const lastSyncedSeconds = Math.floor(
+        new Date('2026-01-01T00:00:00Z').getTime() / 1000
+      );
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [
+          sampleCard({
+            notion_block_id: 'block-1',
+            notion_last_edited_at: new Date('2025-12-01T00:00:00Z'),
+          }),
+        ],
+        diagnostic: { blocks_scanned: 1, blocks_matched: 1, pattern_hits: {} },
+      });
+      const repos = makeRepos();
+      repos.subscriptions = makeSubscriptionsRepo(
+        sampleSubscription({ notion_page_title: 'Algebra' })
+      );
+      repos.mappings.findBySourceId = jest.fn(
+        async (_clientId: number, sourceId: string) => ({
+          ...unchangedMapping(),
+          source_id: sourceId,
+        })
+      );
+      const ac = reflectingStub(['notesModTime', 'multi']);
+      (ac.notesModTime as jest.Mock).mockResolvedValue([
+        { noteId: 900, mod: lastSyncedSeconds - 10 },
+      ]);
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      const result = expectSyncResult(
+        await useCase.execute({
+          owner: 42,
+          notionPageId: 'page-id',
+          trigger: 'polling',
+        })
+      );
+
+      expect(ac.notesModTime).toHaveBeenCalledWith([900]);
+      expect(ac.notesInfo).not.toHaveBeenCalled();
+      expect(result.unchanged).toBe(1);
+      expect(result.updated).toBe(0);
+    });
+
+    test('fetches full info only for the note whose Anki mod advanced past last sync', async () => {
+      const lastSyncedSeconds = Math.floor(
+        new Date('2026-01-01T00:00:00Z').getTime() / 1000
+      );
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [
+          sampleCard({
+            notion_block_id: 'block-1',
+            notion_last_edited_at: new Date('2025-12-01T00:00:00Z'),
+          }),
+          sampleCard({
+            notion_block_id: 'block-2',
+            front: 'Front 2',
+            back: 'Back 2',
+            notion_last_edited_at: new Date('2025-12-01T00:00:00Z'),
+          }),
+        ],
+        diagnostic: { blocks_scanned: 2, blocks_matched: 2, pattern_hits: {} },
+      });
+      const repos = makeRepos();
+      repos.subscriptions = makeSubscriptionsRepo(
+        sampleSubscription({ notion_page_title: 'Algebra' })
+      );
+      repos.mappings.findBySourceId = jest.fn(
+        async (_clientId: number, sourceId: string) => ({
+          ...unchangedMapping(),
+          source_id: sourceId,
+          anki_note_id: sourceId === 'block-1' ? 900 : 901,
+        })
+      );
+      const ac = reflectingStub(['notesModTime', 'multi']);
+      (ac.notesModTime as jest.Mock).mockResolvedValue([
+        { noteId: 900, mod: lastSyncedSeconds - 10 },
+        { noteId: 901, mod: lastSyncedSeconds + 50 },
+      ]);
+      (ac.notesInfo as jest.Mock).mockImplementation(
+        async (notes: number[]) => {
+          if (notes.includes(901)) {
+            return [
+              {
+                noteId: 901,
+                modelName: 'Ankify Basic',
+                tags: [],
+                fields: {
+                  Front: { value: 'stale front', order: 0 },
+                  Back: { value: 'stale back', order: 1 },
+                },
+                cards: [9101],
+                mod: lastSyncedSeconds + 50,
+              },
+            ];
+          }
+          return [];
+        }
+      );
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      expectSyncResult(
+        await useCase.execute({
+          owner: 42,
+          notionPageId: 'page-id',
+          trigger: 'polling',
+        })
+      );
+
+      const fetchedNoteIds = (ac.notesInfo as jest.Mock).mock.calls.flatMap(
+        (call) => call[0] as number[]
+      );
+      expect(ac.notesModTime).toHaveBeenCalledTimes(1);
+      expect(fetchedNoteIds).toContain(901);
+      expect(fetchedNoteIds).not.toContain(900);
+    });
+
+    test('batches changed-note full info into a single notesInfo call', async () => {
+      const lastSyncedSeconds = Math.floor(
+        new Date('2026-01-01T00:00:00Z').getTime() / 1000
+      );
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [
+          sampleCard({
+            notion_block_id: 'block-1',
+            front: 'New front 1',
+            notion_last_edited_at: new Date('2026-02-01T00:00:00Z'),
+          }),
+          sampleCard({
+            notion_block_id: 'block-2',
+            front: 'New front 2',
+            notion_last_edited_at: new Date('2026-02-01T00:00:00Z'),
+          }),
+        ],
+        diagnostic: { blocks_scanned: 2, blocks_matched: 2, pattern_hits: {} },
+      });
+      const repos = makeRepos();
+      repos.subscriptions = makeSubscriptionsRepo(
+        sampleSubscription({ notion_page_title: 'Algebra' })
+      );
+      repos.mappings.findBySourceId = jest.fn(
+        async (_clientId: number, sourceId: string) => ({
+          ...unchangedMapping(),
+          source_id: sourceId,
+          anki_note_id: sourceId === 'block-1' ? 900 : 901,
+        })
+      );
+      const ac = reflectingStub(['notesModTime', 'multi']);
+      (ac.notesModTime as jest.Mock).mockResolvedValue([
+        { noteId: 900, mod: lastSyncedSeconds - 10 },
+        { noteId: 901, mod: lastSyncedSeconds - 10 },
+      ]);
+      (ac.notesInfo as jest.Mock).mockImplementation(
+        async (notes: number[]) =>
+          notes.map((noteId) => ({
+            noteId,
+            modelName: 'Ankify Basic',
+            tags: [],
+            fields: {
+              Front: { value: 'stale', order: 0 },
+              Back: { value: 'Back text', order: 1 },
+            },
+            cards: [noteId + 9000],
+            mod: lastSyncedSeconds - 10,
+          }))
+      );
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      const result = expectSyncResult(
+        await useCase.execute({
+          owner: 42,
+          notionPageId: 'page-id',
+          trigger: 'polling',
+        })
+      );
+
+      expect(ac.notesInfo).toHaveBeenCalledTimes(1);
+      expect(ac.notesInfo).toHaveBeenCalledWith([900, 901]);
+      expect(result.updated).toBe(2);
+    });
+
+    test('falls back to per-note notesInfo when notesModTime is absent from apiReflect', async () => {
+      const lastSyncedSeconds = Math.floor(
+        new Date('2026-01-01T00:00:00Z').getTime() / 1000
+      );
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [
+          sampleCard({
+            notion_block_id: 'block-1',
+            notion_last_edited_at: new Date('2025-12-01T00:00:00Z'),
+          }),
+        ],
+        diagnostic: { blocks_scanned: 1, blocks_matched: 1, pattern_hits: {} },
+      });
+      const repos = makeRepos();
+      repos.subscriptions = makeSubscriptionsRepo(
+        sampleSubscription({ notion_page_title: 'Algebra' })
+      );
+      repos.mappings.findBySourceId = jest.fn(
+        async (_clientId: number, sourceId: string) => ({
+          ...unchangedMapping(),
+          source_id: sourceId,
+        })
+      );
+      const ac = reflectingStub(['deckNames', 'addNote']);
+      (ac.notesInfo as jest.Mock).mockResolvedValue([
+        {
+          noteId: 900,
+          modelName: 'Ankify Basic',
+          tags: [],
+          fields: {
+            Front: { value: 'Front text', order: 0 },
+            Back: { value: 'Back text', order: 1 },
+          },
+          cards: [9001],
+          mod: lastSyncedSeconds - 10,
+        },
+      ]);
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      const result = expectSyncResult(
+        await useCase.execute({
+          owner: 42,
+          notionPageId: 'page-id',
+          trigger: 'polling',
+        })
+      );
+
+      expect(ac.notesModTime).not.toHaveBeenCalled();
+      expect(ac.notesInfo).toHaveBeenCalledWith([900]);
+      expect(result.unchanged).toBe(1);
+    });
+
+    test('skips the prefilter when there are no existing mappings', async () => {
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [sampleCard({ notion_block_id: 'block-1' })],
+        diagnostic: { blocks_scanned: 1, blocks_matched: 1, pattern_hits: {} },
+      });
+      const repos = makeRepos();
+      const ac = reflectingStub(['notesModTime', 'multi']);
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      const result = expectSyncResult(
+        await useCase.execute({
+          owner: 42,
+          notionPageId: 'page-id',
+          trigger: 'polling',
+        })
+      );
+
+      expect(ac.notesModTime).not.toHaveBeenCalled();
+      expect(result.created).toBe(1);
     });
   });
 });

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -2653,19 +2653,18 @@ describe('SyncNotionPageToRacUseCase', () => {
         { noteId: 900, mod: lastSyncedSeconds - 10 },
         { noteId: 901, mod: lastSyncedSeconds - 10 },
       ]);
-      (ac.notesInfo as jest.Mock).mockImplementation(
-        async (notes: number[]) =>
-          notes.map((noteId) => ({
-            noteId,
-            modelName: 'Ankify Basic',
-            tags: [],
-            fields: {
-              Front: { value: 'stale', order: 0 },
-              Back: { value: 'Back text', order: 1 },
-            },
-            cards: [noteId + 9000],
-            mod: lastSyncedSeconds - 10,
-          }))
+      (ac.notesInfo as jest.Mock).mockImplementation(async (notes: number[]) =>
+        notes.map((noteId) => ({
+          noteId,
+          modelName: 'Ankify Basic',
+          tags: [],
+          fields: {
+            Front: { value: 'stale', order: 0 },
+            Back: { value: 'Back text', order: 1 },
+          },
+          cards: [noteId + 9000],
+          mod: lastSyncedSeconds - 10,
+        }))
       );
       const useCase = new SyncNotionPageToRacUseCase(
         repos.clients,

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -18,6 +18,7 @@ import {
 import {
   AnkiConnectClient,
   AnkiConnectUnreachableError,
+  AnkiNoteInfo,
 } from '../../services/ankify/AnkiConnectClient';
 import {
   ANKIFY_BASIC_MODEL,
@@ -106,6 +107,12 @@ export interface SyncNotionPageResult {
   ankiWebSync: AnkiWebSyncStatus;
   ankiWebSyncError: string | null;
   diagnostic: SyncDiagnostic | null;
+}
+
+interface ModTimePrefilter {
+  mappingsByBlock: Map<string, AnkifySyncMapping>;
+  skipBlockIds: Set<string>;
+  infoByNoteId: Map<number, AnkiNoteInfo>;
 }
 
 export type AnkiConnectFactory = (
@@ -443,6 +450,7 @@ export class SyncNotionPageToRacUseCase {
     await this.ensureModelsForOverrides(ac, client, overridesByPage);
 
     const existingMediaNames = await this.loadExistingMediaNames(ac);
+    const prefilter = await this.buildModTimePrefilter(ac, client, cards);
 
     for (const card of cards) {
       await this.processCard({
@@ -459,6 +467,9 @@ export class SyncNotionPageToRacUseCase {
           card,
           input.notionPageId
         ),
+        existing: prefilter.mappingsByBlock.get(card.notion_block_id) ?? null,
+        unchangedByModTime: prefilter.skipBlockIds.has(card.notion_block_id),
+        prefetchedInfo: prefilter.infoByNoteId,
       });
     }
 
@@ -473,6 +484,98 @@ export class SyncNotionPageToRacUseCase {
     });
 
     await this.runFinalAnkiWebSync(ac, result);
+  }
+
+  private async probeAnkiConnectActions(
+    ac: AnkiConnectClient
+  ): Promise<Set<string>> {
+    try {
+      const actions = await ac.apiReflect();
+      return new Set(actions);
+    } catch {
+      return new Set<string>();
+    }
+  }
+
+  private async buildModTimePrefilter(
+    ac: AnkiConnectClient,
+    client: AnkifyClient,
+    cards: WalkedNotionFlashcard[]
+  ): Promise<ModTimePrefilter> {
+    const mappingsByBlock = await this.loadExistingMappings(client, cards);
+    const skipBlockIds = new Set<string>();
+    const infoByNoteId = new Map<number, AnkiNoteInfo>();
+    if (mappingsByBlock.size === 0) {
+      return { mappingsByBlock, skipBlockIds, infoByNoteId };
+    }
+
+    const actions = await this.probeAnkiConnectActions(ac);
+    if (!actions.has('notesModTime')) {
+      return { mappingsByBlock, skipBlockIds, infoByNoteId };
+    }
+
+    const noteIds = [...mappingsByBlock.values()].map((m) => m.anki_note_id);
+    const modTimes = await ac.notesModTime(noteIds);
+    const modByNoteId = new Map(modTimes.map((m) => [m.noteId, m.mod]));
+    const cardByBlock = new Map(cards.map((c) => [c.notion_block_id, c]));
+
+    const changedNoteIds: number[] = [];
+    for (const [blockId, mapping] of mappingsByBlock) {
+      const card = cardByBlock.get(blockId);
+      if (card == null) {
+        continue;
+      }
+      if (this.isUnchangedSinceLastSync(card, mapping, modByNoteId)) {
+        skipBlockIds.add(blockId);
+      } else {
+        changedNoteIds.push(mapping.anki_note_id);
+      }
+    }
+
+    if (changedNoteIds.length > 0) {
+      const infos = await ac.notesInfo(changedNoteIds);
+      for (const info of infos) {
+        if (info?.noteId != null) {
+          infoByNoteId.set(info.noteId, info);
+        }
+      }
+    }
+    return { mappingsByBlock, skipBlockIds, infoByNoteId };
+  }
+
+  private async loadExistingMappings(
+    client: AnkifyClient,
+    cards: WalkedNotionFlashcard[]
+  ): Promise<Map<string, AnkifySyncMapping>> {
+    const mappingsByBlock = new Map<string, AnkifySyncMapping>();
+    for (const card of cards) {
+      const mapping = await this.mappings.findBySourceId(
+        client.id,
+        card.notion_block_id
+      );
+      if (mapping != null) {
+        mappingsByBlock.set(card.notion_block_id, mapping);
+      }
+    }
+    return mappingsByBlock;
+  }
+
+  private isUnchangedSinceLastSync(
+    card: WalkedNotionFlashcard,
+    mapping: AnkifySyncMapping,
+    modByNoteId: Map<number, number>
+  ): boolean {
+    const ankiMod = modByNoteId.get(mapping.anki_note_id);
+    if (ankiMod == null) {
+      return false;
+    }
+    const lastSyncedSeconds = Math.floor(
+      mapping.last_synced_at.getTime() / 1000
+    );
+    const notionUnchanged =
+      card.notion_last_edited_at.getTime() <= mapping.last_synced_at.getTime();
+    const ankiUnchanged = ankiMod <= lastSyncedSeconds;
+    return notionUnchanged && ankiUnchanged;
   }
 
   private cardDeckName(
@@ -832,6 +935,9 @@ export class SyncNotionPageToRacUseCase {
     existingMediaNames: Set<string>;
     deckName: string;
     overrides: AnkifyTemplateOverrides | null;
+    existing: AnkifySyncMapping | null;
+    unchangedByModTime: boolean;
+    prefetchedInfo: Map<number, AnkiNoteInfo>;
   }): Promise<void> {
     const {
       card,
@@ -843,13 +949,16 @@ export class SyncNotionPageToRacUseCase {
       existingMediaNames,
       deckName,
       overrides,
+      existing,
+      unchangedByModTime,
+      prefetchedInfo,
     } = args;
+    if (existing != null && unchangedByModTime) {
+      result.unchanged += 1;
+      return;
+    }
     try {
       await this.uploadCardMedia(ac, card, result, existingMediaNames);
-      const existing = await this.mappings.findBySourceId(
-        client.id,
-        card.notion_block_id
-      );
       if (existing == null) {
         const ankiNoteId = await ac.addNote(
           this.buildBasicNote({
@@ -889,6 +998,7 @@ export class SyncNotionPageToRacUseCase {
         result,
         deckName,
         overrides,
+        prefetchedInfo,
       });
     } catch (error) {
       result.errors.push(
@@ -907,11 +1017,13 @@ export class SyncNotionPageToRacUseCase {
     result: SyncNotionPageResult;
     deckName: string;
     overrides: AnkifyTemplateOverrides | null;
+    prefetchedInfo: Map<number, AnkiNoteInfo>;
   }): Promise<void> {
     const { card, existing, client, ac, result, deckName, overrides } = args;
     const lastSyncedAt = existing.last_synced_at;
-    const ankiInfo = await ac.notesInfo([existing.anki_note_id]);
-    const ankiNote = ankiInfo[0];
+    const ankiNote =
+      args.prefetchedInfo.get(existing.anki_note_id) ??
+      (await ac.notesInfo([existing.anki_note_id]))[0];
 
     if (ankiNote?.noteId == null) {
       await this.mappings.deleteByAnkiNoteId(client.id, existing.anki_note_id);


### PR DESCRIPTION
## What
Ankify sync no longer issues one HTTP round-trip per mapped note. The run probes AnkiConnect once via `apiReflect`; when `notesModTime` is available it batch-fetches mod times for every mapped note in a single call and skips the full `notesInfo` fetch for notes that are unchanged on both sides (Notion edit time and Anki mod both at or before `last_synced_at`). A steady-state tick — every note unchanged, the common case — collapses from O(notes) round-trips to ~2. Notes that did change have their full info pulled in one batched `notesInfo` call rather than one per note.

## Why
Closes #3296. A 157-card database subscription previously meant several hundred sequential AnkiConnect calls per 5-minute tick. The long sync window is what made mid-run "AnkiConnect unreachable" failures likely — every extra round-trip is another chance for the client to go offline partway through. Shrinking the window cuts the torn-sync rate on the $30/mo Auto Sync surface.

## How
- `AnkiConnectClient` gains `apiReflect` (feature detection: `{scopes:['actions'], actions:null}` → action-name list), `notesModTime` (`{id, mod}` only), and `multi` (chunked per-action batching, returns results in order). Appended in their own region; mirror the existing `invoke`/auth/error pattern.
- `SyncNotionPageToRacUseCase` probes capabilities once per run (`probeAnkiConnectActions`, cached for the run), then `buildModTimePrefilter` loads existing mappings, calls `notesModTime` once, marks unchanged blocks to skip, and batch-fetches full info for the remaining changed notes in a single `notesInfo` call. `processCard` short-circuits skipped cards to `result.unchanged`; `reconcileExistingCard` reads from the prefetched info map, falling back to a per-note `notesInfo` when absent.
- Older plugins without `notesModTime` in `apiReflect` fall through to the existing per-note path, unchanged.
- AnkiConnect ids can be `0`-like — presence checks use `value == null`, never `!id`.

`multi` is wired and unit-tested on the client but writes are **not yet routed through it** — that is the bulk-migration follow-up (#3294, still open). This PR delivers the read-side round-trip collapse, which is the dominant win; routing the heterogeneous writes through `multi` with per-action error attribution is the larger, riskier change that belongs in #3294's scope.

Construction sites checked (`grep -rn "new SyncNotionPageToRacUseCase"`): `src/data_layer/index.ts`, `src/routes/AnkifyRouter.ts`, `src/routes/AnkifyWebhookRouter.ts`. The constructor signature is unchanged — all three are unaffected; only private method signatures changed.

## Measuring success
After deploy, watch `ankify_sync_logs` for the polling trigger: tick duration drops and the per-tick error count falls on subscriptions with many cards. The sync-log payload already carries `created`/`updated`/`unchanged`/`conflicts`/`errors` — a steady-state tick should now show high `unchanged` with near-zero AnkiConnect calls and no mid-run unreachable errors. Compare error frequency in `ankify_sync_logs` (status `error`) before vs after for high-card subscriptions.

## Testing
Unit tests added (mock only the AnkiConnect HTTP edge / fetch):
- `AnkiConnectClient`: `apiReflect posts the scopes+actions payload and returns the action names`; `apiReflect returns an empty list when the result lacks an actions array`; `notesModTime posts the note ids and returns id+mod pairs` (covers a `0` id); `multi posts the wrapped actions array and returns per-action results in order` (covers a per-action error entry).
- `SyncNotionPageToRacUseCase` (batch mod-time prefilter): `skips the full notesInfo fetch when both Notion and Anki are unchanged`; `fetches full info only for the note whose Anki mod advanced past last sync`; `batches changed-note full info into a single notesInfo call`; `falls back to per-note notesInfo when notesModTime is absent from apiReflect`; `skips the prefilter when there are no existing mappings`.

`/check`: server `tsc --noEmit` clean; full `src/usecases/ankify` + `src/services/ankify` suites green (224 tests) after rebasing on #3295; oxlint clean on changed files. `sonar-scanner` was **not** run locally — the scanner is not installed and `SONAR_TOKEN` is unset on this machine; expect the CI Sonar pass to be the first rule-engine read (the new methods are flat helpers with no deep nesting).

## Browser check
Browser check: not applicable — server-only change, no rendered output

## Changelog
No entry — internal sync performance and error-spam reduction, no user-visible behavior change.

## Risks
- Touches external-API integration (AnkiConnect + Notion) → run `/security-review` before merge.
- Behavior depends on AnkiConnect's `apiReflect` action list being accurate; if a plugin reports `notesModTime` but behaves differently, the fallback does not trigger. Mitigated: any thrown error in the probe or batch path is caught (`probeAnkiConnectActions` returns an empty set on failure) and the per-note path resumes.
- Prerequisite for #3294's bulk migration (`multi` now exists on the client).
- Rollback: revert is safe; the change adds an optimization layer and falls back to prior behavior on older plugins.

## Coordination
Shares `AnkiConnectClient.ts` + `SyncNotionPageToRacUseCase.ts` with #3295 (`perf/ankify-skip-existing-media`). #3295 has already merged to main; this branch is rebased on it. The two optimizations are complementary — #3295 skips re-uploading existing media, this skips re-reading unchanged notes; an unchanged card now short-circuits before both.

## Goal alignment
Retention-side quality on the $30/mo Auto Sync surface — fewer torn syncs means fewer "my cards stopped showing up" support hits and less churn on the highest-ARPU plan. Metric: tick duration + error counts in `ankify_sync_logs` (polling trigger), read after deploy. No funnel/acquisition impact — internal sync reliability.
