### PR TITLE
fix: render card images and audio in the Ankify web reviewer

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -421,6 +421,28 @@ describe('AnkiConnectClient', () => {
     });
   });
 
+  test('retrieveMediaFile posts the filename and returns the base64 string', async () => {
+    const fetchImpl = makeFetch({ result: 'UEFTREFUQQ==', error: null });
+    const client = new AnkiConnectClient('http://x', fetchImpl);
+
+    const data = await client.retrieveMediaFile('foo.jpg');
+
+    expect(data).toBe('UEFTREFUQQ==');
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'retrieveMediaFile',
+      version: 6,
+      params: { filename: 'foo.jpg' },
+    });
+  });
+
+  test('retrieveMediaFile returns false when the file is missing', async () => {
+    const fetchImpl = makeFetch({ result: false, error: null });
+    const client = new AnkiConnectClient('http://x', fetchImpl);
+
+    expect(await client.retrieveMediaFile('missing.png')).toBe(false);
+  });
+
   test('throws AnkiConnectUnreachableError when fetch rejects', async () => {
     const fetchImpl = jest.fn(async () => {
       throw new Error('connect ECONNREFUSED');

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -245,6 +245,10 @@ export class AnkiConnectClient {
     return this.invoke('cardsInfo', { cards });
   }
 
+  async retrieveMediaFile(filename: string): Promise<string | false> {
+    return this.invoke('retrieveMediaFile', { filename });
+  }
+
   async answerCards(
     answers: { cardId: number; ease: number }[]
   ): Promise<boolean[]> {

--- a/src/usecases/ankify/GetReviewQueueUseCase.test.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.test.ts
@@ -2,6 +2,8 @@ import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/Ankify
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
 import { GetReviewQueueUseCase } from './GetReviewQueueUseCase';
 
+const REVIEW_MEDIA_CSS_MARKER = '.n2a-review-missing{';
+
 const activeClient = {
   id: 1,
   owner: 42,
@@ -51,17 +53,15 @@ describe('GetReviewQueueUseCase', () => {
     const result = await useCase.execute({ owner: 42, deck: 'My Own Deck' });
 
     expect(findCards).toHaveBeenCalledWith('"deck:My Own Deck" is:due');
-    expect(result).toEqual({
-      connected: true,
-      cards: [
-        {
-          cardId: 9001,
-          questionHtml: '<p>Q1</p>',
-          answerHtml: '<p>A1</p>',
-          css: '.card { color: black; }',
-        },
-      ],
+    expect(result.connected).toBe(true);
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0]).toMatchObject({
+      cardId: 9001,
+      questionHtml: '<p>Q1</p>',
+      answerHtml: '<p>A1</p>',
     });
+    expect(result.cards[0].css).toContain('.card { color: black; }');
+    expect(result.cards[0].css).toContain(REVIEW_MEDIA_CSS_MARKER);
   });
 
   it('returns connected:false with no cards when no active client', async () => {
@@ -118,23 +118,19 @@ describe('GetReviewQueueUseCase', () => {
     });
 
     expect(findCards).toHaveBeenCalledWith('"deck:Notion Sync::Pharma" is:due');
-    expect(result).toEqual({
-      connected: true,
-      cards: [
-        {
-          cardId: 9001,
-          questionHtml: '<p>Q1</p>',
-          answerHtml: '<p>A1</p>',
-          css: '.card { color: black; }',
-        },
-        {
-          cardId: 9002,
-          questionHtml: '<p>Q2</p>',
-          answerHtml: '<p>A2</p>',
-          css: '.card { color: black; }',
-        },
-      ],
+    expect(result.connected).toBe(true);
+    expect(result.cards).toHaveLength(2);
+    expect(result.cards[0]).toMatchObject({
+      cardId: 9001,
+      questionHtml: '<p>Q1</p>',
+      answerHtml: '<p>A1</p>',
     });
+    expect(result.cards[1]).toMatchObject({
+      cardId: 9002,
+      questionHtml: '<p>Q2</p>',
+      answerHtml: '<p>A2</p>',
+    });
+    expect(result.cards[0].css).toContain(REVIEW_MEDIA_CSS_MARKER);
   });
 
   it('returns an empty queue when no cards are due', async () => {
@@ -180,5 +176,121 @@ describe('GetReviewQueueUseCase', () => {
     await useCase.execute({ owner: 42, deck: 'Week "18"\\x' });
 
     expect(findCards).toHaveBeenCalledWith('"deck:Week \\"18\\"\\\\x" is:due');
+  });
+
+  it('inlines image and audio media as data URIs and strips raw tokens', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const cardsInfo = jest.fn(async () => [
+      {
+        cardId: 9001,
+        note: 5,
+        deckName: 'Notion Sync::JP',
+        lapses: 0,
+        queue: 2,
+        question: '<img src="a.jpg">[anki:play:q:0]',
+        answer: '[sound:b.mp3][anki:play:a:0]',
+        css: '.card {}',
+      },
+    ]);
+    const retrieveMediaFile = jest.fn(async () =>
+      Buffer.from('BYTES', 'utf-8').toString('base64')
+    );
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+          retrieveMediaFile,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      factory
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      deck: 'Notion Sync::JP',
+    });
+
+    expect(result.cards[0].questionHtml).toContain('data:image/jpeg;base64,');
+    expect(result.cards[0].answerHtml).toContain('<audio');
+    expect(result.cards[0].answerHtml).toContain('data:audio/mpeg;base64,');
+    expect(result.cards[0].questionHtml).not.toContain('[anki:play:');
+    expect(result.cards[0].answerHtml).not.toContain('[sound:');
+    expect(result.cards[0].answerHtml).not.toContain('[anki:play:');
+  });
+
+  it('fetches a media file shared across front and back only once', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const cardsInfo = jest.fn(async () => [
+      {
+        cardId: 9001,
+        note: 5,
+        deckName: 'Notion Sync::JP',
+        lapses: 0,
+        queue: 2,
+        question: '<img src="shared.png">',
+        answer: '<img src="shared.png">',
+        css: '',
+      },
+    ]);
+    const retrieveMediaFile = jest.fn(async () =>
+      Buffer.from('BYTES', 'utf-8').toString('base64')
+    );
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+          retrieveMediaFile,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      factory
+    );
+
+    await useCase.execute({ owner: 42, deck: 'Notion Sync::JP' });
+
+    expect(retrieveMediaFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a missing chip when the media file is not in Anki', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const cardsInfo = jest.fn(async () => [
+      {
+        cardId: 9001,
+        note: 5,
+        deckName: 'Notion Sync::JP',
+        lapses: 0,
+        queue: 2,
+        question: '<img src="gone.png">',
+        answer: '<p>A</p>',
+        css: '',
+      },
+    ]);
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+          retrieveMediaFile: jest.fn(async () => false),
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      factory
+    );
+
+    const result = await useCase.execute({
+      owner: 42,
+      deck: 'Notion Sync::JP',
+    });
+
+    expect(result.cards[0].questionHtml).toContain('n2a-review-missing');
   });
 });

--- a/src/usecases/ankify/GetReviewQueueUseCase.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.ts
@@ -1,6 +1,13 @@
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
 import { AnkiConnectFactory } from './GetAnkifyStatsUseCase';
+import { inlineReviewMedia } from './inlineReviewMedia';
 import { buildDueCardsQuery } from './reviewQueries';
+
+const REVIEW_MEDIA_CSS =
+  'img{max-width:100%!important;height:auto!important;max-height:60vh!important;object-fit:contain;display:block;margin-inline:auto}' +
+  'audio{display:block;width:100%;max-width:320px;margin-inline:auto}' +
+  'body.card{overflow-x:hidden}' +
+  '.n2a-review-missing{display:inline-block;font-size:.75rem;color:#6b7280;background:#f1f1ef;border-radius:.25rem;padding:.125rem .375rem}';
 
 export interface ReviewQueueCard {
   cardId: number;
@@ -46,12 +53,25 @@ export class GetReviewQueueUseCase {
     }
 
     const info = await ac.cardsInfo(cardIds);
-    const cards = info.map((card) => ({
-      cardId: card.cardId,
-      questionHtml: card.question ?? '',
-      answerHtml: card.answer ?? '',
-      css: card.css ?? '',
-    }));
+    const cache = new Map<string, string | null>();
+    const fetchMedia = (filename: string) => ac.retrieveMediaFile(filename);
+
+    const cards = await Promise.all(
+      info.map(async (card) => ({
+        cardId: card.cardId,
+        questionHtml: await inlineReviewMedia(
+          card.question ?? '',
+          fetchMedia,
+          cache
+        ),
+        answerHtml: await inlineReviewMedia(
+          card.answer ?? '',
+          fetchMedia,
+          cache
+        ),
+        css: (card.css ?? '') + REVIEW_MEDIA_CSS,
+      }))
+    );
 
     return { connected: true, cards };
   }

--- a/src/usecases/ankify/inlineReviewMedia.test.ts
+++ b/src/usecases/ankify/inlineReviewMedia.test.ts
@@ -1,0 +1,183 @@
+import { inlineReviewMedia } from './inlineReviewMedia';
+
+const base64Of = (text: string): string =>
+  Buffer.from(text, 'utf-8').toString('base64');
+
+describe('inlineReviewMedia', () => {
+  it('inlines a bare-filename image as a data URI', async () => {
+    const fetchMedia = jest.fn(async () => base64Of('PNGBYTES'));
+    const cache = new Map<string, string | null>();
+
+    const out = await inlineReviewMedia('<img src="a.png">', fetchMedia, cache);
+
+    expect(out).toContain(`data:image/png;base64,${base64Of('PNGBYTES')}`);
+    expect(fetchMedia).toHaveBeenCalledWith('a.png');
+  });
+
+  it('maps each known extension to the right mime', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      '<img src="a.jpg"><img src="b.jpeg"><img src="c.gif"><img src="d.webp"><img src="e.svg">',
+      async () => base64Of('X'),
+      cache
+    );
+
+    expect(out).toContain('data:image/jpeg;base64,');
+    expect(out).toContain('data:image/gif;base64,');
+    expect(out).toContain('data:image/webp;base64,');
+    expect(out).toContain('data:image/svg+xml;base64,');
+  });
+
+  it('leaves external, data, and absolute image srcs untouched', async () => {
+    const fetchMedia = jest.fn(async () => base64Of('X'));
+    const cache = new Map<string, string | null>();
+    const html =
+      '<img src="https://x/y.png"><img src="http://x/z.png">' +
+      '<img src="data:image/png;base64,AAA"><img src="/media/q.png">';
+
+    const out = await inlineReviewMedia(html, fetchMedia, cache);
+
+    expect(out).toBe(html);
+    expect(fetchMedia).not.toHaveBeenCalled();
+  });
+
+  it('replaces a missing image with a muted chip', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      '<img src="gone.png">',
+      async () => false,
+      cache
+    );
+
+    expect(out).toBe(
+      '<span class="n2a-review-missing">Image not in Anki</span>'
+    );
+  });
+
+  it('replaces an unknown extension image with a missing chip (never a broken data URI)', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      '<img src="weird.xyz">',
+      async () => base64Of('X'),
+      cache
+    );
+
+    expect(out).toBe(
+      '<span class="n2a-review-missing">Image not in Anki</span>'
+    );
+  });
+
+  it('renders [sound:X] as an audio element with a data URI', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      'listen [sound:word.mp3]',
+      async () => base64Of('MP3'),
+      cache
+    );
+
+    expect(out).toContain(
+      `<audio controls preload="none" src="data:audio/mpeg;base64,${base64Of('MP3')}"></audio>`
+    );
+    expect(out).not.toContain('[sound:');
+  });
+
+  it('replaces a missing sound with a muted chip', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      '[sound:gone.mp3]',
+      async () => false,
+      cache
+    );
+
+    expect(out).toBe(
+      '<span class="n2a-review-missing">Audio not in Anki</span>'
+    );
+  });
+
+  it('strips [anki:play:q:N] and [anki:play:a:N] tokens entirely', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      'Q[anki:play:q:0] A[anki:play:a:1]',
+      async () => false,
+      cache
+    );
+
+    expect(out).toBe('Q A');
+  });
+
+  it('leaves no raw [sound: or [anki:play: token in the output', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      '[sound:a.mp3] [anki:play:q:0] [anki:play:a:0] [sound:b.wav]',
+      async () => base64Of('X'),
+      cache
+    );
+
+    expect(out).not.toContain('[sound:');
+    expect(out).not.toContain('[anki:play:');
+  });
+
+  it('fetches each unique filename once via the cache', async () => {
+    const fetchMedia = jest.fn(async () => base64Of('X'));
+    const cache = new Map<string, string | null>();
+
+    await inlineReviewMedia('<img src="a.png">', fetchMedia, cache);
+    await inlineReviewMedia(
+      '<img src="a.png"><img src="a.png">',
+      fetchMedia,
+      cache
+    );
+
+    expect(fetchMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches a miss so it is not refetched', async () => {
+    const fetchMedia = jest.fn(async () => false as const);
+    const cache = new Map<string, string | null>();
+
+    await inlineReviewMedia('<img src="gone.png">', fetchMedia, cache);
+    await inlineReviewMedia('<img src="gone.png">', fetchMedia, cache);
+
+    expect(fetchMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops fetching new files once the cache holds 200 entries', async () => {
+    const fetchMedia = jest.fn(async () => base64Of('X'));
+    const cache = new Map<string, string | null>();
+    const refs = Array.from(
+      { length: 201 },
+      (_, i) => `<img src="f${i}.png">`
+    ).join('');
+
+    const out = await inlineReviewMedia(refs, fetchMedia, cache);
+
+    expect(fetchMedia).toHaveBeenCalledTimes(200);
+    expect(out).toContain('n2a-review-missing');
+  });
+
+  it('treats a >5 MB decoded image as missing', async () => {
+    const bigBase64 = 'A'.repeat(Math.ceil((6 * 1024 * 1024) / 0.75));
+    const cache = new Map<string, string | null>();
+
+    const out = await inlineReviewMedia(
+      '<img src="huge.png">',
+      async () => bigBase64,
+      cache
+    );
+
+    expect(out).toBe(
+      '<span class="n2a-review-missing">Image not in Anki</span>'
+    );
+  });
+
+  it('returns non-media html unchanged', async () => {
+    const cache = new Map<string, string | null>();
+    const out = await inlineReviewMedia(
+      '<p>Just text</p>',
+      async () => false,
+      cache
+    );
+
+    expect(out).toBe('<p>Just text</p>');
+  });
+});

--- a/src/usecases/ankify/inlineReviewMedia.ts
+++ b/src/usecases/ankify/inlineReviewMedia.ts
@@ -1,0 +1,133 @@
+type MediaFetcher = (filename: string) => Promise<string | false>;
+
+const MAX_INLINE_MEDIA_FILES = 200;
+const MAX_DECODED_BYTES = 5 * 1024 * 1024;
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+  mp3: 'audio/mpeg',
+  ogg: 'audio/ogg',
+  oga: 'audio/ogg',
+  wav: 'audio/wav',
+  m4a: 'audio/mp4',
+};
+
+const IMAGE_MISSING_CHIP =
+  '<span class="n2a-review-missing">Image not in Anki</span>';
+const AUDIO_MISSING_CHIP =
+  '<span class="n2a-review-missing">Audio not in Anki</span>';
+
+const isBareFilename = (src: string): boolean =>
+  !/^(?:https?:|data:|\/)/i.test(src);
+
+const mimeFor = (filename: string): string | null => {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) {
+    return null;
+  }
+  const ext = filename.slice(dot + 1).toLowerCase();
+  return MIME_BY_EXTENSION[ext] ?? null;
+};
+
+const isOversized = (base64: string): boolean =>
+  base64.length * 0.75 > MAX_DECODED_BYTES;
+
+const resolveDataUri = async (
+  filename: string,
+  fetchMedia: MediaFetcher,
+  cache: Map<string, string | null>
+): Promise<string | null> => {
+  if (cache.has(filename)) {
+    return cache.get(filename) ?? null;
+  }
+
+  const mime = mimeFor(filename);
+  if (mime == null) {
+    cache.set(filename, null);
+    return null;
+  }
+
+  if (cache.size >= MAX_INLINE_MEDIA_FILES) {
+    return null;
+  }
+
+  const fetched = await fetchMedia(filename);
+  if (fetched === false || fetched == null || isOversized(fetched)) {
+    cache.set(filename, null);
+    return null;
+  }
+
+  const dataUri = `data:${mime};base64,${fetched}`;
+  cache.set(filename, dataUri);
+  return dataUri;
+};
+
+const replaceImages = async (
+  html: string,
+  fetchMedia: MediaFetcher,
+  cache: Map<string, string | null>
+): Promise<string> => {
+  const tags = [...html.matchAll(/<img\b[^>]*?>/gi)];
+  let result = html;
+
+  for (const match of tags) {
+    const tag = match[0];
+    const srcMatch = /\bsrc\s*=\s*["']([^"']*)["']/i.exec(tag);
+    if (srcMatch == null || !isBareFilename(srcMatch[1])) {
+      continue;
+    }
+
+    const srcAttr = srcMatch[0];
+    const dataUri = await resolveDataUri(srcMatch[1], fetchMedia, cache);
+    if (dataUri == null) {
+      result = result.replace(tag, IMAGE_MISSING_CHIP);
+      continue;
+    }
+
+    const rewritten = tag.replace(srcAttr, `src="${dataUri}"`);
+    result = result.replace(tag, rewritten);
+  }
+
+  return result;
+};
+
+const replaceSounds = async (
+  html: string,
+  fetchMedia: MediaFetcher,
+  cache: Map<string, string | null>
+): Promise<string> => {
+  const refs = [...html.matchAll(/\[sound:([^\]]+)\]/g)];
+  let result = html;
+
+  for (const match of refs) {
+    const token = match[0];
+    const filename = match[1];
+    const dataUri = await resolveDataUri(filename, fetchMedia, cache);
+    if (dataUri == null) {
+      result = result.replace(token, AUDIO_MISSING_CHIP);
+      continue;
+    }
+
+    result = result.replace(
+      token,
+      `<audio controls preload="none" src="${dataUri}"></audio>`
+    );
+  }
+
+  return result;
+};
+
+export async function inlineReviewMedia(
+  html: string,
+  fetchMedia: MediaFetcher,
+  cache: Map<string, string | null>
+): Promise<string> {
+  const withImages = await replaceImages(html, fetchMedia, cache);
+  const withAudio = await replaceSounds(withImages, fetchMedia, cache);
+  return withAudio.replace(/\[anki:play:[qa]:\d+\]/g, '');
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-media.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-media.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review-media",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Card images and audio now show in the in-app reviewer"
+}


### PR DESCRIPTION
## What
Card media now renders in the in-browser reviewer. Before, the iframe got AnkiConnect's card HTML verbatim — images referenced by bare filename 404'd (broken-image icon) and audio showed as raw text like `[anki:play:a:0]` / `[sound:foo.mp3]`.

## Why
The reviewer's whole value is studying synced cards away from desktop. For the affected user — Japanese vocab decks (Kaishi 1.5k, RRTK) — images (stroke order, mnemonics) and native audio are often the card's actual content; broken media makes the card unreviewable. Retention risk on the paid Auto-Sync/lifetime cohort.

## How (server-side, in `GetReviewQueueUseCase`)
- New `AnkiConnectClient.retrieveMediaFile(filename)` → base64 or `false`.
- New pure helper `inlineReviewMedia(html, fetch, cache)`:
  - `<img src="bare.jpg">` → `data:<mime>;base64,…` (external / `data:` / absolute srcs untouched).
  - `[sound:X]` → `<audio controls preload="none" src="data:…">`.
  - `[anki:play:q|a:N]` → stripped (redundant once `[sound:]` renders as audio). **No raw `[sound:`/`[anki:play:` token can survive** (asserted).
  - Missing file / unknown ext / >5 MB → muted `Image not in Anki` / `Audio not in Anki` chip, never a broken icon.
- Dedupe: one fetch per unique filename per session (shared front+back+all cards; misses cached). Cap: 200 unique files (overflow → chip) to bound payload. base64 inflates ~33%; audio word-clips are single-digit KB.
- Image containment + chip CSS appended to the returned card `css` (literal values — the iframe has no base.css tokens): `img{max-width:100%;max-height:60vh;object-fit:contain;…}`, `audio{max-width:320px;…}`, `body.card{overflow-x:hidden}`.

## Security
- `filename` goes only into the `retrieveMediaFile` JSON param — no shell/SQL/fs path (CWE-22/78 N/A).
- Per-user container (`findActiveByOwner`) — only the user's own media is fetchable.
- SVG via `<img src=data:image/svg+xml>` renders in image mode (scripting disabled) — safe even under `sandbox="allow-scripts"`.

## Testing
- 3 suites, 57 passed: retrieveMediaFile (hit + miss); inlineReviewMedia (16 cases — img/sound/anki:play rewrite, no-token-survives, dedupe call-count, 200-cap, missing/unknown-ext/oversize chip, external untouched); GetReviewQueueUseCase (data-URI output + dedupe + chip + appended css). tsc clean.

## Risks
A large diagram is shown contained (max-height 60vh), not 1:1 — acceptable for an at-a-glance panel; click-to-expand is a follow-up if image-heavy decks dominate. Audio inlined as data URIs; capped + size-skipped.

## Goal alignment
Retention — makes synced cards actually reviewable in-browser for the paid cohort. Read at the Review T+30d adoption issue (#3357).

## Browser check
Not applicable — server-side change; the only `web/src/` file is a changelog entry (changelog-only bypass).

## Sonar
sonar-scanner not run locally (no token) — Automatic Analysis runs on the PR; new helper `inlineReviewMedia` is the main surface.
