### PR TITLE
fix: bundle docx images into the apkg as real media

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -21,6 +21,7 @@ import {
 import { buildPdfPasswordSentinel } from '../../../lib/pdf/pdfPasswordSentinel';
 import { convertXLSXToHTML } from './convertXLSXToHTML';
 import { convertDocxToHTML } from './convertDocxToHTML';
+import { createWorkspaceDocxImageMediaSink } from './docxImageMediaSink';
 import { generateDeckInfo, DeckInfo } from '../../../lib/claude/ClaudeService';
 import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
 import Workspace from '../../../lib/parser/WorkSpace';
@@ -98,9 +99,14 @@ async function convertFile(
   }
 
   if (isDocxFile(file.name)) {
+    const mediaSink = createWorkspaceDocxImageMediaSink(
+      input.workspace.location
+    );
     const result = {
       name: `${file.name}.html`,
-      contents: Buffer.from(await convertDocxToHTML(file.contents as Buffer)),
+      contents: Buffer.from(
+        await convertDocxToHTML(file.contents as Buffer, mediaSink)
+      ),
     };
     console.log('[PrepareDeck] convertFile docx', {
       file: file.name,

--- a/src/infrastracture/adapters/fileConversion/convertDocxToHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/convertDocxToHTML.ts
@@ -1,11 +1,26 @@
 import mammoth from 'mammoth';
 
 import { preprocessDocxHTML } from './preprocessDocxHTML';
+import { DocxImageMediaSink } from './docxImageMediaSink';
 
-export async function convertDocxToHTML(contents: Buffer): Promise<string> {
+function buildImgElementConverter(mediaSink: DocxImageMediaSink) {
+  return mammoth.images.imgElement(async (image) => {
+    const bytes = await image.readAsBuffer();
+    const fileName = mediaSink.write(bytes, image.contentType);
+    return { src: fileName };
+  });
+}
+
+export async function convertDocxToHTML(
+  contents: Buffer,
+  mediaSink?: DocxImageMediaSink
+): Promise<string> {
   let result;
   try {
-    result = await mammoth.convertToHtml({ buffer: contents });
+    const options = mediaSink
+      ? { convertImage: buildImgElementConverter(mediaSink) }
+      : undefined;
+    result = await mammoth.convertToHtml({ buffer: contents }, options);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`docx_parse_failed: ${msg}`);

--- a/src/infrastracture/adapters/fileConversion/convertDocxToHTMLImages.test.ts
+++ b/src/infrastracture/adapters/fileConversion/convertDocxToHTMLImages.test.ts
@@ -1,0 +1,73 @@
+import { DocxImageMediaSink } from './docxImageMediaSink';
+
+jest.mock('mammoth', () => {
+  const imgElement = jest.fn((handler) => ({
+    __brand: 'imgElement',
+    handler,
+  }));
+  return {
+    __esModule: true,
+    default: {
+      convertToHtml: jest.fn(),
+      images: { imgElement },
+    },
+  };
+});
+
+import mammoth from 'mammoth';
+import { convertDocxToHTML } from './convertDocxToHTML';
+
+const mockedConvert = mammoth.convertToHtml as jest.Mock;
+const mockedImgElement = mammoth.images.imgElement as unknown as jest.Mock;
+
+describe('convertDocxToHTML image media handling', () => {
+  beforeEach(() => {
+    mockedConvert.mockReset();
+    mockedImgElement.mockClear();
+  });
+
+  it('passes a convertImage option when a media sink is provided', async () => {
+    mockedConvert.mockResolvedValue({ value: '<p>hello</p>', messages: [] });
+
+    const sink: DocxImageMediaSink = { write: jest.fn(() => 'abc.png') };
+    await convertDocxToHTML(Buffer.from('docx'), sink);
+
+    expect(mockedConvert).toHaveBeenCalledTimes(1);
+    const options = mockedConvert.mock.calls[0][1];
+    expect(options).toMatchObject({ convertImage: { __brand: 'imgElement' } });
+  });
+
+  it('omits the convertImage option when no media sink is provided', async () => {
+    mockedConvert.mockResolvedValue({ value: '<p>hello</p>', messages: [] });
+
+    await convertDocxToHTML(Buffer.from('docx'));
+
+    expect(mockedConvert.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it('writes bytes to the sink and emits a plain filename src, not a data URI', async () => {
+    const written: { bytes: Buffer; contentType: string }[] = [];
+    const sink: DocxImageMediaSink = {
+      write: (bytes, contentType) => {
+        written.push({ bytes, contentType });
+        return 'deadbeef.png';
+      },
+    };
+
+    mockedConvert.mockImplementation(async (_input, options) => {
+      const attrs = await options.convertImage.handler({
+        contentType: 'image/png',
+        readAsBuffer: async () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      });
+      return { value: `<p><img src="${attrs.src}" /></p>`, messages: [] };
+    });
+
+    const html = await convertDocxToHTML(Buffer.from('docx'), sink);
+
+    expect(html).toContain('<img src="deadbeef.png"');
+    expect(html).not.toContain('data:image');
+    expect(written).toHaveLength(1);
+    expect(written[0].contentType).toBe('image/png');
+    expect(written[0].bytes).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/convertDocxToHTMLMediaPipeline.test.ts
+++ b/src/infrastracture/adapters/fileConversion/convertDocxToHTMLMediaPipeline.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as cheerio from 'cheerio';
+
+jest.mock('mammoth', () => {
+  const imgElement = jest.fn((handler) => ({
+    __brand: 'imgElement',
+    handler,
+  }));
+  return {
+    __esModule: true,
+    default: {
+      convertToHtml: jest.fn(),
+      images: { imgElement },
+    },
+  };
+});
+
+import mammoth from 'mammoth';
+import { convertDocxToHTML } from './convertDocxToHTML';
+import { createWorkspaceDocxImageMediaSink } from './docxImageMediaSink';
+import { embedFile } from '../../../lib/parser/exporters/embedFile';
+import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
+import Workspace from '../../../lib/parser/WorkSpace';
+import { isImageFileEmbedable } from '../../../lib/storage/checks';
+
+const mockedConvert = mammoth.convertToHtml as jest.Mock;
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+describe('docx image media pipeline', () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    mockedConvert.mockReset();
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docx-pipeline-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it('packages a docx body image as real apkg media instead of a data URI', async () => {
+    mockedConvert.mockImplementation(async (_input, options) => {
+      const attrs = await options.convertImage.handler({
+        contentType: 'image/png',
+        readAsBuffer: async () => PNG_BYTES,
+      });
+      return {
+        value: `<p>Answer<img src="${attrs.src}" /></p>`,
+        messages: [],
+      };
+    });
+
+    const sink = createWorkspaceDocxImageMediaSink(workspaceDir);
+    const html = await convertDocxToHTML(Buffer.from('docx'), sink);
+
+    expect(html).not.toContain('data:image');
+
+    const dom = cheerio.load(html);
+    const src = dom('img').attr('src');
+    expect(src).toBeDefined();
+    expect(src).not.toContain('data:image');
+    expect(isImageFileEmbedable(src!)).toBe(true);
+
+    expect(fs.existsSync(path.join(workspaceDir, src!))).toBe(true);
+
+    const workspace = Object.create(Workspace.prototype) as Workspace;
+    workspace.location = workspaceDir;
+    const exporter = new CustomExporter('deck', workspaceDir);
+
+    const packagedName = embedFile({
+      exporter,
+      files: [],
+      filePath: src!,
+      workspace,
+      fallbackWorkspaceLocation: workspaceDir,
+    });
+
+    expect(packagedName).not.toBeNull();
+    expect(exporter.media).toHaveLength(1);
+    const packagedBytes = fs.readFileSync(exporter.media[0]);
+    expect(packagedBytes).toEqual(PNG_BYTES);
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/docxImageMediaSink.test.ts
+++ b/src/infrastracture/adapters/fileConversion/docxImageMediaSink.test.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  createWorkspaceDocxImageMediaSink,
+  extensionForContentType,
+} from './docxImageMediaSink';
+
+describe('extensionForContentType', () => {
+  it.each([
+    ['image/png', 'png'],
+    ['image/jpeg', 'jpg'],
+    ['image/gif', 'gif'],
+    ['image/svg+xml', 'svg'],
+    ['IMAGE/PNG', 'png'],
+  ])('maps %s to %s', (contentType, expected) => {
+    expect(extensionForContentType(contentType)).toBe(expected);
+  });
+
+  it('falls back to png for an unknown content type', () => {
+    expect(extensionForContentType('image/unknown')).toBe('png');
+  });
+});
+
+describe('createWorkspaceDocxImageMediaSink', () => {
+  let workspace: string;
+
+  beforeEach(() => {
+    workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'docx-sink-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('writes the bytes into the workspace under a hash-named file', () => {
+    const sink = createWorkspaceDocxImageMediaSink(workspace);
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+
+    const fileName = sink.write(bytes, 'image/png');
+
+    expect(fileName).toMatch(/^[a-f0-9]+\.png$/);
+    const onDisk = fs.readFileSync(path.join(workspace, fileName));
+    expect(onDisk).toEqual(bytes);
+  });
+
+  it('returns a stable filename for identical bytes', () => {
+    const sink = createWorkspaceDocxImageMediaSink(workspace);
+    const bytes = Buffer.from('same-image-bytes');
+
+    const first = sink.write(bytes, 'image/jpeg');
+    const second = sink.write(bytes, 'image/jpeg');
+
+    expect(first).toBe(second);
+  });
+
+  it('rejects empty image bytes', () => {
+    const sink = createWorkspaceDocxImageMediaSink(workspace);
+    expect(() => sink.write(Buffer.alloc(0), 'image/png')).toThrow(
+      /empty/
+    );
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/docxImageMediaSink.test.ts
+++ b/src/infrastracture/adapters/fileConversion/docxImageMediaSink.test.ts
@@ -57,8 +57,6 @@ describe('createWorkspaceDocxImageMediaSink', () => {
 
   it('rejects empty image bytes', () => {
     const sink = createWorkspaceDocxImageMediaSink(workspace);
-    expect(() => sink.write(Buffer.alloc(0), 'image/png')).toThrow(
-      /empty/
-    );
+    expect(() => sink.write(Buffer.alloc(0), 'image/png')).toThrow(/empty/);
   });
 });

--- a/src/infrastracture/adapters/fileConversion/docxImageMediaSink.ts
+++ b/src/infrastracture/adapters/fileConversion/docxImageMediaSink.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+
+import getUniqueFileName from '../../../lib/misc/getUniqueFileName';
+import { resolveSafeEntryPath } from '../../../lib/vocab/safeEntryPath';
+
+const MAX_DOCX_IMAGE_BYTES = 25 * 1024 * 1024;
+
+const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/gif': 'gif',
+  'image/bmp': 'bmp',
+  'image/webp': 'webp',
+  'image/tiff': 'tiff',
+  'image/svg+xml': 'svg',
+  'image/x-emf': 'emf',
+  'image/x-wmf': 'wmf',
+};
+
+export function extensionForContentType(contentType: string): string {
+  const normalized = contentType.trim().toLowerCase();
+  return EXTENSION_BY_CONTENT_TYPE[normalized] ?? 'png';
+}
+
+export interface DocxImageMediaSink {
+  write(bytes: Buffer, contentType: string): string;
+}
+
+export function createWorkspaceDocxImageMediaSink(
+  workspaceLocation: string
+): DocxImageMediaSink {
+  return {
+    write(bytes: Buffer, contentType: string): string {
+      if (bytes.length === 0) {
+        throw new Error('docx image is empty');
+      }
+      if (bytes.length > MAX_DOCX_IMAGE_BYTES) {
+        throw new Error('docx image exceeds the size limit');
+      }
+      const fileName = `${getUniqueFileName(bytes.toString('binary'))}.${extensionForContentType(contentType)}`;
+      const destination = resolveSafeEntryPath(fileName, workspaceLocation);
+      fs.writeFileSync(destination, bytes);
+      return fileName;
+    },
+  };
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-image-media.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-image-media.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-16-docx-image-media",
+  "date": "2026-06-16",
+  "type": "fix",
+  "title": "Images in Word documents bundle into the deck and stay sharp on every device"
+}


### PR DESCRIPTION
## What
Word (.docx) uploads now bundle their embedded images into the `.apkg` as real Anki media instead of keeping them as inline base64 data URIs. This also repairs docx image-on-back, which previously survived only as bloated inline base64.

## Why
Part of #3400 (foundation: media plumbing; the image-on-front mechanism is a separate follow-up PR). `convertDocxToHTML` called mammoth with no `convertImage` option, so mammoth's default `images.dataUri` turned every docx image into a `data:image/...;base64` URI. `isImageFileEmbedable` rejects `data:` URIs, so the parser's `embedFile` path never packaged them — images rendered only as inline base64, bloating the deck and (on the back) breaking the existing media pipeline.

User-visible outcome: a learner uploading a Word doc with diagrams or screenshots gets a clean deck where the images are bundled media, not megabytes of inline base64.

## How
Thread a workspace-backed media sink through the docx boundary. `createWorkspaceDocxImageMediaSink(workspaceLocation)` writes each image's bytes to the deck workspace under a SHA-512 hash filename (reusing `getUniqueFileName`, the same scheme `remoteImageFilename`/`embedFile` use) and returns `{ src: '<hash>.<ext>' }`. The write path is resolved via the existing `resolveSafeEntryPath` and asserted to stay inside the workspace (CWE-22); empty/oversized images are rejected. The emitted HTML carries a plain filename, so the existing `isImageFileEmbedable` → `embedFile` → `CustomExporter.addMedia` path packages it with zero parser changes.

Both call sites confirmed:
- `PrepareDeck.ts` docx branch passes `input.workspace.location` as the sink → real media. (Same `input.workspace` is later passed to `parser.build`, so `embedFile`'s `readFromWorkspaceLocation` resolves the hash filename from disk.)
- `extractAttachmentText.ts` (chat path) passes **no** sink → mammoth keeps the data-URI default; text extraction is unchanged. Confirmed by the existing chat test suite (18 tests green).

No `web/src/` runtime files changed — the only `web/src/` file is the changelog JSON.

## Measuring success
Server log line `[PrepareDeck] convertFile docx` already fires per docx conversion. After deploy, the proof is in the produced deck: docx-sourced `.apkg` files carry hash-named media entries and the HTML payload contains `<img src="<hash>.png">` rather than `data:image/...;base64`. A spot check on a docx-with-image conversion in prod (deck size + media manifest) confirms the switch from inline base64 to bundled media.

## Testing
- Unit tests added:
  - `docxImageMediaSink.test.ts` — extension mapping, hash-named write into the workspace, stable filename for identical bytes, empty-bytes rejection.
  - `convertDocxToHTMLImages.test.ts` — mocks mammoth at the module boundary; asserts a `convertImage` option is passed only when a sink is present, that bytes reach the sink, and that the emitted `src` is a plain filename, **not** a `data:` URI.
  - `convertDocxToHTMLMediaPipeline.test.ts` — integration-ish: real workspace + real sink, drives the emitted filename through the real `embedFile`/`CustomExporter` path and asserts the image lands as packaged media with the original bytes (this is the image-on-back proof — `expect(html).not.toContain('data:image')` and `expect(packagedBytes).toEqual(PNG_BYTES)`).
- Existing `convertDocxToHTML.test.ts` real-mammoth failure tests and the chat `extractAttachmentText.test.ts` remain green.
- Full `src/infrastracture/adapters/fileConversion/` suite: 13 suites / 81 tests green. Server `tsc --noEmit`: clean. `oxfmt --check`: clean.
- `sonar-scanner` was **not** run locally (not installed, `SONAR_TOKEN` unset in this environment) — expect a Sonar pass to run on CI; the two `unicorn(no-new-array)` lint warnings in `PrepareDeck.ts` are pre-existing (lines 37/40, the `mapWithConcurrency` helper) and untouched by this PR.

## Browser check
Browser check: not applicable — changelog-only web/src change, no rendered UI

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-image-media.json` — "Images in Word documents bundle into the deck and stay sharp on every device"

## Risks
- An over-large or malformed docx image throws inside `convertImage`, which mammoth surfaces and `convertDocxToHTML` wraps as `docx_parse_failed:` — same failure surface docx already uses. Rollback is a clean revert; no migration, no schema change.
- Path-traversal is guarded by `resolveSafeEntryPath` against the workspace base (CWE-22).

## Goal alignment
Mission "drop something in, get a clean deck back": a Word doc full of diagrams now produces a clean, correctly-sized deck instead of one bloated with inline base64 (and a broken image on the back). Funnel metric: first-conversion success for visual-subject docx users (med/bio/chem screenshots, handwritten-note photos pasted into Word) — read in the upload→download conversion-success rate for `.docx` sources. No new surface; this hardens an existing conversion path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
