### PR TITLE
fix: review any deck in your Anki, not only Notion-synced ones

### DIFF
--- a/src/controllers/AnkifyController.review.test.ts
+++ b/src/controllers/AnkifyController.review.test.ts
@@ -2,10 +2,10 @@ import { Request, Response } from 'express';
 
 import AnkifyController from './AnkifyController';
 import { AnkiConnectUnreachableError } from '../services/ankify/AnkiConnectClient';
-import { DeckNotOwnedError } from '../usecases/ankify/OpenDeckInAnkiUseCase';
 import {
   InvalidReviewEaseError,
   NoActiveAnkifyClientForReviewError,
+  ReviewCardNotFoundError,
 } from '../usecases/ankify/GradeReviewCardUseCase';
 
 interface CapturingResponse {
@@ -91,9 +91,9 @@ describe('AnkifyController review handlers', () => {
     expect(capture.statusCode).toBe(400);
   });
 
-  test('getReviewQueue maps DeckNotOwnedError to 403', async () => {
+  test('getReviewQueue maps AnkiConnectUnreachableError to 503', async () => {
     const execute = jest.fn(async () => {
-      throw new DeckNotOwnedError();
+      throw new AnkiConnectUnreachableError('http://x', new Error('down'));
     });
     const controller = makeController(QUEUE_INDEX, { execute });
     const capture = makeResponse();
@@ -103,7 +103,7 @@ describe('AnkifyController review handlers', () => {
       capture.res
     );
 
-    expect(capture.statusCode).toBe(403);
+    expect(capture.statusCode).toBe(503);
   });
 
   test('gradeReviewCard grades and returns 200', async () => {
@@ -150,9 +150,9 @@ describe('AnkifyController review handlers', () => {
     expect(capture.statusCode).toBe(400);
   });
 
-  test('gradeReviewCard maps DeckNotOwnedError to 403', async () => {
+  test('gradeReviewCard maps ReviewCardNotFoundError to 404', async () => {
     const execute = jest.fn(async () => {
-      throw new DeckNotOwnedError();
+      throw new ReviewCardNotFoundError();
     });
     const controller = makeController(GRADE_INDEX, { execute });
     const capture = makeResponse();
@@ -162,7 +162,7 @@ describe('AnkifyController review handlers', () => {
       capture.res
     );
 
-    expect(capture.statusCode).toBe(403);
+    expect(capture.statusCode).toBe(404);
   });
 
   test('gradeReviewCard maps an offline client to 503', async () => {

--- a/src/controllers/AnkifyController.ts
+++ b/src/controllers/AnkifyController.ts
@@ -82,6 +82,7 @@ import {
   GradeReviewCardUseCase,
   InvalidReviewEaseError,
   NoActiveAnkifyClientForReviewError,
+  ReviewCardNotFoundError,
 } from '../usecases/ankify/GradeReviewCardUseCase';
 
 const ANKI_CONNECT_UNREACHABLE_MESSAGE =
@@ -931,10 +932,6 @@ class AnkifyController {
       const result = await this.getReviewQueueUseCase.execute({ owner, deck });
       res.status(200).json(result);
     } catch (error) {
-      if (error instanceof DeckNotOwnedError) {
-        res.status(403).json({ message: 'Deck not found for this user' });
-        return;
-      }
       if (error instanceof AnkiConnectUnreachableError) {
         res.status(503).json({ message: ANKI_CONNECT_UNREACHABLE_MESSAGE });
         return;
@@ -962,8 +959,8 @@ class AnkifyController {
         res.status(400).json({ message: 'ease must be an integer 1-4' });
         return;
       }
-      if (error instanceof DeckNotOwnedError) {
-        res.status(403).json({ message: 'Card not found for this user' });
+      if (error instanceof ReviewCardNotFoundError) {
+        res.status(404).json({ message: 'Card not found for this user' });
         return;
       }
       if (error instanceof NoActiveAnkifyClientForReviewError) {

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -395,8 +395,8 @@ const AnkifyRouter = () => {
     new EditLeechNoteUseCase(repo, subscriptionsRepo, ankiConnectFactory),
     new DeleteLeechNoteUseCase(repo, subscriptionsRepo, ankiConnectFactory),
     new ReturnLeechToReviewUseCase(repo, subscriptionsRepo, ankiConnectFactory),
-    new GetReviewQueueUseCase(repo, subscriptionsRepo, ankiConnectFactory),
-    new GradeReviewCardUseCase(repo, subscriptionsRepo, ankiConnectFactory)
+    new GetReviewQueueUseCase(repo, ankiConnectFactory),
+    new GradeReviewCardUseCase(repo, ankiConnectFactory)
   );
 
   /**
@@ -987,8 +987,8 @@ const AnkifyRouter = () => {
    * @swagger
    * /api/ankify/review-queue:
    *   get:
-   *     summary: Snapshot the due cards for one of the user's synced decks
-   *     description: "Allowlisted endpoint. Query deck. Returns the due-card snapshot for an owned deck as connected plus an array of { cardId, questionHtml, answerHtml, css }. Always 200 when reachable — returns connected false when no active client exists or AnkiConnect is unreachable. 403 when the deck is not owned."
+   *     summary: Snapshot the due cards for one of the user's Anki decks
+   *     description: "Allowlisted endpoint. Query deck. Returns the due-card snapshot for any deck in the user's own hosted Anki as connected plus an array of { cardId, questionHtml, answerHtml, css }. Always 200 when reachable — returns connected false when no active client exists or AnkiConnect is unreachable."
    *     tags: [Ankify]
    *     parameters:
    *       - in: query
@@ -1001,8 +1001,6 @@ const AnkifyRouter = () => {
    *         description: "Due-card snapshot (connected true|false)"
    *       400:
    *         description: deck is required
-   *       403:
-   *         description: Deck not owned by this user
    */
   router.get('/api/ankify/review-queue', RequireAnkifyAccess, (req, res) =>
     controller.getReviewQueue(req, res)
@@ -1012,8 +1010,8 @@ const AnkifyRouter = () => {
    * @swagger
    * /api/ankify/review-grade:
    *   post:
-   *     summary: Grade one card in an owned deck via AnkiConnect answerCards
-   *     description: "Allowlisted endpoint. Body cardId and ease (1-4). Re-checks the card belongs to one of the caller's owned decks via a cid: query and validates ease before grading. 200 on success, 400 on invalid ease or cardId, 403 when the card is not owned, 503 when AnkiConnect is unreachable."
+   *     summary: Grade one card in the user's Anki via AnkiConnect answerCards
+   *     description: "Allowlisted endpoint. Body cardId and ease (1-4). Validates ease, then probes the card exists in the caller's own hosted Anki via a cid: query before grading. 200 on success, 400 on invalid ease or cardId, 404 when the card does not exist, 503 when AnkiConnect is unreachable."
    *     tags: [Ankify]
    *     requestBody:
    *       required: true
@@ -1033,8 +1031,8 @@ const AnkifyRouter = () => {
    *         description: Card graded
    *       400:
    *         description: Invalid cardId or ease
-   *       403:
-   *         description: Card not owned by this user
+   *       404:
+   *         description: Card not found in the user's Anki
    *       503:
    *         description: AnkiConnect unreachable
    */

--- a/src/usecases/ankify/GetReviewQueueUseCase.test.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.test.ts
@@ -1,8 +1,6 @@
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
-import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
 import { GetReviewQueueUseCase } from './GetReviewQueueUseCase';
-import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
 
 const activeClient = {
   id: 1,
@@ -22,40 +20,52 @@ const clientsRepo = (
     findActiveByOwner: jest.fn(async () => client),
   }) as unknown as AnkifyClientsRepositoryInterface;
 
-const subsRepo = (
-  rows: { target_deck: string | null; notion_page_title: string | null }[]
-): AnkifyNotionSubscriptionsRepositoryInterface =>
-  ({
-    listByOwner: jest.fn(async () => rows),
-  }) as unknown as AnkifyNotionSubscriptionsRepositoryInterface;
-
-const ownedSubs = subsRepo([
-  { target_deck: 'Notion Sync::Pharma', notion_page_title: null },
-]);
-
 describe('GetReviewQueueUseCase', () => {
-  it('rejects a deck the user does not own', async () => {
-    const factory = jest.fn();
+  it('returns due cards for a deck the user never synced from Notion', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const cardsInfo = jest.fn(async () => [
+      {
+        cardId: 9001,
+        note: 5,
+        deckName: 'My Own Deck',
+        lapses: 0,
+        queue: 2,
+        question: '<p>Q1</p>',
+        answer: '<p>A1</p>',
+        css: '.card { color: black; }',
+      },
+    ]);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+        }) as unknown as AnkiConnectClient
+    );
     const useCase = new GetReviewQueueUseCase(
       clientsRepo(activeClient),
-      subsRepo([
-        { target_deck: 'Notion Sync::Torts', notion_page_title: null },
-      ]),
       factory
     );
 
-    await expect(
-      useCase.execute({ owner: 42, deck: 'Notion Sync::Pharma' })
-    ).rejects.toBeInstanceOf(DeckNotOwnedError);
-    expect(factory).not.toHaveBeenCalled();
+    const result = await useCase.execute({ owner: 42, deck: 'My Own Deck' });
+
+    expect(findCards).toHaveBeenCalledWith('"deck:My Own Deck" is:due');
+    expect(result).toEqual({
+      connected: true,
+      cards: [
+        {
+          cardId: 9001,
+          questionHtml: '<p>Q1</p>',
+          answerHtml: '<p>A1</p>',
+          css: '.card { color: black; }',
+        },
+      ],
+    });
   });
 
   it('returns connected:false with no cards when no active client', async () => {
-    const useCase = new GetReviewQueueUseCase(
-      clientsRepo(null),
-      ownedSubs,
-      jest.fn()
-    );
+    const useCase = new GetReviewQueueUseCase(clientsRepo(null), jest.fn());
 
     const result = await useCase.execute({
       owner: 42,
@@ -65,7 +75,7 @@ describe('GetReviewQueueUseCase', () => {
     expect(result).toEqual({ connected: false, cards: [] });
   });
 
-  it('scopes findCards to the escaped owned deck with is:due and maps card info', async () => {
+  it('scopes findCards to the escaped deck with is:due and maps card info', async () => {
     const findCards = jest.fn(async () => [9001, 9002]);
     const cardsInfo = jest.fn(async () => [
       {
@@ -99,7 +109,6 @@ describe('GetReviewQueueUseCase', () => {
     );
     const useCase = new GetReviewQueueUseCase(
       clientsRepo(activeClient),
-      ownedSubs,
       factory
     );
 
@@ -141,7 +150,6 @@ describe('GetReviewQueueUseCase', () => {
     );
     const useCase = new GetReviewQueueUseCase(
       clientsRepo(activeClient),
-      ownedSubs,
       factory
     );
 
@@ -154,7 +162,7 @@ describe('GetReviewQueueUseCase', () => {
     expect(cardsInfo).not.toHaveBeenCalled();
   });
 
-  it('scopes the due query to a :: hierarchy deck', async () => {
+  it('escapes quotes and backslashes in the deck name', async () => {
     const findCards = jest.fn(async () => []);
     const factory = jest.fn(
       () =>
@@ -166,12 +174,11 @@ describe('GetReviewQueueUseCase', () => {
     );
     const useCase = new GetReviewQueueUseCase(
       clientsRepo(activeClient),
-      subsRepo([{ target_deck: 'MS3::Pharma', notion_page_title: null }]),
       factory
     );
 
-    await useCase.execute({ owner: 42, deck: 'MS3::Pharma' });
+    await useCase.execute({ owner: 42, deck: 'Week "18"\\x' });
 
-    expect(findCards).toHaveBeenCalledWith('"deck:MS3::Pharma" is:due');
+    expect(findCards).toHaveBeenCalledWith('"deck:Week \\"18\\"\\\\x" is:due');
   });
 });

--- a/src/usecases/ankify/GetReviewQueueUseCase.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.ts
@@ -1,8 +1,5 @@
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
-import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
-import { userOwnsDeck } from '../../lib/ankify/deckOwnership';
 import { AnkiConnectFactory } from './GetAnkifyStatsUseCase';
-import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
 import { buildDueCardsQuery } from './reviewQueries';
 
 export interface ReviewQueueCard {
@@ -26,16 +23,10 @@ export interface GetReviewQueueInput {
 export class GetReviewQueueUseCase {
   constructor(
     private readonly clients: AnkifyClientsRepositoryInterface,
-    private readonly subscriptions: AnkifyNotionSubscriptionsRepositoryInterface,
     private readonly ankiConnect: AnkiConnectFactory
   ) {}
 
   async execute(input: GetReviewQueueInput): Promise<GetReviewQueueResult> {
-    const owned = await this.subscriptions.listByOwner(input.owner);
-    if (!userOwnsDeck(input.deck, owned)) {
-      throw new DeckNotOwnedError();
-    }
-
     const client = await this.clients.findActiveByOwner(input.owner);
     if (client == null) {
       return { connected: false, cards: [] };

--- a/src/usecases/ankify/GradeReviewCardUseCase.test.ts
+++ b/src/usecases/ankify/GradeReviewCardUseCase.test.ts
@@ -1,12 +1,11 @@
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
-import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
 import {
   GradeReviewCardUseCase,
   InvalidReviewEaseError,
   NoActiveAnkifyClientForReviewError,
+  ReviewCardNotFoundError,
 } from './GradeReviewCardUseCase';
-import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
 
 const activeClient = {
   id: 1,
@@ -26,17 +25,6 @@ const clientsRepo = (
     findActiveByOwner: jest.fn(async () => client),
   }) as unknown as AnkifyClientsRepositoryInterface;
 
-const subsRepo = (
-  rows: { target_deck: string | null; notion_page_title: string | null }[]
-): AnkifyNotionSubscriptionsRepositoryInterface =>
-  ({
-    listByOwner: jest.fn(async () => rows),
-  }) as unknown as AnkifyNotionSubscriptionsRepositoryInterface;
-
-const ownedSubs = subsRepo([
-  { target_deck: 'Notion Sync::Pharma', notion_page_title: null },
-]);
-
 describe('GradeReviewCardUseCase', () => {
   it.each([0, 5, 1.5, '3', NaN])(
     'rejects ease %p with InvalidReviewEaseError and never calls AnkiConnect',
@@ -47,7 +35,6 @@ describe('GradeReviewCardUseCase', () => {
         {
           findActiveByOwner,
         } as unknown as AnkifyClientsRepositoryInterface,
-        ownedSubs,
         factory
       );
 
@@ -63,7 +50,7 @@ describe('GradeReviewCardUseCase', () => {
     }
   );
 
-  it('grades the card after the cid ownership check passes', async () => {
+  it('grades the card after the cid existence probe passes', async () => {
     const findCards = jest.fn(async () => [9001]);
     const answerCards = jest.fn(async () => [true]);
     const factory = jest.fn(
@@ -76,20 +63,18 @@ describe('GradeReviewCardUseCase', () => {
     );
     const useCase = new GradeReviewCardUseCase(
       clientsRepo(activeClient),
-      ownedSubs,
       factory
     );
 
     const result = await useCase.execute({ owner: 42, cardId: 9001, ease: 3 });
 
     expect(result).toEqual({ graded: true });
-    expect(findCards).toHaveBeenCalledWith(
-      'cid:9001 ("deck:Notion Sync::Pharma")'
-    );
+    expect(findCards).toHaveBeenCalledWith('cid:9001');
+    expect(answerCards).toHaveBeenCalledTimes(1);
     expect(answerCards).toHaveBeenCalledWith([{ cardId: 9001, ease: 3 }]);
   });
 
-  it('rejects a forged cardId not in an owned deck and never grades', async () => {
+  it('rejects a cardId that does not exist and never grades', async () => {
     const findCards = jest.fn(async () => []);
     const answerCards = jest.fn(async () => [true]);
     const factory = jest.fn(
@@ -102,54 +87,21 @@ describe('GradeReviewCardUseCase', () => {
     );
     const useCase = new GradeReviewCardUseCase(
       clientsRepo(activeClient),
-      ownedSubs,
       factory
     );
 
     await expect(
       useCase.execute({ owner: 42, cardId: 1234567, ease: 4 })
-    ).rejects.toBeInstanceOf(DeckNotOwnedError);
+    ).rejects.toBeInstanceOf(ReviewCardNotFoundError);
+    expect(findCards).toHaveBeenCalledWith('cid:1234567');
     expect(answerCards).not.toHaveBeenCalled();
   });
 
   it('throws when there is no active client (offline)', async () => {
-    const useCase = new GradeReviewCardUseCase(
-      clientsRepo(null),
-      ownedSubs,
-      jest.fn()
-    );
+    const useCase = new GradeReviewCardUseCase(clientsRepo(null), jest.fn());
 
     await expect(
       useCase.execute({ owner: 42, cardId: 9001, ease: 3 })
     ).rejects.toBeInstanceOf(NoActiveAnkifyClientForReviewError);
-  });
-
-  it('builds a cid: ownership query scoped to the owned :: hierarchy', async () => {
-    const findCards = jest.fn(async () => [9001]);
-    const answerCards = jest.fn(async () => [true]);
-    const factory = jest.fn(
-      () =>
-        ({
-          ping: jest.fn(async () => 6),
-          findCards,
-          answerCards,
-        }) as unknown as AnkiConnectClient
-    );
-    const useCase = new GradeReviewCardUseCase(
-      clientsRepo(activeClient),
-      subsRepo([
-        {
-          target_deck: 'MS3::Pharma::Sub',
-          notion_page_title: null,
-        },
-      ]),
-      factory
-    );
-
-    await useCase.execute({ owner: 42, cardId: 9001, ease: 2 });
-
-    expect(findCards).toHaveBeenCalledWith(
-      'cid:9001 ("deck:MS3::Pharma::Sub")'
-    );
   });
 });

--- a/src/usecases/ankify/GradeReviewCardUseCase.ts
+++ b/src/usecases/ankify/GradeReviewCardUseCase.ts
@@ -1,9 +1,6 @@
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
-import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
-import { ownedDeckNames } from '../../lib/ankify/deckOwnership';
 import { AnkiConnectFactory } from './GetAnkifyStatsUseCase';
-import { DeckNotOwnedError } from './OpenDeckInAnkiUseCase';
-import { buildCardOwnershipQuery } from './reviewQueries';
+import { buildCardExistsQuery } from './reviewQueries';
 
 export class InvalidReviewEaseError extends Error {
   constructor() {
@@ -16,6 +13,13 @@ export class NoActiveAnkifyClientForReviewError extends Error {
   constructor() {
     super('No active Ankify client');
     this.name = 'NoActiveAnkifyClientForReviewError';
+  }
+}
+
+export class ReviewCardNotFoundError extends Error {
+  constructor() {
+    super('Card not found in the requesting user Anki');
+    this.name = 'ReviewCardNotFoundError';
   }
 }
 
@@ -36,7 +40,6 @@ const isValidEase = (ease: number): boolean =>
 export class GradeReviewCardUseCase {
   constructor(
     private readonly clients: AnkifyClientsRepositoryInterface,
-    private readonly subscriptions: AnkifyNotionSubscriptionsRepositoryInterface,
     private readonly ankiConnect: AnkiConnectFactory
   ) {}
 
@@ -50,12 +53,6 @@ export class GradeReviewCardUseCase {
       throw new NoActiveAnkifyClientForReviewError();
     }
 
-    const owned = await this.subscriptions.listByOwner(input.owner);
-    const query = buildCardOwnershipQuery(input.cardId, ownedDeckNames(owned));
-    if (query == null) {
-      throw new DeckNotOwnedError();
-    }
-
     const ac = this.ankiConnect(
       input.ankiConnectHost ?? 'localhost',
       client.anki_port,
@@ -64,9 +61,9 @@ export class GradeReviewCardUseCase {
 
     await ac.ping();
 
-    const matches = await ac.findCards(query);
+    const matches = await ac.findCards(buildCardExistsQuery(input.cardId));
     if (!matches.includes(input.cardId)) {
-      throw new DeckNotOwnedError();
+      throw new ReviewCardNotFoundError();
     }
 
     await ac.answerCards([{ cardId: input.cardId, ease: input.ease }]);

--- a/src/usecases/ankify/reviewQueries.test.ts
+++ b/src/usecases/ankify/reviewQueries.test.ts
@@ -1,4 +1,4 @@
-import { buildCardOwnershipQuery, buildDueCardsQuery } from './reviewQueries';
+import { buildCardExistsQuery, buildDueCardsQuery } from './reviewQueries';
 
 describe('reviewQueries', () => {
   describe('buildDueCardsQuery', () => {
@@ -21,32 +21,9 @@ describe('reviewQueries', () => {
     });
   });
 
-  describe('buildCardOwnershipQuery', () => {
-    it('constrains a card id to a single owned deck with cid:', () => {
-      expect(buildCardOwnershipQuery(9001, ['Notion Sync::Pharma'])).toBe(
-        'cid:9001 ("deck:Notion Sync::Pharma")'
-      );
-    });
-
-    it('ORs multiple owned decks', () => {
-      expect(
-        buildCardOwnershipQuery(9001, [
-          'Notion Sync::Pharma',
-          'Notion Sync::Torts',
-        ])
-      ).toBe(
-        'cid:9001 ("deck:Notion Sync::Pharma" OR "deck:Notion Sync::Torts")'
-      );
-    });
-
-    it('escapes quotes and backslashes', () => {
-      expect(buildCardOwnershipQuery(42, ['Week "18"\\x'])).toBe(
-        'cid:42 ("deck:Week \\"18\\"\\\\x")'
-      );
-    });
-
-    it('returns null when there are no owned decks', () => {
-      expect(buildCardOwnershipQuery(9001, [])).toBeNull();
+  describe('buildCardExistsQuery', () => {
+    it('matches a single card id with cid:', () => {
+      expect(buildCardExistsQuery(9001)).toBe('cid:9001');
     });
   });
 });

--- a/src/usecases/ankify/reviewQueries.ts
+++ b/src/usecases/ankify/reviewQueries.ts
@@ -1,24 +1,6 @@
 import { escapeDeckQueryValue } from './leechQueries';
 
-const buildDeckScope = (ownedDeckNames: string[]): string | null => {
-  if (ownedDeckNames.length === 0) {
-    return null;
-  }
-  return ownedDeckNames
-    .map((deck) => `"deck:${escapeDeckQueryValue(deck)}"`)
-    .join(' OR ');
-};
-
 export const buildDueCardsQuery = (deck: string): string =>
   `"deck:${escapeDeckQueryValue(deck)}" is:due`;
 
-export const buildCardOwnershipQuery = (
-  cardId: number,
-  ownedDeckNames: string[]
-): string | null => {
-  const scope = buildDeckScope(ownedDeckNames);
-  if (scope == null) {
-    return null;
-  }
-  return `cid:${cardId} (${scope})`;
-};
+export const buildCardExistsQuery = (cardId: number): string => `cid:${cardId}`;

--- a/web/src/lib/backend/Backend.ts
+++ b/web/src/lib/backend/Backend.ts
@@ -64,10 +64,10 @@ export interface ReviewQueueCard {
   css: string;
 }
 
-export interface ReviewQueue {
-  connected: boolean;
-  cards: ReviewQueueCard[];
-}
+export type ReviewQueue =
+  | { connected: true; cards: ReviewQueueCard[] }
+  | { connected: false; reason: 'offline' }
+  | { connected: false; reason: 'error' };
 
 export interface CheckoutPrices {
   cohort: 'legacy' | 'v2';
@@ -991,14 +991,22 @@ export class Backend {
   }
 
   async getAnkifyReviewQueue(deck: string): Promise<ReviewQueue> {
-    const result = await get(
-      `${this.baseURL}ankify/review-queue?deck=${encodeURIComponent(deck)}`,
-      { redirect: false }
-    );
-    if (result?.connected === true && Array.isArray(result.cards)) {
-      return { connected: true, cards: result.cards };
+    try {
+      const result = await get(
+        `${this.baseURL}ankify/review-queue?deck=${encodeURIComponent(deck)}`,
+        { redirect: false }
+      );
+      if (result?.connected === true && Array.isArray(result.cards)) {
+        return { connected: true, cards: result.cards };
+      }
+      return { connected: false, reason: 'offline' };
+    } catch (cause) {
+      const status = (cause as { status?: number }).status;
+      if (status === 503 || status === 0) {
+        return { connected: false, reason: 'offline' };
+      }
+      return { connected: false, reason: 'error' };
     }
-    return { connected: false, cards: [] };
   }
 
   async gradeAnkifyReviewCard(cardId: number, ease: number): Promise<void> {

--- a/web/src/lib/backend/getAnkifyReviewQueue.test.ts
+++ b/web/src/lib/backend/getAnkifyReviewQueue.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Backend } from './Backend';
+
+const fetchSpy = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchSpy);
+  vi.stubGlobal('location', { origin: 'http://localhost', pathname: '/' });
+  fetchSpy.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Backend.getAnkifyReviewQueue', () => {
+  it('returns connected with the cards on 200', async () => {
+    const cards = [
+      {
+        cardId: 9001,
+        questionHtml: '<p>Q</p>',
+        answerHtml: '<p>A</p>',
+        css: '',
+      },
+    ];
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ connected: true, cards }), { status: 200 })
+    );
+
+    const result = await new Backend().getAnkifyReviewQueue('My Deck');
+
+    expect(result).toEqual({ connected: true, cards });
+  });
+
+  it('returns connected with an empty array on 200 with no due cards', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ connected: true, cards: [] }), {
+        status: 200,
+      })
+    );
+
+    const result = await new Backend().getAnkifyReviewQueue('My Deck');
+
+    expect(result).toEqual({ connected: true, cards: [] });
+  });
+
+  it('maps a 503 to the offline reason', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'AnkiConnect is unreachable.' }), {
+        status: 503,
+      })
+    );
+
+    const result = await new Backend().getAnkifyReviewQueue('My Deck');
+
+    expect(result).toEqual({ connected: false, reason: 'offline' });
+  });
+
+  it('maps a network error to the offline reason', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('Failed to fetch'));
+
+    const result = await new Backend().getAnkifyReviewQueue('My Deck');
+
+    expect(result).toEqual({ connected: false, reason: 'offline' });
+  });
+
+  it('maps any other non-200 to the error reason', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'boom' }), { status: 500 })
+    );
+
+    const result = await new Backend().getAnkifyReviewQueue('My Deck');
+
+    expect(result).toEqual({ connected: false, reason: 'error' });
+  });
+});

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -117,7 +117,69 @@ describe('ReviewPanel', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
 
-    expect(await screen.findByText('All caught up.')).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        'All caught up. No cards due across your decks right now.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  test('shows the offline state with Try again when the queue reports offline', async () => {
+    const getAnkifyReviewQueue = vi.fn(async () => ({
+      connected: false as const,
+      reason: 'offline' as const,
+    }));
+    renderPanel(makeBackend({ getAnkifyReviewQueue }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+
+    expect(
+      await screen.findByText(
+        "Anki isn't connected. Open Anki on your computer and try again."
+      )
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    await waitFor(() => expect(getAnkifyReviewQueue).toHaveBeenCalledTimes(2));
+  });
+
+  test('shows the error state with Try again when the queue reports error', async () => {
+    const getAnkifyReviewQueue = vi.fn(async () => ({
+      connected: false as const,
+      reason: 'error' as const,
+    }));
+    renderPanel(makeBackend({ getAnkifyReviewQueue }));
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+
+    expect(
+      await screen.findByText(
+        'Something broke while loading this deck. Try again in a moment.'
+      )
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    await waitFor(() => expect(getAnkifyReviewQueue).toHaveBeenCalledTimes(2));
+  });
+
+  test('shows the empty-decks state when stats has no decks', async () => {
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () => ({
+          connected: true as const,
+          reviewedToday: 0,
+          reviewedThisYear: 0,
+          currentStreak: 0,
+          longestStreak: 0,
+          reviewsByDay: [],
+          decks: [],
+        })),
+      })
+    );
+
+    expect(
+      await screen.findByText(
+        'No decks to review yet. Sync a Notion page to start building cards.'
+      )
+    ).toBeInTheDocument();
   });
 
   test('disables the Review button for a deck with no due cards', async () => {

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -289,7 +289,10 @@ export default function ReviewPanel({ backend }: Props) {
     queryFn: () =>
       stage.kind === 'reviewing'
         ? api.getAnkifyReviewQueue(stage.deck)
-        : Promise.resolve({ connected: false, cards: [] }),
+        : Promise.resolve({
+            connected: false as const,
+            reason: 'offline' as const,
+          }),
     enabled: stage.kind === 'reviewing',
   });
 
@@ -318,27 +321,58 @@ export default function ReviewPanel({ backend }: Props) {
     );
   }
 
+  const retry = (
+    <div className={reviewStyles.summaryActions}>
+      <button
+        type="button"
+        className={sharedStyles.btnGhost}
+        onClick={() => queue.refetch()}
+      >
+        Try again
+      </button>
+    </div>
+  );
+
   if (stage.kind === 'reviewing') {
     if (queue.isLoading) {
       return panel(<p className={styles.emptyLine}>Loading your cards.</p>);
     }
-    if (queue.data?.connected !== true) {
+    if (queue.data?.connected === true) {
+      if (queue.data.cards.length === 0) {
+        return panel(
+          <p className={styles.emptyLine}>
+            All caught up. No cards due across your decks right now.
+          </p>
+        );
+      }
       return panel(
-        <p className={styles.emptyLine}>Anki isn&apos;t connected.</p>
+        <Reviewer
+          cards={queue.data.cards}
+          deckName={stage.deck}
+          onGrade={grade}
+          onDone={(graded) =>
+            setStage({ kind: 'summary', deck: stage.deck, graded })
+          }
+        />
       );
     }
-    if (queue.data.cards.length === 0) {
-      return panel(<p className={styles.emptyLine}>All caught up.</p>);
+    if (queue.data?.reason === 'error') {
+      return panel(
+        <>
+          <p className={styles.emptyLine}>
+            Something broke while loading this deck. Try again in a moment.
+          </p>
+          {retry}
+        </>
+      );
     }
     return panel(
-      <Reviewer
-        cards={queue.data.cards}
-        deckName={stage.deck}
-        onGrade={grade}
-        onDone={(graded) =>
-          setStage({ kind: 'summary', deck: stage.deck, graded })
-        }
-      />
+      <>
+        <p className={styles.emptyLine}>
+          Anki isn&apos;t connected. Open Anki on your computer and try again.
+        </p>
+        {retry}
+      </>
     );
   }
 
@@ -351,7 +385,11 @@ export default function ReviewPanel({ backend }: Props) {
     );
   }
   if (stats.data.decks.length === 0) {
-    return panel(<p className={styles.emptyLine}>All caught up.</p>);
+    return panel(
+      <p className={styles.emptyLine}>
+        No decks to review yet. Sync a Notion page to start building cards.
+      </p>
+    );
   }
 
   return panel(

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-any-deck.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-any-deck.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review-any-deck",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Review any deck in your Anki from the Review tab, not only Notion-synced ones"
+}


### PR DESCRIPTION
## What
Fixes the Review tab showing **"Anki isn't connected"** when a user with Anki running clicks Review on their own deck. Two causes:
1. The deck picker lists every deck in the user's Anki, but the review-queue endpoint rejected any deck not synced from Notion (`userOwnsDeck`) with a 403.
2. The frontend collapsed **every** non-200 (403/503/network) into `{connected:false}` → rendered as the offline message. A 403 looked identical to a real disconnect.

## Why
The AnkiConnect client is strictly per-user (`clients.findActiveByOwner(owner)`) — a user can only ever reach their own container/collection. So the subscription-ownership gate added **zero cross-user security**; it only blocked a paying user from reviewing their own decks (and broke whenever the synced deck's real Anki name didn't match `buildDeckName`). That's pure surprise on the highest-ARPU Auto-Sync cohort — a direct churn risk on the surface meant to drive retention.

## How (trio decision: drop the gate, fix the masking)
- **`GetReviewQueueUseCase`**: removed the `userOwnsDeck`/subscriptions gate. Reviews any deck in the user's own Anki. Deck name still escaped via `escapeDeckQueryValue` (AnkiConnect query-injection guard kept).
- **`GradeReviewCardUseCase`**: ease 1–4 validation unchanged (first, fail-closed). Replaced the owned-deck `cid:` check with an existence probe (`findCards("cid:<id>")`, integer-only) — still bounds against a stale/garbage cardId before `answerCards`, scoped to the user's own container. Missing card → 404 (`ReviewCardNotFoundError`).
- **Frontend**: `getAnkifyReviewQueue` now returns a discriminated result (`offline` vs `error` vs connected); `ReviewPanel` shows distinct copy + a `Try again` button instead of one collapsed "not connected."

## Security
Net effect is removing a check that protected nothing (per-user container isolation is the real boundary). Kept: per-user client resolution, deck-name escaping, fail-closed ease validation, and a cid: existence probe before any write. No cross-user surface introduced. Trio engineer confirmed A/B/C with file:line.

## Error-state copy (designer)
- Offline: `Anki isn't connected. Open Anki on your computer and try again.` + Try again
- Error: `Something broke while loading this deck. Try again in a moment.` + Try again
- All caught up: `All caught up. No cards due across your decks right now.`
- No decks: `No decks to review yet. Sync a Notion page to start building cards.`

## Testing
- Server: 26 passed (review-queue now returns cards for a non-synced deck; grade existence-probe 404 + answerCards-not-called; ease validation; offline 503; escaping).
- Web: 89 passed incl. new `getAnkifyReviewQueue` status-mapping test + ReviewPanel offline/error/Try-again branches.
- Server tsc + web typecheck + web lint: clean.

## Risks
A user can now review decks they built in Anki directly, not only Notion-synced ones — intended per trio (PM). Grade still cannot touch anything outside the caller's own container.

## Goal alignment
Retention — unblocks the Review surface for the paid Auto-Sync/lifetime cohort. Reads at the Review T+30d adoption issue (#3357).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: pick any deck with due cards → should load + grade. Kill AnkiConnect → should show the offline copy with Try again, not a blank.

## Sonar
sonar-scanner not run locally (no token) — SonarCloud Automatic Analysis runs on the PR.
