### PR TITLE
fix: swap dead CSS tokens to real theme tokens across surfaces

### DIFF
--- a/web/src/pages/AccountPage/AccountPage.module.css
+++ b/web/src/pages/AccountPage/AccountPage.module.css
@@ -15,6 +15,10 @@
   box-shadow: var(--shadow-xs);
 }
 
+.mainCard {
+  composes: sectionCard from '../../styles/shared.module.css';
+}
+
 .name {
   font-size: var(--text-xl);
   font-weight: var(--font-semibold);

--- a/web/src/pages/AnkifyPage/stats/StudyStatsSection.module.css
+++ b/web/src/pages/AnkifyPage/stats/StudyStatsSection.module.css
@@ -125,35 +125,19 @@
 }
 
 .cell1 {
-  background: #9be9a8;
+  background: var(--color-heatmap-1);
 }
 
 .cell2 {
-  background: #40c463;
+  background: var(--color-heatmap-2);
 }
 
 .cell3 {
-  background: #30a14e;
+  background: var(--color-heatmap-3);
 }
 
 .cell4 {
-  background: #216e3a;
-}
-
-:global([data-theme='dark']) .cell1 {
-  background: #0e4429;
-}
-
-:global([data-theme='dark']) .cell2 {
-  background: #006d32;
-}
-
-:global([data-theme='dark']) .cell3 {
-  background: #26a641;
-}
-
-:global([data-theme='dark']) .cell4 {
-  background: #39d353;
+  background: var(--color-heatmap-4);
 }
 
 .heatmapLegend {

--- a/web/src/pages/AnswersPage/AnswersPage.module.css
+++ b/web/src/pages/AnswersPage/AnswersPage.module.css
@@ -9,12 +9,12 @@
   font-weight: 600;
   line-height: 1.2;
   margin: 0 0 1rem;
-  color: var(--color-text, #111827);
+  color: var(--color-text-primary);
 }
 
 .intro {
   font-size: 1.125rem;
-  color: var(--color-muted, #4b5563);
+  color: var(--color-text-secondary);
   margin: 0 0 2.5rem;
   line-height: 1.6;
 }
@@ -27,12 +27,12 @@
   font-size: 1.125rem;
   font-weight: 600;
   margin: 0 0 0.5rem;
-  color: var(--color-text, #111827);
+  color: var(--color-text-primary);
 }
 
 .sectionBody {
   font-size: 1rem;
-  color: var(--color-muted, #374151);
+  color: var(--color-text-secondary);
   line-height: 1.7;
   margin: 0;
 }
@@ -40,7 +40,7 @@
 .related {
   margin-top: 3rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--color-border, #e5e7eb);
+  border-top: 1px solid var(--color-border);
 }
 
 .relatedHeading {
@@ -48,7 +48,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-muted, #6b7280);
+  color: var(--color-text-secondary);
   margin: 0 0 0.75rem;
 }
 
@@ -62,7 +62,7 @@
 }
 
 .relatedLink {
-  color: var(--color-link, #2563eb);
+  color: var(--color-text-link);
   text-decoration: none;
   font-size: 0.9375rem;
 }

--- a/web/src/pages/Chat/CodeBlock.module.css
+++ b/web/src/pages/Chat/CodeBlock.module.css
@@ -5,7 +5,7 @@
 }
 
 .header {
-  background: #111827;
+  background: var(--color-code-bg);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -15,14 +15,14 @@
 .language {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.75rem;
-  color: #9ca3af;
+  color: color-mix(in srgb, var(--color-code-text) 60%, transparent);
   text-transform: lowercase;
 }
 
 .copyBtn {
   font-size: 0.75rem;
   font-family: inherit;
-  color: #9ca3af;
+  color: color-mix(in srgb, var(--color-code-text) 60%, transparent);
   background: transparent;
   border: none;
   cursor: pointer;
@@ -32,7 +32,7 @@
 }
 
 .copyBtn:hover {
-  color: #f9fafb;
+  color: var(--color-code-text);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -44,7 +44,7 @@
 .pre {
   margin: 0;
   padding: 0.75rem;
-  background: #1f2937;
+  background: var(--color-code-bg);
   overflow-x: auto;
   font-size: 0.8125rem;
   line-height: var(--leading-normal);
@@ -52,7 +52,7 @@
 
 .pre code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: #f9fafb;
+  color: var(--color-code-text);
   background: transparent;
   padding: 0;
   border-radius: 0;

--- a/web/src/pages/Chat/ConversationsSidebar.module.css
+++ b/web/src/pages/Chat/ConversationsSidebar.module.css
@@ -201,7 +201,7 @@
     width: 280px;
     max-width: 85vw;
     transform: translateX(-100%);
-    transition: transform var(--transition-base);
+    transition: transform var(--transition-normal);
     box-shadow: var(--shadow-md);
   }
 

--- a/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.module.css
+++ b/web/src/pages/ConvertLandingPage/ApkgCsvExportForm.module.css
@@ -4,7 +4,7 @@
   gap: 0.75rem;
   align-items: stretch;
   background: var(--color-bg-primary);
-  border: 1px solid var(--color-border-soft, #e5e7eb);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   box-shadow: var(--shadow-sm);
@@ -102,12 +102,12 @@
 
 .success {
   composes: status;
-  color: var(--color-success, #137333);
+  color: var(--color-success);
 }
 
 .error {
   composes: status;
-  color: var(--color-error, #b91c1c);
+  color: var(--color-text-danger);
 }
 
 .downloadAgain {

--- a/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.module.css
+++ b/web/src/pages/DatabasePreviewPage/DatabasePreviewPage.module.css
@@ -69,7 +69,7 @@
 }
 
 .statsWarning {
-  color: var(--color-warning, #b45309);
+  color: var(--color-warning-text);
   font-weight: var(--font-medium);
 }
 

--- a/web/src/pages/HomePage/ShowcaseSection.module.css
+++ b/web/src/pages/HomePage/ShowcaseSection.module.css
@@ -111,13 +111,13 @@
 
 .toggle code,
 .notionBlock code {
-  background: rgba(135, 131, 120, 0.15);
+  background: var(--color-bg-tertiary);
   border-radius: 3px;
   padding: 0.2em 0.4em;
   font-size: 100%;
   font-family:
     'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
-  color: #c0392b;
+  color: var(--color-text-danger);
 }
 
 .ankiCards {

--- a/web/src/pages/ImageOcclusionPage/components/OcclusionCanvas.tsx
+++ b/web/src/pages/ImageOcclusionPage/components/OcclusionCanvas.tsx
@@ -984,7 +984,7 @@ export function OcclusionCanvas({ entry, onRectsChange }: Readonly<Props>) {
                         y1={last.y * svgSize.h}
                         x2={cursorPt.x}
                         y2={cursorPt.y}
-                        stroke="#4f46e5"
+                        stroke="var(--color-primary)"
                         strokeWidth={1.5}
                         strokeDasharray="5 3"
                         style={{ pointerEvents: 'none' }}
@@ -1007,7 +1007,7 @@ export function OcclusionCanvas({ entry, onRectsChange }: Readonly<Props>) {
                       cy={first.y * svgSize.h}
                       r={POLYGON_CLOSE_DIST / 2}
                       fill="rgba(79,70,229,0.25)"
-                      stroke="#4f46e5"
+                      stroke="var(--color-primary)"
                       strokeWidth={1.5}
                       style={{ pointerEvents: 'none' }}
                     />

--- a/web/src/pages/LimitPage/LimitPage.module.css
+++ b/web/src/pages/LimitPage/LimitPage.module.css
@@ -71,7 +71,7 @@
 }
 
 .planCard {
-  background: var(--color-bg-card);
+  background: var(--color-bg-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   padding: 1.75rem 1.5rem 1.5rem;
@@ -153,7 +153,7 @@
   font-size: var(--text-base);
   font-weight: var(--font-semibold);
   color: var(--color-bg-primary);
-  background: var(--color-primary-hover);
+  background: var(--color-primary);
   border: none;
   border-radius: var(--radius-md);
   text-decoration: none;
@@ -162,16 +162,8 @@
   width: 100%;
 }
 
-:global([data-theme='hotpink']) .planCtaPrimary {
-  background: #be185d;
-}
-
 .planCtaPrimary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-primary-hover) 85%, black);
-}
-
-:global([data-theme='hotpink']) .planCtaPrimary:hover:not(:disabled) {
-  background: color-mix(in srgb, #be185d 85%, black);
+  background: var(--color-primary-hover);
 }
 
 .planCtaPrimary:disabled {
@@ -207,7 +199,7 @@
 
 .planError {
   font-size: var(--text-sm);
-  color: var(--color-error, #dc2626);
+  color: var(--color-text-danger);
   margin: 0.5rem 0 0;
   text-align: center;
 }

--- a/web/src/pages/MindmapsPage/MindmapNode.tsx
+++ b/web/src/pages/MindmapsPage/MindmapNode.tsx
@@ -195,7 +195,7 @@ export function MindmapNode({ data, selected }: NodeProps) {
               title="Delete"
               aria-label="Delete"
               onClick={() => nodeData.onDelete?.()}
-              style={{ ...toolbarButtonStyle, color: '#ef4444' }}
+              style={{ ...toolbarButtonStyle, color: 'var(--color-danger)' }}
             >
               <TrashIcon width={16} height={16} />
             </button>

--- a/web/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
+++ b/web/src/pages/PreviewApkgPage/PreviewApkgPage.module.css
@@ -148,8 +148,8 @@
 }
 
 .downloadButton {
-  background: var(--color-cta, #3b82f6);
-  color: #fff;
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
   border: none;
   border-radius: var(--radius-sm);
   padding: 0.375rem 1rem;
@@ -214,7 +214,7 @@
 .editableField {
   width: 100%;
   padding: 0.5rem;
-  border: 1px solid var(--color-cta, #3b82f6);
+  border: 1px solid var(--color-primary);
   border-radius: var(--radius-sm);
   background: var(--color-bg-primary);
   color: var(--color-text-primary);

--- a/web/src/pages/PreviewApkgPage/SharePopover.module.css
+++ b/web/src/pages/PreviewApkgPage/SharePopover.module.css
@@ -29,7 +29,7 @@
   color: var(--color-text-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-md, 0 4px 16px rgba(0, 0, 0, 0.1));
+  box-shadow: var(--shadow-md);
   padding: 1.25rem;
   z-index: 100;
 }
@@ -62,8 +62,8 @@
 .copyButton {
   flex-shrink: 0;
   padding: 0.375rem 0.875rem;
-  background: var(--color-blue-600, #2563eb);
-  color: #fff;
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -73,7 +73,7 @@
 }
 
 .copyButton:hover {
-  background: var(--color-blue-700, #1d4ed8);
+  background: var(--color-primary-hover);
 }
 
 .helperText {
@@ -116,7 +116,7 @@
 
 .stopButton {
   padding: 0.375rem 0.875rem;
-  background: var(--color-red-600, #dc2626);
+  background: var(--color-danger);
   color: #fff;
   border: none;
   border-radius: var(--radius-sm);
@@ -125,7 +125,7 @@
 }
 
 .stopButton:hover {
-  background: var(--color-red-700, #b91c1c);
+  background: color-mix(in srgb, var(--color-danger) 85%, black);
 }
 
 .keepButton {

--- a/web/src/pages/SharedDeckPage/SharedDeckPage.module.css
+++ b/web/src/pages/SharedDeckPage/SharedDeckPage.module.css
@@ -64,8 +64,8 @@
 .downloadButton {
   display: inline-block;
   padding: 0.75rem 2rem;
-  background: var(--color-blue-600, #2563eb);
-  color: #fff;
+  background: var(--color-primary);
+  color: var(--color-bg-primary);
   border-radius: var(--radius-md);
   text-decoration: none;
   font-weight: var(--font-medium);
@@ -73,7 +73,7 @@
 }
 
 .downloadButton:hover {
-  background: var(--color-blue-700, #1d4ed8);
+  background: var(--color-primary-hover);
 }
 
 .sentinel {

--- a/web/src/pages/StatusPage/StatusPage.module.css
+++ b/web/src/pages/StatusPage/StatusPage.module.css
@@ -14,7 +14,7 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 0;
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border);
   font-size: var(--text-sm);
   color: var(--color-text-secondary);
 }
@@ -31,15 +31,15 @@
 }
 
 .dotGreen {
-  background-color: #22c55e;
+  background-color: var(--color-success);
 }
 
 .dotRed {
-  background-color: #ef4444;
+  background-color: var(--color-text-danger);
 }
 
 .dotGray {
-  background-color: #9ca3af;
+  background-color: var(--color-text-tertiary);
 }
 
 .label {
@@ -62,7 +62,7 @@
 
 .incident {
   padding: 0.75rem 0;
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border);
   font-size: var(--text-sm);
 }
 
@@ -82,7 +82,7 @@
 }
 
 .incidentOpen {
-  color: #ef4444;
+  color: var(--color-text-danger);
   font-size: var(--text-xs);
   font-weight: var(--font-medium);
 }

--- a/web/src/pages/TemplatesPage/components/CodeEditor/CodeEditor.module.css
+++ b/web/src/pages/TemplatesPage/components/CodeEditor/CodeEditor.module.css
@@ -5,7 +5,7 @@
   min-height: 320px;
   border-radius: var(--radius-md);
   overflow: hidden;
-  background: #1e1e1e;
+  background: var(--color-code-bg);
 }
 
 .fallback {
@@ -17,8 +17,8 @@
     ui-monospace, SFMono-Regular, 'JetBrains Mono', Menlo, Consolas, monospace;
   font-size: 0.85rem;
   line-height: 1.55;
-  color: #d4d4d4;
-  background: #1e1e1e;
+  color: var(--color-code-text);
+  background: var(--color-code-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   resize: vertical;

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.module.css
@@ -494,7 +494,7 @@
 }
 
 .apkgRedirectPrimary:hover {
-  background: var(--color-primary-dark, var(--color-primary));
+  background: var(--color-primary-hover);
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
 }
@@ -847,7 +847,7 @@
   max-width: 800px;
   text-align: center;
   font-size: var(--text-sm);
-  color: var(--color-error, #b00020);
+  color: var(--color-danger);
 }
 
 .dropboxIconLarge {
@@ -1048,7 +1048,7 @@
 
 .mcqDrawerOptionCorrect {
   font-size: var(--text-sm);
-  color: var(--color-success, #059669);
+  color: var(--color-success);
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius-sm);
   background: var(--color-success-light);

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-14-theme-color-fixes.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-14-theme-color-fixes.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-14-theme-color-fixes",
+  "date": "2026-06-14",
+  "type": "fix",
+  "title": "Buttons, paywall cards, and status colors now match your theme on dark, gold, purple, and pink"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -112,6 +112,12 @@
   /* Accent palette — Pro card gradients */
   --color-indigo: #6366f1;
   --color-indigo-dark: #4f46e5;
+
+  /* Study heatmap ramp (4 activity steps; cell0 uses --color-bg-tertiary) */
+  --color-heatmap-1: #9be9a8;
+  --color-heatmap-2: #40c463;
+  --color-heatmap-3: #30a14e;
+  --color-heatmap-4: #216e3a;
 }
 
 /* =====================================================================
@@ -172,6 +178,10 @@
   --color-code-text: #e5e7eb;
   --color-indigo: #818cf8;
   --color-indigo-dark: #6366f1;
+  --color-heatmap-1: #0e4429;
+  --color-heatmap-2: #006d32;
+  --color-heatmap-3: #26a641;
+  --color-heatmap-4: #39d353;
 }
 
 /* =====================================================================
@@ -233,6 +243,10 @@
   --color-gold-shadow: rgba(176, 138, 62, 0.25);
   --color-indigo: #7a5b22;
   --color-indigo-dark: #4a3a1f;
+  --color-heatmap-1: #ead8b8;
+  --color-heatmap-2: #c9a96e;
+  --color-heatmap-3: #9a7a3a;
+  --color-heatmap-4: #4a3a1f;
 }
 
 /* =====================================================================
@@ -296,6 +310,10 @@
   --color-code-text: #e0ddef;
   --color-indigo: #9b8fd8;
   --color-indigo-dark: #7c6cc4;
+  --color-heatmap-1: #ddd8ec;
+  --color-heatmap-2: #b5a8e0;
+  --color-heatmap-3: #7c6cc4;
+  --color-heatmap-4: #4c3f86;
 }
 
 /* =====================================================================
@@ -357,6 +375,10 @@
   --color-gold-shadow: rgba(236, 72, 153, 0.2);
   --color-indigo: #f472b6;
   --color-indigo-dark: #ec4899;
+  --color-heatmap-1: #fbcfe8;
+  --color-heatmap-2: #f9a8d4;
+  --color-heatmap-3: #ec4899;
+  --color-heatmap-4: #9d174d;
 }
 
 *,


### PR DESCRIPTION
## What
Cross-cutting sweep replacing dead CSS custom properties with the real theme tokens that exist in `web/src/styles/base.css`. A `var(--undefined-token, #hex)` always resolved to the hardcoded light-mode hex (the token never existed), so dark / gold / purple / hotpink users saw pinned light colors on high-value surfaces. A `var(--undefined)` with no fallback resolved to `transparent`/invalid — that one was a functional bug (the mobile chat drawer slide).

## Why
Theme-break: dead CSS tokens rendered hardcoded hex, breaking dark/gold/purple/hotpink on download/paywall/share/status surfaces. Roughly half of users are not on the light theme, and the broken surfaces are revenue- and conversion-adjacent: the deck download CTA, the public shared-deck download button, the paywall plan cards, the .apkg download, status colors. Each was pinned to a light literal that looks wrong on every other theme.

## How
Each dead token swapped to the real token already defined across all five `:root` / `[data-theme=…]` blocks. No new tokens except one additive set: a 4-step `--color-heatmap-1..4` ramp defined per theme so the Ankify study heatmap tints to the active theme instead of always showing GitHub green. The LimitPage paywall CTA had an inverted rest/hover (rest used `--color-primary-hover`) plus a hand-rolled `:global([data-theme='hotpink'])` literal override block to compensate — fixed the rest/hover to `--color-primary` / `--color-primary-hover` and deleted both override blocks, which the correct tokens make redundant. AccountPage `.mainCard` was referenced by the delete-account page but never defined, so that irreversible page rendered unstyled — added it composing the shared `sectionCard`.

Surfaces: AnswersPage, ConvertLandingPage export form, PreviewApkg download CTA + SharePopover, LimitPage paywall, SharedDeckPage public download, StatusPage dots + borders, Chat sidebar drawer transition, Chat CodeBlock + Templates CodeEditor (raw VS-Code hex → code tokens), HomePage showcase inline-code, UploadForm error/hover/success, AccountPage `.mainCard`, DatabasePreviewPage warning prose, AnkifyPage study heatmap, MindmapNode + OcclusionCanvas chrome.

Content-exception colors honored (left as literals): Anki occlusion mask fills, mindmap node-color presets, photo-delete scrims, the Dropbox brand glyph, PrintForm user-chosen card bg, CardFrame iframe `system-ui`, and the HomePage video-overlay scrims.

## Measuring success
No metric query — this is a correctness/visual fix. Confirmation is visual: on each non-light theme, the four worst offenders (paywall card, shared-deck download, preview download CTA, status dots) now render in theme tokens. The before/after harness comment on this PR captures it for dark + hotpink.

## Testing
- No unit tests for CSS token swaps (CSS values aren't asserted in the suite).
- Scoped vitest green: AnswersPage, LimitPage, SharedDeckPage, StatusPage, PreviewApkgPage, WhatsNewPage — 78 passed.
- `pnpm --filter 2anki-web typecheck` clean.
- `pnpm --filter 2anki-web lint` — 0 errors (pre-existing warnings only, none in changed files).
- `pnpm --filter 2anki-web build` succeeds.
- Sonar: not run locally (no scanner/token in this env). Pure CSS-token swap + two tiny chrome attribute changes — no new functions, components, or complexity for the rule engine to flag. Expect no new Sonar findings.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Pending — I can't drive a real browser. Validated instead with an isolated Playwright harness that `<link>`s the real `base.css` and renders before/after for dark + hotpink (see the before/after comment). A human browser check on the live surfaces is still owed before merge.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-14-theme-color-fixes.json` — "Buttons, paywall cards, and status colors now match your theme on dark, gold, purple, and pink"

## Risks
Low. Every swap targets a token verified present in all five theme blocks. The one behavioral edit (`--transition-base` → `--transition-normal`) fixes a broken mobile drawer slide. The LimitPage hotpink override deletion is safe because the corrected rest/hover tokens already theme-tune. Rollback is a single revert.

## Goal alignment
More beautiful and correct on every theme. The fixed surfaces are revenue/conversion-adjacent — the deck download CTA, public shared-deck download, paywall plan cards, .apkg download, and checkout-adjacent share flow now render correctly for the ~half of users not on the light theme. No single funnel metric is instrumented for color correctness, but a paywall card or download button that renders in stranded off-theme hex erodes trust at exactly the moments that drive page→checkout and download conversion.
