### PR TITLE
fix: distinguish AnkiConnect timeout from unreachable

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -1,6 +1,8 @@
 import {
+  ANKI_CONNECT_SYNC_TIMEOUT_MS,
   AnkiConnectClient,
   AnkiConnectError,
+  AnkiConnectTimeoutError,
   AnkiConnectUnreachableError,
 } from './AnkiConnectClient';
 
@@ -405,5 +407,47 @@ describe('AnkiConnectClient', () => {
     await expect(client.deckNames()).rejects.toBeInstanceOf(
       AnkiConnectUnreachableError
     );
+  });
+
+  const makeHangingFetch = () =>
+    jest.fn(
+      (_url: string, init: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener('abort', () =>
+            reject(new Error('aborted'))
+          );
+        })
+    ) as unknown as typeof fetch;
+
+  test('throws AnkiConnectTimeoutError (a subclass of unreachable) when a call exceeds its deadline', async () => {
+    const fetchImpl = makeHangingFetch();
+    const client = new AnkiConnectClient('http://x', fetchImpl, 5);
+
+    const err = await client.deckNames().catch((e) => e);
+
+    expect(err).toBeInstanceOf(AnkiConnectTimeoutError);
+    // Existing offline-skip paths catch the parent class — keep that working.
+    expect(err).toBeInstanceOf(AnkiConnectUnreachableError);
+    expect(err.action).toBe('deckNames');
+    expect(err.timeoutMs).toBe(5);
+    expect(err.message).toContain('timed out');
+  });
+
+  test('sync aborts on the longer sync timeout, not the per-call default', async () => {
+    jest.useFakeTimers();
+    try {
+      const fetchImpl = makeHangingFetch();
+      const client = new AnkiConnectClient('http://x', fetchImpl);
+
+      const pending = client.sync().catch((e) => e);
+      await jest.advanceTimersByTimeAsync(ANKI_CONNECT_SYNC_TIMEOUT_MS);
+      const err = await pending;
+
+      expect(err).toBeInstanceOf(AnkiConnectTimeoutError);
+      expect(err.action).toBe('sync');
+      expect(err.timeoutMs).toBe(ANKI_CONNECT_SYNC_TIMEOUT_MS);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -1,5 +1,8 @@
 export const ANKI_CONNECT_VERSION = 6;
 export const ANKI_CONNECT_DEFAULT_TIMEOUT_MS = 10_000;
+// `sync` triggers a blocking AnkiWeb round-trip inside the container; it
+// routinely needs far longer than a cheap action like `version` or `addNote`.
+export const ANKI_CONNECT_SYNC_TIMEOUT_MS = 60_000;
 
 export interface AnkiConnectNoteFields {
   [key: string]: string;
@@ -35,6 +38,23 @@ export class AnkiConnectUnreachableError extends Error {
     if (cause instanceof Error) {
       this.stack = cause.stack;
     }
+  }
+}
+
+// A call that exceeded its own deadline, not a dead container. Extends
+// AnkiConnectUnreachableError so existing `instanceof` checks keep treating it
+// as offline, while the name + message say what actually happened (a slow call,
+// usually `sync`, after a pre-flight `ping` already proved the container was up).
+export class AnkiConnectTimeoutError extends AnkiConnectUnreachableError {
+  constructor(
+    readonly url: string,
+    readonly action: string,
+    readonly timeoutMs: number,
+    cause: unknown
+  ) {
+    super(url, cause);
+    this.name = 'AnkiConnectTimeoutError';
+    this.message = `AnkiConnect call '${action}' timed out after ${timeoutMs}ms at ${url}`;
   }
 }
 
@@ -162,7 +182,7 @@ export class AnkiConnectClient {
   }
 
   async sync(): Promise<null> {
-    return this.invoke('sync');
+    return this.invoke('sync', undefined, ANKI_CONNECT_SYNC_TIMEOUT_MS);
   }
 
   async ping(): Promise<number> {
@@ -191,10 +211,11 @@ export class AnkiConnectClient {
 
   private async invoke<T>(
     action: string,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
+    timeoutMs: number = this.timeoutMs
   ): Promise<T> {
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
 
     let response: Response;
     try {
@@ -212,6 +233,14 @@ export class AnkiConnectClient {
         signal: controller.signal,
       });
     } catch (error) {
+      if (controller.signal.aborted) {
+        throw new AnkiConnectTimeoutError(
+          this.baseUrl,
+          action,
+          timeoutMs,
+          error
+        );
+      }
       throw new AnkiConnectUnreachableError(this.baseUrl, error);
     } finally {
       clearTimeout(timer);

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-13-ankify-sync-timeout.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-13-ankify-sync-timeout.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-13-ankify-sync-timeout",
+  "date": "2026-06-13",
+  "type": "fix",
+  "title": "Notion → Anki sync waits out a slow AnkiWeb sync instead of reporting your Anki as offline"
+}


### PR DESCRIPTION
## What

Ankify polling logged `Anki client offline` for one subscription while its container was up and AnkiConnect answered `version` in ~15ms. Root cause: the pre-flight `ping()` passed, then a later call in `runSync` — almost always `ac.sync()`, which blocks on an AnkiWeb round-trip — exceeded the flat **10s** per-call deadline. The `AbortController` fired and `invoke`'s catch wrapped **every** abort as `AnkiConnectUnreachableError`, mislabeling a slow call as a dead client.

## Change

- **`AnkiConnectTimeoutError` now subclasses `AnkiConnectUnreachableError`** — every existing `instanceof AnkiConnectUnreachableError` offline-skip check (15 call sites) keeps working unchanged, while the error name + message now say what actually happened: which action, what deadline.
- **`invoke` takes an optional per-call timeout**; `sync()` gets **60s** instead of the 10s used for cheap actions. This is the actual fix for the false-offline events.
- A timeout on the pre-flight `ping()` still resolves to offline-skip (subclass `instanceof` holds), so the calm "will retry next tick" path is preserved.

## Tests

- `AnkiConnectClient.test.ts`: timeout throws `AnkiConnectTimeoutError` **and** is an instance of the parent; carries `action` + `timeoutMs`; `sync()` aborts on the 60s deadline, not the default.
- `SyncNotionPageToRacUseCase.test.ts` (51) still green — offline-skip unchanged.
- `tsc -p .` clean; oxlint + oxfmt clean.

## Metric

None — internal reliability. Reduces false "Anki offline" sync failures for Ankify ($30/mo Auto Sync) subscribers; no funnel surface.

Browser check: not applicable — server-only change; the one `web/src/` file is a changelog JSON entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)