### PR TITLE
fix: load subdeck due cards and show the Review list as an Anki-style deck tree

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -320,6 +320,32 @@ describe('AnkiConnectClient', () => {
     });
   });
 
+  test('deckNamesAndIds posts the action and returns the full-name to id map', async () => {
+    const fetchImpl = makeFetch({
+      result: {
+        Default: 1,
+        "Jlab's beginner course": 1651445861967,
+        "Jlab's beginner course::Part 1: Listening comprehension": 1651445861999,
+      },
+      error: null,
+    });
+    const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);
+
+    const map = await client.deckNamesAndIds();
+
+    expect(map).toEqual({
+      Default: 1,
+      "Jlab's beginner course": 1651445861967,
+      "Jlab's beginner course::Part 1: Listening comprehension": 1651445861999,
+    });
+    const body = JSON.parse((fetchImpl as jest.Mock).mock.calls[0][1].body);
+    expect(body).toEqual({
+      action: 'deckNamesAndIds',
+      version: 6,
+      params: {},
+    });
+  });
+
   test('guiBrowse posts the query and returns the matched card ids', async () => {
     const fetchImpl = makeFetch({ result: [1502298033753], error: null });
     const client = new AnkiConnectClient('http://localhost:8765', fetchImpl);

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -103,6 +103,10 @@ export class AnkiConnectClient {
     return this.invoke('deckNames');
   }
 
+  async deckNamesAndIds(): Promise<Record<string, number>> {
+    return this.invoke('deckNamesAndIds', {});
+  }
+
   async modelNames(): Promise<string[]> {
     return this.invoke('modelNames');
   }

--- a/src/usecases/ankify/GetAnkifyStatsUseCase.test.ts
+++ b/src/usecases/ankify/GetAnkifyStatsUseCase.test.ts
@@ -24,6 +24,7 @@ const TODAY = '2026-06-12';
 interface FakeAnkiConnect {
   ping: jest.Mock;
   deckNames: jest.Mock;
+  deckNamesAndIds: jest.Mock;
   getNumCardsReviewedToday: jest.Mock;
   getNumCardsReviewedByDay: jest.Mock;
   getDeckStats: jest.Mock;
@@ -36,6 +37,7 @@ const makeAnkiConnect = (
 ): FakeAnkiConnect => ({
   ping: jest.fn(async () => 6),
   deckNames: jest.fn(async () => [] as string[]),
+  deckNamesAndIds: jest.fn(async () => ({}) as Record<string, number>),
   getNumCardsReviewedToday: jest.fn(async () => 0),
   getNumCardsReviewedByDay: jest.fn(async () => [] as Array<[string, number]>),
   getDeckStats: jest.fn(async () => ({}) as Record<string, AnkiDeckStat>),
@@ -101,13 +103,13 @@ describe('GetAnkifyStatsUseCase', () => {
     });
   });
 
-  test('fetches deck stats for the full collection and sorts decks by total desc', async () => {
+  test('recovers full deck paths from deckNamesAndIds and sorts decks by total desc', async () => {
     const ac = makeAnkiConnect({
-      deckNames: jest.fn(async () => [
-        'Default',
-        'Pharmacology',
-        'Spanish::Verbs',
-      ]),
+      deckNamesAndIds: jest.fn(async () => ({
+        Default: 1,
+        Pharmacology: 111,
+        'Spanish::Verbs': 222,
+      })),
       getNumCardsReviewedToday: jest.fn(async () => 12),
       getNumCardsReviewedByDay: jest.fn(async () => [
         ['2026-06-12', 12],
@@ -132,7 +134,7 @@ describe('GetAnkifyStatsUseCase', () => {
         },
         '222': {
           deck_id: 222,
-          name: 'Spanish::Verbs',
+          name: 'Verbs',
           new_count: 1,
           learn_count: 0,
           review_count: 4,
@@ -147,7 +149,8 @@ describe('GetAnkifyStatsUseCase', () => {
 
     const result = await useCase.execute(1, { today: TODAY });
 
-    expect(ac.deckNames).toHaveBeenCalledTimes(1);
+    expect(ac.deckNamesAndIds).toHaveBeenCalledTimes(1);
+    expect(ac.deckNames).not.toHaveBeenCalled();
     expect(ac.getDeckStats).toHaveBeenCalledWith([
       'Default',
       'Pharmacology',
@@ -166,16 +169,115 @@ describe('GetAnkifyStatsUseCase', () => {
         { date: '2026-06-11', count: 8 },
       ],
       decks: [
-        { name: 'Spanish::Verbs', new: 1, learning: 0, review: 4, total: 300 },
-        { name: 'Pharmacology', new: 5, learning: 2, review: 11, total: 120 },
-        { name: 'Default', new: 0, learning: 0, review: 0, total: 0 },
+        {
+          fullName: 'Spanish::Verbs',
+          name: 'Verbs',
+          depth: 1,
+          new: 1,
+          learning: 0,
+          review: 4,
+          total: 300,
+        },
+        {
+          fullName: 'Pharmacology',
+          name: 'Pharmacology',
+          depth: 0,
+          new: 5,
+          learning: 2,
+          review: 11,
+          total: 120,
+        },
+        {
+          fullName: 'Default',
+          name: 'Default',
+          depth: 0,
+          new: 0,
+          learning: 0,
+          review: 0,
+          total: 0,
+        },
+      ],
+    });
+  });
+
+  test('recovers the full path for a database-child subdeck whose stats name is the leaf', async () => {
+    const ac = makeAnkiConnect({
+      deckNamesAndIds: jest.fn(async () => ({
+        "Jlab's beginner course": 100,
+        "Jlab's beginner course::Part 1: Listening comprehension": 200,
+      })),
+      getDeckStats: jest.fn(async () => ({
+        '200': {
+          deck_id: 200,
+          name: 'Part 1: Listening comprehension',
+          new_count: 2,
+          learn_count: 1,
+          review_count: 7,
+          total_in_deck: 40,
+        },
+      })),
+    });
+    const useCase = new GetAnkifyStatsUseCase(
+      makeClientsRepo(activeClient),
+      () => ac as never
+    );
+
+    const result = await useCase.execute(1, { today: TODAY });
+
+    expect(result).toMatchObject({
+      connected: true,
+      decks: [
+        {
+          fullName: "Jlab's beginner course::Part 1: Listening comprehension",
+          name: 'Part 1: Listening comprehension',
+          depth: 1,
+          new: 2,
+          learning: 1,
+          review: 7,
+          total: 40,
+        },
+      ],
+    });
+  });
+
+  test('falls back to the stat name when the deck_id is absent from the names map', async () => {
+    const ac = makeAnkiConnect({
+      deckNamesAndIds: jest.fn(async () => ({ Anatomy: 2 })),
+      getDeckStats: jest.fn(async () => ({
+        '999': {
+          deck_id: 999,
+          name: 'Orphan::Leaf',
+          new_count: 0,
+          learn_count: 0,
+          review_count: 1,
+          total_in_deck: 5,
+        },
+      })),
+    });
+    const useCase = new GetAnkifyStatsUseCase(
+      makeClientsRepo(activeClient),
+      () => ac as never
+    );
+
+    const result = await useCase.execute(1, { today: TODAY });
+
+    expect(result).toMatchObject({
+      connected: true,
+      decks: [
+        {
+          fullName: 'Orphan::Leaf',
+          name: 'Leaf',
+          depth: 1,
+          review: 1,
+          total: 5,
+        },
       ],
     });
   });
 
   test('tie-breaks decks with equal totals by name ascending', async () => {
     const ac = makeAnkiConnect({
-      deckNames: jest.fn(async () => ['Zoology', 'Anatomy']),
+      deckNamesAndIds: jest.fn(async () => ({ Zoology: 1, Anatomy: 2 })),
       getDeckStats: jest.fn(async () => ({
         '1': {
           deck_id: 1,

--- a/src/usecases/ankify/GetAnkifyStatsUseCase.ts
+++ b/src/usecases/ankify/GetAnkifyStatsUseCase.ts
@@ -13,12 +13,21 @@ export type AnkiConnectFactory = (
 ) => AnkiConnectClient;
 
 export interface AnkifyStatsDeck {
+  fullName: string;
   name: string;
+  depth: number;
   new: number;
   learning: number;
   review: number;
   total: number;
 }
+
+const leafName = (fullName: string): string => {
+  const segments = fullName.split('::');
+  return segments[segments.length - 1];
+};
+
+const deckDepth = (fullName: string): number => fullName.split('::').length - 1;
 
 export interface AnkifyStatsReviewDay {
   date: string;
@@ -77,7 +86,12 @@ export class GetAnkifyStatsUseCase {
       throw error;
     }
 
-    const deckNames = await ac.deckNames();
+    const deckNamesAndIds = await ac.deckNamesAndIds();
+    const deckNames = Object.keys(deckNamesAndIds);
+    const fullNameById = new Map<number, string>();
+    for (const [fullName, id] of Object.entries(deckNamesAndIds)) {
+      fullNameById.set(id, fullName);
+    }
 
     const [reviewedToday, reviewsByDayRaw, deckStats] = await Promise.all([
       ac.getNumCardsReviewedToday(),
@@ -101,13 +115,18 @@ export class GetAnkifyStatsUseCase {
       .reduce((sum, entry) => sum + entry.count, 0);
 
     const decks: AnkifyStatsDeck[] = Object.values(deckStats)
-      .map((stat) => ({
-        name: stat.name,
-        new: stat.new_count,
-        learning: stat.learn_count,
-        review: stat.review_count,
-        total: stat.total_in_deck ?? 0,
-      }))
+      .map((stat) => {
+        const fullName = fullNameById.get(stat.deck_id) ?? stat.name;
+        return {
+          fullName,
+          name: leafName(fullName),
+          depth: deckDepth(fullName),
+          new: stat.new_count,
+          learning: stat.learn_count,
+          review: stat.review_count,
+          total: stat.total_in_deck ?? 0,
+        };
+      })
       .sort((a, b) =>
         b.total === a.total ? a.name.localeCompare(b.name) : b.total - a.total
       );

--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -1235,6 +1235,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  padding-left: calc(min(var(--depth, 0), 4) * var(--space-4));
 }
 
 .decksItemTitle a {

--- a/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
+++ b/web/src/pages/AnkifyPage/components/NotionSubscriptions.test.tsx
@@ -1047,7 +1047,9 @@ describe('NotionSubscriptions cockpit data column', () => {
         reviewsByDay: [],
         decks: [
           {
-            name: 'MS3::Pharmacology',
+            fullName: 'MS3::Pharmacology',
+            name: 'Pharmacology',
+            depth: 1,
             new: 3,
             learning: 2,
             review: 5,
@@ -1079,7 +1081,15 @@ describe('NotionSubscriptions cockpit data column', () => {
         longestStreak: 0,
         reviewsByDay: [],
         decks: [
-          { name: 'Other::Deck', new: 9, learning: 9, review: 9, total: 27 },
+          {
+            fullName: 'Other::Deck',
+            name: 'Deck',
+            depth: 1,
+            new: 9,
+            learning: 9,
+            review: 9,
+            total: 27,
+          },
         ],
       })),
     });

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -36,7 +36,15 @@ const statsWithDeck = (review: number): AnkifyStats => ({
   longestStreak: 0,
   reviewsByDay: [],
   decks: [
-    { name: 'Notion Sync::Pharma', new: 3, learning: 1, review, total: 120 },
+    {
+      fullName: 'Notion Sync::Pharma',
+      name: 'Pharma',
+      depth: 1,
+      new: 3,
+      learning: 1,
+      review,
+      total: 120,
+    },
   ],
 });
 
@@ -297,6 +305,88 @@ describe('ReviewPanel', () => {
 
     const reviewButton = await screen.findByRole('button', { name: 'Review' });
     expect(reviewButton).toBeDisabled();
+  });
+
+  test('sends the full deck path to the review queue for a subdeck', async () => {
+    const subdeckStats: AnkifyStats = {
+      connected: true,
+      reviewedToday: 0,
+      reviewedThisYear: 0,
+      currentStreak: 0,
+      longestStreak: 0,
+      reviewsByDay: [],
+      decks: [
+        {
+          fullName: "Jlab's beginner course::Part 1: Listening comprehension",
+          name: 'Part 1: Listening comprehension',
+          depth: 1,
+          new: 0,
+          learning: 0,
+          review: 5,
+          total: 40,
+        },
+      ],
+    };
+    const getAnkifyReviewQueue = vi.fn(async () => ({
+      connected: true as const,
+      cardIds: [9001],
+    }));
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () => subdeckStats),
+        getAnkifyReviewQueue,
+      })
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+
+    await waitFor(() =>
+      expect(getAnkifyReviewQueue).toHaveBeenCalledWith(
+        "Jlab's beginner course::Part 1: Listening comprehension"
+      )
+    );
+  });
+
+  test('shows aggregate counts on a parent and keeps it reviewable via a due child', async () => {
+    const treeStats: AnkifyStats = {
+      connected: true,
+      reviewedToday: 0,
+      reviewedThisYear: 0,
+      currentStreak: 0,
+      longestStreak: 0,
+      reviewsByDay: [],
+      decks: [
+        {
+          fullName: 'Spanish',
+          name: 'Spanish',
+          depth: 0,
+          new: 1,
+          learning: 0,
+          review: 0,
+          total: 10,
+        },
+        {
+          fullName: 'Spanish::Verbs',
+          name: 'Verbs',
+          depth: 1,
+          new: 2,
+          learning: 3,
+          review: 4,
+          total: 20,
+        },
+      ],
+    };
+    renderPanel(makeBackend({ getAnkifyStats: vi.fn(async () => treeStats) }));
+
+    const items = await screen.findAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    const parent = items[0];
+    expect(parent).toHaveTextContent('Spanish');
+    expect(parent).toHaveTextContent('4 due');
+    expect(parent).toHaveTextContent('3 learning');
+    expect(parent).toHaveTextContent('+3 new');
+    const parentReview = parent.querySelector('button');
+    expect(parentReview).not.toBeDisabled();
   });
 
   test('shows the offline state when Anki is not connected', async () => {

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  CSSProperties,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import confetti from 'canvas-confetti';
 
@@ -8,6 +15,7 @@ import sharedStyles from '../../../styles/shared.module.css';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import { Backend, ReviewCard } from '../../../lib/backend/Backend';
 import { AnkifyStatsDeck } from '../stats/types';
+import { buildDeckTree } from './buildDeckTree';
 import { track } from '../../../lib/analytics/track';
 
 interface Props {
@@ -33,6 +41,8 @@ const GRADES = [
   { ease: 4, label: 'Easy', interval: '4d', className: reviewStyles.gradeEasy },
 ];
 
+const MAX_INDENT_DEPTH = 4;
+
 export function DeckPicker({
   decks,
   onReview,
@@ -40,36 +50,47 @@ export function DeckPicker({
   readonly decks: AnkifyStatsDeck[];
   readonly onReview: (deckName: string) => void;
 }) {
+  const tree = buildDeckTree(decks);
   return (
     <ul className={styles.decksList}>
-      {decks.map((deck) => {
-        const due = deck.review;
+      {tree.map((node) => {
+        const due = node.aggregateDue;
         const muted = due === 0;
+        const label =
+          node.deck.name.length > 0 ? node.deck.name : 'Untitled deck';
         return (
           <li
-            key={deck.name}
+            key={node.deck.fullName}
             className={
               muted
                 ? `${styles.decksItem} ${reviewStyles.deckRowMuted}`
                 : styles.decksItem
             }
           >
-            <span className={styles.decksItemTitle} title={deck.name}>
-              {deck.name}
+            <span
+              className={styles.decksItemTitle}
+              title={node.deck.fullName}
+              style={
+                {
+                  ['--depth' as string]: Math.min(node.depth, MAX_INDENT_DEPTH),
+                } as CSSProperties
+              }
+            >
+              {label}
             </span>
             <span className={reviewStyles.deckCounts}>
               <span className={reviewStyles.deckDue}>
                 <span aria-hidden="true">▲</span>
                 {due} due
               </span>
-              <span>{deck.learning} learning</span>
-              <span>+{deck.new} new</span>
+              <span>{node.aggregateLearning} learning</span>
+              <span>+{node.aggregateNew} new</span>
             </span>
             <button
               type="button"
               className={reviewStyles.deckReview}
               disabled={muted}
-              onClick={() => onReview(deck.name)}
+              onClick={() => onReview(node.deck.fullName)}
             >
               Review
             </button>

--- a/web/src/pages/AnkifyPage/components/buildDeckTree.test.ts
+++ b/web/src/pages/AnkifyPage/components/buildDeckTree.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildDeckTree } from './buildDeckTree';
+import { AnkifyStatsDeck } from '../stats/types';
+
+const deck = (
+  fullName: string,
+  partial: Partial<AnkifyStatsDeck> = {}
+): AnkifyStatsDeck => {
+  const segments = fullName.split('::');
+  return {
+    fullName,
+    name: segments[segments.length - 1],
+    depth: segments.length - 1,
+    new: 0,
+    learning: 0,
+    review: 0,
+    total: 0,
+    ...partial,
+  };
+};
+
+describe('buildDeckTree', () => {
+  test('orders parents before children by fullName ascending', () => {
+    const tree = buildDeckTree([
+      deck('Spanish::Verbs'),
+      deck('Spanish'),
+      deck('Anatomy'),
+    ]);
+
+    expect(tree.map((node) => node.deck.fullName)).toEqual([
+      'Anatomy',
+      'Spanish',
+      'Spanish::Verbs',
+    ]);
+  });
+
+  test('carries the depth of each deck through', () => {
+    const tree = buildDeckTree([deck('A'), deck('A::B'), deck('A::B::C')]);
+
+    expect(tree.map((node) => node.depth)).toEqual([0, 1, 2]);
+  });
+
+  test('rolls own + descendant counts into the aggregate for a parent', () => {
+    const tree = buildDeckTree([
+      deck('Spanish', { review: 5, learning: 2, new: 3 }),
+      deck('Spanish::Verbs', { review: 1, learning: 1, new: 4 }),
+    ]);
+
+    const parent = tree.find((node) => node.deck.fullName === 'Spanish');
+    expect(parent).toMatchObject({
+      aggregateDue: 6,
+      aggregateLearning: 3,
+      aggregateNew: 7,
+    });
+  });
+
+  test('leaf aggregate equals its own counts', () => {
+    const tree = buildDeckTree([
+      deck('Spanish', { review: 5, learning: 2, new: 3 }),
+      deck('Spanish::Verbs', { review: 1, learning: 1, new: 4 }),
+    ]);
+
+    const child = tree.find((node) => node.deck.fullName === 'Spanish::Verbs');
+    expect(child).toMatchObject({
+      aggregateDue: 1,
+      aggregateLearning: 1,
+      aggregateNew: 4,
+    });
+  });
+
+  test('a bare-prefix sibling is NOT absorbed into the parent aggregate', () => {
+    const tree = buildDeckTree([
+      deck('Spanish', { review: 1 }),
+      deck('Spanish Advanced', { review: 100 }),
+      deck('Spanish::Verbs', { review: 4 }),
+    ]);
+
+    const parent = tree.find((node) => node.deck.fullName === 'Spanish');
+    expect(parent?.aggregateDue).toBe(5);
+    const sibling = tree.find(
+      (node) => node.deck.fullName === 'Spanish Advanced'
+    );
+    expect(sibling?.aggregateDue).toBe(100);
+  });
+});

--- a/web/src/pages/AnkifyPage/components/buildDeckTree.ts
+++ b/web/src/pages/AnkifyPage/components/buildDeckTree.ts
@@ -1,0 +1,26 @@
+import { AnkifyStatsDeck } from '../stats/types';
+import { isSelfOrDescendantDeck } from '../lib/deckName';
+
+export interface DeckTreeNode {
+  deck: AnkifyStatsDeck;
+  depth: number;
+  aggregateDue: number;
+  aggregateLearning: number;
+  aggregateNew: number;
+}
+
+export const buildDeckTree = (decks: AnkifyStatsDeck[]): DeckTreeNode[] =>
+  [...decks]
+    .sort((a, b) => a.fullName.localeCompare(b.fullName))
+    .map((deck) => {
+      const descendants = decks.filter((other) =>
+        isSelfOrDescendantDeck(other.fullName, deck.fullName)
+      );
+      return {
+        deck,
+        depth: deck.depth,
+        aggregateDue: descendants.reduce((sum, d) => sum + d.review, 0),
+        aggregateLearning: descendants.reduce((sum, d) => sum + d.learning, 0),
+        aggregateNew: descendants.reduce((sum, d) => sum + d.new, 0),
+      };
+    });

--- a/web/src/pages/AnkifyPage/lib/deckBacklog.test.ts
+++ b/web/src/pages/AnkifyPage/lib/deckBacklog.test.ts
@@ -4,16 +4,21 @@ import { formatBacklog, formatMaturity, sumDeckBacklog } from './deckBacklog';
 import { AnkifyStatsDeck } from '../stats/types';
 
 const deck = (
-  name: string,
+  fullName: string,
   partial: Partial<AnkifyStatsDeck> = {}
-): AnkifyStatsDeck => ({
-  name,
-  new: 0,
-  learning: 0,
-  review: 0,
-  total: 0,
-  ...partial,
-});
+): AnkifyStatsDeck => {
+  const segments = fullName.split('::');
+  return {
+    fullName,
+    name: segments[segments.length - 1],
+    depth: segments.length - 1,
+    new: 0,
+    learning: 0,
+    review: 0,
+    total: 0,
+    ...partial,
+  };
+};
 
 describe('sumDeckBacklog', () => {
   test('matches the deck itself', () => {

--- a/web/src/pages/AnkifyPage/lib/deckBacklog.ts
+++ b/web/src/pages/AnkifyPage/lib/deckBacklog.ts
@@ -13,7 +13,7 @@ export const sumDeckBacklog = (
   let due = 0;
   let fresh = 0;
   for (const deck of decks) {
-    if (isSelfOrDescendantDeck(deck.name, ownedDeck)) {
+    if (isSelfOrDescendantDeck(deck.fullName, ownedDeck)) {
       due += deck.review + deck.learning;
       fresh += deck.new;
     }

--- a/web/src/pages/AnkifyPage/stats/DeckBreakdownChart.tsx
+++ b/web/src/pages/AnkifyPage/stats/DeckBreakdownChart.tsx
@@ -40,7 +40,7 @@ const truncate = (name: string): string =>
   name.length > 40 ? `${name.slice(0, 40)}…` : name;
 
 interface DeckRow {
-  name: string;
+  fullName: string;
   new: number;
   learning: number;
   review: number;
@@ -51,7 +51,7 @@ function DeckTooltip({ active, payload }: TooltipContentProps) {
   if (!active || payload == null || payload.length === 0) return null;
   const row = payload[0].payload as DeckRow;
   return (
-    <TimeSeriesTooltipShell title={row.name}>
+    <TimeSeriesTooltipShell title={row.fullName}>
       <TimeSeriesTooltipRow label="New" value={row.new.toLocaleString()} />
       <TimeSeriesTooltipRow
         label="Learning"
@@ -77,7 +77,7 @@ export default function DeckBreakdownChart({
   const rows: DeckRow[] = decks
     .filter((deck) => deck.total > 0)
     .map((deck) => ({
-      name: deck.name,
+      fullName: deck.fullName,
       new: deck.new,
       learning: deck.learning,
       review: deck.review,
@@ -133,7 +133,7 @@ export default function DeckBreakdownChart({
             />
             <YAxis
               type="category"
-              dataKey="name"
+              dataKey="fullName"
               tick={AXIS_TICK_STYLE}
               stroke={AXIS_STROKE}
               width={160}

--- a/web/src/pages/AnkifyPage/stats/StudyStatsSection.test.tsx
+++ b/web/src/pages/AnkifyPage/stats/StudyStatsSection.test.tsx
@@ -69,7 +69,15 @@ describe('StudyStatsSection', () => {
         { date: '2026-06-12', count: 40 },
       ],
       decks: [
-        { name: 'Pharmacology', new: 5, learning: 2, review: 11, total: 120 },
+        {
+          fullName: 'Pharmacology',
+          name: 'Pharmacology',
+          depth: 0,
+          new: 5,
+          learning: 2,
+          review: 11,
+          total: 120,
+        },
       ],
     }));
     renderSection(backend);

--- a/web/src/pages/AnkifyPage/stats/types.ts
+++ b/web/src/pages/AnkifyPage/stats/types.ts
@@ -1,5 +1,7 @@
 export interface AnkifyStatsDeck {
+  fullName: string;
   name: string;
+  depth: number;
   new: number;
   learning: number;
   review: number;

--- a/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
+++ b/web/src/pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage.tsx
@@ -11,24 +11,53 @@ import { AnkifyStatsDeck } from '../AnkifyPage/stats/types';
 
 const decksWithDue: AnkifyStatsDeck[] = [
   {
-    name: 'Notion Sync::Pharmacology',
+    fullName: 'Notion Sync::Pharmacology',
+    name: 'Pharmacology',
+    depth: 1,
     new: 12,
     learning: 3,
     review: 47,
     total: 420,
   },
-  { name: 'Notion Sync::Torts', new: 0, learning: 1, review: 8, total: 90 },
+  {
+    fullName: 'Notion Sync::Pharmacology::Antibiotics',
+    name: 'Antibiotics',
+    depth: 2,
+    new: 4,
+    learning: 1,
+    review: 12,
+    total: 80,
+  },
+  {
+    fullName: 'Notion Sync::Torts',
+    name: 'Torts',
+    depth: 1,
+    new: 0,
+    learning: 1,
+    review: 8,
+    total: 90,
+  },
 ];
 
 const decksCaughtUp: AnkifyStatsDeck[] = [
   {
-    name: 'Notion Sync::Pharmacology',
+    fullName: 'Notion Sync::Pharmacology',
+    name: 'Pharmacology',
+    depth: 1,
     new: 0,
     learning: 0,
     review: 0,
     total: 420,
   },
-  { name: 'Notion Sync::Torts', new: 0, learning: 0, review: 0, total: 90 },
+  {
+    fullName: 'Notion Sync::Torts',
+    name: 'Torts',
+    depth: 1,
+    new: 0,
+    learning: 0,
+    review: 0,
+    total: 90,
+  },
 ];
 
 const previewCard: ReviewQueueCard = {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-subdeck-review.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-subdeck-review.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-subdeck-review",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Reviewing a subdeck now loads its due cards, and the Review list mirrors your Anki deck tree"
+}


### PR DESCRIPTION
## What
The Review deck list now mirrors Anki's deck/subdeck tree, and **subdecks load their due cards** (they returned 0 before).

## Why
A subdeck (e.g. "Part 1: Listening comprehension" under "Jlab's beginner course") showed its due count in the picker but opened to "All caught up." Root cause: AnkiConnect's `getDeckStats` returns the **leaf** name for subdecks, and the reviewer queried `deck:"Part 1: Listening comprehension"` — which matches no deck. Top-level decks worked only because leaf == full path. Any nested-deck user (a serious learner with a structured course) hit a silent dead-end on a paid surface.

## How
- **Recover the full `::` path:** new `AnkiConnectClient.deckNamesAndIds()` (full-name → id map); `GetAnkifyStatsUseCase` resolves each stat's `fullName` from `stat.deck_id` via the reverse map (falls back to `stat.name` only if the id is absent). `AnkifyStatsDeck` now carries `fullName` (query key), `name` (leaf, display), `depth`.
- **Query unchanged** — only the name passed changed. The reporter's subdeck now queries `deck:"Jlab's beginner course::Part 1: Listening comprehension" is:due`. `deck:Parent` is prefix-hierarchical, so reviewing a parent reviews the whole subtree.
- **Tree picker:** `buildDeckTree` orders by `fullName`, computes per-node **aggregate** counts (own + descendants, boundary-matched so `Spanish` rolls up `Spanish::Verbs` but not `Spanish Advanced`). Rows show the leaf label indented by depth (full path on hover), parents are reviewable (subtree), counts are the aggregate, and muted/disabled is driven by aggregate due (a parent with 0 own due but due children stays enabled). Indent lives in the title column only — the mono data column + Review button stay aligned across all depths.
- **By-deck chart:** switched axis/tooltip to `fullName` so same-leaf decks under different parents don't collide.
- v1 is **non-collapsible** (always expanded) — the fold is a deferred follow-up.

## Testing
- Server: 43 passed (full-path recovery from leaf + deck_id; subdeck regression).
- Web: buildDeckTree (nesting, depth, aggregate rollup, `Spanish` vs `Spanish Advanced` boundary), ReviewPanel (sends full path, indent, parent aggregate, parent-0-own-due-enabled), deckBacklog (now matches on `fullName`), stats — all green. tsc + typecheck clean; lint clean on touched files (only pre-existing warnings elsewhere).

## Risks
`AnkifyStatsDeck.name` is now the leaf (was effectively full for top-level) — every consumer audited: picker uses leaf+depth, chart + deckBacklog switched to `fullName`. Aggregate is display-only; the review action relies on Anki's native subtree match, not the summed number.

## Goal alignment
Retention — unblocks Review for every nested-deck user (the structured-course cohort). Read at the Review T+30d adoption issue (#3357).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: open the Review tab — decks render as an indented tree matching Anki; open "Part 1: Listening comprehension" (or any subdeck) → its due cards load; a parent's Review pulls the whole subtree.

## Sonar
sonar-scanner not run locally (no token) — Automatic Analysis runs on the PR.
