### PR TITLE
style: format StudyStatsSection empty-state line

### DIFF
--- a/web/src/pages/AnkifyPage/stats/StudyStatsSection.tsx
+++ b/web/src/pages/AnkifyPage/stats/StudyStatsSection.tsx
@@ -83,7 +83,8 @@ function ConnectedStats({ stats }: Readonly<{ stats: AnkifyStatsConnected }>) {
         />
         {!hasReviews && (
           <p className={styles.stateText}>
-            No reviews yet. Study a deck in Anki and your activity shows up here.
+            No reviews yet. Study a deck in Anki and your activity shows up
+            here.
           </p>
         )}
       </div>


### PR DESCRIPTION
## What
Wraps the over-long empty-state string in `web/src/pages/AnkifyPage/stats/StudyStatsSection.tsx` per oxfmt.

## Why
The Ankify heatmap PR (#3307) merged with a line oxfmt wants wrapped — `pnpm format:check` is now red on main, failing the `static` job on every open PR (#3308, #3310, #3311, #3312, #3313). This restores green.

## How
`oxfmt` line wrap only. No logic, no copy change (same words). `format:check` passes clean across all 2942 files after.

## Testing
`oxfmt -c .oxfmtrc.json --check src web/src` → all files correctly formatted.

## Risks
None — whitespace/wrapping only.

## Goal alignment
None — unblocks CI for in-flight work.

No changelog entry — formatting only, no user-visible behavior change.
Browser check: not applicable — formatting line-wrap, identical rendered output.