### PR TITLE
feat: read tags from strikethrough in Word document uploads

### DIFF
--- a/src/infrastracture/adapters/fileConversion/convertDocxToHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/convertDocxToHTML.ts
@@ -3,6 +3,8 @@ import mammoth from 'mammoth';
 import { preprocessDocxHTML } from './preprocessDocxHTML';
 import { DocxImageMediaSink } from './docxImageMediaSink';
 
+const STRIKETHROUGH_TO_TAG_STYLE_MAP = ['strike => del'];
+
 function buildImgElementConverter(mediaSink: DocxImageMediaSink) {
   return mammoth.images.imgElement(async (image) => {
     const bytes = await image.readAsBuffer();
@@ -18,8 +20,11 @@ export async function convertDocxToHTML(
   let result;
   try {
     const options = mediaSink
-      ? { convertImage: buildImgElementConverter(mediaSink) }
-      : undefined;
+      ? {
+          styleMap: STRIKETHROUGH_TO_TAG_STYLE_MAP,
+          convertImage: buildImgElementConverter(mediaSink),
+        }
+      : { styleMap: STRIKETHROUGH_TO_TAG_STYLE_MAP };
     result = await mammoth.convertToHtml({ buffer: contents }, options);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/infrastracture/adapters/fileConversion/convertDocxToHTMLImages.test.ts
+++ b/src/infrastracture/adapters/fileConversion/convertDocxToHTMLImages.test.ts
@@ -42,7 +42,9 @@ describe('convertDocxToHTML image media handling', () => {
 
     await convertDocxToHTML(Buffer.from('docx'));
 
-    expect(mockedConvert.mock.calls[0][1]).toBeUndefined();
+    const options = mockedConvert.mock.calls[0][1];
+    expect(options.convertImage).toBeUndefined();
+    expect(options.styleMap).toEqual(['strike => del']);
   });
 
   it('writes bytes to the sink and emits a plain filename src, not a data URI', async () => {

--- a/src/infrastracture/adapters/fileConversion/convertDocxToHTMLStrikethrough.test.ts
+++ b/src/infrastracture/adapters/fileConversion/convertDocxToHTMLStrikethrough.test.ts
@@ -1,0 +1,105 @@
+import JSZip from 'jszip';
+
+import { setupTests } from '../../../test/configure-jest';
+import CardOption from '../../../lib/parser/Settings/CardOption';
+import { DeckParser } from '../../../lib/parser/DeckParser';
+import Note from '../../../lib/parser/Note';
+import Workspace from '../../../lib/parser/WorkSpace';
+import { convertDocxToHTML } from './convertDocxToHTML';
+
+async function buildDocx(bodyXml: string): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    '[Content_Types].xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`
+  );
+  zip.folder('_rels')?.file(
+    '.rels',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+  );
+  zip.folder('word')?.file(
+    'document.xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>${bodyXml}</w:body>
+</w:document>`
+  );
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+const strikethroughRun =
+  '<w:r><w:rPr><w:strike/></w:rPr><w:t>biology, anatomy</w:t></w:r>';
+
+describe('convertDocxToHTML strikethrough', () => {
+  it('emits <del> for native Word strikethrough runs so the tag pipeline can read them', async () => {
+    const docx = await buildDocx(
+      `<w:p><w:r><w:t xml:space="preserve">Mitochondria </w:t></w:r>${strikethroughRun}</w:p>`
+    );
+
+    const html = await convertDocxToHTML(docx);
+
+    expect(html).toContain('<del>biology, anatomy</del>');
+    expect(html).not.toContain('<s>biology');
+  });
+
+  it('leaves plain text untouched when no strikethrough is present', async () => {
+    const docx = await buildDocx(
+      '<w:p><w:r><w:t>Plain front and back</w:t></w:r></w:p>'
+    );
+
+    const html = await convertDocxToHTML(docx);
+
+    expect(html).toContain('Plain front and back');
+    expect(html).not.toContain('<del>');
+  });
+});
+
+function makeParser(): DeckParser {
+  return new DeckParser({
+    name: 'word.html',
+    settings: new CardOption({ cherry: 'false' }),
+    files: [{ name: 'word.html', contents: '<html></html>' }],
+    noLimits: true,
+    workspace: new Workspace(true, 'fs'),
+  });
+}
+
+describe('docx strikethrough feeds the existing tag pipeline', () => {
+  beforeEach(() => setupTests());
+
+  it('turns a strikethrough word on a card back into a tag and strips it from the card', async () => {
+    const docx = await buildDocx(
+      `<w:p><w:r><w:t xml:space="preserve">Cell answer </w:t></w:r>${strikethroughRun}</w:p>`
+    );
+
+    const html = await convertDocxToHTML(docx);
+    const back = html.slice(html.indexOf('<p>') + 3, html.indexOf('</p>'));
+    const note = new Note('What organelle makes ATP?', back);
+
+    makeParser().locateTags(note, []);
+
+    expect(note.tags).toEqual(expect.arrayContaining(['biology', 'anatomy']));
+    expect(note.back).not.toContain('<del>');
+    expect(note.back).not.toContain('biology, anatomy');
+  });
+
+  it('does not tag a card when useTags is disabled', () => {
+    const parser = new DeckParser({
+      name: 'word.html',
+      settings: new CardOption({ cherry: 'false', tags: 'false' }),
+      files: [{ name: 'word.html', contents: '<html></html>' }],
+      noLimits: true,
+      workspace: new Workspace(true, 'fs'),
+    });
+
+    expect(parser.settings.useTags).toBe(false);
+  });
+});

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -137,11 +137,11 @@ describe('UploadPage doc/docx hint', () => {
     ).toBeInTheDocument();
   });
 
-  it('states the docx image and tag limits in the same place', () => {
+  it('states the docx image limit and strikethrough-tag rule in the same place', () => {
     renderPage();
     expect(
       screen.getByText(
-        /Images land on the back, and tags aren't read from the document yet\./i
+        /Images land on the back, and strikethrough text on a card becomes an Anki tag\./i
       )
     ).toBeInTheDocument();
   });

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -263,7 +263,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
                 PDF, Word, Notion export, Markdown, HTML, Excel, CSV, or
                 PowerPoint. In Word docs, headings become card fronts and the
                 body text under each heading becomes the back. Images land on
-                the back, and tags aren&apos;t read from the document yet.
+                the back, and strikethrough text on a card becomes an Anki tag.
               </p>
               <p className={pageStyles.stepBody}>
                 Coming from Notion?{' '}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-strikethrough-tags.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-strikethrough-tags.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-16-docx-strikethrough-tags",
+  "date": "2026-06-16",
+  "type": "feature",
+  "title": "Word documents — strike through a word to turn it into an Anki tag"
+}


### PR DESCRIPTION
Closes #3401.

## What

Word `.docx` uploads now read **tags from strikethrough text**, reusing the same `<del>` convention the Notion path already uses — strikethrough = tags everywhere, no new docx-only syntax.

## Mechanism

`convertDocxToHTML` passes mammoth a `styleMap` of `['strike => del']`, so a strikethrough run in Word becomes `<del>…</del>` in the converted HTML. From there the existing parser pipeline does the rest unchanged:
- `DeckParser.locateTags` finds `<del>` inside a card's front/back, comma-splits via `sanitizeTags`, adds them to `card.tags`, and strips the `<del>` so the tag text doesn't render on the card.
- Gated by the existing `CardOption.useTags` (`tags !== 'false'`) — no tagging when tags are disabled.

The image media sink from #3404 is preserved — the `styleMap` is added alongside `convertImage`, not in place of it.

## Why this shape

Reusing `<del>` gives cross-source parity (Notion and Word tag the same way) instead of inventing a docx-only `Tags:` line or `#hashtag` syntax that would fragment the model. mammoth's `strike` matcher catches Word's native strikethrough run property directly — no `transformDocument` workaround.

## Tests

`convertDocxToHTMLStrikethrough.test.ts` (new) + `convertDocxToHTMLImages.test.ts` — 2 suites / 7 tests green. Strikethrough input yields `<del>` output; non-strikethrough docs are unchanged; the image media path is unaffected.

## Funnel note

Organizational, not first-conversion value (a user can tag in Anki post-import) — but it completes the trio of Word-document asks from the inbox (image-on-front, image media, tags). No revenue metric directly; supports retention for power users who organize by tag.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Verified via Playwright against the PR branch on localhost:3000 at 375px. Step 1 of "How it works" renders: "…Images land on the back, and strikethrough text on a card becomes an Anki tag." Golden path intact. All console errors were environmental (api 502 with no backend started, Google ads 403) — none from this change.

## Changelog

`web/src/pages/WhatsNewPage/changelog/2026-06-16-docx-strikethrough-tags.json` — type feature.

