### PR TITLE
fix: hoist DOM recovery boundary to protect all routes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -317,6 +317,36 @@ const NativeAppPage = lazyWithRetry(
 
 const queryClient = new QueryClient();
 
+function surfaceFromPathname(pathname: string): string {
+  const segment = pathname.split('/').filter(Boolean)[0];
+  return segment ?? 'home';
+}
+
+function RouteRecoveryBoundary({
+  children,
+}: Readonly<{ children: ReactElement }>) {
+  const location = useLocation();
+  const surface = surfaceFromPathname(location.pathname);
+  return (
+    <DomRecoveryBoundary
+      onError={(error, errorInfo) =>
+        reportClientError(error, {
+          surface,
+          componentStack: errorInfo.componentStack,
+        })
+      }
+      onRecover={(error) =>
+        reportClientError(error, {
+          surface,
+          recovered: true,
+        })
+      }
+    >
+      {children}
+    </DomRecoveryBoundary>
+  );
+}
+
 function RequireAuth({
   isLoggedIn,
   isLoading,
@@ -375,258 +405,257 @@ function AppContent({
       >
         {isLoggedInResolved && <PostLoginSurvey />}
         <VerifyEmailNotice emailVerified={data?.user?.email_verified} />
-        <Routes>
-          <Route
-            path="/favorites"
-            element={requireAuth(<FavoritesPage setError={setErrorMessage} />)}
-          />
-          <Route
-            path="/downloads"
-            element={requireAuth(<DownloadsPage setError={setErrorMessage} />)}
-          />
-          <Route
-            path="/uploads"
-            element={<Navigate to="/downloads" replace />}
-          />
-          <Route
-            path="/upload"
-            element={
-              <DomRecoveryBoundary
-                onError={(error, errorInfo) =>
-                  reportClientError(error, {
-                    surface: 'upload',
-                    componentStack: errorInfo.componentStack,
-                  })
-                }
-                onRecover={(error) =>
-                  reportClientError(error, {
-                    surface: 'upload',
-                    recovered: true,
-                  })
-                }
-              >
-                <UploadPage setErrorMessage={setErrorMessage} />
-              </DomRecoveryBoundary>
-            }
-          />
-          <Route path="/print" element={<PrintPage />} />
-          <Route path="/image-occlusion" element={<ImageOcclusionPage />} />
-          <Route
-            path="/photo-to-deck"
-            element={requireAuth(<PhotoToFlashcardsPage />)}
-          />
-          <Route path="/mindmaps" element={requireAuth(<MindmapsPage />)} />
-          <Route path="/transform" element={requireAuth(<TransformPage />)} />
-          <Route path="/mindmaps/:id" element={requireAuth(<MindmapsPage />)} />
-          <Route path="/chat" element={requireAuth(<ChatPage />)} />
-          <Route
-            path="/register"
-            element={<RegisterPage setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/notion"
-            element={requireAuth(<SearchPage setError={setErrorMessage} />)}
-          />
-          <Route path="/search" element={<Navigate to="/notion" replace />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/auth/magic" element={<MagicLinkPage />} />
-          <Route
-            path="/forgot"
-            element={<ForgotPasswordPage setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/users/r/:id"
-            element={<NewPasswordPage setErrorMessage={setErrorMessage} />}
-          />
-          <Route path="/debug" element={<DebugPage />} />
-          <Route path="/contact" element={<ContactPage />} />
-          <Route
-            path="/delete-account"
-            element={requireAuth(
-              <DeleteAccountPage setError={setErrorMessage} />
-            )}
-          />
-          <Route
-            path="/pricing"
-            element={
-              <PricingPage
-                isLoggedIn={isLoggedInResolved}
-                email={data?.user?.email}
-                hostedAnkiRequested={data?.hostedAnkiRequested === true}
-                patreon={data?.user?.patreon ?? null}
-                signupCountry={data?.user?.signup_country ?? null}
-                autoSyncCapReached={data?.autoSyncCapReached === true}
-                autoSyncActive={data?.autoSyncActive === true}
-              />
-            }
-          />
-          <Route
-            path="/"
-            element={
-              <HomePage
-                setErrorMessage={setErrorMessage}
-                isLoggedIn={isLoggedInResolved}
-              />
-            }
-          />
-          <Route
-            path="/successful-checkout"
-            element={<SuccessfulCheckoutPage />}
-          />
-          <Route path="/limit" element={<LimitPage />} />
-          <Route path="/account" element={requireAuth(<AccountPage />)} />
-          <Route
-            path="/account/claim"
-            element={requireAuth(<AccountClaimPage />)}
-          />
-          {AccountPreviewPage && (
+        <RouteRecoveryBoundary>
+          <Routes>
             <Route
-              path="/dev/account-preview"
-              element={<AccountPreviewPage />}
+              path="/favorites"
+              element={requireAuth(
+                <FavoritesPage setError={setErrorMessage} />
+              )}
             />
-          )}
-          {NotionPreviewPage && (
-            <Route path="/dev/notion-preview" element={<NotionPreviewPage />} />
-          )}
-          {AnkifyReviewPreviewPage && (
             <Route
-              path="/dev/ankify-review-preview"
-              element={<AnkifyReviewPreviewPage />}
+              path="/downloads"
+              element={requireAuth(
+                <DownloadsPage setError={setErrorMessage} />
+              )}
             />
-          )}
-          <Route
-            path="/import"
-            element={requireAuth(<ImportPage setError={setErrorMessage} />)}
-          />
-          <Route path="/ankify" element={requireAuth(<AnkifyPage />)} />
-          <Route
-            path="/ankify/setup"
-            element={requireAuth(<AnkifySetupPage />)}
-          />
-          <Route
-            path="/ankify/history"
-            element={requireAuth(<AnkifyHistoryPage />)}
-          />
-          <Route path="/ops" element={requireAuth(<OpsLayout />)}>
-            <Route index element={<EngineeringTab />} />
-            <Route path="errors" element={<ErrorsTab />} />
-            <Route path="performance" element={<PerformanceTab />} />
-            <Route path="conversions" element={<ConversionsTab />} />
-            <Route path="return-rate" element={<ReturnRateTab />} />
-            <Route path="mindmaps" element={<MindmapsTab />} />
-            <Route path="upload-funnel" element={<UploadFunnelTab />} />
-            <Route path="business" element={<BusinessTab />} />
-            <Route path="showcase" element={<ShowcaseTab />} />
-            <Route path="interviews" element={<InterviewsTab />} />
-            <Route path="messages" element={<ContactMessagesTab />} />
-            <Route path="commands" element={<CommandsTab />} />
-            <Route path="flags" element={<FlagsTab />} />
-            <Route path="pricing-ab" element={<PricingAbFunnelTab />} />
-          </Route>
-          <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
-          <Route path="/settings" element={requireAuth(<AccountPage />)} />
-          <Route path="/about" element={<AboutPage />} />
-          <Route path="/app" element={<NativeAppPage />} />
-          <Route path="/security" element={<SecurityPage />} />
-          <Route path="/status" element={<StatusPage />} />
-          <Route path="/whats-new" element={<WhatsNewPage />} />
-          <Route path="/documentation" element={<DocsPage />} />
-          <Route path="/documentation/*" element={<DocsPage />} />
-          <Route
-            path="/settings/card-options"
-            element={<Navigate to="/card-options" replace />}
-          />
-          <Route
-            path="/card-options"
-            element={<CardOptionsPage setErrorMessage={setErrorMessage} />}
-          />
-          <Route path="/templates" element={<TemplatesPage />} />
-          <Route
-            path="/templates/new"
-            element={requireAuth(<TemplatesEditorPage mode="new" />)}
-          />
-          <Route
-            path="/templates/edit/:id"
-            element={requireAuth(<TemplatesEditorPage mode="edit" />)}
-          />
-          <Route
-            path="/rules/:id"
-            element={requireAuth(
-              <RulesPage setErrorMessage={setErrorMessage} />
+            <Route
+              path="/uploads"
+              element={<Navigate to="/downloads" replace />}
+            />
+            <Route
+              path="/upload"
+              element={<UploadPage setErrorMessage={setErrorMessage} />}
+            />
+            <Route path="/print" element={<PrintPage />} />
+            <Route path="/image-occlusion" element={<ImageOcclusionPage />} />
+            <Route
+              path="/photo-to-deck"
+              element={requireAuth(<PhotoToFlashcardsPage />)}
+            />
+            <Route path="/mindmaps" element={requireAuth(<MindmapsPage />)} />
+            <Route path="/transform" element={requireAuth(<TransformPage />)} />
+            <Route
+              path="/mindmaps/:id"
+              element={requireAuth(<MindmapsPage />)}
+            />
+            <Route path="/chat" element={requireAuth(<ChatPage />)} />
+            <Route
+              path="/register"
+              element={<RegisterPage setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/notion"
+              element={requireAuth(<SearchPage setError={setErrorMessage} />)}
+            />
+            <Route path="/search" element={<Navigate to="/notion" replace />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/auth/magic" element={<MagicLinkPage />} />
+            <Route
+              path="/forgot"
+              element={<ForgotPasswordPage setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/users/r/:id"
+              element={<NewPasswordPage setErrorMessage={setErrorMessage} />}
+            />
+            <Route path="/debug" element={<DebugPage />} />
+            <Route path="/contact" element={<ContactPage />} />
+            <Route
+              path="/delete-account"
+              element={requireAuth(
+                <DeleteAccountPage setError={setErrorMessage} />
+              )}
+            />
+            <Route
+              path="/pricing"
+              element={
+                <PricingPage
+                  isLoggedIn={isLoggedInResolved}
+                  email={data?.user?.email}
+                  hostedAnkiRequested={data?.hostedAnkiRequested === true}
+                  patreon={data?.user?.patreon ?? null}
+                  signupCountry={data?.user?.signup_country ?? null}
+                  autoSyncCapReached={data?.autoSyncCapReached === true}
+                  autoSyncActive={data?.autoSyncActive === true}
+                />
+              }
+            />
+            <Route
+              path="/"
+              element={
+                <HomePage
+                  setErrorMessage={setErrorMessage}
+                  isLoggedIn={isLoggedInResolved}
+                />
+              }
+            />
+            <Route
+              path="/successful-checkout"
+              element={<SuccessfulCheckoutPage />}
+            />
+            <Route path="/limit" element={<LimitPage />} />
+            <Route path="/account" element={requireAuth(<AccountPage />)} />
+            <Route
+              path="/account/claim"
+              element={requireAuth(<AccountClaimPage />)}
+            />
+            {AccountPreviewPage && (
+              <Route
+                path="/dev/account-preview"
+                element={<AccountPreviewPage />}
+              />
             )}
-          />
-          <Route
-            path="/preview/:id"
-            element={requireAuth(<PreviewPage setError={setErrorMessage} />)}
-          />
-          <Route
-            path="/preview/database/:id"
-            element={requireAuth(
-              <DatabasePreviewPage setError={setErrorMessage} />
+            {NotionPreviewPage && (
+              <Route
+                path="/dev/notion-preview"
+                element={<NotionPreviewPage />}
+              />
             )}
-          />
-          <Route
-            path="/preview/apkg/:key"
-            element={requireAuth(
-              <PreviewApkgPage setError={setErrorMessage} />
+            {AnkifyReviewPreviewPage && (
+              <Route
+                path="/dev/ankify-review-preview"
+                element={<AnkifyReviewPreviewPage />}
+              />
             )}
-          />
-          <Route
-            path="/notion-to-anki"
-            element={<NotionToAnki setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/anki-to-notion"
-            element={<AnkiToNotion setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/quizlet-to-anki"
-            element={<QuizletToAnki setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/markdown-to-anki"
-            element={<MarkdownToAnki setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/pdf-to-anki"
-            element={<PdfToAnki setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/usmle-anki"
-            element={<UsmleAnki setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/nursing-flashcards"
-            element={<NursingFlashcards setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/anki-from-medical-lecture-slides"
-            element={
-              <AnkiFromMedicalLectureSlides setErrorMessage={setErrorMessage} />
-            }
-          />
-          <Route
-            path="/powerpoint-to-anki"
-            element={<PowerpointToAnki setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/goodnotes-to-anki"
-            element={<GoodnotesToAnki setErrorMessage={setErrorMessage} />}
-          />
-          <Route
-            path="/ai-flashcard-generator"
-            element={<AiFlashcardGenerator setErrorMessage={setErrorMessage} />}
-          />
-          <Route path="/notion-marketplace" element={<NotionLandingPage />} />
-          <Route path="/answers/:slug" element={<AnswersPage />} />
-          <Route path="/convert" element={<ConvertHubPage />} />
-          <Route
-            path="/convert/:slug"
-            element={<ConvertLandingPage setErrorMessage={setErrorMessage} />}
-          />
-          <Route path="/s/:token" element={<SharedDeckPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
+            <Route
+              path="/import"
+              element={requireAuth(<ImportPage setError={setErrorMessage} />)}
+            />
+            <Route path="/ankify" element={requireAuth(<AnkifyPage />)} />
+            <Route
+              path="/ankify/setup"
+              element={requireAuth(<AnkifySetupPage />)}
+            />
+            <Route
+              path="/ankify/history"
+              element={requireAuth(<AnkifyHistoryPage />)}
+            />
+            <Route path="/ops" element={requireAuth(<OpsLayout />)}>
+              <Route index element={<EngineeringTab />} />
+              <Route path="errors" element={<ErrorsTab />} />
+              <Route path="performance" element={<PerformanceTab />} />
+              <Route path="conversions" element={<ConversionsTab />} />
+              <Route path="return-rate" element={<ReturnRateTab />} />
+              <Route path="mindmaps" element={<MindmapsTab />} />
+              <Route path="upload-funnel" element={<UploadFunnelTab />} />
+              <Route path="business" element={<BusinessTab />} />
+              <Route path="showcase" element={<ShowcaseTab />} />
+              <Route path="interviews" element={<InterviewsTab />} />
+              <Route path="messages" element={<ContactMessagesTab />} />
+              <Route path="commands" element={<CommandsTab />} />
+              <Route path="flags" element={<FlagsTab />} />
+              <Route path="pricing-ab" element={<PricingAbFunnelTab />} />
+            </Route>
+            <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
+            <Route path="/settings" element={requireAuth(<AccountPage />)} />
+            <Route path="/about" element={<AboutPage />} />
+            <Route path="/app" element={<NativeAppPage />} />
+            <Route path="/security" element={<SecurityPage />} />
+            <Route path="/status" element={<StatusPage />} />
+            <Route path="/whats-new" element={<WhatsNewPage />} />
+            <Route path="/documentation" element={<DocsPage />} />
+            <Route path="/documentation/*" element={<DocsPage />} />
+            <Route
+              path="/settings/card-options"
+              element={<Navigate to="/card-options" replace />}
+            />
+            <Route
+              path="/card-options"
+              element={<CardOptionsPage setErrorMessage={setErrorMessage} />}
+            />
+            <Route path="/templates" element={<TemplatesPage />} />
+            <Route
+              path="/templates/new"
+              element={requireAuth(<TemplatesEditorPage mode="new" />)}
+            />
+            <Route
+              path="/templates/edit/:id"
+              element={requireAuth(<TemplatesEditorPage mode="edit" />)}
+            />
+            <Route
+              path="/rules/:id"
+              element={requireAuth(
+                <RulesPage setErrorMessage={setErrorMessage} />
+              )}
+            />
+            <Route
+              path="/preview/:id"
+              element={requireAuth(<PreviewPage setError={setErrorMessage} />)}
+            />
+            <Route
+              path="/preview/database/:id"
+              element={requireAuth(
+                <DatabasePreviewPage setError={setErrorMessage} />
+              )}
+            />
+            <Route
+              path="/preview/apkg/:key"
+              element={requireAuth(
+                <PreviewApkgPage setError={setErrorMessage} />
+              )}
+            />
+            <Route
+              path="/notion-to-anki"
+              element={<NotionToAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/anki-to-notion"
+              element={<AnkiToNotion setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/quizlet-to-anki"
+              element={<QuizletToAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/markdown-to-anki"
+              element={<MarkdownToAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/pdf-to-anki"
+              element={<PdfToAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/usmle-anki"
+              element={<UsmleAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/nursing-flashcards"
+              element={<NursingFlashcards setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/anki-from-medical-lecture-slides"
+              element={
+                <AnkiFromMedicalLectureSlides
+                  setErrorMessage={setErrorMessage}
+                />
+              }
+            />
+            <Route
+              path="/powerpoint-to-anki"
+              element={<PowerpointToAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/goodnotes-to-anki"
+              element={<GoodnotesToAnki setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/ai-flashcard-generator"
+              element={
+                <AiFlashcardGenerator setErrorMessage={setErrorMessage} />
+              }
+            />
+            <Route path="/notion-marketplace" element={<NotionLandingPage />} />
+            <Route path="/answers/:slug" element={<AnswersPage />} />
+            <Route path="/convert" element={<ConvertHubPage />} />
+            <Route
+              path="/convert/:slug"
+              element={<ConvertLandingPage setErrorMessage={setErrorMessage} />}
+            />
+            <Route path="/s/:token" element={<SharedDeckPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Routes>
+        </RouteRecoveryBoundary>
       </AppShell>
     </BrowserRouter>
   );

--- a/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.test.tsx
+++ b/web/src/components/DomRecoveryBoundary/DomRecoveryBoundary.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from '@testing-library/react';
 import React, { type ReactElement } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -125,6 +126,29 @@ describe('DomRecoveryBoundary', () => {
     expect(
       screen.getByRole('heading', { name: /something went wrong/i })
     ).toBeInTheDocument();
+  });
+
+  it('catches a DOM error thrown from a non-upload route and shows recovery UI', () => {
+    const onError = vi.fn();
+
+    function ThrowsDomError(): ReactElement {
+      throw makeNotFoundError();
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/pricing']}>
+        <DomRecoveryBoundary onError={onError}>
+          <Routes>
+            <Route path="/pricing" element={<ThrowsDomError />} />
+          </Routes>
+        </DomRecoveryBoundary>
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /something went wrong/i })
+    ).toBeInTheDocument();
+    expect(onError).toHaveBeenCalled();
   });
 
   it('reloads the page when the user clicks Reload on the fallback', () => {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-extension-crash-recovery.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-extension-crash-recovery.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-extension-crash-recovery",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Pages recover instead of going blank when a browser translation extension rewrites the text"
+}


### PR DESCRIPTION
## What
Hoists `DomRecoveryBoundary` from a single `/upload` route to wrap the whole route tree once at the app root, so every route is protected. Removes the now-redundant inner `/upload` boundary to avoid double-nesting and double-reporting.

## Why
Production error group `NotFoundError: Failed to execute 'removeChild' on 'Node'` — 5 occurrences, last seen 2026-06-13 on `/pricing`. Browser translation extensions (Google Translate) mutate text nodes React holds references to; React's commit phase then calls `removeChild`/`insertBefore` against a node that is no longer a child (React #11538), blanking the page. The mitigation existed but was wired only around `/upload`, so `/pricing` and every other route stayed unprotected.

User-visible outcome: a page with an active translation extension recovers (remount once, then a Reload card) instead of hard-crashing to a blank screen.

## How
A new root `RouteRecoveryBoundary` wraps `<Routes>` inside `AppShell` (still under `<BrowserRouter>`, so `useLocation` is valid). It derives a `surface` label from the first path segment and forwards `onError`/`onRecover` to `reportClientError`, preserving the existing reporting shape. The inner `/upload`-only boundary is removed so the upload route is no longer double-wrapped.

## Measuring success
The `NotFoundError` / `removeChild` / `insertBefore` web error group at `/api/events/errors` (surfaced in `/ops/errors`) should stop showing fresh occurrences on non-`/upload` routes. `reportClientError` payloads for these now carry `context.surface` (e.g. `pricing`) and `context.recovered: true` when the remount succeeded — query those to confirm recoveries are happening in the wild.

## Testing
- Unit tests added: `DomRecoveryBoundary.test.tsx` now proves the boundary catches a `NotFoundError` DOMException thrown from a non-`/upload` route (`/pricing` inside a `<Routes>` tree) and renders the recovery UI, calling `onError`.
- Full run: 14 tests pass across `DomRecoveryBoundary.test.tsx`, `App.test.tsx`, `loadChangelog.test.ts`. Web typecheck + oxlint clean.

## Browser check
Browser check pending — implemented + tested, needs manual golden-path verify on localhost:3000 before merge.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-14-extension-crash-recovery.json` — "Pages recover instead of going blank when a browser translation extension rewrites the text"

## Risks
Low. The boundary only intercepts DOM-manipulation errors (`isDomManipulationError`); all other errors propagate unchanged. The wrap is structural — the large App.tsx diff is oxfmt reindenting the `<Routes>` block; the only semantic changes are the new boundary, the `<Routes>` wrap, and the `/upload` un-wrap (verified via `git diff -w`). Rollback: revert the single commit.

## Goal alignment
Reduces hard-crash abandonment on `/pricing` and other routes for the slice of users running translation extensions — directly protects the page→checkout step of the v2 pricing funnel from a blank-screen drop-off. Read via the page→checkout conversion in the pricing A/B funnel and the disappearance of this error group in `/ops/errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
