### PR TITLE
feat: wire return-rate and mindmap ops endpoints into the dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -147,6 +147,14 @@ const ConversionsTab = lazyWithRetry(
   () => import('./pages/OpsPage/ConversionsTab'),
   './pages/OpsPage/ConversionsTab'
 );
+const ReturnRateTab = lazyWithRetry(
+  () => import('./pages/OpsPage/ReturnRateTab'),
+  './pages/OpsPage/ReturnRateTab'
+);
+const MindmapsTab = lazyWithRetry(
+  () => import('./pages/OpsPage/MindmapsTab'),
+  './pages/OpsPage/MindmapsTab'
+);
 const BusinessTab = lazyWithRetry(
   () => import('./pages/OpsPage/BusinessTab'),
   './pages/OpsPage/BusinessTab'
@@ -493,6 +501,8 @@ function AppContent({
             <Route path="errors" element={<ErrorsTab />} />
             <Route path="performance" element={<PerformanceTab />} />
             <Route path="conversions" element={<ConversionsTab />} />
+            <Route path="return-rate" element={<ReturnRateTab />} />
+            <Route path="mindmaps" element={<MindmapsTab />} />
             <Route path="upload-funnel" element={<UploadFunnelTab />} />
             <Route path="business" element={<BusinessTab />} />
             <Route path="showcase" element={<ShowcaseTab />} />

--- a/web/src/pages/OpsPage/MindmapsTab.tsx
+++ b/web/src/pages/OpsPage/MindmapsTab.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import ChartPanel from './charts/ChartPanel';
+import MetricCard from './MetricCard';
+import { formatBytes, formatCount, formatRatio } from './opsHelpers';
+import {
+  useMindmapImageStats,
+  useMindmapStorageMetrics,
+} from './useMindmapOpsMetrics';
+import { MindmapUserStorageEntry } from './mindmapOpsTypes';
+
+const renderTopUsers = (rows: MindmapUserStorageEntry[]) => {
+  if (rows.length === 0) {
+    return <p className={styles.emptyHint}>No mindmap images stored yet.</p>;
+  }
+  return (
+    <div className={styles.tableScroll}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Storage</th>
+            <th>Objects</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.user_id}>
+              <td className={styles.numericMuted}>{row.user_id}</td>
+              <td className={styles.numeric}>{formatBytes(row.bytes)}</td>
+              <td className={styles.numeric}>
+                {formatCount(row.object_count)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default function MindmapsTab() {
+  const imageStats = useMindmapImageStats();
+  const storage = useMindmapStorageMetrics();
+
+  const storageInitial = storage.isLoading && storage.data == null;
+  const refreshing =
+    (imageStats.isFetching && !imageStats.isLoading) ||
+    (storage.isFetching && !storage.isLoading);
+
+  const measured = useMemo(() => {
+    const at = storage.data?.measured_at ?? imageStats.data?.as_of;
+    if (at == null) return '—';
+    return new Date(at).toLocaleTimeString();
+  }, [storage.data?.measured_at, imageStats.data?.as_of]);
+
+  const refetchAll = () => {
+    imageStats.refetch();
+    storage.refetch();
+  };
+
+  return (
+    <>
+      <div className={styles.tabHeader}>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={`${sharedStyles.btnSmall} ${styles.refreshButton}`}
+            onClick={refetchAll}
+          >
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      <p className={styles.subtitle}>
+        <span>Updated {measured}</span>
+        <span className={styles.subtitleSeparator}>·</span>
+        <span>image-paste adoption and S3 storage under mindmaps/</span>
+      </p>
+
+      {imageStats.error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          /api/ops/mindmap/image-stats failed: {imageStats.error.message}
+        </div>
+      )}
+      {storage.error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          /api/ops/mindmap/storage failed: {storage.error.message}
+        </div>
+      )}
+
+      <div className={styles.grid}>
+        <MetricCard
+          title="Maps with an image"
+          value={formatRatio(imageStats.data?.ratio ?? null)}
+          footnote={
+            imageStats.data == null
+              ? undefined
+              : `${formatCount(imageStats.data.with_images)} of ${formatCount(imageStats.data.total)} maps`
+          }
+        />
+        <MetricCard
+          title="Image storage on S3"
+          value={
+            storage.data == null ? '—' : formatBytes(storage.data.total_bytes)
+          }
+          footnote={
+            storage.data == null
+              ? undefined
+              : `${formatCount(storage.data.total_objects)} objects`
+          }
+        />
+
+        <ChartPanel
+          title="Top users by image storage"
+          subtitle="Largest mindmap image footprints under the mindmaps/ prefix"
+          isLoading={storageInitial}
+          isEmpty={(storage.data?.top_users.length ?? 0) === 0}
+          emptyText="No mindmap images stored yet."
+          autoHeight
+        >
+          {storage.data != null && renderTopUsers(storage.data.top_users)}
+        </ChartPanel>
+      </div>
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/ReturnRateTab.tsx
+++ b/web/src/pages/OpsPage/ReturnRateTab.tsx
@@ -1,0 +1,121 @@
+import { useMemo } from 'react';
+
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import ChartPanel from './charts/ChartPanel';
+import MetricCard from './MetricCard';
+import { formatCount, formatPercent } from './opsHelpers';
+import { useReturnRateMetrics } from './useReturnRateMetrics';
+import { ReturnRateBySourceType } from './returnRateTypes';
+
+const formatPct = (value: number | null): string =>
+  value == null ? '—' : formatPercent(value);
+
+const renderBySourceType = (rows: ReturnRateBySourceType[]) => {
+  if (rows.length === 0) {
+    return (
+      <p className={styles.emptyHint}>
+        No cohorts with a prior successful conversion in the last 90 days.
+      </p>
+    );
+  }
+  return (
+    <div className={styles.tableScroll}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Source</th>
+            <th>Cohort</th>
+            <th>7d</th>
+            <th>14d</th>
+            <th>30d</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.source_type}>
+              <td>{row.source_type}</td>
+              <td className={styles.numeric}>{formatCount(row.cohort_size)}</td>
+              <td className={styles.numeric}>
+                {formatPct(row.return_rate_7d_pct)}
+              </td>
+              <td className={styles.numeric}>
+                {formatPct(row.return_rate_14d_pct)}
+              </td>
+              <td className={styles.numeric}>
+                {formatPct(row.return_rate_30d_pct)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default function ReturnRateTab() {
+  const { data, error, isLoading, isFetching, refetch } =
+    useReturnRateMetrics();
+  const isInitial = isLoading && data == null;
+  const refreshing = isFetching && !isLoading;
+  const generated = useMemo(() => {
+    if (data?.as_of == null) return '—';
+    return new Date(data.as_of).toLocaleTimeString();
+  }, [data?.as_of]);
+
+  return (
+    <>
+      <div className={styles.tabHeader}>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={`${sharedStyles.btnSmall} ${styles.refreshButton}`}
+            onClick={() => refetch()}
+          >
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      <p className={styles.subtitle}>
+        <span>Updated {generated}</span>
+        <span className={styles.subtitleSeparator}>·</span>
+        <span>second conversion within N days · 90-day cohort window</span>
+      </p>
+
+      {error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          /api/ops/return-rate/metrics failed: {error.message}. Last good data
+          shown below.
+        </div>
+      )}
+
+      <div className={styles.grid}>
+        <MetricCard
+          title="Returned within 7 days"
+          value={formatPct(data?.overall['7d'] ?? null)}
+          footnote="Share of users who converted again within a week"
+        />
+        <MetricCard
+          title="Returned within 14 days"
+          value={formatPct(data?.overall['14d'] ?? null)}
+        />
+        <MetricCard
+          title="Returned within 30 days"
+          value={formatPct(data?.overall['30d'] ?? null)}
+        />
+
+        <ChartPanel
+          title="Return rate by source type"
+          subtitle="Bucketed by the source of the prior successful conversion"
+          isLoading={isInitial}
+          isEmpty={(data?.by_source_type?.length ?? 0) === 0}
+          emptyText="No cohorts in this window."
+          autoHeight
+        >
+          {data != null && renderBySourceType(data.by_source_type ?? [])}
+        </ChartPanel>
+      </div>
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/mindmapOpsTypes.ts
+++ b/web/src/pages/OpsPage/mindmapOpsTypes.ts
@@ -1,0 +1,19 @@
+export interface MindmapImageStatsResponse {
+  total: number;
+  with_images: number;
+  ratio: number | null;
+  as_of: string;
+}
+
+export interface MindmapUserStorageEntry {
+  user_id: string;
+  bytes: number;
+  object_count: number;
+}
+
+export interface MindmapStorageMetricsResponse {
+  total_bytes: number;
+  total_objects: number;
+  top_users: MindmapUserStorageEntry[];
+  measured_at: string;
+}

--- a/web/src/pages/OpsPage/opsHelpers.test.ts
+++ b/web/src/pages/OpsPage/opsHelpers.test.ts
@@ -4,7 +4,9 @@ import {
   errorRateColor,
   errorRatePercent,
   formatBucketLabel,
+  formatBytes,
   formatPercent,
+  formatRatio,
   groupInboundByBucket,
   groupOutboundByBucket,
   truncateRoute,
@@ -94,6 +96,23 @@ describe('groupInboundByBucket', () => {
         '5xx': 0,
       },
     ]);
+  });
+});
+
+describe('formatBytes', () => {
+  it('uses 1024-based consumer labels', () => {
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(850 * 1024)).toBe('850 KB');
+    expect(formatBytes(Math.round(4.2 * 1024 * 1024))).toBe('4.2 MB');
+    expect(formatBytes(Math.round(1.1 * 1024 * 1024 * 1024))).toBe('1.1 GB');
+  });
+});
+
+describe('formatRatio', () => {
+  it('renders a 0-1 ratio as a one-decimal percent and null as a dash', () => {
+    expect(formatRatio(0.4231)).toBe('42.3%');
+    expect(formatRatio(0)).toBe('0.0%');
+    expect(formatRatio(null)).toBe('—');
   });
 });
 

--- a/web/src/pages/OpsPage/opsHelpers.ts
+++ b/web/src/pages/OpsPage/opsHelpers.ts
@@ -62,6 +62,20 @@ export const formatCount = (n: number): string => {
   return n.toLocaleString('en', { useGrouping: true }).replaceAll(',', ' ');
 };
 
+export const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${Math.round(kb)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(1)} GB`;
+};
+
+export const formatRatio = (ratio: number | null): string => {
+  if (ratio == null) return '—';
+  return `${(ratio * 100).toFixed(1)}%`;
+};
+
 export interface InboundBucketRow {
   bucket: string;
   '2xx': number;

--- a/web/src/pages/OpsPage/opsTabs.test.ts
+++ b/web/src/pages/OpsPage/opsTabs.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { OPS_TABS } from './opsTabs';
 
 describe('OPS_TABS', () => {
-  it('lists all 12 ops tabs with the Engineering index first', () => {
-    expect(OPS_TABS).toHaveLength(12);
+  it('lists all 14 ops tabs with the Engineering index first', () => {
+    expect(OPS_TABS).toHaveLength(14);
     expect(OPS_TABS[0]).toMatchObject({ to: '/ops', label: 'Engineering' });
   });
 

--- a/web/src/pages/OpsPage/opsTabs.ts
+++ b/web/src/pages/OpsPage/opsTabs.ts
@@ -26,6 +26,16 @@ export const OPS_TABS: OpsTab[] = [
     match: (path) => path.startsWith('/ops/conversions'),
   },
   {
+    to: '/ops/return-rate',
+    label: 'Return rate',
+    match: (path) => path.startsWith('/ops/return-rate'),
+  },
+  {
+    to: '/ops/mindmaps',
+    label: 'Mindmaps',
+    match: (path) => path.startsWith('/ops/mindmaps'),
+  },
+  {
     to: '/ops/upload-funnel',
     label: 'Upload funnel',
     match: (path) => path.startsWith('/ops/upload-funnel'),

--- a/web/src/pages/OpsPage/returnRateTypes.ts
+++ b/web/src/pages/OpsPage/returnRateTypes.ts
@@ -1,0 +1,22 @@
+export interface ReturnRateWindow {
+  '7d': number | null;
+  '14d': number | null;
+  '30d': number | null;
+}
+
+export interface ReturnRateBySourceType {
+  source_type: string;
+  cohort_size: number;
+  returned_7d: number;
+  returned_14d: number;
+  returned_30d: number;
+  return_rate_7d_pct: number | null;
+  return_rate_14d_pct: number | null;
+  return_rate_30d_pct: number | null;
+}
+
+export interface ReturnRateMetricsResponse {
+  overall: ReturnRateWindow;
+  by_source_type: ReturnRateBySourceType[] | null;
+  as_of: string;
+}

--- a/web/src/pages/OpsPage/useMindmapOpsMetrics.ts
+++ b/web/src/pages/OpsPage/useMindmapOpsMetrics.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  MindmapImageStatsResponse,
+  MindmapStorageMetricsResponse,
+} from './mindmapOpsTypes';
+
+const REFRESH_MS = 60_000;
+
+const fetchJson = async <T>(path: string): Promise<T> => {
+  const response = await fetch(path, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json();
+};
+
+export const useMindmapImageStats = () => {
+  return useQuery<MindmapImageStatsResponse, Error>({
+    queryKey: ['ops-mindmap-image-stats'],
+    queryFn: () =>
+      fetchJson<MindmapImageStatsResponse>('/api/ops/mindmap/image-stats'),
+    refetchInterval: REFRESH_MS,
+    refetchOnWindowFocus: true,
+  });
+};
+
+export const useMindmapStorageMetrics = () => {
+  return useQuery<MindmapStorageMetricsResponse, Error>({
+    queryKey: ['ops-mindmap-storage'],
+    queryFn: () =>
+      fetchJson<MindmapStorageMetricsResponse>('/api/ops/mindmap/storage'),
+    refetchInterval: REFRESH_MS,
+    refetchOnWindowFocus: true,
+  });
+};

--- a/web/src/pages/OpsPage/useReturnRateMetrics.ts
+++ b/web/src/pages/OpsPage/useReturnRateMetrics.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { ReturnRateMetricsResponse } from './returnRateTypes';
+
+const REFRESH_MS = 60_000;
+
+const fetchReturnRateMetrics = async (): Promise<ReturnRateMetricsResponse> => {
+  const response = await fetch('/api/ops/return-rate/metrics', {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  return response.json();
+};
+
+export const useReturnRateMetrics = () => {
+  return useQuery<ReturnRateMetricsResponse, Error>({
+    queryKey: ['ops-return-rate-metrics'],
+    queryFn: fetchReturnRateMetrics,
+    refetchInterval: REFRESH_MS,
+    refetchOnWindowFocus: true,
+  });
+};


### PR DESCRIPTION
## What

Three `RequireOpsAccess` endpoints existed server-side but had **no `/ops` dashboard command** — the data was only reachable via curl. Found during an unused-endpoint audit. This wires them up.

- `GET /api/ops/return-rate/metrics` → **Return rate** tab
- `GET /api/ops/mindmap/image-stats` + `GET /api/ops/mindmap/storage` → **Mindmaps** tab

## Tabs

- **Return rate** — 7/14/30-day second-conversion rate (overall MetricCards + a by-source-type table). 90-day cohort window.
- **Mindmaps** — image-paste adoption ratio and S3 storage under `mindmaps/`, with a top-users-by-storage table.

Mirrors the existing `PerformanceTab` pattern exactly: `useQuery` hook, `ChartPanel` / `MetricCard`, refresh button, error banner. Backend use cases were already constructed in `OpsRouter` (lines 117-119) — only the UI was missing.

## New helpers (tested)

`formatBytes` (1024-based, KB/MB/GB per VOICE.md) and `formatRatio` in `opsHelpers.ts`, with cases in `opsHelpers.test.ts`. `opsTabs.test.ts` count bumped 12 → 14.

## Checks

- `pnpm typecheck` — clean
- `pnpm lint` — clean (my files; only pre-existing warnings elsewhere)
- `oxfmt --check` — clean
- `opsHelpers.test.ts` — 14/14 pass under the node environment

> ⚠️ The default (jsdom) vitest environment is broken **repo-wide** on this machine — the `jsdom: 29.1.1` pnpm override pulls `html-encoding-sniffer@6` → ESM-only `@exodus/bytes@1.15.1`, which the CJS fork worker can't `require()`. An untouched test (`useUploadFunnel`) fails identically. Flagged separately; not caused by this PR. CI runs its own clean install.

> sonar-scanner not run locally (no token configured here) — low Sonar risk; the tabs mirror existing patterns.

No changelog entry — `/ops` is owner-only internal tooling (`RequireOpsAccess`, 404 for everyone else), not user-visible.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: I can't start the dev server per repo policy. Please open `/ops/return-rate` and `/ops/mindmaps` locally and tick these before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)