### PR TITLE
fix: quote brace-bearing Swagger descriptions in AnkifyRouter

### DIFF
--- a/src/routes/AnkifyRouter.ts
+++ b/src/routes/AnkifyRouter.ts
@@ -793,7 +793,7 @@ const AnkifyRouter = () => {
    * /api/ankify/clients/active/ready:
    *   get:
    *     summary: Probe whether the active hosted Anki container is reachable
-   *     description: Allowlisted endpoint. Returns { ready, reason? } where ready is true if AnkiConnect responds inside the container. Used by the UI to show a skeleton while a freshly-provisioned container is still booting.
+   *     description: "Allowlisted endpoint. Returns { ready, reason? } where ready is true if AnkiConnect responds inside the container. Used by the UI to show a skeleton while a freshly-provisioned container is still booting."
    *     tags: [Ankify]
    */
   router.get(
@@ -840,7 +840,7 @@ const AnkifyRouter = () => {
    * /api/ankify/active-profile:
    *   get:
    *     summary: The synced Anki profile name on the user's hosted client
-   *     description: Allowlisted endpoint. Returns { profile }. 409 when no active client, 503 when AnkiConnect is unreachable.
+   *     description: "Allowlisted endpoint. Returns { profile }. 409 when no active client, 503 when AnkiConnect is unreachable."
    *     tags: [Ankify]
    */
   router.get('/api/ankify/active-profile', RequireAnkifyAccess, (req, res) =>
@@ -864,7 +864,7 @@ const AnkifyRouter = () => {
    * /api/ankify/gui-deck-overview:
    *   post:
    *     summary: Jump the user's hosted Anki to a deck's overview
-   *     description: Allowlisted endpoint. Body { deck }. The deck must belong to one of the caller's Notion subscriptions. 403 when the deck is not owned, 503 when AnkiConnect is unreachable.
+   *     description: "Allowlisted endpoint. Body { deck }. The deck must belong to one of the caller's Notion subscriptions. 403 when the deck is not owned, 503 when AnkiConnect is unreachable."
    *     tags: [Ankify]
    *     requestBody:
    *       required: true
@@ -888,7 +888,7 @@ const AnkifyRouter = () => {
    * /api/ankify/deck-maturity:
    *   get:
    *     summary: Maturity breakdown for one of the user's synced decks
-   *     description: Allowlisted endpoint. Query { deck }. Returns { connected, matureCount, total, avgIntervalDays } (mature = interval ≥ 21 days). The deck must belong to the caller. 403 when not owned, 503 when AnkiConnect is unreachable.
+   *     description: "Allowlisted endpoint. Query { deck }. Returns { connected, matureCount, total, avgIntervalDays } (mature = interval ≥ 21 days). The deck must belong to the caller. 403 when not owned, 503 when AnkiConnect is unreachable."
    *     tags: [Ankify]
    *     parameters:
    *       - in: query


### PR DESCRIPTION
Fixes #3376.

## Problem
Every boot logged `YAMLSemanticError: Nested mappings are not allowed in compact mappings` from `src/routes/AnkifyRouter.ts`. swagger-jsdoc parses each `@swagger` JSDoc block as YAML; an unquoted `{ ... }` in a `description:` reads as a nested mapping and throws. The throw aborts the whole file's parse, so **all 28 Ankify routes** were dropped from the Swagger docs.

## Cause
Four `description:` lines carried unquoted braces:
- `ready` — `Returns { ready, reason? } …`
- `profile` — `Returns { profile }. …`
- sync-deck — `Body { deck }. …`
- deck-maturity — `Query { deck }. Returns { connected, matureCount, … }`

The leech `/ok` block named in the issue was already quoted — these four siblings were the persistent cause (swagger-jsdoc aborts on the first error, so one bad block hid the rest).

## Fix
Wrap each value in double quotes so it parses as a YAML string.

Verified locally with swagger-jsdoc against the file: no warning, all 28 paths parse (including the four previously-dropped routes).

No test (JSDoc comments, no runtime logic). No changelog — internal, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
