### PR TITLE
feat: autoplay card audio and collapsible deck groups in the reviewer

### DIFF
--- a/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.module.css
@@ -1,3 +1,32 @@
+.deckDisclosure {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.25rem;
+  padding: 0;
+  border: none;
+  background: none;
+  font-size: var(--text-xs);
+  line-height: 1;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+}
+
+.deckDisclosure:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.deckDisclosureSpacer {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.25rem;
+  vertical-align: middle;
+}
+
 .deckReview {
   display: inline-flex;
   align-items: center;

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -389,6 +389,115 @@ describe('ReviewPanel', () => {
     expect(parentReview).not.toBeDisabled();
   });
 
+  test('renders the card iframe with allow="autoplay"', async () => {
+    renderPanel(makeBackend());
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+
+    const frame = (await screen.findByTitle(
+      'Card preview'
+    )) as HTMLIFrameElement;
+    expect(frame.getAttribute('allow')).toBe('autoplay');
+  });
+
+  test('wires first-audio autoplay into the front and post-reveal srcDoc', async () => {
+    const audioCard: ReviewQueueCard = {
+      cardId: 9001,
+      questionHtml:
+        '<p>Q</p><audio controls src="data:audio/mp3;base64,AA"></audio>',
+      answerHtml:
+        '<p>A</p><audio controls src="data:audio/mp3;base64,BB"></audio>',
+      css: '',
+    };
+    renderPanel(
+      makeBackend({
+        getAnkifyReviewCard: vi.fn(async () => ({
+          connected: true as const,
+          card: audioCard,
+        })),
+        getAnkifyReviewQueue: vi.fn(async () => ({
+          connected: true as const,
+          cardIds: [9001],
+        })),
+      })
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
+
+    const frame = (await screen.findByTitle(
+      'Card preview'
+    )) as HTMLIFrameElement;
+    await waitFor(() => expect(frame.srcdoc).toContain('Q'));
+    expect(frame.srcdoc).toContain("querySelector('audio')");
+    expect(frame.srcdoc).toContain('.play().catch(');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Show answer' }));
+
+    await waitFor(() => expect(frame.srcdoc).toContain('A'));
+    expect(frame.srcdoc).toContain("querySelector('audio')");
+    expect(frame.srcdoc).toContain('.play().catch(');
+  });
+
+  test('collapses and expands a parent deck group', async () => {
+    const treeStats: AnkifyStats = {
+      connected: true,
+      reviewedToday: 0,
+      reviewedThisYear: 0,
+      currentStreak: 0,
+      longestStreak: 0,
+      reviewsByDay: [],
+      decks: [
+        {
+          fullName: 'Spanish',
+          name: 'Spanish',
+          depth: 0,
+          new: 1,
+          learning: 0,
+          review: 2,
+          total: 10,
+        },
+        {
+          fullName: 'Spanish::Verbs',
+          name: 'Verbs',
+          depth: 1,
+          new: 2,
+          learning: 3,
+          review: 4,
+          total: 20,
+        },
+      ],
+    };
+    renderPanel(makeBackend({ getAnkifyStats: vi.fn(async () => treeStats) }));
+
+    expect(await screen.findAllByRole('listitem')).toHaveLength(2);
+
+    const collapse = screen.getByRole('button', { name: 'Collapse Spanish' });
+    expect(collapse).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(collapse);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    const expand = screen.getByRole('button', { name: 'Expand Spanish' });
+    expect(expand).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(expand);
+    expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    expect(
+      screen.getByRole('button', { name: 'Collapse Spanish' })
+    ).toBeInTheDocument();
+  });
+
+  test('does not show a disclosure control on a leaf deck', async () => {
+    renderPanel(makeBackend());
+
+    await screen.findByRole('button', { name: 'Review' });
+    expect(
+      screen.queryByRole('button', { name: /^Collapse / })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^Expand / })
+    ).not.toBeInTheDocument();
+  });
+
   test('shows the offline state when Anki is not connected', async () => {
     renderPanel(
       makeBackend({

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -43,6 +43,15 @@ const GRADES = [
 
 const MAX_INDENT_DEPTH = 4;
 
+function hasCollapsedAncestor(
+  fullName: string,
+  collapsed: Set<string>
+): boolean {
+  return Array.from(collapsed).some((collapsedName) =>
+    fullName.startsWith(`${collapsedName}::`)
+  );
+}
+
 export function DeckPicker({
   decks,
   onReview,
@@ -51,52 +60,90 @@ export function DeckPicker({
   readonly onReview: (deckName: string) => void;
 }) {
   const tree = buildDeckTree(decks);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const toggle = (fullName: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(fullName)) {
+        next.delete(fullName);
+      } else {
+        next.add(fullName);
+      }
+      return next;
+    });
+  };
+
   return (
     <ul className={styles.decksList}>
-      {tree.map((node) => {
-        const due = node.aggregateDue;
-        const muted = due === 0;
-        const label =
-          node.deck.name.length > 0 ? node.deck.name : 'Untitled deck';
-        return (
-          <li
-            key={node.deck.fullName}
-            className={
-              muted
-                ? `${styles.decksItem} ${reviewStyles.deckRowMuted}`
-                : styles.decksItem
-            }
-          >
-            <span
-              className={styles.decksItemTitle}
-              title={node.deck.fullName}
-              style={
-                {
-                  ['--depth' as string]: Math.min(node.depth, MAX_INDENT_DEPTH),
-                } as CSSProperties
+      {tree
+        .filter((node) => !hasCollapsedAncestor(node.deck.fullName, collapsed))
+        .map((node) => {
+          const due = node.aggregateDue;
+          const muted = due === 0;
+          const leaf =
+            node.deck.name.length > 0 ? node.deck.name : 'Untitled deck';
+          const isCollapsed = collapsed.has(node.deck.fullName);
+          return (
+            <li
+              key={node.deck.fullName}
+              className={
+                muted
+                  ? `${styles.decksItem} ${reviewStyles.deckRowMuted}`
+                  : styles.decksItem
               }
             >
-              {label}
-            </span>
-            <span className={reviewStyles.deckCounts}>
-              <span className={reviewStyles.deckDue}>
-                <span aria-hidden="true">▲</span>
-                {due} due
+              <span
+                className={styles.decksItemTitle}
+                title={node.deck.fullName}
+                style={
+                  {
+                    ['--depth' as string]: Math.min(
+                      node.depth,
+                      MAX_INDENT_DEPTH
+                    ),
+                  } as CSSProperties
+                }
+              >
+                {node.hasChildren ? (
+                  <button
+                    type="button"
+                    className={reviewStyles.deckDisclosure}
+                    aria-expanded={!isCollapsed}
+                    aria-label={
+                      isCollapsed ? `Expand ${leaf}` : `Collapse ${leaf}`
+                    }
+                    onClick={() => toggle(node.deck.fullName)}
+                  >
+                    <span aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
+                  </button>
+                ) : (
+                  <span
+                    className={reviewStyles.deckDisclosureSpacer}
+                    aria-hidden="true"
+                  />
+                )}
+                {leaf}
               </span>
-              <span>{node.aggregateLearning} learning</span>
-              <span>+{node.aggregateNew} new</span>
-            </span>
-            <button
-              type="button"
-              className={reviewStyles.deckReview}
-              disabled={muted}
-              onClick={() => onReview(node.deck.fullName)}
-            >
-              Review
-            </button>
-          </li>
-        );
-      })}
+              <span className={reviewStyles.deckCounts}>
+                <span className={reviewStyles.deckDue}>
+                  <span aria-hidden="true">▲</span>
+                  {due} due
+                </span>
+                <span>{node.aggregateLearning} learning</span>
+                <span>+{node.aggregateNew} new</span>
+              </span>
+              <button
+                type="button"
+                className={reviewStyles.deckReview}
+                disabled={muted}
+                onClick={() => onReview(node.deck.fullName)}
+              >
+                Review
+              </button>
+            </li>
+          );
+        })}
     </ul>
   );
 }
@@ -104,7 +151,7 @@ export function DeckPicker({
 const MIN_CARD_FRAME_HEIGHT = 128;
 
 function buildSrcDoc(css: string, body: string): string {
-  const sizingScript = `<script>(function(){function post(){parent.postMessage({type:'n2a-review-height',height:document.documentElement.scrollHeight},'*');}window.addEventListener('load',post);document.querySelectorAll('img').forEach(function(img){img.addEventListener('load',post);img.addEventListener('error',post);});if(window.ResizeObserver){new ResizeObserver(post).observe(document.documentElement);}post();})();</script>`;
+  const sizingScript = `<script>(function(){function post(){parent.postMessage({type:'n2a-review-height',height:document.documentElement.scrollHeight},'*');}window.addEventListener('load',post);document.querySelectorAll('img').forEach(function(img){img.addEventListener('load',post);img.addEventListener('error',post);});if(window.ResizeObserver){new ResizeObserver(post).observe(document.documentElement);}post();var __a=document.querySelector('audio');if(__a){__a.play().catch(function(){});}})();</script>`;
   return `<!doctype html><html><head><meta charset="utf-8"><style>${css}</style></head><body class="card">${body}${sizingScript}</body></html>`;
 }
 
@@ -141,6 +188,7 @@ export function CardFrame({ srcDoc }: { readonly srcDoc: string }) {
       title="Card preview"
       className={reviewStyles.cardFrame}
       sandbox="allow-scripts"
+      allow="autoplay"
       srcDoc={srcDoc}
       style={{ height: `${height}px` }}
     />

--- a/web/src/pages/AnkifyPage/components/buildDeckTree.test.ts
+++ b/web/src/pages/AnkifyPage/components/buildDeckTree.test.ts
@@ -69,6 +69,29 @@ describe('buildDeckTree', () => {
     });
   });
 
+  test('marks a node with descendants as hasChildren and a leaf as not', () => {
+    const tree = buildDeckTree([
+      deck('Spanish'),
+      deck('Spanish::Verbs'),
+      deck('Anatomy'),
+    ]);
+
+    const parent = tree.find((node) => node.deck.fullName === 'Spanish');
+    const child = tree.find((node) => node.deck.fullName === 'Spanish::Verbs');
+    const standalone = tree.find((node) => node.deck.fullName === 'Anatomy');
+
+    expect(parent?.hasChildren).toBe(true);
+    expect(child?.hasChildren).toBe(false);
+    expect(standalone?.hasChildren).toBe(false);
+  });
+
+  test('a bare-prefix sibling does not count as a child', () => {
+    const tree = buildDeckTree([deck('Spanish'), deck('Spanish Advanced')]);
+
+    const parent = tree.find((node) => node.deck.fullName === 'Spanish');
+    expect(parent?.hasChildren).toBe(false);
+  });
+
   test('a bare-prefix sibling is NOT absorbed into the parent aggregate', () => {
     const tree = buildDeckTree([
       deck('Spanish', { review: 1 }),

--- a/web/src/pages/AnkifyPage/components/buildDeckTree.ts
+++ b/web/src/pages/AnkifyPage/components/buildDeckTree.ts
@@ -4,6 +4,7 @@ import { isSelfOrDescendantDeck } from '../lib/deckName';
 export interface DeckTreeNode {
   deck: AnkifyStatsDeck;
   depth: number;
+  hasChildren: boolean;
   aggregateDue: number;
   aggregateLearning: number;
   aggregateNew: number;
@@ -16,9 +17,13 @@ export const buildDeckTree = (decks: AnkifyStatsDeck[]): DeckTreeNode[] =>
       const descendants = decks.filter((other) =>
         isSelfOrDescendantDeck(other.fullName, deck.fullName)
       );
+      const hasChildren = decks.some((other) =>
+        other.fullName.startsWith(`${deck.fullName}::`)
+      );
       return {
         deck,
         depth: deck.depth,
+        hasChildren,
         aggregateDue: descendants.reduce((sum, d) => sum + d.review, 0),
         aggregateLearning: descendants.reduce((sum, d) => sum + d.learning, 0),
         aggregateNew: descendants.reduce((sum, d) => sum + d.new, 0),

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-audio-autoplay.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-audio-autoplay.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review-audio-autoplay",
+  "date": "2026-06-14",
+  "type": "feature",
+  "title": "Card audio plays automatically as you review"
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-collapse.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-collapse.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review-collapse",
+  "date": "2026-06-14",
+  "type": "feature",
+  "title": "Collapse and expand deck groups in the Review list"
+}


### PR DESCRIPTION
## What
Two Review-tab improvements:
1. **Card audio autoplays** as you review (front audio on card show, answer audio on reveal) — Anki parity.
2. **Deck groups collapse/expand** in the Review list via a chevron.

## Why
1. A Japanese vocab learner reported no sound — audio was manual-play only. For these decks the audio is often the answer; autoplay is the expected behavior.
2. The deck tree was always-expanded; a structured course with many subdecks is a long list. A chevron lets users fold branches.

## How
**Autoplay** (`ReviewPanel.tsx` only):
- The card iframe gains `allow="autoplay"` (permissions-policy attr — required for a sandboxed cross-origin iframe to autoplay; it does NOT grant same-origin or script escape; `sandbox="allow-scripts"` is unchanged).
- The existing injected srcDoc script now plays the first `<audio>` on the rendered side: `var __a=document.querySelector('audio');if(__a){__a.play().catch(function(){});}`. The empty catch is required — a blocked autoplay rejects with NotAllowedError; swallowing it keeps the console clean (375px attestation) and degrades silently to the visible play button.
- First clip per side only (sequential chaining gets blocked mid-chain by browsers anyway). `<audio controls>` stays for replay. No server/CSS change.
- **Honest scope:** works on Chrome/Firefox; **Safari often blocks** autoplay-with-sound in a sandboxed iframe and degrades to the manual play button. Not claiming "always."

**Collapse** (`ReviewPanel.tsx` + `buildDeckTree.ts`):
- `buildDeckTree` now marks each node `hasChildren`. Parent rows get a `▾/▸` chevron button (tertiary, `aria-expanded`, `aria-label` Collapse/Expand <leaf>, focus ring); leaves get an aligned spacer.
- Fold state is ephemeral `useState<Set<string>>` keyed by full path (default expanded, no persistence). A row hides when it has a collapsed ancestor (`fullName.startsWith(C + "::")`); the collapsed parent still shows with its aggregate counts. Chevron toggles fold only — never starts a review.

## Testing
- Web: ReviewPanel + buildDeckTree 25 passed (autoplay wiring: `allow="autoplay"` attr + the play snippet present in both front and post-reveal srcDoc; collapse: child hidden on collapse, aria-expanded flips, expand restores; `hasChildren` incl. the `Spanish` vs `Spanish Advanced` boundary). typecheck + lint clean.
- jsdom can't run real audio — autoplay is verified by wiring here + the browser-attestation golden path (where Safari's limit is observed).

## Risks
Low. Autoplay is additive (manual control still there); collapse is ephemeral UI state. `allow="autoplay"` on the sandboxed iframe only permits media playback — no same-origin/script-escape; the untrusted card HTML stays isolated.

## Goal alignment
Retention/parity for the paid Auto-Sync cohort. Read at the Review T+30d adoption issue (#3357); no new analytics event.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: open an audio card (Kaishi) — front audio plays on show, answer on reveal (Chrome/FF; Safari → click the play button). In the deck list, click a parent's chevron to collapse/expand its subdecks.

## Sonar
sonar-scanner not run locally (no token) — Automatic Analysis runs on the PR.
