### PR TITLE
feat: add Notion to Anki for Japanese landing page and guide

### DIFF
--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -73,6 +73,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://2anki.net/anki-for-japanese/</loc>
+    <lastmod>2026-06-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://2anki.net/anki-from-medical-lecture-slides/</loc>
     <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
@@ -225,6 +231,12 @@
   <url>
     <loc>https://2anki.net/documentation/start-here/connect-notion</loc>
     <lastmod>2026-06-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://2anki.net/documentation/cards/notion-to-anki-japanese</loc>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/web/scripts/prerenderLandingPages.test.ts
+++ b/web/scripts/prerenderLandingPages.test.ts
@@ -50,10 +50,13 @@ beforeEach(() => {
 describe('emitLandingPages', () => {
   it('writes one HTML file per landing path', () => {
     const files = emitLandingPages(buildDir);
-    expect(files).toHaveLength(27);
+    expect(files).toHaveLength(28);
     expect(files.some((p) => p.endsWith('notion-to-anki/index.html'))).toBe(
       true
     );
+    expect(
+      files.some((p) => p.endsWith('anki-for-japanese/index.html'))
+    ).toBe(true);
     expect(files.some((p) => p.endsWith('quizlet-to-anki/index.html'))).toBe(
       true
     );

--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -7,6 +7,7 @@ import pdfCopy from '../src/pages/LandingPage/copy/pdf';
 import ankiToNotionCopy from '../src/pages/LandingPage/copy/ankiToNotion';
 import usmleCopy from '../src/pages/LandingPage/copy/usmle';
 import nursingCopy from '../src/pages/LandingPage/copy/nursing';
+import japaneseCopy from '../src/pages/LandingPage/copy/japanese';
 import medicalLectureSlidesCopy from '../src/pages/LandingPage/copy/medical-lecture-slides';
 import powerpointCopy from '../src/pages/LandingPage/copy/powerpoint';
 import goodnotesCopy from '../src/pages/LandingPage/copy/goodnotes';
@@ -23,6 +24,7 @@ const LANDING_COPIES: LandingCopy[] = [
   ankiToNotionCopy,
   usmleCopy,
   nursingCopy,
+  japaneseCopy,
   medicalLectureSlidesCopy,
   powerpointCopy,
   goodnotesCopy,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -220,6 +220,10 @@ const NursingFlashcards = lazyWithRetry(
   () => import('./pages/LandingPage/NursingFlashcards'),
   './pages/LandingPage/NursingFlashcards'
 );
+const Japanese = lazyWithRetry(
+  () => import('./pages/LandingPage/Japanese'),
+  './pages/LandingPage/Japanese'
+);
 const AnkiFromMedicalLectureSlides = lazyWithRetry(
   () => import('./pages/LandingPage/AnkiFromMedicalLectureSlides'),
   './pages/LandingPage/AnkiFromMedicalLectureSlides'
@@ -622,6 +626,10 @@ function AppContent({
             <Route
               path="/nursing-flashcards"
               element={<NursingFlashcards setErrorMessage={setErrorMessage} />}
+            />
+            <Route
+              path="/anki-for-japanese"
+              element={<Japanese setErrorMessage={setErrorMessage} />}
             />
             <Route
               path="/anki-from-medical-lecture-slides"

--- a/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
+++ b/web/src/pages/ConvertLandingPage/convertLandingConfig.ts
@@ -421,6 +421,10 @@ const plecoToAnki: LandingCopy = {
       label: 'Convert a CSV or Excel sheet to Anki',
       href: '/convert/csv-to-anki',
     },
+    {
+      label: 'Build Japanese Anki cards from Notion',
+      href: '/anki-for-japanese',
+    },
     { label: 'Browse every converter', href: '/convert' },
   ],
   pathname: '/convert/pleco-to-anki',
@@ -500,6 +504,10 @@ const languageReactorToAnki: LandingCopy = {
     },
     { label: 'Move Pleco flashcards to Anki', href: '/convert/pleco-to-anki' },
     { label: 'Convert EPUB highlights to Anki', href: '/convert/epub-to-anki' },
+    {
+      label: 'Anki for Japanese — JLPT, kanji, vocab',
+      href: '/anki-for-japanese',
+    },
     { label: 'Browse every converter', href: '/convert' },
   ],
   pathname: '/convert/language-reactor-to-anki',

--- a/web/src/pages/DocsPage/content/cards/card-options.md
+++ b/web/src/pages/DocsPage/content/cards/card-options.md
@@ -94,6 +94,8 @@ Anki reads cards aloud with its on-device voice. No audio file is added to the d
 
 If the picked language has no installed voice on the Anki device, the audio stays silent.
 
+Studying Japanese? See [Notion → Anki for Japanese](/documentation/cards/notion-to-anki-japanese) for how mined sentences, readings, and attached audio come across.
+
 ## Multiple choice
 
 These only fire when **Enable MCQ** is on. See [Multiple choice questions](/documentation/cards/mcq) for the full guide.

--- a/web/src/pages/DocsPage/content/cards/notion-to-anki-japanese.md
+++ b/web/src/pages/DocsPage/content/cards/notion-to-anki-japanese.md
@@ -1,0 +1,62 @@
+---
+title: Notion → Anki for Japanese
+description: Structure mined sentences and vocab in Notion, keep audio and screenshots, choose a note type, and open the deck in Anki.
+---
+
+This guide is for Japanese and language learners who keep notes in Notion and study them in Anki — sentence miners, JLPT studiers, kanji writers, anyone pairing a note-taking tool with spaced repetition. It covers how to lay out a page so 2anki turns it into the cards you want, what survives the conversion, and what 2anki deliberately leaves to you.
+
+2anki converts what you wrote. It does not generate readings, look up words, or add audio that wasn't there — so a card never shows a guess you didn't make. The work below is about giving it a page it can read cleanly.
+
+## Sentence cards vs vocab cards
+
+Both live on the same Notion page. The unit is the toggle: the toggle line is the front, everything inside is the back.
+
+**A sentence card** — put the mined sentence on the toggle line. Inside, put the reading, the meaning, the target word, and any audio or screenshot. One toggle, one card.
+
+**A vocab card** — put the word on the toggle line. Inside, put the reading and the meaning. Shorter, but the same shape.
+
+You can mix them freely. A grammar page might hold ten sentence toggles and a glossary of word toggles below — 2anki makes a card from each, in order.
+
+If you'd rather not use toggles, [parser rules](/documentation/cards/parser-rules) let a Notion table drive cards instead: column 1 becomes the front, column 2 the back. That suits a vocab list you keep as a table — one row per word.
+
+## Readings and furigana
+
+Type the reading the way you want it on the card. Furigana in brackets after the kanji, kana on its own line, romaji, pitch notation — whatever your workflow uses. 2anki carries it across unchanged.
+
+It does not add furigana for you, and it does not change a reading you wrote. If you want readings filled in, do it in Notion first — a dictionary add-on or Yomitan can help you draft them there — then convert. The card shows exactly what the page showed.
+
+## Audio on cards
+
+Attach the audio as a file in Notion — a clip, a recorded sentence, a pronunciation. 2anki downloads the file and packs it into the deck, so the card plays it offline on any device. Put the audio inside the toggle, on the back, where it belongs with the sentence.
+
+A link to an external audio page stays a link, not playable audio. Only an attached file becomes deck audio.
+
+2anki does not record or generate speech during conversion. Separately, Anki can read a card aloud at review time with its own on-device voice — Japanese included — set under [card options](/documentation/cards/card-options). That is Anki speaking live, not an audio file in the deck.
+
+## Screenshots and images
+
+Drop the screenshot — a subtitle frame, a manga panel, a diagram — into the toggle in Notion. It comes across as an image inside the card and is bundled into the deck, so it renders without a connection.
+
+For sentence mining, a screenshot on the back gives you the scene the sentence came from. Keep images reasonably sized; a page packed with full-resolution screenshots makes a large deck.
+
+## Bold and italic
+
+Bold the target word in a sentence, italicise a part of speech — the emphasis stays on the card. This is the cheapest way to mark what a card is testing without adding a separate field.
+
+## Choosing a note type
+
+During conversion you pick the note type 2anki uses. The defaults work, and you can rename a note type to plug in a template you already study with — a sentence-card template, a vocab template, your own styling.
+
+2anki builds your notes into a deck — it does not replace Kaishi 1.5k, RRTK, or JLab. Study those as they are; use this for the cards you write yourself.
+
+## Opening the deck in Anki
+
+The download is a standard `.apkg`. Open it in Anki — desktop or mobile — and the deck, its media, and its note type import together. Full steps are in [open your deck in Anki](/documentation/start-here/open-in-anki).
+
+Import one page or one topic at a time rather than a whole notebook in one file. Smaller decks are easier to schedule and review, and they import faster.
+
+## Related
+
+- [Parser rules](/documentation/cards/parser-rules) — turn tables, callouts, or headings into cards
+- [Card options](/documentation/cards/card-options) — every conversion setting, including Anki's read-aloud voice
+- [Notion blocks we support](/documentation/cards/notion-blocks) — what each block does on the card

--- a/web/src/pages/DocsPage/sidebar.ts
+++ b/web/src/pages/DocsPage/sidebar.ts
@@ -37,6 +37,10 @@ export const sidebar: SidebarGroup[] = [
       { label: 'Notion blocks we support', slug: 'cards/notion-blocks' },
       { label: 'What is a deck?', slug: 'cards/decks' },
       { label: 'Parser rules', slug: 'cards/parser-rules' },
+      {
+        label: 'Notion → Anki for Japanese',
+        slug: 'cards/notion-to-anki-japanese',
+      },
       { label: 'AI flashcard generation', slug: 'cards/ai-flashcards' },
       { label: 'Image occlusion', slug: 'cards/image-occlusion' },
       { label: 'Photo to deck', slug: 'cards/photo-to-deck' },

--- a/web/src/pages/LandingPage/Japanese.tsx
+++ b/web/src/pages/LandingPage/Japanese.tsx
@@ -1,0 +1,11 @@
+import LandingPage from './LandingPage';
+import japaneseCopy from './copy/japanese';
+import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+
+interface Props {
+  setErrorMessage: ErrorHandlerType;
+}
+
+export default function Japanese({ setErrorMessage }: Readonly<Props>) {
+  return <LandingPage copy={japaneseCopy} setErrorMessage={setErrorMessage} />;
+}

--- a/web/src/pages/LandingPage/LandingPage.test.tsx
+++ b/web/src/pages/LandingPage/LandingPage.test.tsx
@@ -11,6 +11,7 @@ import pdfCopy from './copy/pdf';
 import markdownCopy from './copy/markdown';
 import usmleCopy from './copy/usmle';
 import nursingCopy from './copy/nursing';
+import japaneseCopy from './copy/japanese';
 import medicalLectureSlidesCopy from './copy/medical-lecture-slides';
 import { ankiFidelityProof } from './copy/ankiFidelityProof';
 import powerpointCopy from './copy/powerpoint';
@@ -116,6 +117,23 @@ describe('LandingPage', () => {
       'href',
       `/register?source=${encodeURIComponent(nursingCopy.pathname)}`
     );
+  });
+
+  it('renders the Japanese h1, the source-wired CTA, and a FAQ', () => {
+    renderLandingPage(
+      <LandingPage copy={japaneseCopy} setErrorMessage={vi.fn()} />
+    );
+    expect(
+      screen.getByRole('heading', { level: 1, name: japaneseCopy.h1 })
+    ).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /sign up free/i });
+    expect(link).toHaveAttribute(
+      'href',
+      `/register?source=${encodeURIComponent(japaneseCopy.pathname)}`
+    );
+    expect(
+      screen.getByText('Can I mine sentences from Notion?')
+    ).toBeInTheDocument();
   });
 
   it('renders the medical lecture slides h1 and links CTA to the correct source', () => {

--- a/web/src/pages/LandingPage/copy/japanese.ts
+++ b/web/src/pages/LandingPage/copy/japanese.ts
@@ -1,0 +1,66 @@
+import type { LandingCopy } from '../types';
+
+const japaneseCopy: LandingCopy = {
+  relatedLinks: [
+    {
+      label: 'Notion → Anki for Japanese: the full guide',
+      href: '/documentation/cards/notion-to-anki-japanese',
+    },
+    { label: 'Move Pleco flashcards to Anki', href: '/convert/pleco-to-anki' },
+    {
+      label: 'Move Language Reactor saves to Anki',
+      href: '/convert/language-reactor-to-anki',
+    },
+    { label: 'Convert Notion pages to Anki', href: '/notion-to-anki' },
+    { label: 'Browse every converter', href: '/convert' },
+  ],
+  pathname: '/anki-for-japanese',
+  title: 'Notion to Anki for Japanese learners — 2anki',
+  description:
+    'Turn your Notion sentence-mining and vocab notes into Anki decks. Images, audio, and readings come across as you typed them. | 2anki',
+  h1: 'Notion to Anki for Japanese and language learning',
+  subhead:
+    'Drop a Notion page of mined sentences or vocab. Screenshots, audio, and readings come across as you wrote them.',
+  whatComesAcross: [
+    {
+      title: 'Screenshots and images',
+      body: 'Manga panels, subtitle screenshots, and reference images embedded in your Notion notes come across as images inside the card, bundled into the deck so they render offline.',
+    },
+    {
+      title: 'Audio files',
+      body: 'An audio file attached in Notion — a clip from a show, a recorded sentence, a pronunciation — is downloaded and packed into the deck, so the card plays it the same on every device.',
+    },
+    {
+      title: 'Readings and furigana as you typed them',
+      body: 'Whatever you wrote stays: furigana in brackets, kana over kanji, pitch notation, romaji. 2anki preserves your text — it does not add or change readings, so the card shows exactly what you mined.',
+    },
+    {
+      title: 'Bold and italic emphasis',
+      body: 'The word you bolded in a sentence, the part of speech you italicised — emphasis carries through, so the formatting you used to mark the target stays on the card.',
+    },
+  ],
+  faqs: [
+    {
+      q: 'Does audio from my Notion notes come across?',
+      a: 'Yes, when the audio is an actual file attached in Notion. 2anki downloads it and packs it into the deck, so the card plays it offline on every device. A link to an external site stays a link — only attached files become deck audio. 2anki does not generate text-to-speech during conversion; Anki itself can read cards aloud at review time with its on-device voice, including Japanese.',
+    },
+    {
+      q: 'Can I mine sentences from Notion?',
+      a: 'Yes. Write each mined sentence as a toggle: the sentence on the toggle line, the meaning, vocab, and any audio or screenshot inside it. Each toggle becomes one card — sentence on the front, the rest on the back. The same page can hold word cards and sentence cards side by side. The full setup is in the guide.',
+    },
+    {
+      q: 'Does it add furigana or look up readings automatically?',
+      a: 'No. 2anki does not add furigana, look up readings, or color pitch accent — it converts what you wrote. If you want furigana on a card, type it in Notion (Yomitan or a dictionary add-on can help you fill it in there), and it comes across exactly as typed. Keeping the readings yours means a card never shows a wrong auto-guess.',
+    },
+    {
+      q: 'Will my Kaishi or RTK-style cards work?',
+      a: 'The decks themselves are already built — 2anki does not replace Kaishi 1.5k, RRTK, or JLab. What it does is turn your own notes into a deck you study alongside them. You pick the note type during conversion, so cards land on a template that matches how you study, and you can rename the note type to plug in your own.',
+    },
+    {
+      q: 'How is this different from Yomitan or Migaku?',
+      a: 'Yomitan and Migaku create cards while you read, from a browser or a video. 2anki works from notes you already keep in Notion — lecture summaries, grammar pages, mined sentences with your own context. They are not rivals: mine with Yomitan, write up the hard ones in Notion, then convert the page here when you want a clean deck.',
+    },
+  ],
+};
+
+export default japaneseCopy;

--- a/web/src/pages/LandingPage/copy/notion.ts
+++ b/web/src/pages/LandingPage/copy/notion.ts
@@ -12,6 +12,7 @@ const notionCopy: LandingCopy = {
       href: '/markdown-to-anki',
     },
     { label: 'Convert a PDF to Anki', href: '/pdf-to-anki' },
+    { label: 'Anki for Japanese learners', href: '/anki-for-japanese' },
     { label: 'Browse every converter', href: '/convert' },
   ],
   pathname: '/notion-to-anki',


### PR DESCRIPTION
## What
Adds a new `/anki-for-japanese` audience landing page and a `/documentation/cards/notion-to-anki-japanese` docs guide for Japanese and language learners, wired and crawlable exactly like the existing `nursing`/`usmle` audience pages. Inbound internal links added from the Notion landing page, the Pleco and Language Reactor converter pages, and the card-options docs Audio section.

## Why
Acquisition is the starved lane (CLAUDE.md: 2023-25 ran 0% acquisition, 2026 ran 6%). This targets language-learning search intent — primary keyword "anki for japanese" — and the long tail around sentence mining, JLPT, furigana, and mining-tool comparisons (Yomitan/Migaku). Content was produced by seo-content + seo-specialist and verified against the codebase's real behaviour (no auto-furigana, attached-file audio bundling, screenshot media, note-type choice).

Fixes #3366

## How
- `copy/japanese.ts` + `Japanese.tsx` mirror `nursing` copy/wrapper.
- `App.tsx`: `lazyWithRetry` import + `/anki-for-japanese` route mirroring `/nursing-flashcards`.
- `prerenderLandingPages.ts`: `japaneseCopy` added to `LANDING_COPIES` so the page prerenders crawlable static HTML.
- `sitemap.xml`: landing entry (weekly/0.9, trailing slash) + docs entry (monthly/0.5, no trailing slash), `lastmod 2026-06-14` — values verified against the neighbouring nursing/usmle/connect-notion entries.
- `notion-to-anki-japanese.md` docs guide + `sidebar.ts` entry under "Make better cards" after Parser rules.
- Inbound links: `notion.ts`, `convertLandingConfig.ts` (pleco + language-reactor), `card-options.md` Audio section.

Every internal `/documentation/...` link in the new guide resolves to a real doc (`parser-rules`, `card-options`, `notion-blocks`, `start-here/open-in-anki`) — enforced green by `content-links.test.ts`. No link or anchor adjustment was needed; the guide as drafted already only links existing docs. (`/documentation/cards/templates` does exist in the repo, but the drafted guide does not link it, so nothing to add back.)

## Measuring success
- Funnel: organic signups carrying `signupOrigin = /anki-for-japanese` then first upload, read at `/api/ops/metrics` (funnel events) cross-referenced with Stripe for any conversion.
- Search Console: impressions/clicks/avg-position for "anki for japanese" and sentence-mining queries on the new URL.
- SEO compounds; the meaningful read is at 8–12 weeks post-index.

## Testing
- Unit tests added/updated (Vitest, run in the worktree on Node 22.20.0):
  - `LandingPage.test.tsx`: new case asserts the Japanese H1, the source-wired CTA (`/register?source=%2Fanki-for-japanese`), and a FAQ renders.
  - `prerenderLandingPages.test.ts`: landing-page count 27 to 28 and a new assertion that `anki-for-japanese/index.html` is emitted.
  - `content-links.test.ts` and `signupOrigin.test.ts` stay green.
- Full web suite: 228 files / 2004 tests passing. `pnpm typecheck` clean. `pnpm lint` exit 0 (only pre-existing warnings in untouched files).
- `signupOrigin` is regex-based (`/^\/[a-z0-9-]{1,64}$/`), which already accepts `/anki-for-japanese`; the existing parameterized cases enumerate the three medical paths illustratively, not as an exhaustive contract, so no enumeration change was needed.

## Build / crawlability verification
`pnpm build` + `npx tsx scripts/prerenderLandingPages.ts` (in the worktree) emits `build/anki-for-japanese/index.html` with:
- `<title>Notion to Anki for Japanese learners — 2anki</title>`
- `<link rel="canonical" href="https://2anki.net/anki-for-japanese/">` (trailing slash) + matching og:url/og:title
- the H1 baked into the prerendered body

The page-specific FAQPage `application/ld+json` is rendered at runtime by React Helmet, not into the static HTML — identical to the existing nursing and usmle pages (verified all three have the same single site-level ld+json block in static output; the FAQPage schema is JS-rendered for all of them). Matches the established pattern; no regression.

## Browser check
Browser check pending — implemented + tested + build-verified; needs manual golden-path verify on localhost:3000 (open /anki-for-japanese and /documentation/cards/notion-to-anki-japanese).

## Changelog
No entry — acquisition landing page + docs guide, not an in-app behavior change for existing users. (Per CLAUDE.md, marketing landing pages are not in-app What's New; the docs guide is a help reference, not a behaviour change.)

## Risks
Low. New routes and pure-additive copy/links; no shared business logic, no API, no migrations. Worst case is a broken internal link (guarded by `content-links.test.ts`) or a malformed sitemap entry (mirrored byte-for-byte off neighbours). Rollback = revert the single squash commit.

## Goal alignment
Acquisition lane — the only lane that creates users (CLAUDE.md). Targets language-learning search intent; the metric it should move is organic signups with `signupOrigin /anki-for-japanese` then first upload (read at `/api/ops/metrics`) plus Search Console impressions for "anki for japanese". SEO compounds; meaningful read at 8–12 weeks.
