### PR TITLE
fix: stop logging malformed-JSON scanner probes as server errors

### DIFF
--- a/src/routes/middleware/ErrorCaptureMiddleware.test.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.test.ts
@@ -225,6 +225,38 @@ describe('makeErrorCaptureMiddleware', () => {
     expect(repo.inserts[0].context).toBeNull();
   });
 
+  it('does not record a malformed-JSON body-parser error (scanner noise)', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+    const parseError = Object.assign(
+      new SyntaxError('Unexpected token t in JSON at position 0'),
+      {
+        type: 'entity.parse.failed',
+        status: 400,
+        statusCode: 400,
+        expose: true,
+      }
+    );
+
+    await middleware(parseError, makeReq('/_bulk'), makeRes(), next);
+
+    expect(repo.inserts).toHaveLength(0);
+    expect(next).toHaveBeenCalledWith(parseError);
+  });
+
+  it('still records a genuine SyntaxError without the body-parser type tag', async () => {
+    const repo = makeRepository();
+    const middleware = makeErrorCaptureMiddleware(repo);
+    const next = makeNext();
+    const realError = new SyntaxError('thrown by our own code');
+
+    await middleware(realError, makeReq('/api/upload'), makeRes(), next);
+
+    expect(repo.inserts).toHaveLength(1);
+    expect(next).toHaveBeenCalledWith(realError);
+  });
+
   it('calls writeFallback with db-outage phase when the repository insert fails', async () => {
     const brokenRepo: IErrorEventRepository = {
       async insert() {

--- a/src/routes/middleware/ErrorCaptureMiddleware.ts
+++ b/src/routes/middleware/ErrorCaptureMiddleware.ts
@@ -14,6 +14,16 @@ function sha256(value: string): string {
 
 type FallbackWriter = (payload: FallbackErrorPayload) => void;
 
+/**
+ * body-parser tags a request with an unparseable JSON body as
+ * `entity.parse.failed`. These are overwhelmingly scanner probes POSTing
+ * garbage to exploit paths (/_bulk, /jeecg-boot/..., telemetry endpoints) —
+ * a client fault, not a server error. Recording them buries real crashes in
+ * the error dashboard. ErrorHandler still returns 400 to the caller.
+ */
+const isMalformedRequestBody = (err: Error): boolean =>
+  (err as { type?: string })?.type === 'entity.parse.failed';
+
 export const makeErrorCaptureMiddleware = (
   repository: IErrorEventRepository,
   writeFallback?: FallbackWriter,
@@ -25,6 +35,10 @@ export const makeErrorCaptureMiddleware = (
     res: Response,
     next: NextFunction
   ): Promise<void> => {
+    if (isMalformedRequestBody(err)) {
+      next(err);
+      return;
+    }
     try {
       const message = err?.message ?? String(err);
       const messageHash = sha256(message);


### PR DESCRIPTION
## Problem

From the 2026-06-19 error review: **5 of 10 error groups were the same non-bug.** Bots POST garbage JSON to exploit paths (`/_bulk` = Elasticsearch, `/jeecg-boot/jmreport/show`, `/analytics/telemetry/ph/...` = PostHog probe, `/`). `express.json()` throws a `SyntaxError` tagged `entity.parse.failed`, and `makeErrorCaptureMiddleware` recorded each as a `source: 'server'` error — burying real crashes in the dashboard.

`rejectScannerProbes` only catches GET + file-extension probes, so these POST-JSON probes slipped through to the capture layer.

## Fix

The capture middleware now short-circuits on `err.type === 'entity.parse.failed'` and calls `next(err)` without recording. `ErrorHandler` still returns 400 to the caller, so the (bot) client sees no change. A genuine `SyntaxError` thrown by our own code lacks the body-parser type tag and is still recorded.

## Tests

TDD — two new cases in `ErrorCaptureMiddleware.test.ts`:
- malformed-JSON body-parser error → **not** recorded, still `next(err)`
- real `SyntaxError` without the type tag → still recorded

15/15 green, tsc clean.

## Metric impact

None directly — internal observability hygiene. Clears 5 noise groups so real production crashes (the ones that actually cost users decks) surface instead of drowning.

Browser check: not applicable — server-side middleware, no `web/src/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)