### PR TITLE
fix: keep imported card columns aligned to the note template

### DIFF
--- a/src/services/ApkgPreviewService/resolveTemplateFieldIndices.test.ts
+++ b/src/services/ApkgPreviewService/resolveTemplateFieldIndices.test.ts
@@ -154,4 +154,26 @@ describe('resolveTemplateFieldIndices', () => {
       backFieldIndex: 0,
     });
   });
+
+  it('falls back to the first non-front field when the front is past field 1', () => {
+    const noteType = makeNoteType({
+      fields: [
+        { name: 'Audio', ord: 0 },
+        { name: 'Word', ord: 1 },
+        { name: 'Meaning', ord: 2 },
+      ],
+      templates: [
+        {
+          name: 'Listening',
+          ord: 0,
+          qfmt: '{{Meaning}}',
+          afmt: '{{FrontSide}}',
+        },
+      ],
+    });
+    expect(resolveTemplateFieldIndices(noteType)).toEqual({
+      frontFieldIndex: 2,
+      backFieldIndex: 0,
+    });
+  });
 });

--- a/src/services/ApkgPreviewService/resolveTemplateFieldIndices.ts
+++ b/src/services/ApkgPreviewService/resolveTemplateFieldIndices.ts
@@ -48,6 +48,16 @@ export function resolveTemplateFieldIndices(
   const backFieldIndex =
     referencedFieldOrds(template.afmt, ordByName).find(
       (ord) => ord !== frontFieldIndex
-    ) ?? (frontFieldIndex === 1 ? 0 : 1);
+    ) ?? firstFieldOrdExcept(noteType.fields, frontFieldIndex);
   return { frontFieldIndex, backFieldIndex };
+}
+
+function firstFieldOrdExcept(
+  fields: NoteType['fields'],
+  excludedOrd: number
+): number {
+  const sorted = [...fields].sort((a, b) => a.ord - b.ord);
+  const fallback = sorted.find((field) => field.ord !== excludedOrd);
+  if (fallback) return fallback.ord;
+  return excludedOrd === 1 ? 0 : 1;
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-12-card-columns.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-12-card-columns.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-12-card-columns",
+  "date": "2026-06-12",
+  "type": "fix",
+  "title": "Imported decks keep question and answer in the right columns"
+}


### PR DESCRIPTION
## What
`resolveTemplateFieldIndices` decides which source-deck fields a transformed card shows as question and answer. When the answer template referenced no field other than the front, it fell back to the magic constant `1` for the back field. That heuristic only handled front=0 and front=1; a note type whose card renders its question from a later field (common in audio/listening vocab decks) defaulted the answer to ordinal `1`, putting the wrong column on the back of the transformed card.

## Why
A paying user hit "Wrong columns" on `/upload` (#3119): a third-party vocab export came back with question and answer swapped/misplaced. The resolved-index path is otherwise correct end to end — the gap was this one fallback that assumed positional 0/1 instead of reading the note type's fields.

## How
Replaced the `(frontFieldIndex === 1 ? 0 : 1)` constant with `firstFieldOrdExcept`: scan the model's fields in `ord` order and pick the first one that isn't the front field. The degenerate single-field/no-other-field case keeps the prior 0/1 default so the no-templates path is unchanged.

Runtime entry point (first-time-fix): the `/upload` transform path → `parseApkgNotes` → `resolveTemplateFieldIndices`. Call sites verified to read through the resolved `frontFieldIndex`/`backFieldIndex` rather than ordinals: `parseApkgNotes` (sets both indices on every `ParsedNote`), `getFrontField`/`getBackField`, `prompts.ts`, `applyTransformedFields`, `imageTransformService`, and `toAnkiNote` in `TransformApkgUseCase`.

## Measuring success
No metric event here — this is a correctness fix on an existing path. Confirmation is the absence of repeat "wrong columns" reports for `.apkg`/transform exports, and the new regression test asserting `backFieldIndex` resolves to the first non-front field when the front is past field 1.

## Testing
- Unit tests added: `resolveTemplateFieldIndices` now covers a 3-field note where the front renders field 2 and the answer references no new field — back resolves to field 0, not ordinal 1. All 9 resolver cases green; 165 in-scope transform/preview tests green (one unrelated `extractApkg.test.ts` failure is pre-existing on this local Node build — `zlib.zstdCompress` is undefined locally, present on CI's Node 22.20.0).

## Browser check
Browser check: not applicable — changelog-only web change

## Changelog
`Imported decks keep question and answer in the right columns` (`web/src/pages/WhatsNewPage/changelog/2026-06-12-card-columns.json`, type `fix`).

## Risks
Low. Pure function, no I/O. The change only affects the fallback branch (answer template references no field beyond the front); the common case where the answer references a distinct field is unchanged. No-templates default unchanged.

Sonar: `sonar-scanner` not run locally (not installed, no `SONAR_TOKEN`). Change is small and has no security surface (no HTTP, no HTML render, no zip, no file paths) — Sonar bounce unlikely, but flagging per the rule.

## Goal alignment
Mission lever: simpler/faster/more beautiful — a transformed deck with answers in the wrong column is the opposite of "drop something in, get a clean deck back." This was a 1-star report on the core conversion surface. Retention: fixing a visible correctness bug on `/upload` reduces churn-by-disappointment on the free-to-paid funnel. No direct funnel metric to move; this is table-stakes correctness.
