### PR TITLE
fix: bind Stripe subscriptions to accounts by identity, not just email

### DIFF
--- a/src/lib/integrations/stripe.test.ts
+++ b/src/lib/integrations/stripe.test.ts
@@ -1,32 +1,8 @@
 process.env.STRIPE_KEY = 'sk_test_fake_key_for_unit_tests';
 
+import knexLib, { Knex } from 'knex';
 import { updateStoreSubscription } from './stripe';
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
-import { Knex } from 'knex';
-
-const makeInsertChain = () => {
-  const mergeChain = { merge: jest.fn().mockResolvedValue(1) };
-  const onConflictChain = { merge: jest.fn().mockReturnValue(mergeChain) };
-  const insertChain = {
-    onConflict: jest.fn().mockReturnValue(onConflictChain),
-  };
-  return { insertChain, onConflictChain, mergeChain };
-};
-
-const makeKnex = () => {
-  const { insertChain, onConflictChain } = makeInsertChain();
-  const whereChain = { update: jest.fn().mockResolvedValue(1) };
-  const usersChain = { where: jest.fn().mockReturnValue(whereChain) };
-
-  const db = jest.fn((table: string) => {
-    if (table === 'subscriptions') {
-      return { insert: jest.fn().mockReturnValue(insertChain) };
-    }
-    return usersChain;
-  }) as unknown as Knex;
-
-  return { db, insertChain, onConflictChain, whereChain };
-};
 
 const makeCustomer = (
   email: string | null,
@@ -37,84 +13,177 @@ const makeCustomer = (
 const makeSubscription = (
   status: StripeTypes.Subscription['status'],
   productId: string,
-  cancel_at_period_end = false,
-  cancel_at: number | null = null
+  options: {
+    customer?: string;
+    cancelAtPeriodEnd?: boolean;
+    cancelAt?: number | null;
+    userId?: string;
+  } = {}
 ): StripeTypes.Subscription =>
   ({
     status,
-    cancel_at_period_end,
-    cancel_at,
-    customer: 'cus_test123',
-    items: {
-      data: [{ price: { product: productId } }],
-    },
+    cancel_at_period_end: options.cancelAtPeriodEnd ?? false,
+    cancel_at: options.cancelAt ?? null,
+    customer: options.customer ?? 'cus_test123',
+    metadata: options.userId != null ? { user_id: options.userId } : {},
+    items: { data: [{ price: { product: productId } }] },
   }) as unknown as StripeTypes.Subscription;
 
 describe('updateStoreSubscription', () => {
-  test('inserts with stripe_product_id extracted from subscription items', async () => {
-    const { db, onConflictChain } = makeKnex();
-    await updateStoreSubscription(
+  let db: Knex;
+
+  beforeEach(async () => {
+    db = knexLib({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('users', (t) => {
+      t.increments('id');
+      t.string('email');
+      t.string('stripe_customer_id');
+    });
+    await db.schema.createTable('subscriptions', (t) => {
+      t.increments('id');
+      t.string('email').unique();
+      t.boolean('active');
+      t.json('payload');
+      t.string('stripe_product_id');
+      t.string('linked_email');
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test('inserts the subscription row with the extracted product id and active flag', async () => {
+    await db('users').insert({
+      email: 'user@example.com',
+      stripe_customer_id: null,
+    });
+
+    const result = await updateStoreSubscription(
       db,
       makeCustomer('user@example.com'),
       makeSubscription('active', 'prod_auto_sync')
     );
 
-    const subsResult = (db as unknown as jest.Mock).mock.results[0]?.value;
-    expect(subsResult.insert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        stripe_product_id: 'prod_auto_sync',
-        active: true,
-      })
-    );
-    expect(onConflictChain.merge).toHaveBeenCalledWith([
-      'active',
-      'payload',
-      'stripe_product_id',
-    ]);
+    const row = await db('subscriptions')
+      .where({ email: 'user@example.com' })
+      .first();
+    expect(row.stripe_product_id).toBe('prod_auto_sync');
+    expect(Boolean(row.active)).toBe(true);
+    expect(result).toEqual({ status: 'linked', resolvedUserId: 1 });
   });
 
   test('marks active=false when subscription status is canceled', async () => {
-    const { db } = makeKnex();
+    await db('users').insert({ email: 'user@example.com' });
+
     await updateStoreSubscription(
       db,
       makeCustomer('user@example.com'),
       makeSubscription('canceled', 'prod_auto_sync')
     );
 
-    const subsResult = (db as unknown as jest.Mock).mock.results[0]?.value;
-    expect(subsResult.insert).toHaveBeenCalledWith(
-      expect.objectContaining({ active: false })
-    );
+    const row = await db('subscriptions')
+      .where({ email: 'user@example.com' })
+      .first();
+    expect(Boolean(row.active)).toBe(false);
   });
 
-  test('stamps stripe_customer_id on users table using subscription.customer', async () => {
-    const { db, whereChain } = makeKnex();
-    await updateStoreSubscription(
+  test('links by metadata.user_id even when the Stripe email differs from the account', async () => {
+    await db('users').insert({
+      email: 'account@example.com',
+      stripe_customer_id: null,
+    });
+
+    const result = await updateStoreSubscription(
       db,
-      makeCustomer('user@example.com'),
-      makeSubscription('active', 'prod_auto_sync')
+      makeCustomer('paid-with@example.com'),
+      makeSubscription('active', 'prod_auto_sync', { userId: '1' })
     );
 
-    const usersCall = (db as unknown as jest.Mock).mock.calls.find(
-      (c) => c[0] === 'users'
-    );
-    expect(usersCall).toBeDefined();
-    expect(whereChain.update).toHaveBeenCalledWith({
+    expect(result).toEqual({ status: 'linked', resolvedUserId: 1 });
+    const user = await db('users').where({ id: 1 }).first();
+    expect(user.stripe_customer_id).toBe('cus_test123');
+    const row = await db('subscriptions')
+      .where({ email: 'paid-with@example.com' })
+      .first();
+    expect(row.linked_email).toBe('account@example.com');
+  });
+
+  test('links by stripe_customer_id when no metadata is present', async () => {
+    await db('users').insert({
+      email: 'account@example.com',
       stripe_customer_id: 'cus_test123',
     });
-  });
 
-  test('skips users table update when customer email is null', async () => {
-    const { db } = makeKnex();
-    await updateStoreSubscription(
+    const result = await updateStoreSubscription(
       db,
-      makeCustomer(null),
+      makeCustomer('different@example.com'),
       makeSubscription('active', 'prod_auto_sync')
     );
 
-    const usersCall = (db as unknown as jest.Mock).mock.calls.find(
-      (c) => c[0] === 'users'
+    expect(result.status).toBe('linked');
+    const row = await db('subscriptions')
+      .where({ email: 'different@example.com' })
+      .first();
+    expect(row.linked_email).toBe('account@example.com');
+  });
+
+  test('links by email and leaves linked_email null when emails match', async () => {
+    await db('users').insert({ email: 'user@example.com' });
+
+    const result = await updateStoreSubscription(
+      db,
+      makeCustomer('User@Example.com'),
+      makeSubscription('active', 'prod_auto_sync')
     );
-    expect(usersCall).toBeUndefined();
+
+    expect(result).toEqual({ status: 'linked', resolvedUserId: 1 });
+    const row = await db('subscriptions')
+      .where({ email: 'user@example.com' })
+      .first();
+    expect(row.linked_email).toBeNull();
+  });
+
+  test('returns unlinked and fires no users update when no account matches', async () => {
+    const result = await updateStoreSubscription(
+      db,
+      makeCustomer('nobody@example.com'),
+      makeSubscription('active', 'prod_auto_sync')
+    );
+
+    expect(result).toEqual({ status: 'unlinked', resolvedUserId: null });
+    const row = await db('subscriptions')
+      .where({ email: 'nobody@example.com' })
+      .first();
+    expect(row.linked_email).toBeNull();
+  });
+
+  test('preserves an existing linked_email when a later update has matching emails', async () => {
+    await db('users').insert({
+      email: 'account@example.com',
+      stripe_customer_id: 'cus_test123',
+    });
+    await db('subscriptions').insert({
+      email: 'paid-with@example.com',
+      active: true,
+      payload: '{}',
+      stripe_product_id: 'prod_auto_sync',
+      linked_email: 'account@example.com',
+    });
+
+    await updateStoreSubscription(
+      db,
+      makeCustomer('paid-with@example.com'),
+      makeSubscription('active', 'prod_auto_sync', { customer: 'cus_test123' })
+    );
+
+    const row = await db('subscriptions')
+      .where({ email: 'paid-with@example.com' })
+      .first();
+    expect(row.linked_email).toBe('account@example.com');
   });
 });

--- a/src/lib/integrations/stripe.ts
+++ b/src/lib/integrations/stripe.ts
@@ -33,12 +33,75 @@ export const extractProductId = (
   return product.id;
 };
 
+export interface ResolvedAccount {
+  id: number;
+  email: string | null;
+}
+
+export type ProvisionStatus = 'linked' | 'unlinked';
+
+export interface ProvisionResult {
+  status: ProvisionStatus;
+  resolvedUserId: number | null;
+}
+
+const normalizeEmail = (email: string | null | undefined): string | null => {
+  if (email == null) {
+    return null;
+  }
+  const normalized = email.toLowerCase().trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const resolveAccountForSubscription = async (
+  db: Knex,
+  subscription: StripeTypes.Subscription,
+  customerId: string | null,
+  stripeEmail: string | null
+): Promise<ResolvedAccount | null> => {
+  const metaUserId = subscription.metadata?.user_id;
+  if (metaUserId != null && metaUserId.trim().length > 0) {
+    const parsed = Number.parseInt(metaUserId, 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      const byId = await db('users')
+        .where({ id: parsed })
+        .select('id', 'email')
+        .first();
+      if (byId != null) {
+        return { id: byId.id, email: byId.email ?? null };
+      }
+    }
+  }
+
+  if (customerId != null) {
+    const byCustomer = await db('users')
+      .where({ stripe_customer_id: customerId })
+      .select('id', 'email')
+      .first();
+    if (byCustomer != null) {
+      return { id: byCustomer.id, email: byCustomer.email ?? null };
+    }
+  }
+
+  if (stripeEmail != null) {
+    const byEmail = await db('users')
+      .whereRaw('lower(trim(email)) = ?', [stripeEmail])
+      .select('id', 'email')
+      .first();
+    if (byEmail != null) {
+      return { id: byEmail.id, email: byEmail.email ?? null };
+    }
+  }
+
+  return null;
+};
+
 export const updateStoreSubscription = async (
   db: Knex,
   customer: StripeTypes.Customer,
   subscription: StripeTypes.Subscription
-) => {
-  const email = customer.email;
+): Promise<ProvisionResult> => {
+  const stripeEmail = normalizeEmail(customer.email);
   const isActive = subscription.status === 'active';
   const isCancelScheduled = subscription.cancel_at_period_end === true;
 
@@ -56,19 +119,49 @@ export const updateStoreSubscription = async (
       ? subscription.customer
       : (subscription.customer?.id ?? null);
 
-  await db('subscriptions')
-    .insert({
-      email: email?.toLowerCase(),
-      active: shouldRemainActive,
-      payload: JSON.stringify(subscription),
-      stripe_product_id: stripeProductId,
-    })
-    .onConflict('email')
-    .merge(['active', 'payload', 'stripe_product_id']);
+  const account = await resolveAccountForSubscription(
+    db,
+    subscription,
+    customerId,
+    stripeEmail
+  );
 
-  if (email != null && customerId != null) {
+  const accountEmail = normalizeEmail(account?.email);
+  const linkedEmail =
+    accountEmail != null && accountEmail !== stripeEmail ? accountEmail : null;
+
+  const insertRow: Record<string, unknown> = {
+    email: stripeEmail,
+    active: shouldRemainActive,
+    payload: JSON.stringify(subscription),
+    stripe_product_id: stripeProductId,
+  };
+  if (linkedEmail != null) {
+    insertRow.linked_email = linkedEmail;
+  }
+
+  const mergeColumns: Record<string, unknown> = {
+    active: shouldRemainActive,
+    payload: JSON.stringify(subscription),
+    stripe_product_id: stripeProductId,
+  };
+  if (linkedEmail != null) {
+    mergeColumns.linked_email = linkedEmail;
+  }
+
+  await db('subscriptions')
+    .insert(insertRow)
+    .onConflict('email')
+    .merge(mergeColumns);
+
+  if (account != null && customerId != null) {
     await db('users')
-      .where({ email: email.toLowerCase() })
+      .where({ id: account.id })
       .update({ stripe_customer_id: customerId });
   }
+
+  if (account != null) {
+    return { status: 'linked', resolvedUserId: account.id };
+  }
+  return { status: 'unlinked', resolvedUserId: null };
 };

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -143,7 +143,11 @@ const OpsRouter = () => {
     new ReconcileOrphanedSubscriptionsUseCase(
       new OrphanedSubscriptionsRepository(database),
       new SubscriptionRecoveryNotificationsRepository(database),
-      emailService
+      emailService,
+      async (customerId: string) => {
+        const customer = await getStripe().customers.retrieve(customerId);
+        return 'email' in customer ? (customer.email ?? null) : null;
+      }
     )
   );
 

--- a/src/routes/WebhookRouter.test.ts
+++ b/src/routes/WebhookRouter.test.ts
@@ -24,7 +24,10 @@ jest.mock('../lib/integrations/stripe', () => ({
     checkout: { sessions: { retrieve: mockSessionsRetrieve } },
   }),
   getCustomerId: jest.fn().mockReturnValue('cus_abc'),
-  updateStoreSubscription: jest.fn(),
+  extractProductId: jest.fn().mockReturnValue('prod_test'),
+  updateStoreSubscription: jest
+    .fn()
+    .mockResolvedValue({ status: 'linked', resolvedUserId: 1 }),
 }));
 
 jest.mock('../data_layer', () => ({ getDatabase: jest.fn() }));
@@ -999,6 +1002,38 @@ describe('WebhookRouter — customer.subscription.created', () => {
       undefined,
       { id: 'cus_abc', email: 'subscriber@example.com' },
       expect.objectContaining({ id: 'sub_new_123', status: 'active' })
+    );
+  });
+
+  it('records an unlinked_payment alert when no account resolves', async () => {
+    const { updateStoreSubscription } = jest.requireMock(
+      '../lib/integrations/stripe'
+    ) as { updateStoreSubscription: jest.Mock };
+    updateStoreSubscription.mockResolvedValueOnce({
+      status: 'unlinked',
+      resolvedUserId: null,
+    });
+    mockWebhookEvent = {
+      type: 'customer.subscription.created',
+      data: {
+        object: {
+          id: 'sub_orphan_1',
+          customer: 'cus_abc',
+          status: 'active',
+          items: { data: [{ price: { product: 'prod_unlimited' } }] },
+          cancel_at_period_end: false,
+          cancel_at: null,
+        },
+      },
+    };
+
+    const res = await postWebhook();
+    expect(res.status).toBe(200);
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: 'stripe_provisioning',
+        code: 'unlinked_payment',
+      })
     );
   });
 

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
 
 import {
+  extractProductId,
   getCustomerId,
   getStripe,
   updateStoreSubscription,
@@ -131,6 +132,30 @@ const WebhooksRouter = () => {
 
       recordStripeWebhook();
 
+      const alertUnlinkedPayment = async (
+        customer: StripeTypes.Customer,
+        subscription: StripeTypes.Subscription,
+        customerId: string | null
+      ): Promise<void> => {
+        await recordErrorUseCase.execute({
+          userId: null,
+          surface: 'stripe_provisioning',
+          code: 'unlinked_payment',
+          context: {
+            email_hash:
+              customer.email != null ? hashToken(customer.email) : null,
+            customer_id_hash: customerId != null ? hashToken(customerId) : null,
+            product_id: extractProductId(subscription),
+          },
+        });
+        console.error(
+          '[webhook] unlinked payment: no account resolved for active subscription',
+          {
+            customer_id_hash: customerId != null ? hashToken(customerId) : null,
+          }
+        );
+      };
+
       const provisionSubscription = async (
         subscription: StripeTypes.Subscription
       ): Promise<boolean> => {
@@ -139,12 +164,17 @@ const WebhooksRouter = () => {
           console.error('No customer ID found');
           return false;
         }
-        const customer = await stripe.customers.retrieve(customerId);
-        await updateStoreSubscription(
+        const customer = (await stripe.customers.retrieve(
+          customerId
+        )) as StripeTypes.Customer;
+        const provisionResult = await updateStoreSubscription(
           getDatabase(),
-          customer as StripeTypes.Customer,
+          customer,
           subscription
         );
+        if (provisionResult.status === 'unlinked') {
+          await alertUnlinkedPayment(customer, subscription, customerId);
+        }
         return true;
       };
 
@@ -165,13 +195,27 @@ const WebhooksRouter = () => {
             console.error('No customer ID found');
             return;
           }
-          const customer = await stripe.customers.retrieve(customerId);
+          const customer = (await stripe.customers.retrieve(
+            customerId
+          )) as StripeTypes.Customer;
 
-          await updateStoreSubscription(
-            getDatabase(),
-            customer as StripeTypes.Customer,
-            customerSubscriptionUpdated
-          );
+          {
+            const updatedProvisionResult = await updateStoreSubscription(
+              getDatabase(),
+              customer,
+              customerSubscriptionUpdated
+            );
+            if (
+              updatedProvisionResult.status === 'unlinked' &&
+              customerSubscriptionUpdated.status === 'active'
+            ) {
+              await alertUnlinkedPayment(
+                customer,
+                customerSubscriptionUpdated,
+                customerId
+              );
+            }
+          }
 
           {
             const updatedProductId =
@@ -401,8 +445,19 @@ const WebhooksRouter = () => {
                     true
                   );
                   if (rowsAffected === 0) {
+                    await recordErrorUseCase.execute({
+                      userId: null,
+                      surface: 'stripe_provisioning',
+                      code: 'unlinked_lifetime_payment',
+                      context: {
+                        email_hash: hashToken(lifeTimeEmail),
+                        customer_id_hash: hashToken(lifeTimeCustomer.id),
+                      },
+                    });
                     console.error(
-                      `[webhook] checkout.session.completed: no user row matched email=${lifeTimeEmail} for lifetime purchase; quota NOT unlocked. Check for email casing or whitespace mismatch.`
+                      `[webhook] checkout.session.completed: no user row matched a lifetime purchase email (hash=${hashToken(
+                        lifeTimeEmail
+                      )}); quota NOT unlocked.`
                     );
                   } else {
                     console.info(

--- a/src/usecases/checkout/AutoSyncCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/AutoSyncCheckoutUseCase.test.ts
@@ -85,6 +85,7 @@ describe('AutoSyncCheckoutUseCase', () => {
         success_url: expect.stringContaining('/ankify/setup'),
         cancel_url: expect.stringContaining('/pricing'),
         metadata: { user_id: '42' },
+        subscription_data: { metadata: { user_id: '42' } },
       })
     );
   });

--- a/src/usecases/checkout/AutoSyncCheckoutUseCase.ts
+++ b/src/usecases/checkout/AutoSyncCheckoutUseCase.ts
@@ -69,6 +69,7 @@ export class AutoSyncCheckoutUseCase {
         input.stripeCustomerId == null ? input.userEmail : undefined,
       customer: input.stripeCustomerId ?? undefined,
       after_expiration: { recovery: { enabled: true } },
+      subscription_data: { metadata: { user_id: String(input.userId) } },
       metadata: {
         user_id: String(input.userId),
         ...optionalMetadata({

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
@@ -40,6 +40,7 @@ describe('UnlimitedCheckoutUseCase', () => {
         mode: 'subscription',
         line_items: [{ price: MONTHLY_PRICE_ID, quantity: 1 }],
         metadata: { user_id: '1', cohort: 'legacy' },
+        subscription_data: { metadata: { user_id: '1' } },
       })
     );
   });

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
@@ -85,6 +85,7 @@ export class UnlimitedCheckoutUseCase {
         input.stripeCustomerId == null ? input.userEmail : undefined,
       customer: input.stripeCustomerId ?? undefined,
       after_expiration: { recovery: { enabled: true } },
+      subscription_data: { metadata: { user_id: String(input.userId) } },
       metadata: {
         user_id: String(input.userId),
         cohort,

--- a/src/usecases/ops/ReconcileOrphanedSubscriptionsUseCase.test.ts
+++ b/src/usecases/ops/ReconcileOrphanedSubscriptionsUseCase.test.ts
@@ -140,4 +140,59 @@ describe('ReconcileOrphanedSubscriptionsUseCase', () => {
     });
     expect(email.recoveryCalls).toEqual([['a@example.com', 'a@example.com']]);
   });
+
+  it('prefers the live Stripe customer email over the stale stored email', async () => {
+    const orphansRepo = new FakeOrphansRepo([
+      orphan({ id: 1, email: 'stale@example.com', customer_id: 'cus_live' }),
+    ]);
+    const notificationsRepo =
+      new InMemorySubscriptionRecoveryNotificationsRepository();
+    const email = makeEmailSpy();
+    const fetchLive = async (customerId: string) =>
+      customerId === 'cus_live' ? 'fresh@example.com' : null;
+    const useCase = new ReconcileOrphanedSubscriptionsUseCase(
+      orphansRepo,
+      notificationsRepo,
+      email,
+      fetchLive
+    );
+
+    const result = await useCase.execute();
+
+    expect(result.emailed).toBe(1);
+    expect(email.recoveryCalls).toEqual([
+      ['fresh@example.com', 'fresh@example.com'],
+    ]);
+    expect(
+      await notificationsRepo.wasNotifiedSince(
+        emailHash('fresh@example.com'),
+        new Date(0)
+      )
+    ).toBe(true);
+  });
+
+  it('falls back to the stored email when the live lookup throws', async () => {
+    const orphansRepo = new FakeOrphansRepo([
+      orphan({ id: 1, email: 'stored@example.com', customer_id: 'cus_x' }),
+    ]);
+    const notificationsRepo =
+      new InMemorySubscriptionRecoveryNotificationsRepository();
+    const email = makeEmailSpy();
+    const fetchLive = async () => {
+      throw new Error('stripe down');
+    };
+    const useCase = new ReconcileOrphanedSubscriptionsUseCase(
+      orphansRepo,
+      notificationsRepo,
+      email,
+      fetchLive
+    );
+
+    const result = await useCase.execute();
+
+    expect(result.emailed).toBe(1);
+    expect(email.recoveryCalls).toEqual([
+      ['stored@example.com', 'stored@example.com'],
+    ]);
+  });
 });

--- a/src/usecases/ops/ReconcileOrphanedSubscriptionsUseCase.ts
+++ b/src/usecases/ops/ReconcileOrphanedSubscriptionsUseCase.ts
@@ -12,12 +12,39 @@ export interface ReconcileOrphanedSubscriptionsResult {
   skippedNoEmail: number;
 }
 
+export type LiveCustomerEmailFetcher = (
+  customerId: string
+) => Promise<string | null>;
+
 export class ReconcileOrphanedSubscriptionsUseCase {
   constructor(
     private readonly orphansRepo: IOrphanedSubscriptionsRepository,
     private readonly notificationsRepo: ISubscriptionRecoveryNotificationsRepository,
-    private readonly emailService: IEmailService
+    private readonly emailService: IEmailService,
+    private readonly fetchLiveCustomerEmail?: LiveCustomerEmailFetcher
   ) {}
+
+  private async resolveRecipientEmail(
+    storedEmail: string | null,
+    customerId: string | null
+  ): Promise<string | null> {
+    const stored = storedEmail?.trim() ?? null;
+    const storedOrNull = stored != null && stored.length > 0 ? stored : null;
+    if (this.fetchLiveCustomerEmail == null || customerId == null) {
+      return storedOrNull;
+    }
+    try {
+      const live = (await this.fetchLiveCustomerEmail(customerId))?.trim();
+      if (live != null && live.length > 0) {
+        return live;
+      }
+    } catch (error) {
+      console.error('[ops] live customer email lookup failed', {
+        reason: (error as Error).message,
+      });
+    }
+    return storedOrNull;
+  }
 
   async execute(): Promise<ReconcileOrphanedSubscriptionsResult> {
     const orphans = await this.orphansRepo.findOrphanedActiveSubscriptions();
@@ -33,7 +60,10 @@ export class ReconcileOrphanedSubscriptionsUseCase {
     };
 
     for (const orphan of orphans) {
-      const email = orphan.email?.trim();
+      const email = await this.resolveRecipientEmail(
+        orphan.email,
+        orphan.customer_id
+      );
       if (email == null || email.length === 0) {
         result.skippedNoEmail++;
         continue;


### PR DESCRIPTION
## What

Prevents orphaned Stripe subscriptions — paid subscriptions that resolve to no account, so the buyer gets no premium and no signal until they dispute. Cleanup for existing orphans already shipped (#3317); this stops new ones at the source.

## Why

Provisioning bound a subscription to an account only by the Stripe customer email, and `updateStoreSubscription`'s `UPDATE users ... WHERE email` silently affected zero rows when no account matched. The checkout session carried `metadata.user_id` but Stripe doesn't copy session metadata to the subscription object, so `customer.subscription.*` webhooks couldn't see it. Verified in prod today: one payer disputed; another sat orphaned; the lifetime branch had the same silent-no-op shape.

## How

- **Self-identifying subscriptions:** `UnlimitedCheckoutUseCase` and `AutoSyncCheckoutUseCase` (the two subscription-mode checkouts) now set `subscription_data.metadata.user_id`, so every future `customer.subscription.created/updated` carries the authenticated buyer's id. (`CreatePassCheckoutUseCase` is payment-mode — skipped.)
- **Identity-first provisioning:** `updateStoreSubscription` resolves the account in priority order — `metadata.user_id` → `users.stripe_customer_id` → email (lowercased+trimmed). On a match it links `users.stripe_customer_id` by id and sets `subscriptions.linked_email` when the account email differs from the Stripe email, so the email-based `getIsSubscriber` read path actually returns true. It returns `{ status: 'linked' | 'unlinked' }`. An existing `linked_email` is never overwritten to null.
- **Latent claim bug fixed for free:** `ConfirmSubscriptionClaimUseCase` sets `stripe_customer_id` then calls `updateStoreSubscription` in the same transaction — so identity-first resolution now also sets `linked_email`, which the claim flow previously never did (a confirmed cross-email claim didn't flip subscriber status).
- **No more silent no-op:** the webhook records a `stripe_provisioning` / `unlinked_payment` error (hashed email + customer id + product id) when no account resolves on an active subscription, and the lifetime branch records `unlinked_lifetime_payment` instead of a bare `console.error` (the raw-email log is now hashed).
- **Max-reach cleanup:** `ReconcileOrphanedSubscriptionsUseCase` re-fetches the live Stripe customer email (injected fetcher) and prefers it over a stale stored email, falling back to stored on lookup failure.

The read path stays email/`linked_email` based — no `subscriptions` schema change, no migration. Deferred Design B (a `user_id` column + read-path rewrite) was explicitly out of scope.

## Measuring success

Orphaned-active-subscription count trends to 0 for new subs; the new `stripe_provisioning/unlinked_payment` alert (queryable via `/api/ops/metrics` `countBySurfaceAndCode`) surfaces any that still occur so they can be reached before they dispute. Revenue axis — an orphaned paid sub is an ARPU-counted customer who gets nothing, then churns/disputes.

## Testing

- `stripe.test.ts` rewritten onto a real in-memory sqlite knex (the hand-rolled mock couldn't model the new resolver queries): identity-first ordering, linked_email-on-differing-email, unlinked result, linked_email preservation. 7 tests.
- Checkout: both subscription-mode use cases assert `subscription_data.metadata.user_id`.
- Reconcile: live email preferred over stored; falls back on Stripe error.
- Webhook: `unlinked_payment` alert fires on an unlinked active subscription; existing suites updated to the new return shape. 32 tests.
- Touched: tsc clean; `WebhookRouter`, `OpsRouter`, `Upload`, `PersistStripeSessionUseCase`, `ConfirmSubscriptionClaim` suites green.

## Risks

`metadata.user_id` only lands on subscriptions created *after* this ships — existing orphans rely on the #3317 reconcile + claim flow. Email normalization changed to lowercase+trim on write (was lowercase only); harmless for real emails. Payments surface → run `/security-review` before merge. SONAR_TOKEN unset locally — Automatic Analysis covers the gate.

No changelog entry — server-internal provisioning correctness, no new user-facing surface (premium unlocking reliably is the absence of a bug, not a noticeable new capability).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: server-only change; no web/src/ files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
