### PR TITLE
fix: normalize AnkiConnect body-read errors so unreachable catches fire

### DIFF
--- a/src/services/ankify/AnkiConnectClient.test.ts
+++ b/src/services/ankify/AnkiConnectClient.test.ts
@@ -480,6 +480,23 @@ describe('AnkiConnectClient', () => {
     );
   });
 
+  test('throws AnkiConnectUnreachableError when the body read fails mid-stream', async () => {
+    const fetchImpl = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => {
+        throw new TypeError('fetch failed');
+      },
+    })) as unknown as typeof fetch;
+    const client = new AnkiConnectClient('http://x', fetchImpl);
+
+    const err = await client.findNotes('deck:"X"').catch((e) => e);
+
+    expect(err).toBeInstanceOf(AnkiConnectUnreachableError);
+    expect(err).not.toBeInstanceOf(AnkiConnectError);
+  });
+
   const makeHangingFetch = () =>
     jest.fn(
       (_url: string, init: { signal: AbortSignal }) =>

--- a/src/services/ankify/AnkiConnectClient.ts
+++ b/src/services/ankify/AnkiConnectClient.ts
@@ -302,7 +302,20 @@ export class AnkiConnectClient {
       );
     }
 
-    const body = (await response.json()) as AnkiConnectResponse<T>;
+    let body: AnkiConnectResponse<T>;
+    try {
+      body = (await response.json()) as AnkiConnectResponse<T>;
+    } catch (error) {
+      if (controller.signal.aborted) {
+        throw new AnkiConnectTimeoutError(
+          this.baseUrl,
+          action,
+          timeoutMs,
+          error
+        );
+      }
+      throw new AnkiConnectUnreachableError(this.baseUrl, error);
+    }
     if (body.error != null) {
       throw new AnkiConnectError(body.error);
     }

--- a/src/usecases/ankify/ListLeechesUseCase.test.ts
+++ b/src/usecases/ankify/ListLeechesUseCase.test.ts
@@ -232,6 +232,40 @@ describe('ListLeechesUseCase', () => {
     expect(await useCase.execute({ owner: 42 })).toEqual({ connected: false });
   });
 
+  test('degrades to connected:false when the body read fails mid-stream', async () => {
+    const fetchImpl = jest.fn(async (_url: string, init: { body: string }) => {
+      const action = JSON.parse(init.body).action as string;
+      if (action === 'version') {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => ({ result: 6, error: null }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => {
+          throw new TypeError('fetch failed');
+        },
+      };
+    }) as unknown as typeof fetch;
+    const factory = jest.fn(
+      () => new AnkiConnectClient('http://x', fetchImpl, 5000)
+    );
+    const useCase = new ListLeechesUseCase(
+      clientsRepo(activeClient),
+      subsRepo([
+        { target_deck: 'Notion Sync::Pharma', notion_page_title: null },
+      ]),
+      factory
+    );
+
+    expect(await useCase.execute({ owner: 42 })).toEqual({ connected: false });
+  });
+
   test('rethrows a non-AnkiConnect error so real bugs surface', async () => {
     const factory = jest.fn(
       () =>


### PR DESCRIPTION
## What
`AnkiConnectClient.invoke()` guarded only the `fetch` establish call; the `await response.json()` body read sat outside the try/catch. A connection reset / peer-close mid-body resolves the `Response` object once headers arrive, then rejects while draining the body — surfacing as a raw `TypeError: fetch failed`, never converted to `AnkiConnectUnreachableError`. This wraps the body read in the same network-error guard so a mid-stream failure normalizes identically to a connect failure.

## Why
Every Ankify use case and the controller depend on the `instanceof AnkiConnectUnreachableError` contract — they all reach AnkiConnect via `invoke`. The leak made `ListLeechesUseCase` rethrow a raw `TypeError`, failing its `instanceof` check and bubbling a generic 500 to the cockpit instead of the calm `{ connected: false }` "Anki client offline" state. Fixing at `invoke` level is both correct and complete — no per-caller changes needed. Genuine AnkiConnect protocol errors (HTTP-status non-OK, payload `error` string) stay outside the wrap and still propagate as `AnkiConnectError`.

## How
Move `await response.json()` inside a try/catch in `invoke()` that mirrors the existing fetch-establish catch: aborted signal → `AnkiConnectTimeoutError`, otherwise → `AnkiConnectUnreachableError` (original preserved as cause). The `AnkiConnectError` throws for HTTP status and payload errors stay where they were.

## Measuring success
Prod logs: occurrences of unhandled `TypeError: fetch failed` originating from `AnkiConnectClient` should drop to zero. The `GET /api/ankify/leeches` 500 rate (caused by this leak) should fall; the endpoint now returns `{ connected: false }` on a mid-body network drop instead of 500.

## Testing
- Unit tests added:
  - `AnkiConnectClient`: `invoke()` with a fetch whose `response.json()` rejects with `TypeError('fetch failed')` throws `AnkiConnectUnreachableError` (and not the base `AnkiConnectError`).
  - `ListLeechesUseCase`: with a real `AnkiConnectClient` whose `findNotes` body read fails mid-stream (ping succeeds), the use case returns `{ connected: false }` instead of bubbling a raw error.
- Existing 43 tests across both files still pass (45 total green).
- Server `tsc --noEmit` clean; `oxfmt --check` clean on touched files.

## Browser check
Not applicable — server-only change, no `web/src/` files touched.

## Changelog
No entry — server-only error-handling hygiene. The user-visible effect (cockpit shows the calm offline state instead of a 500 on a rare mid-stream drop) is a correctness backstop for an edge case most users never hit; not worth a What's New line.

## Sonar
`sonar-scanner` not run locally — not installed and `SONAR_TOKEN` unset in this environment. Change is small (one try/catch mirroring an existing adjacent block); expect a clean scan but flagging in case of a bounce.

## Risks
Low. The wrap only catches body-read failures; protocol errors (`AnkiConnectError` for non-OK status and payload `error`) are thrown after the wrap and unaffected. Rollback is a one-commit revert.

## Goal alignment
None — internal reliability/observability. Reduces a generic 500 on the Ankify cockpit (paid lifetime/Auto-Sync surface) to the intended offline state, which supports retention of paid power users but moves no funnel metric directly.
