### PR TITLE
chore: add ops command to reconcile orphaned subscriptions

### DIFF
--- a/ops/commands/reconcile-orphaned-subscriptions.ts
+++ b/ops/commands/reconcile-orphaned-subscriptions.ts
@@ -1,0 +1,113 @@
+/**
+ * Ops command: reconcile orphaned active Stripe subscriptions.
+ *
+ * An orphan is an active subscription whose Stripe email no longer matches any
+ * account (no users.email, no linked_email, no stripe_customer_id). These are
+ * the `unlinked_payment` alert source — mostly legacy subs created before the
+ * `subscription_data.metadata.user_id` instrumentation, where the payer's Stripe
+ * email drifted from their registered account email. They are paying customers
+ * who can't access what they bought.
+ *
+ * Default run is READ-ONLY: lists the orphans (emails masked) so you can eyeball
+ * the tail. `--apply` sends the cooldown-guarded subscription-recovery email that
+ * asks each payer to reconnect their purchase, and requires a typed confirmation.
+ *
+ * Run from the repo root with the prod/staging env loaded:
+ *   npx tsx --env-file=.env ops/commands/reconcile-orphaned-subscriptions.ts
+ *   npx tsx --env-file=.env ops/commands/reconcile-orphaned-subscriptions.ts --apply
+ */
+import readline from 'node:readline';
+
+import { getDatabase } from '../../src/data_layer';
+import { getStripe } from '../../src/lib/integrations/stripe';
+import { getDefaultEmailService } from '../../src/services/EmailService/EmailService';
+import { OrphanedSubscriptionsRepository } from '../../src/data_layer/OrphanedSubscriptionsRepository';
+import { SubscriptionRecoveryNotificationsRepository } from '../../src/data_layer/SubscriptionRecoveryNotificationsRepository';
+import { GetOrphanedSubscriptionsUseCase } from '../../src/usecases/ops/GetOrphanedSubscriptionsUseCase';
+import { ReconcileOrphanedSubscriptionsUseCase } from '../../src/usecases/ops/ReconcileOrphanedSubscriptionsUseCase';
+
+function maskEmail(email: string | null): string {
+  if (email == null || email.length === 0) return '<none>';
+  const [local, domain] = email.split('@');
+  if (domain == null) return '<malformed>';
+  const head = local.slice(0, 2);
+  return `${head}***@${domain}`;
+}
+
+async function confirmApply(found: number): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(
+      `About to send recovery emails to up to ${found} orphaned subscribers ` +
+        `(14-day cooldown still applies). Type "send recovery emails" to continue: `,
+      resolve
+    );
+  });
+  rl.close();
+  return answer.trim() === 'send recovery emails';
+}
+
+async function main(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+  const database = getDatabase();
+
+  const listUseCase = new GetOrphanedSubscriptionsUseCase(
+    new OrphanedSubscriptionsRepository(database)
+  );
+  const orphans = await listUseCase.execute();
+
+  console.log(`\nOrphaned active subscriptions: ${orphans.length}\n`);
+  for (const orphan of orphans) {
+    const created =
+      orphan.createdAt == null
+        ? 'unknown'
+        : new Date(orphan.createdAt).toISOString().slice(0, 10);
+    console.log(
+      `  ${created}  ${maskEmail(orphan.email)}  ` +
+        `product=${orphan.stripeProductId ?? 'none'}  ` +
+        `customer=${orphan.customerId ?? 'none'}`
+    );
+  }
+
+  if (!apply) {
+    console.log(
+      '\nDry run — no emails sent. Re-run with --apply to send recovery emails.\n'
+    );
+    await database.destroy();
+    return;
+  }
+
+  const confirmed = await confirmApply(orphans.length);
+  if (!confirmed) {
+    console.log('Aborted — no emails sent.');
+    await database.destroy();
+    return;
+  }
+
+  const reconcileUseCase = new ReconcileOrphanedSubscriptionsUseCase(
+    new OrphanedSubscriptionsRepository(database),
+    new SubscriptionRecoveryNotificationsRepository(database),
+    getDefaultEmailService(),
+    async (customerId: string) => {
+      const customer = await getStripe().customers.retrieve(customerId);
+      return 'email' in customer ? (customer.email ?? null) : null;
+    }
+  );
+
+  const result = await reconcileUseCase.execute();
+  console.log('\nReconcile result:');
+  console.log(`  found:                  ${result.found}`);
+  console.log(`  emailed:                ${result.emailed}`);
+  console.log(`  skipped (recent email): ${result.skippedRecentlyNotified}`);
+  console.log(`  skipped (no email):     ${result.skippedNoEmail}\n`);
+
+  await database.destroy();
+}
+
+main().catch((error) => {
+  console.error('[reconcile-orphaned-subscriptions] failed:', error);
+  process.exitCode = 1;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,7 +70,7 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "exclude": ["web", "scripts"],
+  "exclude": ["web", "scripts", "ops"],
   "ts-node": {
     "transpileOnly": true
   }


### PR DESCRIPTION
## What

CLI command at `ops/commands/reconcile-orphaned-subscriptions.ts` for the orphaned-subscription tail (the `unlinked_payment` alert source).

- **Default (read-only):** lists active subscriptions with no linked account — masked email, product, customer, created date.
- **`--apply`:** runs the existing `ReconcileOrphanedSubscriptionsUseCase` (cooldown-guarded recovery email) behind a typed confirmation.

```
npx tsx --env-file=.env ops/commands/reconcile-orphaned-subscriptions.ts
npx tsx --env-file=.env ops/commands/reconcile-orphaned-subscriptions.ts --apply
```

## Why

Prod investigation: `unlinked_payment` alerts do **not** self-resolve — 0/9 recent alerts resolved; 86 active subs (~11% of 771) are orphaned, mostly legacy subs predating `subscription_data.metadata.user_id` whose Stripe email drifted from the account email. The reconcile use case + recovery email already exist but were only reachable via the admin HTTP route. This gives ops a shell entry point to inspect and work the tail.

No new behavior — wires existing use cases (`GetOrphanedSubscriptionsUseCase`, `ReconcileOrphanedSubscriptionsUseCase`) to a command. `ops/` added to tsconfig exclude alongside `scripts/` (operational tsx scripts, not part of the server build).

No changelog entry — internal ops tooling, no user-visible change.

## Browser check
Browser check: not applicable — server-side ops CLI, no `web/src/` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)