### PR TITLE
fix: scope Ankify reviews breakdown to whole collection

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -376,7 +376,7 @@ const AnkifyRouter = () => {
     new CheckAnkiWebStatusUseCase(repo, ankiConnectFactory),
     new ReissueAnkifySessionUrlUseCase(rac),
     new ValidateAnkifySessionTokenUseCase(rac, authService),
-    new GetAnkifyStatsUseCase(repo, mappings, ankiConnectFactory)
+    new GetAnkifyStatsUseCase(repo, ankiConnectFactory)
   );
 
   /**

--- a/src/usecases/ankify/GetAnkifyStatsUseCase.test.ts
+++ b/src/usecases/ankify/GetAnkifyStatsUseCase.test.ts
@@ -1,6 +1,5 @@
 import { GetAnkifyStatsUseCase } from './GetAnkifyStatsUseCase';
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
-import { AnkifySyncMappingsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncMappingsRepository';
 import {
   AnkiConnectUnreachableError,
   AnkiDeckStat,
@@ -20,22 +19,11 @@ const makeClientsRepo = (
     findActiveByOwner: jest.fn(async () => client),
   }) as unknown as AnkifyClientsRepositoryInterface;
 
-const makeMappingsRepo = (
-  deckNames: string[]
-): AnkifySyncMappingsRepositoryInterface =>
-  ({
-    listByClient: jest.fn(async () =>
-      deckNames.map((deck_name, i) => ({
-        deck_name,
-        anki_note_id: i,
-      }))
-    ),
-  }) as unknown as AnkifySyncMappingsRepositoryInterface;
-
 const TODAY = '2026-06-12';
 
 interface FakeAnkiConnect {
   ping: jest.Mock;
+  deckNames: jest.Mock;
   getNumCardsReviewedToday: jest.Mock;
   getNumCardsReviewedByDay: jest.Mock;
   getDeckStats: jest.Mock;
@@ -47,6 +35,7 @@ const makeAnkiConnect = (
   overrides: Partial<Record<keyof FakeAnkiConnect, jest.Mock>> = {}
 ): FakeAnkiConnect => ({
   ping: jest.fn(async () => 6),
+  deckNames: jest.fn(async () => [] as string[]),
   getNumCardsReviewedToday: jest.fn(async () => 0),
   getNumCardsReviewedByDay: jest.fn(async () => [] as Array<[string, number]>),
   getDeckStats: jest.fn(async () => ({}) as Record<string, AnkiDeckStat>),
@@ -60,7 +49,6 @@ describe('GetAnkifyStatsUseCase', () => {
     const ac = makeAnkiConnect();
     const useCase = new GetAnkifyStatsUseCase(
       makeClientsRepo(null),
-      makeMappingsRepo([]),
       () => ac as never
     );
 
@@ -78,7 +66,6 @@ describe('GetAnkifyStatsUseCase', () => {
     });
     const useCase = new GetAnkifyStatsUseCase(
       makeClientsRepo(activeClient),
-      makeMappingsRepo(['Pharmacology']),
       () => ac as never
     );
 
@@ -89,14 +76,14 @@ describe('GetAnkifyStatsUseCase', () => {
     expect(ac.getDeckStats).not.toHaveBeenCalled();
   });
 
-  test('skips getDeckStats when there are no synced decks', async () => {
+  test('skips getDeckStats when the collection has no decks', async () => {
     const ac = makeAnkiConnect({
+      deckNames: jest.fn(async () => []),
       getNumCardsReviewedToday: jest.fn(async () => 4),
       getNumCardsReviewedByDay: jest.fn(async () => [['2026-06-12', 4]]),
     });
     const useCase = new GetAnkifyStatsUseCase(
       makeClientsRepo(activeClient),
-      makeMappingsRepo([]),
       () => ac as never
     );
 
@@ -114,14 +101,27 @@ describe('GetAnkifyStatsUseCase', () => {
     });
   });
 
-  test('maps the happy path into a typed response and never invokes the fan-out reads', async () => {
+  test('fetches deck stats for the full collection and sorts decks by total desc', async () => {
     const ac = makeAnkiConnect({
+      deckNames: jest.fn(async () => [
+        'Default',
+        'Pharmacology',
+        'Spanish::Verbs',
+      ]),
       getNumCardsReviewedToday: jest.fn(async () => 12),
       getNumCardsReviewedByDay: jest.fn(async () => [
         ['2026-06-12', 12],
         ['2026-06-11', 8],
       ]),
       getDeckStats: jest.fn(async () => ({
+        '1': {
+          deck_id: 1,
+          name: 'Default',
+          new_count: 0,
+          learn_count: 0,
+          review_count: 0,
+          total_in_deck: 0,
+        },
         '111': {
           deck_id: 111,
           name: 'Pharmacology',
@@ -130,17 +130,29 @@ describe('GetAnkifyStatsUseCase', () => {
           review_count: 11,
           total_in_deck: 120,
         },
+        '222': {
+          deck_id: 222,
+          name: 'Spanish::Verbs',
+          new_count: 1,
+          learn_count: 0,
+          review_count: 4,
+          total_in_deck: 300,
+        },
       })),
     });
     const useCase = new GetAnkifyStatsUseCase(
       makeClientsRepo(activeClient),
-      makeMappingsRepo(['Pharmacology', 'Pharmacology']),
       () => ac as never
     );
 
     const result = await useCase.execute(1, { today: TODAY });
 
-    expect(ac.getDeckStats).toHaveBeenCalledWith(['Pharmacology']);
+    expect(ac.deckNames).toHaveBeenCalledTimes(1);
+    expect(ac.getDeckStats).toHaveBeenCalledWith([
+      'Default',
+      'Pharmacology',
+      'Spanish::Verbs',
+    ]);
     expect(ac.cardReviews).not.toHaveBeenCalled();
     expect(ac.getReviewMinutesByDay).not.toHaveBeenCalled();
     expect(result).toEqual({
@@ -154,13 +166,47 @@ describe('GetAnkifyStatsUseCase', () => {
         { date: '2026-06-11', count: 8 },
       ],
       decks: [
-        {
-          name: 'Pharmacology',
-          new: 5,
-          learning: 2,
-          review: 11,
-          total: 120,
+        { name: 'Spanish::Verbs', new: 1, learning: 0, review: 4, total: 300 },
+        { name: 'Pharmacology', new: 5, learning: 2, review: 11, total: 120 },
+        { name: 'Default', new: 0, learning: 0, review: 0, total: 0 },
+      ],
+    });
+  });
+
+  test('tie-breaks decks with equal totals by name ascending', async () => {
+    const ac = makeAnkiConnect({
+      deckNames: jest.fn(async () => ['Zoology', 'Anatomy']),
+      getDeckStats: jest.fn(async () => ({
+        '1': {
+          deck_id: 1,
+          name: 'Zoology',
+          new_count: 0,
+          learn_count: 0,
+          review_count: 0,
+          total_in_deck: 50,
         },
+        '2': {
+          deck_id: 2,
+          name: 'Anatomy',
+          new_count: 0,
+          learn_count: 0,
+          review_count: 0,
+          total_in_deck: 50,
+        },
+      })),
+    });
+    const useCase = new GetAnkifyStatsUseCase(
+      makeClientsRepo(activeClient),
+      () => ac as never
+    );
+
+    const result = await useCase.execute(1, { today: TODAY });
+
+    expect(result).toMatchObject({
+      connected: true,
+      decks: [
+        { name: 'Anatomy', total: 50 },
+        { name: 'Zoology', total: 50 },
       ],
     });
   });

--- a/src/usecases/ankify/GetAnkifyStatsUseCase.ts
+++ b/src/usecases/ankify/GetAnkifyStatsUseCase.ts
@@ -1,5 +1,4 @@
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
-import { AnkifySyncMappingsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncMappingsRepository';
 import {
   AnkiConnectClient,
   AnkiConnectUnreachableError,
@@ -51,7 +50,6 @@ const oneYearAgo = (today: string): string => {
 export class GetAnkifyStatsUseCase {
   constructor(
     private readonly clients: AnkifyClientsRepositoryInterface,
-    private readonly mappings: AnkifySyncMappingsRepositoryInterface,
     private readonly ankiConnect: AnkiConnectFactory
   ) {}
 
@@ -79,7 +77,7 @@ export class GetAnkifyStatsUseCase {
       throw error;
     }
 
-    const deckNames = await this.distinctSyncedDeckNames(client.id);
+    const deckNames = await ac.deckNames();
 
     const [reviewedToday, reviewsByDayRaw, deckStats] = await Promise.all([
       ac.getNumCardsReviewedToday(),
@@ -102,13 +100,17 @@ export class GetAnkifyStatsUseCase {
       .filter((entry) => entry.date >= yearCutoff)
       .reduce((sum, entry) => sum + entry.count, 0);
 
-    const decks: AnkifyStatsDeck[] = Object.values(deckStats).map((stat) => ({
-      name: stat.name,
-      new: stat.new_count,
-      learning: stat.learn_count,
-      review: stat.review_count,
-      total: stat.total_in_deck ?? 0,
-    }));
+    const decks: AnkifyStatsDeck[] = Object.values(deckStats)
+      .map((stat) => ({
+        name: stat.name,
+        new: stat.new_count,
+        learning: stat.learn_count,
+        review: stat.review_count,
+        total: stat.total_in_deck ?? 0,
+      }))
+      .sort((a, b) =>
+        b.total === a.total ? a.name.localeCompare(b.name) : b.total - a.total
+      );
 
     return {
       connected: true,
@@ -119,20 +121,5 @@ export class GetAnkifyStatsUseCase {
       reviewsByDay,
       decks,
     };
-  }
-
-  private async distinctSyncedDeckNames(clientId: number): Promise<string[]> {
-    const rows = await this.mappings.listByClient(clientId);
-    const seen = new Set<string>();
-    const names: string[] = [];
-    for (const row of rows) {
-      const deck = row.deck_name?.trim();
-      if (deck == null || deck.length === 0 || seen.has(deck)) {
-        continue;
-      }
-      seen.add(deck);
-      names.push(deck);
-    }
-    return names;
   }
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-all-decks.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-all-decks.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-ankify-all-decks",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "The Ankify reviews breakdown now lists every Anki deck, not just synced ones"
+}


### PR DESCRIPTION
## What
The Ankify "Your reviews" card has a "By deck" breakdown. It derived deck names from the sync-mappings table, so it only showed the decks Ankify syncs *into* — a user with a single subscription saw just one deck. The rest of the same card (heatmap, streak, reviews this year) is whole-collection. This sources the breakdown from the user's full Anki deck list instead, so the breakdown matches the collection the heatmap reflects.

## Why
A user with many Anki decks saw only the synced deck under a "Live from Anki" whole-collection card — the breakdown contradicted the heatmap/streak above it. Under a whole-collection card the breakdown must reflect the same collection.

## How
- `GetAnkifyStatsUseCase` now calls `ac.deckNames()` (the AnkiConnect client's full deck list) instead of deriving names from sync mappings. The existing `deckNames.length > 0 ? getDeckStats(...) : {}` guard is kept.
- The returned `decks` array is sorted by `total` descending (tie-break by name ascending) so the chart's default top-8 shows the user's biggest decks. Empty decks (Default, parent decks) sort last and are intentionally not filtered out.
- The now-unused `mappings` constructor param and the private `distinctSyncedDeckNames` helper are deleted. The single construction site (`AnkifyRouter.ts:379`) drops the `mappings` argument; the `mappings` variable stays because three other use cases in the same wiring still consume it.

No feature flag — all-decks is the unconditional default.

## Measuring success
The `/api/ankify/stats` response `decks[]` now returns the full collection. In prod, a connected client's stats response should carry more than just the synced deck names. Confirm on the reporter's path: their `/ankify` "By deck" chart shows all their decks (with "Show all" past the top 8), matching the heatmap's whole-collection counts.

## Testing
- Unit tests added/updated in `GetAnkifyStatsUseCase.test.ts`:
  - `fetches deck stats for the full collection and sorts decks by total desc` — asserts `getDeckStats` is called with the full `deckNames()` list and the result is sorted by total desc.
  - `tie-breaks decks with equal totals by name ascending`.
  - `skips getDeckStats when the collection has no decks` (rewritten from the synced-decks variant).
  - The mappings repo mock was removed from the suite.
- All 5 tests pass on Node 22.20.0. `tsc --noEmit` clean.

## Construction sites checked
`grep -rn "new GetAnkifyStatsUseCase("` → single site in `AnkifyRouter.ts`, updated. The reporter's path (the `/ankify` page reading this endpoint) is covered.

## Browser check
Browser check: not applicable — server-side stats scope change, no web/src render. The only `web/src/` file is the changelog JSON (changelog-only bypass).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-12-ankify-all-decks.json` — "The Ankify reviews breakdown now lists every Anki deck, not just synced ones"

## User docs
None — this is a refinement of an existing card, no new surface or flow.

## Risks
- External-API: reuses the AnkiConnect `deckNames()` and `getDeckStats()` methods already used elsewhere — no new external surface, so `/security-review` is not triggered (noted here for completeness).
- A user with hundreds of decks gets a longer `getDeckStats` call. Acceptable — the chart paginates (top 8 + "Show all") and the call is the same one the synced path made, just with more deck names.
- sonar-scanner was not run locally (not installed in this worktree, no `SONAR_TOKEN`). The diff is a small sort + a deleted private method; expect no new smells, but flagging in case of a Sonar bounce.

## Goal alignment
Retention surface — Ankify is the $30/mo Auto Sync product. An accurate whole-collection breakdown makes "Your reviews" trustworthy instead of self-contradicting. Metric: Ankify weekly-active return (do subscribers keep opening `/ankify`). No acquisition impact — internal-to-the-paid-surface refinement.
