### PR TITLE
chore: move CI runners from Blacksmith back to GitHub Actions

### DIFF
--- a/.github/workflows/checkout-smoke.yml
+++ b/.github/workflows/checkout-smoke.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   checkout-smoke:
     name: checkout smoke (22.20.0)
-    runs-on: blacksmith
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,7 +32,7 @@ jobs:
   playwright:
     name: playwright (22.20.0)
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: blacksmith
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   static:
     name: static (22.20.0)
-    runs-on: blacksmith
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -37,7 +37,7 @@ jobs:
   test:
     name: test (22.20.0)
     if: ${{ github.actor != 'dependabot[bot]' }}
-    runs-on: blacksmith
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: build (22.20.0)
-    runs-on: blacksmith
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -45,7 +45,7 @@ jobs:
 
   test:
     name: test (22.20.0)
-    runs-on: blacksmith
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## What
Switches every CI job from `runs-on: blacksmith` back to GitHub-hosted `runs-on: ubuntu-latest` across `server.yml`, `web.yml`, `playwright.yml`, and `checkout-smoke.yml` (6 job definitions).

## Why
Steps off the third-party Blacksmith runner service so CI runs on first-party GitHub Actions infrastructure — no external runner to provision, bill, or keep available.

## How
Mechanical `runs-on` swap only. No `useblacksmith/*` actions, caches, or Blacksmith-specific steps were in use (grep-confirmed zero `blacksmith` references remain), so nothing else changes.

## Measuring success
CI green on this PR using ubuntu-latest runners; no workflow references Blacksmith.

## Testing
N/A — workflow-config only. The workflows themselves run on this PR and are the test.

## Risks
ubuntu-latest may be slower / differently-resourced than Blacksmith runners; watch CI wall-clock on the first few runs. No runtime/app code touched.

## Goal alignment
None — internal CI infrastructure, no user-facing or funnel impact.

No changelog entry — internal CI change, no user-visible behavior.
Browser check: not applicable — CI workflow config, no web/src/ change.