### PR TITLE
feat: make docx image headings a card with image on front

### DIFF
--- a/src/infrastracture/adapters/fileConversion/preprocessDocxFrontImageMedia.test.ts
+++ b/src/infrastracture/adapters/fileConversion/preprocessDocxFrontImageMedia.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as cheerio from 'cheerio';
+
+jest.mock('mammoth', () => {
+  const imgElement = jest.fn((handler) => ({
+    __brand: 'imgElement',
+    handler,
+  }));
+  return {
+    __esModule: true,
+    default: {
+      convertToHtml: jest.fn(),
+      images: { imgElement },
+    },
+  };
+});
+
+import mammoth from 'mammoth';
+import { convertDocxToHTML } from './convertDocxToHTML';
+import { createWorkspaceDocxImageMediaSink } from './docxImageMediaSink';
+import { embedFile } from '../../../lib/parser/exporters/embedFile';
+import CustomExporter from '../../../lib/parser/exporters/CustomExporter';
+import Workspace from '../../../lib/parser/WorkSpace';
+import { isImageFileEmbedable } from '../../../lib/storage/checks';
+
+const mockedConvert = mammoth.convertToHtml as jest.Mock;
+
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+describe('docx heading image becomes front media', () => {
+  let workspaceDir: string;
+
+  beforeEach(() => {
+    mockedConvert.mockReset();
+    workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'docx-front-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  it('packages an image in a heading as real apkg media on the card front', async () => {
+    mockedConvert.mockImplementation(async (_input, options) => {
+      const attrs = await options.convertImage.handler({
+        contentType: 'image/png',
+        readAsBuffer: async () => PNG_BYTES,
+      });
+      return {
+        value: `<h2><img src="${attrs.src}" /></h2><p>The heart pumps blood.</p>`,
+        messages: [],
+      };
+    });
+
+    const sink = createWorkspaceDocxImageMediaSink(workspaceDir);
+    const html = await convertDocxToHTML(Buffer.from('docx'), sink);
+
+    expect(html).not.toContain('data:image');
+
+    const dom = cheerio.load(html);
+    const summaryImg = dom('summary img').attr('src');
+    expect(summaryImg).toBeDefined();
+    expect(summaryImg).not.toContain('data:image');
+    expect(isImageFileEmbedable(summaryImg!)).toBe(true);
+
+    expect(fs.existsSync(path.join(workspaceDir, summaryImg!))).toBe(true);
+
+    const workspace = Object.create(Workspace.prototype) as Workspace;
+    workspace.location = workspaceDir;
+    const exporter = new CustomExporter('deck', workspaceDir);
+
+    const packagedName = embedFile({
+      exporter,
+      files: [],
+      filePath: summaryImg!,
+      workspace,
+      fallbackWorkspaceLocation: workspaceDir,
+    });
+
+    expect(packagedName).not.toBeNull();
+    expect(exporter.media).toHaveLength(1);
+    const packagedBytes = fs.readFileSync(exporter.media[0]);
+    expect(packagedBytes).toEqual(PNG_BYTES);
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.test.ts
+++ b/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.test.ts
@@ -106,4 +106,57 @@ describe('preprocessDocxHTML', () => {
     expect(result).toContain('<summary>Another Heading</summary>');
     expect(result).not.toContain('<summary>Title Only</summary>');
   });
+
+  it('produces a card from an image-only heading with the image on the front', () => {
+    const input =
+      '<h2><img src="diagram.png" /></h2><p>The heart pumps blood.</p>';
+
+    const result = preprocessDocxHTML(input);
+
+    expect(result).toContain('<details>');
+    expect(result).toContain('<summary><img src="diagram.png"></summary>');
+    expect(result).toContain('The heart pumps blood.');
+  });
+
+  it('keeps both text and image on the front of an image heading', () => {
+    const input =
+      '<h2>Figure 1 <img src="aorta.png" /></h2><p>Largest artery in the body.</p>';
+
+    const result = preprocessDocxHTML(input);
+
+    expect(result).toContain(
+      '<summary>Figure 1 <img src="aorta.png"></summary>'
+    );
+    expect(result).toContain('Largest artery in the body.');
+  });
+
+  it('produces no card from an image heading with no following body', () => {
+    const input = '<h2><img src="orphan.png" /></h2><h2>Next</h2><p>Body.</p>';
+
+    const result = preprocessDocxHTML(input);
+
+    expect(result).not.toContain('<summary><img src="orphan.png"></summary>');
+    expect(result).toContain('<h2><img src="orphan.png"></h2>');
+    expect(result).toContain('<summary>Next</summary>');
+  });
+
+  it('produces byte-identical output for a plain text-only heading', () => {
+    const input = '<h2>Blood Vessels</h2><p>body</p>';
+
+    const result = preprocessDocxHTML(input);
+
+    expect(result).toBe(
+      '<html><head></head><body><details><summary>Blood Vessels</summary><p>body</p></details></body></html>'
+    );
+  });
+
+  it('produces byte-identical output for a formatted text-only heading', () => {
+    const input = '<h2><strong>Blood</strong> Vessels</h2><p>body</p>';
+
+    const result = preprocessDocxHTML(input);
+
+    expect(result).toBe(
+      '<html><head></head><body><details><summary>Blood Vessels</summary><p>body</p></details></body></html>'
+    );
+  });
 });

--- a/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.ts
@@ -75,7 +75,10 @@ function convertHeadingsToToggles($: any, originalHTML: string): string {
   headings.each((_: number, heading: any) => {
     const $heading = $(heading);
     const headingText = $heading.text().trim();
-    if (!headingText) return;
+    const hasImage = $heading.find('img').length > 0;
+    if (!headingText && !hasImage) return;
+
+    const summary = hasImage ? ($heading.html() ?? headingText) : headingText;
 
     const contentParts: string[] = [];
     let sibling = $heading.next();
@@ -88,7 +91,7 @@ function convertHeadingsToToggles($: any, originalHTML: string): string {
 
     if (contentParts.length === 0) return;
 
-    const toggle = `<details><summary>${headingText}</summary>${contentParts.join('')}</details>`;
+    const toggle = `<details><summary>${summary}</summary>${contentParts.join('')}</details>`;
 
     contentParts.forEach(() => {
       const next = $heading.next();

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-image-front.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-image-front.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-16-docx-image-front",
+  "date": "2026-06-16",
+  "type": "feature",
+  "title": "Word headings with an image become a card with that image as the question"
+}


### PR DESCRIPTION
## What
A Word (.docx) heading that contains an image now becomes a card whose **front** carries that image. Today such headings are silently dropped — the heading summary was built from `$heading.text()` (which strips `<img>`), and the empty-text guard skipped image-only headings entirely. This branches on image presence: text-only headings are byte-identical to today; an image heading builds its summary from `$heading.html()` so the image (plus any heading text) lands on the card front.

## Why
Closes #3400. Visual subjects — anatomy, histology, chemistry diagrams — routinely put the figure in a heading and the explanation in the body below. Before this change, those headings produced no card at all. Now the learner gets a card with the diagram as the question and the explanation as the answer.

**Why mechanism (a), not (b):** This is additive only — it creates a card from a heading that previously made none. The rejected mechanism (b) "promote the first body block under a heading to the front" would *relocate* images that today correctly render on the card back, regressing every existing docx deck. The byte-identical guarantee for text-only headings is the hard constraint, and the regression tests below enforce it.

The merged #3404 foundation makes the front image **real bundled media**: docx images arrive as `<img src="<hash>.png">` workspace files (not data URIs), and the parser already runs `embedImagesInCardContent` on the front/summary, so an image in the summary flows through the existing embed → `addMedia` path with zero new media plumbing.

## How
In `convertHeadingsToToggles` (`preprocessDocxHTML.ts`):
- `hasImage = $heading.find('img').length > 0`
- Skip only when there is NEITHER text NOR an image (`!headingText && !hasImage`) — was `if (!headingText) return`.
- `summary = hasImage ? $heading.html() : headingText`. For text-only headings `summary === headingText`, so the emitted toggle string is unchanged.
- The existing `if (contentParts.length === 0) return;` guard is untouched — an image heading with no following body still produces no card.

## Scope
- Heading path only. The MCQ list path (`processListItem`/`buildToggle`) is out of scope for v1 — noted as a known follow-up if a reporter's doc turns out to be list-structured.
- No docx-tags change (#3401), no edits under `src/data_layer/public/`.

## Measuring success
First-conversion success for visual-subject docx learners — a docx whose headings are figures now yields cards instead of an empty/partial deck. Read as docx conversions that produce ≥1 card where they previously produced none; no new event added (server parser change). The card count surfaces on the result screen the user already sees.

## Testing
Unit tests added (Jest, colocated):
- Image-only heading → a card IS produced, summary contains the `<img>` (today it's dropped).
- Heading with text + image → front contains BOTH.
- **Byte-identical regression guard:** plain text-only heading AND a formatted text-only heading (`<h2><strong>Blood</strong> Vessels</h2>`) produce EXACTLY the current output (exact `toBe`). Proves the no-image branch is unchanged.
- Image heading with no following body → still no card (existing guard holds; heading stays a raw `<h2>`).
- End-to-end (`preprocessDocxFrontImageMedia.test.ts`): a docx heading image flows through `convertDocxToHTML` → `preprocessDocxHTML` → `embedFile`, asserting the front `<summary>` image is a hash filename packaged by the exporter (`exporter.media` length 1, bytes match), NOT a data URI — i.e. real `.apkg` media via the merged #3404 foundation.

The existing #3404 `convertDocxToHTMLMediaPipeline.test.ts` stays green (no image-on-back regression). `tsc --noEmit` clean; `oxfmt --check` clean on all changed files; `oxlint` clean (the one warning is a pre-existing unused `isAnswerOption`, not in this diff).

**Sonar:** `sonar-scanner` not installed and `SONAR_TOKEN` unset in this environment — not run locally. The diff is a small additive branch with no new HTTP/HTML/zip/path-from-user surface, so I expect no security findings; flagging in case of a maintainability bounce.

## Browser check
Browser check: not applicable — server parser change; only web/src file is the changelog

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-image-front.json` — "Word headings with an image become a card with that image as the question"

## Risks
Low. The change only adds cards from headings that produced none before; the text-only path is byte-identical and regression-tested. Rollback is a one-line revert of the branch condition. No data migration, no API surface change.

## Goal alignment
Mission lever (simpler/faster/more beautiful): a docx of diagram-headed sections now converts to usable image-front cards instead of an empty deck — fewer learners bouncing on a broken first conversion. Funnel: first-conversion success for visual-subject docx uploads (upload → download). Not a revenue surface; the win is reducing first-conversion friction for a content shape we silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
