### PR TITLE
feat: Review tab on /ankify

### DIFF
--- a/src/controllers/AnkifyController.leeches.test.ts
+++ b/src/controllers/AnkifyController.leeches.test.ts
@@ -44,7 +44,7 @@ const DELETE_INDEX = 30;
 const RETURN_INDEX = 31;
 
 const makeController = (index: number, useCase: { execute: jest.Mock }) => {
-  const stubs = Array.from({ length: 32 }, () => ({}));
+  const stubs = Array.from({ length: 34 }, () => ({}));
   stubs[index] = useCase;
   return new AnkifyController(
     ...(stubs as ConstructorParameters<typeof AnkifyController>)

--- a/src/controllers/AnkifyController.review.test.ts
+++ b/src/controllers/AnkifyController.review.test.ts
@@ -1,0 +1,197 @@
+import { Request, Response } from 'express';
+
+import AnkifyController from './AnkifyController';
+import { AnkiConnectUnreachableError } from '../services/ankify/AnkiConnectClient';
+import { DeckNotOwnedError } from '../usecases/ankify/OpenDeckInAnkiUseCase';
+import {
+  InvalidReviewEaseError,
+  NoActiveAnkifyClientForReviewError,
+} from '../usecases/ankify/GradeReviewCardUseCase';
+
+interface CapturingResponse {
+  res: Response;
+  statusCode: number;
+  body: unknown;
+}
+
+const makeResponse = (): CapturingResponse => {
+  const capture: CapturingResponse = {
+    res: {} as Response,
+    statusCode: 200,
+    body: undefined,
+  };
+  const res = {
+    locals: { owner: 42 },
+    status: jest.fn((code: number) => {
+      capture.statusCode = code;
+      return res;
+    }),
+    json: jest.fn((payload: unknown) => {
+      capture.body = payload;
+      return res;
+    }),
+    send: jest.fn(() => res),
+  } as unknown as Response;
+  capture.res = res;
+  return capture;
+};
+
+const QUEUE_INDEX = 32;
+const GRADE_INDEX = 33;
+
+const makeController = (index: number, useCase: { execute: jest.Mock }) => {
+  const stubs = Array.from({ length: 34 }, () => ({}));
+  stubs[index] = useCase;
+  return new AnkifyController(
+    ...(stubs as ConstructorParameters<typeof AnkifyController>)
+  );
+};
+
+describe('AnkifyController review handlers', () => {
+  test('getReviewQueue returns the snapshot for an owned deck', async () => {
+    const result = {
+      connected: true,
+      cards: [
+        {
+          cardId: 9001,
+          questionHtml: '<p>Q</p>',
+          answerHtml: '<p>A</p>',
+          css: '.card{}',
+        },
+      ],
+    };
+    const execute = jest.fn(async () => result);
+    const controller = makeController(QUEUE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.getReviewQueue(
+      { query: { deck: 'Notion Sync::Pharma' } } as unknown as Request,
+      capture.res
+    );
+
+    expect(execute).toHaveBeenCalledWith({
+      owner: 42,
+      deck: 'Notion Sync::Pharma',
+    });
+    expect(capture.statusCode).toBe(200);
+    expect(capture.body).toEqual(result);
+  });
+
+  test('getReviewQueue rejects a missing deck with 400', async () => {
+    const execute = jest.fn();
+    const controller = makeController(QUEUE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.getReviewQueue(
+      { query: {} } as unknown as Request,
+      capture.res
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(capture.statusCode).toBe(400);
+  });
+
+  test('getReviewQueue maps DeckNotOwnedError to 403', async () => {
+    const execute = jest.fn(async () => {
+      throw new DeckNotOwnedError();
+    });
+    const controller = makeController(QUEUE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.getReviewQueue(
+      { query: { deck: 'Other::Deck' } } as unknown as Request,
+      capture.res
+    );
+
+    expect(capture.statusCode).toBe(403);
+  });
+
+  test('gradeReviewCard grades and returns 200', async () => {
+    const execute = jest.fn(async () => ({ graded: true }));
+    const controller = makeController(GRADE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.gradeReviewCard(
+      { body: { cardId: 9001, ease: 3 } } as unknown as Request,
+      capture.res
+    );
+
+    expect(execute).toHaveBeenCalledWith({ owner: 42, cardId: 9001, ease: 3 });
+    expect(capture.statusCode).toBe(200);
+    expect(capture.body).toEqual({ graded: true });
+  });
+
+  test('gradeReviewCard rejects a missing cardId with 400', async () => {
+    const execute = jest.fn();
+    const controller = makeController(GRADE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.gradeReviewCard(
+      { body: { ease: 3 } } as unknown as Request,
+      capture.res
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(capture.statusCode).toBe(400);
+  });
+
+  test('gradeReviewCard maps InvalidReviewEaseError to 400', async () => {
+    const execute = jest.fn(async () => {
+      throw new InvalidReviewEaseError();
+    });
+    const controller = makeController(GRADE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.gradeReviewCard(
+      { body: { cardId: 9001, ease: 9 } } as unknown as Request,
+      capture.res
+    );
+
+    expect(capture.statusCode).toBe(400);
+  });
+
+  test('gradeReviewCard maps DeckNotOwnedError to 403', async () => {
+    const execute = jest.fn(async () => {
+      throw new DeckNotOwnedError();
+    });
+    const controller = makeController(GRADE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.gradeReviewCard(
+      { body: { cardId: 9001, ease: 3 } } as unknown as Request,
+      capture.res
+    );
+
+    expect(capture.statusCode).toBe(403);
+  });
+
+  test('gradeReviewCard maps an offline client to 503', async () => {
+    const execute = jest.fn(async () => {
+      throw new NoActiveAnkifyClientForReviewError();
+    });
+    const controller = makeController(GRADE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.gradeReviewCard(
+      { body: { cardId: 9001, ease: 3 } } as unknown as Request,
+      capture.res
+    );
+
+    expect(capture.statusCode).toBe(503);
+  });
+
+  test('gradeReviewCard maps AnkiConnectUnreachableError to 503', async () => {
+    const execute = jest.fn(async () => {
+      throw new AnkiConnectUnreachableError('http://x', new Error('down'));
+    });
+    const controller = makeController(GRADE_INDEX, { execute });
+    const capture = makeResponse();
+
+    await controller.gradeReviewCard(
+      { body: { cardId: 9001, ease: 3 } } as unknown as Request,
+      capture.res
+    );
+
+    expect(capture.statusCode).toBe(503);
+  });
+});

--- a/src/controllers/AnkifyController.ts
+++ b/src/controllers/AnkifyController.ts
@@ -77,6 +77,12 @@ import { ReturnLeechToReviewUseCase } from '../usecases/ankify/ReturnLeechToRevi
 import { NoteNotOwnedError } from '../usecases/ankify/assertNoteOwned';
 import { NoActiveAnkifyClientForLeechError } from '../usecases/ankify/leechClient';
 import { AnkiConnectNoteFields } from '../services/ankify/AnkiConnectClient';
+import { GetReviewQueueUseCase } from '../usecases/ankify/GetReviewQueueUseCase';
+import {
+  GradeReviewCardUseCase,
+  InvalidReviewEaseError,
+  NoActiveAnkifyClientForReviewError,
+} from '../usecases/ankify/GradeReviewCardUseCase';
 
 const ANKI_CONNECT_UNREACHABLE_MESSAGE =
   'AnkiConnect is unreachable. Make sure the hosted Anki container is healthy.';
@@ -108,6 +114,13 @@ function parseNoteId(raw: string): number | null {
     return null;
   }
   return noteId;
+}
+
+function parseCardId(raw: unknown): number | null {
+  if (typeof raw !== 'number' || !Number.isSafeInteger(raw) || raw <= 0) {
+    return null;
+  }
+  return raw;
 }
 
 function parseLeechFields(raw: unknown): AnkiConnectNoteFields | null {
@@ -157,7 +170,9 @@ class AnkifyController {
     private readonly listLeechesUseCase: ListLeechesUseCase,
     private readonly editLeechNoteUseCase: EditLeechNoteUseCase,
     private readonly deleteLeechNoteUseCase: DeleteLeechNoteUseCase,
-    private readonly returnLeechToReviewUseCase: ReturnLeechToReviewUseCase
+    private readonly returnLeechToReviewUseCase: ReturnLeechToReviewUseCase,
+    private readonly getReviewQueueUseCase: GetReviewQueueUseCase,
+    private readonly gradeReviewCardUseCase: GradeReviewCardUseCase
   ) {}
 
   async list(_req: Request, res: Response) {
@@ -899,6 +914,64 @@ class AnkifyController {
       res.status(200).json(result);
     } catch (error) {
       if (this.mapLeechActionError(error, res)) {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async getReviewQueue(req: Request, res: Response) {
+    const owner = res.locals.owner as number;
+    const deck = readDeckField(req.query?.deck);
+    if (deck == null) {
+      res.status(400).json({ message: 'deck is required' });
+      return;
+    }
+    try {
+      const result = await this.getReviewQueueUseCase.execute({ owner, deck });
+      res.status(200).json(result);
+    } catch (error) {
+      if (error instanceof DeckNotOwnedError) {
+        res.status(403).json({ message: 'Deck not found for this user' });
+        return;
+      }
+      if (error instanceof AnkiConnectUnreachableError) {
+        res.status(503).json({ message: ANKI_CONNECT_UNREACHABLE_MESSAGE });
+        return;
+      }
+      throw error;
+    }
+  }
+
+  async gradeReviewCard(req: Request, res: Response) {
+    const owner = res.locals.owner as number;
+    const cardId = parseCardId(req.body?.cardId);
+    if (cardId == null) {
+      res.status(400).json({ message: 'cardId is required' });
+      return;
+    }
+    try {
+      await this.gradeReviewCardUseCase.execute({
+        owner,
+        cardId,
+        ease: req.body?.ease,
+      });
+      res.status(200).json({ graded: true });
+    } catch (error) {
+      if (error instanceof InvalidReviewEaseError) {
+        res.status(400).json({ message: 'ease must be an integer 1-4' });
+        return;
+      }
+      if (error instanceof DeckNotOwnedError) {
+        res.status(403).json({ message: 'Card not found for this user' });
+        return;
+      }
+      if (error instanceof NoActiveAnkifyClientForReviewError) {
+        res.status(503).json({ message: ANKI_CONNECT_UNREACHABLE_MESSAGE });
+        return;
+      }
+      if (error instanceof AnkiConnectUnreachableError) {
+        res.status(503).json({ message: ANKI_CONNECT_UNREACHABLE_MESSAGE });
         return;
       }
       throw error;

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -44,6 +44,8 @@ import { ListLeechesUseCase } from '../usecases/ankify/ListLeechesUseCase';
 import { EditLeechNoteUseCase } from '../usecases/ankify/EditLeechNoteUseCase';
 import { DeleteLeechNoteUseCase } from '../usecases/ankify/DeleteLeechNoteUseCase';
 import { ReturnLeechToReviewUseCase } from '../usecases/ankify/ReturnLeechToReviewUseCase';
+import { GetReviewQueueUseCase } from '../usecases/ankify/GetReviewQueueUseCase';
+import { GradeReviewCardUseCase } from '../usecases/ankify/GradeReviewCardUseCase';
 import { AnkifyExportSchedulesRepository } from '../data_layer/ankify/AnkifyExportSchedulesRepository';
 import { getAnkifyExportScheduler } from '../lib/ankify/scheduler/instance';
 import { AnkifySessionTokensRepository } from '../data_layer/ankify/AnkifySessionTokensRepository';
@@ -392,7 +394,9 @@ const AnkifyRouter = () => {
     new ListLeechesUseCase(repo, subscriptionsRepo, ankiConnectFactory),
     new EditLeechNoteUseCase(repo, subscriptionsRepo, ankiConnectFactory),
     new DeleteLeechNoteUseCase(repo, subscriptionsRepo, ankiConnectFactory),
-    new ReturnLeechToReviewUseCase(repo, subscriptionsRepo, ankiConnectFactory)
+    new ReturnLeechToReviewUseCase(repo, subscriptionsRepo, ankiConnectFactory),
+    new GetReviewQueueUseCase(repo, subscriptionsRepo, ankiConnectFactory),
+    new GradeReviewCardUseCase(repo, subscriptionsRepo, ankiConnectFactory)
   );
 
   /**
@@ -977,6 +981,65 @@ const AnkifyRouter = () => {
     '/api/ankify/leeches/:noteId/return-to-review',
     RequireAnkifyAccess,
     (req, res) => controller.returnLeechToReview(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ankify/review-queue:
+   *   get:
+   *     summary: Snapshot the due cards for one of the user's synced decks
+   *     description: "Allowlisted endpoint. Query deck. Returns the due-card snapshot for an owned deck as connected plus an array of { cardId, questionHtml, answerHtml, css }. Always 200 when reachable — returns connected false when no active client exists or AnkiConnect is unreachable. 403 when the deck is not owned."
+   *     tags: [Ankify]
+   *     parameters:
+   *       - in: query
+   *         name: deck
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: "Due-card snapshot (connected true|false)"
+   *       400:
+   *         description: deck is required
+   *       403:
+   *         description: Deck not owned by this user
+   */
+  router.get('/api/ankify/review-queue', RequireAnkifyAccess, (req, res) =>
+    controller.getReviewQueue(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ankify/review-grade:
+   *   post:
+   *     summary: Grade one card in an owned deck via AnkiConnect answerCards
+   *     description: "Allowlisted endpoint. Body cardId and ease (1-4). Re-checks the card belongs to one of the caller's owned decks via a cid: query and validates ease before grading. 200 on success, 400 on invalid ease or cardId, 403 when the card is not owned, 503 when AnkiConnect is unreachable."
+   *     tags: [Ankify]
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [cardId, ease]
+   *             properties:
+   *               cardId:
+   *                 type: integer
+   *               ease:
+   *                 type: integer
+   *                 enum: [1, 2, 3, 4]
+   *     responses:
+   *       200:
+   *         description: Card graded
+   *       400:
+   *         description: Invalid cardId or ease
+   *       403:
+   *         description: Card not owned by this user
+   *       503:
+   *         description: AnkiConnect unreachable
+   */
+  router.post('/api/ankify/review-grade', RequireAnkifyAccess, (req, res) =>
+    controller.gradeReviewCard(req, res)
   );
 
   return router;

--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -250,6 +250,29 @@ describe('AnkiConnectClient', () => {
     });
   });
 
+  test('answerCards posts the answerCards action with the answers param', async () => {
+    const fetchImpl = makeFetch({ result: [true, true], error: null });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const result = await client.answerCards([
+      { cardId: 9001, ease: 3 },
+      { cardId: 9002, ease: 1 },
+    ]);
+
+    expect(result).toEqual([true, true]);
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'answerCards',
+      version: 6,
+      params: {
+        answers: [
+          { cardId: 9001, ease: 3 },
+          { cardId: 9002, ease: 1 },
+        ],
+      },
+    });
+  });
+
   test('getNumCardsReviewedToday posts the action and returns the count', async () => {
     const fetchImpl = makeFetch({ result: 42, error: null });
     const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -245,6 +245,12 @@ export class AnkiConnectClient {
     return this.invoke('cardsInfo', { cards });
   }
 
+  async answerCards(
+    answers: { cardId: number; ease: number }[]
+  ): Promise<boolean[]> {
+    return this.invoke('answerCards', { answers });
+  }
+
   private async invoke<T>(
     action: string,
     params?: Record<string, unknown>,
@@ -354,6 +360,10 @@ export interface AnkiCardInfo {
   deckName: string;
   lapses: number;
   queue: number;
+  question?: string;
+  answer?: string;
+  css?: string;
+  due?: number;
 }
 
 export interface AnkiApiReflection {

--- a/src/usecases/ankify/GetReviewQueueUseCase.test.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.test.ts
@@ -1,0 +1,177 @@
+import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
+import { GetReviewQueueUseCase } from './GetReviewQueueUseCase';
+import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
+
+const activeClient = {
+  id: 1,
+  owner: 42,
+  anki_port: 8765,
+  anki_connect_api_key: 'k',
+} as unknown as Awaited<
+  ReturnType<AnkifyClientsRepositoryInterface['findActiveByOwner']>
+>;
+
+const clientsRepo = (
+  client: Awaited<
+    ReturnType<AnkifyClientsRepositoryInterface['findActiveByOwner']>
+  >
+): AnkifyClientsRepositoryInterface =>
+  ({
+    findActiveByOwner: jest.fn(async () => client),
+  }) as unknown as AnkifyClientsRepositoryInterface;
+
+const subsRepo = (
+  rows: { target_deck: string | null; notion_page_title: string | null }[]
+): AnkifyNotionSubscriptionsRepositoryInterface =>
+  ({
+    listByOwner: jest.fn(async () => rows),
+  }) as unknown as AnkifyNotionSubscriptionsRepositoryInterface;
+
+const ownedSubs = subsRepo([
+  { target_deck: 'Notion Sync::Pharma', notion_page_title: null },
+]);
+
+describe('GetReviewQueueUseCase', () => {
+  it('rejects a deck the user does not own', async () => {
+    const factory = jest.fn();
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      subsRepo([
+        { target_deck: 'Notion Sync::Torts', notion_page_title: null },
+      ]),
+      factory
+    );
+
+    await expect(
+      useCase.execute({ owner: 42, deck: 'Notion Sync::Pharma' })
+    ).rejects.toBeInstanceOf(DeckNotOwnedError);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it('returns connected:false with no cards when no active client', async () => {
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(null),
+      ownedSubs,
+      jest.fn()
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      deck: 'Notion Sync::Pharma',
+    });
+
+    expect(result).toEqual({ connected: false, cards: [] });
+  });
+
+  it('scopes findCards to the escaped owned deck with is:due and maps card info', async () => {
+    const findCards = jest.fn(async () => [9001, 9002]);
+    const cardsInfo = jest.fn(async () => [
+      {
+        cardId: 9001,
+        note: 5,
+        deckName: 'Notion Sync::Pharma',
+        lapses: 0,
+        queue: 2,
+        question: '<p>Q1</p>',
+        answer: '<p>A1</p>',
+        css: '.card { color: black; }',
+      },
+      {
+        cardId: 9002,
+        note: 6,
+        deckName: 'Notion Sync::Pharma',
+        lapses: 1,
+        queue: 2,
+        question: '<p>Q2</p>',
+        answer: '<p>A2</p>',
+        css: '.card { color: black; }',
+      },
+    ]);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      ownedSubs,
+      factory
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      deck: 'Notion Sync::Pharma',
+    });
+
+    expect(findCards).toHaveBeenCalledWith('"deck:Notion Sync::Pharma" is:due');
+    expect(result).toEqual({
+      connected: true,
+      cards: [
+        {
+          cardId: 9001,
+          questionHtml: '<p>Q1</p>',
+          answerHtml: '<p>A1</p>',
+          css: '.card { color: black; }',
+        },
+        {
+          cardId: 9002,
+          questionHtml: '<p>Q2</p>',
+          answerHtml: '<p>A2</p>',
+          css: '.card { color: black; }',
+        },
+      ],
+    });
+  });
+
+  it('returns an empty queue when no cards are due', async () => {
+    const findCards = jest.fn(async () => []);
+    const cardsInfo = jest.fn(async () => []);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      ownedSubs,
+      factory
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      deck: 'Notion Sync::Pharma',
+    });
+
+    expect(result).toEqual({ connected: true, cards: [] });
+    expect(cardsInfo).not.toHaveBeenCalled();
+  });
+
+  it('scopes the due query to a :: hierarchy deck', async () => {
+    const findCards = jest.fn(async () => []);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo: jest.fn(),
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      subsRepo([{ target_deck: 'MS3::Pharma', notion_page_title: null }]),
+      factory
+    );
+
+    await useCase.execute({ owner: 42, deck: 'MS3::Pharma' });
+
+    expect(findCards).toHaveBeenCalledWith('"deck:MS3::Pharma" is:due');
+  });
+});

--- a/src/usecases/ankify/GetReviewQueueUseCase.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.ts
@@ -1,0 +1,67 @@
+import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import { userOwnsDeck } from '../../lib/ankify/deckOwnership';
+import { AnkiConnectFactory } from './GetAnkifyStatsUseCase';
+import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
+import { buildDueCardsQuery } from './reviewQueries';
+
+export interface ReviewQueueCard {
+  cardId: number;
+  questionHtml: string;
+  answerHtml: string;
+  css: string;
+}
+
+export interface GetReviewQueueResult {
+  connected: boolean;
+  cards: ReviewQueueCard[];
+}
+
+export interface GetReviewQueueInput {
+  owner: number;
+  deck: string;
+  ankiConnectHost?: string;
+}
+
+export class GetReviewQueueUseCase {
+  constructor(
+    private readonly clients: AnkifyClientsRepositoryInterface,
+    private readonly subscriptions: AnkifyNotionSubscriptionsRepositoryInterface,
+    private readonly ankiConnect: AnkiConnectFactory
+  ) {}
+
+  async execute(input: GetReviewQueueInput): Promise<GetReviewQueueResult> {
+    const owned = await this.subscriptions.listByOwner(input.owner);
+    if (!userOwnsDeck(input.deck, owned)) {
+      throw new DeckNotOwnedError();
+    }
+
+    const client = await this.clients.findActiveByOwner(input.owner);
+    if (client == null) {
+      return { connected: false, cards: [] };
+    }
+
+    const ac = this.ankiConnect(
+      input.ankiConnectHost ?? 'localhost',
+      client.anki_port,
+      client.anki_connect_api_key
+    );
+
+    await ac.ping();
+
+    const cardIds = await ac.findCards(buildDueCardsQuery(input.deck));
+    if (cardIds.length === 0) {
+      return { connected: true, cards: [] };
+    }
+
+    const info = await ac.cardsInfo(cardIds);
+    const cards = info.map((card) => ({
+      cardId: card.cardId,
+      questionHtml: card.question ?? '',
+      answerHtml: card.answer ?? '',
+      css: card.css ?? '',
+    }));
+
+    return { connected: true, cards };
+  }
+}

--- a/src/usecases/ankify/GradeReviewCardUseCase.test.ts
+++ b/src/usecases/ankify/GradeReviewCardUseCase.test.ts
@@ -1,0 +1,155 @@
+import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
+import {
+  GradeReviewCardUseCase,
+  InvalidReviewEaseError,
+  NoActiveAnkifyClientForReviewError,
+} from './GradeReviewCardUseCase';
+import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
+
+const activeClient = {
+  id: 1,
+  owner: 42,
+  anki_port: 8765,
+  anki_connect_api_key: 'k',
+} as unknown as Awaited<
+  ReturnType<AnkifyClientsRepositoryInterface['findActiveByOwner']>
+>;
+
+const clientsRepo = (
+  client: Awaited<
+    ReturnType<AnkifyClientsRepositoryInterface['findActiveByOwner']>
+  >
+): AnkifyClientsRepositoryInterface =>
+  ({
+    findActiveByOwner: jest.fn(async () => client),
+  }) as unknown as AnkifyClientsRepositoryInterface;
+
+const subsRepo = (
+  rows: { target_deck: string | null; notion_page_title: string | null }[]
+): AnkifyNotionSubscriptionsRepositoryInterface =>
+  ({
+    listByOwner: jest.fn(async () => rows),
+  }) as unknown as AnkifyNotionSubscriptionsRepositoryInterface;
+
+const ownedSubs = subsRepo([
+  { target_deck: 'Notion Sync::Pharma', notion_page_title: null },
+]);
+
+describe('GradeReviewCardUseCase', () => {
+  it.each([0, 5, 1.5, '3', NaN])(
+    'rejects ease %p with InvalidReviewEaseError and never calls AnkiConnect',
+    async (ease) => {
+      const findActiveByOwner = jest.fn();
+      const factory = jest.fn();
+      const useCase = new GradeReviewCardUseCase(
+        {
+          findActiveByOwner,
+        } as unknown as AnkifyClientsRepositoryInterface,
+        ownedSubs,
+        factory
+      );
+
+      await expect(
+        useCase.execute({
+          owner: 42,
+          cardId: 9001,
+          ease: ease as unknown as number,
+        })
+      ).rejects.toBeInstanceOf(InvalidReviewEaseError);
+      expect(findActiveByOwner).not.toHaveBeenCalled();
+      expect(factory).not.toHaveBeenCalled();
+    }
+  );
+
+  it('grades the card after the cid ownership check passes', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const answerCards = jest.fn(async () => [true]);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          answerCards,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GradeReviewCardUseCase(
+      clientsRepo(activeClient),
+      ownedSubs,
+      factory
+    );
+
+    const result = await useCase.execute({ owner: 42, cardId: 9001, ease: 3 });
+
+    expect(result).toEqual({ graded: true });
+    expect(findCards).toHaveBeenCalledWith(
+      'cid:9001 ("deck:Notion Sync::Pharma")'
+    );
+    expect(answerCards).toHaveBeenCalledWith([{ cardId: 9001, ease: 3 }]);
+  });
+
+  it('rejects a forged cardId not in an owned deck and never grades', async () => {
+    const findCards = jest.fn(async () => []);
+    const answerCards = jest.fn(async () => [true]);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          answerCards,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GradeReviewCardUseCase(
+      clientsRepo(activeClient),
+      ownedSubs,
+      factory
+    );
+
+    await expect(
+      useCase.execute({ owner: 42, cardId: 1234567, ease: 4 })
+    ).rejects.toBeInstanceOf(DeckNotOwnedError);
+    expect(answerCards).not.toHaveBeenCalled();
+  });
+
+  it('throws when there is no active client (offline)', async () => {
+    const useCase = new GradeReviewCardUseCase(
+      clientsRepo(null),
+      ownedSubs,
+      jest.fn()
+    );
+
+    await expect(
+      useCase.execute({ owner: 42, cardId: 9001, ease: 3 })
+    ).rejects.toBeInstanceOf(NoActiveAnkifyClientForReviewError);
+  });
+
+  it('builds a cid: ownership query scoped to the owned :: hierarchy', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const answerCards = jest.fn(async () => [true]);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          answerCards,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GradeReviewCardUseCase(
+      clientsRepo(activeClient),
+      subsRepo([
+        {
+          target_deck: 'MS3::Pharma::Sub',
+          notion_page_title: null,
+        },
+      ]),
+      factory
+    );
+
+    await useCase.execute({ owner: 42, cardId: 9001, ease: 2 });
+
+    expect(findCards).toHaveBeenCalledWith(
+      'cid:9001 ("deck:MS3::Pharma::Sub")'
+    );
+  });
+});

--- a/src/usecases/ankify/GradeReviewCardUseCase.ts
+++ b/src/usecases/ankify/GradeReviewCardUseCase.ts
@@ -1,0 +1,75 @@
+import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
+import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
+import { ownedDeckNames } from '../../lib/ankify/deckOwnership';
+import { AnkiConnectFactory } from './GetAnkifyStatsUseCase';
+import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
+import { buildCardOwnershipQuery } from './reviewQueries';
+
+export class InvalidReviewEaseError extends Error {
+  constructor() {
+    super('ease must be an integer between 1 and 4');
+    this.name = 'InvalidReviewEaseError';
+  }
+}
+
+export class NoActiveAnkifyClientForReviewError extends Error {
+  constructor() {
+    super('No active Ankify client');
+    this.name = 'NoActiveAnkifyClientForReviewError';
+  }
+}
+
+export interface GradeReviewCardInput {
+  owner: number;
+  cardId: number;
+  ease: number;
+  ankiConnectHost?: string;
+}
+
+export interface GradeReviewCardResult {
+  graded: true;
+}
+
+const isValidEase = (ease: number): boolean =>
+  Number.isInteger(ease) && ease >= 1 && ease <= 4;
+
+export class GradeReviewCardUseCase {
+  constructor(
+    private readonly clients: AnkifyClientsRepositoryInterface,
+    private readonly subscriptions: AnkifyNotionSubscriptionsRepositoryInterface,
+    private readonly ankiConnect: AnkiConnectFactory
+  ) {}
+
+  async execute(input: GradeReviewCardInput): Promise<GradeReviewCardResult> {
+    if (!isValidEase(input.ease)) {
+      throw new InvalidReviewEaseError();
+    }
+
+    const client = await this.clients.findActiveByOwner(input.owner);
+    if (client == null) {
+      throw new NoActiveAnkifyClientForReviewError();
+    }
+
+    const owned = await this.subscriptions.listByOwner(input.owner);
+    const query = buildCardOwnershipQuery(input.cardId, ownedDeckNames(owned));
+    if (query == null) {
+      throw new DeckNotOwnedError();
+    }
+
+    const ac = this.ankiConnect(
+      input.ankiConnectHost ?? 'localhost',
+      client.anki_port,
+      client.anki_connect_api_key
+    );
+
+    await ac.ping();
+
+    const matches = await ac.findCards(query);
+    if (!matches.includes(input.cardId)) {
+      throw new DeckNotOwnedError();
+    }
+
+    await ac.answerCards([{ cardId: input.cardId, ease: input.ease }]);
+    return { graded: true };
+  }
+}

--- a/src/usecases/ankify/reviewQueries.test.ts
+++ b/src/usecases/ankify/reviewQueries.test.ts
@@ -1,0 +1,52 @@
+import { buildCardOwnershipQuery, buildDueCardsQuery } from './reviewQueries';
+
+describe('reviewQueries', () => {
+  describe('buildDueCardsQuery', () => {
+    it('scopes is:due to a single deck', () => {
+      expect(buildDueCardsQuery('Notion Sync::Pharma')).toBe(
+        '"deck:Notion Sync::Pharma" is:due'
+      );
+    });
+
+    it('escapes quotes and backslashes in the deck name', () => {
+      expect(buildDueCardsQuery('Week "18"\\x')).toBe(
+        '"deck:Week \\"18\\"\\\\x" is:due'
+      );
+    });
+
+    it('preserves the :: hierarchy separator', () => {
+      expect(buildDueCardsQuery('MS3::Pharma::Sub')).toBe(
+        '"deck:MS3::Pharma::Sub" is:due'
+      );
+    });
+  });
+
+  describe('buildCardOwnershipQuery', () => {
+    it('constrains a card id to a single owned deck with cid:', () => {
+      expect(buildCardOwnershipQuery(9001, ['Notion Sync::Pharma'])).toBe(
+        'cid:9001 ("deck:Notion Sync::Pharma")'
+      );
+    });
+
+    it('ORs multiple owned decks', () => {
+      expect(
+        buildCardOwnershipQuery(9001, [
+          'Notion Sync::Pharma',
+          'Notion Sync::Torts',
+        ])
+      ).toBe(
+        'cid:9001 ("deck:Notion Sync::Pharma" OR "deck:Notion Sync::Torts")'
+      );
+    });
+
+    it('escapes quotes and backslashes', () => {
+      expect(buildCardOwnershipQuery(42, ['Week "18"\\x'])).toBe(
+        'cid:42 ("deck:Week \\"18\\"\\\\x")'
+      );
+    });
+
+    it('returns null when there are no owned decks', () => {
+      expect(buildCardOwnershipQuery(9001, [])).toBeNull();
+    });
+  });
+});

--- a/src/usecases/ankify/reviewQueries.ts
+++ b/src/usecases/ankify/reviewQueries.ts
@@ -1,0 +1,24 @@
+import { escapeDeckQueryValue } from './leechQueries';
+
+const buildDeckScope = (ownedDeckNames: string[]): string | null => {
+  if (ownedDeckNames.length === 0) {
+    return null;
+  }
+  return ownedDeckNames
+    .map((deck) => `"deck:${escapeDeckQueryValue(deck)}"`)
+    .join(' OR ');
+};
+
+export const buildDueCardsQuery = (deck: string): string =>
+  `"deck:${escapeDeckQueryValue(deck)}" is:due`;
+
+export const buildCardOwnershipQuery = (
+  cardId: number,
+  ownedDeckNames: string[]
+): string | null => {
+  const scope = buildDeckScope(ownedDeckNames);
+  if (scope == null) {
+    return null;
+  }
+  return `cid:${cardId} (${scope})`;
+};

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -75,6 +75,11 @@ const AccountPreviewPage = import.meta.env.DEV
 const NotionPreviewPage = import.meta.env.DEV
   ? lazy(() => import('./pages/NotionPreviewPage/NotionPreviewPage'))
   : null;
+const AnkifyReviewPreviewPage = import.meta.env.DEV
+  ? lazy(
+      () => import('./pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage')
+    )
+  : null;
 const SuccessfulCheckoutPage = lazyWithRetry(
   () => import('./pages/SuccessfulCheckout/SuccessfulCheckout'),
   './pages/SuccessfulCheckout/SuccessfulCheckout'
@@ -482,6 +487,12 @@ function AppContent({
           )}
           {NotionPreviewPage && (
             <Route path="/dev/notion-preview" element={<NotionPreviewPage />} />
+          )}
+          {AnkifyReviewPreviewPage && (
+            <Route
+              path="/dev/ankify-review-preview"
+              element={<AnkifyReviewPreviewPage />}
+            />
           )}
           <Route
             path="/import"

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -59,6 +59,8 @@ export const KNOWN_EVENTS = new Set([
   'ankify_sync_ankiweb',
   'ankify_leeches_viewed',
   'ankify_leech_action',
+  'ankify_review_session_started',
+  'ankify_review_completed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -57,6 +57,18 @@ export type LeechList =
   | { connected: false }
   | { connected: true; leeches: LeechNote[] };
 
+export interface ReviewQueueCard {
+  cardId: number;
+  questionHtml: string;
+  answerHtml: string;
+  css: string;
+}
+
+export interface ReviewQueue {
+  connected: boolean;
+  cards: ReviewQueueCard[];
+}
+
 export interface CheckoutPrices {
   cohort: 'legacy' | 'v2';
   legacy: boolean;
@@ -974,6 +986,36 @@ export class Backend {
         status?: number;
       };
       error.status = response?.status;
+      throw error;
+    }
+  }
+
+  async getAnkifyReviewQueue(deck: string): Promise<ReviewQueue> {
+    const result = await get(
+      `${this.baseURL}ankify/review-queue?deck=${encodeURIComponent(deck)}`,
+      { redirect: false }
+    );
+    if (result?.connected === true && Array.isArray(result.cards)) {
+      return { connected: true, cards: result.cards };
+    }
+    return { connected: false, cards: [] };
+  }
+
+  async gradeAnkifyReviewCard(cardId: number, ease: number): Promise<void> {
+    const response = await post(`${this.baseURL}ankify/review-grade`, {
+      cardId,
+      ease,
+    });
+    if (!response.ok) {
+      const body = await response
+        .json()
+        .catch(() => ({ message: response.statusText }));
+      const error = new Error(
+        body.message ?? 'Failed to grade card'
+      ) as Error & {
+        status?: number;
+      };
+      error.status = response.status;
       throw error;
     }
   }

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -16,6 +16,7 @@ import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import { Backend } from '../../../lib/backend/Backend';
 import NotionPagePicker from './NotionPagePicker';
 import LeechesPanel from './LeechesPanel';
+import ReviewPanel from './ReviewPanel';
 import DotsHorizontal from '../../../components/icons/DotsHorizontal';
 import { BlockIcon } from '../../SearchPage/components/BlockIcon';
 import { mapSubscribeError } from './mapSubscribeError';
@@ -238,7 +239,7 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
   const [advancedInput, setAdvancedInput] = useState('');
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<
-    'decks' | 'find' | 'leeches' | null
+    'decks' | 'find' | 'leeches' | 'review' | null
   >(null);
   const [search, setSearch] = useState('');
   const [openMenuId, setOpenMenuId] = useState<number | null>(null);
@@ -484,7 +485,7 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
     return undefined;
   }, [openMenuId]);
 
-  const effectiveTab: 'decks' | 'find' | 'leeches' =
+  const effectiveTab: 'decks' | 'find' | 'leeches' | 'review' =
     activeTab ?? (subscriptions.length === 0 ? 'find' : 'decks');
   const showSearch = subscriptions.length >= SEARCH_THRESHOLD;
   const filteredSubscriptions =
@@ -550,9 +551,26 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
             <span className={styles.tabCount}>{leechCount}</span>
           )}
         </button>
+        <button
+          type="button"
+          role="tab"
+          id="ankify-tab-review"
+          aria-selected={effectiveTab === 'review'}
+          aria-controls="ankify-tabpanel-review"
+          className={
+            effectiveTab === 'review'
+              ? `${styles.tab} ${styles.tabActive}`
+              : styles.tab
+          }
+          onClick={() => setActiveTab('review')}
+        >
+          Review
+        </button>
       </div>
 
       {effectiveTab === 'leeches' && <LeechesPanel backend={backend} />}
+
+      {effectiveTab === 'review' && <ReviewPanel backend={backend} />}
 
       {effectiveTab === 'find' && (
         <div

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
@@ -1,0 +1,217 @@
+.deckReview {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  border-radius: var(--radius-sm);
+  border: none;
+  background: var(--color-primary);
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.deckReview:disabled {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-tertiary);
+  cursor: not-allowed;
+}
+
+.deckRowMuted .decksItemTitle,
+.deckRowMuted .deckCounts {
+  color: var(--color-text-tertiary);
+}
+
+.deckCounts {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+}
+
+.deckDue {
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
+.progressTrack {
+  position: relative;
+  height: 2px;
+  background: var(--color-border);
+  margin-bottom: 1.5rem;
+}
+
+.progressFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 2px;
+  background: var(--color-primary);
+  transition: width 120ms ease;
+}
+
+.progressLabel {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0 0 1rem;
+  text-align: right;
+}
+
+.cardArea {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: opacity 120ms ease;
+}
+
+.cardFrame {
+  width: 100%;
+  min-height: 8rem;
+  border: none;
+  background: transparent;
+}
+
+.cardDivider {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 0;
+}
+
+.showAnswer {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.grades {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.gradeButton {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.75rem 0.5rem;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  cursor: pointer;
+}
+
+.gradeButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.gradeAgain {
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-danger);
+}
+
+.gradeHard {
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-tertiary);
+}
+
+.gradeGood {
+  border: none;
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.gradeEasy {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-primary);
+}
+
+.gradeInterval {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--text-xs);
+  font-weight: var(--font-regular);
+  opacity: 0.8;
+}
+
+.summary {
+  max-width: 640px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.summaryHeadline {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.summaryStreak {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.summaryActions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+
+.undoBar {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.75rem;
+}
+
+.undoButton {
+  font-size: var(--text-xs);
+  color: var(--color-text-link);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  padding: 2rem;
+}
+
+.previewCell {
+  flex: 1;
+  min-width: 320px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.previewLabel {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+  margin: 0 0 1rem;
+}

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
@@ -18,6 +18,11 @@
   cursor: not-allowed;
 }
 
+.deckReview:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .deckRowMuted .decksItemTitle,
 .deckRowMuted .deckCounts {
   color: var(--color-text-tertiary);
@@ -98,6 +103,11 @@
   cursor: pointer;
 }
 
+.showAnswer:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .grades {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -119,6 +129,11 @@
 .gradeButton:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.gradeButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .gradeAgain {
@@ -148,8 +163,23 @@
 .gradeInterval {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--text-xs);
-  font-weight: var(--font-regular);
+  font-weight: var(--font-normal);
   opacity: 0.8;
+}
+
+.gradeShortcut {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.shortcutHint {
+  margin-left: 0.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
 }
 
 .summary {
@@ -165,12 +195,6 @@
   font-size: var(--text-2xl);
   font-weight: var(--font-medium);
   color: var(--color-text-primary);
-  margin: 0;
-}
-
-.summaryStreak {
-  font-size: var(--text-sm);
-  color: var(--color-text-secondary);
   margin: 0;
 }
 
@@ -193,6 +217,11 @@
   background: none;
   border: none;
   cursor: pointer;
+}
+
+.undoButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .preview {

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import ReviewPanel from './ReviewPanel';
+import { Backend, ReviewQueueCard } from '../../../lib/backend/Backend';
+import { AnkifyStats } from '../stats/types';
+
+const trackMock = vi.fn();
+vi.mock('../../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+const renderPanel = (backend: Backend) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ReviewPanel backend={backend} />
+    </QueryClientProvider>
+  );
+};
+
+const statsWithDeck = (review: number): AnkifyStats => ({
+  connected: true,
+  reviewedToday: 0,
+  reviewedThisYear: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  reviewsByDay: [],
+  decks: [
+    { name: 'Notion Sync::Pharma', new: 3, learning: 1, review, total: 120 },
+  ],
+});
+
+const cards: ReviewQueueCard[] = [
+  {
+    cardId: 9001,
+    questionHtml: '<p>Q1</p>',
+    answerHtml: '<p>A1</p>',
+    css: '',
+  },
+  {
+    cardId: 9002,
+    questionHtml: '<p>Q2</p>',
+    answerHtml: '<p>A2</p>',
+    css: '',
+  },
+];
+
+const makeBackend = (overrides: Partial<Backend> = {}): Backend =>
+  ({
+    getAnkifyStats: vi.fn(async () => statsWithDeck(2)),
+    getAnkifyReviewQueue: vi.fn(async () => ({
+      connected: true as const,
+      cards,
+    })),
+    gradeAnkifyReviewCard: vi.fn(async () => {}),
+    ...overrides,
+  }) as unknown as Backend;
+
+beforeEach(() => {
+  trackMock.mockClear();
+});
+
+describe('ReviewPanel', () => {
+  test('runs front -> reveal -> grade -> next -> summary', async () => {
+    const grade = vi.fn(async () => {});
+    renderPanel(makeBackend({ gradeAnkifyReviewCard: grade }));
+
+    const reviewButton = await screen.findByRole('button', { name: 'Review' });
+    fireEvent.click(reviewButton);
+
+    const showAnswer = await screen.findByRole('button', {
+      name: 'Show answer',
+    });
+    expect(
+      screen.queryByRole('button', { name: /Good/ })
+    ).not.toBeInTheDocument();
+    fireEvent.click(showAnswer);
+
+    const good = await screen.findByRole('button', { name: /Good/ });
+    fireEvent.click(good);
+
+    await waitFor(() => expect(grade).toHaveBeenCalledWith(9001, 3));
+
+    const showAnswer2 = await screen.findByRole('button', {
+      name: 'Show answer',
+    });
+    fireEvent.click(showAnswer2);
+    fireEvent.click(await screen.findByRole('button', { name: /Again/ }));
+
+    await waitFor(() => expect(grade).toHaveBeenCalledWith(9002, 1));
+    expect(await screen.findByText('2 cards. Done.')).toBeInTheDocument();
+    expect(trackMock).toHaveBeenCalledWith(
+      'ankify_review_session_started',
+      expect.anything()
+    );
+    expect(trackMock).toHaveBeenCalledWith(
+      'ankify_review_completed',
+      expect.objectContaining({ graded: 2 })
+    );
+  });
+
+  test('shows the all-caught-up state when no cards are due', async () => {
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () => statsWithDeck(5)),
+        getAnkifyReviewQueue: vi.fn(async () => ({
+          connected: true as const,
+          cards: [],
+        })),
+      })
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+
+    expect(await screen.findByText('All caught up.')).toBeInTheDocument();
+  });
+
+  test('disables the Review button for a deck with no due cards', async () => {
+    renderPanel(
+      makeBackend({ getAnkifyStats: vi.fn(async () => statsWithDeck(0)) })
+    );
+
+    const reviewButton = await screen.findByRole('button', { name: 'Review' });
+    expect(reviewButton).toBeDisabled();
+  });
+
+  test('shows the offline state when Anki is not connected', async () => {
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () => ({ connected: false as const })),
+      })
+    );
+
+    expect(
+      await screen.findByText("Anki isn't connected.")
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -1,0 +1,362 @@
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import styles from '../AnkifyPage.module.css';
+import reviewStyles from './ReviewPanel.module.css';
+import sharedStyles from '../../../styles/shared.module.css';
+import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
+import { Backend, ReviewQueueCard } from '../../../lib/backend/Backend';
+import { AnkifyStatsDeck } from '../stats/types';
+import { track } from '../../../lib/analytics/track';
+
+interface Props {
+  readonly backend?: Backend;
+}
+
+const EASE_BY_KEY: Record<string, number> = { '1': 1, '2': 2, '3': 3, '4': 4 };
+
+const GRADES = [
+  {
+    ease: 1,
+    label: 'Again',
+    interval: '<1m',
+    className: reviewStyles.gradeAgain,
+  },
+  {
+    ease: 2,
+    label: 'Hard',
+    interval: '<6m',
+    className: reviewStyles.gradeHard,
+  },
+  { ease: 3, label: 'Good', interval: '1d', className: reviewStyles.gradeGood },
+  { ease: 4, label: 'Easy', interval: '4d', className: reviewStyles.gradeEasy },
+];
+
+export function DeckPicker({
+  decks,
+  onReview,
+}: {
+  readonly decks: AnkifyStatsDeck[];
+  readonly onReview: (deckName: string) => void;
+}) {
+  return (
+    <ul className={styles.decksList}>
+      {decks.map((deck) => {
+        const due = deck.review;
+        const muted = due === 0;
+        return (
+          <li
+            key={deck.name}
+            className={
+              muted
+                ? `${styles.decksItem} ${reviewStyles.deckRowMuted}`
+                : styles.decksItem
+            }
+          >
+            <span className={styles.decksItemTitle} title={deck.name}>
+              {deck.name}
+            </span>
+            <span className={reviewStyles.deckCounts}>
+              <span className={reviewStyles.deckDue}>▲{due} due</span>
+              <span>{deck.learning} learning</span>
+              <span>+{deck.new} new</span>
+            </span>
+            <button
+              type="button"
+              className={reviewStyles.deckReview}
+              disabled={muted}
+              onClick={() => onReview(deck.name)}
+            >
+              Review
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function Reviewer({
+  cards,
+  deckName,
+  onGrade,
+  onDone,
+}: {
+  readonly cards: ReviewQueueCard[];
+  readonly deckName: string;
+  readonly onGrade: (cardId: number, ease: number) => Promise<void>;
+  readonly onDone: (graded: number) => void;
+}) {
+  const [index, setIndex] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [history, setHistory] = useState<
+    { index: number; revealed: boolean }[]
+  >([]);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!startedRef.current && cards.length > 0) {
+      startedRef.current = true;
+      track('ankify_review_session_started', { deck: deckName });
+    }
+  }, [cards.length, deckName]);
+
+  const total = cards.length;
+  const current = cards[index];
+
+  const reveal = useCallback(() => setRevealed(true), []);
+
+  const grade = useCallback(
+    async (ease: number) => {
+      if (current == null || busy) {
+        return;
+      }
+      setBusy(true);
+      try {
+        await onGrade(current.cardId, ease);
+        setHistory((prev) => [...prev, { index, revealed: true }]);
+        const next = index + 1;
+        if (next >= total) {
+          track('ankify_review_completed', { deck: deckName, graded: total });
+          onDone(total);
+          return;
+        }
+        setIndex(next);
+        setRevealed(false);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, current, deckName, index, onDone, onGrade, total]
+  );
+
+  const undo = useCallback(() => {
+    setHistory((prev) => {
+      if (prev.length === 0) {
+        return prev;
+      }
+      const last = prev[prev.length - 1];
+      setIndex(last.index);
+      setRevealed(true);
+      return prev.slice(0, -1);
+    });
+  }, []);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === ' ') {
+        event.preventDefault();
+        if (revealed) {
+          return;
+        }
+        reveal();
+        return;
+      }
+      if (revealed && EASE_BY_KEY[event.key] != null) {
+        event.preventDefault();
+        grade(EASE_BY_KEY[event.key]);
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [grade, reveal, revealed]);
+
+  if (current == null) {
+    return null;
+  }
+
+  const srcDoc = `<!doctype html><html><head><meta charset="utf-8"><style>${current.css}</style></head><body class="card">${revealed ? current.answerHtml : current.questionHtml}</body></html>`;
+
+  return (
+    <div>
+      <div className={reviewStyles.progressTrack}>
+        <span
+          className={reviewStyles.progressFill}
+          style={{ width: `${(index / total) * 100}%` }}
+        />
+      </div>
+      <p className={reviewStyles.progressLabel}>
+        {index + 1} / {total}
+      </p>
+      <div className={reviewStyles.cardArea}>
+        <iframe
+          title="Card preview"
+          className={reviewStyles.cardFrame}
+          sandbox="allow-scripts"
+          srcDoc={srcDoc}
+        />
+        {revealed ? (
+          <>
+            <hr className={reviewStyles.cardDivider} />
+            <div className={reviewStyles.grades}>
+              {GRADES.map((g) => (
+                <button
+                  key={g.ease}
+                  type="button"
+                  className={`${reviewStyles.gradeButton} ${g.className}`}
+                  disabled={busy}
+                  onClick={() => grade(g.ease)}
+                >
+                  {g.label}
+                  <span className={reviewStyles.gradeInterval}>
+                    {g.interval}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <button
+            type="button"
+            className={reviewStyles.showAnswer}
+            onClick={reveal}
+          >
+            Show answer
+          </button>
+        )}
+        {history.length > 0 && (
+          <div className={reviewStyles.undoBar}>
+            <button
+              type="button"
+              className={reviewStyles.undoButton}
+              onClick={undo}
+              disabled={busy}
+            >
+              Undo last grade
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ReviewSummary({
+  deckName,
+  graded,
+  onBack,
+}: {
+  readonly deckName: string;
+  readonly graded: number;
+  readonly onBack: () => void;
+}) {
+  return (
+    <div className={reviewStyles.summary}>
+      <p className={reviewStyles.summaryHeadline}>{graded} cards. Done.</p>
+      <p className={reviewStyles.summaryStreak}>
+        Your review streak in {deckName} just moved forward.
+      </p>
+      <div className={reviewStyles.summaryActions}>
+        <button
+          type="button"
+          className={sharedStyles.btnGhost}
+          onClick={onBack}
+        >
+          Back to decks
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type Stage =
+  | { kind: 'picker' }
+  | { kind: 'reviewing'; deck: string }
+  | { kind: 'summary'; deck: string; graded: number };
+
+export default function ReviewPanel({ backend }: Props) {
+  const api = backend ?? get2ankiApi();
+  const [stage, setStage] = useState<Stage>({ kind: 'picker' });
+
+  const stats = useQuery({
+    queryKey: ['ankify-review-stats'],
+    queryFn: () => api.getAnkifyStats(),
+  });
+
+  const queue = useQuery({
+    queryKey: [
+      'ankify-review-queue',
+      stage.kind === 'reviewing' ? stage.deck : null,
+    ],
+    queryFn: () =>
+      stage.kind === 'reviewing'
+        ? api.getAnkifyReviewQueue(stage.deck)
+        : Promise.resolve({ connected: false, cards: [] }),
+    enabled: stage.kind === 'reviewing',
+  });
+
+  const grade = useCallback(
+    (cardId: number, ease: number) => api.gradeAnkifyReviewCard(cardId, ease),
+    [api]
+  );
+
+  const panel = (children: ReactNode) => (
+    <div
+      role="tabpanel"
+      id="ankify-tabpanel-review"
+      aria-labelledby="ankify-tab-review"
+      className={styles.tabPanel}
+    >
+      {children}
+    </div>
+  );
+
+  if (stage.kind === 'summary') {
+    return panel(
+      <ReviewSummary
+        deckName={stage.deck}
+        graded={stage.graded}
+        onBack={() => setStage({ kind: 'picker' })}
+      />
+    );
+  }
+
+  if (stage.kind === 'reviewing') {
+    if (queue.isLoading) {
+      return panel(<p className={styles.emptyLine}>Loading your cards.</p>);
+    }
+    if (queue.data?.connected !== true) {
+      return panel(
+        <p className={styles.emptyLine}>Anki isn&apos;t connected.</p>
+      );
+    }
+    if (queue.data.cards.length === 0) {
+      return panel(<p className={styles.emptyLine}>All caught up.</p>);
+    }
+    return panel(
+      <Reviewer
+        cards={queue.data.cards}
+        deckName={stage.deck}
+        onGrade={grade}
+        onDone={(graded) =>
+          setStage({ kind: 'summary', deck: stage.deck, graded })
+        }
+      />
+    );
+  }
+
+  if (stats.isLoading) {
+    return panel(<p className={styles.emptyLine}>Loading your cards.</p>);
+  }
+  if (stats.data?.connected !== true) {
+    return panel(
+      <p className={styles.emptyLine}>Anki isn&apos;t connected.</p>
+    );
+  }
+  if (stats.data.decks.length === 0) {
+    return panel(<p className={styles.emptyLine}>All caught up.</p>);
+  }
+
+  return panel(
+    <>
+      <p className={styles.decksHelper}>
+        Pick a deck to review its due cards without opening Anki.
+      </p>
+      <DeckPicker
+        decks={stats.data.decks}
+        onReview={(deck) => setStage({ kind: 'reviewing', deck })}
+      />
+    </>
+  );
+}

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -57,7 +57,10 @@ export function DeckPicker({
               {deck.name}
             </span>
             <span className={reviewStyles.deckCounts}>
-              <span className={reviewStyles.deckDue}>▲{due} due</span>
+              <span className={reviewStyles.deckDue}>
+                <span aria-hidden="true">▲</span>
+                {due} due
+              </span>
               <span>{deck.learning} learning</span>
               <span>+{deck.new} new</span>
             </span>
@@ -199,7 +202,11 @@ export function Reviewer({
                   onClick={() => grade(g.ease)}
                 >
                   {g.label}
-                  <span className={reviewStyles.gradeInterval}>
+                  <span
+                    className={reviewStyles.gradeInterval}
+                    aria-hidden="true"
+                  >
+                    <span className={reviewStyles.gradeShortcut}>{g.ease}</span>{' '}
                     {g.interval}
                   </span>
                 </button>
@@ -213,6 +220,9 @@ export function Reviewer({
             onClick={reveal}
           >
             Show answer
+            <span className={reviewStyles.shortcutHint} aria-hidden="true">
+              Space
+            </span>
           </button>
         )}
         {history.length > 0 && (
@@ -233,19 +243,16 @@ export function Reviewer({
 }
 
 export function ReviewSummary({
-  deckName,
   graded,
   onBack,
 }: {
-  readonly deckName: string;
   readonly graded: number;
   readonly onBack: () => void;
 }) {
   return (
     <div className={reviewStyles.summary}>
-      <p className={reviewStyles.summaryHeadline}>{graded} cards. Done.</p>
-      <p className={reviewStyles.summaryStreak}>
-        Your review streak in {deckName} just moved forward.
+      <p className={reviewStyles.summaryHeadline}>
+        {graded} card{graded === 1 ? '' : 's'}. Done.
       </p>
       <div className={reviewStyles.summaryActions}>
         <button
@@ -305,7 +312,6 @@ export default function ReviewPanel({ backend }: Props) {
   if (stage.kind === 'summary') {
     return panel(
       <ReviewSummary
-        deckName={stage.deck}
         graded={stage.graded}
         onBack={() => setStage({ kind: 'picker' })}
       />

--- a/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
+++ b/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
@@ -67,14 +67,7 @@ export default function AnkifyReviewPreviewPage() {
           onDone={() => {}}
         />
       )}
-      {cell(
-        'Reviewer — done',
-        <ReviewSummary
-          deckName="Notion Sync::Pharmacology"
-          graded={47}
-          onBack={() => {}}
-        />
-      )}
+      {cell('Reviewer — done', <ReviewSummary graded={47} onBack={() => {}} />)}
       {cell(
         'Reviewer — offline',
         <p style={{ color: 'var(--color-text-tertiary)' }}>

--- a/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
+++ b/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react';
+
+import {
+  DeckPicker,
+  Reviewer,
+  ReviewSummary,
+} from '../AnkifyPage/components/ReviewPanel';
+import reviewStyles from '../AnkifyPage/components/ReviewPanel.module.css';
+import { ReviewQueueCard } from '../../lib/backend/Backend';
+import { AnkifyStatsDeck } from '../AnkifyPage/stats/types';
+
+const decksWithDue: AnkifyStatsDeck[] = [
+  {
+    name: 'Notion Sync::Pharmacology',
+    new: 12,
+    learning: 3,
+    review: 47,
+    total: 420,
+  },
+  { name: 'Notion Sync::Torts', new: 0, learning: 1, review: 8, total: 90 },
+];
+
+const decksCaughtUp: AnkifyStatsDeck[] = [
+  {
+    name: 'Notion Sync::Pharmacology',
+    new: 0,
+    learning: 0,
+    review: 0,
+    total: 420,
+  },
+  { name: 'Notion Sync::Torts', new: 0, learning: 0, review: 0, total: 90 },
+];
+
+const cards: ReviewQueueCard[] = [
+  {
+    cardId: 9001,
+    questionHtml: '<p>What is the half-life of caffeine?</p>',
+    answerHtml: '<p>About 5 hours.</p>',
+    css: '.card { font-family: sans-serif; text-align: center; }',
+  },
+];
+
+const cell = (label: string, node: ReactNode) => (
+  <div className={reviewStyles.previewCell}>
+    <p className={reviewStyles.previewLabel}>{label}</p>
+    {node}
+  </div>
+);
+
+export default function AnkifyReviewPreviewPage() {
+  return (
+    <div className={reviewStyles.preview}>
+      {cell(
+        'Picker — decks due',
+        <DeckPicker decks={decksWithDue} onReview={() => {}} />
+      )}
+      {cell(
+        'Picker — all caught up',
+        <DeckPicker decks={decksCaughtUp} onReview={() => {}} />
+      )}
+      {cell(
+        'Reviewer — front',
+        <Reviewer
+          cards={cards}
+          deckName="Notion Sync::Pharmacology"
+          onGrade={async () => {}}
+          onDone={() => {}}
+        />
+      )}
+      {cell(
+        'Reviewer — done',
+        <ReviewSummary
+          deckName="Notion Sync::Pharmacology"
+          graded={47}
+          onBack={() => {}}
+        />
+      )}
+      {cell(
+        'Reviewer — offline',
+        <p style={{ color: 'var(--color-text-tertiary)' }}>
+          Anki isn&apos;t connected.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/DocsPage/content/sync/review-cards.md
+++ b/web/src/pages/DocsPage/content/sync/review-cards.md
@@ -1,0 +1,32 @@
+---
+title: Review your synced decks in the browser
+description: Pick a synced deck on the Ankify page and grade its due cards without opening Anki.
+---
+
+The Review tab lets you study your synced decks' due cards straight in 2anki — on a phone, a borrowed laptop, anywhere your hosted Anki is running. No desktop window to launch.
+
+**Plan:** Available to Auto Sync subscribers and Lifetime members. The Review tab sits alongside Decks, Find pages, and Leeches on the Ankify page.
+
+## How a session works
+
+1. Open the **Review** tab. Each synced deck shows its due, learning, and new counts.
+2. Pick a deck and choose **Review**. Decks with nothing due are dimmed.
+3. The card front shows first. Choose **Show answer** (or press space) to reveal the back.
+4. Grade the card — **Again**, **Hard**, **Good**, or **Easy** (keys 1 to 4). The grade schedules the card in Anki exactly as the desktop app would.
+5. The next card appears. A counter at the top tracks your progress through the session.
+6. When the queue is empty you see a done-summary and your review streak moves forward.
+
+## Undo a misgrade
+
+Tapped the wrong button? Choose **Undo last grade** to bring the previous card back and grade it again.
+
+## Keyboard shortcuts
+
+- **Space** — reveal the answer, then advance.
+- **1 / 2 / 3 / 4** — grade Again / Hard / Good / Easy once the answer is showing.
+
+## When the queue won't load
+
+Cards are read live from your hosted Anki when you start a session. If the container is offline you'll see "Anki isn't connected." Open the Anki app on this computer, then try again. Grades only ever apply to decks 2anki synced for you.
+
+If a count looks wrong after a session, see [When sync gets stuck](/documentation/sync/troubleshooting).

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -56,6 +56,7 @@ export const sidebar: SidebarGroup[] = [
     items: [
       { label: 'How sync works', slug: 'sync/how-it-works' },
       { label: 'See your study stats', slug: 'sync/study-stats' },
+      { label: 'Review your decks in the browser', slug: 'sync/review-cards' },
       {
         label: 'Send your reviews back to Notion',
         slug: 'sync/review-export',

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review",
+  "date": "2026-06-14",
+  "type": "feature",
+  "title": "Review your synced decks in 2anki — pick a deck and grade due cards without opening Anki"
+}


### PR DESCRIPTION
## What
A **Review tab on `/ankify`** — paid Ankify users pick an owned deck and review its due cards in a calm in-browser UI (front → Show answer → grade Again/Hard/Good/Easy → next → done-summary), graded through AnkiConnect `answerCards`. Onigiri-inspired focus, delivered inside the locked Swiss Panel DNA. Implements spec PR (now graduated; spec removed from the branch).

## Why
Synced cards are stranded unless desktop Anki is open. A browser reviewer gives Auto-Sync/lifetime subscribers a daily reason to return and study from anywhere — a retention lever, not acquisition. Closes the sync loop: synced cards you can actually study.

## How
- **2 endpoints** behind `RequireAnkifyAccess`:
  - `GET /api/ankify/review-queue?deck=<owned>` → `{ connected, cards: { cardId, questionHtml, answerHtml, css }[] }`. Ownership-first (`userOwnsDeck`), `ping`, `findCards("deck:… is:due")` + `cardsInfo`. No client/unreachable → `connected:false` (200), never throws.
  - `POST /api/ankify/review-grade` `{ cardId, ease }` → `{ graded:true }`.
- **`GradeReviewCardUseCase` (the crux):** ease validated to integer 1–4 **before any AnkiConnect call**; card-level ownership re-checked server-side via `findCards("cid:<id> (deck:<owned…>)")` (`cid:` not `nid:`, decks escaped) before `answerCards`. Forged cardId → 403, bad ease → 400, neither reaches AnkiConnect.
- **Snapshot queue once** at session start; grade against snapshot ids (no per-card due re-query). `answerCards` schedules the card directly — no VNC/`gui*` coupling.
- **Frontend:** `ReviewPanel.tsx` deck picker (mono/tabular `due · learning · new`, 0-due muted) → reveal/grade state machine, card HTML in `<iframe sandbox="allow-scripts">` (no `allow-same-origin`) with card css, one-step Undo, keyboard (Space reveal/next, 1–4 grade) with visible hints + focus rings. DEV-gated `/dev/ankify-review-preview`.
- **No migration, no DB, no TS↔Python.**

## Measuring success
Usage events `ankify_review_session_started` (first card) + `ankify_review_completed` (summary), read at `/api/ops/metrics`. Target: ≥25% of weekly `/ankify` openers start ≥1 review session within 30 days. T+30d keep/remove adoption issue opened at merge.

## Testing
- Server 238 passed: ownership-bypass on grade (forged cardId → 403, `answerCards` never called), ease validation `it.each([0,5,1.5,'3',NaN])` → 400 no AnkiConnect call, queue scoping (escaped owned deck + `is:due`, non-owned → 403), calm-offline (queue `connected:false` 200 / grade 503), query-escaping (`"`/`::`).
- Web: ReviewPanel 4/4 + AnkifyPage/docs/WhatsNew suites green. Server tsc + web typecheck clean. Lint: new files clean.
- **Security review (adversarial, separate pass): all 7 checks PASS** — no SRS-corruption hole. Ownership re-derived from the caller's subscriptions, never the request body; errors mapped to generic 400/403/503 (no stack/AnkiConnect leak).
- **Designer review:** 5 blockers fixed (broken CSS token, focus-visible rings, keyboard hints, plural `card(s)`, removed fake-warmth streak line); copy + Swiss DNA otherwise clean.

## Risks
Grading writes a paying user's real SRS schedule — mitigated by fail-closed ease validation + `cid:` ownership re-check before every `answerCards`. Surface-lifecycle: queued behind Leeches (#3346, merged) per one-surface-in-flight; T+30d review will decide keep/remove.

## Goal alignment
Retention (paid Auto-Sync/lifetime). Moves monthly-active-uploader churn signal. Not acquisition.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: open `/dev/ankify-review-preview` (DEV-gated) to compare picker + reviewer states.

## Sonar
sonar-scanner not run locally (no token configured) — SonarCloud Automatic Analysis runs on the PR.
