### PR TITLE
test: golden-file snapshot for the .apkg conversion path

### DIFF
--- a/src/lib/parser/golden/__snapshots__/conversionGolden.test.ts.snap
+++ b/src/lib/parser/golden/__snapshots__/conversionGolden.test.ts.snap
@@ -1,0 +1,295 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`produces a stable deck for Markdown upload 1`] = `
+[
+  {
+    "cardCount": 4,
+    "cards": [
+      {
+        "back": "<p>Nairobi</p>
+",
+        "front": "<ul>
+<li>What is the capital of Kenya?</li>
+</ul>
+",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "<p>Oslo</p>
+",
+        "front": "<ul>
+<li>What is the capital of Norway</li>
+</ul>
+",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "<p>Stockholm</p>
+",
+        "front": "<ul>
+<li>What is the capital of Sweden</li>
+</ul>
+",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "<p><strong>Helsinki</strong></p>
+",
+        "front": "<ul>
+<li>What is the capital of Finland</li>
+</ul>
+",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+    ],
+    "globalTags": [],
+    "name": "Simple Deck",
+    "styleBytes": 0,
+  },
+]
+`;
+
+exports[`produces a stable deck for Notion cloze export 1`] = `
+[
+  {
+    "cardCount": 10,
+    "cards": [
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>1️⃣{{c1::Canberra}} was founded in 1️⃣{{c2::1913}}.
+						</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::second}} number is 2️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::third}} number is 3️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::fourth}} number is 4️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::fifth}} number is 5️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::sixth}} number is 6️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::seventh}} number is 7️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::eight}} number is 8️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::nineth}} number is 9️⃣</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "
+						<summary class="toggle"></summary>
+					",
+        "front": "<div class='toggle'>The {{c1::tenth}} number is 🔟</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+    ],
+    "globalTags": [],
+    "name": "Grouped Cloze Deletions",
+    "styleBytes": 27554,
+  },
+]
+`;
+
+exports[`produces a stable deck for Notion nested toggles 1`] = `
+[
+  {
+    "cardCount": 1,
+    "cards": [
+      {
+        "back": "
+						<summary class="toggle"></summary>
+						<ul id="0c61603c-a49f-49fd-87c2-4230f074c27d" class="toggle">
+							<li>
+								<details class="toggle">
+									<summary class="toggle">Child - 🍒 Capital of
+										<code>Sweden</code> is
+										<code>Stockholm</code></summary>
+								</details>
+							</li>
+						</ul>
+						<ul id="93c2865d-8751-4b2c-ab93-35c0bd035d3e" class="toggle">
+							<li>
+								<details class="toggle">
+									<summary class="toggle">Grand child - Nested</summary>
+									<ul id="38cea757-9174-4805-9b76-153900721eae" class="toggle">
+										<li>
+											<details class="toggle">
+												<summary class="toggle">🍒 Capital of
+													<code>Albania</code>
+													is
+													<code>Tirana</code>
+												</summary>
+											</details>
+										</li>
+									</ul>
+									<ul id="d385bcab-ba39-4647-8dc6-ddd73848cb62" class="toggle">
+										<li>
+											<details class="toggle">
+												<summary class="toggle">🍒 Capital of
+													<code>Austria</code>
+													is
+													<code>Vienna</code>
+												</summary>
+											</details>
+										</li>
+									</ul>
+									<ul id="3fcf063f-30f1-40b9-b6bf-864e34a0e928" class="toggle">
+										<li>
+											<details class="toggle">
+												<summary class="toggle">🍒 Capital of
+													<code>Azerbaijan</code>
+													is
+													<code>Baku</code>
+												</summary>
+											</details>
+										</li>
+									</ul>
+									<p id="c6879c4f-0e40-4e38-a816-6aa74224186d" class="">
+									</p>
+								</details>
+							</li>
+						</ul>
+					",
+        "front": "<div class='toggle'>Parent - Top level</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+    ],
+    "globalTags": [],
+    "name": "🗺️ Capitals in Europe",
+    "styleBytes": 27554,
+  },
+]
+`;
+
+exports[`produces a stable deck for Notion page with a remote image 1`] = `
+[
+  {
+    "cardCount": 1,
+    "cards": [
+      {
+        "back": "<html><head></head><body><summary class="toggle"></summary>
+<figure class="image"><img src="c97cfbb92381fe7b4b44188669ef61fd7beff685e1c85810e13e53a21fb0fe3f8ed74901c1db96f90834fbe964e9823f8798.png"></figure>
+<p>The mitochondrion.</p></body></html>",
+        "front": "<div class='toggle'>What does the diagram show?</div>",
+        "media": [
+          "c97cfbb92381fe7b4b44188669ef61fd7beff685e1c85810e13e53a21fb0fe3f8ed74901c1db96f90834fbe964e9823f8798.png",
+        ],
+        "tags": [],
+        "type": "cloze",
+      },
+    ],
+    "globalTags": [],
+    "name": "Remote image deck",
+    "styleBytes": 15012,
+  },
+]
+`;
+
+exports[`produces a stable deck for Notion page with an image 1`] = `
+[
+  {
+    "cardCount": 3,
+    "cards": [
+      {
+        "back": "<summary class="toggle"></summary><p id="2429bda0-3b9f-47af-b7d0-c9f2edfab3f3" class=""><strong>This is the back. In bold font.</strong></p>",
+        "front": "<div class='toggle'><strong>Front</strong></div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+      {
+        "back": "<summary class="toggle"></summary><p id="410dc1a5-1b5d-487b-ae39-ef9f5deea236" class=""></p>",
+        "front": "<div class='toggle'><em>Back </em><a href="https://google.com"><strong><em>https://google.com</em></strong></a></div>",
+        "media": [],
+        "tags": [
+          "Colored",
+        ],
+        "type": "cloze",
+      },
+      {
+        "back": "<html><head></head><body><summary class="toggle"></summary><figure id="202b0d67-c058-4bc6-b1ce-9e35b753128b" class="image"><a href="HTML%20test%20202b0d67c0584bc6b1ce9e35b753128b/Skjermbilde_2020-05-13_kl._19.45.08.png"><img style="width:532px" src="Skjermbilde_2020-05-13_kl._19.45.08.png"></a></figure></body></html>",
+        "front": "<div class='toggle'>With an image</div>",
+        "media": [],
+        "tags": [],
+        "type": "cloze",
+      },
+    ],
+    "globalTags": [],
+    "name": "HTML test",
+    "styleBytes": 26220,
+  },
+]
+`;

--- a/src/lib/parser/golden/conversionGolden.test.ts
+++ b/src/lib/parser/golden/conversionGolden.test.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+
+import { setupTests } from '../../../test/configure-jest';
+import CardOption from '../Settings';
+import Deck from '../Deck';
+import { DeckParser } from '../DeckParser';
+import Workspace from '../WorkSpace';
+
+/**
+ * Behaviour-harness golden test for the .apkg conversion path.
+ *
+ * Real users hand us a file and expect a correct deck back. Unit tests cover
+ * individual parser branches, but nothing locks the *whole* shape of a produced
+ * deck — the regressions that break real decks (wrong field in front/back per
+ * #3119, a dropped media reference, a cloze that stopped being a cloze) are
+ * invisible to a green unit suite. This snapshots the stable shape of the deck
+ * model that CustomExporter serializes to deck_info.json — exactly the payload
+ * the Python packager reads. card.media is asserted because create_deck.py only
+ * bundles a file that appears on some card's media array (see
+ * src/lib/ankify/FEATURE.md), so a dropped reference here means a broken deck.
+ *
+ * No Python venv: we read parser.payload directly, so this runs in plain Jest
+ * and in CI. Remote media is mocked with fixed bytes, so media filenames (a
+ * hash of the bytes) are deterministic.
+ *
+ * Regenerate intentionally after a real deck-output change:
+ *   pnpm test -- src/lib/parser/golden/conversionGolden.test.ts -u
+ * Review the snapshot diff like code — an unexpected change is a regression.
+ */
+
+const downloadMediaOrSkipMock = jest.fn<Promise<Buffer | null>, [string]>();
+
+jest.mock(
+  '../../../services/NotionService/helpers/downloadMediaOrSkip',
+  () => ({
+    __esModule: true,
+    downloadMediaOrSkip: (url: string) => downloadMediaOrSkipMock(url),
+  })
+);
+
+beforeEach(() => {
+  setupTests();
+  downloadMediaOrSkipMock.mockReset();
+  downloadMediaOrSkipMock.mockResolvedValue(
+    Buffer.from('golden-fixture-bytes')
+  );
+});
+
+function cardType(card: Deck['cards'][number]): string {
+  if (card.cloze) return 'cloze';
+  if (card.mcq) return 'mcq';
+  if (card.enableInput) return 'input';
+  return 'basic';
+}
+
+function snapshotShape(payload: Deck[]) {
+  return payload.map((deck) => ({
+    name: deck.name,
+    cardCount: deck.cards.length,
+    globalTags: deck.globalTags,
+    styleBytes: (deck.style ?? '').length,
+    cards: deck.cards.map((card) => ({
+      type: cardType(card),
+      ...(card.customModelName ? { modelName: card.customModelName } : {}),
+      front: card.name,
+      back: card.back,
+      tags: card.tags,
+      media: card.media,
+    })),
+  }));
+}
+
+async function convert(file: string, opts = new CardOption({})) {
+  const workspace = new Workspace(true, 'fs');
+  const contents = fs
+    .readFileSync(path.join(__dirname, '../../../test/fixtures', file))
+    .toString();
+  const parser = new DeckParser({
+    name: file,
+    settings: opts,
+    files: [{ name: file, contents }],
+    noLimits: true,
+    workspace,
+  });
+  await parser.build(workspace);
+  return snapshotShape(parser.payload);
+}
+
+const cases: [string, string, CardOption][] = [
+  [
+    'Notion cloze export',
+    'Grouped Cloze Deletions fbf856ad7911423dbef0bfd3e3c5ce5c 3.html',
+    new CardOption({}),
+  ],
+  ['Notion nested toggles', 'Nested Toggles.html', new CardOption({})],
+  ['Notion page with an image', 'with-image.html', new CardOption({})],
+  [
+    'Notion page with a remote image',
+    'golden-remote-image.html',
+    new CardOption({}),
+  ],
+  [
+    'Markdown upload',
+    'simple-deck.md',
+    new CardOption({ 'markdown-nested-bullet-points': 'true' }),
+  ],
+];
+
+it.each(cases)('produces a stable deck for %s', async (_label, file, opts) => {
+  const shape = await convert(file, opts);
+  expect(shape).toMatchSnapshot();
+});

--- a/src/test/fixtures/golden-remote-image.html
+++ b/src/test/fixtures/golden-remote-image.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"/><title>Remote image deck</title></head>
+<body><article class="page sans"><header><h1 class="page-title">Remote image deck</h1></header><div class="page-body">
+<ul class="toggle"><li><details open=""><summary>What does the diagram show?</summary>
+<figure class="image"><img src="https://example.com/assets/diagram.png"/></figure>
+<p>The mitochondrion.</p></details></li></ul>
+</div></article></body></html>


### PR DESCRIPTION
Closes #3428.

## Why

The harness review (PR #3427) found the **behaviour harness** the weakest category: unit tests cover individual parser branches, but nothing locked the *whole shape* of a produced deck. The regressions that actually break real decks — wrong field in front/back (#3119), a dropped media reference, a cloze that stopped being a cloze — are invisible to a green unit suite.

## What

A golden-file snapshot over the conversion hot path. It snapshots the stable shape of the deck model that `CustomExporter` serializes to `deck_info.json` — the exact payload the Python packager reads — for five real fixtures:

| Fixture | Locks |
|---|---|
| Notion cloze export | cloze cards stay cloze, front/back rendering |
| Notion nested toggles | nested toggle → card shape |
| Local-image page (`with-image.html`) | relative image with no bytes → no media, no crash |
| Remote-image page (new fixture) | **media passthrough** — `card.media` filename matches the rewritten `<img src>` |
| Markdown upload | markdown → cards |

`card.media` is asserted because `create_deck.py` only bundles a file that appears on a card's media array (`src/lib/ankify/FEATURE.md`) — a dropped reference there means a broken deck.

## Why no Python venv (the #3428 concern)

The test reads `parser.payload` directly rather than producing a real `.apkg`, so it runs in plain Jest and in CI — no `create_deck/` venv, no `SKIP_CREATE_DECK` gymnastics. `deck_info.json` *is* the stable shape; the genanki step is a thin deterministic packager downstream of it. Remote media is mocked with fixed bytes, so the hash-derived media filename is deterministic — **verified by running twice with zero snapshot rewrites**.

Regenerate intentionally after a real deck-output change:
```
pnpm test -- src/lib/parser/golden/conversionGolden.test.ts -u
```
Review the snapshot diff like code — an unexpected change is a regression.

## Notes

- `test:` — no source change, no user-visible behaviour → no changelog entry.
- No source logic changed → local `sonar-scanner` skipped per `.claude/rules/sonar.md`.
- No `web/src/` files → browser-attestation gate N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
