### PR TITLE
fix: clean message when a page is already converting

### DIFF
--- a/web/src/pages/PreviewPage/PreviewPage.test.tsx
+++ b/web/src/pages/PreviewPage/PreviewPage.test.tsx
@@ -284,4 +284,69 @@ describe('PreviewPage Convert to Anki CTA', () => {
       ).not.toBeDisabled();
     });
   });
+
+  function renderPreviewWithError(setError: (error: unknown) => void) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+      <QueryClientProvider client={client}>
+        <MemoryRouter initialEntries={['/preview/page-abc']}>
+          <Routes>
+            <Route
+              path="/preview/:id"
+              element={<PreviewPage setError={setError} />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+
+  it('shows friendly copy and not raw JSON on a 409 already_in_progress', async () => {
+    const setError = vi.fn();
+    mockConvert.mockResolvedValue({
+      status: 409,
+      text: async () => '{"reason":"already_in_progress"}',
+    });
+    mockUsePreviewStream.mockReturnValue(makeStreamReturn([]));
+
+    renderPreviewWithError(setError);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Convert to Anki' }));
+
+    await waitFor(() => {
+      expect(setError).toHaveBeenCalled();
+    });
+
+    const passedError = setError.mock.calls[0][0] as Error;
+    expect(passedError.message).toBe(
+      'This page is already converting — check Downloads in a moment.'
+    );
+    expect(passedError.message).not.toContain('already_in_progress');
+    expect(passedError.message).not.toContain('{');
+  });
+
+  it('surfaces a readable message and not a raw JSON body on other errors', async () => {
+    const setError = vi.fn();
+    mockConvert.mockResolvedValue({
+      status: 500,
+      text: async () => '{"error":"boom"}',
+    });
+    mockUsePreviewStream.mockReturnValue(makeStreamReturn([]));
+
+    renderPreviewWithError(setError);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Convert to Anki' }));
+
+    await waitFor(() => {
+      expect(setError).toHaveBeenCalled();
+    });
+
+    const passedError = setError.mock.calls[0][0] as Error;
+    expect(passedError.message).not.toContain('{');
+    expect(passedError.message).toBe(
+      'Could not start the conversion. Try again in a moment.'
+    );
+  });
 });

--- a/web/src/pages/PreviewPage/PreviewPage.tsx
+++ b/web/src/pages/PreviewPage/PreviewPage.tsx
@@ -86,14 +86,24 @@ export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
     setConverting(true);
     get2ankiApi()
       .convert(id, 'page', pageTitle)
-      .then(async (response) => {
+      .then((response) => {
         if (response.status === 202) {
           navigate('/downloads');
-        } else {
-          const text = await response.text().catch(() => '');
-          if (text) setError(new Error(text));
-          setConverting(false);
+          return;
         }
+        if (response.status === 409) {
+          setError(
+            new Error(
+              'This page is already converting — check Downloads in a moment.'
+            )
+          );
+          setConverting(false);
+          return;
+        }
+        setError(
+          new Error('Could not start the conversion. Try again in a moment.')
+        );
+        setConverting(false);
       })
       .catch((err: unknown) => {
         setError(err as Error);

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-preview-already-converting.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-preview-already-converting.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-preview-already-converting",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Converting a page that's already running shows a clear message instead of a raw error"
+}


### PR DESCRIPTION
## What
On the preview page, clicking Convert to Anki for a page whose conversion is already running surfaced the raw server JSON body `{"reason":"already_in_progress"}` as the error banner and reported it to the error tracker. This handles the 409 with a clear, VOICE.md-compliant message and stops dumping raw response bodies on other non-202 statuses.

## Why
Verified production error group `{"reason":"already_in_progress"}` (web, 2 occurrences, last 2026-06-13, on `/preview/...`). The server correctly returns `409 {"reason":"already_in_progress"}` when a conversion for that page is already in flight (54x 409s in prod access logs are expected server behavior, left as is). The client bug was in `PreviewPage.handleConvert`, which set `new Error(text)` from the raw body. User-visible outcome: a readable message instead of raw JSON, and no error-tracker noise for an expected condition.

## How
In `handleConvert`, branch on the response status: 202 navigates to Downloads; 409 shows "This page is already converting — check Downloads in a moment." (a job is genuinely running, so it points the user there); any other non-202 status shows a generic "Could not start the conversion. Try again in a moment." instead of the raw body. Dropped the `response.text()` read entirely, so no raw body can ever reach the banner. Server side untouched.

## Measuring success
The production error group keyed on `{"reason":"already_in_progress"}` (and any raw-JSON-bodied error from the preview convert path) should stop receiving new events. Confirm in the web error tracker by date after deploy.

## Testing
- Unit tests added (Vitest): a 409 `already_in_progress` response shows the friendly copy, not the raw JSON, and does not throw; a 500 with a JSON body surfaces the generic readable message, not the raw body. Existing PreviewPage tests (13 total) stay green.

## Browser check
Browser check pending — implemented + tested, needs manual verify on localhost:3000.
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Could not run a real browser in this environment.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-14-preview-already-converting.json` — "Converting a page that's already running shows a clear message instead of a raw error"

## Risks
Low. Change is confined to the client error-handling branch of one handler; no server, API, or data changes. Rollback is a revert of this single PR. Note: Sonar was not run locally (no scanner configured in this environment) — expect a possible Sonar pass on CI.

## Goal alignment
Removes a confusing raw-JSON error from a core conversion surface (preview to convert), making the experience clearer when a user double-clicks Convert. No direct funnel metric; reduces error-tracker noise so genuine conversion failures stay visible.