### PR TITLE
fix: explain the docx heading-to-card model on upload

### DIFF
--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -136,6 +136,15 @@ describe('UploadPage doc/docx hint', () => {
       )
     ).toBeInTheDocument();
   });
+
+  it('states the docx image and tag limits in the same place', () => {
+    renderPage();
+    expect(
+      screen.getByText(
+        /Images land on the back, and tags aren't read from the document yet\./i
+      )
+    ).toBeInTheDocument();
+  });
 });
 
 describe('UploadPage AI badge anon link', () => {

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -262,7 +262,8 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
               <p className={pageStyles.stepBody}>
                 PDF, Word, Notion export, Markdown, HTML, Excel, CSV, or
                 PowerPoint. In Word docs, headings become card fronts and the
-                body text under each heading becomes the back.
+                body text under each heading becomes the back. Images land on
+                the back, and tags aren&apos;t read from the document yet.
               </p>
               <p className={pageStyles.stepBody}>
                 Coming from Notion?{' '}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-card-model-help.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-card-model-help.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-16-docx-card-model-help",
+  "date": "2026-06-16",
+  "type": "fix",
+  "title": "The upload page now explains how Word documents become cards — each heading is a front, the text under it is the back"
+}


### PR DESCRIPTION
## What
Extends the upload page "How it works" step 1 with the Word-document card model and its two current limits. It already stated that headings become card fronts and the body under each heading becomes the back; this adds the honest caveats in the same place — images land on the back, and tags aren't read from the document yet.

## Why
Closes #3399. A returning user ran four formatting experiments against a .docx (headings, indentations, bullet points) and produced zero working cards because the heading→front / body→back model was undocumented and the two limits were invisible. The capability they wanted already works; they had no way to discover the required document structure or to stop chasing image-on-front and document tags that aren't supported yet. No parser change — help copy only.

## How
One sentence added to the existing step-1 `stepBody` paragraph in `UploadPage.tsx`. Real rendered text (screen-reader readable), reusing the existing `stepBody` token — no new element, no icon-only tooltip, AA contrast inherited from the surrounding copy.

## Measuring success
docx download-after-upload rate and first-conversion success for `.docx`/`.doc` uploads, read from the upload funnel events (`upload_started` → `deck_downloaded`). A user who reads the model should structure their document once and download a non-empty deck instead of abandoning after repeated empty conversions.

## Testing
- Unit test added: `UploadPage.test.tsx` asserts the image/tag limit sentence renders. Failed for the right reason before the copy, passes after. Full file green (27 tests). Changelog loader test green (4 tests). Web typecheck clean. `oxfmt --check` clean on both changed `.tsx` files. Lint shows only pre-existing warnings in these files (unused imports, exhaustive-deps) — none introduced here.
- `sonar-scanner` not run: not installed in this environment, and this is a copy + test-only change with no new function/component, so it falls in the documented skip category. Expect no Sonar findings.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified via Playwright against the PR branch on localhost:3000 at 375px. The new sentence renders in step 1 of "How it works": "…In Word docs, headings become card fronts and the body text under each heading becomes the back. Images land on the back, and tags aren't read from the document yet." Dropzone and all three steps render. Console errors observed were all environmental, none from this change: `/api/*` 502 (no backend started — vite proxies to a down server) and a Google ads 403. No PR-caused console errors.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-card-model-help.json` — "The upload page now explains how Word documents become cards — each heading is a front, the text under it is the back"

## Risks
Copy-only, no logic path touched. Rollback is reverting one sentence. Worst case the copy reads slightly long in the step; no functional regression possible.

## Goal alignment
Acquisition + first-conversion friction. Targets the docx funnel: turning a failed first session into a downloaded deck moves first-conversion success, the lane that creates and retains users toward the 300K goal. Read in the upload funnel events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

