### PR TITLE
fix: clearer restart and AnkiWeb-sync icons in Ankify toolbar

### DIFF
--- a/web/src/components/icons/CloudArrowUpIcon.tsx
+++ b/web/src/components/icons/CloudArrowUpIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function CloudArrowUpIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 16.5V9.75m0 0 3 3m-3-3-3 3M6.75 19.5a4.5 4.5 0 0 1-1.41-8.775 5.25 5.25 0 0 1 10.233-2.33 3 3 0 0 1 3.758 3.848A3.752 3.752 0 0 1 18 19.5H6.75Z"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/icons/PowerIcon.tsx
+++ b/web/src/components/icons/PowerIcon.tsx
@@ -1,0 +1,27 @@
+interface Props {
+  width?: number;
+  height?: number;
+}
+
+export default function PowerIcon({
+  width = 20,
+  height = 20,
+}: Readonly<Props>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      width={width}
+      height={height}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M5.636 5.636a9 9 0 1 0 12.728 0M12 3v9"
+      />
+    </svg>
+  );
+}

--- a/web/src/pages/AnkifyPage/components/WorkspaceBar.tsx
+++ b/web/src/pages/AnkifyPage/components/WorkspaceBar.tsx
@@ -7,9 +7,9 @@ import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import { Backend } from '../../../lib/backend/Backend';
 import AnkifyClient from '../../../lib/interfaces/AnkifyClient';
 import ExternalLinkIcon from '../../../components/icons/ExternalLinkIcon';
-import RefreshIcon from '../../../components/icons/RefreshIcon';
+import PowerIcon from '../../../components/icons/PowerIcon';
 import ArrowRightOnRectangleIcon from '../../../components/icons/ArrowRightOnRectangleIcon';
-import ArrowUpTrayIcon from '../../../components/icons/ArrowUpTrayIcon';
+import CloudArrowUpIcon from '../../../components/icons/CloudArrowUpIcon';
 import DotsHorizontal from '../../../components/icons/DotsHorizontal';
 import { track } from '../../../lib/analytics/track';
 
@@ -288,7 +288,7 @@ export default function WorkspaceBar({
           onClick={onSyncToAnkiWeb}
           disabled={syncToAnkiWeb.isPending || !containerReady}
         >
-          <ArrowUpTrayIcon width={18} height={18} />
+          <CloudArrowUpIcon width={18} height={18} />
         </button>
         <button
           type="button"
@@ -298,7 +298,7 @@ export default function WorkspaceBar({
           onClick={onRestart}
           disabled={respin.isPending}
         >
-          <RefreshIcon width={18} height={18} />
+          <PowerIcon width={18} height={18} />
         </button>
         <button
           type="button"

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-restart-sync-icons.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-restart-sync-icons.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-restart-sync-icons",
+  "date": "2026-06-14",
+  "type": "style",
+  "title": "Clearer icons for restart and sync to AnkiWeb in the Ankify toolbar"
+}


### PR DESCRIPTION
## What
Distinct icons for the two Ankify toolbar actions that were easy to confuse: **Restart** and **Sync to AnkiWeb**.

## Why
**Restart wore a refresh (circular-arrows) icon** — which universally reads as "reload the page". A misclick there doesn't reload anything; it **power-cycles the Anki container and drops the live session**. That's a dangerous mismatch between what the icon promises and what it does. Sync to AnkiWeb used a bare up-arrow, which is also vague.

## How
- Restart → **power icon** (new `PowerIcon`) — reads "power-cycle", not "reload".
- Sync to AnkiWeb → **cloud-upload icon** (new `CloudArrowUpIcon`) — reads "push to the cloud".
Both match the existing Heroicons-outline style. Labels/titles unchanged.

## Testing
- WorkspaceBar vitest: 8 pass. Web typecheck clean.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px

Verify the toolbar: power icon = Restart, cloud-up = Sync to AnkiWeb, neither looks like a page refresh.

## Changelog
`2026-06-14-ankify-restart-sync-icons.json`

## Goal alignment
Safety/clarity on a paid surface — removes an icon that invited an accidental session-killing restart.
