### PR TITLE
style: stop the Ankify deck menu labels from wrapping

### DIFF
--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -1121,17 +1121,21 @@
   position: absolute;
   right: 0;
   top: calc(100% + 0.25rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
   background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
   padding: 0.25rem;
   z-index: 20;
-  min-width: 7rem;
+  min-width: 11rem;
 }
 
 .decksItemMenuItem {
   text-align: left;
+  white-space: nowrap;
   background: transparent;
   border: none;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
## What

The deck-row "…" menu on /ankify was 7rem wide, so **Update now** and **Set deck location** broke onto two lines. Widen to 11rem, add `white-space: nowrap` so labels stay on one line regardless of length, and add a 0.125rem gap between items.

CSS-only, scoped to `.decksItemMenu` / `.decksItemMenuItem` in `AnkifyPage.module.css`.

## Metric

None — visual polish on an existing paid surface (Ankify). Removes a layout rough edge a power user is hitting daily; no funnel claim.

## Changelog

No entry — visual nit (dropdown labels no longer wrap); not a behaviour change a user would call out.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: pending Alexander's visual check on /ankify (deck-row "…" menu) — boxes to be ticked before merge.