### PR TITLE
fix: drop over-constrained return type breaking server typecheck

### DIFF
--- a/src/data_layer/InactivityEmailRepository.ts
+++ b/src/data_layer/InactivityEmailRepository.ts
@@ -104,9 +104,7 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
     return rows.map((row) => ({ id: row.id, email: row.email }));
   }
 
-  buildDeadAddressCandidatesQuery(
-    limit: number
-  ): Knex.QueryBuilder<UserRow, UserRow[]> {
+  buildDeadAddressCandidatesQuery(limit: number) {
     return this.database<UserRow>('users as u')
       .select('u.id', 'u.email')
       .where(function () {


### PR DESCRIPTION
## What
Remove the explicit `Knex.QueryBuilder<UserRow, UserRow[]>` return annotation on `InactivityEmailRepository.buildDeadAddressCandidatesQuery` and let it infer.

## Why
The method's `.select('u.id', 'u.email')` narrows the builder's result type to a `DeferredKeySelection`, which is **not assignable** to the declared `UserRow[]`. Under a clean `--frozen-lockfile` install (what CI's `static` job does), `tsc` fails:
```
src/data_layer/InactivityEmailRepository.ts(110,5): error TS2322:
Type 'QueryBuilder<UserRow, DeferredKeySelection<...>[]>' is not assignable to type 'QueryBuilder<UserRow, UserRow[]>'.
```
This is **latent on main** — a long-drifted local `node_modules` masks it, but any server-touching PR trips it (surfaced on the `static` job of an unrelated migration PR). It blocks merges for every server PR.

## How
Drop the over-constrained second generic; the inferred builder type is self-consistent. `getDeadAddressCandidates` still does `rows.map(row => ({ id: row.id, email: row.email }))` unchanged — no runtime/behaviour change.

## Testing
Type-only change. Verified `tsc -p . --noEmit` → **EXIT 0** in a fresh `--frozen-lockfile` worktree (the local main checkout passes regardless because its node_modules has drifted from the lockfile — that's exactly why this stayed hidden). Existing `InactivityEmailRepository` tests cover the query behaviour; no behaviour changed.

## Changelog
None — internal type fix, no user-visible behaviour change.

## Goal alignment
None — internal. Unblocks the server CI `static` gate so server PRs can merge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)