### PR TITLE
fix: strip internal data from status and checkout copy

### DIFF
--- a/web/src/pages/AccountClaimPage/AccountClaimPage.tsx
+++ b/web/src/pages/AccountClaimPage/AccountClaimPage.tsx
@@ -55,52 +55,56 @@ export default function AccountClaimPage() {
   if (state === 'loading') return <SkeletonPage rows={2} />;
 
   return (
-    <div style={{ maxWidth: 480, margin: '4rem auto', padding: '0 1.5rem' }}>
-      {state === 'success' && (
-        <>
-          <h1>Subscription claimed.</h1>
-          <p>Your subscription is now attached to this account.</p>
-          <a href="/account" className={sharedStyles.btnPrimary}>
-            Go to account
-          </a>
-        </>
-      )}
-      {(state === 'expired' || state === 'error') && (
-        <>
-          <h1>Invalid or expired link.</h1>
-          <p>
-            This confirmation link is no longer valid. Start over from your
-            account to request a new one.
-          </p>
-          <a href="/account" className={sharedStyles.btnPrimary}>
-            Go to account
-          </a>
-        </>
-      )}
-      {state === 'already_claimed' && (
-        <>
-          <h1>Link already used.</h1>
-          <p>
-            This link is already used. Sign in and try again from /account if
-            you need to reclaim.
-          </p>
-          <a href="/account" className={sharedStyles.btnPrimary}>
-            Go to account
-          </a>
-        </>
-      )}
-      {state === 'active_sub' && (
-        <>
-          <h1>Account already has a subscription.</h1>
-          <p>
-            This account already has an active subscription. Cancel it first or
-            contact support.
-          </p>
-          <a href="/account" className={sharedStyles.btnPrimary}>
-            Go to account
-          </a>
-        </>
-      )}
+    <div className={sharedStyles.pageNarrow}>
+      <div className={sharedStyles.card}>
+        {state === 'success' && (
+          <>
+            <h1 className={sharedStyles.title}>Subscription claimed.</h1>
+            <p>Your subscription is now attached to this account.</p>
+            <a href="/account" className={sharedStyles.btnPrimary}>
+              Go to account
+            </a>
+          </>
+        )}
+        {(state === 'expired' || state === 'error') && (
+          <>
+            <h1 className={sharedStyles.title}>Invalid or expired link.</h1>
+            <p>
+              This confirmation link is no longer valid. Start over from your
+              account to request a new one.
+            </p>
+            <a href="/account" className={sharedStyles.btnPrimary}>
+              Go to account
+            </a>
+          </>
+        )}
+        {state === 'already_claimed' && (
+          <>
+            <h1 className={sharedStyles.title}>Link already used.</h1>
+            <p>
+              This link is already used. Sign in and try again from your account
+              page if you need to reclaim.
+            </p>
+            <a href="/account" className={sharedStyles.btnPrimary}>
+              Go to account
+            </a>
+          </>
+        )}
+        {state === 'active_sub' && (
+          <>
+            <h1 className={sharedStyles.title}>
+              Account already has a subscription.
+            </h1>
+            <p>
+              This account already has an active subscription. Cancel it first
+              or contact support.
+            </p>
+            <a href="/account" className={sharedStyles.btnPrimary}>
+              Go to account
+            </a>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/pages/StatusPage/StatusPage.test.tsx
+++ b/web/src/pages/StatusPage/StatusPage.test.tsx
@@ -110,4 +110,58 @@ describe('StatusPage', () => {
       expect(screen.getByText('ongoing')).toBeInTheDocument();
     });
   });
+
+  it('renders the last deploy as a relative time, never a raw git SHA', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-05-29T13:00:00Z').getTime()
+    );
+    const withDeploy = {
+      ...mockStatus,
+      lastDeploy: {
+        sha: '693f569bc826abc0001122334455667788990011',
+        time: '2026-05-29T11:00:00Z',
+      },
+    };
+    setupFetch(withDeploy);
+    render(
+      <MemoryRouter>
+        <StatusPage />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText('2 hours ago')).toBeInTheDocument();
+    });
+    const body = document.body.textContent ?? '';
+    expect(body).not.toMatch(/\b[0-9a-f]{7,40}\b/);
+  });
+
+  it('renders incident timestamps as relative time, not toLocaleString output', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-05-29T13:00:00Z').getTime()
+    );
+    const withIncident = {
+      ...mockStatus,
+      incidents: [
+        {
+          id: '1',
+          start: '2026-05-29T10:00:00Z',
+          end: '2026-05-29T11:00:00Z',
+          summary: 'Conversion service degraded',
+        },
+      ],
+    };
+    setupFetch(withIncident);
+    render(
+      <MemoryRouter>
+        <StatusPage />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Started 3 hours ago/)).toBeInTheDocument();
+    });
+    const body = document.body.textContent ?? '';
+    const localeSample = new Date('2026-05-29T10:00:00Z').toLocaleString();
+    expect(body).not.toContain(localeSample);
+    expect(screen.getByText(/resolved 2 hours ago/)).toBeInTheDocument();
+  });
 });

--- a/web/src/pages/StatusPage/StatusPage.tsx
+++ b/web/src/pages/StatusPage/StatusPage.tsx
@@ -30,6 +30,13 @@ function formatRelative(ms: number | null): string {
   return `${days} day${days === 1 ? '' : 's'} ago`;
 }
 
+function formatRelativeFromIso(iso: string | null): string {
+  if (iso == null) return 'no data';
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return 'no data';
+  return formatRelative(ms);
+}
+
 function dotClass(ok: boolean | null): string {
   if (ok == null) return pageStyles.dotGray;
   return ok ? pageStyles.dotGreen : pageStyles.dotRed;
@@ -117,17 +124,12 @@ export default function StatusPage() {
             </div>
           </section>
 
-          {status.lastDeploy.sha != null && (
+          {status.lastDeploy.time != null && (
             <section className={pageStyles.section}>
               <h2>Last deploy</h2>
               <div className={pageStyles.signalRow}>
-                <span className={pageStyles.label}>Version</span>
-                <span>{status.lastDeploy.sha.slice(0, 7)}</span>
-                {status.lastDeploy.time != null && (
-                  <span className={pageStyles.meta}>
-                    {status.lastDeploy.time}
-                  </span>
-                )}
+                <span className={pageStyles.label}>Updated</span>
+                <span>{formatRelativeFromIso(status.lastDeploy.time)}</span>
               </div>
             </section>
           )}
@@ -141,7 +143,7 @@ export default function StatusPage() {
                     {incident.summary}
                   </p>
                   <p className={pageStyles.incidentTime}>
-                    Started {new Date(incident.start).toLocaleString()}
+                    Started {formatRelativeFromIso(incident.start)}
                     {incident.end == null ? (
                       <>
                         {' '}
@@ -151,8 +153,7 @@ export default function StatusPage() {
                     ) : (
                       <>
                         {' '}
-                        &mdash; resolved{' '}
-                        {new Date(incident.end).toLocaleString()}
+                        &mdash; resolved {formatRelativeFromIso(incident.end)}
                       </>
                     )}
                   </p>

--- a/web/src/pages/SuccessfulCheckout/components/UserActionCards.tsx
+++ b/web/src/pages/SuccessfulCheckout/components/UserActionCards.tsx
@@ -12,8 +12,6 @@ export const UserActionCards = () => {
         <a href={loginLink} className={styles.btnPrimary}>
           Log in
         </a>
-        <br />
-        <a href={loginLink}>{loginLink}</a> (link for reference)
       </div>
 
       <div>
@@ -24,8 +22,6 @@ export const UserActionCards = () => {
         <a href={registerLink} className={styles.btnPrimary}>
           Sign up
         </a>
-        <br />
-        <a href={registerLink}>{registerLink}</a> (link for reference)
       </div>
     </div>
   );

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-15-status-readable-copy.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-15-status-readable-copy.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-15-status-readable-copy",
+  "date": "2026-06-15",
+  "type": "fix",
+  "title": "The status page shows when things last updated in plain language, and the post-checkout screen drops the raw link text"
+}


### PR DESCRIPTION
## What
Removes internal/developer-grade data from three user-facing surfaces: the status page stops showing a raw git SHA and raw ISO/`toLocaleString` timestamps, the post-checkout screen drops the raw full-URL reference lines, and the account-claim page moves off an inline style object onto shared tokens while replacing a raw route path in its copy.

## Why
VOICE.md bans internal IDs, ISO timestamps, and dev paths in user copy; DESIGN.md kill-list flags "exposing internal identifiers as status text." The status page and the post-payment screen are high-trust moments — leaking a git hash, a route path (`/account`), or a copy-paste URL there reads as unfinished. This is a data-presentation / copy sweep, TSX-only, disjoint from the in-flight CSS PRs.

## How
- **StatusPage**: dropped the 7-char SHA; relabeled the deploy row "Version" to "Updated"; added `formatRelativeFromIso` (a thin ISO wrapper over the existing `formatRelative` helper already used for the Notion/Stripe rows) and routed the deploy time plus both incident timestamps through it, replacing the raw `new Date(...).toLocaleString()` calls. The "Last deploy" section now keys on `lastDeploy.time` rather than `sha`. Live-incident red semantic untouched. `StatusPage.module.css` not touched (owned by an in-flight PR).
- **UserActionCards**: removed the `<a>{fullUrl}</a> (link for reference)` lines under each button; the buttons are the links.
- **AccountClaimPage**: swapped the inline `style={{...}}` object plus unclassed `<h1>`/`<p>` for `sharedStyles.pageNarrow` + `sharedStyles.card` + `sharedStyles.title` (same pattern as `FeedbackPage`); fixed the already-used copy "...from /account if you need to reclaim" to "...from your account page if you need to reclaim".

## Measuring success
This is a copy/presentation change with no new event. Confirm visually in prod: load `/status` and the deploy and incident rows render relative phrases ("2 hours ago"), no hex string; load the post-checkout screen and there is no `https://...` body text; trigger the account-claim already-used state and there is no `/account` literal in the sentence. The before/after comment below shows the rendered diff captured with Playwright against the real `base.css`.

## Testing
- Unit tests added (Vitest): StatusPage — "renders the last deploy as a relative time, never a raw git SHA" (asserts no 7-40 char hex in the rendered body) and "renders incident timestamps as relative time, not toLocaleString output" (asserts the `toLocaleString` sample is absent and the relative phrases render). Existing StatusPage / AccountClaimPage / UserActionCards suites still green (20 tests across the three pages).

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Pending — agent cannot drive a browser. Rendered output verified via Playwright stills against the real `base.css` (see before/after comment). Reviewer to tick after a local pass.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-15-status-readable-copy.json` — "The status page shows when things last updated in plain language, and the post-checkout screen drops the raw link text"

## Risks
Low. The `StatusPayload.sha` field stays in the type (API contract) but is no longer rendered. If the status API ever sends a deploy with a `sha` but no `time`, the "Last deploy" section now hides (previously it showed on `sha`); acceptable since the only remaining value in that section is the relative time. Rollback is a straight revert.

## Goal alignment
Trust lever. The status page and the post-payment screen (the highest-trust moment in the funnel) stop leaking developer-grade data — no funnel event attached; this is brand/trust hygiene, not a conversion experiment.

## Deferred
- **SuccessfulCheckout dual-primary button hierarchy** (two `btnPrimary` buttons side by side) is a revenue/hierarchy decision for the trio, out of scope here — left unchanged.
- Any `*.module.css` change (`StatusPage.module.css` owned by an in-flight CSS PR).
