### PR TITLE
fix: quote open-in-anki swagger description so the YAML parses

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -715,7 +715,7 @@ const AnkifyRouter = () => {
    * /api/ankify/conflicts/{id}/open-in-anki:
    *   post:
    *     summary: Open the conflicting note in the user's hosted Anki browser
-   *     description: Allowlisted endpoint. Looks up the owner's conflict row, derives its Anki note id, and invokes AnkiConnect guiBrowse(nid:<id>) so Anki's browser focuses that note. Returns { opened: false } when the client is offline.
+   *     description: "Allowlisted endpoint. Looks up the owner's conflict row, derives its Anki note id, and invokes AnkiConnect guiBrowse(nid:<id>) so Anki's browser focuses that note. Returns { opened: false } when the client is offline."
    *     tags: [Ankify]
    *     parameters:
    *       - in: path


### PR DESCRIPTION
## What
Wraps the `description` of the `POST /api/ankify/conflicts/{id}/open-in-anki` swagger block (`src/routes/AnkifyRouter.ts:718`) in double quotes.

## Why
The description is an unquoted YAML scalar containing `Returns { opened: false }`. The `opened: false` colon-space makes swagger-jsdoc's YAML parser interpret a nested mapping and throw `YAMLSemanticError: Nested mappings are not allowed in compact mappings` at boot — visible in prod logs (server-blue) and dropping this route from the generated API docs. Same class as #3304 (stats-route description); the response `description` just below (line 728) and the stats route (804) are already quoted.

## How
Quote the value. No behavior change — swagger doc text only.

## Testing
`tsc --noEmit` clean. Matches the known-good quoted pattern at line 804.

## Risks
None — OpenAPI annotation comment only.

## Goal alignment
None — internal API-doc correctness / removes a prod boot error. 

No changelog entry — internal swagger fix, no user-visible behavior.
Browser check: not applicable — server route annotation, no web/src/ change.