### PR TITLE
style: oxfmt-format two auth test files drifted on main

### DIFF
--- a/web/src/components/forms/NewPasswordForm.test.tsx
+++ b/web/src/components/forms/NewPasswordForm.test.tsx
@@ -60,10 +60,9 @@ describe('NewPasswordForm', () => {
     const message = screen.getByText("Passwords don't match.");
     expect(message).toBeInTheDocument();
     expect(message).toHaveAttribute('id', 'confirm-password-help');
-    expect(screen.getByPlaceholderText('Re-enter new password')).toHaveAttribute(
-      'aria-describedby',
-      'confirm-password-help'
-    );
+    expect(
+      screen.getByPlaceholderText('Re-enter new password')
+    ).toHaveAttribute('aria-describedby', 'confirm-password-help');
   });
 
   it('hides the mismatch message when the fields match', () => {

--- a/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
+++ b/web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx
@@ -34,7 +34,9 @@ describe('MagicLinkPage', () => {
     renderMagicLinkPage('');
     expect(screen.getByText('Link expired or invalid')).toBeInTheDocument();
     expect(
-      screen.getByText('This link is invalid or has expired. Request a new one.')
+      screen.getByText(
+        'This link is invalid or has expired. Request a new one.'
+      )
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What
The repo-wide `static` CI job runs `oxfmt -c .oxfmtrc.json --check src web/src` across the whole tree. It is currently **red on `main`**: commit `3843fbf8ef24` ("fix: announce auth form errors and progress to screen readers") landed two test files with lines exceeding oxfmt's wrap width, so the format check fails. Because the check scans the whole tree, **every open PR inherits the failure** and cannot reach a green required `static` check — regardless of what the PR changes.

This applies oxfmt's reformat to exactly those two files to unblock the gate for all branches.

## Files
- `web/src/components/forms/NewPasswordForm.test.tsx`
- `web/src/pages/MagicLinkPage/MagicLinkPage.test.tsx`

Pure line wrapping (a long `expect(...).toHaveAttribute(...)` / `getByText(...)` call wrapped onto the next line). No test logic, assertions, or behavior change — `oxfmt --check` passes on both files after the change.

## Why separate from other work
Scoped deliberately to the two drifted files so the unblock is reviewable on its own and doesn't ride along with an unrelated change. No other cleanup bundled in.

## Browser check
Browser check: not applicable — test-only files, no rendered output; pure formatter line-wrapping with no behavior change.

## Goal alignment
None — internal CI hygiene. Unblocks the required `static` check for every open PR in the repo.
