### PR TITLE
fix: skip unsupported Notion audio/file media instead of leaking JSON

### DIFF
--- a/src/services/NotionService/BlockHandler/BlockHandler.toggleBackMedia.test.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.toggleBackMedia.test.ts
@@ -1,0 +1,181 @@
+import {
+  AudioBlockObjectResponse,
+  ImageBlockObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
+import Note from '../../../lib/parser/Note';
+import ParserRules from '../../../lib/parser/ParserRules';
+import CardOption from '../../../lib/parser/Settings/CardOption';
+import Workspace from '../../../lib/parser/WorkSpace';
+import { setupTests } from '../../../test/configure-jest';
+import MockNotionAPI from '../_mock/MockNotionAPI';
+import BlockHandler from './BlockHandler';
+
+jest.mock('../helpers/isTesting', () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
+}));
+
+jest.mock('../helpers/downloadMediaOrSkip', () => ({
+  __esModule: true,
+  downloadMediaOrSkip: jest.fn(async () => Buffer.from('fake-media-bytes')),
+}));
+
+const defaultAnnotations = {
+  bold: false,
+  italic: false,
+  strikethrough: false,
+  underline: false,
+  code: false,
+  color: 'default' as const,
+};
+
+function richText(content: string) {
+  return {
+    type: 'text' as const,
+    text: { content, link: null },
+    annotations: { ...defaultAnnotations },
+    plain_text: content,
+    href: null,
+  };
+}
+
+function buildToggleBlock(id: string, summary: string) {
+  return {
+    object: 'block' as const,
+    id,
+    parent: { type: 'page_id' as const, page_id: 'page-id' },
+    created_time: '',
+    last_edited_time: '',
+    created_by: { object: 'user' as const, id: 'user-id' },
+    last_edited_by: { object: 'user' as const, id: 'user-id' },
+    has_children: true,
+    archived: false,
+    in_trash: false,
+    type: 'toggle' as const,
+    toggle: { rich_text: [richText(summary)], color: 'default' as const },
+  };
+}
+
+function imageChild(
+  id: string,
+  source: 'file' | 'external',
+  url: string
+): ImageBlockObjectResponse {
+  const image =
+    source === 'file'
+      ? { type: 'file', file: { url, expiry_time: '' }, caption: [] }
+      : { type: 'external', external: { url }, caption: [] };
+  return {
+    object: 'block',
+    id,
+    parent: { type: 'block_id', block_id: 'parent-toggle' },
+    created_time: '',
+    last_edited_time: '',
+    created_by: { object: 'user', id: 'user-id' },
+    last_edited_by: { object: 'user', id: 'user-id' },
+    has_children: false,
+    archived: false,
+    in_trash: false,
+    type: 'image',
+    image,
+  } as unknown as ImageBlockObjectResponse;
+}
+
+function audioChild(id: string, url: string): AudioBlockObjectResponse {
+  return {
+    object: 'block',
+    id,
+    parent: { type: 'block_id', block_id: 'parent-toggle' },
+    created_time: '',
+    last_edited_time: '',
+    created_by: { object: 'user', id: 'user-id' },
+    last_edited_by: { object: 'user', id: 'user-id' },
+    has_children: false,
+    archived: false,
+    in_trash: false,
+    type: 'audio',
+    audio: { type: 'file', file: { url, expiry_time: '' }, caption: [] },
+  } as unknown as AudioBlockObjectResponse;
+}
+
+class ChildStubApi extends MockNotionAPI {
+  constructor(
+    private readonly toggleId: string,
+    private readonly children: unknown[]
+  ) {
+    super(process.env.NOTION_KEY!, '3');
+  }
+
+  async getBlocks(
+    params: Parameters<MockNotionAPI['getBlocks']>[0]
+  ): ReturnType<MockNotionAPI['getBlocks']> {
+    const results = params.id === this.toggleId ? this.children : [];
+    return {
+      type: 'block',
+      block: {},
+      object: 'list',
+      next_cursor: null,
+      has_more: false,
+      results,
+    } as Awaited<ReturnType<MockNotionAPI['getBlocks']>>;
+  }
+}
+
+async function runToggle(
+  toggleId: string,
+  summary: string,
+  children: unknown[]
+): Promise<Note[]> {
+  const api = new ChildStubApi(toggleId, children);
+  const exporter = new CustomExporter('', new Workspace(true, 'fs').location);
+  const bl = new BlockHandler(exporter, api, new CardOption({}));
+  return bl.getFlashcards(
+    new ParserRules(),
+    [buildToggleBlock(toggleId, summary)],
+    [],
+    undefined
+  );
+}
+
+beforeEach(() => setupTests());
+
+describe('toggle back-side media bundles instead of leaking a raw URL', () => {
+  test('file-type image inside a toggle body is bundled as media, not the signed URL', async () => {
+    const cards = await runToggle('img-toggle', 'Front', [
+      imageChild(
+        'img-child',
+        'file',
+        'https://prod-files-secure.s3.us-west-2.amazonaws.com/ultrasound.png?sig=abc'
+      ),
+    ]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].back).toMatch(/<img src="[^"]+\.png" \/>/);
+    expect(cards[0].back).not.toContain('prod-files-secure.s3');
+    expect(cards[0].back).not.toContain('sig=abc');
+  });
+
+  test('file-type audio inside a toggle body is a bundled [sound:] tag, not a link', async () => {
+    const cards = await runToggle('audio-toggle', 'Listen', [
+      audioChild(
+        'audio-child',
+        'https://prod-files-secure.s3.us-west-2.amazonaws.com/heartbeat.mp3?sig=xyz'
+      ),
+    ]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].back).toMatch(/\[sound:[^\]]+\]/);
+    expect(cards[0].back).not.toContain('prod-files-secure.s3');
+    expect(cards[0].back).not.toContain('<a ');
+  });
+
+  test('external-type image inside a toggle body still renders as an img', async () => {
+    const cards = await runToggle('ext-toggle', 'Diagram', [
+      imageChild('ext-child', 'external', 'https://example.com/diagram.png'),
+    ]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0].back).toMatch(/<img src="[^"]+" \/>/);
+  });
+});

--- a/src/services/NotionService/helpers/getAudioUrl.test.ts
+++ b/src/services/NotionService/helpers/getAudioUrl.test.ts
@@ -1,0 +1,38 @@
+import { AudioBlockObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+import { getAudioUrl } from './getAudioUrl';
+
+jest.mock('@notionhq/client', () => ({
+  isFullBlock: () => true,
+}));
+
+function audioBlock(type: string, extra: object): AudioBlockObjectResponse {
+  return {
+    object: 'block',
+    id: 'b',
+    type: 'audio',
+    has_children: false,
+    archived: false,
+    audio: { type, ...extra },
+  } as unknown as AudioBlockObjectResponse;
+}
+
+describe('getAudioUrl', () => {
+  test('returns url for external audio', () => {
+    const block = audioBlock('external', {
+      external: { url: 'https://example.com/clip.mp3' },
+    });
+    expect(getAudioUrl(block)).toBe('https://example.com/clip.mp3');
+  });
+
+  test('returns url for hosted file audio', () => {
+    const block = audioBlock('file', {
+      file: { url: 'https://s3.example.com/clip.mp3', expiry_time: '' },
+    });
+    expect(getAudioUrl(block)).toBe('https://s3.example.com/clip.mp3');
+  });
+
+  test('returns null for unsupported audio type instead of a bad URL string', () => {
+    const block = audioBlock('unsupported_type' as never, {});
+    expect(getAudioUrl(block)).toBeNull();
+  });
+});

--- a/src/services/NotionService/helpers/getAudioUrl.ts
+++ b/src/services/NotionService/helpers/getAudioUrl.ts
@@ -11,6 +11,6 @@ export const getAudioUrl = (block: AudioBlockObjectResponse): string | null => {
     case 'file':
       return block.audio.file.url;
     default:
-      return 'unsupported audio: ' + JSON.stringify(block);
+      return null;
   }
 };

--- a/src/services/NotionService/helpers/getFileUrl.test.ts
+++ b/src/services/NotionService/helpers/getFileUrl.test.ts
@@ -1,0 +1,59 @@
+import {
+  FileBlockObjectResponse,
+  PdfBlockObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import { getFileUrl } from './getFileUrl';
+
+jest.mock('@notionhq/client', () => ({
+  isFullBlock: () => true,
+}));
+
+function fileBlock(type: string, extra: object): FileBlockObjectResponse {
+  return {
+    object: 'block',
+    id: 'b',
+    type: 'file',
+    has_children: false,
+    archived: false,
+    file: { type, ...extra },
+  } as unknown as FileBlockObjectResponse;
+}
+
+function pdfBlock(type: string, extra: object): PdfBlockObjectResponse {
+  return {
+    object: 'block',
+    id: 'b',
+    type: 'pdf',
+    has_children: false,
+    archived: false,
+    pdf: { type, ...extra },
+  } as unknown as PdfBlockObjectResponse;
+}
+
+describe('getFileUrl', () => {
+  test('returns url for external file', () => {
+    const block = fileBlock('external', {
+      external: { url: 'https://example.com/notes.pdf' },
+    });
+    expect(getFileUrl(block)).toBe('https://example.com/notes.pdf');
+  });
+
+  test('returns url for hosted file', () => {
+    const block = fileBlock('file', {
+      file: { url: 'https://s3.example.com/notes.pdf', expiry_time: '' },
+    });
+    expect(getFileUrl(block)).toBe('https://s3.example.com/notes.pdf');
+  });
+
+  test('returns url for hosted pdf block', () => {
+    const block = pdfBlock('file', {
+      file: { url: 'https://s3.example.com/slides.pdf', expiry_time: '' },
+    });
+    expect(getFileUrl(block)).toBe('https://s3.example.com/slides.pdf');
+  });
+
+  test('returns null for unsupported file type instead of a bad URL string', () => {
+    const block = fileBlock('unsupported_type' as never, {});
+    expect(getFileUrl(block)).toBeNull();
+  });
+});

--- a/src/services/NotionService/helpers/getFileUrl.ts
+++ b/src/services/NotionService/helpers/getFileUrl.ts
@@ -17,6 +17,6 @@ export const getFileUrl = (
     case 'file':
       return source.file.url;
     default:
-      return 'unsupported file: ' + JSON.stringify(block);
+      return null;
   }
 };

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-notion-toggle-media.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-notion-toggle-media.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-notion-toggle-media",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Notion pages with an unusual image, audio, or file block convert instead of stalling"
+}


### PR DESCRIPTION
## What

`getAudioUrl` and `getFileUrl` returned `"unsupported audio/file: <block JSON>"` for an unknown media source type. That string was then handed to `downloadMediaOrSkip` -> `instrumentedAxios` as if it were a URL — the SSRF guard rejects it and throws, aborting the whole conversion, and the block JSON (block IDs, `created_by` user IDs) leaked into the fetch path. Both helpers now return `null` on an unknown type, matching `getImageUrl` (which was already hardened). `embedAudioFile`/`embedFile` already guard on `!url`, so the odd block is skipped and the rest of the page converts.

Also adds the toggle back-side media regression tests the issue asked for.

## Why

Closes #3183. Recurring YouTube feedback over several years reports three media failures in converted cards: (1) images inside a Notion toggle don't appear, (2) Notion audio converts to a bare link, (3) images render too narrow with a white frame.

Tracing the hot path showed (1) and (2) were already fixed: toggle children — front and back — route every `image`/`audio`/`file` block through `blockToStaticMarkup` -> `embedImage`/`embedAudioFile`/`embedFile`, which download bytes via `instrumentedAxios` and bundle them as SHA-512-named Anki media. Front-side toggle media shipped in #3265; back-side and column media were already correct. This PR locks that behavior with regression tests and closes the one genuine remaining defect in the same media path: the unknown-source-type junk-URL crash/leak above.

See the URL-lifecycle paragraph in Risks for the file-vs-external reasoning.

## How

- `getAudioUrl`/`getFileUrl`: `default` arm returns `null` instead of a junk `"unsupported …"` string (one line each).
- New `getAudioUrl.test.ts` / `getFileUrl.test.ts`: external URL, hosted-file URL, and `null` on unknown type (mirrors `getImageUrl.test.ts`).
- New `BlockHandler.toggleBackMedia.test.ts`: a `file`-type image and audio nested in a toggle body bundle as SHA-512 media (no `prod-files-secure.s3` host, no `sig=` signature, no bare `<a>`); an `external` image still renders as `<img>`. Mocks only the external edge (`downloadMediaOrSkip`).

## Measuring success

- Drop in YouTube/support reports of missing images / dead audio in converted decks.
- Server logs: the `Skipping media fetch for <url> — received 403` warning in `downloadMediaOrSkip` is the existing signal that a signed URL lapsed before download; with toggle/column media bundled at convert time it should not appear for in-app Notion conversions. No new log line was added — the regression tests are the durable guard.

## Testing

- Unit tests added: `getAudioUrl.test.ts` (3), `getFileUrl.test.ts` (4), `BlockHandler.toggleBackMedia.test.ts` (3).
- Confirmed the two `null`-on-unknown-type cases fail against the old junk-string behavior before the fix, then pass after.
- Server `tsc --noEmit`: clean. Web `tsc`: clean. oxlint on changed files: clean.
- Web vitest could not run in this worktree — the hoisted `html-encoding-sniffer` dep `require()`s an ES module (`@exodus/bytes/encoding-lite.js`), so the vitest worker fails to start for the whole web suite (pre-existing env break, unrelated to this diff). Validated the new changelog JSON against the loader schema (id == filename, date pattern, valid type, unique id) with a standalone node check across all 480 entries — all valid.
- `sonar-scanner` not installed / `SONAR_TOKEN` unset locally — not run. The diff is two one-line `return null` edits plus tests and one JSON file; low Sonar risk. Expect a clean scan or flag if it bounces.

## Browser check

Browser check: not applicable — server-side conversion change; the only `web/src/` file is a changelog JSON entry (no rendered behavior change).

## Risks

Touches external-API integration (Notion media URLs -> `instrumentedAxios`). **Run `/security-review` before merge.**

**URL lifecycle (the bot review will not verify this):** Notion's `file.url` for images, audio, and file blocks is a signed S3 URL that expires ~1h after generation. The conversion path routes every `block.<type>.type === 'file'` asset through download-and-bundle (`embedImage`/`embedAudioFile`/`embedFile` -> `downloadMediaOrSkip` via `instrumentedAxios` -> SHA-512-named media inside the `.apkg`), so the bytes are durable and the card never depends on the signature. `type === 'external'` assets (a real third-party URL the user pasted into Notion) do not expire; the embed methods rehost them too, which is durable and strictly safer than a link. The expiring-signed-URL failure is closed because no `file`-type asset's raw URL reaches a card face — and this PR removes the last path where a malformed/unknown source type fed a non-URL string into the fetcher.

Rollback: revert the two helper edits; behavior returns to the prior junk-string-on-unknown-type (which only triggers on an unexpected Notion source type, so user-invisible in the common case).

## Bug (3) — split to follow-up

The width / white-frame complaint is **not fixed here**. The shipped `img` rule in `src/templates/notion.css` is already `max-width: 100%; height: auto; display: block; margin: 0 auto` — no fixed narrow width, no border, no white frame. The reported artifact likely originates in Anki's own webview rendering or older exports and needs reproduction that could balloon the diff and risk other card layouts. Per the issue's scope guidance, I shipped the correctness fixes (1)+(2) cleanly and left (3) for a separate investigation. A follow-up issue should be filed to reproduce the white-frame/narrow-width case with a specific deck before touching shared card CSS.

## Changelog

`Notion pages with an unusual image, audio, or file block convert instead of stalling` (`web/src/pages/WhatsNewPage/changelog/2026-06-12-notion-toggle-media.json`). The headline toggle-media behavior shipped earlier (#3265); this entry honestly describes what this PR's source change does — keeps a conversion from stalling on an unexpected media block.

## Goal alignment

Core product + acquisition. Media correctness serves the dominant pay-willing segment (med students, language learners) — a deck with missing images or dead audio breaks the "drop something in, get a clean deck back" promise. Metric: drop in media-failure feedback / support reports, and conversion-success quality for media-heavy Notion decks. Read via YouTube/support inbox volume; no in-product funnel event added.

Closes #3183
