### PR TITLE
style: split text-tertiary from secondary token

### DIFF
--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -1,7 +1,7 @@
 :root {
   --color-text-primary: #1f2937;
   --color-text-secondary: #6b7280;
-  --color-text-tertiary: #6b7280;
+  --color-text-tertiary: #838b99;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
   --color-text-link: #2563eb;
@@ -120,7 +120,7 @@
 [data-theme='dark'] {
   --color-text-primary: #f9fafb;
   --color-text-secondary: #9ca3af;
-  --color-text-tertiary: #9ca3af;
+  --color-text-tertiary: #7b8494;
   --color-text-danger: #f87171;
   --color-text-success: #34d399;
   --color-text-link: #60a5fa;
@@ -304,7 +304,7 @@
 [data-theme='hotpink'] {
   --color-text-primary: #1a0a10;
   --color-text-secondary: #831843;
-  --color-text-tertiary: #9d174d;
+  --color-text-tertiary: #bd4f7c;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
   --color-text-link: #db2777;


### PR DESCRIPTION
## What
The default `:root` set `--color-text-secondary` and `--color-text-tertiary` to the same hex `#6b7280`. The intended 3-tier text hierarchy was really only 2 tiers — anything coded "tertiary" (timestamps, helper text, deck paths) rendered identical to "secondary". This gives tertiary a visibly lighter, muted value in the three theme blocks where it collided with or read too close to secondary.

## Why
Hierarchy is established by value — a level that renders identically to another does not exist (Design for Hackers, ch07). With tertiary == secondary, the third tier carried no information; meta text could not be distinguished from secondary copy.

## How
Tertiary is non-essential meta text, never body copy, so the target is ≥ 3:1 contrast against each theme's background (not the 4.5:1 body-copy threshold). Verified WCAG contrast per theme:

- **`:root` (light)** — `--color-text-tertiary` `#6b7280` → `#838b99` (3.43:1 on `#ffffff`, 3.28:1 on the `#f9fafb` card bg). Secondary `#6b7280` left as-is.
- **dark** — tertiary `#9ca3af` → `#7b8494`, dimmer than the `#9ca3af` secondary (4.71:1 on `#111827`, 3.89:1 on `#1f2937`).
- **hotpink** — tertiary `#9d174d` → `#bd4f7c`, clearly lighter/muted vs the `#831843` secondary (4.36:1 on `#fff7f9`, 4.21:1 on `#fdf2f8`).

`gold` (sec `#7a5b22` / tert `#9a7a3a`) and `purple` (sec `#5b5675` / tert `#8a84a0`) already define a distinct, lighter tertiary above 3:1 — left untouched.

## Measuring success
Visual only — no log or metric. Tertiary-coded text (timestamps, deck paths, helper copy) reads one step lighter than secondary in light, dark, and hotpink themes.

## Testing
- Unit tests added: none — CSS token value change only, no logic.
- `pnpm --filter 2anki-web typecheck` clean.
- `pnpm --filter 2anki-web lint` clean (only pre-existing warnings in unrelated TSX files; none in `base.css`).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: pending Alexander's visual check — app-wide text-color token change

## Changelog
No changelog — subtle text-color polish, no behaviour change.

## Risks
Low. Only three token values change; all stay within the existing palette and clear ≥ 3:1 contrast. Rollback is reverting the single commit. Surfaces that already used a distinct tertiary (gold/purple) are unaffected.

## Goal alignment
None — internal visual polish. Sharpens the "beautiful" leg of the mission (a real 3-tier hierarchy instead of a phantom one) but moves no funnel or revenue metric directly.