### PR TITLE
style: polish Ankify deck list and workspace bar

### DIFF
--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -765,7 +765,6 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-variant-numeric: tabular-nums;
 }
 
@@ -1049,7 +1048,7 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 0;
-  border-bottom: 1px solid var(--color-border-light);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .decksItem:last-child {
@@ -1077,11 +1076,21 @@
 .decksItemTitle {
   flex: 1;
   font-size: var(--text-sm);
+  font-weight: var(--font-medium);
   color: var(--color-text-primary);
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.decksItemTitle a {
+  color: var(--color-text-primary);
+  text-decoration: none;
+}
+
+.decksItemTitle a:hover {
+  text-decoration: underline;
 }
 
 .decksItemTime {
@@ -1100,21 +1109,8 @@
 
 .decksItemRowMenu {
   position: relative;
-  opacity: 0.55;
+  opacity: 1;
   transition: opacity var(--transition-fast);
-}
-
-@media (hover: hover) {
-  .decksItem:hover .decksItemRowMenu,
-  .decksItem:focus-within .decksItemRowMenu {
-    opacity: 1;
-  }
-}
-
-@media (hover: none) {
-  .decksItemRowMenu {
-    opacity: 1;
-  }
 }
 
 .decksItemMenu {

--- a/web/src/pages/AnkifyPage/components/WorkspaceBar.tsx
+++ b/web/src/pages/AnkifyPage/components/WorkspaceBar.tsx
@@ -33,16 +33,6 @@ const writeCachedSessionUrl = (clientId: number, url: string | null) => {
   } catch {}
 };
 
-const formatSessionLabel = (url: string): string => {
-  try {
-    const parsed = new URL(url);
-    const path = parsed.pathname.replace(/\/$/, '');
-    return `${parsed.host}${path}`;
-  } catch {
-    return url;
-  }
-};
-
 interface Props {
   readonly backend?: Backend;
   readonly showWorkspaceLink?: boolean;
@@ -224,7 +214,7 @@ export default function WorkspaceBar({
       <span className={styles.workspaceBarStatus}>{statusContent}</span>
       {sessionUrl != null && (
         <span className={styles.workspaceBarSession} title={sessionUrl}>
-          {formatSessionLabel(sessionUrl)}
+          Session active
         </span>
       )}
       <div className={styles.workspaceBarActions}>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-13-ankify-deck-list-polish.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-13-ankify-deck-list-polish.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-13-ankify-deck-list-polish",
+  "date": "2026-06-13",
+  "type": "style",
+  "title": "Ankify deck list — clearer deck names and a tidier sync status"
+}


### PR DESCRIPTION
## What
Visual-polish fixes on the /ankify surface from a Design for Hackers audit. CSS only plus one label swap — no behavior change.

## Why
Five small issues hurt the squint test and signal-to-noise on the Ankify workspace: the deck name was mis-colored as a link competing with real action links, the deck row was a flat type plateau, row separators were near-invisible, the per-row "…" menu was half-hidden, and the workspace bar showed an opaque VNC token URL as status.

## How
- `.decksItemTitle a` inherits primary text color and only underlines on hover (dominance, ch07).
- `.decksItemTitle` gains `font-weight: var(--font-medium)`; size stays `--text-sm` (squint test, ch03).
- `.decksItem` border-bottom uses `--color-border` instead of `--color-border-light` (separation, ch06).
- `.decksItemRowMenu` base opacity set to 1; redundant hover/no-hover media queries removed (affordance, ch07).
- Workspace bar renders a static "Session active" label, keeping `title={sessionUrl}` for debugging; the dead `formatSessionLabel` helper and the monospace font on `.workspaceBarSession` are removed (signal-to-noise, ch06).

**Skipped (audit fix 3, functional color ch09):** the calm "Anki client offline — will retry next tick" `last_error` renders through `.decksItemError` via `renderSecondLine` in NotionSubscriptions.tsx — `renderSecondLine` styles every `last_error` with `.decksItemError`. Turning `.decksItemError` red would mis-signal a routine offline state as an error. This needs a separate change that distinguishes the calm-offline case from genuine errors before the color flips; out of scope here.

## Measuring success
None — visual polish, no funnel/metric instrumentation. Confirmed via the /ankify deck list and workspace bar in the browser.

## Testing
- Web typecheck clean, web lint clean (only pre-existing warnings), full web vitest green (1922 passed).
- No WorkspaceBar/NotionSubscriptions test asserts on the old session label or the changed CSS classes.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: pending Alexander's visual check on /ankify

## Changelog
`Ankify deck list — clearer deck names and a tidier sync status`

## Risks
Low — scoped to two files in one page's styles plus one label swap. Rollback is a revert; no data or API surface touched.

## Goal alignment
None — internal polish on a paid-gated surface. Improves the experience (simpler/clearer) for existing Ankify users but does not move an acquisition or revenue metric on its own.