### PR TITLE
fix: load due cards for decks with spaces or colons, and unblock reviewer back-nav

### DIFF
--- a/src/usecases/ankify/EditLeechNoteUseCase.test.ts
+++ b/src/usecases/ankify/EditLeechNoteUseCase.test.ts
@@ -57,7 +57,7 @@ describe('EditLeechNoteUseCase', () => {
     });
 
     expect(findNotes).toHaveBeenCalledWith(
-      'nid:7001 ("deck:Notion Sync::Pharma")'
+      'nid:7001 (deck:"Notion Sync::Pharma")'
     );
     expect(updateNoteFields).toHaveBeenCalledWith(7001, { Front: 'new front' });
   });

--- a/src/usecases/ankify/GetReviewQueueUseCase.test.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.test.ts
@@ -39,7 +39,7 @@ describe('GetReviewQueueUseCase', () => {
 
     const result = await useCase.execute({ owner: 42, deck: 'My Own Deck' });
 
-    expect(findCards).toHaveBeenCalledWith('"deck:My Own Deck" is:due');
+    expect(findCards).toHaveBeenCalledWith('deck:"My Own Deck" is:due');
     expect(result).toEqual({ connected: true, cardIds: [9001, 9002] });
     expect(cardsInfo).not.toHaveBeenCalled();
   });
@@ -95,6 +95,6 @@ describe('GetReviewQueueUseCase', () => {
 
     await useCase.execute({ owner: 42, deck: 'Week "18"\\x' });
 
-    expect(findCards).toHaveBeenCalledWith('"deck:Week \\"18\\"\\\\x" is:due');
+    expect(findCards).toHaveBeenCalledWith('deck:"Week \\"18\\"\\\\x" is:due');
   });
 });

--- a/src/usecases/ankify/ListLeechesUseCase.test.ts
+++ b/src/usecases/ankify/ListLeechesUseCase.test.ts
@@ -117,7 +117,7 @@ describe('ListLeechesUseCase', () => {
     const result = await useCase.execute({ owner: 42 });
 
     expect(findNotes).toHaveBeenCalledWith(
-      'tag:leech ("deck:Notion Sync::Pharma")'
+      'tag:leech (deck:"Notion Sync::Pharma")'
     );
     expect(result).toEqual({
       connected: true,

--- a/src/usecases/ankify/assertNoteOwned.test.ts
+++ b/src/usecases/ankify/assertNoteOwned.test.ts
@@ -12,7 +12,7 @@ describe('assertNoteOwned', () => {
     await assertNoteOwned(ac, ['Notion Sync::Pharma'], 7001);
 
     expect(findNotes).toHaveBeenCalledWith(
-      'nid:7001 ("deck:Notion Sync::Pharma")'
+      'nid:7001 (deck:"Notion Sync::Pharma")'
     );
   });
 

--- a/src/usecases/ankify/leechQueries.test.ts
+++ b/src/usecases/ankify/leechQueries.test.ts
@@ -19,7 +19,13 @@ describe('leechQueries', () => {
   describe('buildLeechListQuery', () => {
     it('scopes tag:leech to a single owned deck', () => {
       expect(buildLeechListQuery(['Notion Sync::Pharmacology'])).toBe(
-        'tag:leech ("deck:Notion Sync::Pharmacology")'
+        'tag:leech (deck:"Notion Sync::Pharmacology")'
+      );
+    });
+
+    it('matches a deck name with a space and a colon', () => {
+      expect(buildLeechListQuery(['Part 1: Listening comprehension'])).toBe(
+        'tag:leech (deck:"Part 1: Listening comprehension")'
       );
     });
 
@@ -27,13 +33,13 @@ describe('leechQueries', () => {
       expect(
         buildLeechListQuery(['Notion Sync::Pharma', 'Notion Sync::Torts'])
       ).toBe(
-        'tag:leech ("deck:Notion Sync::Pharma" OR "deck:Notion Sync::Torts")'
+        'tag:leech (deck:"Notion Sync::Pharma" OR deck:"Notion Sync::Torts")'
       );
     });
 
     it('escapes deck names with quotes and backslashes', () => {
       expect(buildLeechListQuery(['Week "18"\\x'])).toBe(
-        'tag:leech ("deck:Week \\"18\\"\\\\x")'
+        'tag:leech (deck:"Week \\"18\\"\\\\x")'
       );
     });
 
@@ -45,8 +51,14 @@ describe('leechQueries', () => {
   describe('buildNoteOwnershipQuery', () => {
     it('constrains a note id to a single owned deck', () => {
       expect(buildNoteOwnershipQuery(7001, ['Notion Sync::Pharma'])).toBe(
-        'nid:7001 ("deck:Notion Sync::Pharma")'
+        'nid:7001 (deck:"Notion Sync::Pharma")'
       );
+    });
+
+    it('matches a deck name with a space and a colon', () => {
+      expect(
+        buildNoteOwnershipQuery(7001, ['Part 1: Listening comprehension'])
+      ).toBe('nid:7001 (deck:"Part 1: Listening comprehension")');
     });
 
     it('ORs multiple owned decks', () => {
@@ -56,13 +68,13 @@ describe('leechQueries', () => {
           'Notion Sync::Torts',
         ])
       ).toBe(
-        'nid:7001 ("deck:Notion Sync::Pharma" OR "deck:Notion Sync::Torts")'
+        'nid:7001 (deck:"Notion Sync::Pharma" OR deck:"Notion Sync::Torts")'
       );
     });
 
     it('escapes deck names with quotes and backslashes', () => {
       expect(buildNoteOwnershipQuery(42, ['Week "18"\\x'])).toBe(
-        'nid:42 ("deck:Week \\"18\\"\\\\x")'
+        'nid:42 (deck:"Week \\"18\\"\\\\x")'
       );
     });
 

--- a/src/usecases/ankify/leechQueries.ts
+++ b/src/usecases/ankify/leechQueries.ts
@@ -6,7 +6,7 @@ const buildDeckScope = (ownedDeckNames: string[]): string | null => {
     return null;
   }
   return ownedDeckNames
-    .map((deck) => `"deck:${escapeDeckQueryValue(deck)}"`)
+    .map((deck) => `deck:"${escapeDeckQueryValue(deck)}"`)
     .join(' OR ');
 };
 

--- a/src/usecases/ankify/reviewQueries.test.ts
+++ b/src/usecases/ankify/reviewQueries.test.ts
@@ -4,19 +4,25 @@ describe('reviewQueries', () => {
   describe('buildDueCardsQuery', () => {
     it('scopes is:due to a single deck', () => {
       expect(buildDueCardsQuery('Notion Sync::Pharma')).toBe(
-        '"deck:Notion Sync::Pharma" is:due'
+        'deck:"Notion Sync::Pharma" is:due'
+      );
+    });
+
+    it('matches a deck name with a space and a colon', () => {
+      expect(buildDueCardsQuery('Part 1: Listening comprehension')).toBe(
+        'deck:"Part 1: Listening comprehension" is:due'
       );
     });
 
     it('escapes quotes and backslashes in the deck name', () => {
       expect(buildDueCardsQuery('Week "18"\\x')).toBe(
-        '"deck:Week \\"18\\"\\\\x" is:due'
+        'deck:"Week \\"18\\"\\\\x" is:due'
       );
     });
 
     it('preserves the :: hierarchy separator', () => {
       expect(buildDueCardsQuery('MS3::Pharma::Sub')).toBe(
-        '"deck:MS3::Pharma::Sub" is:due'
+        'deck:"MS3::Pharma::Sub" is:due'
       );
     });
   });

--- a/src/usecases/ankify/reviewQueries.ts
+++ b/src/usecases/ankify/reviewQueries.ts
@@ -1,6 +1,6 @@
 import { escapeDeckQueryValue } from './leechQueries';
 
 export const buildDueCardsQuery = (deck: string): string =>
-  `"deck:${escapeDeckQueryValue(deck)}" is:due`;
+  `deck:"${escapeDeckQueryValue(deck)}" is:due`;
 
 export const buildCardExistsQuery = (cardId: number): string => `cid:${cardId}`;

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -207,6 +207,31 @@ describe('ReviewPanel', () => {
     ).toBeInTheDocument();
   });
 
+  test('returns to the deck picker from the all-caught-up state', async () => {
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () => statsWithDeck(5)),
+        getAnkifyReviewQueue: vi.fn(async () => ({
+          connected: true as const,
+          cardIds: [],
+        })),
+      })
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+    await screen.findByText(
+      'All caught up. No cards due across your decks right now.'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to decks' }));
+
+    expect(
+      await screen.findByText(
+        'Pick a deck to review its due cards without opening Anki.'
+      )
+    ).toBeInTheDocument();
+  });
+
   test('shows the offline state with Try again when the queue reports offline', async () => {
     const getAnkifyReviewQueue = vi.fn(async () => ({
       connected: false as const,

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -447,6 +447,19 @@ export default function ReviewPanel({ backend }: Props) {
     );
   }
 
+  const backToDecks = (
+    <div className={reviewStyles.reviewHeader}>
+      <button
+        type="button"
+        className={reviewStyles.exitButton}
+        aria-label="Back to decks"
+        onClick={() => setStage({ kind: 'picker' })}
+      >
+        ← Decks
+      </button>
+    </div>
+  );
+
   const retry = (
     <div className={reviewStyles.summaryActions}>
       <button
@@ -466,9 +479,12 @@ export default function ReviewPanel({ backend }: Props) {
     if (queue.data?.connected === true) {
       if (queue.data.cardIds.length === 0) {
         return panel(
-          <p className={styles.emptyLine}>
-            All caught up. No cards due across your decks right now.
-          </p>
+          <>
+            <p className={styles.emptyLine}>
+              All caught up. No cards due across your decks right now.
+            </p>
+            {backToDecks}
+          </>
         );
       }
       return panel(
@@ -491,6 +507,7 @@ export default function ReviewPanel({ backend }: Props) {
             Something broke while loading this deck. Try again in a moment.
           </p>
           {retry}
+          {backToDecks}
         </>
       );
     }
@@ -500,6 +517,7 @@ export default function ReviewPanel({ backend }: Props) {
           Anki isn&apos;t connected. Open Anki on your computer and try again.
         </p>
         {retry}
+        {backToDecks}
       </>
     );
   }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-deck-query.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-deck-query.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review-deck-query",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Decks with spaces or colons in their name now load their due cards in the reviewer"
+}


### PR DESCRIPTION
## What
Two reviewer bugs:
1. A deck whose name has spaces or a colon (e.g. "Part 1: Listening comprehension") showed **65 due** in the picker but **"All caught up. No cards due"** when you opened it.
2. The all-caught-up / offline / error states inside a review session had **no way back** to the deck list — a dead end.

## Why
1. The AnkiConnect deck filter wrapped the whole term in quotes (`"deck:NAME"`). Anki parses that form by re-splitting on spaces, so a multi-word/colon name matched zero cards — even though `getDeckStats` found the deck by the same name (hence the picker count). The canonical form quotes the value: `deck:"NAME"`.
2. Only the active Reviewer and the done-summary had a back control; the empty/offline/error branches rendered text only.

## How
- `buildDueCardsQuery` and `leechQueries.buildDeckScope`: `"deck:${value}"` → `deck:"${value}"`. Escaping (`\`, `"`) unchanged. For "Part 1: Listening comprehension" the query is now exactly `deck:"Part 1: Listening comprehension" is:due`. Same fix also unbreaks Leeches + note-ownership for spaced/colon deck names.
- `ReviewPanel`: added the `← Decks` control (same style/focus ring, `aria-label="Back to decks"`, `setStage(picker)`) to the all-caught-up, offline, and error states.

## Testing
- Server: reviewQueries + leechQueries 19 passed; 4 affected use-case suites 15 passed (asserted the new `deck:"..."` form, incl. a spaced+colon case). 
- Web: ReviewPanel 12 passed (added all-caught-up → back-to-picker test).
- tsc + web typecheck + lint clean.

## Risks
Low — a query-string form correction + a navigation affordance. The spaced+colon case is now covered by a test so it can't regress silently.

## Goal alignment
Retention — the reviewer was unusable for any deck with a space/colon in its name (most real decks). Read at the Review T+30d adoption issue (#3357).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: open "Part 1: Listening comprehension" (or any deck with a space/colon) — its due cards should load now; from the all-caught-up/offline state, the ← Decks control returns to the picker.

## Sonar
sonar-scanner not run locally (no token) — Automatic Analysis runs on the PR.
