### PR TITLE
chore: show last week's commits at session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# SessionStart: print branch, last 5 commits, open TODOs in tracked source.
+# SessionStart: print branch, last week's commits, open TODOs in tracked source.
 # Output goes to additionalContext (stdout). Always exits 0.
 set -u
 
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "<not a git repo>")
-LAST_COMMITS=$(git log --pretty=format:'  %h %s (%cr)' -n 5 2>/dev/null || echo "  <no commits>")
+LAST_COMMITS=$(git log --pretty=format:'  %h %s (%cr)' --since='1 week ago' 2>/dev/null)
+[ -z "$LAST_COMMITS" ] && LAST_COMMITS="  <no commits in the last week>"
 
 # Cap TODO scan to tracked TS/TSX in src/, excluding test files.
 # Test fixtures often contain the literal string "TODO" inside markdown samples,
@@ -21,7 +22,7 @@ cat <<EOF
 ## Session start
 
 - Branch: $BRANCH
-- Last 5 commits:
+- Commits in the last week:
 $LAST_COMMITS
 - Open TODOs (first 15, tracked .ts/.tsx in src/): $TODO_COUNT match(es)
 EOF


### PR DESCRIPTION
## What

SessionStart hook (`.claude/hooks/session-start.sh`) now lists commits from the last week (`git log --since='1 week ago'`) instead of a fixed `-n 5`. Falls back to "<no commits in the last week>" when the window is empty.

## Why

Five commits is a thin slice on a busy repo — a one-week window gives a fuller picture of what just shipped when a session opens.

## Notes

No changelog entry — internal tooling, no user-visible behavior change. No browser check — no `web/src/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)