### PR TITLE
fix: use Notion's real background tints for highlights

### DIFF
--- a/src/lib/notion-render/richText.test.ts
+++ b/src/lib/notion-render/richText.test.ts
@@ -41,7 +41,7 @@ describe('renderRichText', () => {
         { plain_text: 'hl', annotations: { color: 'blue_background' } },
       ])
     ).toBe(
-      '<span class="n2a-highlight-blue_background" style="background-color: #0B6E99">hl</span>'
+      '<span class="n2a-highlight-blue_background" style="background-color: rgb(231, 243, 248)">hl</span>'
     );
   });
 

--- a/src/lib/notion-render/richText.ts
+++ b/src/lib/notion-render/richText.ts
@@ -3,12 +3,21 @@ import { NotionRichTextItem } from './types';
 import notionColorToHex, {
   NOTION_COLORS,
   isNotionColorBackground,
+  notionBackgroundColor,
 } from '../../services/NotionService/NotionColors';
 
 const COLOR_NAMES = new Set(NOTION_COLORS.map((c) => c.name));
 
 const wrap = (open: string, close: string, inner: string): string =>
   `${open}${inner}${close}`;
+
+const colorStyle = (color: string): string | null => {
+  if (isNotionColorBackground(color)) {
+    const background = notionBackgroundColor(color);
+    return background == null ? null : `background-color: ${background}`;
+  }
+  return `color: ${notionColorToHex(color)}`;
+};
 
 export const wrapWithColorClass = (
   color: string | undefined,
@@ -17,11 +26,11 @@ export const wrapWithColorClass = (
   if (color == null || color === 'default' || !COLOR_NAMES.has(color)) {
     return inner;
   }
-  const property = isNotionColorBackground(color)
-    ? 'background-color'
-    : 'color';
-  const hex = notionColorToHex(color);
-  return `<span class="n2a-highlight-${color}" style="${property}: ${hex}">${inner}</span>`;
+  const style = colorStyle(color);
+  if (style == null) {
+    return inner;
+  }
+  return `<span class="n2a-highlight-${color}" style="${style}">${inner}</span>`;
 };
 
 export const renderRichTextItem = (item: NotionRichTextItem): string => {

--- a/src/services/NotionService/NotionColors.ts
+++ b/src/services/NotionService/NotionColors.ts
@@ -29,6 +29,25 @@ export function isNotionColorBackground(color: string) {
   return color.endsWith('_background');
 }
 
+// Notion's background highlight tints differ from its text colours; these
+// mirror the .n2a-highlight-*_background rules in src/templates/notion.css
+// (the bundled Notion export CSS) so inline styles match the legacy path.
+export const NOTION_BACKGROUND_COLORS: Record<string, string> = {
+  gray_background: 'rgb(241, 241, 239)',
+  brown_background: 'rgb(244, 238, 238)',
+  orange_background: 'rgb(251, 236, 221)',
+  yellow_background: 'rgb(251, 243, 219)',
+  green_background: 'rgb(237, 243, 236)',
+  blue_background: 'rgb(231, 243, 248)',
+  purple_background: 'rgba(244, 240, 247, 0.8)',
+  pink_background: 'rgba(249, 238, 243, 0.8)',
+  red_background: 'rgb(253, 235, 236)',
+};
+
+export function notionBackgroundColor(color: string): string | null {
+  return NOTION_BACKGROUND_COLORS[color] ?? null;
+}
+
 export function styleWithColors(color?: string): string {
   if (!color || color === 'default') {
     return '';

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-notion-background-colours.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-notion-background-colours.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-notion-background-colours",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Notion highlight backgrounds now use the right tint, not a solid colour"
+}


### PR DESCRIPTION
## What
Fix Notion **background** highlights so they use Notion's real light tint instead of a solid dark colour.

## Why
The inline-style colour fix (#3351) resolved every colour through `notionColorToHex`. But `NOTION_COLORS` maps each `*_background` name to the **text** hex (`blue_background → #0B6E99`), so a background highlight rendered as a solid dark block (`background-color: #0B6E99`) instead of Notion's light tint. Reported: Notion uses a translucent tint for `blue_background` (the app now shows `rgba(35,131,226,.28)`); our canonical value is the export-CSS tint `rgb(231, 243, 248)`.

**Where the colours live:** `src/templates/notion.css` — the bundled Notion export CSS. Text colours (`.n2a-highlight-blue`, line 636) and background tints (`.n2a-highlight-blue_background`, line 645) are **separate** values there; the bug was collapsing both to one hex.

## How
Add `NOTION_BACKGROUND_COLORS` to `NotionColors.ts`, mirroring the `.n2a-highlight-*_background` rules in notion.css. `wrapWithColorClass` now resolves background variants through it (and emits no style if a variant is unknown). Text colours unchanged.

## Testing
- notion-render + notionPageWalker + NotionColors: 348 pass (blue_background now asserts `rgb(231, 243, 248)`). Root tsc clean.

Browser check: not applicable — server-side render change, no `web/src/` runtime files (changelog only).

## Goal alignment
Colour fidelity for med/law card templates — follow-up correctness fix to #3351 for the heaviest Ankify user.
