### PR TITLE
fix: harden commit-msg hook parsing and document commit/PR mechanics

### DIFF
--- a/.claude/hooks/check-commit-message.py
+++ b/.claude/hooks/check-commit-message.py
@@ -50,13 +50,24 @@ def deny(reason):
     sys.exit(0)
 
 
+def commit_heredoc_message(command):
+    # A heredoc is the commit message only when it actually feeds `git commit`
+    # (e.g. `git commit -F- <<EOF`), not when it writes a file (`cat > x <<EOF`)
+    # or supplies an unrelated body (`gh pr create` with a here-doc).
+    for match in HEREDOC.finditer(command):
+        line_start = command.rfind("\n", 0, match.start()) + 1
+        prefix = command[line_start:match.start()]
+        if "git commit" in prefix and ">" not in prefix and "tee" not in prefix:
+            return match.group(2)
+    return None
+
+
 def extract_message(command):
-    heredoc = HEREDOC.search(command)
-    if heredoc:
-        return heredoc.group(2)
-    plain = DASH_M_QUOTED.search(command)
-    if plain:
-        return plain.group(2)
+    # Join every -m: git treats the first as the subject and each subsequent
+    # one as a body paragraph, so the hook must read them all (not just -m #1).
+    dash_m = DASH_M_QUOTED.findall(command)
+    if dash_m:
+        return "\n\n".join(value for _quote, value in dash_m)
     eq = LONG_FLAG.search(command)
     if eq:
         return eq.group(2)
@@ -77,13 +88,22 @@ def main():
 
     command = data.get("tool_input", {}).get("command", "")
 
-    if "git commit" not in command:
-        allow()
+    # A heredoc feeding `git commit` is the message; otherwise strip heredoc
+    # bodies so unrelated content (a changelog being written, a PR body that
+    # merely mentions committing, example -m flags in prose) can't be mistaken
+    # for the command structure or the message.
+    message = commit_heredoc_message(command)
+    if message is None:
+        stripped = HEREDOC.sub("", command)
 
-    if any(flag in command for flag in ["--amend", "--no-edit", "--squash", "--fixup"]):
-        allow()
+        if "git commit" not in stripped:
+            allow()
 
-    message = extract_message(command)
+        if any(flag in stripped for flag in ["--amend", "--no-edit", "--squash", "--fixup"]):
+            allow()
+
+        message = extract_message(stripped)
+
     if message is None:
         allow()
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,13 @@ Pricing v2 shipped 2026-06-10: $7.99/mo + $64/yr for new members, legacy $6/$60 
 
 ## Git
 
-- Conventional commit prefixes: `feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`, `perf:`, `ci:`, `build:`, `style:`, `revert:`. Keep the **subject ≤ 72 characters** — a commit-message hook rejects longer subjects; push the detail into the body.
+- Conventional commit prefixes: `feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`, `perf:`, `ci:`, `build:`, `style:`, `revert:`. Keep the **subject ≤ 72 characters** — a commit-message hook rejects longer subjects; push the detail into the body, which must carry a real **why** (≥40 chars of non-trailer text).
+- **Commit-message mechanics — avoid the hook fighting you.** Use `git commit -m "<type>: subject" -m "<why body>"` (the hook reads *every* `-m`: subject = first, body = the rest), or `git commit -F <file>` where the file was written in a **separate** Bash call. **Never put a `cat <<EOF` heredoc in the same Bash call as `git commit`** — a *failed* commit-msg check reverts the working tree and deletes the untracked file you just wrote (e.g. a changelog). Two calls: (1) write files, (2) `git add <paths> && git commit …`. See `.claude/hooks/check-commit-message.py`.
 - Suggest a branch name before starting code changes; format `<type>/<short-slug>`.
 - Always rebase on `origin/main` before opening a PR.
 - One PR per feature. Never stack PRs — the deploy pipeline pulls a single branch.
 - Push pattern: `git push -u origin <branch>` — never bare `git push`, never to `main`. The `safety.py` hook blocks both.
+- **Open PRs with `gh pr create --repo 2anki/server --base main --head <branch>`.** Bare `gh pr create` resolves the base to the upstream fork parent and fails with `No commits between Laer-Smart:main and 2anki:<branch>`; the explicit `--repo`/`--base`/`--head` form is the reliable one. (The PR URL prints as `Laer-Smart/2anki.net` — that's the canonical remote; same repo.) Same `--repo 2anki/server` for `gh pr view`/`merge`/`list`.
 - When a unit of work is done, ship it: commit, push, and open the PR **ready for review** with `gh pr create` — not `--draft`. A finished unit of work handed to Alexander is something he's meant to look at, so it goes up ready. Reserve `--draft` for work that genuinely isn't reviewable yet: a `/spec-draft-pr` spec awaiting `/implement`, or a WIP you've explicitly flagged as WIP.
 - **Before flipping a PR ready (or before pushing a non-trivial code change), run `sonar-scanner` locally.** `/check` does not run SonarCloud's rule engine; cognitive complexity, nesting depth, redundant type assertions, and a11y smells only surface after the push. See `.claude/rules/sonar.md` for setup and the exact command. Skip only for pure doc/dep/test/typo changes.
 - Before `gh pr merge`: every `statusCheckRollup` entry must be non-FAILURE (not just required ones). The `check-merge-status.py` hook enforces this.


### PR DESCRIPTION
## What
Reliability fixes drawn from today's multi-PR session friction:
1. The commit-message PreToolUse hook (`.claude/hooks/check-commit-message.py`) no longer mistakes an unrelated heredoc for the commit message, reads multi-message commits, and ignores heredoc bodies entirely (so it doesn't fire on `gh pr create` whose body merely mentions committing).
2. CLAUDE.md documents the safe commit-message + `gh pr create` incantations.

## Why
During a long session these cost real time:
- **Heredoc false-positive:** `extract_message` ran the heredoc regex first, so writing a changelog file alongside a commit in one Bash call parsed the changelog JSON as the "message" (bogus length, false reject). On rejection the hook reverts the tree, deleting the untracked changelog — so each retry also had to recreate it (~6 failed attempts on one commit).
- **Single-message only:** the hook read just the first message flag, so the idiomatic two-flag form (subject + body) always failed the body gate.
- **Bodies that mention committing:** the gate fired whenever the string appeared anywhere — including a PR description passed to a different command — and matched example flags in prose.
- **PR base default:** the bare create command resolved to the upstream fork parent and failed with "No commits between Laer-Smart:main and 2anki:branch"; the explicit repo/base/head form is reliable but wasn't written down.

## How
- Strip heredoc bodies from a working copy of the command before the gate and message extraction, so heredoc contents never influence detection.
- Prefer explicit message flags first and join all of them (subject = first, body = the rest); a heredoc is treated as the message only when it actually feeds the commit.
- CLAUDE.md Git section: commit-message mechanics (two flags, or a file written in a separate Bash call; never a heredoc in the same call as the commit) and the explicit repo/base/head create incantation.

## Testing
Ran the hook against the failing patterns plus regressions — all correct: changelog-heredoc + two flags → allow; bad no-body → deny; good two-flag → allow; file form → allow; bad subject → deny; create-command whose body mentions committing → allow.

## Risks
Low — hook logic only; the bypass env var and the conventional-prefix/body gates are unchanged. A heredoc-fed commit message (rare; discouraged) now passes unvalidated, same as the file form.

## Goal alignment
Internal tooling — faster, more reliable delivery. No user-facing change, no changelog entry.

## Browser check
Not applicable — no `web/src/` change (hook + CLAUDE.md only).

## Sonar
Not applicable — Python hook + Markdown only.
