### PR TITLE
fix: quote AnkifyRouter swagger description so the YAML parses

### DIFF
--- a/src/config/swagger.test.ts
+++ b/src/config/swagger.test.ts
@@ -346,4 +346,30 @@ describe('Swagger Documentation Coverage', () => {
       expect(op.description).toMatch(/get-notion-link/);
     });
   });
+
+  describe('Ankify swagger descriptions parse as YAML', () => {
+    const spec = swaggerSpec as SwaggerSpec;
+
+    it('registers /api/ankify/sync-to-ankiweb with its full description string', () => {
+      const op = spec.paths['/api/ankify/sync-to-ankiweb']?.post;
+      expect(op).toBeDefined();
+      expect(op.description).toBe(
+        'Allowlisted endpoint. Returns { ok: true }. 409 when no active client, 503 when AnkiConnect is unreachable.'
+      );
+    });
+
+    it('keeps every Ankify description as a string, never a parsed mapping', () => {
+      const ankifyPaths = Object.keys(spec.paths).filter((p) =>
+        p.startsWith('/api/ankify/')
+      );
+      expect(ankifyPaths.length).toBeGreaterThan(0);
+      ankifyPaths.forEach((p) => {
+        Object.values(spec.paths[p]).forEach((op: { description?: unknown }) => {
+          if (op.description != null) {
+            expect(typeof op.description).toBe('string');
+          }
+        });
+      });
+    });
+  });
 });

--- a/src/config/swagger.test.ts
+++ b/src/config/swagger.test.ts
@@ -364,11 +364,13 @@ describe('Swagger Documentation Coverage', () => {
       );
       expect(ankifyPaths.length).toBeGreaterThan(0);
       ankifyPaths.forEach((p) => {
-        Object.values(spec.paths[p]).forEach((op: { description?: unknown }) => {
-          if (op.description != null) {
-            expect(typeof op.description).toBe('string');
+        Object.values(spec.paths[p]).forEach(
+          (op: { description?: unknown }) => {
+            if (op.description != null) {
+              expect(typeof op.description).toBe('string');
+            }
           }
-        });
+        );
       });
     });
   });

--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -852,7 +852,7 @@ const AnkifyRouter = () => {
    * /api/ankify/sync-to-ankiweb:
    *   post:
    *     summary: Trigger an AnkiWeb sync on the user's hosted Anki
-   *     description: Allowlisted endpoint. Returns { ok: true }. 409 when no active client, 503 when AnkiConnect is unreachable.
+   *     description: "Allowlisted endpoint. Returns { ok: true }. 409 when no active client, 503 when AnkiConnect is unreachable."
    *     tags: [Ankify]
    */
   router.post('/api/ankify/sync-to-ankiweb', RequireAnkifyAccess, (req, res) =>


### PR DESCRIPTION
## What
Quotes the swagger `description` on the `/api/ankify/sync-to-ankiweb` doc block in `AnkifyRouter.ts`, and adds a guard test that the path registers in the built OpenAPI spec with its full description string.

## Why
The unquoted scalar contains `{ ok: true }` — the colon-space inside the braces makes swagger-jsdoc's YAML parser open a nested compact mapping and reject the whole block, logging `YAMLSemanticError: Nested mappings are not allowed in compact mappings` on every prod boot (seen 14 Jun and 15 Jun). The server boots, but that endpoint's API doc silently fails to register. Same class as the guiBrowse description quoted in #3321 (commit `2c0003254515`); this is the next site.

## How
Wrapped the description value in double quotes so YAML treats it as a plain string. Swept the rest of `AnkifyRouter.ts`: I parsed every `description`/`summary` value through swagger-jsdoc's own bundled `yaml` lib and through a full `swaggerJsdoc()` build — only this line throws. The other brace-bearing descriptions (`{ profile }`, `{ deck }`, `{ ready, reason? }`) carry no inner colon-space, so YAML cannot open a compact mapping and they parse as strings. Quoting them would be churn untraceable to the bug, so they're left as-is.

## Measuring success
On the next deploy, the prod boot log no longer carries `YAMLSemanticError ... AnkifyRouter.ts` (it recurred on the 14th and 15th). The endpoint also shows up at `/api/docs` with its full description.

## Testing
- Added `swagger.test.ts` guards: one asserts `/api/ankify/sync-to-ankiweb` registers with its exact description; one asserts every `/api/ankify/*` operation keeps its `description` as a string (never a parsed mapping).
- TDD-verified: reverting the source quote makes the first guard fail with the exact prod `YAMLSemanticError` (the path drops from the spec), then the fix passes it.
- `tsc --noEmit` clean. Full `swagger.test.ts` suite green (15 passed).

## Browser check
Browser check: not applicable — no web/src change (backend swagger comment only).

## Changelog
No entry — internal API-doc fix, no user-visible change.

## Risks
None meaningful. The change is a JSDoc comment quote plus a colocated test. If wrong, the only effect would be the doc block still failing to parse — caught by the new guard test.

## Goal alignment
None — internal correctness. The Ankify API docs register cleanly and the boot log stops spamming `YAMLSemanticError` on every deploy.
