### PR TITLE
refactor: route ankify sync diagnostics off the error dashboard

### DIFF
--- a/src/data_layer/index.ts
+++ b/src/data_layer/index.ts
@@ -195,7 +195,6 @@ export const setupDatabase = async (database: Knex) => {
         notionBlockChildrenFetcherFactory,
         (token) => buildNotionPageMetaFetcher(token),
         undefined,
-        undefined,
         (owner: number) =>
           new MarkNotionTokenInvalidUseCase(
             notionRepo,

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -63,7 +63,6 @@ import {
 } from '../services/ApkgPreviewService/extractApkg';
 import SettingsRepository from '../data_layer/SettingsRepository';
 import RequireAnkifyAccess from './middleware/RequireAnkifyAccess';
-import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { MarkNotionTokenInvalidUseCase } from '../usecases/notion/MarkNotionTokenInvalidUseCase';
 import { buildNotionPageMetaFetcher } from '../services/ankify/buildNotionPageMetaFetcher';
@@ -316,7 +315,6 @@ const AnkifyRouter = () => {
     notionBlockChildrenFetcherFactory,
     buildNotionPageMetaFetcher,
     undefined,
-    new ErrorEventRepository(db),
     (owner: number) =>
       new MarkNotionTokenInvalidUseCase(
         ankifyNotionRepo,

--- a/src/routes/AnkifyWebhookRouter.ts
+++ b/src/routes/AnkifyWebhookRouter.ts
@@ -14,7 +14,6 @@ import { verifyNotionWebhookSignature } from '../lib/ankify/notionWebhookSignatu
 import { hasAnkifyAccess } from '../lib/ankify/access';
 import UsersRepository from '../data_layer/UsersRepository';
 import SubscriptionService from '../services/SubscriptionService';
-import { ErrorEventRepository } from '../data_layer/ErrorEventRepository';
 import { getDefaultEmailService } from '../services/EmailService/EmailService';
 import { MarkNotionTokenInvalidUseCase } from '../usecases/notion/MarkNotionTokenInvalidUseCase';
 import { makeAnkifyTemplateOverridesProvider } from '../services/ankify/templateOverrides';
@@ -42,7 +41,6 @@ const AnkifyWebhookRouter = () => {
     notionBlockChildrenFetcherFactory,
     undefined,
     undefined,
-    new ErrorEventRepository(db),
     (owner: number) =>
       new MarkNotionTokenInvalidUseCase(
         notionRepo,

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -76,6 +76,8 @@ export const KNOWN_EVENTS = new Set([
   'ankify_sync_ankiweb',
   'ankify_leeches_viewed',
   'ankify_leech_action',
+  'ankify_zero_cards',
+  'ankify_sync_followed_deck',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -13,13 +13,16 @@ import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/
 import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import { AnkifySyncLogsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncLogsRepository';
 import { INotionRepository } from '../../data_layer/NotionRespository';
-import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
 import { AnkiConnectClient } from '../../services/ankify/AnkiConnectClient';
 import { WalkedNotionFlashcard } from '../../services/ankify/notionPageWalker';
 
 jest.mock('../../services/ankify/notionPageWalker', () => ({
   walkNotionPageForFlashcards: jest.fn(),
   walkNotionDatabaseForFlashcards: jest.fn(),
+}));
+
+jest.mock('../../services/events/track', () => ({
+  track: jest.fn(),
 }));
 
 jest.mock('axios');
@@ -34,9 +37,11 @@ import {
   walkNotionPageForFlashcards,
   walkNotionDatabaseForFlashcards,
 } from '../../services/ankify/notionPageWalker';
+import { track } from '../../services/events/track';
 
 const mockAxiosGet = axios.get as jest.Mock;
 const mockDnsLookup = dns.promises.lookup as jest.Mock;
+const mockTrack = track as jest.Mock;
 
 const sampleClient = (): AnkifyClient => ({
   id: 1,
@@ -198,6 +203,7 @@ describe('SyncNotionPageToRacUseCase', () => {
     (walkNotionDatabaseForFlashcards as jest.Mock).mockResolvedValue(
       emptyWalkResult()
     );
+    mockTrack.mockClear();
   });
 
   test('falls back to a database walk when the subscribed id is a Notion database', async () => {
@@ -234,7 +240,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       repos.notionRepo,
       () => ac,
       () => async () => [],
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -289,16 +294,6 @@ describe('SyncNotionPageToRacUseCase', () => {
 
     const repos = makeRepos();
     const ac = makeAnkiConnectStub();
-    const insert = jest.fn().mockResolvedValue(undefined);
-    const errorEvents = {
-      insert,
-      existsWithinWindow: jest.fn().mockResolvedValue(false),
-      listGroups: jest.fn().mockResolvedValue([]),
-      countGroups: jest.fn().mockResolvedValue(0),
-      latestSamples: jest.fn().mockResolvedValue([]),
-      resolveGroup: jest.fn().mockResolvedValue(undefined),
-      reopenGroup: jest.fn().mockResolvedValue(undefined),
-    } as unknown as IErrorEventRepository;
     const databasePages = jest.fn(async () => [{ id: 'row-1' }]);
     const useCase = new SyncNotionPageToRacUseCase(
       repos.clients,
@@ -315,7 +310,6 @@ describe('SyncNotionPageToRacUseCase', () => {
         icon: '🧪',
       }),
       undefined,
-      errorEvents,
       undefined,
       undefined,
       () => databasePages
@@ -341,7 +335,10 @@ describe('SyncNotionPageToRacUseCase', () => {
       databasePages
     );
     expect(result.created).toBe(1);
-    expect(insert).not.toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      'ankify_zero_cards',
+      expect.anything()
+    );
   });
 
   test('walks the database child pages when the page walk finds no blocks of its own', async () => {
@@ -359,16 +356,6 @@ describe('SyncNotionPageToRacUseCase', () => {
 
     const repos = makeRepos();
     const ac = makeAnkiConnectStub();
-    const insert = jest.fn().mockResolvedValue(undefined);
-    const errorEvents = {
-      insert,
-      existsWithinWindow: jest.fn().mockResolvedValue(false),
-      listGroups: jest.fn().mockResolvedValue([]),
-      countGroups: jest.fn().mockResolvedValue(0),
-      latestSamples: jest.fn().mockResolvedValue([]),
-      resolveGroup: jest.fn().mockResolvedValue(undefined),
-      reopenGroup: jest.fn().mockResolvedValue(undefined),
-    } as unknown as IErrorEventRepository;
     const databasePages = jest.fn(async () => [
       { id: 'row-1' },
       { id: 'row-2' },
@@ -384,7 +371,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       () => async () => [],
       undefined,
       undefined,
-      errorEvents,
       undefined,
       undefined,
       () => databasePages
@@ -404,7 +390,10 @@ describe('SyncNotionPageToRacUseCase', () => {
       databasePages
     );
     expect(result.created).toBe(1);
-    expect(insert).not.toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      'ankify_zero_cards',
+      expect.anything()
+    );
   });
 
   test('records the database object type when the meta fetch resolves a null-typed id as a database', async () => {
@@ -448,7 +437,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       () => ac,
       () => async () => [],
       () => metaFetch,
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -510,7 +498,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       () => databasePages
     );
 
@@ -536,16 +523,6 @@ describe('SyncNotionPageToRacUseCase', () => {
 
     const repos = makeRepos();
     const ac = makeAnkiConnectStub();
-    const insert = jest.fn().mockResolvedValue(undefined);
-    const errorEvents = {
-      insert,
-      existsWithinWindow: jest.fn().mockResolvedValue(false),
-      listGroups: jest.fn().mockResolvedValue([]),
-      countGroups: jest.fn().mockResolvedValue(0),
-      latestSamples: jest.fn().mockResolvedValue([]),
-      resolveGroup: jest.fn().mockResolvedValue(undefined),
-      reopenGroup: jest.fn().mockResolvedValue(undefined),
-    } as unknown as IErrorEventRepository;
     const databasePages = jest.fn(async () => {
       throw Object.assign(
         new Error('page-id is not a database. Use the retrieve a page API.'),
@@ -563,7 +540,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       () => async () => [],
       undefined,
       undefined,
-      errorEvents,
       undefined,
       undefined,
       () => databasePages
@@ -578,8 +554,9 @@ describe('SyncNotionPageToRacUseCase', () => {
     );
 
     expect(result.created).toBe(0);
-    expect(insert).toHaveBeenCalledWith(
-      expect.objectContaining({ message: 'ankify.zero_cards' })
+    expect(mockTrack).toHaveBeenCalledWith(
+      'ankify_zero_cards',
+      expect.anything()
     );
   });
 
@@ -752,7 +729,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       async () => ({
         basicModelName: 'ATTI BASIC',
         basicTemplate: {
@@ -816,7 +792,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       repos.notionRepo,
       () => ac,
       () => async () => [],
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -1132,6 +1107,14 @@ describe('SyncNotionPageToRacUseCase', () => {
         deck_name: 'MS3::Pharmacology',
       })
     );
+    expect(mockTrack).toHaveBeenCalledWith('ankify_sync_followed_deck', {
+      userId: 42,
+      props: expect.objectContaining({
+        source_type: 'notion_page',
+        moved_notes: 1,
+        trigger: 'polling',
+      }),
+    });
   });
 
   test('puts each database child page into its own subdeck under the database deck', async () => {
@@ -1179,7 +1162,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       repos.notionRepo,
       () => ac,
       () => async () => [],
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -1257,7 +1239,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       undefined,
       undefined,
       undefined,
-      undefined,
       () => async () => [{ id: 'row-1' }]
     );
 
@@ -1319,7 +1300,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       repos.notionRepo,
       () => ac,
       () => async () => [],
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -1411,7 +1391,6 @@ describe('SyncNotionPageToRacUseCase', () => {
       repos.notionRepo,
       () => ac,
       () => async () => [],
-      undefined,
       undefined,
       undefined,
       undefined,
@@ -2123,20 +2102,9 @@ describe('SyncNotionPageToRacUseCase', () => {
   });
 
   describe('zero-card structured event emission', () => {
-    const makeErrorEventRepo = (): jest.Mocked<IErrorEventRepository> => ({
-      insert: jest.fn().mockResolvedValue(undefined),
-      existsWithinWindow: jest.fn().mockResolvedValue(false),
-      listGroups: jest.fn().mockResolvedValue([]),
-      countGroups: jest.fn().mockResolvedValue(0),
-      latestSamples: jest.fn().mockResolvedValue([]),
-      resolveGroup: jest.fn().mockResolvedValue(undefined),
-      reopenGroup: jest.fn().mockResolvedValue(undefined),
-    });
-
-    it('emits ankify.zero_cards event when page produces no cards', async () => {
+    it('tracks ankify_zero_cards analytics event when page produces no cards', async () => {
       const repos = makeRepos();
       const ac = makeAnkiConnectStub();
-      const errorEventRepo = makeErrorEventRepo();
       (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
         cards: [],
         diagnostic: { blocks_scanned: 5, blocks_matched: 0, pattern_hits: {} },
@@ -2150,10 +2118,7 @@ describe('SyncNotionPageToRacUseCase', () => {
         repos.logs,
         repos.notionRepo,
         () => ac,
-        () => async () => [],
-        undefined,
-        undefined,
-        errorEventRepo
+        () => async () => []
       );
 
       await useCase.execute({
@@ -2162,25 +2127,21 @@ describe('SyncNotionPageToRacUseCase', () => {
         trigger: 'manual',
       });
 
-      expect(errorEventRepo.insert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          source: 'server',
-          message: 'ankify.zero_cards',
-          context: expect.objectContaining({
-            user_id: 42,
-            source_type: 'notion_page',
-            parser_path: 'ankify/notionPageWalker',
-            reason_code: 'all_blocks_unmatched',
-            blocks_scanned: 5,
-          }),
-        })
-      );
+      expect(mockTrack).toHaveBeenCalledWith('ankify_zero_cards', {
+        userId: 42,
+        props: expect.objectContaining({
+          source_type: 'notion_page',
+          parser_path: 'ankify/notionPageWalker',
+          reason_code: 'all_blocks_unmatched',
+          blocks_scanned: 5,
+          trigger: 'manual',
+        }),
+      });
     });
 
     it('derives reason_code empty_page when blocks_scanned is zero', async () => {
       const repos = makeRepos();
       const ac = makeAnkiConnectStub();
-      const errorEventRepo = makeErrorEventRepo();
       (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
         cards: [],
         diagnostic: { blocks_scanned: 0, blocks_matched: 0, pattern_hits: {} },
@@ -2194,10 +2155,7 @@ describe('SyncNotionPageToRacUseCase', () => {
         repos.logs,
         repos.notionRepo,
         () => ac,
-        () => async () => [],
-        undefined,
-        undefined,
-        errorEventRepo
+        () => async () => []
       );
 
       await useCase.execute({
@@ -2206,17 +2164,17 @@ describe('SyncNotionPageToRacUseCase', () => {
         trigger: 'polling',
       });
 
-      expect(errorEventRepo.insert).toHaveBeenCalledWith(
+      expect(mockTrack).toHaveBeenCalledWith(
+        'ankify_zero_cards',
         expect.objectContaining({
-          context: expect.objectContaining({ reason_code: 'empty_page' }),
+          props: expect.objectContaining({ reason_code: 'empty_page' }),
         })
       );
     });
 
-    it('does not emit zero_cards event when cards are produced', async () => {
+    it('does not track ankify_zero_cards when cards are produced', async () => {
       const repos = makeRepos();
       const ac = makeAnkiConnectStub();
-      const errorEventRepo = makeErrorEventRepo();
       (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
         cards: [sampleCard()],
         diagnostic: {
@@ -2234,10 +2192,7 @@ describe('SyncNotionPageToRacUseCase', () => {
         repos.logs,
         repos.notionRepo,
         () => ac,
-        () => async () => [],
-        undefined,
-        undefined,
-        errorEventRepo
+        () => async () => []
       );
 
       await useCase.execute({
@@ -2246,10 +2201,13 @@ describe('SyncNotionPageToRacUseCase', () => {
         trigger: 'manual',
       });
 
-      expect(errorEventRepo.insert).not.toHaveBeenCalled();
+      expect(mockTrack).not.toHaveBeenCalledWith(
+        'ankify_zero_cards',
+        expect.anything()
+      );
     });
 
-    it('does not throw if errorEventRepo is not provided', async () => {
+    it('does not route the zero-card diagnostic to the error dashboard', async () => {
       const repos = makeRepos();
       const ac = makeAnkiConnectStub();
       (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
@@ -2268,13 +2226,15 @@ describe('SyncNotionPageToRacUseCase', () => {
         () => async () => []
       );
 
-      await expect(
-        useCase.execute({
-          owner: 42,
-          notionPageId: 'page-no-repo',
-          trigger: 'manual',
-        })
-      ).resolves.not.toThrow();
+      await useCase.execute({
+        owner: 42,
+        notionPageId: 'page-no-repo',
+        trigger: 'manual',
+      });
+
+      const trackedNames = mockTrack.mock.calls.map((call) => call[0]);
+      expect(trackedNames).toContain('ankify_zero_cards');
+      expect(trackedNames).not.toContain('ankify.zero_cards');
     });
   });
 
@@ -2470,7 +2430,6 @@ describe('SyncNotionPageToRacUseCase', () => {
         undefined,
         undefined,
         undefined,
-        undefined,
         () => async () => [{ id: 'row-1' }]
       );
 
@@ -2505,7 +2464,6 @@ describe('SyncNotionPageToRacUseCase', () => {
         repos.notionRepo,
         () => ac,
         () => async () => [],
-        undefined,
         undefined,
         undefined,
         undefined,

--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.ts
@@ -6,7 +6,7 @@ import { AnkifySyncConflictsRepositoryInterface } from '../../data_layer/ankify/
 import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import { AnkifySyncLogsRepositoryInterface } from '../../data_layer/ankify/AnkifySyncLogsRepository';
 import { INotionRepository } from '../../data_layer/NotionRespository';
-import { IErrorEventRepository } from '../../data_layer/ErrorEventRepository';
+import { track } from '../../services/events/track';
 
 export type OnTokenInvalidFn = (owner: number) => Promise<void>;
 import {
@@ -202,7 +202,6 @@ export class SyncNotionPageToRacUseCase {
     private readonly notionFetcher: NotionFetcherFactory,
     private readonly notionPageMeta?: NotionPageMetaFetcher,
     private readonly mediaFetcher: AnkifyMediaFetcher = guardedMediaFetcher,
-    private readonly errorEvents?: IErrorEventRepository,
     private readonly onTokenInvalid?: OnTokenInvalidFn,
     private readonly templateOverridesProvider?: AnkifyTemplateOverridesProvider,
     private readonly databasePagesFetcher: NotionDatabasePagesFetcherFactory = notionDatabasePagesFetcherFactory
@@ -383,38 +382,23 @@ export class SyncNotionPageToRacUseCase {
     input: SyncNotionPageInput,
     diagnostic: SyncDiagnostic
   ): void {
-    if (this.errorEvents == null) {
-      return;
-    }
     const reasonCode = deriveReasonCode(diagnostic);
     const pageIdHash = crypto
       .createHash('sha256')
       .update(input.notionPageId)
       .digest('hex');
-    this.errorEvents
-      .insert({
-        source: 'server',
-        message: 'ankify.zero_cards',
-        message_hash: crypto
-          .createHash('sha256')
-          .update(`ankify.zero_cards:${pageIdHash}:${input.owner}`)
-          .digest('hex'),
-        context: {
-          user_id: input.owner,
-          source_type: 'notion_page',
-          file_hash: pageIdHash,
-          input_chars: diagnostic.blocks_scanned,
-          ai_response_chars: 0,
-          parser_path: 'ankify/notionPageWalker',
-          reason_code: reasonCode,
-          blocks_scanned: diagnostic.blocks_scanned,
-          blocks_matched: diagnostic.blocks_matched,
-          trigger: input.trigger,
-        },
-      })
-      .catch((err) => {
-        console.error('[ankify-sync] failed to emit zero_cards event', err);
-      });
+    track('ankify_zero_cards', {
+      userId: input.owner,
+      props: {
+        source_type: 'notion_page',
+        file_hash: pageIdHash,
+        parser_path: 'ankify/notionPageWalker',
+        reason_code: reasonCode,
+        blocks_scanned: diagnostic.blocks_scanned,
+        blocks_matched: diagnostic.blocks_matched,
+        trigger: input.trigger,
+      },
+    });
   }
 
   private async runSync(args: {
@@ -721,37 +705,21 @@ export class SyncNotionPageToRacUseCase {
     deckName: string,
     movedNotes: number
   ): void {
-    if (this.errorEvents == null) {
-      return;
-    }
     const pageIdHash = crypto
       .createHash('sha256')
       .update(input.notionPageId)
       .digest('hex');
     const deckHash = crypto.createHash('sha256').update(deckName).digest('hex');
-    this.errorEvents
-      .insert({
-        source: 'server',
-        message: 'ankify.sync_followed_deck',
-        message_hash: crypto
-          .createHash('sha256')
-          .update(`ankify.sync_followed_deck:${pageIdHash}:${input.owner}`)
-          .digest('hex'),
-        context: {
-          user_id: input.owner,
-          source_type: 'notion_page',
-          file_hash: pageIdHash,
-          deck_hash: deckHash,
-          moved_notes: movedNotes,
-          trigger: input.trigger,
-        },
-      })
-      .catch((err) => {
-        console.error(
-          '[ankify-sync] failed to emit sync_followed_deck event',
-          err
-        );
-      });
+    track('ankify_sync_followed_deck', {
+      userId: input.owner,
+      props: {
+        source_type: 'notion_page',
+        file_hash: pageIdHash,
+        deck_hash: deckHash,
+        moved_notes: movedNotes,
+        trigger: input.trigger,
+      },
+    });
   }
 
   private async walkSource(


### PR DESCRIPTION
## What
The Ankify Notion→Anki sync wrote two **diagnostics** straight into the `error_events` table — the same table the error dashboard groups by `message`. They showed up as production "error groups" that are not errors. This routes both to the existing analytics events sink instead, leaving the error dashboard for genuine errors.

## Why
Verified dashboard pollution (occurrence counts from the dashboard, no user identifiers):

- `ankify.sync_followed_deck` — **14 occurrences** (a **success** signal: notes were relocated to follow a renamed deck), emitted in `SyncNotionPageToRacUseCase.emitFollowedDeckEvent`.
- `ankify.zero_cards` — **1 occurrence** (a diagnostic: a synced page produced no cards), emitted in `SyncNotionPageToRacUseCase.emitZeroCardsEvent`.

Both called `errorEvents.insert({ source: 'server', message: 'ankify.*', ... })` → `ErrorEventRepository` → `error_events`, so the error dashboard counted them as error groups.

## How
Approach **(A)** — route the diagnostics into the analytics events sink that already exists server-side (`track()` → `EventsSink` → `events` table), rather than `error_events`. Chosen because a dedicated non-error events channel already exists with a typed `KnownEvent` catalog and a buffered, non-blocking sink; no schema change is needed.

- Added `ankify_zero_cards` and `ankify_sync_followed_deck` to `KNOWN_EVENTS` (`src/types/AnalyticsEvents.ts`).
- Rewrote the two emit methods to call `track(...)` with the same diagnostic fields as event `props` (`reason_code`, `blocks_scanned`, `blocks_matched`, `trigger`, hashed `file_hash`/`deck_hash`, `moved_notes`). `user_id` moves from a `context` field to the first-class `userId` on the event row. Dropped the redundant `input_chars`/`ai_response_chars: 0` fields (duplicated `blocks_scanned` / constant zero).
- Removed the now-unused `errorEvents` constructor argument from `SyncNotionPageToRacUseCase`.
- **The web client error reporter (`POST /api/events/errors`, real JS errors) is untouched and still lands on the error dashboard.** Only these two server diagnostics moved.

**Construction sites checked (per first-time-fix rule, `grep -rn "new SyncNotionPageToRacUseCase"`):** all three production sites updated — `src/data_layer/index.ts` (the 5-min poll path), `src/routes/AnkifyRouter.ts` (manual sync), `src/routes/AnkifyWebhookRouter.ts` (webhook). Note: `data_layer/index.ts` (the poll path) was already passing `undefined` for `errorEvents`, so these diagnostics were **silently dropped on the polling path before this PR** — routing through `track()` recovers that signal as a side benefit.

## Measuring success
- Error dashboard: `ankify.sync_followed_deck` and `ankify.zero_cards` stop appearing as new error groups (the `/api/events/errors` listing, server source).
- Analytics: rows appear in the `events` table with `name IN ('ankify_zero_cards','ankify_sync_followed_deck')` — query `select name, count(*) from events where name like 'ankify_%' group by name`.

## Migration
**None.** Approach (A) reuses the existing `events` table — no schema change, no Knex migration.

## Testing
- Unit tests updated in `SyncNotionPageToRacUseCase.test.ts`: the zero-card emission suite now asserts `track('ankify_zero_cards', …)` instead of `errorEvents.insert(... 'ankify.zero_cards')`; added a test asserting the diagnostic does **not** carry the old dotted error-dashboard name; added a `track('ankify_sync_followed_deck', …)` assertion on the existing followed-deck relocation test.
- `pnpm test src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts` → **53 passed**. Ankify area (`src/usecases/ankify` + `src/routes/Ankify*`) → **205 passed**. Events sink/track → **14 passed**. Server tsc clean. oxfmt clean. oxlint clean on the diff (one pre-existing `no-negated-condition` warning on untouched line 289).

## Browser check
Browser check: not applicable — no `web/src/` files; server-only change.

## Changelog
No changelog — internal, no user-visible change. These events are operational telemetry; users never saw them.

## Risks
Low. No external behavior changes; the events still fire on the same triggers with the same meaning, only the storage destination/classification changed. The analytics sink is buffered and best-effort (drops on flush failure with a console.error), matching every other `track()` call site — acceptable for diagnostics. Rollback: revert the single commit.

## Goal alignment
None — internal. Cleans operational signal (the error dashboard) so genuine errors are not buried under non-error Ankify telemetry; faster triage of real conversion failures protects the conversion funnel indirectly, but no funnel metric moves directly.
