### PR TITLE
fix: heal null-typed Ankify database subscription from meta path

### DIFF
--- a/src/services/ankify/buildNotionPageMetaFetcher.test.ts
+++ b/src/services/ankify/buildNotionPageMetaFetcher.test.ts
@@ -37,6 +37,7 @@ describe('buildNotionPageMetaFetcher', () => {
       title: 'Pharmacology notes',
       url: 'https://www.notion.so/page-1',
       icon: '📘',
+      objectType: 'page',
     });
   });
 
@@ -61,6 +62,7 @@ describe('buildNotionPageMetaFetcher', () => {
       title: 'Pharmacology',
       url: 'https://www.notion.so/db-1',
       icon: '🧪',
+      objectType: 'database',
     });
   });
 
@@ -84,6 +86,7 @@ describe('buildNotionPageMetaFetcher', () => {
       title: 'Pharmacology',
       url: 'https://www.notion.so/db-1',
       icon: '🧪',
+      objectType: 'database',
     });
   });
 

--- a/src/services/ankify/buildNotionPageMetaFetcher.ts
+++ b/src/services/ankify/buildNotionPageMetaFetcher.ts
@@ -7,6 +7,7 @@ export interface NotionPageMeta {
   title: string | null;
   url: string | null;
   icon: string | null;
+  objectType?: NotionObjectType | null;
 }
 
 type NotionPageIconBlock =
@@ -85,7 +86,7 @@ const fetchDatabaseMeta = async (
   const icon = extractNotionPageIcon(
     (database as { icon?: NotionPageIconBlock }).icon
   );
-  return { title, url, icon };
+  return { title, url, icon, objectType: 'database' };
 };
 
 const fetchPageMeta = async (
@@ -100,7 +101,7 @@ const fetchPageMeta = async (
   const icon = extractNotionPageIcon(
     (page as { icon?: NotionPageIconBlock }).icon
   );
-  return { title, url, icon };
+  return { title, url, icon, objectType: 'page' };
 };
 
 export const buildNotionPageMetaFetcher =

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -407,6 +407,125 @@ describe('SyncNotionPageToRacUseCase', () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  test('records the database object type when the meta fetch resolves a null-typed id as a database', async () => {
+    (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue(
+      emptyWalkResult()
+    );
+    (walkNotionDatabaseForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [sampleCard()],
+      diagnostic: {
+        blocks_scanned: 8,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+
+    const repos = makeRepos();
+    repos.subscriptions = makeSubscriptionsRepo(
+      sampleSubscription({
+        id: 5,
+        notion_page_id: 'database-id',
+        notion_object_type: null,
+      })
+    );
+    const ac = makeAnkiConnectStub();
+    const databasePages = jest.fn(async () => [{ id: 'row-1' }]);
+    const metaFetch = jest.fn(
+      async (_id: string, _knownObjectType?: 'page' | 'database' | null) => ({
+        title: 'Pharmacology',
+        url: 'https://www.notion.so/db-1',
+        icon: '🧪',
+        objectType: 'database' as const,
+      })
+    );
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      () => metaFetch,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => databasePages
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'database-id',
+      knownObjectType: null,
+      trigger: 'polling',
+    });
+
+    expect(metaFetch).toHaveBeenCalledWith('database-id', null);
+    expect(repos.subscriptions.recordObjectType).toHaveBeenCalledWith(
+      5,
+      'database'
+    );
+  });
+
+  test('skips the page-meta retrieve on the next tick once the database type is known', async () => {
+    (walkNotionDatabaseForFlashcards as jest.Mock).mockResolvedValue({
+      cards: [sampleCard()],
+      diagnostic: {
+        blocks_scanned: 8,
+        blocks_matched: 1,
+        pattern_hits: { toggle: 1 },
+      },
+    });
+
+    const repos = makeRepos();
+    repos.subscriptions = makeSubscriptionsRepo(
+      sampleSubscription({
+        id: 5,
+        notion_page_id: 'database-id',
+        notion_object_type: 'database',
+      })
+    );
+    const ac = makeAnkiConnectStub();
+    const databasePages = jest.fn(async () => [{ id: 'row-1' }]);
+    const metaFetch = jest.fn(
+      async (_id: string, _knownObjectType?: 'page' | 'database' | null) => ({
+        title: 'Pharmacology',
+        url: 'https://www.notion.so/db-1',
+        icon: '🧪',
+        objectType: 'database' as const,
+      })
+    );
+    const useCase = new SyncNotionPageToRacUseCase(
+      repos.clients,
+      repos.mappings,
+      repos.conflicts,
+      repos.subscriptions,
+      repos.logs,
+      repos.notionRepo,
+      () => ac,
+      () => async () => [],
+      () => metaFetch,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => databasePages
+    );
+
+    await useCase.execute({
+      owner: 42,
+      notionPageId: 'database-id',
+      knownObjectType: 'database',
+      trigger: 'polling',
+    });
+
+    expect(metaFetch).toHaveBeenCalledWith('database-id', 'database');
+    expect(walkNotionPageForFlashcards).not.toHaveBeenCalled();
+    expect(repos.subscriptions.recordObjectType).not.toHaveBeenCalled();
+  });
+
   test('keeps the empty-page result when the database probe finds no child pages', async () => {
     (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue(
       emptyWalkResult()

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -85,6 +85,7 @@ export interface NotionPageMeta {
   title: string | null;
   url: string | null;
   icon: string | null;
+  objectType?: NotionObjectType | null;
 }
 
 export type NotionPageMetaFetcher = (
@@ -239,10 +240,8 @@ export class SyncNotionPageToRacUseCase {
       throw new NotionNotConnectedError();
     }
 
-    const { pageTitle, pageUrl, pageIcon } = await this.resolvePageMeta(
-      token,
-      input
-    );
+    const { pageTitle, pageUrl, pageIcon, resolvedObjectType } =
+      await this.resolvePageMeta(token, input);
 
     const subscription = await this.subscriptions.upsert({
       owner: input.owner,
@@ -254,6 +253,10 @@ export class SyncNotionPageToRacUseCase {
       target_deck: input.targetDeck,
       enabled: true,
     });
+
+    if (resolvedObjectType != null) {
+      await this.rememberObjectType(subscription, resolvedObjectType);
+    }
 
     const result: SyncNotionPageResult = {
       client,
@@ -349,12 +352,13 @@ export class SyncNotionPageToRacUseCase {
     pageTitle: string | null | undefined;
     pageUrl: string | null | undefined;
     pageIcon: string | null | undefined;
+    resolvedObjectType: NotionObjectType | null;
   }> {
     let pageTitle: string | null | undefined = input.notionPageTitle;
     let pageUrl: string | null | undefined = input.notionPageUrl;
     let pageIcon: string | null | undefined = input.notionPageIcon;
     if (this.notionPageMeta == null) {
-      return { pageTitle, pageUrl, pageIcon };
+      return { pageTitle, pageUrl, pageIcon, resolvedObjectType: null };
     }
     try {
       const meta = await this.notionPageMeta(token)(
@@ -364,10 +368,15 @@ export class SyncNotionPageToRacUseCase {
       pageTitle = meta.title;
       pageUrl = meta.url;
       pageIcon = meta.icon;
+      return {
+        pageTitle,
+        pageUrl,
+        pageIcon,
+        resolvedObjectType: meta.objectType ?? null,
+      };
     } catch {
-      // Notion API hiccup — keep whatever the input or DB already has.
+      return { pageTitle, pageUrl, pageIcon, resolvedObjectType: null };
     }
-    return { pageTitle, pageUrl, pageIcon };
   }
 
   private emitZeroCardsEvent(


### PR DESCRIPTION
## What
An Ankify polling subscription whose `notion_object_type` is `null` but points at a Notion **database** id re-paid one guaranteed-failing `pages.retrieve` on every 5-minute poll tick. The page-meta fetcher resolves the id correctly (it self-heals internally to `databases.retrieve`) but never threw, so the subscription's object type was never recorded; and the block-children walk does not throw the database-not-page error either, so the walk path's `recordObjectType` self-heal was unreachable for this row. The row stayed `null` forever. This change makes the meta fetcher report which object type it resolved, and the sync use case records `notion_object_type` via the existing `recordObjectType` path right after the upsert.

## Why
Prod logs showed the `@notionhq/client warn: … is a database, not a page` validation_error **342× in the last 24h**, all from one subscription (id `379cbac1…`). The user-visible outcome: no behavior change — this removes pure log noise and stops one wasted Notion call per tick per affected subscription. The next tick forwards `knownObjectType: 'database'`, skips `pages.retrieve` entirely, and the warn loop stops.

## How
- `buildNotionPageMetaFetcher` now sets `objectType: 'page' | 'database'` on the returned `NotionPageMeta` based on which retrieve succeeded.
- `SyncNotionPageToRacUseCase.resolvePageMeta` returns the resolved `objectType`; `execute` calls the existing `rememberObjectType` (→ `recordObjectType`) right after the subscription upsert when the type is known.
- Only a confirmed database (or page) resolution heals — genuinely transient Notion hiccups are still swallowed without writing a bogus type.

## Measuring success
After deploy, the `@notionhq/client warn: … is a database, not a page` line should stop appearing for the affected subscription within one poll tick (≤5 min). Confirm the row self-healed in prod: `select id, notion_object_type from ankify_notion_subscriptions where notion_page_id = '379cbac1…'` reads `database` instead of `null`. Grep prod logs (`pm2 logs`) for the warn message — count should drop from ~14/h to 0 for that id.

## Construction-site check (first-time-fix rule)
`grep -rn "new SyncNotionPageToRacUseCase" src/` — three production sites:
- `src/data_layer/index.ts` — the poll path's use case (reporter's actual entry point: `scheduleAnkifyPolling` → `RefreshAnkifySubscriptionUseCase` → this use case). Passes `buildNotionPageMetaFetcher`. **Fix reachable.**
- `src/routes/AnkifyRouter.ts` — manual sync. Passes `buildNotionPageMetaFetcher`. **Fix reachable.**
- `src/routes/AnkifyWebhookRouter.ts` — passes no meta fetcher (`notionPageMeta` undefined). Heal is guarded by `notionPageMeta != null`, so this site is unaffected and cannot regress.

## Testing
- Unit tests added (`SyncNotionPageToRacUseCase.test.ts`):
  - "records the database object type when the meta fetch resolves a null-typed id as a database" — the reporter's shape: `notion_object_type: null`, `trigger: 'polling'`, page walk returns empty, database fallback yields cards, meta fetcher reports `objectType: 'database'`. Asserts `recordObjectType(5, 'database')` is called. Verified it fails (0 calls) without the source fix.
  - "skips the page-meta retrieve on the next tick once the database type is known" — second tick with `knownObjectType: 'database'`: meta fetcher receives `'database'`, the page walk is never attempted, and `recordObjectType` is not re-called.
- `buildNotionPageMetaFetcher.test.ts` updated to assert the new `objectType` field.
- Full ankify suites green (317 tests); server `tsc -p .` clean.
- Sonar: not run locally — no `SONAR_TOKEN` configured in this environment. The diff adds no new HTTP sink, zip extraction, user-path write, or rendered HTML; expect no new security findings. One pre-existing `no-negated-condition` warning on an untouched `if/else` was left as-is (out of scope).

## Browser check
Browser check: not applicable — no web/src/ change

## Changelog
No entry — internal, no user-visible behavior change (removes log noise and a redundant Notion call; users don't see it).

## Risks
Low. The heal only fires on a confirmed `objectType` from the meta fetcher and routes through the already-tested `recordObjectType` path. If the meta fetcher is absent (webhook site) nothing changes. Rollback: revert the commit — the warn loop returns but no data is corrupted.

## Goal alignment
None — internal reliability/observability. Removes prod log noise and one wasted Notion API call per tick on affected Ankify subscriptions; no funnel or revenue metric moves.
