### PR TITLE
fix: stop session-start TODO count emitting a double zero

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -16,7 +16,7 @@ TODOS=$(git ls-files 'src/*.ts' 'src/*.tsx' 2>/dev/null \
   | grep -v -E '\.test\.tsx?$' \
   | xargs grep -nE '\b(TODO|FIXME|XXX|HACK)\b' 2>/dev/null \
   | head -n 15)
-TODO_COUNT=$(printf '%s\n' "$TODOS" | grep -c . 2>/dev/null || echo 0)
+TODO_COUNT=$(printf '%s' "$TODOS" | grep -c .)
 
 cat <<EOF
 ## Session start


### PR DESCRIPTION
## What

The SessionStart hook printed `0\n0 match(es)` and threw `[: 0\n0: integer expression expected` whenever there were no TODOs.

## Why

`grep -c .` prints the count but **exits 1** when nothing matches. The `|| echo 0` fallback then ran on top of grep's own `0`, capturing `"0\n0"`. That broke the `[ "$TODO_COUNT" -gt 0 ]` integer test and doubled the printed count.

## Fix

Drop `|| echo 0` (grep -c always prints a number) and use `printf '%s'` so an empty TODO list is zero lines, not one blank line. Now prints a clean `0 match(es)` with no error.

## Notes

No changelog entry — internal tooling, no user-visible behavior change. No browser check — no `web/src/` files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)