### PR TITLE
feat: add Convert a deck free CTA to pricing for logged-out visitors

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -48,6 +48,7 @@ export const KNOWN_EVENTS = new Set([
   'tts_lang_injected',
   'paywall_dismissed',
   'pricing_left',
+  'pricing_try_clicked',
   'upload_failed',
   'cancel_during_generating',
   'pdf_print_options_used',

--- a/web/src/components/NavigationBar/NavigationBar.tsx
+++ b/web/src/components/NavigationBar/NavigationBar.tsx
@@ -44,7 +44,7 @@ function NavigationBar({ isLoggedIn }: Readonly<NavigationBarProps>) {
       </div>
 
       <div className={active ? styles.menuActive : styles.menu}>
-        {isResolved && <RightSide path={path} />}
+        {isResolved && <RightSide path={path} isLoggedIn={isLoggedIn} />}
       </div>
     </nav>
   );

--- a/web/src/components/NavigationBar/components/RightSide.test.tsx
+++ b/web/src/components/NavigationBar/components/RightSide.test.tsx
@@ -10,29 +10,40 @@ function getNavLinks() {
 }
 
 describe('RightSide (anonymous nav)', () => {
-  it('renders Upload, Docs, Pricing, and Login in order', () => {
-    render(<RightSide path="/" />);
+  it('renders Upload, Docs, and Login in order', () => {
+    render(<RightSide path="/" isLoggedIn={false} />);
     const upload = screen.getByRole('link', { name: 'Make flashcards' });
     const docs = screen.getByRole('link', { name: 'Docs' });
-    const pricing = screen.getByRole('link', { name: 'Pricing' });
     const login = screen.getByRole('link', { name: 'Log in' });
 
     expect(upload).toBeInTheDocument();
     expect(docs).toBeInTheDocument();
-    expect(pricing).toBeInTheDocument();
     expect(login).toBeInTheDocument();
 
     const positions = getNavLinks().map((a) => a.textContent);
     const uploadIdx = positions.indexOf('Make flashcards');
     const docsIdx = positions.indexOf('Docs');
-    const pricingIdx = positions.indexOf('Pricing');
     expect(uploadIdx).toBeGreaterThanOrEqual(0);
     expect(docsIdx).toBeGreaterThan(uploadIdx);
-    expect(pricingIdx).toBeGreaterThan(docsIdx);
+  });
+
+  it('omits the Pricing link for logged-out visitors', () => {
+    render(<RightSide path="/" isLoggedIn={false} />);
+    expect(
+      screen.queryByRole('link', { name: 'Pricing' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the Pricing link for logged-in visitors', () => {
+    render(<RightSide path="/" isLoggedIn />);
+    expect(screen.getByRole('link', { name: 'Pricing' })).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
   });
 
   it('Docs link points to /documentation', () => {
-    render(<RightSide path="/" />);
+    render(<RightSide path="/" isLoggedIn={false} />);
     expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
       'href',
       '/documentation'
@@ -40,7 +51,7 @@ describe('RightSide (anonymous nav)', () => {
   });
 
   it('does not render the legacy Documentation label', () => {
-    render(<RightSide path="/" />);
+    render(<RightSide path="/" isLoggedIn={false} />);
     expect(
       screen.queryByRole('link', { name: 'Documentation' })
     ).not.toBeInTheDocument();

--- a/web/src/components/NavigationBar/components/RightSide.tsx
+++ b/web/src/components/NavigationBar/components/RightSide.tsx
@@ -5,9 +5,10 @@ import styles from '../NavigationBar.module.css';
 
 interface RightSideProps {
   path: string;
+  isLoggedIn: boolean;
 }
 
-export function RightSide({ path }: Readonly<RightSideProps>) {
+export function RightSide({ path, isLoggedIn }: Readonly<RightSideProps>) {
   return (
     <div className={styles.navEnd}>
       <NavbarItem href="/upload" path={path}>
@@ -19,9 +20,11 @@ export function RightSide({ path }: Readonly<RightSideProps>) {
       <NavbarItem href="/documentation" path={path}>
         {getVisibleText('navigation.docs')}
       </NavbarItem>
-      <NavbarItem href="/pricing" path={path}>
-        {getVisibleText('navigation.pricing')}
-      </NavbarItem>
+      {isLoggedIn && (
+        <NavbarItem href="/pricing" path={path}>
+          {getVisibleText('navigation.pricing')}
+        </NavbarItem>
+      )}
       <NavbarItem href="/login#login" path={path}>
         {getVisibleText('navigation.login')}
       </NavbarItem>

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -33,6 +33,7 @@ export const KNOWN_EVENTS = new Set([
   'home_card_options_link_clicked',
   'paywall_dismissed',
   'pricing_left',
+  'pricing_try_clicked',
   'upload_failed',
   'cancel_during_generating',
   'transform_apkg_submitted',

--- a/web/src/pages/PricingPage/PricingPage.module.css
+++ b/web/src/pages/PricingPage/PricingPage.module.css
@@ -82,31 +82,32 @@
   font-weight: var(--font-medium);
 }
 
-.introLink {
-  color: var(--color-primary);
-  font-weight: var(--font-semibold);
-  white-space: nowrap;
+.tryFreeCta {
   display: inline-flex;
   align-items: center;
-  gap: 0.2rem;
-  border-bottom: 1px solid transparent;
+  justify-content: center;
+  margin: 1.5rem auto 0;
+  padding: 0.875rem 1.75rem;
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  color: #fff;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  letter-spacing: 0.01em;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
   transition:
-    color var(--transition-fast),
-    border-color var(--transition-fast);
+    background var(--transition-fast),
+    transform var(--transition-fast);
 }
 
-.introLink:hover {
-  color: var(--color-primary-hover);
-  border-bottom-color: currentColor;
+.tryFreeCta:hover {
+  background: var(--color-primary-hover);
+  transform: translateY(-1px);
 }
 
-.introArrow {
-  display: inline-block;
-  transition: transform var(--transition-fast);
-}
-
-.introLink:hover .introArrow {
-  transform: translateX(3px);
+.tryFreeCta:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 /* =====================================================================
@@ -729,7 +730,7 @@
   .card,
   .cardButton,
   .cardButton::after,
-  .introArrow,
+  .tryFreeCta,
   .cardPriceChip::before {
     transition: none !important;
     animation: none !important;

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -78,6 +78,41 @@ const renderAt = (
   );
 };
 
+describe('PricingPage try-free CTA', () => {
+  beforeEach(() => {
+    mockUseCardUsage.mockReturnValue(null);
+  });
+
+  it('renders the Convert a deck free button routing to /upload for logged-out visitors', () => {
+    renderAt('/pricing', { isLoggedIn: false });
+    const cta = screen.getByRole('link', { name: 'Convert a deck free' });
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute('href', '/upload');
+  });
+
+  it('hides the Convert a deck free button for logged-in visitors', () => {
+    renderAt('/pricing', { isLoggedIn: true });
+    expect(
+      screen.queryByRole('link', { name: 'Convert a deck free' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('fires pricing_try_clicked once when the CTA is clicked', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    renderAt('/pricing', { isLoggedIn: false });
+    fireEvent.click(screen.getByRole('link', { name: 'Convert a deck free' }));
+
+    expect(
+      trackMock.mock.calls.filter(([event]) => event === 'pricing_try_clicked')
+    ).toEqual([
+      ['pricing_try_clicked', { surface: 'pricing_page', variant: 'minimal' }],
+    ]);
+  });
+});
+
 describe('PricingPage Unlimited benefits', () => {
   it('lists parallel conversions as a benefit', () => {
     renderAt('/pricing');

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -149,6 +149,13 @@ export default function PricingPage({
     }
   }, [fromPaywall]);
 
+  const handleTryFreeClick = () => {
+    track('pricing_try_clicked', {
+      surface: 'pricing_page',
+      variant: pricingOrder,
+    });
+  };
+
   const handleWaitlistRequest = async () => {
     if (!isLoggedIn) {
       globalThis.location.href = '/login?redirect=/pricing';
@@ -364,18 +371,16 @@ export default function PricingPage({
             {isUS
               ? 'Built for spaced repetition — MCAT, USMLE, bar exam, and language prep. Turn Notion pages, PDFs, and photos into Anki decks with AI — no account needed to start.'
               : 'Turn Notion pages, PDFs, and photos into Anki decks with AI — no account needed to start. Sign up free for 100 cards per month, then pay once by the day or week.'}
-            {!isLoggedIn && (
-              <>
-                {' '}
-                <a href="/register" className={styles.introLink}>
-                  Start free{' '}
-                  <span className={styles.introArrow} aria-hidden="true">
-                    →
-                  </span>
-                </a>
-              </>
-            )}
           </p>
+        )}
+        {!isLoggedIn && (
+          <a
+            href="/upload"
+            className={styles.tryFreeCta}
+            onClick={handleTryFreeClick}
+          >
+            Convert a deck free
+          </a>
         )}
         {!minimalHeader && (
           <p className={styles.socialProof}>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-pricing-try-free.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-pricing-try-free.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-pricing-try-free",
+  "date": "2026-06-12",
+  "type": "feature",
+  "title": "Convert a deck free straight from the pricing page — no account needed"
+}


### PR DESCRIPTION
## What
Replaces the buried `Start free →` text link in the pricing intro with a prominent above-the-fold primary button labeled **Convert a deck free** that routes logged-out visitors to the anonymous `/upload` convert path (no account required). Logged-in visitors keep their plan-first layout — the button is hidden for them. Clicking the button fires a `pricing_try_clicked` analytics event once.

Also drops the `/pricing` nav item for logged-out users only (kept for logged-in users). `/pricing` stays reachable from the footer and the sitemap — no SEO internal links removed.

## Why
This week's acquisition change. The pricing page currently sends a curious anonymous visitor toward `/register` via a low-prominence text link, adding signup friction before they ever see the product work. The anonymous `/upload` path converts a deck without an account; surfacing it as the primary action on `/pricing` lets visitors experience the product first, then convert. Removing the `/pricing` nav item for logged-out users keeps acquisition attention on "try it" rather than "compare plans" before they've seen value.

User-visible outcome: a logged-out visitor on `/pricing` gets a clear "Convert a deck free" button that drops them straight into the upload flow.

## How
- `PricingPage.tsx`: new `handleTryFreeClick` fires `track('pricing_try_clicked', { surface: 'pricing_page', variant: pricingOrder })`, mirroring the existing `paywall_*` event shape. The CTA is an `<a href="/upload">` so it stays crawlable and works without the router; rendered for `!isLoggedIn` in all pricing-order variants (always above the fold). The old `introLink`/`introArrow` markup and now-dead CSS were removed.
- `RightSide.tsx` / `NavigationBar.tsx`: `RightSide` takes `isLoggedIn` and renders the `/pricing` NavbarItem only when logged in. `NavigationBar` already had `isLoggedIn` and only renders `RightSide` once it's resolved, so the boolean is passed straight through.
- `pricing_try_clicked` added to the `KNOWN_EVENTS` catalog in both `web/src/lib/analytics/events.ts` and `src/types/AnalyticsEvents.ts` so it's a tracked event server-side.

## Measuring success
- New funnel hop: `pricing_try_clicked` (surface `pricing_page`) appears in the events stream — read at `/api/ops/metrics`, new-user cohort. This is the pricing→try click-through.
- Landing→upload-start lift: `upload_started` / `upload_page_viewed` for sessions whose prior event was `pricing_try_clicked` — read at `/api/ops/metrics` and cross-referenced with the pricing A/B funnel at `/api/ops/pricing-ab/funnel`. Expect the pricing page to start feeding the anonymous upload path it previously didn't.

## Testing
- Unit tests added (Vitest):
  - PricingPage: CTA renders + routes to `/upload` for logged-out, hidden for logged-in, fires `pricing_try_clicked` exactly once on click.
  - RightSide: omits `/pricing` for logged-out, keeps it (href `/pricing`) for logged-in, existing anonymous-nav order test updated.
- Full suite green: server `tsc` clean, web `typecheck` clean, web Vitest 1915 passing, server `EventsController` 86 passing, web lint shows only pre-existing warnings in untouched files.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified `/pricing` logged-out shows the "Convert a deck free" button above the fold and navigates to `/upload`; nav omits Pricing when logged-out and shows it when logged-in. Footer + sitemap links to `/pricing` untouched.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-12-pricing-try-free.json` — "Convert a deck free straight from the pricing page — no account needed"

## Risks
- Low. One conditional nav item + one anchor button + one event. Rollback is a single revert.
- `sonar-scanner` not run locally (scanner not installed, `SONAR_TOKEN` unset in this environment) — expect a possible Sonar pass on CI. The change is small and low-complexity (one boolean branch, one handler), so a maintainability bounce is unlikely.
- Shared-file note: `RightSide.tsx` is touched here; no other agent in this batch touches it.

## Goal alignment
Acquisition lane (the only lane that creates users). Moves the pricing→try click-through (`pricing_try_clicked`) and landing→upload-start (`upload_started`), read at `/api/ops/metrics` and `/api/ops/pricing-ab/funnel` for the new-user cohort, week of this merge. Lowers first-conversion friction by letting anonymous visitors experience the product from the pricing page instead of being routed to signup first.
