### PR TITLE
fix: verify IAP receipts against Production and Sandbox always (#3409)

### DIFF
--- a/src/env.example
+++ b/src/env.example
@@ -50,9 +50,9 @@ APPLE_IAP_BUNDLE_ID=''
 APPLE_IAP_ROOT_CERTS_DIR=''
 # Optional numeric App Apple ID; recommended for production-environment verification.
 APPLE_IAP_APP_APPLE_ID=''
-# Comma-separated Apple environments to accept: Production, Sandbox. Unset = Production only.
-# Sandbox transactions are free to generate, so only add Sandbox for TestFlight/dev/App Store review.
-APPLE_IAP_ENVIRONMENT='Production'
+# IAP receipts are always verified against both Production and Sandbox — no env knob.
+# Each JWS only validates against its matching environment; real buyers hit Production,
+# App Review/TestFlight testers hit Sandbox even against the live app.
 # Get a free API key at https://www.pexels.com/api/. Required for the add_image transform on /transform when source=pexels.
 PEXELS_API_KEY=''
 # Release label stamped on captured error events (error_events.release).

--- a/src/services/AppleStoreKitService/createAppleStoreKitService.test.ts
+++ b/src/services/AppleStoreKitService/createAppleStoreKitService.test.ts
@@ -1,32 +1,69 @@
-import { Environment } from '@apple/app-store-server-library';
+import fs from 'fs';
 
-import { parseAcceptedEnvironments } from './createAppleStoreKitService';
+import {
+  Environment,
+  SignedDataVerifier,
+} from '@apple/app-store-server-library';
 
-describe('parseAcceptedEnvironments', () => {
-  it('defaults to Production only when unset', () => {
-    expect(parseAcceptedEnvironments(undefined)).toEqual([
-      Environment.PRODUCTION,
-    ]);
+import {
+  createAppleStoreKitService,
+  VERIFIED_ENVIRONMENTS,
+} from './createAppleStoreKitService';
+
+jest.mock('@apple/app-store-server-library', () => {
+  const actual = jest.requireActual('@apple/app-store-server-library');
+  return { ...actual, SignedDataVerifier: jest.fn() };
+});
+
+const MockedVerifier = SignedDataVerifier as unknown as jest.Mock;
+
+function environmentsPassedToVerifiers(): Environment[] {
+  return MockedVerifier.mock.calls.map((call) => call[2] as Environment);
+}
+
+describe('createAppleStoreKitService', () => {
+  const original = { ...process.env };
+
+  beforeEach(() => {
+    MockedVerifier.mockClear();
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest
+      .spyOn(fs, 'readdirSync')
+      .mockReturnValue(['AppleRootCA-G3.cer'] as never);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(Buffer.from('cert'));
+    process.env.APPLE_IAP_BUNDLE_ID = 'net.2anki.app';
+    process.env.APPLE_IAP_ROOT_CERTS_DIR = '/certs';
+    process.env.APPLE_IAP_APP_APPLE_ID = '1234567890';
   });
 
-  it('defaults to Production only for an empty string', () => {
-    expect(parseAcceptedEnvironments('')).toEqual([Environment.PRODUCTION]);
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = { ...original };
   });
 
-  it('accepts a single named environment case-insensitively', () => {
-    expect(parseAcceptedEnvironments('sandbox')).toEqual([Environment.SANDBOX]);
-  });
+  it('verifies against both Production and Sandbox when the env var is unset', () => {
+    delete process.env.APPLE_IAP_ENVIRONMENT;
 
-  it('accepts both environments when listed', () => {
-    expect(parseAcceptedEnvironments('Production, Sandbox')).toEqual([
+    createAppleStoreKitService();
+
+    expect(environmentsPassedToVerifiers()).toEqual([
       Environment.PRODUCTION,
       Environment.SANDBOX,
     ]);
   });
 
-  it('ignores unknown tokens and falls back to Production', () => {
-    expect(parseAcceptedEnvironments('xcode, nonsense')).toEqual([
+  it('still builds a Production verifier when prod is misconfigured to Sandbox only', () => {
+    process.env.APPLE_IAP_ENVIRONMENT = 'Sandbox';
+
+    createAppleStoreKitService();
+
+    expect(environmentsPassedToVerifiers()).toContain(Environment.PRODUCTION);
+  });
+
+  it('exposes both environments as the verified set', () => {
+    expect(VERIFIED_ENVIRONMENTS).toEqual([
       Environment.PRODUCTION,
+      Environment.SANDBOX,
     ]);
   });
 });

--- a/src/services/AppleStoreKitService/createAppleStoreKitService.ts
+++ b/src/services/AppleStoreKitService/createAppleStoreKitService.ts
@@ -19,26 +19,16 @@ function loadRootCertificates(dir: string): Buffer[] {
     .map((file) => fs.readFileSync(path.join(dir, file)));
 }
 
-const KNOWN_ENVIRONMENTS: Record<string, Environment> = {
-  production: Environment.PRODUCTION,
-  sandbox: Environment.SANDBOX,
-};
-
-export function parseAcceptedEnvironments(
-  raw: string | undefined
-): Environment[] {
-  if (raw == null || raw === '') {
-    return [Environment.PRODUCTION];
-  }
-  const seen = new Set<Environment>();
-  for (const token of raw.split(',')) {
-    const environment = KNOWN_ENVIRONMENTS[token.trim().toLowerCase()];
-    if (environment != null) {
-      seen.add(environment);
-    }
-  }
-  return seen.size > 0 ? [...seen] : [Environment.PRODUCTION];
-}
+// Always verify against both environments. Production credits real App Store
+// buyers; Sandbox credits App Review and TestFlight testers, who exercise IAP
+// with Sandbox transactions even against the live app. verifyTransaction
+// iterates verifiers and skips the non-matching one on INVALID_ENVIRONMENT, so
+// each JWS only validates against its own environment. Gating this on an env
+// var let production reject every real purchase when it was set to Sandbox only.
+export const VERIFIED_ENVIRONMENTS: Environment[] = [
+  Environment.PRODUCTION,
+  Environment.SANDBOX,
+];
 
 export function createAppleStoreKitService(): IAppleStoreKitService {
   const bundleId = process.env.APPLE_IAP_BUNDLE_ID;
@@ -75,9 +65,7 @@ export function createAppleStoreKitService(): IAppleStoreKitService {
       : undefined;
 
   const enableOnlineChecks = true;
-  const verifiers = parseAcceptedEnvironments(
-    process.env.APPLE_IAP_ENVIRONMENT
-  ).map(
+  const verifiers = VERIFIED_ENVIRONMENTS.map(
     (environment) =>
       new SignedDataVerifier(
         rootCertificates,

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-16-app-store-purchases-credited.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-16-app-store-purchases-credited.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-16-app-store-purchases-credited",
+  "date": "2026-06-16",
+  "type": "fix",
+  "title": "Purchases in the iOS and Mac app now unlock your account"
+}


### PR DESCRIPTION
Fixes #3409.

## Problem
Production verified IAP receipts against **Sandbox only**, so real App Store purchases were charged by Apple and then rejected by `/api/iap/redeem` with `INVALID_ENVIRONMENT` → buyers paid, got no entitlement.

The `APPLE_IAP_ENVIRONMENT` knob was a footgun in both directions:
- default `Production`-only → rejects App Review's Sandbox IAP (re-triggers Guideline 2.1)
- prod set to `Sandbox`-only → rejects every real buyer

This is the env-gated-runtime-behavior pattern `.claude/rules/code-quality.md` forbids — wrong default, silently degrades the product.

## Fix
Always build verifiers for **both** Production and Sandbox; remove the env knob entirely. `verifyTransaction` already iterates verifiers and `continue`s on `INVALID_ENVIRONMENT`, so each JWS only validates against its matching environment. No prod `.env` edit needed — the misconfig cannot recur, and the fix lands on deploy.

## Changes
- `createAppleStoreKitService.ts` — verifiers always cover `[PRODUCTION, SANDBOX]`; dropped `parseAcceptedEnvironments`/`APPLE_IAP_ENVIRONMENT`
- `createAppleStoreKitService.test.ts` — regression: a Production verifier is built even when the (now-ignored) env was Sandbox-only
- `src/env.example` — removed the dead knob, documented always-both
- changelog entry

## Backfill (ops, not in this PR)
Purchases made while Sandbox-only was live were charged but never credited. Client re-attempts redeem on next launch (transactions stay unfinished until credited), so most self-heal once this deploys; spot-check Apple sales for purchases with no matching `apple_transactions` row.

## Expected impact
Restores IAP revenue from the iOS/Mac app — every real App Store purchase now credits the buyer. Read via `iap.redeem.granted` log line (`environment: "Production"` for real buyers).

## Test plan
- `npx jest src/services/AppleStoreKitService/` — 9 pass
- server `tsc -p . --noEmit` clean

Browser check: not applicable — server-side IAP verification, only web/src change is a changelog JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)