### PR TITLE
feat: add log out everywhere to the account page

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -2945,3 +2945,64 @@ describe('UsersController.submitCancellationFeedback', () => {
     expect(insert).not.toHaveBeenCalled();
   });
 });
+
+describe('UsersController.logOutEverywhere', () => {
+  const buildLogOutEverywhereController = (logOutEverywhere: jest.Mock) => {
+    const authService = {
+      logOutEverywhere,
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      {} as UsersService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    return { controller };
+  };
+
+  const buildResWithLocals = (owner: number | null) => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnValue({ json });
+    const clearCookie = jest.fn();
+    return {
+      json,
+      status,
+      clearCookie,
+      locals: { owner },
+    } as unknown as express.Response & {
+      json: jest.Mock;
+      status: jest.Mock;
+      clearCookie: jest.Mock;
+    };
+  };
+
+  it('revokes every session for the session owner and clears the cookie', async () => {
+    const logOutEverywhere = jest.fn().mockResolvedValue(3);
+    const { controller } = buildLogOutEverywhereController(logOutEverywhere);
+    const req = {
+      body: { owner: 999 },
+    } as unknown as express.Request;
+    const res = buildResWithLocals(7);
+    const next = jest.fn();
+
+    await controller.logOutEverywhere(req, res, next);
+
+    expect(logOutEverywhere).toHaveBeenCalledWith(7);
+    expect(logOutEverywhere).not.toHaveBeenCalledWith(999);
+    expect(res.clearCookie).toHaveBeenCalledWith('token');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects when there is no session owner and never revokes', async () => {
+    const logOutEverywhere = jest.fn();
+    const { controller } = buildLogOutEverywhereController(logOutEverywhere);
+    const req = {} as express.Request;
+    const res = buildResWithLocals(null);
+    const next = jest.fn();
+
+    await controller.logOutEverywhere(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(logOutEverywhere).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -103,6 +103,26 @@ class UsersController {
     }
   }
 
+  async logOutEverywhere(
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) {
+    const { owner } = res.locals;
+
+    if (owner == null) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+
+    try {
+      await this.authService.logOutEverywhere(owner);
+      res.clearCookie('token');
+      return res.status(200).json({ message: 'ok' });
+    } catch (error) {
+      return next(error);
+    }
+  }
+
   async login(
     req: express.Request,
     res: express.Response,

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -249,6 +249,36 @@ const UserRouter = () => {
 
   /**
    * @swagger
+   * /api/users/logout-everywhere:
+   *   post:
+   *     summary: Revoke every session for the authenticated user
+   *     description: Deletes all access tokens owned by the signed-in user, including the current session. Derives the owner from the session, never from the request body.
+   *     tags: [Authentication]
+   *     security:
+   *       - bearerAuth: []
+   *       - cookieAuth: []
+   *     responses:
+   *       200:
+   *         description: All sessions revoked
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Success'
+   *       401:
+   *         description: Authentication required
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/Error'
+   */
+  router.post(
+    '/api/users/logout-everywhere',
+    RequireAuthentication,
+    (req, res, next) => controller.logOutEverywhere(req, res, next)
+  );
+
+  /**
+   * @swagger
    * /api/users/login:
    *   post:
    *     summary: Login user

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -1254,3 +1254,53 @@ describe('revokeSessionsByResetToken', () => {
     expect(tokens).toEqual(['web']);
   });
 });
+
+describe('logOutEverywhere', () => {
+  let database: Knex;
+  let service: AuthenticationService;
+
+  beforeEach(async () => {
+    database = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await database.schema.createTable('access_tokens', (t) => {
+      t.integer('owner').notNullable().index();
+      t.text('token').notNullable().index();
+      t.timestamp('created_at').defaultTo(database.fn.now());
+    });
+    service = new AuthenticationService(
+      new TokenRepository(database),
+      new UsersRepository(database)
+    );
+  });
+
+  afterEach(async () => {
+    await database.destroy();
+  });
+
+  it('deletes every session owned by the given owner', async () => {
+    await database('access_tokens').insert([
+      { token: 'web', owner: 7 },
+      { token: 'app', owner: 7 },
+      { token: 'other', owner: 8 },
+    ]);
+
+    const deleted = await service.logOutEverywhere(7);
+
+    expect(deleted).toBe(2);
+    const tokens = (await database('access_tokens').select('token')).map(
+      (row) => row.token
+    );
+    expect(tokens).toEqual(['other']);
+  });
+
+  it('accepts a numeric owner and coerces it for the lookup', async () => {
+    await database('access_tokens').insert({ token: 'web', owner: 7 });
+
+    const deleted = await service.logOutEverywhere(7);
+
+    expect(deleted).toBe(1);
+  });
+});

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -180,6 +180,10 @@ class AuthenticationService {
     return this.tokenRepository.deleteAccessToken(token);
   }
 
+  logOutEverywhere(owner: string | number): Promise<number> {
+    return this.tokenRepository.deleteAllForOwner(owner.toString());
+  }
+
   async revokeSessionsByResetToken(resetToken: string): Promise<number> {
     const user = await this.usersRepository.getByResetToken(resetToken);
     if (user?.id == null) {

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -54,6 +54,16 @@ export class Backend {
     globalThis.location.href = '/';
   }
 
+  async logoutEverywhere() {
+    cancelPendingSync();
+    await post(`${this.baseURL}users/logout-everywhere`, {});
+    localStorage.clear();
+    sessionStorage.clear();
+    const cookies = new Cookies();
+    cookies.remove('token');
+    globalThis.location.href = '/login';
+  }
+
   async getNotionConnectionInfo(): Promise<ConnectionInfo> {
     return get(`${this.baseURL}notion/get-notion-link`);
   }

--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -333,3 +333,63 @@
   color: var(--color-text-primary);
   text-decoration: underline;
 }
+
+.sessionsTitle {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-secondary);
+  margin: 0 0 0.75rem;
+}
+
+.sessionsNotice {
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  margin-bottom: 0.75rem;
+  line-height: var(--leading-normal);
+}
+
+.sessionsButton {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.sessionsButton:hover {
+  background: var(--color-bg-secondary);
+}
+
+.sessionsButton:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.sessionsButtonGhost {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.sessionsButtonGhost:hover {
+  color: var(--color-text-primary);
+}
+
+.sessionsButtonGhost:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/web/src/pages/AccountPage/AccountPage.test.tsx
+++ b/web/src/pages/AccountPage/AccountPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock('./components', () => ({
   ClaimSubscription: () => <div>Paid with a different email?</div>,
   SubscriptionManagement: () => null,
   AccountDeletion: () => null,
+  LogOutEverywhere: () => null,
 }));
 
 import { useUserLocals } from '../../lib/hooks/useUserLocals';

--- a/web/src/pages/AccountPage/AccountPage.tsx
+++ b/web/src/pages/AccountPage/AccountPage.tsx
@@ -8,6 +8,7 @@ import {
   ClaimSubscription,
   SubscriptionManagement,
   AccountDeletion,
+  LogOutEverywhere,
 } from './components';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './AccountPage.module.css';
@@ -91,6 +92,8 @@ export default function AccountPage() {
         hasActivePlan={hasActivePlan}
         onRefetch={refetch}
       />
+
+      <LogOutEverywhere />
 
       <AccountDeletion />
 

--- a/web/src/pages/AccountPage/components/LogOutEverywhere.test.tsx
+++ b/web/src/pages/AccountPage/components/LogOutEverywhere.test.tsx
@@ -26,9 +26,7 @@ describe('LogOutEverywhere', () => {
   it('revokes every session when the confirm step is clicked', async () => {
     render(<LogOutEverywhere />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Log out everywhere' })
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log out everywhere' }));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
     expect(logoutEverywhere).toHaveBeenCalledTimes(1);
@@ -37,9 +35,7 @@ describe('LogOutEverywhere', () => {
   it('does nothing when the confirm step is cancelled', () => {
     render(<LogOutEverywhere />);
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Log out everywhere' })
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Log out everywhere' }));
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(logoutEverywhere).not.toHaveBeenCalled();

--- a/web/src/pages/AccountPage/components/LogOutEverywhere.test.tsx
+++ b/web/src/pages/AccountPage/components/LogOutEverywhere.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LogOutEverywhere } from './LogOutEverywhere';
+
+const logoutEverywhere = vi.fn();
+
+vi.mock('../../../lib/backend/get2ankiApi', () => ({
+  get2ankiApi: () => ({ logoutEverywhere }),
+}));
+
+describe('LogOutEverywhere', () => {
+  beforeEach(() => {
+    logoutEverywhere.mockReset();
+    logoutEverywhere.mockResolvedValue(undefined);
+  });
+
+  it('renders the trigger button and does not revoke before confirming', () => {
+    render(<LogOutEverywhere />);
+
+    expect(
+      screen.getByRole('button', { name: 'Log out everywhere' })
+    ).toBeInTheDocument();
+    expect(logoutEverywhere).not.toHaveBeenCalled();
+  });
+
+  it('revokes every session when the confirm step is clicked', async () => {
+    render(<LogOutEverywhere />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Log out everywhere' })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(logoutEverywhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the confirm step is cancelled', () => {
+    render(<LogOutEverywhere />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Log out everywhere' })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(logoutEverywhere).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', { name: 'Log out everywhere' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AccountPage/components/LogOutEverywhere.tsx
+++ b/web/src/pages/AccountPage/components/LogOutEverywhere.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+import styles from '../AccountPage.module.css';
+
+export function LogOutEverywhere() {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isWorking, setIsWorking] = useState(false);
+
+  const revokeAll = async () => {
+    setIsWorking(true);
+    await get2ankiApi().logoutEverywhere();
+  };
+
+  return (
+    <section className={styles.section}>
+      <h4 className={styles.sessionsTitle}>Sessions</h4>
+      <div className={styles.sessionsNotice}>
+        Lost a device? Log out everywhere to end every session, including this
+        one. Sign back in to continue.
+      </div>
+      {isConfirming ? (
+        <div className={styles.buttonRow}>
+          <button
+            type="button"
+            className={styles.sessionsButton}
+            onClick={revokeAll}
+            disabled={isWorking}
+          >
+            Confirm
+          </button>
+          <button
+            type="button"
+            className={styles.sessionsButtonGhost}
+            onClick={() => setIsConfirming(false)}
+            disabled={isWorking}
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className={styles.sessionsButton}
+          onClick={() => setIsConfirming(true)}
+        >
+          Log out everywhere
+        </button>
+      )}
+    </section>
+  );
+}

--- a/web/src/pages/AccountPage/components/index.ts
+++ b/web/src/pages/AccountPage/components/index.ts
@@ -3,3 +3,4 @@ export { PlanDetails } from './PlanDetails';
 export { SubscriptionManagement } from './SubscriptionManagement';
 export { AccountDeletion } from './AccountDeletion';
 export { ClaimSubscription } from './ClaimSubscription';
+export { LogOutEverywhere } from './LogOutEverywhere';

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-log-out-everywhere.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-log-out-everywhere.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-log-out-everywhere",
+  "date": "2026-06-12",
+  "type": "feature",
+  "title": "Log out of every device at once from your account page"
+}


### PR DESCRIPTION
## What
Adds a "Log out everywhere" control to the Account page and an authenticated `POST /api/users/logout-everywhere` endpoint that revokes every session for the signed-in user (including the current one) via `TokenRepository.deleteAllForOwner`.

## Why
Closes #3189. Follow-up to #3187/#3188 — multi-session auth removed the accidental revocation users used to get. Password reset already revokes all sessions, but a user who lost a device should not have to reset their password just to end remote sessions. The trio review that scoped this lives on #3188 (already done — not re-run here).

## How
- **Service:** `AuthenticationService.logOutEverywhere(owner)` to `tokenRepository.deleteAllForOwner(owner.toString())`. Mirrors the altitude of the existing `logOut(token)`.
- **Controller:** `UsersController.logOutEverywhere` derives the owner from `res.locals` (set by `RequireAuthentication`), never from the request body or param — the IDOR guard. Uses `owner == null` for the presence check, clears the cookie, returns 200.
- **Route:** `POST /api/users/logout-everywhere` behind `RequireAuthentication` middleware (auth in the route, not the controller). State-mutating, so POST.
- **Frontend:** `Backend.logoutEverywhere()` posts to the endpoint, then clears local auth and redirects to `/login` (the current session is now dead — that is the point). New `LogOutEverywhere` component is a neutral, two-step inline "Log out everywhere then Confirm" — no new heavy modal; understated per VOICE.md, no celebratory toast. Neutral (ghost/secondary) styling, not the red destructive variant — the action is reversible by signing back in.

Out of scope (per the issue): session list, device naming, per-session revoke.

## Measuring success
- Endpoint usage: count of `POST /api/users/logout-everywhere` 200s in access logs.
- Support load: volume of "log me out of other devices" / "I lost my device" tickets should fall — these users no longer need a password reset.

## Testing
- Server (Jest, 157 passing across the two touched suites):
  - `UsersController.logOutEverywhere` — revokes for the session owner (7) and never the body-supplied owner (999); clears the cookie; returns 200.
  - `UsersController.logOutEverywhere` — no session owner gives 401 and `logOutEverywhere` is never called.
  - `AuthenticationService.logOutEverywhere` — deletes every session owned by the owner, leaves others untouched; coerces a numeric owner.
- Web (Vitest, real component, backend mocked at the edge):
  - `LogOutEverywhere` renders the trigger and does not revoke before confirming.
  - Confirming calls `logoutEverywhere` once.
  - Cancelling does nothing and returns to the trigger.
  - `AccountPage` mock updated so the page renders with the new component.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Could not drive a live browser in this environment (no display, Playwright MCP not wired here). Verified instead via the render-based component test (trigger then confirm then backend call; cancel then no-op) and by reasoning through the redirect: after the endpoint succeeds the current token is revoked, so the client clears local auth and navigates to `/login`, matching the existing logout teardown. The control is a real accessible `<button>` with text labels at all breakpoints; the neutral two-step is layout-stable at 375px (single `.buttonRow` with two buttons). Flagging that this was not a live drive so a reviewer can re-confirm on `pnpm dev`.

## Tooling notes
- `sonar-scanner` was NOT run — not installed in this environment and no `SONAR_TOKEN`. Expect a possible Sonar pass on the new controller method and component. The button is a native `<button type="button">`; the new controller method is a flat try/catch with a single early return (low complexity).
- `/check` is green: server `tsc --noEmit` clean, web `typecheck` clean, web `lint` exit 0 (no new warnings on the touched files), web `vitest` for `AccountPage/` and `backend/` 107 passing.

## Docs
No user docs change — there is no existing account/security docs page under `web/src/pages/DocsPage/content/` that enumerates account actions (no "manage/delete your account" doc), so per the issue I did not create a whole new docs page for one button.

## Risks
- **AUTH change — `/security-review` MUST run before merge.** The IDOR guard is the load-bearing line: the owner comes from `res.locals` (trusted, set by `RequireAuthentication`), never from `req.body` or `req.params`. A controller test asserts the body-supplied owner (999) is ignored in favour of the session owner (7).
- Revoking the current session is intentional (that is the point of the feature). The client redirects to `/login`; a user who clicks it is signed out everywhere and signs back in to continue.
- No token or session id is logged.
- Rollback: revert the PR; the endpoint and button disappear cleanly, no migration involved.

## Goal alignment
Trust/retention — an account-security control that reduces support load (users no longer must reset their password to end a remote session). Metric to move: support-ticket volume for "log me out of other devices" plus `logout-everywhere` endpoint usage, read from access logs and the support inbox. Not a direct funnel/MRR mover; it is a retention/trust hygiene change on an existing surface.
