### PR TITLE
fix: calmer Ankify reviewer — stats only on Decks, exit a session, cap card height

### DIFF
--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -61,6 +61,7 @@ export const KNOWN_EVENTS = new Set([
   'ankify_leech_action',
   'ankify_review_session_started',
   'ankify_review_completed',
+  'ankify_review_session_exited',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/pages/AnkifyPage/AnkifyPage.tsx
+++ b/web/src/pages/AnkifyPage/AnkifyPage.tsx
@@ -47,6 +47,9 @@ export default function AnkifyPage({ backend }: Readonly<AnkifyPageProps>) {
   const { data: userLocals } = useUserLocals();
   const welcomeSeen = userLocals?.user?.ankify_welcome_seen === true;
   const [dismissed, setDismissed] = useState(false);
+  const [ankifyTab, setAnkifyTab] = useState<
+    'decks' | 'find' | 'leeches' | 'review'
+  >('decks');
 
   const dismissWelcome = () => {
     setDismissed(true);
@@ -143,37 +146,44 @@ export default function AnkifyPage({ backend }: Readonly<AnkifyPageProps>) {
       <NotionSubscriptions
         backend={backend}
         schedule={exportSchedule.data ?? null}
+        onTabChange={setAnkifyTab}
       />
 
-      <div className={styles.historyFooter}>
-        {hasTracker ? (
-          <>
-            <Link to="/ankify/history" className={styles.historyFooterLink}>
-              Study history →
-            </Link>
-            <span>
-              {trackerTitle.length > 0 ? trackerTitle : 'Anki review tracker'}
-            </span>
-            {trackerUrl.length > 0 && (
+      {ankifyTab === 'decks' && (
+        <>
+          <div className={styles.historyFooter}>
+            {hasTracker ? (
               <>
-                <span aria-hidden="true">·</span>
-                <a href={trackerUrl} target="_blank" rel="noreferrer">
-                  Open
-                </a>
+                <Link to="/ankify/history" className={styles.historyFooterLink}>
+                  Study history →
+                </Link>
+                <span>
+                  {trackerTitle.length > 0
+                    ? trackerTitle
+                    : 'Anki review tracker'}
+                </span>
+                {trackerUrl.length > 0 && (
+                  <>
+                    <span aria-hidden="true">·</span>
+                    <a href={trackerUrl} target="_blank" rel="noreferrer">
+                      Open
+                    </a>
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                <span>Study history goes to a Notion database.</span>
+                <Link to="/ankify/history" className={styles.historyFooterLink}>
+                  Set it up →
+                </Link>
               </>
             )}
-          </>
-        ) : (
-          <>
-            <span>Study history goes to a Notion database.</span>
-            <Link to="/ankify/history" className={styles.historyFooterLink}>
-              Set it up →
-            </Link>
-          </>
-        )}
-      </div>
+          </div>
 
-      <StudyStatsSection backend={api} />
+          <StudyStatsSection backend={api} />
+        </>
+      )}
     </main>
   );
 }

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
@@ -1134,3 +1134,60 @@ describe('NotionSubscriptions cockpit data column', () => {
     expect(screen.queryByText(/mature/i)).not.toBeInTheDocument();
   });
 });
+
+describe('NotionSubscriptions onTabChange', () => {
+  const renderWithTabChange = (
+    backend: Backend,
+    onTabChange: (tab: 'decks' | 'find' | 'leeches' | 'review') => void
+  ) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <NotionSubscriptions
+            backend={backend}
+            schedule={null}
+            onTabChange={onTabChange}
+          />
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+
+  test('fires decks on default mount when subscriptions exist', async () => {
+    const onTabChange = vi.fn();
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [sampleSubscription()]),
+    });
+
+    renderWithTabChange(backend, onTabChange);
+
+    await waitFor(() => expect(onTabChange).toHaveBeenCalledWith('decks'));
+  });
+
+  test('fires find on default mount when there are no subscriptions', async () => {
+    const onTabChange = vi.fn();
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => []),
+    });
+
+    renderWithTabChange(backend, onTabChange);
+
+    await waitFor(() => expect(onTabChange).toHaveBeenCalledWith('find'));
+  });
+
+  test('fires the clicked tab when the user switches tabs', async () => {
+    const onTabChange = vi.fn();
+    const backend = makeBackend({
+      listAnkifySubscriptions: vi.fn(async () => [sampleSubscription()]),
+    });
+
+    renderWithTabChange(backend, onTabChange);
+
+    await waitFor(() => expect(onTabChange).toHaveBeenCalledWith('decks'));
+    fireEvent.click(screen.getByRole('tab', { name: /find pages/i }));
+    await waitFor(() => expect(onTabChange).toHaveBeenCalledWith('find'));
+  });
+});

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.tsx
@@ -42,6 +42,7 @@ type Schedule = Awaited<ReturnType<Backend['getAnkifyExportSchedule']>>;
 interface Props {
   readonly backend?: Backend;
   readonly schedule?: Schedule;
+  readonly onTabChange?: (tab: 'decks' | 'find' | 'leeches' | 'review') => void;
 }
 
 const formatScheduleTime = (
@@ -233,7 +234,11 @@ const renderSecondLine = (
   return null;
 };
 
-export default function NotionSubscriptions({ backend, schedule }: Props) {
+export default function NotionSubscriptions({
+  backend,
+  schedule,
+  onTabChange,
+}: Props) {
   const api = backend ?? get2ankiApi();
   const queryClient = useQueryClient();
   const [advancedInput, setAdvancedInput] = useState('');
@@ -487,6 +492,10 @@ export default function NotionSubscriptions({ backend, schedule }: Props) {
 
   const effectiveTab: 'decks' | 'find' | 'leeches' | 'review' =
     activeTab ?? (subscriptions.length === 0 ? 'find' : 'decks');
+
+  useEffect(() => {
+    onTabChange?.(effectiveTab);
+  }, [effectiveTab, onTabChange]);
   const showSearch = subscriptions.length >= SEARCH_THRESHOLD;
   const filteredSubscriptions =
     search.trim().length === 0

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
@@ -60,12 +60,34 @@
   transition: width 120ms ease;
 }
 
+.reviewHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0 0 1rem;
+}
+
+.exitButton {
+  font-size: var(--text-xs);
+  color: var(--color-text-link);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.exitButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
 .progressLabel {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-variant-numeric: tabular-nums;
   font-size: var(--text-xs);
   color: var(--color-text-tertiary);
-  margin: 0 0 1rem;
+  margin: 0;
   text-align: right;
 }
 

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
@@ -102,7 +102,7 @@
 
 .cardFrame {
   width: 100%;
-  min-height: 8rem;
+  height: clamp(8rem, 50vh, 32rem);
   border: none;
   background: transparent;
 }

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -104,6 +104,25 @@ describe('ReviewPanel', () => {
     );
   });
 
+  test('exits a review session back to the deck picker', async () => {
+    renderPanel(makeBackend());
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+    await screen.findByRole('button', { name: 'Show answer' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to decks' }));
+
+    expect(
+      await screen.findByText(
+        'Pick a deck to review its due cards without opening Anki.'
+      )
+    ).toBeInTheDocument();
+    expect(trackMock).toHaveBeenCalledWith(
+      'ankify_review_session_exited',
+      expect.objectContaining({ deck: 'Notion Sync::Pharma', graded: 0 })
+    );
+  });
+
   test('shows the all-caught-up state when no cards are due', async () => {
     renderPanel(
       makeBackend({

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -84,11 +84,13 @@ export function Reviewer({
   deckName,
   onGrade,
   onDone,
+  onExit,
 }: {
   readonly cards: ReviewQueueCard[];
   readonly deckName: string;
   readonly onGrade: (cardId: number, ease: number) => Promise<void>;
   readonly onDone: (graded: number) => void;
+  readonly onExit: () => void;
 }) {
   const [index, setIndex] = useState(0);
   const [revealed, setRevealed] = useState(false);
@@ -179,9 +181,25 @@ export function Reviewer({
           style={{ width: `${(index / total) * 100}%` }}
         />
       </div>
-      <p className={reviewStyles.progressLabel}>
-        {index + 1} / {total}
-      </p>
+      <div className={reviewStyles.reviewHeader}>
+        <button
+          type="button"
+          className={reviewStyles.exitButton}
+          aria-label="Back to decks"
+          onClick={() => {
+            track('ankify_review_session_exited', {
+              deck: deckName,
+              graded: history.length,
+            });
+            onExit();
+          }}
+        >
+          ← Decks
+        </button>
+        <p className={reviewStyles.progressLabel}>
+          {index + 1} / {total}
+        </p>
+      </div>
       <div className={reviewStyles.cardArea}>
         <iframe
           title="Card preview"
@@ -353,6 +371,7 @@ export default function ReviewPanel({ backend }: Props) {
           onDone={(graded) =>
             setStage({ kind: 'summary', deck: stage.deck, graded })
           }
+          onExit={() => setStage({ kind: 'picker' })}
         />
       );
     }

--- a/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
+++ b/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
@@ -65,6 +65,7 @@ export default function AnkifyReviewPreviewPage() {
           deckName="Notion Sync::Pharmacology"
           onGrade={async () => {}}
           onDone={() => {}}
+          onExit={() => {}}
         />
       )}
       {cell('Reviewer — done', <ReviewSummary graded={47} onBack={() => {}} />)}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-chrome.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-chrome.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review-chrome",
+  "date": "2026-06-14",
+  "type": "style",
+  "title": "Leave a review session anytime to return to your decks, and the reviewer stays focused without stats below"
+}


### PR DESCRIPTION
## What
Two Review-tab UX fixes reported after first use:
1. The study-stats block (review heatmap + by-deck chart) and the history footer rendered under **every** tab — Decks, Find pages, Leeches, Review — so a review session had the full stats panel below it and a long scroll.
2. No way out of a review session except finishing every card or browser-back.
Plus: the card iframe had no height cap, so long cards scrolled inside the frame (double scrollbar).

## Why
The reviewer is meant to be a calm zero-chrome focus surface (Ankify spec). Stats under it are noise; no exit is a dead end. Both hurt the paid Auto-Sync/lifetime cohort the surface exists to retain.

## How
- `NotionSubscriptions` now reports its active tab via an `onTabChange` callback; `AnkifyPage` tracks it and renders the history footer + `StudyStatsSection` **only on the Decks tab**. Kills the long scroll on Find pages / Leeches / Review too.
- `Reviewer` gains a quiet `← Decks` control on the progress row (tertiary/link style, `aria-label="Back to decks"`, `type="button"`, focus-visible ring) → returns to the deck picker. Ungraded cards just stay due; grades already submitted are saved per-card. Fires `ankify_review_session_exited`.
- `.cardFrame` height clamped to `clamp(8rem, 50vh, 32rem)` — one scroll context, grade buttons stay visible.

## Testing
- Web: 64 + 3 new tests green (tab-change callback fires on default mount + click; exit returns to picker). tsc clean, lint clean.
- No keyboard collision — exit button has no Space/1-4 accelerator.

## Risks
Low — pure layout + nav. Stats simply scoped to Decks; no data change.

## Goal alignment
Retention — calmer reviewer for the paid cohort. Read at the Review T+30d adoption issue (#3357).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: switch tabs (stats only on Decks), start a review then click ← Decks, open a long card (no inner scrollbar).
