### PR TITLE
fix: re-validate redirects per hop in instrumentedAxios; lock down Dropbox upload

### DIFF
--- a/src/routes/UploadRouter.test.ts
+++ b/src/routes/UploadRouter.test.ts
@@ -1,0 +1,142 @@
+import express from 'express';
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+
+let mockAuthOwner: number | null = 42;
+
+jest.mock('./middleware/RequireAuthentication', () => {
+  const middleware = (
+    _req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
+    if (mockAuthOwner == null) {
+      res.status(401).json({ message: 'Authentication required' });
+      return;
+    }
+    res.locals.owner = mockAuthOwner;
+    next();
+  };
+  return {
+    __esModule: true,
+    default: middleware,
+    OptionalAuthentication: middleware,
+  };
+});
+
+jest.mock('./middleware/RequireAllowedOrigin', () => ({
+  __esModule: true,
+  default: (
+    _req: express.Request,
+    _res: express.Response,
+    next: express.NextFunction
+  ) => next(),
+}));
+
+jest.mock('../data_layer', () => ({
+  __esModule: true,
+  getDatabase: () => ({}),
+}));
+
+jest.mock('../lib/storage/StorageHandler', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
+
+const mockDropbox = jest.fn();
+
+jest.mock('../controllers/Upload/UploadController', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    dropbox: mockDropbox,
+    googleDrive: jest.fn(),
+    getDropboxUploads: jest.fn(),
+    deleteDropboxUpload: jest.fn(),
+    getGoogleDriveUploads: jest.fn(),
+    deleteGoogleDriveUpload: jest.fn(),
+  })),
+}));
+
+jest.mock('../controllers/Upload/SaveNativeDeckController', () => ({
+  SaveNativeDeckController: jest.fn().mockImplementation(() => ({
+    save: jest.fn(),
+  })),
+}));
+
+jest.mock('../controllers/JobController', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    getJobs: jest.fn(),
+    deleteJob: jest.fn(),
+  })),
+}));
+
+jest.mock('../controllers/Upload/RecentSourcesController', () => ({
+  RecentSourcesController: jest.fn().mockImplementation(() => ({
+    getRecentSources: jest.fn(),
+  })),
+}));
+
+import UploadRouter from './UploadRouter';
+
+const startServer = async () => {
+  const app = express();
+  app.use(UploadRouter());
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+};
+
+const postDropbox = (url: string) =>
+  fetch(`${url}/api/upload/dropbox`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      files: [
+        {
+          link: 'https://uc8.dl.dropboxusercontent.com/x',
+          name: 'a.zip',
+          bytes: 1,
+        },
+      ],
+    }),
+  });
+
+describe('UploadRouter POST /api/upload/dropbox', () => {
+  beforeEach(() => {
+    mockAuthOwner = 42;
+    mockDropbox.mockReset();
+    mockDropbox.mockImplementation(
+      (_req: express.Request, res: express.Response) => {
+        res.status(200).json({ ok: true });
+      }
+    );
+  });
+
+  it('rejects unauthenticated dropbox uploads with 401', async () => {
+    mockAuthOwner = null;
+    const { url, close } = await startServer();
+    try {
+      const res = await postDropbox(url);
+      expect(res.status).toBe(401);
+      expect(mockDropbox).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it('forwards an authenticated dropbox upload to the controller', async () => {
+    const { url, close } = await startServer();
+    try {
+      const res = await postDropbox(url);
+      expect(res.status).toBe(200);
+      expect(mockDropbox).toHaveBeenCalledTimes(1);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/routes/UploadRouter.ts
+++ b/src/routes/UploadRouter.ts
@@ -254,6 +254,7 @@ const UploadRouter = () => {
   router.post(
     '/api/upload/dropbox',
     RequireAllowedOrigin,
+    RequireAuthentication,
     multer({ dest: '/tmp' }).none(),
     (req, res) => uploadController.dropbox(req, res)
   );

--- a/src/services/observability/FEATURE.md
+++ b/src/services/observability/FEATURE.md
@@ -9,12 +9,14 @@ Express controllers used to call `axios.get(...)` directly with user-controlled 
 1. Validates the URL is `https`, not a private/loopback host, and not an IPv4-mapped IPv6 address.
 2. Resolves the host once via `dns.promises.lookup`, refuses any private IP in the answer set, and pins the resolved address through `axios`'s `lookup` option so the connection cannot be re-targeted at request time.
 3. Records latency, status, and error class into `ObservabilitySink` so `OpsController` can render service health without scraping logs.
+4. Sets `maxRedirects: 0` and follows redirects itself, re-running the full validation (scheme + private-host + allowlist + DNS pin) on every hop up to `MAX_REDIRECTS`. An allowlisted origin that 302s to a private/internal host or an off-allowlist host is rejected on the hop, not followed. A 3xx arrives either as a resolved response or — under axios's default `validateStatus` — as a rejected error carrying `error.response`; both paths read the `Location` header and re-validate.
 
 ## Public surface
 
 - `instrumentedAxios(service, config)` — drop-in replacement for `axios(...)`. `service` must be one of `OBSERVABILITY_SERVICES`.
 - `OBSERVABILITY_SERVICES` — frozen list. Adding a new outbound integration means **adding it here first**, then writing the wrapper.
-- `FIXED_HOST_ALLOWLIST` — per-service host pin. Set to `null` for services that need wildcard hosts (e.g. Notion's per-tenant CDNs); set to an explicit list for services that only ever talk to one or two endpoints.
+- `FIXED_HOST_ALLOWLIST` — per-service exact-host pin. Set to `null` for services that need wildcard hosts (e.g. Notion's per-tenant CDNs); set to an explicit list for services that only ever talk to one or two endpoints.
+- `DOMAIN_SUFFIX_ALLOWLIST` — per-service domain-suffix pin for services whose content hosts vary by subdomain but share a registrable domain. `dropbox` is pinned to `dropboxusercontent.com` (the Chooser's `linkType: 'direct'` links resolve to `*.dl.dropboxusercontent.com`); this is what stops the upload route from being an arbitrary-public-host GET. A suffix entry takes precedence over the service's `FIXED_HOST_ALLOWLIST` row.
 - `getObservabilitySink()` / `ObservabilitySinkInstance` — singleton sink. The query service (`ObservabilityQueryService`) reads from it.
 - `ObservabilityQueryService.getMetrics(window)` — read API for `/ops`. Aggregates inbound volume + route latency, outbound volume + per-service latency percentiles (p50/p95/p99), and route/service error rates over a `1h | 24h | 7d` window. Adding a new aggregation means extending `IObservabilityRepository`, the `OpsMetricsResponse` shape, and the engineering tab in one PR.
 

--- a/src/services/observability/instrumentedAxios.test.ts
+++ b/src/services/observability/instrumentedAxios.test.ts
@@ -162,7 +162,7 @@ describe('instrumentedAxios', () => {
     });
     await client.put(
       'dropbox',
-      'https://content.dropboxapi.com/2/files/upload'
+      'https://uc8.dl.dropboxusercontent.com/cd/0/put/abc'
     );
     await client.delete(
       'google_drive',
@@ -235,7 +235,7 @@ describe('instrumentedAxios', () => {
     expect(mockedAxios.get).not.toHaveBeenCalled();
   });
 
-  it('allows arbitrary public hosts for variable-host services (notion media, dropbox files)', async () => {
+  it('allows arbitrary public hosts for notion media and the dropbox content family', async () => {
     const repo = new FakeRepo();
     const sink = new ObservabilitySink(repo);
     const client = makeInstrumentedAxios(sink);
@@ -289,7 +289,7 @@ describe('instrumentedAxios', () => {
     const cases: Array<[Parameters<typeof client.get>[0], string]> = [
       ['notion', 'https://api.notion.com/v1/pages/abc'],
       ['claude', 'https://api.anthropic.com/v1/messages'],
-      ['dropbox', 'https://content.dropboxapi.com/2/files/upload'],
+      ['dropbox', 'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'],
       ['google_drive', 'https://www.googleapis.com/drive/v3/files/abc'],
       ['google_drive', 'https://oauth2.googleapis.com/token'],
       ['patreon', 'https://www.patreon.com/api/oauth2/v2/identity'],
@@ -361,7 +361,7 @@ describe('instrumentedAxios', () => {
     ).rejects.toThrow(/resolved IP .* is private\/loopback\/link-local/i);
 
     await expect(
-      client.get('dropbox', 'https://imds.attacker.example/file')
+      client.get('dropbox', 'https://rebind.dl.dropboxusercontent.com/file')
     ).rejects.toThrow(/resolved IP .* is private\/loopback\/link-local/i);
 
     expect(mockedAxios.get).not.toHaveBeenCalled();
@@ -448,6 +448,225 @@ describe('instrumentedAxios', () => {
       ).rejects.toThrow(/private\/loopback\/link-local/i);
     }
     expect(mockedAxios.get).not.toHaveBeenCalled();
+  });
+
+  const makeRedirect = (location: string) => ({
+    status: 302,
+    data: '',
+    headers: { location },
+  });
+
+  const makeRedirectError = (location: string): AxiosError => {
+    const err = new Error('status 302') as AxiosError;
+    err.isAxiosError = true;
+    err.response = {
+      status: 302,
+      statusText: '',
+      headers: { location },
+      config: {} as never,
+      data: null,
+    };
+    return err;
+  };
+
+  it('re-validates a redirect surfaced as an axios error (maxRedirects: 0 production path)', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get.mockRejectedValueOnce(
+      makeRedirectError('https://127.0.0.1/internal')
+    );
+    mockPublicLookup();
+
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).rejects.toThrow(/private\/loopback address/i);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows a redirect surfaced as an axios error to its allowed target', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get
+      .mockRejectedValueOnce(
+        makeRedirectError('https://uc9.dl.dropboxusercontent.com/cd/0/final')
+      )
+      .mockResolvedValueOnce({ status: 200, data: 'bytes' });
+    mockPublicLookup();
+
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).resolves.toEqual({ status: 200, data: 'bytes' });
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes maxRedirects: 0 to axios so the wrapper owns redirect following', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get.mockResolvedValueOnce({ status: 200, data: 'ok' });
+    mockPublicLookup();
+
+    await client.get(
+      'dropbox',
+      'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+    );
+
+    const opts = mockedAxios.get.mock.calls[0][1] as { maxRedirects: number };
+    expect(opts.maxRedirects).toBe(0);
+  });
+
+  it('re-validates the redirect target and rejects a hop to a private host', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get.mockResolvedValueOnce(
+      makeRedirect('https://rebind.dl.dropboxusercontent.com/file')
+    );
+    mockedLookup.mockImplementation(async (host: string) => {
+      if (host === 'rebind.dl.dropboxusercontent.com') {
+        return [{ address: '169.254.169.254', family: 4 }];
+      }
+      return [{ address: '13.224.0.1', family: 4 }];
+    });
+
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).rejects.toThrow(/private\/loopback\/link-local/i);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-validates the redirect target and rejects a hop to an IP-literal private host', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get.mockResolvedValueOnce(
+      makeRedirect('https://127.0.0.1/internal')
+    );
+    mockPublicLookup();
+
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).rejects.toThrow(/private\/loopback address/i);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-validates the redirect target against the service allowlist', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get.mockResolvedValueOnce(
+      makeRedirect('https://api.notion.com/v1/pages/abc')
+    );
+    mockPublicLookup();
+
+    await expect(
+      client.get('claude', 'https://api.anthropic.com/v1/messages')
+    ).rejects.toThrow(/host.*not allowed.*claude/i);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a non-https redirect target', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get.mockResolvedValueOnce(
+      makeRedirect('http://uc8.dl.dropboxusercontent.com/cd/0/get/abc')
+    );
+    mockPublicLookup();
+
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).rejects.toThrow(/https/i);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows an allowed redirect hop and returns the final response', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get
+      .mockResolvedValueOnce(
+        makeRedirect('https://uc9.dl.dropboxusercontent.com/cd/0/final')
+      )
+      .mockResolvedValueOnce({ status: 200, data: 'bytes' });
+    mockPublicLookup();
+
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).resolves.toEqual({ status: 200, data: 'bytes' });
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops following after the redirect cap is exceeded', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockedAxios.get.mockResolvedValue(
+      makeRedirect('https://uc9.dl.dropboxusercontent.com/cd/0/loop')
+    );
+    mockPublicLookup();
+
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).rejects.toThrow(/too many redirects/i);
+  });
+
+  it('constrains the dropbox allowlist to dropboxusercontent content hosts', async () => {
+    const repo = new FakeRepo();
+    const sink = new ObservabilitySink(repo);
+    const client = makeInstrumentedAxios(sink);
+
+    mockPublicLookup();
+
+    await expect(
+      client.get('dropbox', 'https://attacker.example.com/exfil')
+    ).rejects.toThrow(/host.*not allowed.*dropbox/i);
+
+    await expect(
+      client.get('dropbox', 'https://www.dropbox.com/s/abc/file?dl=1')
+    ).rejects.toThrow(/host.*not allowed.*dropbox/i);
+
+    expect(mockedAxios.get).not.toHaveBeenCalled();
+
+    mockedAxios.get.mockResolvedValue({ status: 200, data: 'ok' });
+    await expect(
+      client.get(
+        'dropbox',
+        'https://uc8a13.dl.dropboxusercontent.com/cd/0/get/abc'
+      )
+    ).resolves.toEqual({ status: 200, data: 'ok' });
   });
 
   it('does not throw when sink itself rejects (instrumentation must never break the caller)', async () => {

--- a/src/services/observability/instrumentedAxios.ts
+++ b/src/services/observability/instrumentedAxios.ts
@@ -40,13 +40,26 @@ const FIXED_HOST_ALLOWLIST: Record<
   ],
 };
 
+const DOMAIN_SUFFIX_ALLOWLIST: Partial<
+  Record<ObservabilityService, readonly string[]>
+> = {
+  dropbox: ['dropboxusercontent.com'],
+};
+
+const matchesDomainSuffix = (lowered: string, suffix: string): boolean =>
+  lowered === suffix || lowered.endsWith(`.${suffix}`);
+
 const isHostOnFixedAllowlist = (
   host: string,
   service: ObservabilityService
 ): boolean => {
+  const lowered = host.toLowerCase();
+  const suffixes = DOMAIN_SUFFIX_ALLOWLIST[service];
+  if (suffixes != null) {
+    return suffixes.some((suffix) => matchesDomainSuffix(lowered, suffix));
+  }
   const allowlist = FIXED_HOST_ALLOWLIST[service];
   if (allowlist == null) return true;
-  const lowered = host.toLowerCase();
   return allowlist.includes(lowered);
 };
 
@@ -259,12 +272,52 @@ const extractStatusFromError = (error: unknown): number | null => {
   return null;
 };
 
-const mergeLookupOption = (
+const MAX_REDIRECTS = 5;
+
+const mergeRequestOptions = (
   config: AxiosRequestConfig | undefined,
   lookup: AxiosLookup
-): AxiosRequestConfig => {
-  if (config == null) return { lookup };
-  return { ...config, lookup };
+): AxiosRequestConfig => ({
+  ...config,
+  lookup,
+  maxRedirects: 0,
+});
+
+const isRedirectStatus = (status: number): boolean =>
+  status >= 300 && status < 400;
+
+const headerValue = (
+  headers: AxiosResponse['headers'] | undefined,
+  name: string
+): string | null => {
+  if (headers == null) return null;
+  const raw = (headers as Record<string, unknown>)[name];
+  if (typeof raw === 'string') return raw;
+  if (Array.isArray(raw) && typeof raw[0] === 'string') return raw[0];
+  return null;
+};
+
+const redirectLocationFromResponse = (
+  response: AxiosResponse | undefined,
+  baseUrl: string
+): string | null => {
+  if (response == null) return null;
+  if (!isRedirectStatus(response.status)) return null;
+  const location = headerValue(response.headers, 'location');
+  if (location == null) return null;
+  try {
+    return new URL(location, baseUrl).toString();
+  } catch {
+    throw new Error(`[observability] invalid redirect location: ${location}`);
+  }
+};
+
+const redirectLocationFromError = (
+  error: unknown,
+  baseUrl: string
+): string | null => {
+  if (!axios.isAxiosError(error)) return null;
+  return redirectLocationFromResponse(error.response, baseUrl);
 };
 
 export interface InstrumentedAxios {
@@ -292,54 +345,97 @@ export interface InstrumentedAxios {
   ): Promise<AxiosResponse<T>>;
 }
 
+const resolveNextHop = async (
+  nextUrl: string,
+  service: ObservabilityService
+): Promise<{ currentUrl: string; endpoint: string; lookup: AxiosLookup }> => {
+  const parsed = parseRequestUrl(nextUrl);
+  const { endpoint, lookup } = await validateAndResolveUrl(parsed, service);
+  return { currentUrl: nextUrl, endpoint, lookup };
+};
+
 const measure = async <T>(
   sink: ObservabilitySink,
   service: string,
   url: string,
-  exec: (lookup: AxiosLookup) => Promise<AxiosResponse<T>>
+  exec: (hopUrl: string, lookup: AxiosLookup) => Promise<AxiosResponse<T>>
 ): Promise<AxiosResponse<T>> => {
   if (!isAllowedService(service)) {
     throw new Error(
       `[observability] unknown service "${service}". Allowed: ${OBSERVABILITY_SERVICES.join(', ')}`
     );
   }
-  const parsed = parseRequestUrl(url);
-  const { endpoint, lookup } = await validateAndResolveUrl(parsed, service);
-  const start = Date.now();
-  try {
-    const response = await exec(lookup);
+  const firstParsed = parseRequestUrl(url);
+  const { endpoint: firstEndpoint, lookup: firstLookup } =
+    await validateAndResolveUrl(firstParsed, service);
+
+  let currentUrl = url;
+  let endpoint = firstEndpoint;
+  let lookup = firstLookup;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const start = Date.now();
+    let response: AxiosResponse<T>;
+    try {
+      response = await exec(currentUrl, lookup);
+    } catch (error) {
+      const redirectTarget = redirectLocationFromError(error, currentUrl);
+      recordSafely(
+        sink,
+        service,
+        endpoint,
+        extractStatusFromError(error),
+        Date.now() - start
+      );
+      if (redirectTarget == null) throw error;
+      ({ currentUrl, endpoint, lookup } = await resolveNextHop(
+        redirectTarget,
+        service
+      ));
+      continue;
+    }
+
+    const redirectTarget = redirectLocationFromResponse(response, currentUrl);
+    if (redirectTarget == null) {
+      recordSafely(
+        sink,
+        service,
+        endpoint,
+        response.status,
+        Date.now() - start
+      );
+      return response;
+    }
     recordSafely(sink, service, endpoint, response.status, Date.now() - start);
-    return response;
-  } catch (error) {
-    recordSafely(
-      sink,
-      service,
-      endpoint,
-      extractStatusFromError(error),
-      Date.now() - start
-    );
-    throw error;
+    ({ currentUrl, endpoint, lookup } = await resolveNextHop(
+      redirectTarget,
+      service
+    ));
   }
+
+  throw new Error(
+    `[observability] too many redirects for service "${service}" (max ${MAX_REDIRECTS})`
+  );
 };
 
 export const makeInstrumentedAxios = (
   sink: ObservabilitySink
 ): InstrumentedAxios => ({
   get: (service, url, config) =>
-    measure(sink, service, url, (lookup) =>
-      axios.get(url, mergeLookupOption(config, lookup))
+    measure(sink, service, url, (hopUrl, lookup) =>
+      axios.get(hopUrl, mergeRequestOptions(config, lookup))
     ),
   post: (service, url, data, config) =>
-    measure(sink, service, url, (lookup) =>
-      axios.post(url, data, mergeLookupOption(config, lookup))
+    measure(sink, service, url, (hopUrl, lookup) =>
+      axios.post(hopUrl, data, mergeRequestOptions(config, lookup))
     ),
   put: (service, url, data, config) =>
-    measure(sink, service, url, (lookup) =>
-      axios.put(url, data, mergeLookupOption(config, lookup))
+    measure(sink, service, url, (hopUrl, lookup) =>
+      axios.put(hopUrl, data, mergeRequestOptions(config, lookup))
     ),
   delete: (service, url, config) =>
-    measure(sink, service, url, (lookup) =>
-      axios.delete(url, mergeLookupOption(config, lookup))
+    measure(sink, service, url, (hopUrl, lookup) =>
+      axios.delete(hopUrl, mergeRequestOptions(config, lookup))
     ),
 });
 


### PR DESCRIPTION
## What

Two SSRF hardening changes in the outbound HTTP wrapper.

**Redirect re-validation.** `instrumentedAxios` validated only the first URL, then let axios follow up to 5 redirects unchecked — an allowlisted origin returning a redirect to a private/internal host (or an IP-literal that skips the DNS pin) was followed. Now `maxRedirects: 0` and redirects are walked manually, re-running `validateAndResolveUrl` (DNS pin + private/loopback/link-local rejection + allowlist) on **every hop**, bounded at 5.

**Dropbox lockdown.** The `dropbox` service had a `null` (open) allowlist and its upload route was gated only by a spoofable `Origin` header. Constrained to the `dropboxusercontent.com` domain suffix and added `RequireAuthentication` to `POST /api/upload/dropbox`.

The existing Notion `null`-allowlist exposure is covered by the per-hop re-validation.

## Tests

- Per-hop validation: a redirect to a private host / IP-literal is rejected on the hop, not followed; legitimate single-hop requests still resolve. (`instrumentedAxios.test.ts`)
- Dropbox route returns 401 without a session. (`UploadRouter.test.ts`, new)
- 32 tests pass across both files; server `tsc --noEmit` clean.

## Notes

- No changelog — internal security hardening, no user-visible behavior change.
- No `web/src/` changes → browser attestation not applicable.
- `sonar-scanner` not run locally (not installed / `SONAR_TOKEN` unset); complexity kept low via extracted helpers. CI is the first Sonar pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)