### PR TITLE
feat: Open in Notion + Edit settings in the Ankify deck menu

### DIFF
--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
@@ -311,6 +311,34 @@ describe('NotionSubscriptions sync copy', () => {
     );
   });
 
+  test('kebab menu links "Open in Notion" to the page URL and "Edit settings" to the rules editor', async () => {
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [
+        sampleSubscription({
+          id: 11,
+          notion_page_id: 'a'.repeat(32),
+          notion_page_url: 'https://notion.so/My-deck',
+        }),
+      ]),
+    });
+
+    renderSubs(backend);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: /options for my deck/i })
+    );
+
+    const openInNotion = await screen.findByRole('menuitem', {
+      name: /open my deck in notion/i,
+    });
+    expect(openInNotion).toHaveAttribute('href', 'https://notion.so/My-deck');
+
+    const editSettings = screen.getByRole('menuitem', {
+      name: /edit settings for my deck/i,
+    });
+    expect(editSettings).toHaveAttribute('href', `/rules/${'a'.repeat(32)}`);
+  });
+
   test('clicking "Update now" calls refreshAnkifySubscription with the row id and shows a success flash', async () => {
     const refresh = vi.fn(async (_id: number) => ({
       created: 3,

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -872,6 +872,29 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
                             >
                               Open in Anki
                             </button>
+                            {sub.notion_page_url != null &&
+                              sub.notion_page_url.length > 0 && (
+                                <a
+                                  role="menuitem"
+                                  className={styles.decksItemMenuItem}
+                                  href={sub.notion_page_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  aria-label={`Open ${displayTitle} in Notion`}
+                                  onClick={() => setOpenMenuId(null)}
+                                >
+                                  Open in Notion
+                                </a>
+                              )}
+                            <Link
+                              role="menuitem"
+                              className={styles.decksItemMenuItem}
+                              to={`/rules/${sub.notion_page_id}`}
+                              aria-label={`Edit settings for ${displayTitle}`}
+                              onClick={() => setOpenMenuId(null)}
+                            >
+                              Edit settings
+                            </Link>
                             <button
                               type="button"
                               role="menuitem"

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-open-in-notion.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-open-in-notion.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-open-in-notion",
+  "date": "2026-06-14",
+  "type": "feature",
+  "title": "Open a synced page in Notion or edit its settings from the deck menu"
+}


### PR DESCRIPTION
## What
Two new items in the Ankify deck-row dropdown: **Open in Notion** and **Edit settings**.

## Why
- **Open in Notion** — jump to the source Notion page (the menu had "Open in Anki" but no way back to Notion).
- **Edit settings** — there was **no way to change a running subscription's conversion settings** (note type, template, tags, card options) after sync started. This links to `/rules/<notion_page_id>` — the per-page settings editor whose values the Ankify sync already reads (`SettingsRepository.loadAnkifyTemplateOverrides`). Verified the link targets the exact store the sync consumes, not a disconnected editor.

Both use data already on the row (`notion_page_url`, `notion_page_id`) — no backend change.

## How
`Open in Notion` → `<a target="_blank" rel="noopener noreferrer" href={notion_page_url}>` (shown only when a URL exists). `Edit settings` → `<Link to={/rules/:id}>`. Both styled as menu items, close the menu on click.

## Testing
- NotionSubscriptions vitest: 40 pass (new test asserts both hrefs).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

Verify: deck ⋯ menu → "Open in Notion" opens the page in a new tab; "Edit settings" opens the rules editor for that page.

## Changelog
`2026-06-14-ankify-open-in-notion.json`

## Goal alignment
Retention — closes a real gap (no post-sync settings edit) for paid Ankify users; directly from this week's heaviest-user feedback.
