### PR TITLE
fix: register native_app_store_clicked in server event allowlist

### DIFF
--- a/src/controllers/EventsController.test.ts
+++ b/src/controllers/EventsController.test.ts
@@ -218,6 +218,20 @@ describe('EventsController', () => {
       expect.objectContaining({ name: eventName, unknown: false })
     );
   });
+
+  it.each([
+    'native_app_page_viewed',
+    'native_app_interest_clicked',
+    'native_app_store_clicked',
+  ])('accepts native-app event %s as known, not unknown', (eventName) => {
+    const { controller, req, res, executeSpy } = buildMocks({ userId: 1 });
+    req.body = { name: eventName };
+    controller.track(req, res);
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ name: eventName, unknown: false })
+    );
+  });
 });
 
 describe('EventsController — regression: all client events return 202 (AC #5)', () => {

--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -66,6 +66,7 @@ export const KNOWN_EVENTS = new Set([
   'recent_page_reconvert_clicked',
   'native_app_page_viewed',
   'native_app_interest_clicked',
+  'native_app_store_clicked',
   'checkout_started',
   'plan_interval_selected',
   'lock_in_banner_shown',


### PR DESCRIPTION
## Problem

Found analysing prod logs (last 24h): `[events] unknown event received: native_app_store_clicked` firing on the new download-page badge clicks.

PR #3417 registered `native_app_store_clicked` in the **web** event union (`web/src/lib/analytics/events.ts`) but not the **server** allowlist (`src/types/AnalyticsEvents.ts`). The two lists must stay in sync.

## Impact

Low — no data lost. The controller tags unknown events with `unknown: true` and the use case still records them; it just emits a warn per event. So the funnel signal was captured but the warn log was noisy and the allowlist (the safety net for typo'd/unregistered events) was inaccurate.

## Why CI didn't catch it

The existing client-event regression test (`EventsController.test.ts`, bottom block) asserts only `202` — which unknown events also return — so the drift passed green. Added a `native_app_*` `it.each` asserting `unknown: false` to guard the sync properly.

## Fix

- Register `native_app_store_clicked` in `src/types/AnalyticsEvents.ts`.
- Test: native-app events resolve as known (`unknown: false`), not just `202`.

Internal-only (analytics hygiene), no user-visible behavior change → no changelog entry. Server tsc + EventsController suite (100 tests) green; oxfmt clean. SonarCloud not run locally (token unset); trivial change.

Found during a prod log review; relates to #3411 / #3417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
