### PR TITLE
feat: revamp /app native app marketing page

### DIFF
--- a/web/src/pages/NativeAppPage/NativeAppPage.module.css
+++ b/web/src/pages/NativeAppPage/NativeAppPage.module.css
@@ -1,33 +1,64 @@
 /* Local .page: shared.page has no flex/gap (see web/CLAUDE.md) */
 .page {
-  composes: pageNarrow from '../../styles/shared.module.css';
+  composes: pageWide from '../../styles/shared.module.css';
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-  text-align: center;
-  max-width: 420px;
+  gap: 4rem;
 }
 
-.mascot {
-  display: block;
-  width: 128px;
-  height: 128px;
-  margin-bottom: 0.5rem;
+/* ---- Hero ---- */
+.hero {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.heroCopy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.heroArt {
+  display: flex;
+  justify-content: center;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.75rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  border-radius: var(--radius-full);
 }
 
 .title {
-  composes: title from '../../styles/shared.module.css';
-  font-size: var(--text-4xl);
+  font-size: var(--text-5xl);
+  font-weight: var(--font-bold);
   line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text-primary);
   margin: 0;
 }
 
 .body {
   margin: 0;
-  max-width: 34ch;
+  max-width: 42ch;
+  font-size: var(--text-lg);
   color: var(--color-text-secondary);
   line-height: var(--leading-relaxed);
+}
+
+.ctaGroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1.25rem;
 }
 
 .badge {
@@ -41,6 +72,18 @@
   width: auto;
 }
 
+.macLink {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-link);
+  text-decoration: none;
+}
+
+.macLink:hover {
+  color: var(--color-text-link-hover);
+  text-decoration: underline;
+}
+
 .caption {
   margin: 0;
   font-size: var(--text-sm);
@@ -50,9 +93,10 @@
 .notice {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.75rem;
   width: 100%;
+  max-width: 34rem;
   padding: 1.5rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
@@ -68,7 +112,469 @@
 
 .noticeBody {
   margin: 0;
-  max-width: 34ch;
+  max-width: 40ch;
   color: var(--color-text-secondary);
   line-height: var(--leading-relaxed);
+}
+
+/* ---- Formats strip ---- */
+.formats {
+  text-align: center;
+}
+
+.formatsLabel {
+  margin: 0 0 1rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.formatsRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.625rem;
+}
+
+.formatChip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.9rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+/* ---- Section heading ---- */
+.sectionHeading {
+  font-size: var(--text-3xl);
+  font-weight: var(--font-semibold);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text-primary);
+  margin: 0 0 2rem;
+  text-align: center;
+}
+
+/* ---- Feature grid ---- */
+.features {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+}
+
+.featureCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 1.75rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.featureIcon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.featureTitle {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.featureBody {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+/* ---- Steps ---- */
+.stepsRow {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+}
+
+.stepCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stepNumber {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  font-size: var(--text-lg);
+  font-weight: var(--font-bold);
+  color: var(--color-bg-primary);
+  background: var(--color-primary);
+  border-radius: var(--radius-full);
+}
+
+.stepTitle {
+  margin: 0.25rem 0 0;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.stepBody {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+/* ---- Showcase (Mac) ---- */
+.showcase {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  align-items: center;
+}
+
+.showcase .sectionHeading {
+  text-align: left;
+  margin-bottom: 1rem;
+}
+
+.showcaseBody {
+  margin: 0;
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  max-width: 44ch;
+}
+
+.showcaseArt {
+  min-width: 0;
+}
+
+/* ---- FAQ ---- */
+.faqList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 44rem;
+  margin: 0 auto;
+}
+
+.faqItem {
+  padding: 1rem 1.25rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.faqQuestion {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  list-style: none;
+}
+
+.faqQuestion::-webkit-details-marker {
+  display: none;
+}
+
+.faqQuestion::after {
+  content: '+';
+  float: right;
+  color: var(--color-text-tertiary);
+  font-weight: var(--font-medium);
+}
+
+.faqItem[open] .faqQuestion::after {
+  content: '−';
+}
+
+.faqAnswer {
+  margin: 0.75rem 0 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+/* ---- Final CTA ---- */
+.finalCta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  text-align: center;
+  padding: 3rem 1.5rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.finalTitle {
+  margin: 0;
+  font-size: var(--text-3xl);
+  font-weight: var(--font-bold);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text-primary);
+}
+
+.finalBody {
+  margin: 0;
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+}
+
+.finalCta .ctaGroup {
+  justify-content: center;
+}
+
+/* ====================================================================
+   Device mockups — pure CSS, theme-token driven. Placeholder art until
+   real App Store screenshots land (see AppStore/screenshots.md).
+   ==================================================================== */
+
+/* iPhone */
+.phone {
+  position: relative;
+  width: 248px;
+  padding: 12px;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: 38px;
+  box-shadow: var(--shadow-md);
+}
+
+.phoneNotch {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 88px;
+  height: 22px;
+  background: var(--color-bg-tertiary);
+  border-radius: 0 0 12px 12px;
+  z-index: 2;
+}
+
+.phoneScreen {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 1.25rem 0.875rem 1rem;
+  background: var(--color-bg-secondary);
+  border-radius: 28px;
+  min-height: 440px;
+}
+
+.mockHeader {
+  padding: 0.5rem 0.25rem;
+}
+
+.mockHeaderTitle {
+  font-size: var(--text-lg);
+  font-weight: var(--font-bold);
+  color: var(--color-text-primary);
+}
+
+.mockCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.875rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.mockCardSlim {
+  composes: mockCard;
+}
+
+.mockChip {
+  align-self: flex-start;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.625rem;
+  font-weight: var(--font-medium);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+  border-radius: var(--radius-full);
+}
+
+.mockFront {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  line-height: var(--leading-normal);
+}
+
+.mockRule {
+  height: 1px;
+  background: var(--color-border);
+}
+
+.mockBack {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.mockCta {
+  margin-top: auto;
+  padding: 0.625rem;
+  text-align: center;
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-bg-primary);
+  background: var(--color-primary);
+  border-radius: var(--radius-md);
+}
+
+/* Mac window */
+.mac {
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+}
+
+.macBar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.625rem 0.875rem;
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.macDot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--color-bg-tertiary);
+}
+
+.macBarTitle {
+  margin-left: 0.5rem;
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-tertiary);
+}
+
+.macBody {
+  display: grid;
+  grid-template-columns: 150px 1fr;
+  min-height: 280px;
+}
+
+.macSidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.875rem 0.625rem;
+  background: var(--color-bg-secondary);
+  border-right: 1px solid var(--color-border);
+}
+
+.macNav,
+.macNavActive {
+  padding: 0.45rem 0.625rem;
+  font-size: var(--text-xs);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-secondary);
+}
+
+.macNavActive {
+  font-weight: var(--font-semibold);
+  color: var(--color-primary);
+  background: var(--color-primary-light);
+}
+
+.macContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 1rem;
+}
+
+.macRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0.875rem;
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.macRowName {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-primary);
+}
+
+.macRowMeta {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+/* ---- Responsive ---- */
+@media (min-width: 769px) {
+  .hero {
+    grid-template-columns: 1.1fr 0.9fr;
+  }
+
+  .features {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .stepsRow {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .showcase {
+    grid-template-columns: 0.9fr 1.1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .title {
+    font-size: var(--text-4xl);
+  }
+
+  .heroCopy {
+    align-items: center;
+    text-align: center;
+  }
+
+  .body {
+    max-width: 36ch;
+  }
+
+  .showcase .sectionHeading {
+    text-align: center;
+  }
+
+  .showcaseCopy {
+    text-align: center;
+  }
+
+  .showcaseBody {
+    margin: 0 auto;
+  }
 }

--- a/web/src/pages/NativeAppPage/NativeAppPage.test.tsx
+++ b/web/src/pages/NativeAppPage/NativeAppPage.test.tsx
@@ -54,6 +54,17 @@ describe('NativeAppPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the marketing sections', () => {
+    renderPage();
+    expect(
+      screen.getByRole('heading', {
+        name: 'From file to deck in three steps',
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Parsed on your device')).toBeInTheDocument();
+    expect(screen.getByText('Is the app free?')).toBeInTheDocument();
+  });
+
   it('tracks native_app_page_viewed once on mount', () => {
     renderPage();
     expect(callsFor('native_app_page_viewed')).toHaveLength(1);
@@ -63,24 +74,38 @@ describe('NativeAppPage', () => {
     getAppStoreLinksMock.mockResolvedValue(links);
     renderPage();
 
-    const badge = await screen.findByRole('link', {
+    const badges = await screen.findAllByRole('link', {
       name: 'Download on the App Store',
     });
-    expect(badge).toHaveAttribute('href', links.iosUrl);
+    expect(badges[0]).toHaveAttribute('href', links.iosUrl);
     expect(
       screen.getByText('Free on the App Store — iPhone, iPad, and Mac.')
     ).toBeInTheDocument();
   });
 
-  it('fires native_app_store_clicked on a badge click', async () => {
+  it('renders the Mac App Store link when macUrl is present', async () => {
+    getAppStoreLinksMock.mockResolvedValue(links);
+    renderPage();
+
+    const macLinks = await screen.findAllByRole('link', {
+      name: 'Also on the Mac App Store →',
+    });
+    expect(macLinks[0]).toHaveAttribute('href', links.macUrl);
+  });
+
+  it('fires native_app_store_clicked with placement on a badge click', async () => {
     getAppStoreLinksMock.mockResolvedValue(links);
     renderPage();
 
     fireEvent.click(
-      await screen.findByRole('link', { name: 'Download on the App Store' })
+      (
+        await screen.findAllByRole('link', {
+          name: 'Download on the App Store',
+        })
+      )[0]
     );
     expect(callsFor('native_app_store_clicked')).toEqual([
-      ['native_app_store_clicked', { store: 'ios' }],
+      ['native_app_store_clicked', { store: 'ios', placement: 'hero' }],
     ]);
   });
 
@@ -91,8 +116,10 @@ describe('NativeAppPage', () => {
     expect(
       await screen.findByText('Coming soon to the App Store')
     ).toBeInTheDocument();
-    const cta = screen.getByRole('link', { name: 'Convert a deck on the web' });
-    expect(cta).toHaveAttribute('href', '/');
+    const ctas = screen.getAllByRole('link', {
+      name: 'Convert a deck on the web',
+    });
+    expect(ctas[0]).toHaveAttribute('href', '/');
     expect(
       screen.queryByRole('link', { name: 'Download on the App Store' })
     ).not.toBeInTheDocument();

--- a/web/src/pages/NativeAppPage/NativeAppPage.tsx
+++ b/web/src/pages/NativeAppPage/NativeAppPage.tsx
@@ -7,6 +7,147 @@ import { AppStoreLinks } from '../../lib/interfaces/AppStoreLinks';
 import styles from './NativeAppPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 
+const CANONICAL = 'https://2anki.net/app';
+const META_DESCRIPTION =
+  'Convert your notes and files into Anki decks on iPhone, iPad, and Mac. Markdown, PDF, Notion, CSV, OPML, Kindle — parsed on your device. Free on the App Store.';
+
+const FORMATS = [
+  'Markdown',
+  'PDF',
+  'Notion',
+  'CSV',
+  'OPML',
+  'Kindle',
+  '.apkg',
+];
+
+const FEATURES = [
+  {
+    icon: '🔒',
+    title: 'Parsed on your device',
+    body: 'Your files never leave your Mac, iPhone, or iPad to become cards. Markdown, PDFs, and exports are converted locally — private by default.',
+  },
+  {
+    icon: '✨',
+    title: 'Build decks with AI chat',
+    body: 'Paste a topic or a wall of notes and let chat draft the cards. Preview every front and back before anything reaches Anki.',
+  },
+  {
+    icon: '📦',
+    title: 'Every format, one tap to Anki',
+    body: 'Markdown, PDF, Notion exports, CSV, OPML, and Kindle highlights all land as a clean .apkg you open straight in Anki.',
+  },
+];
+
+const STEPS = [
+  {
+    n: '1',
+    title: 'Drop a file or paste notes',
+    body: 'Pick a Markdown file, PDF, Notion export, CSV, or Kindle clipping — or just paste text.',
+  },
+  {
+    n: '2',
+    title: 'Preview the cards',
+    body: 'See every generated front and back. Tidy them up before they leave the app.',
+  },
+  {
+    n: '3',
+    title: 'Open in Anki',
+    body: 'Export a ready-to-study .apkg and review it in Anki — the app you already trust.',
+  },
+];
+
+const FAQS = [
+  {
+    q: 'Is the app free?',
+    a: 'Yes — downloading and converting files on-device is free. AI deck generation and unlimited use are optional paid upgrades.',
+  },
+  {
+    q: 'Do I need an account?',
+    a: 'No account is needed to convert your own files locally. You only sign in for AI chat decks and live Notion sync.',
+  },
+  {
+    q: 'Does it replace Anki?',
+    a: 'No. 2anki builds the deck; Anki reviews it. The app hands off a standard .apkg and gets out of the way.',
+  },
+  {
+    q: 'Which files can it convert?',
+    a: 'Markdown, PDF, Notion exports (.zip), CSV, OPML, Kindle highlights, and existing .apkg files.',
+  },
+  {
+    q: 'Does it run on Mac and iPhone?',
+    a: 'It is a universal app — one download covers iPhone, iPad, and Mac with the same on-device conversion.',
+  },
+];
+
+function PhoneMockup() {
+  return (
+    <div className={styles.phone} aria-hidden="true">
+      <div className={styles.phoneNotch} />
+      <div className={styles.phoneScreen}>
+        <div className={styles.mockHeader}>
+          <span className={styles.mockHeaderTitle}>Make flashcards</span>
+        </div>
+        <div className={styles.mockCard}>
+          <span className={styles.mockChip}>Basic</span>
+          <p className={styles.mockFront}>What is spaced repetition?</p>
+          <div className={styles.mockRule} />
+          <p className={styles.mockBack}>
+            Reviewing material at increasing intervals to fight forgetting.
+          </p>
+        </div>
+        <div className={styles.mockCardSlim}>
+          <span className={styles.mockChip}>Cloze</span>
+          <p className={styles.mockFront}>
+            The mitochondria is the {'{{c1::powerhouse}}'} of the cell.
+          </p>
+        </div>
+        <div className={styles.mockCta}>Export deck</div>
+      </div>
+    </div>
+  );
+}
+
+function MacMockup() {
+  return (
+    <div className={styles.mac} aria-hidden="true">
+      <div className={styles.macBar}>
+        <span className={styles.macDot} />
+        <span className={styles.macDot} />
+        <span className={styles.macDot} />
+        <span className={styles.macBarTitle}>My Decks</span>
+      </div>
+      <div className={styles.macBody}>
+        <div className={styles.macSidebar}>
+          <span className={styles.macNavActive}>Make flashcards</span>
+          <span className={styles.macNav}>My Decks</span>
+          <span className={styles.macNav}>Chat</span>
+          <span className={styles.macNav}>Notion</span>
+          <span className={styles.macNav}>Account</span>
+        </div>
+        <div className={styles.macContent}>
+          <div className={styles.macRow}>
+            <span className={styles.macRowName}>Biology — Chapter 4</span>
+            <span className={styles.macRowMeta}>128 cards</span>
+          </div>
+          <div className={styles.macRow}>
+            <span className={styles.macRowName}>Spanish verbs</span>
+            <span className={styles.macRowMeta}>64 cards</span>
+          </div>
+          <div className={styles.macRow}>
+            <span className={styles.macRowName}>Kindle — Atomic Habits</span>
+            <span className={styles.macRowMeta}>41 cards</span>
+          </div>
+          <div className={styles.macRow}>
+            <span className={styles.macRowName}>USMLE lecture slides</span>
+            <span className={styles.macRowMeta}>210 cards</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function NativeAppPage() {
   const pageViewTracked = useRef(false);
   const [links, setLinks] = useState<AppStoreLinks | null>(null);
@@ -32,45 +173,155 @@ export default function NativeAppPage() {
     };
   }, []);
 
+  const downloadCta = (placement: string) =>
+    links?.available && (
+      <div className={styles.ctaGroup}>
+        <a
+          className={styles.badge}
+          href={links.iosUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() =>
+            track('native_app_store_clicked', { store: 'ios', placement })
+          }
+        >
+          <img src="/badges/app-store.svg" alt="Download on the App Store" />
+        </a>
+        {links.macUrl && (
+          <a
+            className={styles.macLink}
+            href={links.macUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() =>
+              track('native_app_store_clicked', { store: 'mac', placement })
+            }
+          >
+            Also on the Mac App Store →
+          </a>
+        )}
+      </div>
+    );
+
   return (
     <div className={styles.page}>
       <Helmet>
         <title>2anki for iPhone, iPad, and Mac</title>
+        <meta name="description" content={META_DESCRIPTION} />
+        <link rel="canonical" href={CANONICAL} />
+        <meta property="og:title" content="2anki for iPhone, iPad, and Mac" />
+        <meta property="og:description" content={META_DESCRIPTION} />
+        <meta property="og:url" content={CANONICAL} />
+        <meta property="og:type" content="website" />
       </Helmet>
-      <img src="/mascot/Notion 1.png" alt="" className={styles.mascot} />
-      <h1 className={styles.title}>2anki for iPhone, iPad, and Mac</h1>
-      <p className={styles.body}>
-        Convert your notes into Anki decks on the device you study with — no
-        browser needed.
-      </p>
-      {links?.available && (
-        <>
-          <a
-            className={styles.badge}
-            href={links.iosUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={() => track('native_app_store_clicked', { store: 'ios' })}
-          >
-            <img src="/badges/app-store.svg" alt="Download on the App Store" />
-          </a>
-          <p className={styles.caption}>
-            Free on the App Store — iPhone, iPad, and Mac.
+
+      <section className={styles.hero}>
+        <div className={styles.heroCopy}>
+          <span className={styles.pill}>Now on iPhone, iPad &amp; Mac</span>
+          <h1 className={styles.title}>2anki for iPhone, iPad, and Mac</h1>
+          <p className={styles.body}>
+            Convert your notes into Anki decks on the device you study with — no
+            browser needed.
           </p>
-        </>
-      )}
-      {links?.available === false && (
-        <div className={styles.notice}>
-          <p className={styles.noticeTitle}>Coming soon to the App Store</p>
-          <p className={styles.noticeBody}>
-            The app is in final review. Keep using 2anki on the web in the
-            meantime.
+          {downloadCta('hero')}
+          {links?.available && (
+            <p className={styles.caption}>
+              Free on the App Store — iPhone, iPad, and Mac.
+            </p>
+          )}
+          {links?.available === false && (
+            <div className={styles.notice}>
+              <p className={styles.noticeTitle}>Coming soon to the App Store</p>
+              <p className={styles.noticeBody}>
+                The app is in final review. Keep using 2anki on the web in the
+                meantime.
+              </p>
+              <Link to="/" className={sharedStyles.btnPrimary}>
+                Convert a deck on the web
+              </Link>
+            </div>
+          )}
+        </div>
+        <div className={styles.heroArt}>
+          <PhoneMockup />
+        </div>
+      </section>
+
+      <section className={styles.formats}>
+        <p className={styles.formatsLabel}>Converts the files you already have</p>
+        <div className={styles.formatsRow}>
+          {FORMATS.map((f) => (
+            <span key={f} className={styles.formatChip}>
+              {f}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.features}>
+        {FEATURES.map((feature) => (
+          <div key={feature.title} className={styles.featureCard}>
+            <span className={styles.featureIcon} aria-hidden="true">
+              {feature.icon}
+            </span>
+            <h2 className={styles.featureTitle}>{feature.title}</h2>
+            <p className={styles.featureBody}>{feature.body}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className={styles.steps}>
+        <h2 className={styles.sectionHeading}>From file to deck in three steps</h2>
+        <div className={styles.stepsRow}>
+          {STEPS.map((step) => (
+            <div key={step.n} className={styles.stepCard}>
+              <span className={styles.stepNumber}>{step.n}</span>
+              <h3 className={styles.stepTitle}>{step.title}</h3>
+              <p className={styles.stepBody}>{step.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.showcase}>
+        <div className={styles.showcaseCopy}>
+          <h2 className={styles.sectionHeading}>
+            Your whole deck library, on the desktop
+          </h2>
+          <p className={styles.showcaseBody}>
+            Build on your phone on the train, polish on your Mac at the desk.
+            The same on-device engine, the same decks, everywhere you study.
           </p>
+        </div>
+        <div className={styles.showcaseArt}>
+          <MacMockup />
+        </div>
+      </section>
+
+      <section className={styles.faq}>
+        <h2 className={styles.sectionHeading}>Questions</h2>
+        <div className={styles.faqList}>
+          {FAQS.map((faq) => (
+            <details key={faq.q} className={styles.faqItem}>
+              <summary className={styles.faqQuestion}>{faq.q}</summary>
+              <p className={styles.faqAnswer}>{faq.a}</p>
+            </details>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.finalCta}>
+        <h2 className={styles.finalTitle}>Start building decks today</h2>
+        <p className={styles.finalBody}>
+          Free to download. Convert your first file in seconds.
+        </p>
+        {downloadCta('footer')}
+        {links?.available === false && (
           <Link to="/" className={sharedStyles.btnPrimary}>
             Convert a deck on the web
           </Link>
-        </div>
-      )}
+        )}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## What

Total revamp of the `/app` native-app marketing page (`web/src/pages/NativeAppPage`). It went from a bare mascot + one sentence + a single App Store badge to a full landing page that actually sells the iPhone/iPad/Mac app.

New sections:
- **Hero** — eyebrow pill, large headline, value-prop subhead, App Store badge, an optional **Mac App Store** link (renders when the API returns `macUrl`), and a theme-aware **iPhone mockup** of the card-preview screen.
- **Formats strip** — Markdown / PDF / Notion / CSV / OPML / Kindle / `.apkg` chips, showing on-device breadth at a glance.
- **Feature grid** — on-device parsing (privacy), AI chat decks, every format → Anki.
- **How it works** — three steps (drop a file → preview cards → open in Anki), honoring the "app builds decks, Anki reviews" invariant (no study/SRS claims).
- **Desktop showcase** — a CSS Mac-window mockup of the *My Decks* library.
- **FAQ** + **final CTA**.
- **SEO/OG meta** (description, canonical, `og:*`) the stub never had.

## Why

The old page undersold a shipping App Store product — no screenshots, no feature story, no reason to download. This makes `/app` a real marketing surface.

## Screenshots note

The device frames are **pure CSS mockups driven entirely by theme tokens**, so they track every palette (light/dark/sepia/…) with zero image assets. They are **intentional placeholders for real App Store screenshots**, which will swap in via a follow-up PR once captured (see `AppStore/screenshots.md` in the app repo). Chose mockups now so the redesign can ship without blocking on a screenshot capture session.

## Behavior preserved

- Badges render only when `getAppStoreLinks()` returns `available: true`; the **coming-soon notice + web CTA** still show when unavailable.
- Analytics preserved and extended: `native_app_page_viewed` fires once on mount; `native_app_store_clicked` now carries `store` + `placement` (`hero` / `footer`).

## Verification

- `pnpm typecheck` — clean
- `pnpm test:run src/pages/NativeAppPage` — 7 passed
- `pnpm lint` — no new warnings on changed files
- `pnpm build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
