### PR TITLE
fix: announce auth form errors and progress to screen readers

### DIFF
--- a/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/web/src/components/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -76,7 +76,7 @@ function ForgotPasswordForm({ setError }: Readonly<ForgotPasswordProps>) {
               className={styles.submitButton}
               disabled={loading || email.length === 0}
             >
-              {loading ? 'Sending…' : 'Send reset link'}
+              {loading ? 'Sending' : 'Send reset link'}
             </button>
           </div>
         </form>

--- a/web/src/components/forms/NewPasswordForm.test.tsx
+++ b/web/src/components/forms/NewPasswordForm.test.tsx
@@ -47,6 +47,48 @@ describe('NewPasswordForm', () => {
     });
   });
 
+  it('shows a mismatch message when both fields are touched and differ', () => {
+    renderForm();
+
+    fireEvent.change(screen.getByPlaceholderText('New password'), {
+      target: { value: 'validpassword' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Re-enter new password'), {
+      target: { value: 'different' },
+    });
+
+    const message = screen.getByText("Passwords don't match.");
+    expect(message).toBeInTheDocument();
+    expect(message).toHaveAttribute('id', 'confirm-password-help');
+    expect(screen.getByPlaceholderText('Re-enter new password')).toHaveAttribute(
+      'aria-describedby',
+      'confirm-password-help'
+    );
+  });
+
+  it('hides the mismatch message when the fields match', () => {
+    renderForm();
+
+    fireEvent.change(screen.getByPlaceholderText('New password'), {
+      target: { value: 'validpassword' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Re-enter new password'), {
+      target: { value: 'validpassword' },
+    });
+
+    expect(screen.queryByText("Passwords don't match.")).toBeNull();
+  });
+
+  it('does not show the mismatch message before the confirm field is touched', () => {
+    renderForm();
+
+    fireEvent.change(screen.getByPlaceholderText('New password'), {
+      target: { value: 'validpassword' },
+    });
+
+    expect(screen.queryByText("Passwords don't match.")).toBeNull();
+  });
+
   it('redirects to /login on a 200 response', async () => {
     mockNewPassword.mockResolvedValue({ status: 200 });
     renderForm();

--- a/web/src/components/forms/NewPasswordForm.tsx
+++ b/web/src/components/forms/NewPasswordForm.tsx
@@ -19,6 +19,8 @@ function NewPasswordForm({ setErrorMessage }: Readonly<Props>) {
   const passwordTouched = password.length > 0;
   const passwordMeetsMinimum = password.length >= MIN_PASSWORD_LENGTH;
   const passwordsMatch = password === confirmPassword;
+  const confirmTouched = confirmPassword.length > 0;
+  const showMismatch = passwordTouched && confirmTouched && !passwordsMatch;
 
   const isValid = () =>
     passwordsMatch && passwordMeetsMinimum && password.length < 256;
@@ -101,8 +103,20 @@ function NewPasswordForm({ setErrorMessage }: Readonly<Props>) {
                 autoComplete="new-password"
                 placeholder="Re-enter new password"
                 required
+                aria-describedby={
+                  showMismatch ? 'confirm-password-help' : undefined
+                }
               />
             </label>
+            {showMismatch && (
+              <p
+                id="confirm-password-help"
+                role="alert"
+                className={styles.helpDanger}
+              >
+                Passwords don&apos;t match.
+              </p>
+            )}
           </div>
           <div className={styles.field}>
             <button
@@ -110,7 +124,7 @@ function NewPasswordForm({ setErrorMessage }: Readonly<Props>) {
               className={styles.submitButton}
               disabled={!isValid() || loading}
             >
-              {loading ? 'Saving…' : 'Reset password'}
+              {loading ? 'Saving' : 'Reset password'}
             </button>
             {resetError && <p className={styles.helpDanger}>{resetError}</p>}
           </div>

--- a/web/src/components/forms/RegisterForm.tsx
+++ b/web/src/components/forms/RegisterForm.tsx
@@ -134,7 +134,7 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
 
   const passwordHelpText = (() => {
     if (passwordMeetsMinimum) {
-      return '✓ Good';
+      return 'Good';
     }
     return 'Use at least 8 characters.';
   })();
@@ -158,11 +158,11 @@ function RegisterForm({ setErrorMessage, redirect }: Props) {
           {getVisibleText('navigation.register.title')}
         </h1>
         <div className={styles.oauthGrid}>
-          <WithNotionLink variant="card" text="Continue with Notion" />
           <WithGoogleLink
             variant="card"
             text={getVisibleText('navigation.register.google')}
           />
+          <WithNotionLink variant="card" text="Continue with Notion" />
           <WithMicrosoftLink
             variant="card"
             text={getVisibleText('navigation.register.microsoft')}

--- a/web/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
+++ b/web/src/pages/DeleteAccountPage/DeleteAccountPage.tsx
@@ -52,7 +52,7 @@ export function DeleteAccountPage({ setError }: Readonly<Prop>) {
         </p>
 
         {isDeleting && (
-          <div className={sharedStyles.infoBox}>
+          <div className={sharedStyles.infoBox} role="status">
             Deleting your account and cancelling subscriptions
           </div>
         )}

--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
@@ -5,12 +5,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { CookiesProvider } from 'react-cookie';
 import LoginForm from './index';
 
+const mockLogin = vi.fn();
+
 vi.mock('../../../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({
-    login: vi.fn().mockResolvedValue({
-      status: 200,
-      json: () => Promise.resolve({ token: 'test-token' }),
-    }),
+    login: mockLogin,
     requestMagicLink: vi.fn().mockResolvedValue({ ok: true }),
   }),
 }));
@@ -28,6 +27,11 @@ function renderLoginForm() {
 describe('LoginForm', () => {
   beforeEach(() => {
     localStorage.clear();
+    mockLogin.mockReset();
+    mockLogin.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ token: 'test-token' }),
+    });
   });
 
   it('renders email step with email input and primary CTA', () => {
@@ -206,5 +210,31 @@ describe('LoginForm', () => {
       name: 'Email',
     }) as HTMLInputElement;
     expect(emailInput.value).toBe('saved@example.com');
+  });
+
+  it('announces a failed login via role=alert wired to the submit button', async () => {
+    mockLogin.mockResolvedValue({
+      status: 401,
+      json: () => Promise.resolve({}),
+    });
+    renderLoginForm();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByText('Use password instead'));
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'wrongpassword' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(
+      'Wrong email or password. Try again or reset your password.'
+    );
+    expect(alert).toHaveAttribute('id', 'login-error');
+    expect(screen.getByRole('button', { name: 'Log in' })).toHaveAttribute(
+      'aria-describedby',
+      'login-error'
+    );
   });
 });

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -100,10 +100,15 @@ function LoginForm() {
                 className={styles.submitButton}
                 disabled={email.length === 0 || magicLinkLoading}
                 onClick={handleSendMagicLink}
+                aria-describedby={error ? 'login-error' : undefined}
               >
                 {magicLinkLoading ? 'Sending' : 'Email me a sign-in link'}
               </button>
-              {error && <p className={styles.helpDanger}>{error}</p>}
+              {error && (
+                <p id="login-error" role="alert" className={styles.helpDanger}>
+                  {error}
+                </p>
+              )}
             </div>
             <p className={styles.footerText}>
               <a
@@ -188,10 +193,15 @@ function LoginForm() {
                 type="submit"
                 className={styles.submitButton}
                 disabled={!isValidCredentials(email, password) || loading}
+                aria-describedby={error ? 'login-error' : undefined}
               >
-                {loading ? 'Logging in…' : 'Log in'}
+                {loading ? 'Logging in' : 'Log in'}
               </button>
-              {error && <p className={styles.helpDanger}>{error}</p>}
+              {error && (
+                <p id="login-error" role="alert" className={styles.helpDanger}>
+                  {error}
+                </p>
+              )}
             </div>
             <p className={styles.footerText}>
               <a rel="noreferrer" href="/forgot">

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
@@ -33,13 +33,23 @@ describe('MagicLinkPage', () => {
   it('shows error when no token is present', () => {
     renderMagicLinkPage('');
     expect(screen.getByText('Link expired or invalid')).toBeInTheDocument();
-    expect(screen.getByText(/No token found/)).toBeInTheDocument();
+    expect(
+      screen.getByText('This link is invalid or has expired. Request a new one.')
+    ).toBeInTheDocument();
   });
 
   it('shows loading state while validating token', () => {
     mockValidateMagicToken.mockReturnValue(new Promise(() => {}));
     renderMagicLinkPage('?token=abc123');
-    expect(screen.getByText('Verifying your link')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Verifying your link' })
+    ).toBeInTheDocument();
+  });
+
+  it('announces the verifying state to screen readers', () => {
+    mockValidateMagicToken.mockReturnValue(new Promise(() => {}));
+    renderMagicLinkPage('?token=abc123');
+    expect(screen.getByRole('status')).toHaveTextContent('Verifying your link');
   });
 
   it('shows error state on failed validation', async () => {

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.tsx
@@ -29,7 +29,7 @@ function MagicLinkPage() {
     if (token == null) {
       setState({
         status: 'error',
-        message: 'No token found. The link may be invalid or expired.',
+        message: 'This link is invalid or has expired. Request a new one.',
       });
       return;
     }
@@ -105,8 +105,9 @@ function MagicLinkPage() {
       <div className={styles.formPage}>
         <div className={styles.formCard}>
           <h1 className={styles.formTitle}>Verifying your link</h1>
-          <div className={sharedStyles.flexCenter}>
+          <div className={sharedStyles.flexCenter} role="status">
             <div className={sharedStyles.spinner} />
+            <span className={sharedStyles.srOnly}>Verifying your link</span>
           </div>
         </div>
       </div>

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-auth-form-feedback.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-auth-form-feedback.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-auth-form-feedback",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Sign-in and password forms tell you what went wrong, and screen readers announce it"
+}


### PR DESCRIPTION
## What
One cross-cutting accessibility + voice sweep across the auth and account forms — TSX only, no CSS. Login, register, set-new-password, forgot-password, magic-link, and delete-account screens.

## Why
A designer audit found recurring a11y gaps on conversion-critical, security-adjacent screens: error and progress states were rendered visually but never announced to screen readers, and the forms used ellipsis loading labels that VOICE.md bans. Signup and login are the front door of the conversion funnel — a silent failure there is a user who never learns why they're stuck.

## How
- **LoginForm**: failed logins render via `role="alert"` on the error `<p id="login-error">`, wired to the submit button with `aria-describedby`. "Logging in…" → "Logging in".
- **NewPasswordForm**: new "Passwords don't match." line shown once both fields are touched and differ, wired via `aria-describedby="confirm-password-help"` on the confirm input (was a silently-disabled button). "Saving…" → "Saving".
- **RegisterForm**: dropped the literal `✓` from the password help (color already signals it; matches NewPasswordForm). Aligned the OAuth provider order to LoginForm (Google, Notion, Microsoft, Apple) — labels unchanged.
- **ForgotPasswordForm**: "Sending…" → "Sending".
- **MagicLinkPage**: verifying spinner wrapped in `role="status"` with an `.srOnly` "Verifying your link"; the no-token error reworded to "This link is invalid or has expired. Request a new one." (drops "token" jargon, matches the other branch).
- **DeleteAccountPage**: `role="status"` on the delete-in-progress notice so the irreversible action is announced. (`.mainCard` left untouched — a parallel CSS sweep owns this file.)

## Measuring success
No metric/log instrumentation in this PR — the change is presentation-layer ARIA + copy. Confirmation is qualitative: a screen reader announces login failure, password mismatch, and magic-link/delete progress, verifiable with VoiceOver/NVDA on the auth pages. The funnel signal it should help is login/signup completion (read in the existing `funnel events at /api/ops/metrics`), via fewer silent dead-ends.

## Testing
- Unit tests added/extended (Vitest):
  - LoginForm: a failed login exposes `role="alert"` with `id="login-error"`, and the submit button carries `aria-describedby="login-error"`.
  - NewPasswordForm: mismatch message renders when both fields are touched and differ (with correct `id` + `aria-describedby`), is absent when they match, and is absent before the confirm field is touched.
  - MagicLinkPage: the verifying state is exposed via `role="status"`; the no-token error asserts the reworded string.
- Full target suites green: `pnpm --filter 2anki-web test src/components/forms src/pages/MagicLinkPage src/pages/LoginPage/components/LoginForm` → 60 passed. `typecheck` clean, `lint` exit 0 (no findings in changed files).
- Sonar: `sonar-scanner` not run — not installed locally and no token configured. Changes are JSX-attribute-level (role/aria/id) + copy strings, low Sonar risk; expect no new findings, flag if CI bounces.

## Before/after
Not applicable for the ARIA wiring (no visual change). The visible changes are the new "Passwords don't match." message and the reworded magic-link error, both covered by tests.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Pending — I can't drive a browser in this environment. Boxes left unticked honestly; please run the golden path before merge.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-14-auth-form-feedback.json` — "Sign-in and password forms tell you what went wrong, and screen readers announce it"

## Risks
Low. Presentation-layer only — no data, auth, or network logic touched. The shared `id="login-error"` on the two LoginForm error `<p>`s renders only in mutually-exclusive branches (email step vs password step), so there is never a duplicate id at runtime. Rollback is a plain revert.

## Goal alignment
Login and signup are the conversion funnel's front door. Clearer error feedback plus screen-reader support reduce silent drop-off — a user who can't tell why login failed, or whose two passwords disagree without explanation, abandons. Funnel metric: login/signup completion at `/api/ops/metrics`. No MRR change — friction reduction at the top of funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
