### PR TITLE
fix: clarify the empty leeches state copy

### DIFF
--- a/web/src/pages/AnkifyPage/components/LeechesPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/LeechesPanel.test.tsx
@@ -76,7 +76,7 @@ describe('LeechesPanel', () => {
     renderPanel(backend);
 
     expect(
-      await screen.findByText(/no leeches — every card is sticking/i)
+      await screen.findByText(/no leeches yet\. anki flags a card/i)
     ).toBeInTheDocument();
   });
 

--- a/web/src/pages/AnkifyPage/components/LeechesPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/LeechesPanel.tsx
@@ -229,7 +229,9 @@ export default function LeechesPanel({ backend }: Props) {
         aria-labelledby="ankify-tab-leeches"
         className={styles.tabPanel}
       >
-        <p className={styles.emptyLine}>No leeches — every card is sticking.</p>
+        <p className={styles.emptyLine}>
+          No leeches yet. Anki flags a card after you fail it 8 times in review.
+        </p>
       </div>
     );
   }


### PR DESCRIPTION
## What
Fix the Leeches tab empty state so it doesn't read as broken.

## Why
A freshly Notion→Anki-synced deck has **no** `leech`-tagged cards — Anki only flags a card as a leech after it's failed 8 times in review. So for most users (and any new deck) the tab opens empty. The old copy — "No leeches — every card is sticking." — implied a success state where there was really just no data yet, which reads as "is this thing working?".

New copy: **"No leeches yet. Anki flags a card after you fail it 8 times in review."** — says what a leech is and why the list is empty.

## How
One string in `LeechesPanel.tsx` + its test assertion. No logic change.

## Testing
- `LeechesPanel` vitest: 7/7 pass.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

Verify: open the Leeches tab with no leech-tagged cards → the new empty copy shows.

## Goal alignment
Retention surface clarity — an empty tab that explains itself instead of looking broken. No funnel/revenue metric.
