### PR TITLE
fix: reload when a lazy page chunk loads without a default export

### DIFF
--- a/web/src/lib/chunkReload.test.ts
+++ b/web/src/lib/chunkReload.test.ts
@@ -264,6 +264,48 @@ describe('lazyWithRetry', () => {
     ).toBeNull();
   });
 
+  it('reloads once when the chunk loads but is missing a default export', async () => {
+    const factory = vi.fn(async () => ({}) as { default: React.ComponentType });
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    void readLazyFactory(Component);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(reloadMock).toHaveBeenCalledOnce();
+    expect(
+      sessionStorage.getItem(`${PER_CHUNK_KEY_PREFIX}./pages/Foo`)
+    ).not.toBeNull();
+    expect(sessionStorage.getItem(RELOADING_FLAG_KEY)).toBe('1');
+  });
+
+  it('reloads once when the chunk resolves to a null module', async () => {
+    const factory = vi.fn(
+      async () => null as unknown as { default: React.ComponentType }
+    );
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    void readLazyFactory(Component);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(reloadMock).toHaveBeenCalledOnce();
+  });
+
+  it('throws a chunk-load error on a second missing-default load → no reload', async () => {
+    sessionStorage.setItem(
+      `${PER_CHUNK_KEY_PREFIX}./pages/Foo`,
+      String(Date.now())
+    );
+    const factory = vi.fn(async () => ({}) as { default: React.ComponentType });
+    const Component = lazyWithRetry(factory, './pages/Foo');
+
+    await expect(readLazyFactory(Component)).rejects.toSatisfy(
+      isChunkLoadError
+    );
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
   it('reloads independently for a different chunk key on the same session', async () => {
     sessionStorage.setItem(
       `${PER_CHUNK_KEY_PREFIX}./pages/Foo`,

--- a/web/src/lib/chunkReload.ts
+++ b/web/src/lib/chunkReload.ts
@@ -71,6 +71,26 @@ export function isReloadingForFreshChunks(): boolean {
   }
 }
 
+function reloadOnceForChunk<T>(
+  chunkKey: string,
+  error: Error
+): Promise<{ default: T }> {
+  const perChunkKey = `${PER_CHUNK_KEY_PREFIX}${chunkKey}`;
+  if (sessionStorage.getItem(perChunkKey) != null) {
+    throw error;
+  }
+  if (
+    typeof document !== 'undefined' &&
+    document.visibilityState !== 'visible'
+  ) {
+    throw error;
+  }
+  sessionStorage.setItem(perChunkKey, String(Date.now()));
+  markReloading();
+  location.reload();
+  return new Promise<{ default: T }>(() => {});
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- React.lazy's generic requires ComponentType<any> to preserve route component prop shapes.
 export function lazyWithRetry<T extends ComponentType<any>>(
   factory: () => Promise<{ default: T }>,
@@ -78,25 +98,19 @@ export function lazyWithRetry<T extends ComponentType<any>>(
 ): LazyExoticComponent<T> {
   return lazy<T>(async () => {
     try {
-      return await factory();
+      const mod = await factory();
+      if (mod == null || (mod as { default?: T }).default == null) {
+        return reloadOnceForChunk<T>(
+          chunkKey,
+          new Error('Importing a module script failed.')
+        );
+      }
+      return mod;
     } catch (error) {
       if (!isChunkLoadError(error)) {
         throw error;
       }
-      const perChunkKey = `${PER_CHUNK_KEY_PREFIX}${chunkKey}`;
-      if (sessionStorage.getItem(perChunkKey) != null) {
-        throw error;
-      }
-      if (
-        typeof document !== 'undefined' &&
-        document.visibilityState !== 'visible'
-      ) {
-        throw error;
-      }
-      sessionStorage.setItem(perChunkKey, String(Date.now()));
-      markReloading();
-      location.reload();
-      return new Promise<{ default: T }>(() => {});
+      return reloadOnceForChunk<T>(chunkKey, error as Error);
     }
   });
 }


### PR DESCRIPTION
## Problem

From the 2026-06-19 error review, **3 web error groups** (#4 `/register`, #7 `/login`, #8 `/card-options`):

```
TypeError: Cannot read properties of undefined (reading 'default')
undefined is not an object (evaluating 'e._result.default')
can't access property "default", e._result is undefined
```

`lazyWithRetry` only recovered when the dynamic import **rejected**. After a deploy purges old hashed chunks, a stale tab can fetch a chunk that resolves HTTP-OK but evaluates to a module with **no default export** (partial/mismatched asset). The factory resolves, the catch never fires, and React throws `reading 'default'` from its internals — which `isChunkLoadError` doesn't match, so `RootErrorBoundary` reports it as a generic crash instead of offering a reload.

## Fix

A route's lazy page module always has a `default` by contract → loaded-but-missing-default is always a bad load. After `await factory()`, if the module is null or lacks `default`, route it through the **same reload-once recovery** as a thrown chunk error (synthesising `Importing a module script failed.` so a second failure is recognised as a chunk load and the boundary shows the friendly reload UI). Reload logic extracted to `reloadOnceForChunk`, shared by both paths.

## Tests

TDD — 3 new cases: missing-default → reload once; null module → reload once; second missing-default load → throws a chunk-load error, no reload. 2036/2036 vitest green, typecheck + oxlint clean.

## Metric impact

None directly — reliability. Stale-tab users after a deploy get a silent reload to the fresh build instead of a dead page on `/register` / `/login` — i.e. fewer broken signups/logins right after we ship.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: backed by a green `pnpm --filter 2anki-web test:golden-path` run (2 passed, 375px viewport, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)