### PR TITLE
fix: leeches degrade to a calm offline state when AnkiConnect is unreachable

### DIFF
--- a/src/usecases/ankify/ListLeechesUseCase.test.ts
+++ b/src/usecases/ankify/ListLeechesUseCase.test.ts
@@ -2,6 +2,7 @@ import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/Ankify
 import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/ankify/AnkifyNotionSubscriptionsRepository';
 import {
   AnkiConnectClient,
+  AnkiConnectTimeoutError,
   AnkiConnectUnreachableError,
 } from '../../services/ankify/AnkiConnectClient';
 import { ListLeechesUseCase } from './ListLeechesUseCase';
@@ -175,7 +176,8 @@ describe('ListLeechesUseCase', () => {
     });
   });
 
-  test('propagates AnkiConnectUnreachableError from the ping', async () => {
+  test('degrades to connected:false when AnkiConnect is unreachable on ping', async () => {
+    const findNotes = jest.fn();
     const factory = jest.fn(
       () =>
         ({
@@ -184,6 +186,58 @@ describe('ListLeechesUseCase', () => {
               'http://x',
               new Error('down')
             );
+          }),
+          findNotes,
+          notesInfo: jest.fn(),
+          cardsInfo: jest.fn(),
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new ListLeechesUseCase(
+      clientsRepo(activeClient),
+      subsRepo([
+        { target_deck: 'Notion Sync::Pharma', notion_page_title: null },
+      ]),
+      factory
+    );
+
+    expect(await useCase.execute({ owner: 42 })).toEqual({ connected: false });
+    expect(findNotes).not.toHaveBeenCalled();
+  });
+
+  test('degrades to connected:false when a timeout subclass is thrown', async () => {
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findNotes: jest.fn(async () => {
+            throw new AnkiConnectTimeoutError(
+              'http://x',
+              'findNotes',
+              10_000,
+              new Error('slow')
+            );
+          }),
+          notesInfo: jest.fn(),
+          cardsInfo: jest.fn(),
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new ListLeechesUseCase(
+      clientsRepo(activeClient),
+      subsRepo([
+        { target_deck: 'Notion Sync::Pharma', notion_page_title: null },
+      ]),
+      factory
+    );
+
+    expect(await useCase.execute({ owner: 42 })).toEqual({ connected: false });
+  });
+
+  test('rethrows a non-AnkiConnect error so real bugs surface', async () => {
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => {
+            throw new Error('unexpected');
           }),
           findNotes: jest.fn(),
           notesInfo: jest.fn(),
@@ -198,8 +252,6 @@ describe('ListLeechesUseCase', () => {
       factory
     );
 
-    await expect(useCase.execute({ owner: 42 })).rejects.toBeInstanceOf(
-      AnkiConnectUnreachableError
-    );
+    await expect(useCase.execute({ owner: 42 })).rejects.toThrow('unexpected');
   });
 });

--- a/src/usecases/ankify/ListLeechesUseCase.ts
+++ b/src/usecases/ankify/ListLeechesUseCase.ts
@@ -3,6 +3,7 @@ import { AnkifyNotionSubscriptionsRepositoryInterface } from '../../data_layer/a
 import { ownedDeckNames } from '../../lib/ankify/deckOwnership';
 import {
   AnkiCardInfo,
+  AnkiConnectUnreachableError,
   AnkiNoteInfo,
 } from '../../services/ankify/AnkiConnectClient';
 import { AnkiConnectFactory } from './GetAnkifyStatsUseCase';
@@ -72,25 +73,32 @@ export class ListLeechesUseCase {
       client.anki_connect_api_key
     );
 
-    await ac.ping();
+    try {
+      await ac.ping();
 
-    const noteIds = await ac.findNotes(query);
-    if (noteIds.length === 0) {
-      return { connected: true, leeches: [] };
+      const noteIds = await ac.findNotes(query);
+      if (noteIds.length === 0) {
+        return { connected: true, leeches: [] };
+      }
+
+      const notes = await ac.notesInfo(noteIds);
+      const cardIds = notes.flatMap((note) => note.cards ?? []);
+      const cards = cardIds.length > 0 ? await ac.cardsInfo(cardIds) : [];
+      const cardById = new Map<number, AnkiCardInfo>(
+        cards.map((card) => [card.cardId, card])
+      );
+
+      const leeches = notes
+        .map((note) => this.toLeechNote(note, cardById))
+        .sort((a, b) => b.lapses - a.lapses);
+
+      return { connected: true, leeches };
+    } catch (error) {
+      if (error instanceof AnkiConnectUnreachableError) {
+        return { connected: false };
+      }
+      throw error;
     }
-
-    const notes = await ac.notesInfo(noteIds);
-    const cardIds = notes.flatMap((note) => note.cards ?? []);
-    const cards = cardIds.length > 0 ? await ac.cardsInfo(cardIds) : [];
-    const cardById = new Map<number, AnkiCardInfo>(
-      cards.map((card) => [card.cardId, card])
-    );
-
-    const leeches = notes
-      .map((note) => this.toLeechNote(note, cardById))
-      .sort((a, b) => b.lapses - a.lapses);
-
-    return { connected: true, leeches };
   }
 
   private toLeechNote(

--- a/web/src/pages/AnkifyPage/AnkifyPage.module.css
+++ b/web/src/pages/AnkifyPage/AnkifyPage.module.css
@@ -446,6 +446,12 @@
   width: auto;
 }
 
+.offlineActions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
 .firstRunBlock {
   display: flex;
   flex-direction: column;

--- a/web/src/pages/AnkifyPage/components/LeechesPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/LeechesPanel.test.tsx
@@ -80,16 +80,23 @@ describe('LeechesPanel', () => {
     ).toBeInTheDocument();
   });
 
-  test('offline degrades calmly without crashing', async () => {
-    const backend = makeBackend({
-      listAnkifyLeeches: vi.fn(async () => ({ connected: false as const })),
-    });
+  test('offline degrades calmly with a Try again refetch control', async () => {
+    const listAnkifyLeeches = vi.fn(async () => ({
+      connected: false as const,
+    }));
+    const backend = makeBackend({ listAnkifyLeeches });
 
     renderPanel(backend);
 
     expect(
-      await screen.findByText(/leeches load once anki is running/i)
+      await screen.findByText(
+        "Anki isn't connected. Open Anki on your computer and try again."
+      )
     ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    await waitFor(() => expect(listAnkifyLeeches).toHaveBeenCalledTimes(2));
   });
 
   test('editing fires the leech_action event and calls the edit endpoint', async () => {

--- a/web/src/pages/AnkifyPage/components/LeechesPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/LeechesPanel.tsx
@@ -213,8 +213,17 @@ export default function LeechesPanel({ backend }: Props) {
         className={styles.tabPanel}
       >
         <p className={styles.emptyLine}>
-          Leeches load once Anki is running. Open Anki, then try again.
+          Anki isn&apos;t connected. Open Anki on your computer and try again.
         </p>
+        <div className={styles.offlineActions}>
+          <button
+            type="button"
+            className={sharedStyles.btnGhost}
+            onClick={() => leeches.refetch()}
+          >
+            Try again
+          </button>
+        </div>
       </div>
     );
   }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-leeches-offline.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-leeches-offline.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-leeches-offline",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Leeches load calmly when Anki is briefly unreachable instead of showing an error"
+}


### PR DESCRIPTION
## What
The Leeches tab now shows a calm "Anki isn't connected" state (with Try again) when the container's AnkiConnect is momentarily unreachable — instead of a hard error that leaked an internal address.

## Why
`GET /api/ankify/leeches` intermittently returned `{"code":"unknown","message":"AnkiConnect unreachable at http://localhost:20001"}`. Two problems: (1) it failed hard instead of degrading like the reviewer does, and (2) it leaked the internal host:port to the client (CWE-209). The container's AnkiConnect blips under load/restart; the UI should ride that out quietly.

## How
- `ListLeechesUseCase`: the AnkiConnect calls (`ping`/`findNotes`/`notesInfo`/`cardsInfo`) are wrapped in try/catch; an `AnkiConnectUnreachableError` (its `AnkiConnectTimeoutError` subclass included) returns `{ connected: false }` — the same graceful shape it already returns when there's no active client. Any other error rethrows (real bugs still surface). `listLeeches` stays a 200 with no message, so nothing internal reaches the client.
- `LeechesPanel`: the `connected !== true` branch now shows `Anki isn't connected. Open Anki on your computer and try again.` + a `Try again` button that refetches — matching the reviewer's offline treatment.

## Testing
- Server `ListLeechesUseCase`: 7 passed — unreachable-on-ping → `{connected:false}` (and `findNotes` not called), timeout subclass → `{connected:false}`, non-AnkiConnect error rethrown.
- Web `LeechesPanel`: 7 passed — offline copy + refetch. tsc + typecheck + lint clean. Confirmed no `localhost`/port string reaches the client.

## Risks
Low — a catch that narrows to the unreachable error class and degrades; all other failures still propagate.

## Goal alignment
Retention/trust on the paid Ankify surface — a transient AnkiConnect blip no longer reads as a broken feature.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: open Leeches while AnkiConnect is reachable (list loads); stop AnkiConnect → calm offline state with Try again, no raw error.

## Sonar
sonar-scanner not run locally (no token) — Automatic Analysis runs on the PR.
