### PR TITLE
fix: stop reporting expected 4xx client faults to /ops/errors

### DIFF
--- a/web/src/lib/reportClientError.test.ts
+++ b/web/src/lib/reportClientError.test.ts
@@ -142,6 +142,29 @@ describe('reportClientError', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it.each([400, 404, 409, 429])(
+    'skips expected client-fault errors carrying a %s status',
+    (status) => {
+      const err = Object.assign(new Error('Resource not found'), { status });
+      reportClientError(err);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  it('still reports a server-fault error carrying a 500 status', () => {
+    const err = Object.assign(new Error('HTTP error! status: 500'), {
+      status: 500,
+    });
+    reportClientError(err);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it('still reports an error with a 0 status (network failure shape)', () => {
+    const err = Object.assign(new Error('boom'), { status: 0 });
+    reportClientError(err);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
   it.each([
     'Failed to fetch',
     'NetworkError when attempting to fetch resource.',

--- a/web/src/lib/reportClientError.ts
+++ b/web/src/lib/reportClientError.ts
@@ -27,6 +27,18 @@ function isAbortError(error: unknown): boolean {
   );
 }
 
+/**
+ * Errors from api.ts carry a numeric `status` (set by taggedHttpError). A 4xx
+ * is a client fault — an expired preview (404), a duplicate signup (409), a
+ * rate limit (429) — not a bug to investigate. Recording these buries real
+ * crashes in /ops/errors. The mirror of the server-side entity.parse.failed
+ * skip. 5xx and status 0 (network failure shape) still report.
+ */
+function isExpectedClientFault(error: unknown): boolean {
+  const status = (error as { status?: unknown })?.status;
+  return typeof status === 'number' && status >= 400 && status < 500;
+}
+
 export function reportClientError(
   error: unknown,
   context?: Record<string, unknown>
@@ -34,6 +46,7 @@ export function reportClientError(
   if (error instanceof UserNotice) return;
   if (isAbortError(error)) return;
   if (isDomManipulationError(error)) return;
+  if (isExpectedClientFault(error)) return;
   try {
     if (navigator.onLine === false) return;
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Problem

From the 2026-06-19 error review: `GET /api/apkg/<key>/cards status: 404` (#2) showed up in `/ops/errors` as a web error group. It's thrown when the apkg temp file was reaped between preview load and the cards fetch — a client-fault 404, not a bug. `reportClientError` had no HTTP-status filter (only UserNotice / AbortError / DOM / offline / transient-network), so every 4xx from `api.ts` got recorded, burying real crashes.

This is the web mirror of #3436 (server-side `entity.parse.failed` skip).

## Fix

Errors from `api.ts` carry a numeric `status` (set by `taggedHttpError`). `reportClientError` now skips an error whose `status` is 400–499. 5xx and `status: 0` (the network-failure shape) still report. The `PreviewApkgPage` UI is unchanged — it already renders a retry presenter; this only stops the dashboard noise.

## Tests

TDD — 4xx (400/404/409/429) skipped; 500 still reported; status 0 still reported. 2042/2042 vitest green, typecheck + oxlint clean.

## Not in this PR — #1 "account already exists"

Investigated: `RegisterForm` is the only web register caller, and its 400 + "already exists" path string-matches to the in-form recovery panel and **never calls the reporter**. The backend returns **400** (not 409) for a duplicate, so there's no live code path producing that dashboard group — the 5 occurrences are historical (stale cached bundles, which #3437 now auto-reloads). Safe to resolve in `/ops/errors`; watch for recurrence post-deploy. Changing the backend to a semantic 409 was rejected — the iOS app also consumes `register` and keys on the current status.

## Metric impact

None directly — observability hygiene. Clears the apkg-preview 404 group + future 4xx noise (rate limits, etc.) so real crashes surface.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: backed by a green `pnpm --filter 2anki-web test:golden-path` run (2 passed, 375px, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)