### PR TITLE
fix: quote guiBrowse swagger description so the YAML parses

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -715,7 +715,7 @@ const AnkifyRouter = () => {
    * /api/ankify/conflicts/{id}/open-in-anki:
    *   post:
    *     summary: Open the conflicting note in the user's hosted Anki browser
-   *     description: Allowlisted endpoint. Looks up the owner's conflict row, derives its Anki note id, and invokes AnkiConnect guiBrowse(nid:<id>) so Anki's browser focuses that note. Returns { opened: false } when the client is offline.
+   *     description: "Allowlisted endpoint. Looks up the owner's conflict row, derives its Anki note id, and invokes AnkiConnect guiBrowse(nid:<id>) so Anki's browser focuses that note. Returns { opened: false } when the client is offline."
    *     tags: [Ankify]
    *     parameters:
    *       - in: path


### PR DESCRIPTION
## What

Quotes the swagger `description` on the `/api/ankify/conflicts/{id}/open-in-anki` doc block.

## Why

The unquoted scalar contains `{ opened: false }` — the colon-space makes swagger-jsdoc's YAML parser open a nested mapping and reject the block, logging a `YAMLSemanticError` on every prod boot (seen on both blue and green slots). Same class as the ankify stats description fixed in #3304; this is the second site, introduced with the guiBrowse endpoint.

## Testing

Greped all route files for other unquoted descriptions carrying a mid-value colon-space — this was the only remaining site. tsc clean.

No changelog entry — internal doc-comment fix, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)