### PR TITLE
fix: play card audio stored in a separate field (resolve [anki:play] directives)

### DIFF
--- a/src/usecases/ankify/GetReviewCardUseCase.test.ts
+++ b/src/usecases/ankify/GetReviewCardUseCase.test.ts
@@ -107,6 +107,14 @@ describe('GetReviewCardUseCase', () => {
         css: '.card {}',
       },
     ]);
+    const notesInfo = jest.fn(async () => [
+      {
+        noteId: 5,
+        modelName: 'JlabNote-JlabConverted-1',
+        tags: [],
+        fields: { Audio: { value: '[sound:b.mp3]', order: 0 } },
+      },
+    ]);
     const retrieveMediaFile = jest.fn(async () =>
       Buffer.from('BYTES', 'utf-8').toString('base64')
     );
@@ -116,6 +124,7 @@ describe('GetReviewCardUseCase', () => {
           ping: jest.fn(async () => 6),
           findCards,
           cardsInfo,
+          notesInfo,
           retrieveMediaFile,
         }) as unknown as AnkiConnectClient
     );
@@ -127,10 +136,99 @@ describe('GetReviewCardUseCase', () => {
     const result = await useCase.execute({ owner: 42, cardId: 9001 });
 
     expect(result.card?.questionHtml).toContain('data:image/jpeg;base64,');
+    expect(result.card?.questionHtml).toContain('<audio');
     expect(result.card?.answerHtml).toContain('<audio');
     expect(result.card?.answerHtml).toContain('data:audio/mpeg;base64,');
     expect(result.card?.questionHtml).not.toContain('[anki:play:');
     expect(result.card?.answerHtml).not.toContain('[sound:');
+  });
+
+  it('resolves [anki:play] directives to audio from the note field sounds', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const cardsInfo = jest.fn(async () => [
+      {
+        cardId: 9001,
+        note: 77,
+        deckName: 'Notion Sync::JP',
+        lapses: 0,
+        queue: 2,
+        question: '日本語 [anki:play:q:0]',
+        answer: 'translation',
+        css: '.card {}',
+      },
+    ]);
+    const notesInfo = jest.fn(async () => [
+      {
+        noteId: 77,
+        modelName: 'JlabNote-JlabConverted-1',
+        tags: [],
+        fields: {
+          Expression: { value: '日本語', order: 0 },
+          Audio: { value: '[sound:1600420050000.mp3]', order: 1 },
+          Meaning: { value: 'Japanese', order: 2 },
+        },
+      },
+    ]);
+    const retrieveMediaFile = jest.fn(async () =>
+      Buffer.from('MP3BYTES', 'utf-8').toString('base64')
+    );
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+          notesInfo,
+          retrieveMediaFile,
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewCardUseCase(
+      clientsRepo(activeClient),
+      factory
+    );
+
+    const result = await useCase.execute({ owner: 42, cardId: 9001 });
+
+    expect(notesInfo).toHaveBeenCalledWith([77]);
+    expect(retrieveMediaFile).toHaveBeenCalledWith('1600420050000.mp3');
+    expect(result.card?.questionHtml).toContain('<audio');
+    expect(result.card?.questionHtml).toContain('data:audio/mpeg;base64,');
+    expect(result.card?.questionHtml).not.toContain('[anki:play:');
+  });
+
+  it('does not fetch note info for a card without [anki:play] directives', async () => {
+    const findCards = jest.fn(async () => [9001]);
+    const cardsInfo = jest.fn(async () => [
+      {
+        cardId: 9001,
+        note: 5,
+        deckName: 'Notion Sync::Pharma',
+        lapses: 0,
+        queue: 2,
+        question: '<p>Q1</p>',
+        answer: '<p>A1</p>',
+        css: '',
+      },
+    ]);
+    const notesInfo = jest.fn();
+    const factory = jest.fn(
+      () =>
+        ({
+          ping: jest.fn(async () => 6),
+          findCards,
+          cardsInfo,
+          notesInfo,
+          retrieveMediaFile: jest.fn(),
+        }) as unknown as AnkiConnectClient
+    );
+    const useCase = new GetReviewCardUseCase(
+      clientsRepo(activeClient),
+      factory
+    );
+
+    await useCase.execute({ owner: 42, cardId: 9001 });
+
+    expect(notesInfo).not.toHaveBeenCalled();
   });
 
   it('fetches a media file shared across front and back only once', async () => {

--- a/src/usecases/ankify/GetReviewCardUseCase.ts
+++ b/src/usecases/ankify/GetReviewCardUseCase.ts
@@ -55,22 +55,53 @@ export class GetReviewCardUseCase {
     const cache = new Map<string, string | null>();
     const fetchMedia = (filename: string) => ac.retrieveMediaFile(filename);
 
+    const question = card.question ?? '';
+    const answer = card.answer ?? '';
+    const noteSounds = await this.collectNoteSounds(ac, card.note, [
+      question,
+      answer,
+    ]);
+
     return {
       connected: true,
       card: {
         cardId: card.cardId,
         questionHtml: await inlineReviewMedia(
-          card.question ?? '',
+          question,
           fetchMedia,
-          cache
+          cache,
+          noteSounds
         ),
         answerHtml: await inlineReviewMedia(
-          card.answer ?? '',
+          answer,
           fetchMedia,
-          cache
+          cache,
+          noteSounds
         ),
         css: (card.css ?? '') + REVIEW_MEDIA_CSS,
       },
     };
+  }
+
+  private async collectNoteSounds(
+    ac: ReturnType<AnkiConnectFactory>,
+    noteId: number,
+    sides: string[]
+  ): Promise<string[]> {
+    const hasPlayDirective = sides.some((side) => side.includes('[anki:play:'));
+    if (!hasPlayDirective) {
+      return [];
+    }
+
+    const notes = await ac.notesInfo([noteId]);
+    const note = notes[0];
+    if (note == null) {
+      return [];
+    }
+
+    return Object.values(note.fields)
+      .sort((a, b) => a.order - b.order)
+      .flatMap((field) => [...field.value.matchAll(/\[sound:([^\]]+)\]/g)])
+      .map((match) => match[1]);
   }
 }

--- a/src/usecases/ankify/inlineReviewMedia.test.ts
+++ b/src/usecases/ankify/inlineReviewMedia.test.ts
@@ -105,6 +105,51 @@ describe('inlineReviewMedia', () => {
     expect(out).toBe('Q A');
   });
 
+  it('resolves [anki:play:q:0] to an audio element using note-field sounds', async () => {
+    const fetchMedia = jest.fn(async () => base64Of('MP3'));
+    const cache = new Map<string, string | null>();
+
+    const out = await inlineReviewMedia(
+      'listen [anki:play:q:0]',
+      fetchMedia,
+      cache,
+      ['1600420050000.mp3']
+    );
+
+    expect(out).toContain(
+      `<audio controls preload="none" src="data:audio/mpeg;base64,${base64Of('MP3')}"></audio>`
+    );
+    expect(out).not.toContain('[anki:play:');
+    expect(fetchMedia).toHaveBeenCalledWith('1600420050000.mp3');
+  });
+
+  it('strips [anki:play:q:0] when noteSounds is empty', async () => {
+    const fetchMedia = jest.fn(async () => base64Of('MP3'));
+    const cache = new Map<string, string | null>();
+
+    const out = await inlineReviewMedia(
+      'listen [anki:play:q:0]',
+      fetchMedia,
+      cache,
+      []
+    );
+
+    expect(out).toBe('listen ');
+    expect(out).not.toContain('[anki:play:');
+    expect(out).not.toContain('<audio');
+    expect(fetchMedia).not.toHaveBeenCalled();
+  });
+
+  it('fetches a note-field sound shared by q and a sides only once', async () => {
+    const fetchMedia = jest.fn(async () => base64Of('MP3'));
+    const cache = new Map<string, string | null>();
+
+    await inlineReviewMedia('[anki:play:q:0]', fetchMedia, cache, ['s.mp3']);
+    await inlineReviewMedia('[anki:play:a:0]', fetchMedia, cache, ['s.mp3']);
+
+    expect(fetchMedia).toHaveBeenCalledTimes(1);
+  });
+
   it('leaves no raw [sound: or [anki:play: token in the output', async () => {
     const cache = new Map<string, string | null>();
     const out = await inlineReviewMedia(

--- a/src/usecases/ankify/inlineReviewMedia.ts
+++ b/src/usecases/ankify/inlineReviewMedia.ts
@@ -122,12 +122,52 @@ const replaceSounds = async (
   return result;
 };
 
+const replacePlayDirectives = async (
+  html: string,
+  fetchMedia: MediaFetcher,
+  cache: Map<string, string | null>,
+  noteSounds: string[]
+): Promise<string> => {
+  const refs = [...html.matchAll(/\[anki:play:[qa]:(\d+)\]/g)];
+  let result = html;
+
+  for (const match of refs) {
+    const token = match[0];
+    const index = Number(match[1]);
+    const filename = noteSounds[index];
+    if (filename == null) {
+      result = result.replace(token, '');
+      continue;
+    }
+
+    const dataUri = await resolveDataUri(filename, fetchMedia, cache);
+    if (dataUri == null) {
+      result = result.replace(token, '');
+      continue;
+    }
+
+    result = result.replace(
+      token,
+      `<audio controls preload="none" src="${dataUri}"></audio>`
+    );
+  }
+
+  return result;
+};
+
 export async function inlineReviewMedia(
   html: string,
   fetchMedia: MediaFetcher,
-  cache: Map<string, string | null>
+  cache: Map<string, string | null>,
+  noteSounds?: string[]
 ): Promise<string> {
   const withImages = await replaceImages(html, fetchMedia, cache);
   const withAudio = await replaceSounds(withImages, fetchMedia, cache);
-  return withAudio.replace(/\[anki:play:[qa]:\d+\]/g, '');
+  const withPlay = await replacePlayDirectives(
+    withAudio,
+    fetchMedia,
+    cache,
+    noteSounds ?? []
+  );
+  return withPlay.replace(/\[anki:play:[qa]:\d+\]/g, '');
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-jlab-audio.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-ankify-review-jlab-audio.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-ankify-review-jlab-audio",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Card audio plays in the reviewer for decks that store sound in a separate field"
+}


### PR DESCRIPTION
## What
Card audio now plays in the reviewer for decks that keep their sound in a separate note field (jlab, subs2srs, and similar) — previously these cards were silent.

## Why
Confirmed against a real deck (`Jlab's beginner course::Part 1: Listening comprehension`, model `JlabNote-JlabConverted-1`): the audio lives in a note field `Audio` as `[sound:….mp3]`, but AnkiConnect's rendered `question`/`answer` does NOT contain that `[sound:]` — it emits Anki's replay directive `[anki:play:q:0]` instead. Our media inliner only converted inline `[sound:X]` and **stripped** `[anki:play:*]`, so no `<audio>` was produced and nothing played. (The autoplay wiring shipped earlier was fine — there was simply no audio element.)

## How
- `GetReviewCardUseCase`: when a side contains `[anki:play:`, fetch `notesInfo([card.note])` and collect the note's field `[sound:FILE]` filenames in field `order` → `noteSounds`. (No extra round-trip for cards without `[anki:play:`.)
- `inlineReviewMedia(html, fetchMedia, cache, noteSounds?)`: resolves `[anki:play:q:N]` / `[anki:play:a:N]` by taking `noteSounds[N]`, fetching the bytes (shared cache → `retrieveMediaFile`), and emitting `<audio controls preload="none" src="data:audio/mpeg;base64,…">`. Missing index / unfetchable → strip (no raw marker ever survives). Existing `[sound:X]` + `<img>` handling unchanged.
- Example: `[anki:play:q:0]` + field `Audio=[sound:1600420050000.mp3]` → an inlined `<audio>` on the question, which the existing autoplay plays.

## Testing
- 24 passed: `[anki:play:q:0]` + noteSounds → `<audio>` data URI + no `[anki:play`; empty noteSounds → stripped; dedupe; the real-card regression (question `[anki:play:q:0]` + `Audio` field) → inlined audio; `notesInfo` NOT called for cards without `[anki:play:`. tsc clean.

## Risks
v1 limitation: both `q:` and `a:` directives index the same ordered `noteSounds` list — per-side disambiguation isn't exposed by `cardsInfo`. Most cards carry a single audio, so this resolves correctly; a card with distinct front/back audio could map the wrong index (rare). No raw marker ever shows either way.

## Goal alignment
Retention — listening/audio cards (a core use for the JP-learner cohort) are now reviewable in-browser. Read at the Review T+30d adoption issue (#3357).

## Browser check
Not applicable — server-side change; the only web/src file is a changelog entry (changelog-only bypass). Audio playback verified manually against the real prod deck's card shape; first-clip autoplay + the controls bar already shipped in #3368.

## Sonar
sonar-scanner not run locally (no token) — Automatic Analysis runs on the PR.
