### PR TITLE
test: guard ankify diagnostics off the /ops/errors feed

### DIFF
--- a/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
+++ b/src/usecases/ankify/SyncNotionPageToRacUseCase.test.ts
@@ -2238,6 +2238,115 @@ describe('SyncNotionPageToRacUseCase', () => {
     });
   });
 
+  describe('benign sync diagnostics never reach the error feed', () => {
+    const ERROR_FEED_MESSAGES = [
+      'ankify.zero_cards',
+      'ankify.sync_followed_deck',
+    ];
+
+    const followedDeckSubscription = () =>
+      makeSubscriptionsRepo(
+        sampleSubscription({
+          notion_page_title: 'Pharmacology',
+          target_deck: 'MS3::Pharmacology',
+        })
+      );
+
+    const followedDeckMapping = {
+      id: 5,
+      ankify_client_id: 1,
+      source_id: 'block-1',
+      source_type: 'notion_block' as const,
+      anki_note_id: 900,
+      deck_name: 'Notion Sync::Pharmacology',
+      last_synced_at: new Date(2020, 0, 1),
+    };
+
+    const stubFollowedDeckNotesInfo = (ac: AnkiConnectClient) => {
+      (ac.notesInfo as jest.Mock).mockImplementation(
+        async (notes: number[]) => {
+          if (notes.includes(900)) {
+            return [
+              {
+                noteId: 900,
+                modelName: 'Ankify Basic',
+                tags: [],
+                fields: {
+                  Front: { value: 'Front text', order: 0 },
+                  Back: { value: 'Back text', order: 1 },
+                },
+                cards: [9001, 9002],
+                mod: Math.floor(new Date(2020, 0, 1).getTime() / 1000),
+              },
+            ];
+          }
+          return [];
+        }
+      );
+    };
+
+    it('routes the followed-deck diagnostic to analytics, not the error feed', async () => {
+      (walkNotionPageForFlashcards as jest.Mock).mockResolvedValue({
+        cards: [sampleCard()],
+        diagnostic: {
+          blocks_scanned: 1,
+          blocks_matched: 1,
+          pattern_hits: { toggle: 1 },
+        },
+      });
+      const repos = makeRepos();
+      repos.subscriptions = followedDeckSubscription();
+      repos.mappings.findBySourceId = jest.fn(
+        async (_clientId: number, _sourceId: string) => followedDeckMapping
+      );
+      const ac = makeAnkiConnectStub();
+      stubFollowedDeckNotesInfo(ac);
+
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      await useCase.execute({
+        owner: 42,
+        notionPageId: 'page-id',
+        trigger: 'polling',
+      });
+
+      const trackedNames = mockTrack.mock.calls.map((call) => call[0]);
+      expect(trackedNames).toContain('ankify_sync_followed_deck');
+      for (const message of ERROR_FEED_MESSAGES) {
+        expect(trackedNames).not.toContain(message);
+      }
+    });
+
+    it('builds the production use case without an error-event sink', () => {
+      const repos = makeRepos();
+      const ac = makeAnkiConnectStub();
+
+      const useCase = new SyncNotionPageToRacUseCase(
+        repos.clients,
+        repos.mappings,
+        repos.conflicts,
+        repos.subscriptions,
+        repos.logs,
+        repos.notionRepo,
+        () => ac,
+        () => async () => []
+      );
+
+      expect(useCase).toBeInstanceOf(SyncNotionPageToRacUseCase);
+      const sink = (useCase as unknown as Record<string, unknown>).errorEvents;
+      expect(sink).toBeUndefined();
+    });
+  });
+
   test('marks token invalid and disables subscription when Notion returns Unauthorized', async () => {
     const unauthorizedError = Object.assign(
       new Error('API token is invalid.'),


### PR DESCRIPTION
## What
Adds a regression guard around the Ankify sync diagnostics so two benign events
(`ankify.zero_cards`, `ankify.sync_followed_deck`) can never again be recorded
into the `error_events` feed shown at `/ops/errors`.

## Why
The Ankify sync used to write these two benign diagnostics directly into
`error_events` via the error repository. The dashboard groups `error_events` by
`message`, so they surfaced as fake "error groups" with dotted names. The
source-level write was already removed in `c43d981db8f2` — the diagnostics now
route through `track()` with underscore analytics names
(`ankify_zero_cards`, `ankify_sync_followed_deck`) and the unused error-event
constructor argument was dropped at all three production construction sites.

What remained was a regression guard. The existing suite covered the zero-card
path; this PR adds the missing followed-deck coverage and an explicit assertion
that the production use case is constructed with no error-event sink.

## How
Test-only. No source change — the fix itself is already merged in `c43d981db8f2`,
and a `grep` for `errorEvents` / `.insert` in the current `.ts` returns nothing.
New `describe('benign sync diagnostics never reach the error feed')`:
- asserts the followed-deck path emits `ankify_sync_followed_deck` and never the
  dotted error-feed names (`ankify.zero_cards`, `ankify.sync_followed_deck`)
- asserts the production-shaped use case is built without an error-event sink

Verified the guard fails for the right reason: temporarily reintroducing a
`track('ankify.sync_followed_deck')` call made the new test fail on the
`not.toContain` assertion; restoring source returned it to green.

Genuine error capture is untouched — the change only asserts the benign-event
names, never the real-failure paths (e.g. the Unauthorized → markTokenInvalid
test still passes).

## Measuring success
After deploy of `c43d981db8f2`, no new rows with
`message IN ('ankify.sync_followed_deck', 'ankify.zero_cards')` appear in
`error_events`; the existing ~15 historical rows stop growing. Cosmetic cleanup
of those historical rows is an ops step (a one-line `DELETE`), out of scope for
this code PR.

## Testing
- `SyncNotionPageToRacUseCase.test.ts`: 55 passed (2 new).
- `tsc --noEmit`: clean.
- Regression-direction verified by injecting the old dotted-name behavior and
  watching the new test fail, then restoring.

## Changelog
No entry — server-only observability/error-feed hygiene, no user-visible
behavior change. The user-facing behavior was already shipped in `c43d981db8f2`.

## Risks
None — test-only. No production code path changes.

## Goal alignment
None — internal. Keeps `/ops/errors` honest so real conversion/sync failures
aren't buried under benign diagnostics, which protects the team's ability to
spot and fix issues that affect retention.

## Sonar
Test-only change; `sonar-scanner` not run locally (no token configured in this
worktree). Expect at most maintainability noise on the test file, no security
findings.
