### PR TITLE
feat: set Notion page rules before making a deck

### DIFF
--- a/web/src/pages/AnkifyPage/components/NotionPagePicker.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionPagePicker.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 
 import NotionPagePicker from './NotionPagePicker';
 import { Backend } from '../../../lib/backend/Backend';
@@ -25,14 +26,16 @@ const renderPicker = (
   onSelect: (id: string, page?: NotionObject) => void = vi.fn()
 ) =>
   render(
-    <NotionPagePicker
-      backend={backend}
-      onSelect={onSelect}
-      busyId={null}
-      selectLabel="Make this a deck"
-      busyLabel="Subscribing…"
-      subscribedLabel="Subscribed"
-    />
+    <MemoryRouter>
+      <NotionPagePicker
+        backend={backend}
+        onSelect={onSelect}
+        busyId={null}
+        selectLabel="Make this a deck"
+        busyLabel="Subscribing…"
+        subscribedLabel="Subscribed"
+      />
+    </MemoryRouter>
   );
 
 describe('NotionPagePicker — link to source Notion page', () => {
@@ -49,6 +52,16 @@ describe('NotionPagePicker — link to source Notion page', () => {
     );
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
+  test('renders a "Set rules" link to /rules/<page id> using the same id as make-deck', async () => {
+    const backend = makeBackend([samplePage({ id: 'page-xyz' })]);
+    renderPicker(backend);
+
+    const setRules = await screen.findByRole('link', {
+      name: /set rules for slash commands before making a deck/i,
+    });
+    expect(setRules).toHaveAttribute('href', '/rules/page-xyz');
   });
 
   test('aria-label and title include the page title and "(new tab)"', async () => {

--- a/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionPagePicker.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import sharedStyles from '../../../styles/shared.module.css';
 import styles from '../AnkifyPage.module.css';
@@ -135,6 +136,14 @@ export default function NotionPagePicker({
                       />
                     </a>
                   )}
+                  <Link
+                    to={`/rules/${page.id}`}
+                    className={`${sharedStyles.btnSmall} ${styles.inlineButton}`}
+                    aria-label={`Set rules for ${page.title} before making a deck`}
+                    title="Set conversion rules before making a deck"
+                  >
+                    Set rules
+                  </Link>
                   <button
                     type="button"
                     className={`${sharedStyles.btnSmall} ${styles.inlineButton}`}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-set-rules-before-deck.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-set-rules-before-deck.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-set-rules-before-deck",
+  "date": "2026-06-14",
+  "type": "feature",
+  "title": "Set a Notion page's conversion rules before making it a deck"
+}


### PR DESCRIPTION
## What
Add a **Set rules** link to each Find-pages search result, so you can configure a Notion page's conversion rules (note type, template, tags, card options) **before** turning it into a deck.

## Why
"Make this a deck" creates the subscription with default settings and syncs immediately — there was no way to set rules first, so the first deck always built with defaults and had to be re-synced after editing. From this week's heaviest-user feedback ("why can't I set the rules before making deck?").

## How
"Set rules" links each result to `/rules/<page id>` — the existing per-page rules editor. **Verified the id binds correctly:** rules are keyed by `SettingsRepository.object_id` = the Notion page id; that's the same `page.id` "Make this a deck" stores as `notion_page_id` and the sync reads via `loadAnkifyTemplateOverrides`. So rules set before the deck exists apply on the first sync. (Match is exact `object_id`, with a safe fallback to the user's global custom model if unset.)

No backend change — reuses the page id already on the search result.

## Testing
- NotionPagePicker vitest: 5 pass (new test asserts the link targets `/rules/<page id>` with the same id as make-deck).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

Verify: Find pages → search → "Set rules" opens the rules editor for that page; set a note type; "Make this a deck"; first sync uses it.

## Changelog
`2026-06-14-ankify-set-rules-before-deck.json`

## Goal alignment
Retention/onboarding — removes a "first deck is always wrong" friction for paid Ankify users.
