### PR TITLE
test: lock full rendered HTML for a mixed Notion block tree

### DIFF
--- a/src/lib/notion-render/golden/__snapshots__/renderBlocksGolden.test.ts.snap
+++ b/src/lib/notion-render/golden/__snapshots__/renderBlocksGolden.test.ts.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`produces a stable rendered page for a mixed Notion block tree 1`] = `
+{
+  "html": "<h1>Cell biology</h1>
+<p><span class="n2a-highlight-red" style="color: #E03E3E">A quick review.</span></p>
+<ul><li>Mitochondria</li><li>Ribosomes</li></ul>
+<img src="ankify-diagram1.png">
+<ul><li>Nucleus</li></ul>
+<ol><li>First</li><li>Second</li></ol>
+<div class="todo">☐ Memorise the diagram</div>
+<blockquote>The cell is the unit of life.</blockquote>
+<pre><code class="hljs language-javascript"><span class="hljs-keyword">const</span> atp = <span class="hljs-title function_">synthesise</span>();</code></pre>
+\\[E = mc^2\\]
+<hr>
+<div class="callout">💡 Exam tip<p>Cells were first observed by Hooke.</p></div>
+<details><summary>Reveal answer</summary><p>ATP is the energy currency.</p></details>
+[sound:ankify-audio1.mp3]
+<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ?" frameborder="0" allowfullscreen></iframe>
+<a href="https://example.com/source">https://example.com/source</a>",
+  "media": [
+    {
+      "block_id": "diagram1",
+      "filename": "ankify-diagram1.png",
+      "kind": "image",
+      "source": "external",
+      "url": "https://x/cell.png",
+    },
+    {
+      "block_id": "audio1",
+      "filename": "ankify-audio1.mp3",
+      "kind": "audio",
+      "source": "external",
+      "url": "https://x/pronounce.mp3",
+    },
+    {
+      "block_id": "video1",
+      "kind": "video",
+      "source": "external",
+      "url": "https://youtu.be/dQw4w9WgXcQ",
+    },
+  ],
+}
+`;

--- a/src/lib/notion-render/golden/renderBlocksGolden.test.ts
+++ b/src/lib/notion-render/golden/renderBlocksGolden.test.ts
@@ -1,0 +1,142 @@
+import { renderNotionBlocks } from '../renderBlocks';
+import { NotionBlockChildrenFetcher, NotionRenderableBlock } from '../types';
+
+/**
+ * Approval (golden) test for the Notion block renderer.
+ *
+ * The unit tests next door each render ONE block type in isolation with an
+ * exact `toBe`. They are precise but blind to interaction: list grouping that
+ * flushes around an intervening media block, output ordering across a mixed
+ * page, and the media[] array accumulating refs from several blocks at once.
+ * A regression in any of those leaves every isolated unit test green.
+ *
+ * This locks the WHOLE rendered shape of one representative page — a "kitchen
+ * sink" that exercises text, color wrapping, both list kinds, to-do, quote,
+ * code, equation, divider, a callout with nested children, a nested toggle,
+ * and image / audio / video media — and verifies the produced {html, media}
+ * in a single comparison. One verify replaces the dozens of assertions this
+ * mixed tree would otherwise need (Bache, Approval Testing).
+ *
+ * Output is deterministic: media filenames derive from block.id, and there is
+ * no time or randomness in the renderer, so no mocking is required.
+ *
+ * Regenerate intentionally after a real renderer change:
+ *   pnpm test -- src/lib/notion-render/golden/renderBlocksGolden.test.ts -u
+ * Review the snapshot diff like code — an unexpected change is a regression.
+ */
+
+const para = (text: string): NotionRenderableBlock => ({
+  type: 'paragraph',
+  paragraph: { rich_text: [{ plain_text: text }] },
+});
+
+const fetcherFor = (
+  byParent: Record<string, NotionRenderableBlock[]>
+): NotionBlockChildrenFetcher => {
+  return async (id: string) => byParent[id] ?? [];
+};
+
+const kitchenSinkPage: NotionRenderableBlock[] = [
+  {
+    type: 'heading_1',
+    heading_1: { rich_text: [{ plain_text: 'Cell biology' }] },
+  },
+  {
+    type: 'paragraph',
+    paragraph: {
+      rich_text: [{ plain_text: 'A quick review.' }],
+      color: 'red',
+    },
+  },
+  {
+    type: 'bulleted_list_item',
+    bulleted_list_item: { rich_text: [{ plain_text: 'Mitochondria' }] },
+  },
+  {
+    type: 'bulleted_list_item',
+    bulleted_list_item: { rich_text: [{ plain_text: 'Ribosomes' }] },
+  },
+  {
+    type: 'image',
+    id: 'diagram1',
+    image: { type: 'external', external: { url: 'https://x/cell.png' } },
+  },
+  {
+    type: 'bulleted_list_item',
+    bulleted_list_item: { rich_text: [{ plain_text: 'Nucleus' }] },
+  },
+  {
+    type: 'numbered_list_item',
+    numbered_list_item: { rich_text: [{ plain_text: 'First' }] },
+  },
+  {
+    type: 'numbered_list_item',
+    numbered_list_item: { rich_text: [{ plain_text: 'Second' }] },
+  },
+  {
+    type: 'to_do',
+    to_do: {
+      rich_text: [{ plain_text: 'Memorise the diagram' }],
+      checked: false,
+    },
+  },
+  {
+    type: 'quote',
+    quote: { rich_text: [{ plain_text: 'The cell is the unit of life.' }] },
+  },
+  {
+    type: 'code',
+    code: {
+      rich_text: [{ plain_text: 'const atp = synthesise();' }],
+      language: 'javascript',
+    },
+  },
+  { type: 'equation', equation: { expression: 'E = mc^2' } },
+  { type: 'divider', divider: {} },
+  {
+    type: 'callout',
+    id: 'callout1',
+    has_children: true,
+    callout: {
+      rich_text: [{ plain_text: 'Exam tip' }],
+      icon: { type: 'emoji', emoji: '💡' },
+    },
+  },
+  {
+    type: 'toggle',
+    id: 'toggle1',
+    has_children: true,
+    toggle: { rich_text: [{ plain_text: 'Reveal answer' }] },
+  },
+  {
+    type: 'audio',
+    id: 'audio1',
+    audio: { type: 'external', external: { url: 'https://x/pronounce.mp3' } },
+  },
+  {
+    type: 'video',
+    id: 'video1',
+    video: {
+      type: 'external',
+      external: { url: 'https://youtu.be/dQw4w9WgXcQ' },
+    },
+  },
+  {
+    type: 'bookmark',
+    id: 'bm1',
+    bookmark: { url: 'https://example.com/source' },
+  },
+];
+
+const childrenByParent = {
+  callout1: [para('Cells were first observed by Hooke.')],
+  toggle1: [para('ATP is the energy currency.')],
+};
+
+it('produces a stable rendered page for a mixed Notion block tree', async () => {
+  const out = await renderNotionBlocks(
+    kitchenSinkPage,
+    fetcherFor(childrenByParent)
+  );
+  expect(out).toMatchSnapshot();
+});


### PR DESCRIPTION
## What

Adds one approval (golden) test for `renderNotionBlocks` over a representative kitchen-sink Notion page, snapshotting the produced `{html, media}` in a single comparison.

## Why

The existing `renderBlocks.test.ts` unit tests each render **one block type in isolation** with an exact `toBe`. Precise, but blind to cross-block interaction — and those are the regressions that break real decks:

- an intervening **image splitting a bulleted list** into two separate `<ul>` elements
- **output ordering** across a mixed page
- the **media[] array accumulating** image→audio→video refs in document order

A break in any of those leaves the whole unit suite green. This locks the whole rendered shape, following the `conversionGolden.test.ts` convention (one verify replaces the dozens of assertions a mixed tree would otherwise need).

The accepted snapshot also documents one cosmetic oddity worth a later look: the YouTube embed renders a trailing empty query string (`embed/<id>?`).

## Metric impact

None — internal test coverage. Hardens the Notion→Anki render path (the core conversion product) against silent regressions.

Browser check: not applicable — server-side Jest test, no `web/src/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)