### PR TITLE
fix: enforce monthly quota on all chat Claude paths

### DIFF
--- a/src/controllers/TagCardsController.test.ts
+++ b/src/controllers/TagCardsController.test.ts
@@ -1,0 +1,104 @@
+import type { Request, Response } from 'express';
+import TagCardsController from './TagCardsController';
+import { TagCardsUseCase } from '../usecases/chat/TagCardsUseCase';
+import { InMemoryChatMessagesRepository } from '../data_layer/ChatMessagesRepository';
+
+function makeAnthropic(text: string) {
+  return {
+    messages: {
+      create: jest.fn().mockResolvedValue({
+        content: [{ type: 'text', text }],
+        usage: { input_tokens: 5, output_tokens: 5 },
+      }),
+    },
+  } as unknown as ConstructorParameters<typeof TagCardsUseCase>[0];
+}
+
+function makeRes(locals: Record<string, unknown>) {
+  const res = {
+    locals,
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as unknown as Response & {
+    statusCode: number;
+    body: unknown;
+  };
+}
+
+async function repoAtCount(userId: number, count: number) {
+  const repo = new InMemoryChatMessagesRepository();
+  for (let i = 0; i < count; i++) {
+    await repo.insert({
+      userId,
+      conversationId: null,
+      role: 'user',
+      content: `msg ${i}`,
+    });
+  }
+  return repo;
+}
+
+describe('TagCardsController', () => {
+  it('returns 429 with a resetDate for a free user over the monthly cap', async () => {
+    const anthropic = makeAnthropic('[["geography"]]');
+    const create = (anthropic.messages as unknown as { create: jest.Mock })
+      .create;
+    const repo = await repoAtCount(7, 20);
+    const controller = new TagCardsController(
+      new TagCardsUseCase(anthropic, repo)
+    );
+
+    const req = { body: { cards: [{ front: 'q', back: 'a' }] } } as Request;
+    const res = makeRes({ owner: 7, patreon: false, subscriber: false });
+
+    await controller.tag(req, res);
+
+    expect(res.statusCode).toBe(429);
+    expect(res.body).toMatchObject({ error: 'Message limit reached' });
+    expect((res.body as { resetDate: string }).resetDate).toMatch(
+      /^\d{4}-\d{2}-\d{2}T/
+    );
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with tags for a free user under the cap', async () => {
+    const anthropic = makeAnthropic('[["geography"]]');
+    const repo = await repoAtCount(7, 19);
+    const controller = new TagCardsController(
+      new TagCardsUseCase(anthropic, repo)
+    );
+
+    const req = { body: { cards: [{ front: 'q', back: 'a' }] } } as Request;
+    const res = makeRes({ owner: 7, patreon: false, subscriber: false });
+
+    await controller.tag(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ tags: [['geography']] });
+  });
+
+  it('does not cap a subscriber over the free limit', async () => {
+    const anthropic = makeAnthropic('[["geography"]]');
+    const repo = await repoAtCount(7, 50);
+    const controller = new TagCardsController(
+      new TagCardsUseCase(anthropic, repo)
+    );
+
+    const req = { body: { cards: [{ front: 'q', back: 'a' }] } } as Request;
+    const res = makeRes({ owner: 7, patreon: false, subscriber: true });
+
+    await controller.tag(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ tags: [['geography']] });
+  });
+});

--- a/src/controllers/TagCardsController.ts
+++ b/src/controllers/TagCardsController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { TagCardsUseCase } from '../usecases/chat/TagCardsUseCase';
+import { ChatRateLimitError } from '../usecases/chat/ChatUseCase';
 
 const MAX_CARDS = 200;
 
@@ -54,14 +55,27 @@ class TagCardsController {
     }
 
     const owner = res.locals.owner as number;
+    const patreon = (res.locals.patreon as boolean) ?? false;
+    const subscriber = (res.locals.subscriber as boolean) ?? false;
     const conversationId = parseConversationId(req.body?.conversationId);
 
-    const result = await this.useCase.execute({
-      cards: parsedCards as TagCardInput[],
-      userId: owner,
-      conversationId,
-    });
-    res.status(200).json(result);
+    try {
+      const result = await this.useCase.execute({
+        cards: parsedCards as TagCardInput[],
+        userId: owner,
+        patreon: patreon || subscriber,
+        conversationId,
+      });
+      res.status(200).json(result);
+    } catch (err) {
+      if (err instanceof ChatRateLimitError) {
+        res
+          .status(429)
+          .json({ error: 'Message limit reached', resetDate: err.resetDate });
+        return;
+      }
+      throw err;
+    }
   }
 }
 

--- a/src/usecases/chat/ChatUseCase.test.ts
+++ b/src/usecases/chat/ChatUseCase.test.ts
@@ -1409,6 +1409,52 @@ describe('ChatUseCase', () => {
         })
       ).rejects.toBeInstanceOf(ChatConversationNotFoundError);
     });
+
+    it('rejects a free user over the monthly cap without calling Claude', async () => {
+      const { messagesRepo, conversationsRepo, anthropic, useCase } =
+        buildUseCase('should not be produced');
+      const conversationId = await seedConversation(
+        messagesRepo,
+        conversationsRepo,
+        FREE_USER.owner
+      );
+      for (let i = 0; i < 20; i++) {
+        await messagesRepo.insert({
+          userId: FREE_USER.owner,
+          conversationId,
+          role: 'user',
+          content: `filler ${i}`,
+        });
+      }
+
+      await expect(
+        useCase.regenerate({
+          user: FREE_USER,
+          conversationId,
+          templateSlug: null,
+        })
+      ).rejects.toBeInstanceOf(ChatRateLimitError);
+      expect(anthropic.messages.stream).not.toHaveBeenCalled();
+    });
+
+    it('lets a free user under the monthly cap regenerate', async () => {
+      const { messagesRepo, conversationsRepo, anthropic, useCase } =
+        buildUseCase('fresh reply');
+      const conversationId = await seedConversation(
+        messagesRepo,
+        conversationsRepo,
+        FREE_USER.owner
+      );
+
+      const result = await useCase.regenerate({
+        user: FREE_USER,
+        conversationId,
+        templateSlug: null,
+      });
+
+      expect(result.content).toBe('fresh reply');
+      expect(anthropic.messages.stream).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('ChatRateLimitError', () => {

--- a/src/usecases/chat/ChatUseCase.ts
+++ b/src/usecases/chat/ChatUseCase.ts
@@ -206,6 +206,17 @@ function firstOfNextMonth(): string {
   return next.toISOString();
 }
 
+export async function assertWithinMonthlyQuota(
+  messagesRepo: Pick<IChatMessagesRepository, 'countThisMonth'>,
+  user: ChatUser
+): Promise<void> {
+  if (user.patreon) return;
+  const count = await messagesRepo.countThisMonth(user.owner);
+  if (count >= FREE_MONTHLY_LIMIT) {
+    throw new ChatRateLimitError(firstOfNextMonth());
+  }
+}
+
 export interface ExtractCardsResult {
   cards: ChatCard[] | undefined;
   contentBefore: string | undefined;
@@ -447,12 +458,7 @@ export class ChatUseCase {
     const { user, content, conversationHistory, onToken } = input;
     const attachments = input.attachments ?? [];
 
-    if (!user.patreon) {
-      const count = await this.messagesRepo.countThisMonth(user.owner);
-      if (count >= FREE_MONTHLY_LIMIT) {
-        throw new ChatRateLimitError(firstOfNextMonth());
-      }
-    }
+    await assertWithinMonthlyQuota(this.messagesRepo, user);
 
     let conversationId: number;
     if (input.conversationId != null) {
@@ -511,6 +517,8 @@ export class ChatUseCase {
     onToken?: (text: string) => void;
   }): Promise<SendMessageResult> {
     const { user, onToken } = input;
+
+    await assertWithinMonthlyQuota(this.messagesRepo, user);
 
     const conversation = await this.conversationsRepo.findForUser({
       userId: user.owner,

--- a/src/usecases/chat/TagCardsUseCase.test.ts
+++ b/src/usecases/chat/TagCardsUseCase.test.ts
@@ -1,4 +1,6 @@
 import { parseTagsResponse, TagCardsUseCase } from './TagCardsUseCase';
+import { ChatRateLimitError } from './ChatUseCase';
+import { InMemoryChatMessagesRepository } from '../../data_layer/ChatMessagesRepository';
 
 describe('parseTagsResponse', () => {
   it('returns one normalized list per card', () => {
@@ -134,5 +136,71 @@ describe('TagCardsUseCase', () => {
     });
     expect(repo.findLatestAssistantInConversation).not.toHaveBeenCalled();
     expect(repo.updateContent).not.toHaveBeenCalled();
+  });
+
+  describe('monthly quota enforcement', () => {
+    async function repoAtCount(userId: number, count: number) {
+      const repo = new InMemoryChatMessagesRepository();
+      for (let i = 0; i < count; i++) {
+        await repo.insert({
+          userId,
+          conversationId: null,
+          role: 'user',
+          content: `msg ${i}`,
+        });
+      }
+      return repo;
+    }
+
+    it('rejects a free user over the monthly cap without calling Claude', async () => {
+      const anthropic = makeAnthropic('[["geography"]]');
+      const create = (anthropic.messages as unknown as { create: jest.Mock })
+        .create;
+      const repo = await repoAtCount(7, 20);
+      const useCase = new TagCardsUseCase(anthropic, repo);
+
+      await expect(
+        useCase.execute({
+          cards: [{ front: 'q', back: 'a' }],
+          userId: 7,
+          patreon: false,
+        })
+      ).rejects.toBeInstanceOf(ChatRateLimitError);
+      expect(create).not.toHaveBeenCalled();
+    });
+
+    it('lets a free user under the monthly cap tag cards', async () => {
+      const anthropic = makeAnthropic('[["geography"]]');
+      const create = (anthropic.messages as unknown as { create: jest.Mock })
+        .create;
+      const repo = await repoAtCount(7, 19);
+      const useCase = new TagCardsUseCase(anthropic, repo);
+
+      const result = await useCase.execute({
+        cards: [{ front: 'q', back: 'a' }],
+        userId: 7,
+        patreon: false,
+      });
+
+      expect(result.tags).toEqual([['geography']]);
+      expect(create).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cap a patreon user over the free limit', async () => {
+      const anthropic = makeAnthropic('[["geography"]]');
+      const create = (anthropic.messages as unknown as { create: jest.Mock })
+        .create;
+      const repo = await repoAtCount(7, 50);
+      const useCase = new TagCardsUseCase(anthropic, repo);
+
+      const result = await useCase.execute({
+        cards: [{ front: 'q', back: 'a' }],
+        userId: 7,
+        patreon: true,
+      });
+
+      expect(result.tags).toEqual([['geography']]);
+      expect(create).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/usecases/chat/TagCardsUseCase.ts
+++ b/src/usecases/chat/TagCardsUseCase.ts
@@ -4,6 +4,7 @@ import type { IChatMessagesRepository } from '../../data_layer/ChatMessagesRepos
 import {
   rewriteAssistantContentWithTaggedCards,
   extractCards,
+  assertWithinMonthlyQuota,
 } from './ChatUseCase';
 
 const TAGGING_MODEL = 'claude-haiku-4-5-20251001';
@@ -23,6 +24,7 @@ Example output:
 export interface TagCardsInput {
   cards: { front: string; back: string }[];
   userId?: number;
+  patreon?: boolean;
   conversationId?: number | null;
 }
 
@@ -92,6 +94,13 @@ export class TagCardsUseCase {
   ) {}
 
   async execute(input: TagCardsInput): Promise<TagCardsResult> {
+    if (this.messagesRepo != null && input.userId != null) {
+      await assertWithinMonthlyQuota(this.messagesRepo, {
+        owner: input.userId,
+        patreon: input.patreon ?? false,
+      });
+    }
+
     if (input.cards.length === 0) {
       return { tags: [] };
     }


### PR DESCRIPTION
## What
The free-tier monthly chat message cap was enforced in only one of the three code paths that call Claude. This adds the same cap to the other two: regenerating an assistant turn, and tag-cards.

## Why
`ChatUseCase.execute()` checked `countThisMonth` against the free monthly limit before calling Claude, but `ChatUseCase.regenerate()` and `TagCardsUseCase.execute()` did not. A free user at or over the cap could keep invoking Claude through those two endpoints (`POST /api/chat/conversations/:id/regenerate` and `POST /api/chat/tag-cards`, the latter up to 200 cards per request), so the limit did not actually bound spend.

## How
Extracted one shared helper, `assertWithinMonthlyQuota(messagesRepo, user)`, in `ChatUseCase.ts` — same count source, same `FREE_MONTHLY_LIMIT`, same `ChatRateLimitError(firstOfNextMonth())` that `execute()` already produced. Called at the top of all three paths before any Claude call:
1. `ChatUseCase.execute()`
2. `ChatUseCase.regenerate()`
3. `TagCardsUseCase.execute()`

For tag-cards, `TagCardsInput` gains an optional `patreon` flag (the controller passes `patreon || subscriber`, matching the message path), and `TagCardsController` maps `ChatRateLimitError` to HTTP 429 with the `resetDate`. The SSE chat/regenerate paths surface the same error through the existing `error` frame.

## Measuring success
The cap throws `ChatRateLimitError`. In production a free user over the cap hitting regenerate or tag-cards now gets the same `ChatRateLimitError`/`rate_limit` outcome as the message endpoint, and `logClaudeUsage('TagCardsUseCase'/'ChatUseCase', …)` no longer logs a usage line for those over-cap calls — the absence of Claude-usage log lines from over-cap free users on these two paths confirms the fix.

## Testing
- Unit tests added:
  - `ChatUseCase.regenerate` — free user over cap is rejected with `ChatRateLimitError` and the Anthropic stream is not called; under-cap free user regenerates normally.
  - `TagCardsUseCase.execute` — over-cap free user rejected with no `messages.create` call; under-cap free user succeeds; patreon user over the free limit is not capped.
  - `TagCardsController.tag` — over-cap free user → 429 with `resetDate` and no Claude call; under-cap → 200; subscriber over the free limit → 200.
- All chat use-case and chat controller suites green (214 tests). Server `tsc --noEmit` clean. oxfmt/oxlint clean on the changed files (only pre-existing warnings on untouched lines remain).
- Pre-existing unrelated suite failures (`DeckParser`, `extractApkg` zstd, `runParserCanary`, `CardGenerator` Python spawn) reproduce identically on a clean `origin/main` checkout — environment/native-dep driven, not from this change.

## Browser check
Browser check: not applicable — server-only change, no `web/src` files touched.

## Changelog
No entry — security/abuse hardening with no new or changed user-visible capability. Legitimate users see no behavior change; only over-cap free users on two previously-unbounded paths are now stopped, the same way the message endpoint already stopped them.

## Sonar
sonar-scanner not run locally (scanner not installed, no `SONAR_TOKEN` on this machine). The change is a small helper extraction plus one transforming try/catch — no new nesting, no `any`, no user-URL-to-HTTP, no HTML reflection. Expect a clean Sonar pass; flagging here in case of a bounce.

## Risks
Low. The helper preserves the exact existing quota semantics (only `execute()`'s logic, moved). The only new user-visible surface is the tag-cards 429 for over-cap free users, which is the intended behavior. Rollback is a straight revert of this single commit.

## Goal alignment
Revenue/cost protection: closes an unbounded Claude (Haiku) spend path for free users, directly defending margin — relevant to the MRR-over-cost goal in CLAUDE.md. No funnel metric to move; this is internal abuse hardening.
