### PR TITLE
fix: snapshot upload bytes so conversions survive temp-file reaping

### DIFF
--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -6,6 +6,7 @@ import Workspace from '../../lib/parser/WorkSpace';
 import { EmptyDeckError } from '../jobs/EmptyDeckError';
 import { runUploadGeneration } from '../../lib/conversionPool';
 import { UploadGenerationFailure } from './uploadGenerationTypes';
+import { ensureUploadBytes } from './ensureUploadBytes';
 
 export interface PackageResult {
   packages: Package[];
@@ -42,6 +43,7 @@ class GeneratePackagesUseCase {
     onProgress?: (step: string) => void,
     userId: number | null = null
   ): Promise<PackageResult> {
+    ensureUploadBytes(files);
     const enqueuedAt = Date.now();
     const channel = onProgress ? new MessageChannel() : null;
     channel?.port1.on('message', (step: string) => onProgress?.(step));

--- a/src/usecases/uploads/ensureUploadBytes.test.ts
+++ b/src/usecases/uploads/ensureUploadBytes.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ensureUploadBytes } from './ensureUploadBytes';
+import { UploadedFile } from '../../lib/storage/types';
+import { getFileContents } from './worker';
+
+function makeFile(overrides: Partial<UploadedFile>): UploadedFile {
+  return {
+    originalname: 'notes.html',
+    key: 'notes.html',
+    ...overrides,
+  } as UploadedFile;
+}
+
+describe('ensureUploadBytes', () => {
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-bytes-')),
+      'upload.bin'
+    );
+    fs.writeFileSync(tmpPath, Buffer.from('disk-bytes'));
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpPath)) fs.rmSync(tmpPath);
+  });
+
+  it('snapshots disk bytes into buffer when the file has a path but no buffer', () => {
+    const file = makeFile({ path: tmpPath });
+
+    ensureUploadBytes([file]);
+
+    expect(file.buffer).toEqual(Buffer.from('disk-bytes'));
+  });
+
+  it('keeps the worker readable after the temp file is reaped mid-dwell', () => {
+    const file = makeFile({ path: tmpPath });
+
+    ensureUploadBytes([file]);
+    fs.rmSync(tmpPath); // simulate the OS/multer reaping UPLOAD_BASE
+
+    // Before the fix this threw "no longer available on disk and has no buffer
+    // fallback"; the snapshot keeps the conversion alive.
+    expect(getFileContents(file)).toEqual(Buffer.from('disk-bytes'));
+  });
+
+  it('leaves an already-buffered upload untouched', () => {
+    const existing = Buffer.from('memory-bytes');
+    const file = makeFile({ buffer: existing });
+
+    ensureUploadBytes([file]);
+
+    expect(file.buffer).toBe(existing);
+  });
+
+  it('does not throw when the file is already gone at request time', () => {
+    fs.rmSync(tmpPath);
+    const file = makeFile({ path: tmpPath });
+
+    expect(() => ensureUploadBytes([file])).not.toThrow();
+    expect(file.buffer).toBeUndefined();
+  });
+});

--- a/src/usecases/uploads/ensureUploadBytes.ts
+++ b/src/usecases/uploads/ensureUploadBytes.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { UploadedFile } from '../../lib/storage/types';
+
+// Multer disk storage gives each upload a `path` but no `buffer`. The conversion
+// runs later in a Piscina worker that reads the file lazily; when the pool queue
+// is busy the OS or multer can reap the temp file out of UPLOAD_BASE before the
+// worker reads it, and the job dies with "Uploaded file is no longer available
+// on disk and has no buffer fallback" (#3414).
+//
+// Capture the bytes here — in the request thread, where the file is guaranteed
+// to still exist — so the worker's buffer fallback is actually populated. The
+// worker still prefers the disk path on the happy path; the buffer only matters
+// when the temp file vanished mid-dwell.
+export function ensureUploadBytes(files: UploadedFile[]): void {
+  for (const file of files) {
+    if (file.buffer != null || !file.path) continue;
+    try {
+      file.buffer = fs.readFileSync(file.path);
+    } catch (error) {
+      // The file is already gone or unreadable at request time (rare). Leave the
+      // buffer unset; the worker surfaces its own clear error if the disk read
+      // also fails by the time it runs.
+      console.warn('[upload] could not snapshot upload bytes', {
+        file: path.basename(file.path),
+        error: String(error),
+      });
+    }
+  }
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-17-upload-queue-reliability.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-17-upload-queue-reliability.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-17-upload-queue-reliability",
+  "date": "2026-06-17",
+  "type": "fix",
+  "title": "Uploads that wait in a busy conversion queue convert instead of failing"
+}


### PR DESCRIPTION
Closes #3414.

## Problem

Async upload jobs fail intermittently with:

```
Error: Uploaded file is no longer available on disk and has no buffer fallback
    at getFileContents (src/usecases/uploads/worker.ts:76)
```

2× in a 48h prod window.

## Root cause

Multer disk storage (`dest: UPLOAD_BASE`) gives each upload a `path` but no `buffer`. The conversion runs later in a Piscina worker that reads the file lazily. When the pool queue is busy, the OS or multer reaps the temp file out of `UPLOAD_BASE` before the worker reads it — and the job dies.

`worker.getFileContents` already has a `buffer-fallback` branch, but disk storage never populates `file.buffer`, so the fallback was dead code: disk gone + no buffer = throw.

## Fix

`ensureUploadBytes(files)` runs in the **request thread** (where the temp file is guaranteed to still exist), just before the worker handoff in `GeneratePackagesUseCase.execute`. For each disk-backed file with no buffer, it snapshots the bytes into `file.buffer`. The worker still prefers the disk path on the happy path; the buffer only matters when the temp file vanished mid-dwell.

## Tests

- `ensureUploadBytes.test.ts`: snapshots disk bytes; leaves already-buffered uploads untouched; does not throw when the file is already gone; and — the regression — `getFileContents` stays readable after the temp file is `rm`'d post-snapshot (the exact failure shape).
- Worker + use-case suites green (20/20); server tsc clean; oxlint + oxfmt clean.

## Notes

- Changelog entry included (user-visible: previously-failing uploads now convert).
- Local SonarCloud not run (SONAR_TOKEN unset); small isolated change, self-reviewed for complexity/nesting smells.

Browser check: not applicable — the only web/src file is a changelog entry; no rendered behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
