### PR TITLE
fix: surface suppressed-address signal on login-link request

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -57,6 +57,7 @@ jest.mock('../data_layer/UsersRepository', () => {
 import UsersController from './UsersControllers';
 import UsersService, {
   MagicLinkRateLimitError,
+  MagicLinkSuppressedError,
 } from '../services/UsersService';
 import AuthenticationService from '../services/AuthenticationService';
 import SubscriptionService, {
@@ -576,6 +577,27 @@ describe('UsersController.requestMagicLink', () => {
     await controller.requestMagicLink(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 200 with suppressed flag when the address is on the suppression list', async () => {
+    const requestMagicLink = jest
+      .fn()
+      .mockRejectedValue(new MagicLinkSuppressedError());
+    const { controller } = buildMagicController({ requestMagicLink });
+    const req = {
+      body: { email: 'blocked@example.com', purpose: 'login' },
+    } as express.Request;
+    const res = buildRes();
+    const next = jest.fn();
+
+    await controller.requestMagicLink(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      message: 'suppressed',
+      suppressed: true,
+    });
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('forwards infrastructure errors to next() so ErrorHandler can surface them', async () => {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -15,7 +15,10 @@ import SubscriptionService, {
   SubscriptionNotOwnedError,
 } from '../services/SubscriptionService';
 import { OPS_OWNER_EMAIL } from '../routes/middleware/RequireOpsAccess';
-import { MagicLinkRateLimitError } from '../services/UsersService';
+import {
+  MagicLinkRateLimitError,
+  MagicLinkSuppressedError,
+} from '../services/UsersService';
 import { MONTHLY_CARD_LIMIT } from '../usecases/users/CheckMonthlyCardLimitUseCase';
 import UsersRepository from '../data_layer/UsersRepository';
 import OauthIdentitiesRepository from '../data_layer/OauthIdentitiesRepository';
@@ -1247,6 +1250,11 @@ class UsersController {
     } catch (error) {
       if (error instanceof MagicLinkRateLimitError) {
         return res.status(200).json({ message: 'ok' });
+      }
+      if (error instanceof MagicLinkSuppressedError) {
+        return res
+          .status(200)
+          .json({ message: 'suppressed', suppressed: true });
       }
       return next(error);
     }

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -29,6 +29,8 @@ import SuppressionEventsRepository from '../../data_layer/SuppressionEventsRepos
 
 type EmailResponse = { didSend: boolean; error?: Error };
 
+export type MagicLinkSendResult = { suppressed: boolean };
+
 export interface IEmailService {
   sendResetEmail(email: string, token: string): Promise<void>;
   sendConversionEmail(
@@ -61,7 +63,7 @@ export interface IEmailService {
     email: string,
     token: string,
     purpose: 'login' | 'password_reset'
-  ): Promise<void>;
+  ): Promise<MagicLinkSendResult>;
   sendReEngagementEmail(to: string, name: string, token: string): Promise<void>;
   sendInactivityWarningEmail(
     to: string,
@@ -254,7 +256,7 @@ export class EmailService implements IEmailService {
     email: string,
     token: string,
     purpose: 'login' | 'password_reset'
-  ): Promise<void> {
+  ): Promise<MagicLinkSendResult> {
     const link = `${process.env.DOMAIN ?? 'https://2anki.net'}/auth/magic?token=${token}`;
     const isLogin = purpose === 'login';
     const subject = isLogin
@@ -288,7 +290,8 @@ export class EmailService implements IEmailService {
     };
 
     try {
-      await this.deliver(msg);
+      const result = await this.deliver(msg);
+      return { suppressed: result == null };
     } catch (error) {
       console.error('Failed to send magic link email:', error);
       throw error;
@@ -719,8 +722,9 @@ export class UnimplementedEmailService implements IEmailService {
     email: string,
     token: string,
     purpose: 'login' | 'password_reset'
-  ): Promise<void> {
+  ): Promise<MagicLinkSendResult> {
     console.info('sendMagicLinkEmail not handled');
+    return { suppressed: false };
   }
 
   async sendReEngagementEmail(

--- a/src/services/EmailService/EmailServiceSuppression.test.ts
+++ b/src/services/EmailService/EmailServiceSuppression.test.ts
@@ -41,6 +41,34 @@ describe('EmailService suppression gate', () => {
     expect(msg.to).toBe('ok@example.com');
   });
 
+  it('reports suppressed for a magic link to a suppressed recipient', async () => {
+    const isSuppressed = jest.fn().mockResolvedValue(true);
+    const service = new EmailService('test-key', DEFAULT_SENDER, isSuppressed);
+
+    const result = await service.sendMagicLinkEmail(
+      'blocked@example.com',
+      'tok-3',
+      'login'
+    );
+
+    expect(result).toEqual({ suppressed: true });
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('reports not suppressed for a magic link that sends', async () => {
+    const isSuppressed = jest.fn().mockResolvedValue(false);
+    const service = new EmailService('test-key', DEFAULT_SENDER, isSuppressed);
+
+    const result = await service.sendMagicLinkEmail(
+      'ok@example.com',
+      'tok-4',
+      'login'
+    );
+
+    expect(result).toEqual({ suppressed: false });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
   it('sends when the suppression lookup itself fails (fail-open)', async () => {
     const isSuppressed = jest
       .fn()

--- a/src/services/UsersService.test.ts
+++ b/src/services/UsersService.test.ts
@@ -1,4 +1,7 @@
-import UsersService, { MagicLinkRateLimitError } from './UsersService';
+import UsersService, {
+  MagicLinkRateLimitError,
+  MagicLinkSuppressedError,
+} from './UsersService';
 import type UsersRepository from '../data_layer/UsersRepository';
 import type { IEmailService } from './EmailService/EmailService';
 import type AuthenticationService from './AuthenticationService';
@@ -19,7 +22,7 @@ function buildEmailService(
     sendHostedAnkiAccessRequestEmail: jest
       .fn()
       .mockResolvedValue({ didSend: true }),
-    sendMagicLinkEmail: jest.fn().mockResolvedValue(undefined),
+    sendMagicLinkEmail: jest.fn().mockResolvedValue({ suppressed: false }),
     sendReEngagementEmail: jest.fn().mockResolvedValue(undefined),
     sendInactivityWarningEmail: jest.fn().mockResolvedValue(undefined),
     ...overrides,
@@ -278,6 +281,22 @@ describe('UsersService.requestMagicLink', () => {
     await service.requestMagicLink('nobody@example.com', 'login');
 
     expect(emailService.sendMagicLinkEmail).not.toHaveBeenCalled();
+  });
+
+  it('throws MagicLinkSuppressedError when the recipient is suppressed', async () => {
+    const getByEmail = jest
+      .fn()
+      .mockResolvedValue({ id: 9, email: 'blocked@example.com' });
+    const repository = { getByEmail } as unknown as UsersRepository;
+    const emailService = buildEmailService({
+      sendMagicLinkEmail: jest.fn().mockResolvedValue({ suppressed: true }),
+    });
+    const magicTokenRepo = new InMemoryMagicTokenRepository();
+    const service = new UsersService(repository, emailService, magicTokenRepo);
+
+    await expect(
+      service.requestMagicLink('blocked@example.com', 'login')
+    ).rejects.toThrow(MagicLinkSuppressedError);
   });
 
   it('throws MagicLinkRateLimitError after 5 requests in an hour', async () => {

--- a/src/services/UsersService.ts
+++ b/src/services/UsersService.ts
@@ -18,6 +18,13 @@ export class MagicLinkRateLimitError extends Error {
   }
 }
 
+export class MagicLinkSuppressedError extends Error {
+  constructor() {
+    super('Recipient address is on the suppression list');
+    this.name = 'MagicLinkSuppressedError';
+  }
+}
+
 class UsersService {
   constructor(
     private readonly repository: UsersRepository,
@@ -173,8 +180,13 @@ class UsersService {
     const token = crypto.randomBytes(64).toString('hex');
     const expiresAt = new Date(Date.now() + MAGIC_LINK_EXPIRY_MS);
     await this.magicTokenRepository.create(token, user.id, purpose, expiresAt);
+    let sendResult;
     try {
-      await this.emailService.sendMagicLinkEmail(email, token, purpose);
+      sendResult = await this.emailService.sendMagicLinkEmail(
+        email,
+        token,
+        purpose
+      );
     } catch (error) {
       console.info('password_reset.magic_link', {
         outcome: 'send_failed',
@@ -183,6 +195,14 @@ class UsersService {
         error: error instanceof Error ? error.constructor.name : 'UnknownError',
       });
       throw error;
+    }
+    if (sendResult.suppressed) {
+      console.info('password_reset.magic_link', {
+        outcome: 'suppressed',
+        purpose,
+        user_id_hash: userIdHash,
+      });
+      throw new MagicLinkSuppressedError();
     }
     console.info('password_reset.magic_link', {
       outcome: 'sent',

--- a/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/LoginForm.test.tsx
@@ -6,11 +6,12 @@ import { CookiesProvider } from 'react-cookie';
 import LoginForm from './index';
 
 const mockLogin = vi.fn();
+const mockRequestMagicLink = vi.fn();
 
 vi.mock('../../../../lib/backend/get2ankiApi', () => ({
   get2ankiApi: () => ({
     login: mockLogin,
-    requestMagicLink: vi.fn().mockResolvedValue({ ok: true }),
+    requestMagicLink: mockRequestMagicLink,
   }),
 }));
 
@@ -31,6 +32,11 @@ describe('LoginForm', () => {
     mockLogin.mockResolvedValue({
       status: 200,
       json: () => Promise.resolve({ token: 'test-token' }),
+    });
+    mockRequestMagicLink.mockReset();
+    mockRequestMagicLink.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ message: 'ok' }),
     });
   });
 
@@ -165,6 +171,26 @@ describe('LoginForm', () => {
     await waitFor(() => {
       expect(screen.getByText('Check your email')).toBeInTheDocument();
     });
+  });
+
+  it('shows a recovery message instead of check-email when the address is suppressed', async () => {
+    mockRequestMagicLink.mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ message: 'suppressed', suppressed: true }),
+    });
+    renderLoginForm();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Email' }), {
+      target: { value: 'blocked@example.com' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Email me a sign-in link' })
+    );
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(
+      "We can't email this address — it bounced or was unsubscribed earlier. Contact support@2anki.net to restore it, or use your password below."
+    );
+    expect(screen.queryByText('Check your email')).toBeNull();
   });
 
   it('shows create account button on the email step', () => {

--- a/web/src/pages/LoginPage/components/LoginForm/index.tsx
+++ b/web/src/pages/LoginPage/components/LoginForm/index.tsx
@@ -32,7 +32,14 @@ function LoginForm() {
     setMagicLinkLoading(true);
     setError(null);
     try {
-      await get2ankiApi().requestMagicLink(email, 'login');
+      const response = await get2ankiApi().requestMagicLink(email, 'login');
+      const body = await response.json().catch(() => ({}));
+      if (body?.suppressed) {
+        setError(
+          "We can't email this address — it bounced or was unsubscribed earlier. Contact support@2anki.net to restore it, or use your password below."
+        );
+        return;
+      }
       setStep('check-email');
     } catch {
       setError(

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-15-login-link-suppressed.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-15-login-link-suppressed.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-15-login-link-suppressed",
+  "date": "2026-06-15",
+  "type": "fix",
+  "title": "The sign-in link request now tells you when your email can't receive mail and how to restore it"
+}


### PR DESCRIPTION
Fixes #3380.

## Problem
A user requesting a login link whose address is on the SendGrid suppression list (prior bounce, spam report, or unsubscribe) got the generic check-your-email state and no email — locked out of every surface, including the cancel flow, with no recovery path. The send-time guard (`492977f`) correctly skipped the send but swallowed the outcome, so the request route answered the same `{ message: 'ok' }` regardless.

## Runtime entry point (per first-time-fix)
Confirmed reachable on the actual login path:
`LoginForm.handleSendMagicLink` → `POST /api/users/magic-link` → `UsersController.requestMagicLink` → `UsersService.requestMagicLink` → `EmailService.sendMagicLinkEmail` → `deliver()` returns `null` on suppression (swallowed) → controller returns `ok`.

## Fix
Thread the suppressed result back up:
- `EmailService.sendMagicLinkEmail` returns `{ suppressed }` from `deliver()` (null = suppressed).
- `UsersService.requestMagicLink` throws `MagicLinkSuppressedError` and logs `outcome: 'suppressed'`.
- The controller answers `200` with `{ message: 'suppressed', suppressed: true }`.
- `LoginForm` shows an honest recovery message pointing at support@2anki.net instead of the false check-email step.

Default behavior, no toggle. Out of scope: self-serve un-suppress (support-mediated for v1, per the issue).

## Security trade-off
A suppressed response now reveals the address exists **and** is suppressed — a minor email-enumeration leak narrower than the existing unknown-vs-known distinction. Accepted per #3380: a locked-out paying user needs the signal and a way back in. Flagging for `/security-review` since this touches the auth surface.

## Tests
- `EmailServiceSuppression.test.ts` — magic-link send returns `{ suppressed: true|false }`.
- `UsersService.test.ts` — suppressed recipient throws `MagicLinkSuppressedError`.
- `UsersControllers.test.ts` — suppressed → `200 { suppressed: true }`, not forwarded to `next()`.
- `LoginForm.test.tsx` — suppressed response shows the recovery alert, not check-email.

All four `/check` legs green (server tsc, web typecheck, web vitest 2028 passed, web lint). Sonar not run locally (scanner not installed); change is small and lint-clean — expect a Sonar pass.

## Browser check
- [ ] Golden path on localhost:3000
- [ ] No console errors at 375px
Notes: NOT yet run — dev server not started (asking before starting per project rules). Covered by the new `LoginForm.test.tsx` suppressed-response test; a manual localhost pass is still pending before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)