### PR TITLE
fix: add global focus-visible rings to buttons and links

### DIFF
--- a/web/src/pages/WhatsNewPage/changelog/2026-06-13-keyboard-focus.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-13-keyboard-focus.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-13-keyboard-focus",
+  "date": "2026-06-13",
+  "type": "fix",
+  "title": "Keyboard focus is now visible on buttons and links"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -419,6 +419,15 @@ select:focus {
   box-shadow: 0 0 0 3px var(--color-focus-ring);
 }
 
+button:focus-visible,
+a:focus-visible,
+[role='button']:focus-visible,
+[role='menuitem']:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 input::placeholder,
 textarea::placeholder {
   color: var(--color-text-tertiary);


### PR DESCRIPTION
## What
Adds one global `:focus-visible` rule to `base.css` so keyboard focus is visible on every custom button, link, menu trigger, menu item, tab, and `<summary>` across the app.

## Why
`base.css` only rendered a focus ring on `input/textarea/select`, and the shared button classes (`.btnPrimary`/`.btnSecondary`/`.btnIcon` in `shared.module.css`) define none. Keyboard and switch-control users had no visible focus indicator on the primary interactive controls — Open Anki, the row "…" menu trigger, menu items, tabs. Critical a11y gap surfaced in a Design for Hackers polish pass.

## How
One global rule near the existing `input:focus` block, matching the per-component focus style already used by `.aiToggle` / `.checkboxControl input`:
```css
button:focus-visible,
a:focus-visible,
[role='button']:focus-visible,
[role='menuitem']:focus-visible,
summary:focus-visible {
  outline: 2px solid var(--color-primary);
  outline-offset: 2px;
}
```
`:focus-visible` (not `:focus`) so the ring shows for keyboard nav only, not mouse clicks. The scoped `outline: none` rules in `base.css`/`shared.module.css` target `input/textarea/select`, `.infoButton`, and `.select` — none of them strip the outline on bare `button`/`a`/`[role]`/`summary`, so this rule is not suppressed. The per-component `:focus-visible` styles already present are more specific and continue to win where present.

Principle: focus rings are never removed; `:focus-visible` must be visible.

## Measuring success
Not a metric-moving change — a11y correctness. Confirmable in browser by tabbing through buttons/links and seeing the ring.

## Testing
- No unit tests — CSS-only global focus rule. Web typecheck + oxlint clean.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: pending Alexander's visual check — tab through buttons/links

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-13-keyboard-focus.json` — "Keyboard focus is now visible on buttons and links"

## Risks
Low. Adds an outline only on keyboard focus. If a per-component focus style is less specific than this rule somewhere, both could render — but the existing per-component rules are class/attribute-scoped and win. Rollback is a one-line revert.

## Goal alignment
None — internal a11y correctness. Removes a keyboard-navigation barrier; supports the "simpler/more accessible experience" leg but doesn't directly move a funnel metric.