### PR TITLE
fix: accept Ankify review events in server allowlist

### DIFF
--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -204,6 +204,20 @@ describe('EventsController', () => {
       expect.objectContaining({ name: eventName, unknown: false })
     );
   });
+
+  it.each([
+    'ankify_review_session_started',
+    'ankify_review_completed',
+    'ankify_review_session_exited',
+  ])('accepts Ankify review event %s as known, not unknown', (eventName) => {
+    const { controller, req, res, executeSpy } = buildMocks({ userId: 1 });
+    req.body = { name: eventName };
+    controller.track(req, res);
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: eventName, unknown: false })
+    );
+  });
 });
 
 describe('EventsController — regression: all client events return 202 (AC #5)', () => {

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -78,6 +78,9 @@ export const KNOWN_EVENTS = new Set([
   'ankify_leech_action',
   'ankify_zero_cards',
   'ankify_sync_followed_deck',
+  'ankify_review_session_started',
+  'ankify_review_completed',
+  'ankify_review_session_exited',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;


### PR DESCRIPTION
Fixes #3377.

## Problem
The Review surface (#3359) fires three events from the web side — `ankify_review_session_started`, `ankify_review_completed`, `ankify_review_session_exited` — but **none** were in the server's `KNOWN_EVENTS` allowlist (`src/types/AnalyticsEvents.ts`). Each landed flagged `unknown`, producing the `[events] unknown event received` warnings in prod and excluding the events from `/api/ops/metrics`.

The issue suspected only `_exited` had drifted; on inspection all three reviewer events were missing server-side. Adding only `_exited` would leave the other two flagged.

This skews the abandoned-session signal read at the T+30d adoption review (#3357).

## Fix
- Add the three reviewer events to `KNOWN_EVENTS`.
- Add a colocated test asserting each is tagged `unknown: false` (truly accepted).

The pre-existing client-events regression test only asserted a `202`, which unknown events also return (the controller never 400s on an unknown name — it records with `unknown: true`). So that test could never catch this drift. The new test checks the `unknown` flag, closing the class.

No changelog entry — internal telemetry plumbing, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
