### PR TITLE
chore: pin @xmldom/xmldom >=0.8.13 to clear advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
       "jsdom": "29.1.1",
       "picomatch": ">=4.0.4",
       "path-to-regexp": ">=8.4.0",
-      "2anki-web>yaml": ">=2.8.3"
+      "2anki-web>yaml": ">=2.8.3",
+      "@xmldom/xmldom": ">=0.8.13 <0.9.0"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   picomatch: '>=4.0.4'
   path-to-regexp: '>=8.4.0'
   2anki-web>yaml: '>=2.8.3'
+  '@xmldom/xmldom': '>=0.8.13 <0.9.0'
 
 importers:
 
@@ -2837,10 +2838,9 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
-  '@xmldom/xmldom@0.8.12':
-    resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xyflow/react@12.11.0':
     resolution: {integrity: sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==}
@@ -9749,7 +9749,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.12': {}
+  '@xmldom/xmldom@0.8.13': {}
 
   '@xyflow/react@12.11.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(immer@11.1.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -12276,7 +12276,7 @@ snapshots:
 
   mammoth@1.12.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.12
+      '@xmldom/xmldom': 0.8.13
       argparse: 1.0.10
       base64-js: 1.5.1
       bluebird: 3.4.7


### PR DESCRIPTION
## What
Pins `@xmldom/xmldom` to `>=0.8.13 <0.9.0` via `pnpm.overrides` so the patched version replaces the advisory-affected `0.8.12` across the dependency tree.

## Why
`@xmldom/xmldom` `0.8.12` reaches the tree transitively through `mammoth@1.12.0`, which we use for `.docx` text extraction (`convertDocxToHTML` → `PrepareDeck` and `extractAttachmentText`). That version carries known high-severity advisories, patched in `0.8.13`. No user-visible behavior change — this is a transitive dependency security patch.

## How
Added `"@xmldom/xmldom": ">=0.8.13 <0.9.0"` to `pnpm.overrides` in the root `package.json`, matching the existing override style (`path-to-regexp`, `picomatch`, `rollup`, `yaml`), then ran `pnpm install` to update the lockfile.

The upper bound is deliberate: a bare `>=0.8.13` resolves to the latest `0.9.10`, a major bump outside mammoth's declared `^0.8.6` range and unvalidated against it. Capping below `0.9.0` lands the patched `0.8.13` — a true patch-level bump that stays inside mammoth's compatible range.

`pnpm why @xmldom/xmldom` after the change:

```
notion2anki-server@2.0.0
dependencies:
mammoth 1.12.0
└── @xmldom/xmldom 0.8.13
```

Lockfile now references only `0.8.13`; `0.8.12` is fully gone.

## Testing
- `.docx` extraction path verified — `convertDocxToHTML.test.ts` (2 tests) and `extractAttachmentText.test.ts` (18 tests) pass against `0.8.13`.
- Server `tsc --noEmit` clean.

## Browser check
Browser check: not applicable — no `web/src/` files; transitive dependency security patch with no rendered output.

## Changelog
No changelog — transitive dependency security patch, no user-visible behavior change.

## Sonar
sonar-scanner not run — pure dependency bump, no source change (per `.claude/rules/sonar.md`).

## Risks
`@xmldom/xmldom` `0.8.13` is a patch release over `0.8.12` and stays inside mammoth's declared range, so API drift is not expected; the two `.docx`-consuming test suites confirm the path still works. Rollback is reverting the override line and re-running `pnpm install`.

## Goal alignment
None — internal dependency security hygiene. No funnel or revenue metric moves.
