### PR TITLE
fix: raise engines.node floor to match .nvmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Alexander Alemayhu",
   "version": "2.0.0",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=22.20.0"
   },
   "release": {
     "branches": [

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": ">=22.20.0"
+  },
   "packageManager": "pnpm@10.18.2",
   "scripts": {
     "start": "cross-env REACT_SKIP_SENTRY=true vite",


### PR DESCRIPTION
## What
Raise `engines.node` to `>=22.20.0` in both workspaces (root + `web/`) to match `.nvmrc`.

## Why
The root `engines.node` floor was a stale `>=12.0.0` that never warned a contributor installing on an unsupported Node. Node **22.12.0** made `require(ESM)` the default; below that, `pnpm --filter 2anki-web test` crashes the forks worker with `ERR_REQUIRE_ESM` the moment Vitest's jsdom env pulls the ESM-only `@exodus/bytes` (a transitive of `jsdom@29.1.1`). The reporter hit this on Node 22.2.0; the suite runs clean on the `.nvmrc`-pinned 22.20.0.

This is direction 3 from Laer-Smart/2anki.net#3334 — the Node-version interaction, not a dep override. An honest floor makes pnpm warn on an unsupported Node instead of letting the install proceed to a baffling ESM crash three layers down in a test worker.

## How
- `package.json`: `engines.node` `>=12.0.0` → `>=22.20.0`
- `web/package.json`: add `engines.node` `>=22.20.0` (web had none)

`engines` is resolution-neutral — the lockfile is unchanged.

## What I dropped (and why) — note for reviewer
I initially also added `engine-strict=true` to `.npmrc` to turn the engines warning into a hard install failure. **That broke CI** and I reverted it. Mechanism: this repo's root `package.json` declares `@rolldown/binding-darwin-arm64@1.1.1` as a **direct, non-optional dependency** (leftover from the rolldown/oxlint migration). pnpm normally skips a platform-mismatched dep with a warning; with `engine-strict=true` (pnpm 10.18.2) the mismatch escalates to a hard `ERR_PNPM_UNSUPPORTED_PLATFORM` on every non-darwin-arm64 machine — i.e. all of Linux CI. Until that binding moves to `optionalDependencies` (separate concern, owned by the rolldown migration), `engine-strict` cannot be enabled. The engines floor alone still upgrades the contributor experience from silent to a `WARN unsupported engine` line.

## Testing
`/check` green on `.nvmrc` Node 22.20.0: server `tsc -p .` (exit 0), web typecheck clean, web Vitest 1922/1922 pass, web lint (pre-existing warnings only). Acceptance criterion — `pnpm --filter 2anki-web test` runs to completion under default jsdom env on the `.nvmrc` Node with no `ERR_REQUIRE_ESM` — passes.

## Risks
Minimal. `engines` only emits an install-time warning on an unsupported Node; no runtime code touched, lockfile unchanged.

## Goal alignment
Internal contributor DX. No user-visible behavior change.

No changelog entry — internal tooling, no user-visible behavior.

Browser check: not applicable — no `web/src/` change.

Closes Laer-Smart/2anki.net#3334