### PR TITLE
fix: verify Google OAuth id_token via instrumentedAxios JWKS

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -809,9 +809,11 @@ describe('UsersController.loginWithGoogle', () => {
     const authService = {
       loginWithGoogle:
         overrides?.loginWithGoogle ??
-        jest
-          .fn()
-          .mockResolvedValue({ email: 'g@example.com', name: 'Google User' }),
+        jest.fn().mockResolvedValue({
+          ok: true,
+          email: 'g@example.com',
+          name: 'Google User',
+        }),
       getHashPassword: jest.fn().mockReturnValue('hashed'),
       newJWTToken:
         overrides?.newJWTToken ?? jest.fn().mockResolvedValue('google-jwt'),
@@ -875,7 +877,11 @@ describe('UsersController.loginWithGoogle', () => {
   });
 
   it('redirects with error=google_signin_failed when the token exchange fails', async () => {
-    const loginWithGoogle = jest.fn().mockResolvedValue(null);
+    const loginWithGoogle = jest.fn().mockResolvedValue({
+      ok: false,
+      reason: 'token_exchange_failed',
+      message: 'Error: invalid_grant',
+    });
     const { controller } = buildGoogleController({ loginWithGoogle });
     const req = {
       query: { code: 'gauth-code' },
@@ -1775,8 +1781,12 @@ describe('UsersController.loginWithGoogle — error recording', () => {
     );
   });
 
-  it('records oauth_token_exchange_failed when loginWithGoogle returns null', async () => {
-    const { controller, recordExecute } = buildOAuthController(null);
+  it('records the real failure reason when loginWithGoogle reports a verify failure', async () => {
+    const { controller, recordExecute } = buildOAuthController({
+      ok: false,
+      reason: 'verify_failed',
+      message: 'JsonWebTokenError: invalid signature',
+    });
     const req = {
       query: { code: 'auth-code-123' },
     } as unknown as express.Request;
@@ -1788,6 +1798,10 @@ describe('UsersController.loginWithGoogle — error recording', () => {
       userId: null,
       surface: 'oauth_google',
       code: 'oauth_token_exchange_failed',
+      context: {
+        reason: 'verify_failed',
+        message: 'JsonWebTokenError: invalid signature',
+      },
     });
     expect(res.redirect).toHaveBeenCalledWith(
       '/login?error=google_signin_failed'
@@ -1796,7 +1810,7 @@ describe('UsersController.loginWithGoogle — error recording', () => {
 
   it('records oauth_user_creation_failed when user lookup returns null after register', async () => {
     const { controller, recordExecute } = buildOAuthController(
-      { email: 'x@google.com', name: 'X' },
+      { ok: true, email: 'x@google.com', name: 'X' },
       null
     );
     const req = {
@@ -2059,7 +2073,7 @@ describe('UsersController cookie options — 30-day persistent session', () => {
     const authService = {
       loginWithGoogle: jest
         .fn()
-        .mockResolvedValue({ email: 'g@example.com', name: 'G' }),
+        .mockResolvedValue({ ok: true, email: 'g@example.com', name: 'G' }),
       getHashPassword: jest.fn().mockReturnValue('hashed'),
       newJWTToken,
       persistToken: jest.fn().mockResolvedValue(undefined),

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -647,76 +647,81 @@ class UsersController {
 
     const loginRequest = await this.authService.loginWithGoogle(code as string);
 
-    if (loginRequest) {
-      const { email, name } = loginRequest;
-      if (email == null) {
-        await this.recordError?.execute({
-          userId: null,
-          surface: 'oauth_google',
-          code: 'oauth_token_exchange_failed',
-        });
-        return res.redirect('/login?error=google_signin_failed');
-      }
-      let user = await this.userService.getUserFrom(email);
-      const isNewUser = !user;
-      if (!user) {
-        const hashedPassword =
-          this.authService.getHashPassword(getRandomUUID());
-        await this.userService.register(
-          name ?? email,
-          hashedPassword,
-          email,
-          'google'
-        );
-        user = await this.userService.getUserFrom(email);
-      }
-      if (isNewUser && user) {
-        try {
-          const country = extractCountryFromRequest(req);
-          if (country != null) {
-            await new UsersRepository(this.db).setSignupCountryIfMissing(
-              user.id,
-              country
-            );
-          }
-        } catch {
-          // country capture is best-effort
-        }
-      }
-
-      if (!user) {
-        console.info('Failed to create user');
-        await this.recordError?.execute({
-          userId: null,
-          surface: 'oauth_google',
-          code: 'oauth_user_creation_failed',
-        });
-        return res
-          .status(400)
-          .send('Unknown error. Please try again or register a new account.');
-      }
-
-      await this.userService.markEmailVerified(user.id.toString());
-
-      const token = await this.authService.newJWTToken(user);
-      if (!token) {
-        console.info('Failed to create token');
-        return res
-          .status(400)
-          .send('Unknown error. Please try again or register a new account.');
-      }
-      await this.authService.persistToken(token, user.id.toString());
-      await this.userService.updateLastLoginAt(user.id.toString());
-      res.cookie('token', token, sessionCookieOptions());
-      res.status(200).redirect(await this.landingForUser(req, user.id));
-    } else {
+    if (!loginRequest.ok) {
       await this.recordError?.execute({
         userId: null,
         surface: 'oauth_google',
         code: 'oauth_token_exchange_failed',
+        context: {
+          reason: loginRequest.reason,
+          message: loginRequest.message,
+        },
       });
-      res.redirect('/login?error=google_signin_failed');
+      return res.redirect('/login?error=google_signin_failed');
     }
+
+    const { email, name } = loginRequest;
+    if (email == null) {
+      await this.recordError?.execute({
+        userId: null,
+        surface: 'oauth_google',
+        code: 'oauth_token_exchange_failed',
+        context: { reason: 'missing_email_claim' },
+      });
+      return res.redirect('/login?error=google_signin_failed');
+    }
+
+    let user = await this.userService.getUserFrom(email);
+    const isNewUser = !user;
+    if (!user) {
+      const hashedPassword = this.authService.getHashPassword(getRandomUUID());
+      await this.userService.register(
+        name ?? email,
+        hashedPassword,
+        email,
+        'google'
+      );
+      user = await this.userService.getUserFrom(email);
+    }
+    if (isNewUser && user) {
+      try {
+        const country = extractCountryFromRequest(req);
+        if (country != null) {
+          await new UsersRepository(this.db).setSignupCountryIfMissing(
+            user.id,
+            country
+          );
+        }
+      } catch {
+        // country capture is best-effort
+      }
+    }
+
+    if (!user) {
+      console.info('Failed to create user');
+      await this.recordError?.execute({
+        userId: null,
+        surface: 'oauth_google',
+        code: 'oauth_user_creation_failed',
+      });
+      return res
+        .status(400)
+        .send('Unknown error. Please try again or register a new account.');
+    }
+
+    await this.userService.markEmailVerified(user.id.toString());
+
+    const token = await this.authService.newJWTToken(user);
+    if (!token) {
+      console.info('Failed to create token');
+      return res
+        .status(400)
+        .send('Unknown error. Please try again or register a new account.');
+    }
+    await this.authService.persistToken(token, user.id.toString());
+    await this.userService.updateLastLoginAt(user.id.toString());
+    res.cookie('token', token, sessionCookieOptions());
+    res.status(200).redirect(await this.landingForUser(req, user.id));
   }
 
   async loginWithMicrosoft(req: express.Request, res: express.Response) {

--- a/src/env.example
+++ b/src/env.example
@@ -1,6 +1,13 @@
 NOTION_CLIENT_ID=''
 NOTION_CLIENT_SECRET=''
 NOTION_REDIRECT_URI=''
+# Google OAuth login (GET /api/users/auth/google). All three are required for "Sign in with Google".
+# The id_token returned by the token exchange is verified against Google's JWKS
+# (https://www.googleapis.com/oauth2/v3/certs); GOOGLE_CLIENT_ID is the expected audience.
+# Unset = the route records oauth_token_exchange_failed and redirects back to /login; the server boots normally.
+GOOGLE_CLIENT_ID=''
+GOOGLE_CLIENT_SECRET=''
+GOOGLE_REDIRECT_URI=''
 SENDGRID_API_KEY=''
 # Base64 ECDSA public key from SendGrid's Signed Event Webhook settings (Mail Settings -> Event Webhook).
 # Verifies POST /api/internal/sendgrid/events against the raw request body. Unset = the endpoint

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -6,15 +6,14 @@ import knex, { Knex } from 'knex';
 import AuthenticationService, {
   __resetMicrosoftJwksCacheForTests,
   __resetAppleJwksCacheForTests,
+  __resetGoogleJwksCacheForTests,
 } from './AuthenticationService';
 import TokenRepository from '../data_layer/TokenRepository';
 import UsersRepository from '../data_layer/UsersRepository';
 import { SESSION_MAX_AGE_MS } from '../shared/session';
 import instrumentedAxios from './observability/instrumentedAxios';
-import { OAuth2Client } from 'google-auth-library';
 
 jest.mock('./observability/instrumentedAxios');
-jest.mock('google-auth-library');
 
 const SECRET = 'test-secret';
 
@@ -158,77 +157,246 @@ describe('loginWithNotion', () => {
 });
 
 describe('loginWithGoogle', () => {
-  const MockedOAuth2Client = OAuth2Client as jest.MockedClass<
-    typeof OAuth2Client
-  >;
+  const KID = 'google-key-id-001';
+  const CLIENT_ID = 'test-google-client-id';
+  let privateKey: crypto.KeyObject;
+  let publicJwk: {
+    kid: string;
+    kty: string;
+    n: string;
+    e: string;
+    alg: string;
+  };
+
+  const signIdToken = (payload: Record<string, unknown>): string =>
+    jwt.sign(payload, privateKey.export({ type: 'pkcs8', format: 'pem' }), {
+      algorithm: 'RS256',
+      header: { alg: 'RS256', kid: KID },
+    });
+
+  beforeAll(() => {
+    const { privateKey: priv, publicKey } = crypto.generateKeyPairSync('rsa', {
+      modulusLength: 2048,
+    });
+    privateKey = priv;
+    const jwk = publicKey.export({ format: 'jwk' });
+    publicJwk = {
+      kid: KID,
+      kty: jwk.kty as string,
+      n: jwk.n as string,
+      e: jwk.e as string,
+      alg: 'RS256',
+    };
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.GOOGLE_CLIENT_ID = 'test-google-client-id';
+    __resetGoogleJwksCacheForTests();
+    process.env.GOOGLE_CLIENT_ID = CLIENT_ID;
     process.env.GOOGLE_CLIENT_SECRET = 'test-google-client-secret';
     process.env.GOOGLE_REDIRECT_URI = 'http://localhost:2020/api/auth/google';
+    mockedAxios.get = jest.fn().mockResolvedValue({
+      data: { keys: [publicJwk] },
+    });
   });
 
   it('returns email and name when the ID token is valid', async () => {
-    mockedAxios.post = jest.fn().mockResolvedValue({
-      data: { id_token: 'valid.id.token' },
-    });
-
-    const mockGetPayload = jest.fn().mockReturnValue({
+    const idToken = signIdToken({
+      iss: 'https://accounts.google.com',
+      aud: CLIENT_ID,
+      sub: 'google-sub-001',
       email: 'user@example.com',
       name: 'Test User',
     });
-    MockedOAuth2Client.prototype.verifyIdToken = jest.fn().mockResolvedValue({
-      getPayload: mockGetPayload,
-    });
-
-    const service = createService();
-    const result = await service.loginWithGoogle('auth-code');
-
-    expect(result).toEqual({ email: 'user@example.com', name: 'Test User' });
-    expect(MockedOAuth2Client.prototype.verifyIdToken).toHaveBeenCalledWith({
-      idToken: 'valid.id.token',
-      audience: 'test-google-client-id',
-    });
-  });
-
-  it('returns undefined when the ID token fails verification', async () => {
-    mockedAxios.post = jest.fn().mockResolvedValue({
-      data: { id_token: 'tampered.token' },
-    });
-
-    MockedOAuth2Client.prototype.verifyIdToken = jest
+    mockedAxios.post = jest
       .fn()
-      .mockRejectedValue(new Error('Token used too late'));
+      .mockResolvedValue({ data: { id_token: idToken } });
 
     const service = createService();
     const result = await service.loginWithGoogle('auth-code');
 
-    expect(result).toBeUndefined();
-  });
-
-  it('returns undefined when the audience claim does not match', async () => {
-    mockedAxios.post = jest.fn().mockResolvedValue({
-      data: { id_token: 'wrong.audience.token' },
+    expect(result).toEqual({
+      ok: true,
+      email: 'user@example.com',
+      name: 'Test User',
     });
-
-    MockedOAuth2Client.prototype.verifyIdToken = jest
-      .fn()
-      .mockRejectedValue(new Error('Wrong recipient'));
-
-    const service = createService();
-    const result = await service.loginWithGoogle('auth-code');
-
-    expect(result).toBeUndefined();
   });
 
-  it('returns undefined when the token exchange call fails', async () => {
-    mockedAxios.post = jest.fn().mockRejectedValue(new Error('network error'));
+  it('fetches the Google JWKS through instrumentedAxios', async () => {
+    const idToken = signIdToken({
+      iss: 'accounts.google.com',
+      aud: CLIENT_ID,
+      sub: 'google-sub-002',
+      email: 'user@example.com',
+    });
+    mockedAxios.post = jest
+      .fn()
+      .mockResolvedValue({ data: { id_token: idToken } });
+
+    const service = createService();
+    await service.loginWithGoogle('auth-code');
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      'google_drive',
+      'https://www.googleapis.com/oauth2/v3/certs'
+    );
+  });
+
+  it('returns a failure reason when the ID token signature is invalid', async () => {
+    const otherKey = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const idToken = jwt.sign(
+      {
+        iss: 'https://accounts.google.com',
+        aud: CLIENT_ID,
+        sub: 'google-sub-003',
+        email: 'user@example.com',
+      },
+      otherKey.privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      { algorithm: 'RS256', header: { alg: 'RS256', kid: KID } }
+    );
+    mockedAxios.post = jest
+      .fn()
+      .mockResolvedValue({ data: { id_token: idToken } });
 
     const service = createService();
     const result = await service.loginWithGoogle('auth-code');
 
-    expect(result).toBeUndefined();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('verify_failed');
+      expect(typeof result.message).toBe('string');
+      expect(result.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns a failure reason when the audience does not match the client id', async () => {
+    const idToken = signIdToken({
+      iss: 'https://accounts.google.com',
+      aud: 'a-different-app',
+      sub: 'google-sub-004',
+      email: 'user@example.com',
+    });
+    mockedAxios.post = jest
+      .fn()
+      .mockResolvedValue({ data: { id_token: idToken } });
+
+    const service = createService();
+    const result = await service.loginWithGoogle('auth-code');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('verify_failed');
+    }
+  });
+
+  it('returns a failure reason when the issuer is not Google', async () => {
+    const idToken = signIdToken({
+      iss: 'https://evil.example.com',
+      aud: CLIENT_ID,
+      sub: 'google-sub-005',
+      email: 'user@example.com',
+    });
+    mockedAxios.post = jest
+      .fn()
+      .mockResolvedValue({ data: { id_token: idToken } });
+
+    const service = createService();
+    const result = await service.loginWithGoogle('auth-code');
+
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns a failure reason when the kid is not in the JWKS', async () => {
+    const idToken = jwt.sign(
+      {
+        iss: 'https://accounts.google.com',
+        aud: CLIENT_ID,
+        sub: 'google-sub-006',
+        email: 'user@example.com',
+      },
+      privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      { algorithm: 'RS256', header: { alg: 'RS256', kid: 'unknown-kid' } }
+    );
+    mockedAxios.post = jest
+      .fn()
+      .mockResolvedValue({ data: { id_token: idToken } });
+
+    const service = createService();
+    const result = await service.loginWithGoogle('auth-code');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('unknown_signing_key');
+    }
+  });
+
+  it('returns a failure reason when the JWKS fetch fails', async () => {
+    const idToken = signIdToken({
+      iss: 'https://accounts.google.com',
+      aud: CLIENT_ID,
+      sub: 'google-sub-007',
+      email: 'user@example.com',
+    });
+    mockedAxios.post = jest
+      .fn()
+      .mockResolvedValue({ data: { id_token: idToken } });
+    mockedAxios.get = jest.fn().mockRejectedValue(new Error('jwks down'));
+
+    const service = createService();
+    const result = await service.loginWithGoogle('auth-code');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('verify_failed');
+    }
+  });
+
+  it('returns a failure reason when the token exchange call fails', async () => {
+    mockedAxios.post = jest.fn().mockRejectedValue(new Error('invalid_grant'));
+
+    const service = createService();
+    const result = await service.loginWithGoogle('auth-code');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('token_exchange_failed');
+    }
+  });
+
+  it('rejects an ES256-signed id_token (algorithm substitution defense)', async () => {
+    const ecPair = crypto.generateKeyPairSync('ec', {
+      namedCurve: 'prime256v1',
+    });
+    const ecPublicJwk = {
+      ...(ecPair.publicKey.export({ format: 'jwk' }) as Record<
+        string,
+        unknown
+      >),
+      kid: KID,
+      alg: 'ES256',
+      use: 'sig',
+    };
+    mockedAxios.get = jest
+      .fn()
+      .mockResolvedValue({ data: { keys: [ecPublicJwk] } });
+    const idToken = jwt.sign(
+      {
+        iss: 'https://accounts.google.com',
+        aud: CLIENT_ID,
+        sub: 'google-sub-008',
+        email: 'user@example.com',
+      },
+      ecPair.privateKey.export({ type: 'pkcs8', format: 'pem' }),
+      { algorithm: 'ES256', header: { alg: 'ES256', kid: KID } }
+    );
+    mockedAxios.post = jest
+      .fn()
+      .mockResolvedValue({ data: { id_token: idToken } });
+
+    const service = createService();
+    const result = await service.loginWithGoogle('auth-code');
+
+    expect(result.ok).toBe(false);
   });
 });
 

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -4,7 +4,6 @@ import crypto from 'crypto';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
-import { OAuth2Client } from 'google-auth-library';
 
 import TokenRepository from '../data_layer/TokenRepository';
 import UsersRepository from '../data_layer/UsersRepository';
@@ -13,14 +12,7 @@ import { Knex } from 'knex';
 import instrumentedAxios from './observability/instrumentedAxios';
 import { SESSION_JWT_EXPIRY } from '../shared/session';
 
-const MICROSOFT_JWKS_URL =
-  'https://login.microsoftonline.com/common/discovery/v2.0/keys';
-const MICROSOFT_JWKS_TTL_MS = 60 * 60 * 1000;
-const MICROSOFT_ISSUER_REGEX =
-  /^https:\/\/login\.microsoftonline\.com\/[^/]+\/v2\.0$/;
-const MICROSOFT_CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
-
-interface MicrosoftJwk {
+interface RsaJwk {
   kid: string;
   kty: string;
   n: string;
@@ -28,6 +20,41 @@ interface MicrosoftJwk {
   alg?: string;
   use?: string;
 }
+
+const describeError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`.slice(0, 200);
+  }
+  return String(error).slice(0, 200);
+};
+
+const resolveRsaSigningKey = (
+  idToken: string,
+  jwks: RsaJwk[]
+): crypto.KeyObject | null => {
+  const decoded = jwt.decode(idToken, { complete: true });
+  if (!decoded || typeof decoded === 'string') {
+    return null;
+  }
+  const { kid, alg } = decoded.header;
+  if (alg !== 'RS256' || typeof kid !== 'string') {
+    return null;
+  }
+  const jwk = jwks.find((k) => k.kid === kid);
+  if (!jwk) {
+    return null;
+  }
+  return crypto.createPublicKey({ key: jwk, format: 'jwk' });
+};
+
+const MICROSOFT_JWKS_URL =
+  'https://login.microsoftonline.com/common/discovery/v2.0/keys';
+const MICROSOFT_JWKS_TTL_MS = 60 * 60 * 1000;
+const MICROSOFT_ISSUER_REGEX =
+  /^https:\/\/login\.microsoftonline\.com\/[^/]+\/v2\.0$/;
+const MICROSOFT_CONSUMER_TENANT_ID = '9188040d-6c67-4c5b-b112-36a304b66dad';
+
+type MicrosoftJwk = RsaJwk;
 
 let cachedMicrosoftJwks: { keys: MicrosoftJwk[]; fetchedAt: number } | null =
   null;
@@ -88,6 +115,39 @@ async function getAppleJwks(): Promise<AppleJwk[]> {
 export const __resetAppleJwksCacheForTests = () => {
   cachedAppleJwks = null;
 };
+
+const GOOGLE_JWKS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+const GOOGLE_JWKS_TTL_MS = 60 * 60 * 1000;
+const GOOGLE_ISSUERS: [string, ...string[]] = [
+  'https://accounts.google.com',
+  'accounts.google.com',
+];
+
+let cachedGoogleJwks: { keys: RsaJwk[]; fetchedAt: number } | null = null;
+
+async function getGoogleJwks(): Promise<RsaJwk[]> {
+  const now = Date.now();
+  if (
+    cachedGoogleJwks &&
+    now - cachedGoogleJwks.fetchedAt < GOOGLE_JWKS_TTL_MS
+  ) {
+    return cachedGoogleJwks.keys;
+  }
+  const result = await instrumentedAxios.get<{ keys: RsaJwk[] }>(
+    'google_drive',
+    GOOGLE_JWKS_URL
+  );
+  cachedGoogleJwks = { keys: result.data.keys, fetchedAt: now };
+  return result.data.keys;
+}
+
+export const __resetGoogleJwksCacheForTests = () => {
+  cachedGoogleJwks = null;
+};
+
+export type GoogleLoginResult =
+  | { ok: true; email?: string; name?: string }
+  | { ok: false; reason: string; message: string };
 
 export interface UserWithOwner extends Users {
   owner: number;
@@ -292,7 +352,7 @@ class AuthenticationService {
     }
   }
 
-  async loginWithGoogle(code: string) {
+  async loginWithGoogle(code: string): Promise<GoogleLoginResult> {
     const url = 'https://oauth2.googleapis.com/token';
     const values = {
       code,
@@ -301,6 +361,8 @@ class AuthenticationService {
       redirect_uri: process.env.GOOGLE_REDIRECT_URI,
       grant_type: 'authorization_code',
     };
+
+    let idToken: string;
     try {
       const result = await instrumentedAxios.post<{ id_token: string }>(
         'google_drive',
@@ -312,20 +374,49 @@ class AuthenticationService {
           },
         }
       );
-      const idToken = result.data.id_token;
-      const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
-      const ticket = await client.verifyIdToken({
-        idToken,
-        audience: process.env.GOOGLE_CLIENT_ID,
-      });
-      const payload = ticket.getPayload();
-      return {
-        email: payload?.email,
-        name: payload?.name,
-      };
+      idToken = result.data.id_token;
     } catch (error) {
-      console.info("Couldn't login with Google");
-      console.error(error);
+      return {
+        ok: false,
+        reason: 'token_exchange_failed',
+        message: describeError(error),
+      };
+    }
+
+    try {
+      const jwks = await getGoogleJwks();
+      const publicKey = resolveRsaSigningKey(idToken, jwks);
+      if (!publicKey) {
+        return {
+          ok: false,
+          reason: 'unknown_signing_key',
+          message: 'no matching RS256 signing key in Google JWKS',
+        };
+      }
+      const payload = jwt.verify(idToken, publicKey, {
+        algorithms: ['RS256'],
+        audience: process.env.GOOGLE_CLIENT_ID,
+        issuer: GOOGLE_ISSUERS,
+      });
+      if (typeof payload === 'string') {
+        return {
+          ok: false,
+          reason: 'verify_failed',
+          message: 'unexpected string payload',
+        };
+      }
+      const email =
+        typeof payload.email === 'string' && payload.email.length > 0
+          ? payload.email
+          : undefined;
+      const name = typeof payload.name === 'string' ? payload.name : undefined;
+      return { ok: true, email, name };
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'verify_failed',
+        message: describeError(error),
+      };
     }
   }
 


### PR DESCRIPTION
## What
Replaces Google's `OAuth2Client.verifyIdToken` (which fetched Google's JWKS over google-auth-library's own gaxios transport, bypassing our SSRF guard and observability) with the same JWKS-fetch + manual `jwt.verify` pattern that Microsoft and Apple already use. The id_token signature is still verified (closes CWE-347, preserving #2245), but the egress now goes through `instrumentedAxios`, and the previously-swallowed failure reason is now recorded.

## Why
Google login is ~97% reliable in prod, but the ~3% that fail were invisible: the service `catch` logged a bare `console.info("Couldn't login with Google")` and returned `undefined`, so the actual error never reached prod logs, and the controller redirected the user back to `/login?error=google_signin_failed` (which loops behind RequireAuth). We were blind to *why* it failed. This change routes Google verify through the project wrapper (observable, SSRF-guarded) and surfaces the real reason so the next failure is diagnosable.

User-visible outcome: the same "Sign in with Google" flow, with the failure path now recorded instead of silently dropped. This is framed as "route Google verify through instrumentedAxios + surface the real failure reason" — **not** "fixes all Google login failures." We do not yet know the cause of the 3%; this PR makes it visible.

## How
- `loginWithGoogle` returns a discriminated `GoogleLoginResult` (`{ ok: true, email?, name? }` | `{ ok: false, reason, message }`).
- JWKS fetched from `https://www.googleapis.com/oauth2/v3/certs` via `instrumentedAxios` under the existing `google_drive` service tag (host already on the allowlist — no allowlist change needed), 1h cache mirroring Microsoft/Apple.
- `jwt.verify` pinned to `algorithms: ['RS256']`, `audience: GOOGLE_CLIENT_ID`, `issuer: ['https://accounts.google.com', 'accounts.google.com']`.
- Controller records the real reason via the existing `recordError` path: `surface: 'oauth_google'`, `code: 'oauth_token_exchange_failed'`, `context: { reason, message }` — matching the `stripe_webhook_signature_invalid` `context` shape already in `WebhookRouter`.
- `describeError` returns only `error.name + error.message` truncated to 200 chars — never the id_token, JWT payload, or OAuth code (CWE-532).
- Extracted `resolveRsaSigningKey` (kid to public key) as the shared helper now that this is the third RSA-JWKS provider. Microsoft and Apple are intentionally **left untouched** to keep this fix scoped to the Google path; routing them through the helper is a clean follow-up `refactor:`.
- Added `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `GOOGLE_REDIRECT_URI` to `src/env.example` (placeholders only, documented).

## Measuring success
Query the `user_visible_errors` table for `surface = 'oauth_google'` and read `context->>'reason'` / `context->>'message'`. Before this PR the reason was never recorded; after it, every Google login failure carries a concrete reason (`token_exchange_failed`, `verify_failed`, `unknown_signing_key`, `missing_email_claim`). Expect the bot-replay failures (consumed codes from scanner IPs) to surface as `token_exchange_failed` with an `invalid_grant`-class message, distinguishable from genuine `verify_failed`. Outbound JWKS calls also appear in the observability sink under the `google_drive` service.

## Testing
- Unit tests added (service, stubbing the JWKS fetch at the `instrumentedAxios` boundary — not mocking verify away, which is why the old suite shipped this green):
  - valid Google id_token + matching JWKS key → `{ ok: true, email, name }`
  - JWKS fetched through `instrumentedAxios` with the `google_drive` tag + certs URL
  - bad signature / wrong audience / wrong issuer → `{ ok: false, reason: 'verify_failed' }`
  - unknown kid → `unknown_signing_key`
  - JWKS fetch failure → `verify_failed`
  - token exchange failure → `token_exchange_failed`
  - ES256-signed token rejected (algorithm-substitution defense)
- Controller tests updated to the discriminated shape, including the new outside-in test asserting the real reason is recorded via `recordError` with `context: { reason, message }` and the user is redirected to `/login?error=google_signin_failed`.
- 162 tests pass across the two affected files; server `tsc --noEmit` clean.

## Browser check
Browser check: not applicable — no `web/src/` files changed (server-only auth path).

## Changelog
No changelog entry — internal auth reliability/observability fix. The user-visible effect ("Google sign-in is more reliable") is borderline and unproven (we don't yet know the cause of the 3%); shipping a "fix" changelog claiming reliability we can't demonstrate would be a false artifact.

## Risks
- Behavior change: the service return shape changed from `{ email, name } | undefined` to `GoogleLoginResult`. The only call site is `UsersController.loginWithGoogle` (confirmed via grep: route to controller to service, single construction site on the user's runtime path); the controller was updated in the same PR.
- JWKS key rotation: a token signed with a kid not yet in the 1h cache resolves to `unknown_signing_key`. Microsoft/Apple share this behavior; the recorded reason makes a rotation-driven spike visible. No action needed unless that reason spikes.
- Rollback: revert the commit. No migration, no data change.
- `google-auth-library` is now unused by source but left in `package.json` (removing it is out of scope; harmless).

## Goal alignment
Acquisition/activation funnel: Google sign-in is a top-of-funnel signup path. Making its ~3% failure rate diagnosable (read at `user_visible_errors` for `surface = 'oauth_google'`) is the prerequisite to recovering those signups — we cannot fix what we cannot see. No direct MRR move this PR; it unblocks the next one. When read: first review of the oauth_google error reasons after deploy.

## Sonar
`sonar-scanner` not run locally — not installed and `SONAR_TOKEN` unset on this machine. Self-reviewed against the common smells: the controller method got flatter (early-return on failure, no negated-else), the new helpers are small and shallow, no nested ternaries, no redundant assertions. Expect a possible CI Sonar pass; flagging here per the rule rather than going silent.
