### PR TITLE
fix: register /anki-for-japanese as a known app route (unbreaks main)

### DIFF
--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -74,6 +74,7 @@ const LANDING_SLUGS = new Set<string>([
   'powerpoint-to-anki',
   'goodnotes-to-anki',
   'ai-flashcard-generator',
+  'anki-for-japanese',
 ]);
 
 const CONVERT_SLUGS = new Set<string>([

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-anki-for-japanese-route.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-anki-for-japanese-route.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-anki-for-japanese-route",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "The Anki for Japanese page loads when opened directly or from search"
+}


### PR DESCRIPTION
## What
Registers `/anki-for-japanese` as a known app route so the server serves the SPA (not a 404) for direct visits and crawlers, and the sitemap-parity test passes.

## Why
The `/anki-for-japanese` landing page shipped to main with its route (`App.tsx`), sitemap entry, and copy — but was never added to `isKnownAppRoute` (`src/routes/knownRoutes.ts`). Two consequences on current main:
- `DefaultRouter.test.ts` "sitemap parity" fails (`Expected true, Received false`), turning the server test suite red on every PR branched off main.
- `DefaultRouter` 404s any path not in `isKnownAppRoute`, so a direct visit or search-engine crawl of `https://2anki.net/anki-for-japanese/` was served a 404 instead of the page — bad for the exact SEO the landing page exists for.

## How
Add `'anki-for-japanese'` to `LANDING_SLUGS`.

## Testing
`DefaultRouter.test.ts` + `knownRoutes.test.ts`: 94 passed (sitemap parity green).

## Risks
None — one slug added to an allowlist; no behavior change beyond recognizing an already-shipped route.

## Goal alignment
Acquisition/SEO — unblocks indexing + direct loads of the Japanese landing page (the JP-learner acquisition lane). Also de-reds main so other PRs can merge.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: visit /anki-for-japanese/ directly — it serves the page, not a 404.

## Sonar
sonar-scanner not run locally (no token) — Automatic Analysis runs on the PR.
