### PR TITLE
fix: stop reporting client non-failures to /ops/errors

### DIFF
--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -19,6 +19,12 @@ window.addEventListener('unhandledrejection', (event) => {
   recoverFromChunkError(event.reason);
 });
 
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault();
+  const preloadError = (event as Event & { payload?: unknown }).payload;
+  recoverFromChunkError(preloadError);
+});
+
 function main() {
   initTheme();
 

--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -156,4 +156,30 @@ describe('reportClientError', () => {
     reportClientError(new Error('Parser said: Load failed is not a card'));
     expect(fetchSpy).toHaveBeenCalledOnce();
   });
+
+  it.each([
+    "Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.",
+    "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+  ])('skips DOM-manipulation error %s', (message) => {
+    const domError = new Error(message);
+    domError.name = 'NotFoundError';
+    reportClientError(domError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips a HierarchyRequestError from extension-driven DOM mutation', () => {
+    const domError = new Error('appendChild failure');
+    domError.name = 'HierarchyRequestError';
+    reportClientError(domError);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips an Unable to preload CSS chunk error', () => {
+    reportClientError(
+      new Error(
+        'Unable to preload CSS for https://cdn.2anki.net/assets/index-abc123.css'
+      )
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/lib/reportClientError.ts
+++ b/web/src/lib/reportClientError.ts
@@ -1,4 +1,5 @@
 import { UserNotice } from './errors/UserNotice';
+import { isDomManipulationError } from './isDomManipulationError';
 import { getClientRelease } from './release';
 
 const ENDPOINT = '/api/events/errors';
@@ -8,6 +9,7 @@ const TRANSIENT_MESSAGE_PREFIXES = [
   'NetworkError when attempting to fetch resource.',
   'Load failed',
   'Network error on ',
+  'Unable to preload',
 ];
 
 function isTransientNetworkMessage(message: string): boolean {
@@ -31,6 +33,7 @@ export function reportClientError(
 ): void {
   if (error instanceof UserNotice) return;
   if (isAbortError(error)) return;
+  if (isDomManipulationError(error)) return;
   try {
     if (navigator.onLine === false) return;
     const message = error instanceof Error ? error.message : String(error);

--- a/web/src/pages/PreviewPage/PreviewPage.test.tsx
+++ b/web/src/pages/PreviewPage/PreviewPage.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import PreviewPage from './PreviewPage';
+import { UserNotice } from '../../lib/errors/UserNotice';
 
 const mockUsePreviewStream = vi.fn();
 const mockConvert = vi.fn();
@@ -325,9 +326,34 @@ describe('PreviewPage Convert to Anki CTA', () => {
     );
     expect(passedError.message).not.toContain('already_in_progress');
     expect(passedError.message).not.toContain('{');
+    expect(passedError).toBeInstanceOf(UserNotice);
   });
 
-  it('surfaces a readable message and not a raw JSON body on other errors', async () => {
+  it('shows a readable message on other 4xx errors without reporting them', async () => {
+    const setError = vi.fn();
+    mockConvert.mockResolvedValue({
+      status: 400,
+      text: async () => '{"error":"bad request"}',
+    });
+    mockUsePreviewStream.mockReturnValue(makeStreamReturn([]));
+
+    renderPreviewWithError(setError);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Convert to Anki' }));
+
+    await waitFor(() => {
+      expect(setError).toHaveBeenCalled();
+    });
+
+    const passedError = setError.mock.calls[0][0] as Error;
+    expect(passedError.message).toBe(
+      'Could not start the conversion. Try again in a moment.'
+    );
+    expect(passedError.message).not.toContain('{');
+    expect(passedError).toBeInstanceOf(UserNotice);
+  });
+
+  it('reports a genuine 5xx failure as a plain Error', async () => {
     const setError = vi.fn();
     mockConvert.mockResolvedValue({
       status: 500,
@@ -348,5 +374,6 @@ describe('PreviewPage Convert to Anki CTA', () => {
     expect(passedError.message).toBe(
       'Could not start the conversion. Try again in a moment.'
     );
+    expect(passedError).not.toBeInstanceOf(UserNotice);
   });
 });

--- a/web/src/pages/PreviewPage/PreviewPage.tsx
+++ b/web/src/pages/PreviewPage/PreviewPage.tsx
@@ -5,6 +5,7 @@ import { SkeletonList } from '../../components/Skeleton/Skeleton';
 import { ErrorPresenter } from '../../components/errors/ErrorPresenter';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
+import { UserNotice } from '../../lib/errors/UserNotice';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './PreviewPage.module.css';
 import { usePreviewStream } from './usePreviewStream';
@@ -93,15 +94,20 @@ export default function PreviewPage({ setError }: Readonly<PreviewPageProps>) {
         }
         if (response.status === 409) {
           setError(
-            new Error(
+            new UserNotice(
               'This page is already converting — check Downloads in a moment.'
             )
           );
           setConverting(false);
           return;
         }
+        const fallbackMessage =
+          'Could not start the conversion. Try again in a moment.';
+        const isServerError = response.status >= 500;
         setError(
-          new Error('Could not start the conversion. Try again in a moment.')
+          isServerError
+            ? new Error(fallbackMessage)
+            : new UserNotice(fallbackMessage)
         );
         setConverting(false);
       })


### PR DESCRIPTION
## What
Stops the web client from forwarding three non-failures to `/api/events/errors`, which were polluting the `/ops/errors` feed. Lightly improves chunk-error recovery. Web-only.

## Why
`/ops/errors` was buried under 58+ lines of noise from three sources, none of which is a real failure:
1. React DOM `insertBefore`/`removeChild` `NotFoundError` (45×) — browser extensions (Google Translate) mutating the DOM under React. Already recovered by `DomRecoveryBoundary`, but still reported.
2. "Unable to preload CSS for <CDN url>" (8×) — Vite dynamic-chunk fetch fails on a stale deploy / CDN cache lag. No `vite:preloadError` handler existed, and the error was reported.
3. PreviewPage convert guards (5×) — the 409 in-progress debounce and a non-202 fallback were wrapped in `new Error()` and reported, even though the 409 is expected (double-click / in-flight job).

User-visible outcome: a cleaner error feed so a real conversion-path or auth regression surfaces instead of hiding under extension/CDN noise. No behavior the user sees changes.

## How
- `reportClientError.ts`: early-return on `isDomManipulationError(error)` (mirrors the existing UserNotice / AbortError filters); add `Unable to preload` to the transient-message prefixes.
- `index.tsx`: add a `vite:preloadError` listener that calls `event.preventDefault()` then routes `event.payload` through `recoverFromChunkError` — reuses the existing 30s reload cooldown so a stale CDN cannot loop a user (no bare `location.reload()`).
- `PreviewPage.tsx`: the 409 branch and the non-5xx convert fallback now raise `UserNotice` instead of `Error`. The inline message is unchanged — `handledError` in `App.tsx` renders via `setApiError(getErrorMessage(error))` regardless of error type, and `UserNotice extends Error` so `getErrorMessage` returns the identical string. Only the backend report is suppressed. Genuine 5xx fallbacks stay a plain `Error`, and the `.catch` branch (thrown/network errors) is untouched — both still report.

Message strings are byte-identical to before; no copy changed.

## Measuring success
`/ops/errors` (ops-gated): the count of `insertBefore`/`removeChild` `NotFoundError`, "Unable to preload CSS", and the two PreviewPage convert-guard messages drops to ~0 after deploy. Real errors continue to land.

## Testing
- `reportClientError.test.ts`: added cases asserting DOM-manipulation errors (`NotFoundError`, `HierarchyRequestError`) and "Unable to preload CSS" are NOT posted.
- `PreviewPage.test.tsx`: 409 and other-4xx assert the visible message string AND `instanceof UserNotice` (user still sees it, report dropped); 5xx asserts a plain `Error` (still reported).
- `pnpm --filter 2anki-web test` (touched files): 38 passed / 0 failed.
- `pnpm --filter 2anki-web typecheck`: clean. `oxlint`/`oxfmt --check` on touched files: clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified the PreviewPage convert guard still renders the same inline message; the swap to UserNotice does not change what the user sees.

## Changelog
No changelog entry — internal observability hygiene, no user-visible behavior change.

## Risks
Low. If a real DOM-mutation error ever originated from our own code (not an extension), it would now be filtered — but `DomRecoveryBoundary` already treats these as recoverable, so this aligns reporting with existing recovery. Rollback is a straight revert of one commit.

## Goal alignment
None — internal observability hygiene. No funnel or revenue metric to move. The indirect value: a quieter `/ops/errors` shortens time-to-detect for a real conversion-path or auth regression, protecting the conversion-success / deck-download leading indicators. This does not count toward the weekly acquisition-facing change.
