### PR TITLE
fix: render Notion text colour in Ankify-synced cards

### DIFF
--- a/src/lib/notion-render/index.ts
+++ b/src/lib/notion-render/index.ts
@@ -1,7 +1,9 @@
 export { renderNotionBlocks } from './renderBlocks';
+export { renderRichText } from './richText';
 export type {
   NotionBlockChildrenFetcher,
   NotionRenderableBlock,
+  NotionRichTextItem,
   RenderOptions,
   RenderedBlocks,
   WalkedMediaKind,

--- a/src/lib/notion-render/renderBlocks.test.ts
+++ b/src/lib/notion-render/renderBlocks.test.ts
@@ -21,6 +21,45 @@ describe('renderNotionBlocks — text blocks', () => {
     expect(out.media).toEqual([]);
   });
 
+  it('wraps a block-colored paragraph, heading, and list item in a color class', async () => {
+    const blocks: NotionRenderableBlock[] = [
+      {
+        type: 'paragraph',
+        paragraph: { rich_text: [{ plain_text: 'p' }], color: 'red' },
+      },
+      {
+        type: 'heading_2',
+        heading_2: { rich_text: [{ plain_text: 'h' }], color: 'blue' },
+      },
+      {
+        type: 'numbered_list_item',
+        numbered_list_item: {
+          rich_text: [{ plain_text: 'n' }],
+          color: 'purple',
+        },
+      },
+    ];
+    const out = await renderNotionBlocks(blocks, noChildren);
+    expect(out.html).toBe(
+      '<p><span class="n2a-highlight-red">p</span></p>\n' +
+        '<h2><span class="n2a-highlight-blue">h</span></h2>\n' +
+        '<ol><li><span class="n2a-highlight-purple">n</span></li></ol>'
+    );
+  });
+
+  it('leaves a default-colored block unwrapped', async () => {
+    const out = await renderNotionBlocks(
+      [
+        {
+          type: 'paragraph',
+          paragraph: { rich_text: [{ plain_text: 'x' }], color: 'default' },
+        },
+      ],
+      noChildren
+    );
+    expect(out.html).toBe('<p>x</p>');
+  });
+
   it('renders headings 1/2/3 (and folds heading_4 into h3)', async () => {
     const blocks: NotionRenderableBlock[] = [
       { type: 'heading_1', heading_1: { rich_text: [{ plain_text: 'A' }] } },

--- a/src/lib/notion-render/renderBlocks.ts
+++ b/src/lib/notion-render/renderBlocks.ts
@@ -1,7 +1,11 @@
 import { escapeAttribute, escapeHtml } from './escape';
 import { highlightCode } from './highlightCode';
 import { resolveEmbedUrl, resolveVideoUrl } from './embedUrl';
-import { renderPlainText, renderRichText } from './richText';
+import {
+  renderPlainText,
+  renderRichText,
+  wrapWithColorClass,
+} from './richText';
 import {
   NotionBlockChildrenFetcher,
   NotionRenderableBlock,
@@ -225,20 +229,20 @@ const renderHeading = (
         : block.heading_3;
   const inner = renderRichText(holder?.rich_text);
   if (inner === '') return '';
-  return `<h${level}>${inner}</h${level}>`;
+  return `<h${level}>${wrapWithColorClass(holder?.color, inner)}</h${level}>`;
 };
 
 const renderTodo = (block: NotionRenderableBlock): string => {
   const inner = renderRichText(block.to_do?.rich_text);
   if (inner === '') return '';
   const mark = block.to_do?.checked === true ? '☑' : '☐';
-  return `<div class="todo">${mark} ${inner}</div>`;
+  return `<div class="todo">${mark} ${wrapWithColorClass(block.to_do?.color, inner)}</div>`;
 };
 
 const renderQuote = (block: NotionRenderableBlock): string => {
   const inner = renderRichText(block.quote?.rich_text);
   if (inner === '') return '';
-  return `<blockquote>${inner}</blockquote>`;
+  return `<blockquote>${wrapWithColorClass(block.quote?.color, inner)}</blockquote>`;
 };
 
 const renderCode = (block: NotionRenderableBlock): string => {
@@ -289,7 +293,7 @@ const renderCallout = async (
       : '';
   const childrenHtml = await renderChildren(block, ctx, depth);
   const head = emoji === '' ? inner : `${escapeHtml(emoji)} ${inner}`;
-  return `<div class="callout">${head}${childrenHtml}</div>`;
+  return `<div class="callout">${wrapWithColorClass(block.callout?.color, head)}${childrenHtml}</div>`;
 };
 
 const renderChildren = async (
@@ -323,7 +327,10 @@ const renderBlockList = async (
     switch (block.type) {
       case 'paragraph': {
         const inner = renderRichText(block.paragraph?.rich_text);
-        if (inner !== '') out.push(`<p>${inner}</p>`);
+        if (inner !== '')
+          out.push(
+            `<p>${wrapWithColorClass(block.paragraph?.color, inner)}</p>`
+          );
         break;
       }
       case 'heading_1':
@@ -337,13 +344,17 @@ const renderBlockList = async (
         out.push(renderHeading(3, block));
         break;
       case 'bulleted_list_item': {
-        const inner = renderRichText(block.bulleted_list_item?.rich_text);
-        if (inner !== '') pushListItem(buf, 'ul', inner, out);
+        const holder = block.bulleted_list_item;
+        const text = renderRichText(holder?.rich_text);
+        if (text !== '')
+          pushListItem(buf, 'ul', wrapWithColorClass(holder?.color, text), out);
         break;
       }
       case 'numbered_list_item': {
-        const inner = renderRichText(block.numbered_list_item?.rich_text);
-        if (inner !== '') pushListItem(buf, 'ol', inner, out);
+        const holder = block.numbered_list_item;
+        const text = renderRichText(holder?.rich_text);
+        if (text !== '')
+          pushListItem(buf, 'ol', wrapWithColorClass(holder?.color, text), out);
         break;
       }
       case 'to_do':

--- a/src/lib/notion-render/richText.test.ts
+++ b/src/lib/notion-render/richText.test.ts
@@ -29,6 +29,45 @@ describe('renderRichText', () => {
     ).toBe('<u><del><em><strong><code>hi</code></strong></em></del></u>');
   });
 
+  it('wraps text in a color class for non-default text colors', () => {
+    expect(
+      renderRichText([{ plain_text: 'red', annotations: { color: 'red' } }])
+    ).toBe('<span class="n2a-highlight-red">red</span>');
+  });
+
+  it('wraps text in a background color class', () => {
+    expect(
+      renderRichText([
+        { plain_text: 'hl', annotations: { color: 'blue_background' } },
+      ])
+    ).toBe('<span class="n2a-highlight-blue_background">hl</span>');
+  });
+
+  it('keeps color inside bold and link wrapping', () => {
+    expect(
+      renderRichText([
+        {
+          plain_text: 'word',
+          href: 'https://example.com',
+          annotations: { bold: true, color: 'purple' },
+        },
+      ])
+    ).toBe(
+      '<a href="https://example.com"><span class="n2a-highlight-purple"><strong>word</strong></span></a>'
+    );
+  });
+
+  it('does not wrap default color or unknown color names', () => {
+    expect(
+      renderRichText([{ plain_text: 'a', annotations: { color: 'default' } }])
+    ).toBe('a');
+    expect(
+      renderRichText([
+        { plain_text: 'b', annotations: { color: 'chartreuse' } },
+      ])
+    ).toBe('b');
+  });
+
   it('renders an anchor tag when href is present', () => {
     expect(
       renderRichText([

--- a/src/lib/notion-render/richText.ts
+++ b/src/lib/notion-render/richText.ts
@@ -1,8 +1,21 @@
 import { escapeAttribute, escapeHtml } from './escape';
 import { NotionRichTextItem } from './types';
+import { NOTION_COLORS } from '../../services/NotionService/NotionColors';
+
+const COLOR_NAMES = new Set(NOTION_COLORS.map((c) => c.name));
 
 const wrap = (open: string, close: string, inner: string): string =>
   `${open}${inner}${close}`;
+
+export const wrapWithColorClass = (
+  color: string | undefined,
+  inner: string
+): string => {
+  if (color == null || color === 'default' || !COLOR_NAMES.has(color)) {
+    return inner;
+  }
+  return `<span class="n2a-highlight-${color}">${inner}</span>`;
+};
 
 export const renderRichTextItem = (item: NotionRichTextItem): string => {
   if (item.type === 'equation' && item.equation?.expression != null) {
@@ -15,6 +28,7 @@ export const renderRichTextItem = (item: NotionRichTextItem): string => {
   if (a.italic) inner = wrap('<em>', '</em>', inner);
   if (a.strikethrough) inner = wrap('<del>', '</del>', inner);
   if (a.underline) inner = wrap('<u>', '</u>', inner);
+  inner = wrapWithColorClass(a.color, inner);
   if (item.href != null && item.href !== '') {
     inner = `<a href="${escapeAttribute(item.href)}">${inner}</a>`;
   }

--- a/src/lib/notion-render/types.ts
+++ b/src/lib/notion-render/types.ts
@@ -15,6 +15,7 @@ export interface NotionRichTextItem {
 
 interface RichTextHolder {
   rich_text?: NotionRichTextItem[];
+  color?: string;
 }
 
 interface MediaContent {
@@ -29,7 +30,7 @@ export interface NotionRenderableBlock {
   id?: string;
   type: string;
   has_children?: boolean;
-  paragraph?: RichTextHolder & { color?: string };
+  paragraph?: RichTextHolder;
   heading_1?: RichTextHolder;
   heading_2?: RichTextHolder;
   heading_3?: RichTextHolder;

--- a/src/services/ankify/notionPageWalker.test.ts
+++ b/src/services/ankify/notionPageWalker.test.ts
@@ -246,6 +246,38 @@ describe('walkNotionPageForFlashcards', () => {
     expect(cards).toHaveLength(1);
     expect(cards[0].notion_block_id).toBe('t-real');
   });
+
+  test('carries front text color from rich-text annotation and toggle block color', async () => {
+    const fetchChildren = jest.fn(async (blockId: string) => {
+      if (blockId === 'page-id') {
+        return [
+          toggleBlock({
+            id: 't-inline',
+            toggle: {
+              rich_text: [
+                { plain_text: 'red word', annotations: { color: 'red' } },
+              ],
+            },
+          }),
+          toggleBlock({
+            id: 't-block',
+            toggle: { rich_text: [{ plain_text: 'blue line' }], color: 'blue' },
+          }),
+        ];
+      }
+      return [paragraphChild('answer')];
+    });
+
+    const { cards } = await walkNotionPageForFlashcards(
+      'page-id',
+      fetchChildren as never
+    );
+
+    expect(cards.map((c) => c.front)).toEqual([
+      '<span class="n2a-highlight-red">red word</span>',
+      '<span class="n2a-highlight-blue">blue line</span>',
+    ]);
+  });
 });
 
 describe('walkNotionPageForFlashcards diagnostic', () => {

--- a/src/services/ankify/notionPageWalker.ts
+++ b/src/services/ankify/notionPageWalker.ts
@@ -1,20 +1,21 @@
 import {
   NotionRenderableBlock,
+  NotionRichTextItem,
   WalkedMediaKind,
   WalkedNotionMediaRef,
   renderNotionBlocks,
+  renderRichText,
 } from '../../lib/notion-render';
+import { wrapWithColorClass } from '../../lib/notion-render/richText';
 
-interface RichTextItem {
-  plain_text?: string;
-}
+type RichTextItem = NotionRichTextItem;
 
 interface NotionToggleBlock {
   id: string;
   type: 'toggle';
   last_edited_time: string;
   has_children: boolean;
-  toggle: { rich_text: RichTextItem[] };
+  toggle: { rich_text: RichTextItem[]; color?: string };
 }
 
 type NotionTopLevelBlock = NotionToggleBlock | { type: string; id?: string };
@@ -60,14 +61,6 @@ export type NotionDatabasePagesFetcher = (
 const MAX_BLOCKS_SCANNED = 1000;
 const MAX_UNMATCHED_SAMPLES = 3;
 const MAX_DATABASE_PAGES = 250;
-
-const renderRichText = (items: RichTextItem[] | undefined): string => {
-  if (items == null) return '';
-  return items
-    .map((item) => item.plain_text ?? '')
-    .join('')
-    .trim();
-};
 
 const renderToggleBack = async (
   toggle: NotionToggleBlock,
@@ -118,10 +111,17 @@ export const walkNotionPageForFlashcards = async (
       continue;
     }
     const toggle = block as NotionToggleBlock;
-    const front = renderRichText(toggle.toggle.rich_text);
-    if (front.length === 0) {
+    const frontText = toggle.toggle.rich_text
+      .map((item) => item.plain_text ?? '')
+      .join('')
+      .trim();
+    if (frontText.length === 0) {
       continue;
     }
+    const front = wrapWithColorClass(
+      toggle.toggle.color,
+      renderRichText(toggle.toggle.rich_text)
+    );
     patternHits['toggle'] = (patternHits['toggle'] ?? 0) + 1;
     const { back, media } = await renderToggleBack(toggle, fetchChildren);
     cards.push({

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-13-ankify-text-color.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-13-ankify-text-color.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-13-ankify-text-color",
+  "date": "2026-06-13",
+  "type": "fix",
+  "title": "Synced Notion cards keep their text colours"
+}


### PR DESCRIPTION
## What

Ankify cards synced from a Notion database lost all text/background colour. The legacy zip/html upload path kept colours (Notion's own HTML export carries them inline), so a lifetime user comparing the two paths reported the regression.

Root cause: the Ankify Notion-sync renderer (`src/lib/notion-render/richText.ts`) wrapped bold/italic/strike/underline/code annotations but silently dropped `annotations.color`, and `renderBlocks.ts` never read block-level colour. The card **front** went through a separate plain-text extractor that stripped everything.

## Fix

- `richText.ts` — apply `annotations.color` via the existing `n2a-highlight-<color>` class (validated against `NOTION_COLORS`). Export `wrapWithColorClass`.
- `renderBlocks.ts` — honour block-level colour on paragraph, headings, list items, quote, callout, to_do.
- `notionPageWalker.ts` — render the card front through the colour-aware `renderRichText` (escaped) and apply the toggle's block colour, replacing the plain-text extractor.

The Ankify note type already ships `notion.css`, so the classes resolve. Existing cards repair on the next sync (content diff triggers an update).

## Tests

- `richText.test.ts` — inline text/background colour, colour inside bold+link, default/unknown colour left unwrapped.
- `renderBlocks.test.ts` — block-colour wrapping on paragraph/heading/list-item, default left unwrapped.
- `notionPageWalker.test.ts` — front carries inline annotation colour and toggle block colour.
- Full ankify suite green (235 tests); web suite green (1922).

## Metric

No direct funnel metric — correctness fix on a paid surface (Ankify). Reduces churn risk on the lifetime/Auto-Sync cohort.

## Browser check
Browser check: not applicable — only the changelog JSON touches web/src/; no rendered UI change (server-side card HTML generation + one What's New entry).