### PR TITLE
fix: refuse legacy price fallback for v2 checkout after lock-in window

### DIFF
--- a/src/controllers/UnlimitedCheckoutController.test.ts
+++ b/src/controllers/UnlimitedCheckoutController.test.ts
@@ -3,6 +3,7 @@ import UnlimitedCheckoutController, {
   UnlimitedCheckoutContext,
 } from './UnlimitedCheckoutController';
 import { UnlimitedCheckoutUseCase } from '../usecases/checkout/UnlimitedCheckoutUseCase';
+import { PricingResolutionError } from '../usecases/checkout/PricingResolutionError';
 
 const makeResponse = (locals: Record<string, unknown> = {}) => {
   const res = {
@@ -134,6 +135,27 @@ describe('UnlimitedCheckoutController', () => {
     expect(uc.execute as jest.Mock).toHaveBeenCalledWith(
       expect.objectContaining({ anonId: 'anon-uuid-123' })
     );
+  });
+
+  it('returns 503 and records no event when pricing resolution fails', async () => {
+    const execute = jest
+      .fn()
+      .mockRejectedValue(new PricingResolutionError('v2_monthly'));
+    const uc = { execute } as unknown as UnlimitedCheckoutUseCase;
+    const req = { body: { interval: 'month' } } as Request;
+    const res = makeResponse();
+    const sink = makeSink();
+    const controller = new UnlimitedCheckoutController(
+      uc,
+      makeContext({ pricingV2On: true }),
+      sink
+    );
+
+    await controller.createSession(req, res as unknown as Response);
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toMatchObject({ message: expect.any(String) });
+    expect(sink.record).not.toHaveBeenCalled();
   });
 
   it('propagates use case errors', async () => {

--- a/src/controllers/UnlimitedCheckoutController.ts
+++ b/src/controllers/UnlimitedCheckoutController.ts
@@ -6,6 +6,7 @@ import {
 import { parsePricingVariant } from '../usecases/checkout/pricingVariant';
 import { parseCheckoutSurface } from '../usecases/checkout/checkoutSurface';
 import { parseGaClientId } from '../usecases/checkout/gaClientId';
+import { PricingResolutionError } from '../usecases/checkout/PricingResolutionError';
 import type { EventsSink } from '../services/events/EventsSink';
 
 const VALID_INTERVALS: ReadonlySet<string> = new Set(['month', 'year']);
@@ -35,17 +36,29 @@ class UnlimitedCheckoutController {
     const gaClientId = parseGaClientId(req.cookies?._ga);
     const createdAt = await this.context.getUserCreatedAt(userId);
 
-    const result = await this.useCase.execute({
-      userId,
-      userEmail,
-      interval: interval as UnlimitedInterval,
-      variant: parsePricingVariant(req.body?.variant),
-      anonId,
-      surface: parseCheckoutSurface(req.body?.surface),
-      gaClientId,
-      pricingV2On: this.context.pricingV2On,
-      createdAt,
-    });
+    let result;
+    try {
+      result = await this.useCase.execute({
+        userId,
+        userEmail,
+        interval: interval as UnlimitedInterval,
+        variant: parsePricingVariant(req.body?.variant),
+        anonId,
+        surface: parseCheckoutSurface(req.body?.surface),
+        gaClientId,
+        pricingV2On: this.context.pricingV2On,
+        createdAt,
+      });
+    } catch (error) {
+      if (error instanceof PricingResolutionError) {
+        res.status(503).json({
+          message:
+            'Checkout is temporarily unavailable. Try again in a moment.',
+        });
+        return;
+      }
+      throw error;
+    }
 
     this.eventsSink.record({
       name: 'checkout_started',

--- a/src/usecases/checkout/PricingResolutionError.ts
+++ b/src/usecases/checkout/PricingResolutionError.ts
@@ -1,0 +1,6 @@
+export class PricingResolutionError extends Error {
+  constructor(public readonly lookupKey: string) {
+    super(`Could not resolve an active price for lookup_key ${lookupKey}`);
+    this.name = 'PricingResolutionError';
+  }
+}

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.test.ts
@@ -1,6 +1,7 @@
 jest.mock('../../lib/misc/hashToken', () => (s: string) => `hashed:${s}`);
 
 import { UnlimitedCheckoutUseCase } from './UnlimitedCheckoutUseCase';
+import { PricingResolutionError } from './PricingResolutionError';
 
 const mockStripeCreateSession = jest.fn();
 
@@ -482,6 +483,29 @@ describe('UnlimitedCheckoutUseCase', () => {
         metadata: { user_id: '23', cohort: 'v2' },
       })
     );
+  });
+
+  it('throws and creates no session when v2 resolution fails after the window', async () => {
+    const resolver = makeResolver(null);
+    const uc = new UnlimitedCheckoutUseCase(
+      makeStripe(),
+      MONTHLY_PRICE_ID,
+      YEARLY_PRICE_ID,
+      resolver as never
+    );
+
+    await expect(
+      uc.execute({
+        userEmail: 'user@example.com',
+        userId: 25,
+        interval: 'month',
+        pricingV2On: true,
+        createdAt: afterCutover,
+        now: afterWindow,
+      })
+    ).rejects.toBeInstanceOf(PricingResolutionError);
+
+    expect(mockStripeCreateSession).not.toHaveBeenCalled();
   });
 
   it('uses legacy env prices for everyone when the flag is off', async () => {

--- a/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
+++ b/src/usecases/checkout/UnlimitedCheckoutUseCase.ts
@@ -3,11 +3,13 @@ import hashToken from '../../lib/misc/hashToken';
 import { optionalMetadata } from './checkoutMetadata';
 import { StripePriceResolver } from '../../services/StripePriceResolver';
 import {
+  LEGACY_LOCK_IN_WINDOW_END,
   PricingCohort,
   resolveCohort,
   V2_ANNUAL_LOOKUP_KEY,
   V2_MONTHLY_LOOKUP_KEY,
 } from './pricingV2';
+import { PricingResolutionError } from './PricingResolutionError';
 
 export type UnlimitedInterval = 'month' | 'year';
 
@@ -26,7 +28,8 @@ export class UnlimitedCheckoutUseCase {
 
   private async resolvePriceId(
     interval: UnlimitedInterval,
-    cohort: PricingCohort
+    cohort: PricingCohort,
+    now: Date
   ): Promise<string> {
     const legacyId =
       interval === 'year' ? this.yearlyPriceId : this.monthlyPriceId;
@@ -36,7 +39,12 @@ export class UnlimitedCheckoutUseCase {
     const lookupKey =
       interval === 'year' ? V2_ANNUAL_LOOKUP_KEY : V2_MONTHLY_LOOKUP_KEY;
     const resolved = await this.priceResolver.resolveByLookupKey(lookupKey);
-    if (resolved == null) {
+    if (resolved != null) {
+      return resolved;
+    }
+    const legacyStillActive =
+      now.getTime() < LEGACY_LOCK_IN_WINDOW_END.getTime();
+    if (legacyStillActive) {
       console.error('unlimited.checkout.v2_resolve_fallback', {
         cohort,
         interval,
@@ -45,7 +53,14 @@ export class UnlimitedCheckoutUseCase {
       });
       return legacyId;
     }
-    return resolved;
+    console.error('unlimited.checkout.v2_resolve_failed', {
+      cohort,
+      interval,
+      lookup_key: lookupKey,
+      reason:
+        'lookup_key resolution returned null after the lock-in window; legacy price is archived, refusing to serve it',
+    });
+    throw new PricingResolutionError(lookupKey);
   }
 
   async execute(input: {
@@ -61,10 +76,11 @@ export class UnlimitedCheckoutUseCase {
     createdAt?: Date | null;
     now?: Date;
   }): Promise<UnlimitedCheckoutResult> {
+    const now = input.now ?? new Date();
     const cohort = resolveCohort({
       flagOn: input.pricingV2On === true,
       createdAt: input.createdAt ?? null,
-      now: input.now ?? new Date(),
+      now,
     });
 
     console.info('unlimited.checkout.started', {
@@ -73,7 +89,7 @@ export class UnlimitedCheckoutUseCase {
       cohort,
     });
 
-    const priceId = await this.resolvePriceId(input.interval, cohort);
+    const priceId = await this.resolvePriceId(input.interval, cohort, now);
     const appUrl = process.env.APP_URL ?? 'https://2anki.net';
 
     const sessionParams: StripeTypes.Checkout.SessionCreateParams = {


### PR DESCRIPTION
## What

After the pricing-v2 lock-in window closes, an Unlimited checkout that resolves to the **v2 cohort** no longer falls back to the legacy (soon-to-be-archived) Stripe price when `lookup_key` resolution returns null. Inside the window the fallback stays (rollout safety net); once `now` is past `LEGACY_LOCK_IN_WINDOW_END` the use case throws `PricingResolutionError` and the controller returns **503**.

## Why

`UnlimitedCheckoutUseCase.resolvePriceId` fell back to the env `UNLIMITED_*_PRICE_ID` whenever the v2 `lookup_key` lookup returned null. Post-window every checkout is cohort `v2` and those legacy prices get **archived in Stripe** (issue #3211). The old fallback then either:

- serves an archived price → Stripe rejects it at `sessions.create` → opaque 500 to the user, or
- (if the legacy price is only hidden, not archived) **silently bills a v2 user the old $6/$60 instead of $7.99/$64** — a quiet revenue leak.

This closes the **server-side** half of the #3211 archive checklist: "the legacy fallback path never serves an archived price to a NEW checkout." The Stripe-dashboard archive steps (items 1, 2, 4) remain a manual op for after 2026-06-21 23:59 CEST.

## How

- New `PricingResolutionError` (carries the `lookupKey`).
- `resolvePriceId` now takes `now`; on a null v2 resolution it falls back only while `now < LEGACY_LOCK_IN_WINDOW_END`, otherwise logs `unlimited.checkout.v2_resolve_failed` and throws.
- `UnlimitedCheckoutController` catches `PricingResolutionError` → 503 with a generic, VOICE-compliant message; all other errors propagate unchanged. No event is recorded on the failure path.

## Measuring success

Post-window, zero v2 checkouts billed at a legacy price; a resolver outage surfaces as a clean 503 + `v2_resolve_failed` log line instead of a Stripe 500 or mispriced subscription.

## Testing

- Use case: throws `PricingResolutionError` and creates no Stripe session when v2 resolution fails after the window; existing in-window fallback test stays green.
- Controller: returns 503 and records no `checkout_started` event on `PricingResolutionError`; generic errors still propagate.
- `/check` green (server build, web typecheck, web vitest 2017, web lint). Security review: clean, no findings.

## Risks

Low. Behavior only changes on the rare double-condition (v2 `lookup_key` resolution fails **and** `now` is past the window). Worst case shifts from "wrong price / opaque 500" to "clean 503, retry."

## Goal alignment

Protects pricing integrity as 2anki scales past 300K users — a v2 user is never quietly charged the wrong price, and a transient Stripe blip degrades to an honest "try again" instead of a confusing failure.

## Notes

- No changelog entry — the change is a post-window resolver-failure edge a normal user never perceives, and it can't be described without internal pricing detail.
- No user-docs change — internal payments safety, not a user-facing feature.
- `sonar-scanner` not run locally (scanner not installed, `SONAR_TOKEN` unset). Diff is small — one guard branch + a typed catch — so low Sonar risk; expect the CI Sonar pass to confirm.

Closes part of #3211 (server-side fallback hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
