### PR TITLE
fix: respect reduced-motion on Ankify starting status dot

### DIFF
--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -757,6 +757,12 @@
   }
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .workspaceBarDotStarting {
+    animation: none;
+  }
+}
+
 .workspaceBarSession {
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
## What
Adds a `prefers-reduced-motion: reduce` block to `AnkifyPage.module.css` that disables the infinite `workspaceBarPulse` animation on the `.workspaceBarDotStarting` status dot.

## Why
The "starting / almost there" status dot ran `animation: workspaceBarPulse 1.4s ease-in-out infinite` with no reduced-motion guard, and this stylesheet had no `prefers-reduced-motion` block at all — an infinite decorative animation that ignored the user's OS-level reduced-motion preference. Motion polish principle: `prefers-reduced-motion` must be respected.

## How
After the `@keyframes workspaceBarPulse` block, added:
```css
@media (prefers-reduced-motion: reduce) {
  .workspaceBarDotStarting {
    animation: none;
  }
}
```
The dot keeps its `background` color, so it stays visible for everyone — it just stops pulsing for users who asked for reduced motion. `workspaceBarPulse` is the only `animation:` declaration in the file (verified by grep), so it's the only rule that needs the guard.

## Measuring success
No production metric — this is a niche a11y gate. Verifiable visually: macOS System Settings → Accessibility → Display → Reduce motion (or DevTools "Emulate CSS prefers-reduced-motion: reduce") on `/ankify` in the starting state shows the dot static instead of pulsing.

## Testing
- No unit tests — CSS media-query behaviour isn't covered by the Vitest suite and isn't unit-testable; verified via typecheck + lint and the visual check below.
- `pnpm --filter 2anki-web typecheck` clean.
- `pnpm --filter 2anki-web lint` clean (exit 0; only pre-existing warnings unrelated to this change).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: pending Alexander's visual check — /ankify starting state with reduced-motion on.

## Changelog
No entry — niche a11y motion gate; no behaviour change for users without the OS reduced-motion preference.

## Risks
Minimal. CSS-only, scoped to a single selector behind a media query. The dot's visibility is unaffected (background color preserved); only the pulse animation stops under reduced-motion. Rollback is a one-line revert.

## Goal alignment
None — internal a11y polish, no funnel or revenue metric. Respects the reduced-motion preference for users who set it; no behaviour change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)