### PR TITLE
fix: remove infinite decorative motion + glassmorphism on search, docs, gallery

### DIFF
--- a/web/src/pages/DocsPage/DocsPage.module.css
+++ b/web/src/pages/DocsPage/DocsPage.module.css
@@ -755,8 +755,6 @@
   position: absolute;
   inset: 0;
   background: var(--color-backdrop);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
   border: none;
   padding: 0;
   cursor: pointer;

--- a/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
+++ b/web/src/pages/ImageOcclusionPage/ImageOcclusionPage.module.css
@@ -754,6 +754,13 @@
   animation: shimmer 1.4s infinite linear;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .gallerySkeletonTile {
+    animation: none;
+    background: var(--color-bg-secondary);
+  }
+}
+
 .galleryTile {
   position: relative;
   border: 2px solid var(--color-border);

--- a/web/src/pages/SearchPage/SearchPage.module.css
+++ b/web/src/pages/SearchPage/SearchPage.module.css
@@ -111,17 +111,6 @@
 
 .searchInput[data-searching='true'] {
   border-bottom-color: var(--color-primary);
-  animation: searchPulse 1.4s ease-in-out infinite;
-}
-
-@keyframes searchPulse {
-  0%,
-  100% {
-    border-bottom-color: var(--color-primary);
-  }
-  50% {
-    border-bottom-color: var(--color-border);
-  }
 }
 
 .workspaceLine {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-15-calmer-motion.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-15-calmer-motion.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-15-calmer-motion",
+  "date": "2026-06-15",
+  "type": "style",
+  "title": "Search and the occlusion gallery stay still while loading, and respect reduced-motion settings"
+}


### PR DESCRIPTION
## What
Removes infinite decorative motion + glassmorphism (DESIGN.md kill-list) on the disjoint slice: search, docs, and the occlusion gallery.

- **SearchPage** — the searching-state input ran `animation: searchPulse 1.4s ease-in-out infinite`, an infinite pulse for a finite request, ungated under `prefers-reduced-motion`. Replaced with a static `--color-primary` border; removed the now-unused `searchPulse` keyframe.
- **DocsPage** — the search backdrop carried `backdrop-filter: blur(4px)` (+ `-webkit-` prefix), a glassmorphism kill-list item. Removed the blur; the existing `--color-backdrop` dim already conveys the modal layer.
- **ImageOcclusionPage** — `.gallerySkeletonTile` shimmer had no `prefers-reduced-motion` guard while its `queueShimmer` sibling did. Added the matching `@media (prefers-reduced-motion: reduce)` guard (`animation: none` + flat background).

Out of scope (separate PRs own them): Pricing motion, Account `badgeShine`, `OcclusionCanvas.tsx`, occlusion mask colors.

## Why
DESIGN.md kill-list cleanup — perpetual decorative motion reads as an "AI tell" and ignores accessibility. Infinite motion is the wrong signal for a finite action, and animation that ignores `prefers-reduced-motion` is an a11y miss for motion-sensitive users.

## How
CSS-only. Drop the infinite keyframe + its now-dead `@keyframes`, drop the blur, add the missing reduced-motion guard matching the file's existing pattern.

## Measuring success
No runtime metric — visual/a11y restraint. Verifiable in-product: the search input shows a steady primary border (not a pulsing one) while searching, the docs search overlay dims without blurring, and the occlusion gallery skeleton holds still under OS "reduce motion".

## Testing
- Unit tests added: none — CSS-only change with no logic. Ran the affected suites green under Node 22.20.0: `src/pages/SearchPage`, `src/pages/ImageOcclusionPage`, `src/pages/DocsPage`, and the changelog loader — 126 tests passing. `pnpm --filter 2anki-web typecheck`, `lint`, and `build` all green.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: Pending — captured before/after with Playwright instead of a live local browser drive (see the Before / after PR comment). CSS-only, no JS path touched.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-15-calmer-motion.json` — "Search and the occlusion gallery stay still while loading, and respect reduced-motion settings" (type `style`). The pulse stopping and reduced-motion respect is a calm-down a motion-sensitive user notices.

## Risks
Minimal — removing decorative styling only. No behavior, no layout shift (the backdrop keeps its dim; the searching border keeps its color). Rollback is a one-commit revert.

## Goal alignment
More beautiful + calmer (Sage restraint) and accessibility: perpetual motion removed, `prefers-reduced-motion` respected. No funnel/MRR metric — internal polish on the kill-list, no acquisition or conversion surface touched.

## Visual evidence
Captured with Playwright; see the "Before / after" comment below.
