### PR TITLE
feat: Open in Anki link on Ankify conflict rows

### DIFF
--- a/src/controllers/AnkifyController.openConflict.test.ts
+++ b/src/controllers/AnkifyController.openConflict.test.ts
@@ -1,0 +1,110 @@
+import { Request, Response } from 'express';
+
+import AnkifyController from './AnkifyController';
+import {
+  ConflictNotFoundForOpenError,
+  OpenConflictInAnkiUseCase,
+} from '../usecases/ankify/OpenConflictInAnkiUseCase';
+
+interface CapturingResponse {
+  res: Response;
+  statusCode: number;
+  body: unknown;
+}
+
+const makeResponse = (): CapturingResponse => {
+  const capture: CapturingResponse = {
+    res: {} as Response,
+    statusCode: 200,
+    body: undefined,
+  };
+  const res = {
+    locals: { owner: 42 },
+    status: jest.fn((code: number) => {
+      capture.statusCode = code;
+      return res;
+    }),
+    json: jest.fn((payload: unknown) => {
+      capture.body = payload;
+      return res;
+    }),
+  } as unknown as Response;
+  capture.res = res;
+  return capture;
+};
+
+const makeController = (openUseCase: OpenConflictInAnkiUseCase) => {
+  const stubs = Array.from({ length: 24 }, () => ({}));
+  stubs[16] = openUseCase;
+  return new AnkifyController(
+    ...(stubs as ConstructorParameters<typeof AnkifyController>)
+  );
+};
+
+describe('AnkifyController.openConflictInAnki', () => {
+  test('200 with opened true for a valid owned conflict', async () => {
+    const execute = jest.fn(async () => ({ opened: true }));
+    const controller = makeController({
+      execute,
+    } as unknown as OpenConflictInAnkiUseCase);
+    const capture = makeResponse();
+
+    await controller.openConflictInAnki(
+      { params: { id: '7' } } as unknown as Request,
+      capture.res
+    );
+
+    expect(execute).toHaveBeenCalledWith({ id: 7, owner: 42 });
+    expect(capture.statusCode).toBe(200);
+    expect(capture.body).toEqual({ opened: true });
+  });
+
+  test('200 with opened false when the client is offline', async () => {
+    const execute = jest.fn(async () => ({ opened: false }));
+    const controller = makeController({
+      execute,
+    } as unknown as OpenConflictInAnkiUseCase);
+    const capture = makeResponse();
+
+    await controller.openConflictInAnki(
+      { params: { id: '7' } } as unknown as Request,
+      capture.res
+    );
+
+    expect(capture.statusCode).toBe(200);
+    expect(capture.body).toEqual({ opened: false });
+  });
+
+  test('400 for a non-integer id without invoking the use case', async () => {
+    const execute = jest.fn();
+    const controller = makeController({
+      execute,
+    } as unknown as OpenConflictInAnkiUseCase);
+    const capture = makeResponse();
+
+    await controller.openConflictInAnki(
+      { params: { id: 'nope' } } as unknown as Request,
+      capture.res
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(capture.statusCode).toBe(400);
+  });
+
+  test('404 when the conflict is not owned by the requester', async () => {
+    const execute = jest.fn(async () => {
+      throw new ConflictNotFoundForOpenError();
+    });
+    const controller = makeController({
+      execute,
+    } as unknown as OpenConflictInAnkiUseCase);
+    const capture = makeResponse();
+
+    await controller.openConflictInAnki(
+      { params: { id: '99' } } as unknown as Request,
+      capture.res
+    );
+
+    expect(capture.statusCode).toBe(404);
+  });
+});

--- a/src/controllers/AnkifyController.ts
+++ b/src/controllers/AnkifyController.ts
@@ -44,6 +44,10 @@ import {
   ConflictNotFoundError,
   ResolveConflictUseCase,
 } from '../usecases/ankify/ResolveConflictUseCase';
+import {
+  ConflictNotFoundForOpenError,
+  OpenConflictInAnkiUseCase,
+} from '../usecases/ankify/OpenConflictInAnkiUseCase';
 import { AnkifyConflictResolution } from '../entities/ankify';
 import {
   DockerUnavailableError,
@@ -82,6 +86,7 @@ class AnkifyController {
     private readonly refreshSubscriptionUseCase: RefreshAnkifySubscriptionUseCase,
     private readonly listConflictsUseCase: ListConflictsUseCase,
     private readonly resolveConflictUseCase: ResolveConflictUseCase,
+    private readonly openConflictInAnkiUseCase: OpenConflictInAnkiUseCase,
     private readonly listNotionDatabasesUseCase: ListNotionDatabasesUseCase,
     private readonly createReviewTrackerUseCase: CreateReviewTrackerDatabaseUseCase,
     private readonly checkReadinessUseCase: CheckActiveClientReadinessUseCase,
@@ -495,6 +500,32 @@ class AnkifyController {
       res.status(204).send();
     } catch (error) {
       if (error instanceof ConflictNotFoundError) {
+        res.status(404).json({ message: 'Conflict not found' });
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async openConflictInAnki(req: Request, res: Response) {
+    const owner = res.locals.owner as number;
+    const id = Number.parseInt(req.params.id, 10);
+    if (!Number.isInteger(id)) {
+      res.status(400).json({ message: 'Invalid conflict id' });
+      return;
+    }
+    try {
+      const result = await this.openConflictInAnkiUseCase.execute({
+        id,
+        owner,
+      });
+      track('ankify_open_in_anki_clicked', {
+        userId: owner,
+        props: { opened: result.opened },
+      });
+      res.status(200).json({ opened: result.opened });
+    } catch (error) {
+      if (error instanceof ConflictNotFoundForOpenError) {
         res.status(404).json({ message: 'Conflict not found' });
         return;
       }

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -28,6 +28,7 @@ import { ListNotionSubscriptionsUseCase } from '../usecases/ankify/ListNotionSub
 import { DeleteNotionSubscriptionUseCase } from '../usecases/ankify/DeleteNotionSubscriptionUseCase';
 import { ListConflictsUseCase } from '../usecases/ankify/ListConflictsUseCase';
 import { ResolveConflictUseCase } from '../usecases/ankify/ResolveConflictUseCase';
+import { OpenConflictInAnkiUseCase } from '../usecases/ankify/OpenConflictInAnkiUseCase';
 import { ListNotionDatabasesUseCase } from '../usecases/ankify/ListNotionDatabasesUseCase';
 import { CreateReviewTrackerDatabaseUseCase } from '../usecases/ankify/CreateReviewTrackerDatabaseUseCase';
 import { CheckActiveClientReadinessUseCase } from '../usecases/ankify/CheckActiveClientReadinessUseCase';
@@ -364,6 +365,7 @@ const AnkifyRouter = () => {
       ankiConnectFactory,
       buildNotionConflictResolver
     ),
+    new OpenConflictInAnkiUseCase(repo, conflictsRepo, ankiConnectFactory),
     new ListNotionDatabasesUseCase(new NotionRepository(db), {
       listDatabases: listNotionDatabasesViaSearch,
     }),
@@ -706,6 +708,33 @@ const AnkifyRouter = () => {
     '/api/ankify/conflicts/:id/resolve',
     RequireAnkifyAccess,
     (req, res) => controller.resolveConflict(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ankify/conflicts/{id}/open-in-anki:
+   *   post:
+   *     summary: Open the conflicting note in the user's hosted Anki browser
+   *     description: Allowlisted endpoint. Looks up the owner's conflict row, derives its Anki note id, and invokes AnkiConnect guiBrowse(nid:<id>) so Anki's browser focuses that note. Returns { opened: false } when the client is offline.
+   *     tags: [Ankify]
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: integer
+   *     responses:
+   *       200:
+   *         description: '{ opened: boolean } — opened is false when Anki is offline'
+   *       400:
+   *         description: Invalid conflict id
+   *       404:
+   *         description: Conflict not found for this user
+   */
+  router.post(
+    '/api/ankify/conflicts/:id/open-in-anki',
+    RequireAnkifyAccess,
+    (req, res) => controller.openConflictInAnki(req, res)
   );
 
   /**

--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -295,6 +295,21 @@ describe('AnkiConnectClient', () => {
     });
   });
 
+  test('guiBrowse posts the query and returns the matched card ids', async () => {
+    const fetchImpl = makeFetch({ result: [1502298033753], error: null });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const cardIds = await client.guiBrowse('nid:1502298033753');
+
+    expect(cardIds).toEqual([1502298033753]);
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'guiBrowse',
+      version: 6,
+      params: { query: 'nid:1502298033753' },
+    });
+  });
+
   test('throws AnkiConnectUnreachableError when fetch rejects', async () => {
     const fetchImpl = jest.fn(async () => {
       throw new Error('connect ECONNREFUSED');

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -169,6 +169,10 @@ export class AnkiConnectClient {
     return this.invoke('version');
   }
 
+  async guiBrowse(query: string): Promise<number[]> {
+    return this.invoke('guiBrowse', { query });
+  }
+
   private async invoke<T>(
     action: string,
     params?: Record<string, unknown>

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -70,6 +70,7 @@ export const KNOWN_EVENTS = new Set([
   'lock_in_banner_shown',
   'lock_in_banner_clicked',
   'ankify_stats_viewed',
+  'ankify_open_in_anki_clicked',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/ankify/OpenConflictInAnkiUseCase.test.ts
+++ b/src/usecases/ankify/OpenConflictInAnkiUseCase.test.ts
@@ -1,0 +1,119 @@
+import {
+  ConflictNotFoundForOpenError,
+  OpenConflictInAnkiUseCase,
+} from './OpenConflictInAnkiUseCase';
+import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
+import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncConflictsRepository';
+import {
+  AnkiConnectClient,
+  AnkiConnectUnreachableError,
+} from '../../services/ankify/AnkiConnectClient';
+import { AnkifySyncConflict } from '../../entities/ankify';
+
+const sampleConflict = (
+  overrides: Partial<AnkifySyncConflict> = {}
+): AnkifySyncConflict =>
+  ({
+    id: 7,
+    owner: 42,
+    ankify_client_id: 1,
+    subscription_id: null,
+    source_id: 'block-id',
+    anki_note_id: 1502298033753,
+    kind: 'both_edited',
+    notion_last_edited_at: null,
+    anki_modified_at: null,
+    notion_snapshot: { front: 'a', back: 'b' },
+    anki_snapshot: { front: 'c', back: 'd' },
+    status: 'pending',
+    resolution: null,
+    resolved_at: null,
+    created_at: new Date(),
+    ...overrides,
+  }) as AnkifySyncConflict;
+
+const activeClient = {
+  id: 1,
+  anki_port: 8765,
+  anki_connect_api_key: null,
+} as Awaited<ReturnType<AnkifyClientsRepositoryInterface['findActiveByOwner']>>;
+
+const makeConflicts = (
+  conflict: AnkifySyncConflict | null
+): AnkifySyncConflictsRepositoryInterface =>
+  ({
+    findById: jest.fn(async () => conflict),
+  }) as unknown as AnkifySyncConflictsRepositoryInterface;
+
+const makeClients = (
+  client: Awaited<
+    ReturnType<AnkifyClientsRepositoryInterface['findActiveByOwner']>
+  >
+): AnkifyClientsRepositoryInterface =>
+  ({
+    findActiveByOwner: jest.fn(async () => client),
+  }) as unknown as AnkifyClientsRepositoryInterface;
+
+describe('OpenConflictInAnkiUseCase', () => {
+  test('opens the owned conflict note via guiBrowse with nid: query', async () => {
+    const guiBrowse = jest.fn(async () => [1]);
+    const ping = jest.fn(async () => 6);
+    const client = makeClients(activeClient);
+    const conflicts = makeConflicts(sampleConflict());
+    const factory = jest.fn(
+      () => ({ ping, guiBrowse }) as unknown as AnkiConnectClient
+    );
+
+    const useCase = new OpenConflictInAnkiUseCase(client, conflicts, factory);
+    const result = await useCase.execute({ id: 7, owner: 42 });
+
+    expect(result).toEqual({ opened: true });
+    expect(conflicts.findById).toHaveBeenCalledWith(7, 42);
+    expect(guiBrowse).toHaveBeenCalledWith('nid:1502298033753');
+  });
+
+  test('returns opened false without calling guiBrowse when the client is offline', async () => {
+    const guiBrowse = jest.fn(async () => [1]);
+    const ping = jest.fn(async () => {
+      throw new AnkiConnectUnreachableError('http://x', new Error('down'));
+    });
+    const useCase = new OpenConflictInAnkiUseCase(
+      makeClients(activeClient),
+      makeConflicts(sampleConflict()),
+      jest.fn(() => ({ ping, guiBrowse }) as unknown as AnkiConnectClient)
+    );
+
+    const result = await useCase.execute({ id: 7, owner: 42 });
+
+    expect(result).toEqual({ opened: false });
+    expect(guiBrowse).not.toHaveBeenCalled();
+  });
+
+  test('returns opened false when the user has no active client', async () => {
+    const guiBrowse = jest.fn(async () => [1]);
+    const useCase = new OpenConflictInAnkiUseCase(
+      makeClients(null),
+      makeConflicts(sampleConflict()),
+      jest.fn(
+        () => ({ ping: jest.fn(), guiBrowse }) as unknown as AnkiConnectClient
+      )
+    );
+
+    const result = await useCase.execute({ id: 7, owner: 42 });
+
+    expect(result).toEqual({ opened: false });
+    expect(guiBrowse).not.toHaveBeenCalled();
+  });
+
+  test('throws when the conflict is not owned by the requester', async () => {
+    const useCase = new OpenConflictInAnkiUseCase(
+      makeClients(activeClient),
+      makeConflicts(null),
+      jest.fn()
+    );
+
+    await expect(useCase.execute({ id: 99, owner: 42 })).rejects.toBeInstanceOf(
+      ConflictNotFoundForOpenError
+    );
+  });
+});

--- a/src/usecases/ankify/OpenConflictInAnkiUseCase.ts
+++ b/src/usecases/ankify/OpenConflictInAnkiUseCase.ts
@@ -1,0 +1,64 @@
+import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
+import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncConflictsRepository';
+import { AnkiConnectUnreachableError } from '../../services/ankify/AnkiConnectClient';
+import { AnkiConnectFactory } from './SyncNotionPageToRacUseCase';
+
+export class ConflictNotFoundForOpenError extends Error {
+  constructor() {
+    super('Conflict not found');
+    this.name = 'ConflictNotFoundForOpenError';
+  }
+}
+
+export interface OpenConflictInAnkiInput {
+  id: number;
+  owner: number;
+  ankiConnectHost?: string;
+}
+
+export interface OpenConflictInAnkiResult {
+  opened: boolean;
+}
+
+export class OpenConflictInAnkiUseCase {
+  constructor(
+    private readonly clients: AnkifyClientsRepositoryInterface,
+    private readonly conflicts: AnkifySyncConflictsRepositoryInterface,
+    private readonly ankiConnect: AnkiConnectFactory
+  ) {}
+
+  async execute(
+    input: OpenConflictInAnkiInput
+  ): Promise<OpenConflictInAnkiResult> {
+    const conflict = await this.conflicts.findById(input.id, input.owner);
+    if (conflict == null) {
+      throw new ConflictNotFoundForOpenError();
+    }
+    if (!Number.isInteger(conflict.anki_note_id)) {
+      throw new ConflictNotFoundForOpenError();
+    }
+
+    const client = await this.clients.findActiveByOwner(input.owner);
+    if (client == null) {
+      return { opened: false };
+    }
+
+    const ac = this.ankiConnect(
+      input.ankiConnectHost ?? 'localhost',
+      client.anki_port,
+      client.anki_connect_api_key
+    );
+
+    try {
+      await ac.ping();
+    } catch (error) {
+      if (error instanceof AnkiConnectUnreachableError) {
+        return { opened: false };
+      }
+      throw error;
+    }
+
+    await ac.guiBrowse(`nid:${conflict.anki_note_id}`);
+    return { opened: true };
+  }
+}

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -800,6 +800,21 @@ export class Backend {
     }
   }
 
+  async openAnkifyConflictInAnki(id: number): Promise<{ opened: boolean }> {
+    const response = await post(
+      `${this.baseURL}ankify/conflicts/${id}/open-in-anki`,
+      {}
+    );
+    if (!response.ok) {
+      const error = await response
+        .json()
+        .catch(() => ({ message: response.statusText }));
+      throw new Error(error.message ?? 'Failed to open in Anki');
+    }
+    const body = await response.json().catch(() => ({ opened: false }));
+    return { opened: body.opened === true };
+  }
+
   async checkAnkifyActiveClientReady(): Promise<{
     ready: boolean;
     reason?: 'no_active_client' | 'unreachable' | 'error';

--- a/web/src/pages/AnkifyPage/components/SyncConflicts.test.tsx
+++ b/web/src/pages/AnkifyPage/components/SyncConflicts.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import SyncConflicts from './SyncConflicts';
+import { Backend } from '../../../lib/backend/Backend';
+
+type Conflict = Awaited<ReturnType<Backend['listAnkifyConflicts']>>[number];
+
+const sampleConflict = (overrides: Partial<Conflict> = {}): Conflict => ({
+  id: 7,
+  source_id: 'block-id',
+  anki_note_id: 1502298033753,
+  kind: 'both_edited',
+  notion_snapshot: { front: 'Notion front', back: 'Notion back' },
+  anki_snapshot: { front: 'Anki front', back: 'Anki back' },
+  created_at: new Date().toISOString(),
+  ...overrides,
+});
+
+const makeBackend = (overrides: Partial<Backend> = {}): Backend =>
+  ({
+    listAnkifyConflicts: vi.fn(async () => [sampleConflict()]),
+    listAnkifySubscriptions: vi.fn(async () => []),
+    resolveAnkifyConflict: vi.fn(),
+    openAnkifyConflictInAnki: vi.fn(async () => ({ opened: true })),
+    ...overrides,
+  }) as unknown as Backend;
+
+const renderConflicts = (backend: Backend) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <SyncConflicts backend={backend} />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+};
+
+describe('SyncConflicts open in Anki', () => {
+  test('clicking Open in Anki calls the backend with the conflict id', async () => {
+    const open = vi.fn(async () => ({ opened: true }));
+    const backend = makeBackend({ openAnkifyConflictInAnki: open });
+
+    renderConflicts(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /open in anki/i })
+    );
+
+    await waitFor(() => expect(open).toHaveBeenCalledWith(7));
+  });
+
+  test('shows the offline message when the client is not connected', async () => {
+    const backend = makeBackend({
+      openAnkifyConflictInAnki: vi.fn(async () => ({ opened: false })),
+    });
+
+    renderConflicts(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /open in anki/i })
+    );
+
+    expect(
+      await screen.findByText(
+        /anki isn't connected right now\. open anki and try again\./i
+      )
+    ).toBeInTheDocument();
+  });
+
+  test('does not show the offline message on a successful open', async () => {
+    const backend = makeBackend({
+      openAnkifyConflictInAnki: vi.fn(async () => ({ opened: true })),
+    });
+
+    renderConflicts(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /open in anki/i })
+    );
+
+    await waitFor(() =>
+      expect(backend.openAnkifyConflictInAnki).toHaveBeenCalled()
+    );
+    expect(
+      screen.queryByText(/anki isn't connected right now/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AnkifyPage/components/SyncConflicts.tsx
+++ b/web/src/pages/AnkifyPage/components/SyncConflicts.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import sharedStyles from '../../../styles/shared.module.css';
@@ -12,10 +13,15 @@ interface Props {
 
 const CONFLICTS_KEY = ['ankify-conflicts'];
 const SUBSCRIPTIONS_KEY = ['ankify-subscriptions'];
+const ANKI_OFFLINE_MESSAGE =
+  "Anki isn't connected right now. Open Anki and try again.";
 
 export default function SyncConflicts({ backend, embedded = false }: Props) {
   const api = backend ?? get2ankiApi();
   const queryClient = useQueryClient();
+  const [offlineConflictId, setOfflineConflictId] = useState<number | null>(
+    null
+  );
 
   const conflicts = useQuery({
     queryKey: CONFLICTS_KEY,
@@ -37,6 +43,14 @@ export default function SyncConflicts({ backend, embedded = false }: Props) {
       resolution: 'keep_notion' | 'keep_anki' | 'dismissed';
     }) => api.resolveAnkifyConflict(id, resolution),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: CONFLICTS_KEY }),
+  });
+
+  const openInAnki = useMutation({
+    mutationFn: (id: number) => api.openAnkifyConflictInAnki(id),
+    onSuccess: (result, id) => {
+      setOfflineConflictId(result.opened ? null : id);
+    },
+    onError: (_error, id) => setOfflineConflictId(id),
   });
 
   const items = conflicts.data ?? [];
@@ -121,7 +135,23 @@ export default function SyncConflicts({ backend, embedded = false }: Props) {
               >
                 Decide later
               </button>
+              <button
+                type="button"
+                className={`${sharedStyles.btnSmall} ${styles.inlineButton}`}
+                onClick={() => openInAnki.mutate(conflict.id)}
+                disabled={
+                  openInAnki.isPending &&
+                  openInAnki.variables === conflict.id
+                }
+              >
+                Open in Anki
+              </button>
             </div>
+            {offlineConflictId === conflict.id && (
+              <p className={styles.emptyLine} role="status">
+                {ANKI_OFFLINE_MESSAGE}
+              </p>
+            )}
           </article>
         );
       })}

--- a/web/src/pages/AnkifyPage/components/SyncConflicts.tsx
+++ b/web/src/pages/AnkifyPage/components/SyncConflicts.tsx
@@ -140,8 +140,7 @@ export default function SyncConflicts({ backend, embedded = false }: Props) {
                 className={`${sharedStyles.btnSmall} ${styles.inlineButton}`}
                 onClick={() => openInAnki.mutate(conflict.id)}
                 disabled={
-                  openInAnki.isPending &&
-                  openInAnki.variables === conflict.id
+                  openInAnki.isPending && openInAnki.variables === conflict.id
                 }
               >
                 Open in Anki

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-open-in-anki.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-open-in-anki.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-ankify-open-in-anki",
+  "date": "2026-06-12",
+  "type": "feature",
+  "title": "Open a conflicting note straight in Anki from the sync conflict list"
+}


### PR DESCRIPTION
## What
Adds an "Open in Anki" button to each `both_edited` row on the Ankify sync-conflict surface. Clicking it opens the conflicting note directly in the user's hosted Anki browser, so they can look at the real card before choosing which version to keep.

## Why
Closes #3298. On the conflict surface a user often wants to see the actual note in Anki before resolving. AnkiConnect's `guiBrowse("nid:<id>")` focuses Anki's browser on exactly that note — a cheap, additive UX lift on an existing surface.

## How
- `AnkiConnectClient.guiBrowse(query)` — new append-only method invoking the `guiBrowse` action.
- `OpenConflictInAnkiUseCase` — looks up the conflict by owner + id, derives the stored Anki note id from THAT row, validates it is an integer, pings AnkiConnect, and on success calls `guiBrowse(nid:<id>)`. Returns `{ opened: false }` when there is no active client or the client is offline (mirrors the `GetAnkifyStatsUseCase` ping pattern) — never a 500.
- `POST /api/ankify/conflicts/:id/open-in-anki` behind `RequireAnkifyAccess`; controller validates the id, maps not-found to 404, returns `{ opened: boolean }`, fires `ankify_open_in_anki_clicked`.
- Frontend: `Backend.openAnkifyConflictInAnki(id)` and a secondary "Open in Anki" button on each conflict row. On `opened: false` the row shows a calm inline message: "Anki isn't connected right now. Open Anki and try again." No noisy success toast — Anki's window popping forward is the feedback. The button is not preemptively disabled; the click drives the reachability check.

Security: the `nid:` query is built server-side from the looked-up id (`Number.isInteger` guard, never a raw client string) to block AnkiConnect search injection, and the conflict is fetched owner-scoped (`findById(id, owner)`) to block IDOR. The query and secrets are never logged.

## Measuring success
- Usage event `ankify_open_in_anki_clicked` (props `{ opened }`) in the events sink — read via `/api/ops/metrics`. Confirms adoption and how often the client was reachable on click.
- Server log: the endpoint returns 200 with `{ opened }`; offline clicks surface as `opened: false` rather than 5xx (watch the route's error rate stays flat).

## Testing
- Unit tests added:
  - `AnkiConnectClient.test.ts` — `guiBrowse` posts the `guiBrowse` action with the query, returns card ids.
  - `OpenConflictInAnkiUseCase.test.ts` — owned conflict → `guiBrowse(nid:<id>)`; offline ping → `{ opened: false }`, no `guiBrowse`; no active client → `{ opened: false }`; unowned id → throws (IDOR).
  - `AnkifyController.openConflict.test.ts` — 200 opened true/false, 400 non-integer id (use case not called), 404 unowned.
  - `SyncConflicts.test.tsx` — button calls backend with the row id; `opened: false` shows the offline message; success shows no message.
- `/check`: server tsc clean, web typecheck clean, web vitest green (35 in the touched files), web lint exit 0 (only pre-existing warnings in unrelated files). Full ankify server suites: 216 passed.
- Sonar: `sonar-scanner` not run — not installed locally and `SONAR_TOKEN` unset. Expect a possible Sonar pass on the new controller method / use case; the button is a real `<button>` with a text label and the offline message carries `role="status"`.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Not driven live (no local hosted-Anki client to provision). Verified via render-test (`SyncConflicts.test.tsx`) and reasoning: the button renders on each `both_edited` row, the offline path renders the calm message, and the component reuses the existing conflict-row layout and shared button styles. Flagging that this was render-test + reasoning, not a live click against a running container.

## Risks
- Touches external-API integration (AnkiConnect) → run `/security-review` before merge. The injection guard (server-side `nid:${Number.isInteger}` query) and the IDOR guard (owner-scoped `findById`) are the load-bearing mitigations.
- AnkiConnect lifecycle: `guiBrowse` is fire-and-forget; if the client is up but the note was deleted in Anki, `guiBrowse` simply opens an empty browser — acceptable, no error surfaced. Rollback: revert the PR; the conflict surface returns to resolve-only.

## User docs
Skipped — this is a small button on an existing surface, not a new input format, converter capability, or account feature.

## Coordination
Shares `AnkiConnectClient.ts` (append-only) with #3295 and #3296; merge those first, then rebase this. Already rebased on origin/main: #3295's `getMediaFilesNames` is present and coexists with `guiBrowse` (clean, no conflict). #3296 (`notesModTime`, `multi`, `apiReflect`) not yet on main — rebase again before merge to pick it up; resolve the append-only region by keeping ALL methods. This PR merges LAST.

## Changelog
`Open a conflicting note straight in Anki from the sync conflict list` (`web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-open-in-anki.json`)

## Goal alignment
Retention/quality on the $30/mo Auto Sync surface — removes friction in conflict resolution (a "simpler/faster" change on an existing surface). Metric to move: conflict-resolution completion rate and Ankify weekly-active return; read via the `ankify_open_in_anki_clicked` usage event at `/api/ops/metrics`. No direct acquisition impact — this is a retention surface for existing paid Ankify users.
