### PR TITLE
fix: count Notion conversions in the upload→download funnel

### DIFF
--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -309,7 +309,9 @@ describe('NotionController', () => {
       expect(res.status).toHaveBeenCalledWith(402);
       expect(track).toHaveBeenCalledWith(
         'upload_started',
-        expect.objectContaining({ props: expect.objectContaining({ source: 'notion' }) })
+        expect.objectContaining({
+          props: expect.objectContaining({ source: 'notion' }),
+        })
       );
     });
 

--- a/src/controllers/NotionController.test.ts
+++ b/src/controllers/NotionController.test.ts
@@ -15,6 +15,10 @@ jest.mock('../lib/conversionPool', () => ({
   __esModule: true,
   runConversion: jest.fn().mockResolvedValue(undefined),
 }));
+jest.mock('../services/events/track', () => ({
+  __esModule: true,
+  track: jest.fn(),
+}));
 jest.mock('../data_layer', () => ({
   getDatabase: jest.fn().mockReturnValue({}),
 }));
@@ -26,6 +30,7 @@ jest.mock('../usecases/jobs/CancelJobUseCase');
 jest.mock('../usecases/jobs/StartJobUseCase');
 
 import { runConversion } from '../lib/conversionPool';
+import { track } from '../services/events/track';
 import JobRepository from '../data_layer/JobRepository';
 import { FindOrCreateJobUseCase } from '../usecases/jobs/FindOrCreateJobUseCase';
 import { CheckInProgressJobUseCase } from '../usecases/jobs/CheckInProgressJobUseCase';
@@ -277,6 +282,35 @@ describe('NotionController', () => {
 
       expect(res.status).toHaveBeenCalledWith(202);
       expect(res.json).toHaveBeenCalledWith({ jobId: 77, restarted: false });
+    });
+
+    it('emits upload_started so the Notion path enters the upload→download funnel', async () => {
+      setupConvertMocks();
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(track).toHaveBeenCalledWith(
+        'upload_started',
+        expect.objectContaining({
+          userId: null,
+          props: expect.objectContaining({ source: 'notion' }),
+        })
+      );
+    });
+
+    it('emits upload_started at funnel entry even when a free user is over the limit', async () => {
+      setupConvertMocks();
+      jest
+        .spyOn(UsersRepository.prototype, 'getCardUsage')
+        .mockResolvedValue({ cards_used: 200, month_started_at: new Date() });
+
+      await controller.convert(req as express.Request, res as express.Response);
+
+      expect(res.status).toHaveBeenCalledWith(402);
+      expect(track).toHaveBeenCalledWith(
+        'upload_started',
+        expect.objectContaining({ props: expect.objectContaining({ source: 'notion' }) })
+      );
     });
 
     it('returns restarted: true when re-converting a page whose job row is done', async () => {

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -45,10 +45,20 @@ import { MarkNotionTokenInvalidUseCase } from '../usecases/notion/MarkNotionToke
 import { INotionRepository } from '../data_layer/NotionRespository';
 import { IEmailService } from '../services/EmailService/EmailService';
 import UsersRepository from '../data_layer/UsersRepository';
+import { track } from '../services/events/track';
+import { classifyDevice } from '../lib/analytics/classifyDevice';
 
 const DEFAULT_PREVIEW_PAGE_SIZE = 15;
 const MAX_PREVIEW_PAGE_SIZE = 50;
 const NATIVE_NOTION_RETURN_URL = 'twoanki://x-callback-url/notion-connected';
+
+function conversionSourceFromType(type?: string): 'notion' | 'google_drive' {
+  return type === 'google_drive' ? 'google_drive' : 'notion';
+}
+
+function funnelUserId(owner: string): number | null {
+  return Number.isFinite(Number(owner)) ? Number(owner) : null;
+}
 
 function clampPageSize(input: unknown): number {
   const raw = typeof input === 'string' ? input : '';
@@ -269,6 +279,17 @@ class NotionController {
     const owner = res.locals.owner as string;
     const database = getDatabase();
 
+    const cookies = req.cookies as Record<string, unknown> | undefined;
+    const anonId = cookies?.anon_id;
+    track('upload_started', {
+      userId: funnelUserId(owner),
+      anonymousId: typeof anonId === 'string' && anonId.length > 0 ? anonId : null,
+      props: {
+        source: conversionSourceFromType(type),
+        device: classifyDevice(req.headers?.['user-agent']),
+      },
+    });
+
     try {
       if (!paying) {
         const usersRepository = new UsersRepository(database);
@@ -321,8 +342,6 @@ class NotionController {
       const safeString = (v: unknown): string | undefined =>
         typeof v === 'string' && v.length > 0 ? v : undefined;
 
-      const cookies = req.cookies as Record<string, unknown> | undefined;
-
       runConversion({
         id,
         type,
@@ -332,7 +351,7 @@ class NotionController {
         jobDbId: job.id,
         frontField: safeString(frontField),
         backField: safeString(backField),
-        anonId: safeString(cookies?.anon_id),
+        anonId: safeString(anonId),
       }).catch((err: unknown) => {
         console.error('notion convert worker:', err);
       });

--- a/src/controllers/NotionController.ts
+++ b/src/controllers/NotionController.ts
@@ -283,7 +283,8 @@ class NotionController {
     const anonId = cookies?.anon_id;
     track('upload_started', {
       userId: funnelUserId(owner),
-      anonymousId: typeof anonId === 'string' && anonId.length > 0 ? anonId : null,
+      anonymousId:
+        typeof anonId === 'string' && anonId.length > 0 ? anonId : null,
       props: {
         source: conversionSourceFromType(type),
         device: classifyDevice(req.headers?.['user-agent']),

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -985,6 +985,58 @@ describe('UploadService.promoteClaudeJobToUpload — async fs reads', () => {
     expect(Buffer.compare(uploadedBuffer, apkgContents)).toBe(0);
   });
 
+  it('emits conversion_succeeded so the async Claude path matches the sync funnel', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'my-deck.apkg'), Buffer.from('apkg'));
+
+    let resolveFind!: () => void;
+    const findCalled = new Promise<void>((r) => {
+      resolveFind = r;
+    });
+    const repo: IUploadRepository = {
+      ...buildRepository(),
+      update: jest.fn().mockResolvedValue([]),
+    };
+    const jobRepository = {
+      create: jest.fn().mockResolvedValue(undefined),
+      updateJobStatus: jest.fn().mockResolvedValue(undefined),
+      findJobById: jest.fn().mockImplementation(() => {
+        resolveFind();
+        return Promise.resolve(null);
+      }),
+      deleteJob: jest.fn().mockResolvedValue(undefined),
+    } as unknown as JobRepository;
+
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [{ name: 'my-deck', cardCount: 7 }],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(repo, jobRepository, buildUsersRepo());
+    const req = buildRequest({
+      body: { 'claude-ai-flashcards': 'true' },
+      cookies: { anon_id: 'anon-async-1' },
+    } as Partial<express.Request>);
+    const { res } = buildResponse();
+    (res.locals as Record<string, unknown>).owner = 42;
+    (res.locals as Record<string, unknown>).subscriber = true;
+
+    await service.handleUpload(req, res);
+    await findCalled;
+    await new Promise((r) => setImmediate(r));
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'conversion_succeeded',
+      expect.objectContaining({
+        userId: 42,
+        props: expect.objectContaining({ card_count_bucket: '<50' }),
+      })
+    );
+  });
+
   async function runAsyncUploadWithBody(
     body: Record<string, unknown>
   ): Promise<jest.Mock> {

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -521,6 +521,14 @@ class UploadService {
             source,
             paying
           );
+          track('conversion_succeeded', {
+            userId: Number(owner),
+            anonymousId: this.resolveAnonId(req),
+            props: {
+              source: this.resolveUploadSource(req),
+              card_count_bucket: this.toCardCountBucket(totalCards),
+            },
+          });
         } else {
           logNoPackageDiagnostics(req.files as UploadedFile[]);
           await this.jobRepository.updateJobStatus(


### PR DESCRIPTION
## What
`upload_started` now fires on the Notion conversion path (and Google Drive / Dropbox, which share the same conversion worker). The async Claude-upload path now also emits `conversion_succeeded` on success, matching the sync path.

## Why
The ops metric `upload_to_download_rate` — distinct `deck_downloaded` actors divided by distinct `upload_started` actors, computed in `EventsMetricsRepository.buildUploadToDownloadRateQuery` and read at `/api/ops/metrics` via `UploadFunnelService` — was inflated.

Confirmed emit gap:
- **Denominator** `upload_started`: fired **only** in `UploadService.handleUpload` (file uploads). `grep -rn "upload_started" src/` shows no other emit site.
- **Numerator** `deck_downloaded`: fires in `DownloadController` for **every** deck, including Notion.
- `NotionController.convert` -> `runConversion` -> `performConversion` emitted `conversion_succeeded` (performConversion.ts:207) but never `upload_started`. So every Notion user reached the numerator and never the denominator, pushing the rate above its true value.

Second gap (named in the task): the async upload 202 path (`handleAsyncUpload` -> `promoteClaudeJobToUpload`) emitted `upload_started` (in `handleUpload`) but never `conversion_succeeded` on success — only the sync 200 branch did. This undercounted `conversion_succeeded` in the funnel stages for paid Claude uploads.

## How
- **Notion path (the inflation fix):** emit `upload_started` in `NotionController.convert` right after `id` validation, before any paywall/limit gate — symmetric with `handleUpload`, which fires before its own limit check, so a free over-limit user counts as a funnel entrant who dropped (correct). `source` is `notion` (or `google_drive`), mirroring the worker's `toConversionSource` mapping. `userId`/`anonymousId` derived the same way as the worker (`Number.isFinite` guard + `anon_id` cookie). Reused the existing `cookies`/`anonId` locals so the `runConversion` call still forwards the same `anon_id`.
- **Async upload path:** emit `conversion_succeeded` after `promoteClaudeJobToUpload` resolves with cards, using the same `source` / `card_count_bucket` shape as the sync branch.
- **No SQL change.** The rate query is correct; the bug was missing emits, not the query. Smaller correct fix = align emit populations rather than rewrite the metric.

Chose "emit the funnel-entry event on the Notion path" over "rewrite the metric to count a shared stage event" because the two paths *should* both report `upload_started`/`conversion_succeeded` — the events were simply missing, and other consumers (`UploadFunnelService`, future cohort queries) benefit from complete data, not a metric-local workaround.

## Measuring success
After deploy, `upload_to_download_rate` at `/api/ops/metrics` should drop toward its true value as Notion conversions start landing in the denominator. Direct confirmation query:

```
select name, count(*) from events
where name in ('upload_started','conversion_succeeded')
  and props->>'source' = 'notion'
  and created_at > now() - interval '1 day'
group by name;
```

Before this change that returns rows only for `conversion_succeeded`; after, `upload_started` appears with a comparable count.

## Testing
- Unit tests added:
  - `NotionController.test.ts` — `convert` emits `upload_started` with `source: notion`; still emits it (before the 402) when a free user is over the monthly limit.
  - `UploadService.test.ts` — async Claude path emits `conversion_succeeded` (`userId: 42`, `card_count_bucket: <50`) after the deck is promoted.
- Existing `EventsMetricsRepository.sql.test.ts` already asserts the generated rate SQL; unchanged because the query is unchanged.
- `npx tsc --noEmit` clean; `oxlint` adds no new warnings (the 2 unused-import warnings in `NotionController.test.ts` are pre-existing).

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files touched.

## Changelog
No changelog entry — internal instrumentation, no user-visible behavior change.

## Sonar
`sonar-scanner` not run locally (binary not installed, `SONAR_TOKEN` unset on this box). Change is low-complexity (two `track` emits + two small pure helpers), no new HTTP/HTML/zip/file-path surface, so the security gate is not at risk. Flagging per `.claude/rules/sonar.md` rather than going silent.

## Risks
Over-counting if `upload_started` fired on a path that never produces a download — but the Notion path either downloads on success or drops on failure/paywall, both of which are correct funnel outcomes. Rollback: revert the two emits; the metric returns to its prior (inflated) value.

## Goal alignment
Internal metrics correctness. `upload_to_download_rate` is the read used to size the upload->download drop-off in prioritization; an inflated rate hides real first-conversion friction (the acquisition lane in CLAUDE.md). Fixing it makes the funnel-analyst pull trustworthy so acquisition work targets the right step. No direct user-facing or MRR movement.
