### PR TITLE
fix: theme-map MCQ correct-answer box and trim upload motion tells

### DIFF
--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -104,15 +104,11 @@
   color: var(--color-primary);
 }
 
-.iconBob {
-  animation: bobUp 1.2s ease-in-out infinite;
-}
-
 .iconSuccess {
   width: 48px;
   height: 48px;
   color: var(--color-success);
-  animation: scaleIn 300ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  animation: scaleIn 300ms ease-out;
 }
 
 .iconError {
@@ -500,7 +496,7 @@
 .apkgRedirectPrimary:hover {
   background: var(--color-primary-dark, var(--color-primary));
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  box-shadow: var(--shadow-md);
 }
 
 .apkgRedirectSecondary {
@@ -512,7 +508,7 @@
 .apkgRedirectSecondary:hover {
   border-color: var(--color-primary);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-md);
 }
 
 .apkgRedirectActionLabel {
@@ -618,16 +614,6 @@
 }
 
 /* ── Keyframes ── */
-
-@keyframes bobUp {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-4px);
-  }
-}
 
 @keyframes fadeIn {
   from {
@@ -1065,8 +1051,8 @@
   color: var(--color-success, #059669);
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-sm);
-  background: #ecfdf5;
-  border: 1px solid #10b981;
+  background: var(--color-success-light);
+  border: 1px solid var(--color-success);
   font-weight: var(--font-medium);
 }
 

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1233,9 +1233,7 @@ function UploadForm({
 
   const renderIdleState = () => (
     <div className={formStyles.stateContent}>
-      <UploadCloudIcon
-        className={`${formStyles.icon} ${dropHover ? formStyles.iconBob : ''}`}
-      />
+      <UploadCloudIcon className={formStyles.icon} />
       <span className={formStyles.dropText}>
         {dropHover ? 'Drop it right here' : 'Drop your files here'}
       </span>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-upload-dark-theme-mcq.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-upload-dark-theme-mcq.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-upload-dark-theme-mcq",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "The correct answer in a multiple-choice preview no longer glares on dark themes"
+}


### PR DESCRIPTION
## What
Four design-consistency fixes on `/upload` (`UploadForm`), from a Design-for-Hackers audit. The headline is a theme break; the other three are invisible motion/token polish.

## Why
**Theme break (user-visible win):** `.mcqDrawerOptionCorrect` hardcoded `#ecfdf5` / `#10b981` — those are the *light*-theme values of `--color-success-light` / `--color-success`. On the dark theme that token is `#0b3d2e`, so the correct-answer box in the multiple-choice preview glared as a near-white slab on dark/gold/purple/pink themes. Now it follows the active theme.

The remaining three remove off-system tells with no behavior change.

## How
1. `.mcqDrawerOptionCorrect` — `background`/`border` mapped to `var(--color-success-light)` / `var(--color-success)`. (The `color` line was already token-first.)
2. `.iconSuccess` — swapped the `cubic-bezier(0.34, 1.56, 0.64, 1)` bounce overshoot (a DESIGN.md kill-list AI-tell) for `ease-out`. `scaleIn` keyframe untouched.
3. Removed the infinite idle bob: deleted the `.iconBob` rule, the `@keyframes bobUp` block, and the `iconBob` className clause in `UploadForm.tsx`. Idle dropzone icon now stays still — no dead class or keyframe left. (`dropHover` is still used for the dropzone text, so it stays.)
4. `.apkgRedirectPrimary:hover` / `.apkgRedirectSecondary:hover` — raw `rgba(0, 0, 0, …)` shadows replaced with `var(--shadow-md)` (theme-aware token already used elsewhere in this file).

## Measuring success
No metric/log — visual consistency fix. Confirmation is visual: open the MCQ preview on the dark theme and verify the correct-answer box reads as a muted green, not a white slab.

## Testing
- Existing `src/pages/UploadPage` Vitest suite stays green: 15 files, 171 tests passing.
- No new unit test — these are token/motion swaps with no new behavior.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified on this branch via Playwright at 375px — /upload renders cleanly, idle dropzone icon static (bob removed). The only console messages are environmental: backend-proxy 502s (frontend-only vite, no API server running) and a third-party AdSense 403 — none from the app code or this diff. CI's playwright job is also green on this branch. Dark-theme MCQ box + motion fixes shown before/after in the PR comment.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-14-upload-dark-theme-mcq.json` — "The correct answer in a multiple-choice preview no longer glares on dark themes". One entry total; fixes 2-4 are invisible polish folded under its spirit.

## Risks
Low. CSS-token swaps and the removal of one decorative animation. Tokens (`--color-success-light`, `--color-success`, `--shadow-md`) are all defined per-theme in `base.css`. Rollback is a revert.

## Goal alignment
More beautiful / consistent — the dark-theme readability bug is the user-facing win (the MCQ correct-answer box no longer glares on 4 of 5 themes). No funnel/MRR metric moves; this is product-restraint polish on an existing surface.
