### PR TITLE
fix: skip AdSense in the iOS app's login webview

### DIFF
--- a/web/src/components/AppShell/AppShell.tsx
+++ b/web/src/components/AppShell/AppShell.tsx
@@ -6,6 +6,7 @@ import {
   removeAdSenseScript,
 } from '../AdSense/AdSenseScript';
 import { PageLayout } from '../Layout/PageLayout';
+import { isEmbeddedAppWebView } from './isEmbeddedAppWebView';
 import { SidebarFeatures, SidebarLocals } from './Sidebar';
 import { SidebarLayout } from './SidebarLayout';
 
@@ -39,7 +40,10 @@ export function AppShell({
   useEffect(() => {
     if (isLoggedIn == null) return;
     const isPricingRoute = pathname === '/pricing';
-    const shouldShowAds = !isLoggedIn && !isPricingRoute;
+    const shouldShowAds =
+      !isLoggedIn &&
+      !isPricingRoute &&
+      !isEmbeddedAppWebView(navigator.userAgent);
     if (shouldShowAds) {
       injectAdSenseScript();
     } else {

--- a/web/src/components/AppShell/isEmbeddedAppWebView.test.ts
+++ b/web/src/components/AppShell/isEmbeddedAppWebView.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { isEmbeddedAppWebView } from './isEmbeddedAppWebView';
+
+describe('isEmbeddedAppWebView', () => {
+  it('matches the native 2anki iOS app user agent', () => {
+    expect(isEmbeddedAppWebView('2anki-iOS-App/1.0 (WKWebView)')).toBe(true);
+  });
+
+  it('matches a bare WKWebView token', () => {
+    expect(
+      isEmbeddedAppWebView(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) WKWebView'
+      )
+    ).toBe(true);
+  });
+
+  it('does not match a normal Safari user agent', () => {
+    expect(
+      isEmbeddedAppWebView(
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+      )
+    ).toBe(false);
+  });
+
+  it('does not match a normal Chrome user agent', () => {
+    expect(
+      isEmbeddedAppWebView(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36'
+      )
+    ).toBe(false);
+  });
+
+  it('does not match an empty string', () => {
+    expect(isEmbeddedAppWebView('')).toBe(false);
+  });
+});

--- a/web/src/components/AppShell/isEmbeddedAppWebView.ts
+++ b/web/src/components/AppShell/isEmbeddedAppWebView.ts
@@ -1,0 +1,3 @@
+export function isEmbeddedAppWebView(userAgent: string): boolean {
+  return /2anki-iOS-App|WKWebView/i.test(userAgent);
+}


### PR DESCRIPTION
## What
Skip Google AdSense injection when the page is rendered inside the native 2anki iOS/macOS app's `WKWebView`. A new pure helper `isEmbeddedAppWebView(userAgent)` matches `/2anki-iOS-App|WKWebView/i`; `AppShell` folds it into the existing `shouldShowAds` gate.

## Why
Closes #3332. The native app hosts `/login`, `/signup`, and `/forgot-password` inside a `WKWebView` whose UA is `2anki-iOS-App/1.0 (WKWebView)`. Those pages are always logged-out, so AdSense was loading inside the app's sign-in flow. That violates AdSense program policy (web ads inside app webviews), invites App Review scrutiny on a credential surface the app was just rejected over (Guideline 4), and looks untrustworthy mid sign-in.

## How
`shouldShowAds = !isLoggedIn && !isPricingRoute && !isEmbeddedAppWebView(navigator.userAgent)`. The UA test lives in a small pure exported helper (`web/src/components/AppShell/isEmbeddedAppWebView.ts`) so it is unit-testable without jsdom navigator gymnastics. Safari proper never carries the `WKWebView` token, so the regex is false-positive-safe — regular browsers keep current behavior: ads when logged-out, none when logged-in or on `/pricing`.

## Measuring success
AdSense fill / impression volume from inside the app drops to zero in the AdSense dashboard (no `pagead2.googlesyndication.com` requests with the app UA). On the App Store side: the auth-flow rejection reason no longer applies on resubmission.

## Testing
- Unit tests added: `isEmbeddedAppWebView.test.ts` — exact app UA (true), bare `WKWebView` token (true), normal Safari UA (false), normal Chrome UA (false), empty string (false). Run green under `npx vitest run … --environment node`.
- Note: the default jsdom vitest environment is broken in this local checkout (pre-existing, unrelated — a `jsdom: 29.1.1` override pulls an ESM-only `@exodus/bytes` the CJS fork worker can't require). The helper is pure (UA string in, boolean out) so it needs no DOM and was verified under the node environment. CI runs a clean install and exercises the jsdom suite, including any AppShell render test.
- Web `pnpm typecheck` green; oxlint and oxfmt clean on all three changed files.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: I cannot start the dev server (repo policy). Please verify `/login` still renders normally with ads in a regular browser (logged-out) before merge — the change only adds a UA guard, so regular-browser behavior is unchanged.

## Changelog
No changelog entry — app-webview-only behavior, no web-user-visible change. Regular web users see no difference (ads still show logged-out, hidden logged-in / on `/pricing`).

## Risks
Low. The only behavior change is suppressing AdSense for UAs carrying `2anki-iOS-App` or `WKWebView`. `WKWebView` is broad on purpose (the issue's acceptance criteria call for it) and is absent from Safari proper, so no regular browser is affected. Rollback is a one-line revert of the gate.

## Goal alignment
None — internal/infrastructure protection. Protects the AdSense account (a revenue surface) from a program-policy violation and unblocks the in-progress App Store submission, which is acquisition infrastructure. No direct funnel metric moves.