### PR TITLE
feat: version deploys with TrunkVer instead of a static 2.0.0

### DIFF
--- a/.github/workflows/deploy.2anki.net.yml
+++ b/.github/workflows/deploy.2anki.net.yml
@@ -19,6 +19,8 @@ jobs:
         uses: appleboy/ssh-action@v1.2.5
         env:
           GIT_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           ASSET_BASE_URL: ${{ secrets.ASSET_BASE_URL }}
           SPACES_ASSETS_ACCESS_KEY_ID: ${{ secrets.SPACES_ASSETS_ACCESS_KEY_ID }}
           SPACES_ASSETS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_ASSETS_SECRET_ACCESS_KEY }}
@@ -28,7 +30,7 @@ jobs:
           host: 2anki.net
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: GIT_SHA,ASSET_BASE_URL,SPACES_ASSETS_ACCESS_KEY_ID,SPACES_ASSETS_SECRET_ACCESS_KEY,SPACES_ASSETS_BUCKET,SPACES_ASSETS_REGION
+          envs: GIT_SHA,RUN_ID,RUN_ATTEMPT,ASSET_BASE_URL,SPACES_ASSETS_ACCESS_KEY_ID,SPACES_ASSETS_SECRET_ACCESS_KEY,SPACES_ASSETS_BUCKET,SPACES_ASSETS_REGION
           script: |
             set -e
             set -o pipefail
@@ -48,6 +50,15 @@ jobs:
             git -C ${SERVER_DIR} reset --hard origin/main
             git -C ${SERVER_DIR} clean -fd
 
+            # TrunkVer for this artifact: when (UTC build time) . what (deployed
+            # short sha) . where (this Actions run, the build log). Exported as
+            # RELEASE so resolveRelease() surfaces it on /api/version and every
+            # /ops/errors group. GIT_SHA is left untouched — the blue-green
+            # health check still verifies /api/version .sha == GIT_SHA.
+            TRUNKVER="$(date -u +%Y%m%d%H%M%S).0.0-g$(git -C ${SERVER_DIR} rev-parse --short HEAD)-${RUN_ID}-${RUN_ATTEMPT}"
+            export RELEASE="$TRUNKVER"
+            echo "TrunkVer: $RELEASE"
+
             pnpm --dir ${SERVER_DIR} install --frozen-lockfile
             pnpm --dir ${SERVER_DIR} exec puppeteer browsers install chrome
             pip install -r ${SERVER_DIR}/create_deck/requirements.txt
@@ -60,7 +71,7 @@ jobs:
             aws --version
 
             pnpm --dir ${SERVER_DIR} run build
-            ASSET_BASE_URL="$ASSET_BASE_URL" REACT_APP_RELEASE="$GIT_SHA" pnpm --filter 2anki-web -C ${SERVER_DIR} build
+            ASSET_BASE_URL="$ASSET_BASE_URL" REACT_APP_RELEASE="$RELEASE" pnpm --filter 2anki-web -C ${SERVER_DIR} build
 
             echo "Syncing web/build/assets/ to s3://${SPACES_ASSETS_BUCKET}/assets/..."
             AWS_ACCESS_KEY_ID="$SPACES_ASSETS_ACCESS_KEY_ID" \

--- a/migrations/20260913000000_widen_error_events_release_for_trunkver.js
+++ b/migrations/20260913000000_widen_error_events_release_for_trunkver.js
@@ -1,0 +1,16 @@
+// Widen error_events.release from varchar(40) to varchar(64) so a full
+// TrunkVer (timestamp.0.0-g<sha>-<buildref>, ~44 chars with a 12-char short
+// sha) fits without truncating its build reference — the part that links an
+// error group back to its build log. Increasing a varchar length limit is a
+// metadata-only change in Postgres (no table rewrite, no lock of note).
+exports.up = async (knex) => {
+  await knex.schema.alterTable('error_events', (t) => {
+    t.string('release', 64).nullable().alter();
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('error_events', (t) => {
+    t.string('release', 40).nullable().alter();
+  });
+};

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -99,6 +99,10 @@ log "current=$CURRENT (:$CURRENT_PORT) next=$NEXT (:$NEXT_PORT) sha=$GIT_SHA"
 
 cd "$SERVER_DIR"
 export GIT_SHA
+# RELEASE carries the TrunkVer when the deploy workflow set it; pm2 --update-env
+# forwards it to the app so resolveRelease() reports it. Unset on a manual run
+# is fine — resolveRelease() falls back to GIT_SHA.
+export RELEASE
 
 # Bring up the next color; pm2 keeps the current color serving on its port.
 run pm2 start "$ECOSYSTEM" --only "server-$NEXT" --update-env

--- a/src/lib/release.test.ts
+++ b/src/lib/release.test.ts
@@ -20,9 +20,14 @@ describe('normalizeRelease', () => {
     expect(normalizeRelease('  abc1234\n')).toBe('abc1234');
   });
 
-  it('caps non-sha values at 40 chars to fit the column', () => {
-    const long = 'x'.repeat(60);
-    expect(normalizeRelease(long)).toBe('x'.repeat(40));
+  it('caps non-sha values at 64 chars to fit the column', () => {
+    const long = 'x'.repeat(80);
+    expect(normalizeRelease(long)).toBe('x'.repeat(64));
+  });
+
+  it('keeps a full TrunkVer intact (timestamp.0.0-g<sha>-<buildref>)', () => {
+    const trunkver = '20260619125336.0.0-g4579478f93dc-20652898919-1';
+    expect(normalizeRelease(trunkver)).toBe(trunkver);
   });
 });
 

--- a/src/lib/release.ts
+++ b/src/lib/release.ts
@@ -1,7 +1,9 @@
 import { execFileSync } from 'node:child_process';
 
 const SHORT_SHA_LENGTH = 7;
-const MAX_RELEASE_LENGTH = 40;
+// Wide enough for a full TrunkVer (timestamp.0.0-g<sha>-<buildref>); the
+// error_events.release column is varchar(64) to match.
+const MAX_RELEASE_LENGTH = 64;
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/i;
 
 export function normalizeRelease(

--- a/src/services/VersionService.test.ts
+++ b/src/services/VersionService.test.ts
@@ -2,13 +2,19 @@ import VersionService from './VersionService';
 
 describe('VersionService', () => {
   const originalSha = process.env.GIT_SHA;
+  const originalRelease = process.env.RELEASE;
+
+  const restore = (key: 'GIT_SHA' | 'RELEASE', value: string | undefined) => {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  };
 
   afterEach(() => {
-    if (originalSha === undefined) {
-      delete process.env.GIT_SHA;
-    } else {
-      process.env.GIT_SHA = originalSha;
-    }
+    restore('GIT_SHA', originalSha);
+    restore('RELEASE', originalRelease);
   });
 
   it('returns package.json version + GIT_SHA from env', () => {
@@ -21,5 +27,12 @@ describe('VersionService', () => {
   it('falls back to "unknown" when GIT_SHA is unset (local dev)', () => {
     delete process.env.GIT_SHA;
     expect(new VersionService().getVersion().sha).toBe('unknown');
+  });
+
+  it('reports the TrunkVer from RELEASE as the release', () => {
+    process.env.RELEASE = '20260619125336.0.0-g4579478f93dc-20652898919-1';
+    expect(new VersionService().getVersion().release).toBe(
+      '20260619125336.0.0-g4579478f93dc-20652898919-1'
+    );
   });
 });

--- a/src/services/VersionService.ts
+++ b/src/services/VersionService.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import { resolvePath } from '../lib/constants';
+import { resolveRelease } from '../lib/release';
 
 const appInfo = JSON.parse(
   fs.readFileSync(resolvePath(__dirname, '../../package.json')).toString()
@@ -9,6 +10,7 @@ const appInfo = JSON.parse(
 export interface VersionInfo {
   version: string;
   sha: string;
+  release: string;
 }
 
 class VersionService {
@@ -16,6 +18,7 @@ class VersionService {
     return {
       version: appInfo.version,
       sha: process.env.GIT_SHA ?? 'unknown',
+      release: resolveRelease() ?? 'unknown',
     };
   }
 }


### PR DESCRIPTION
Tries out [TrunkVer](https://github.com/crftd-tech/trunkver) (crftd.tech) on 2anki.

## Why it fits

2anki is trunk-based, blue-green continuously-delivered, with no SemVer release ceremony — TrunkVer's exact target. Today the artifact is versioned by a static `package.json` `2.0.0` plus a bare short sha in the `/ops/errors` `release` field: a group tells you *what* shipped but not *when* or *where to find the build log*.

## What ships

Each deploy stamps a TrunkVer — `<utc-timestamp>.0.0-g<short-sha>-<run-id>-<attempt>`, e.g. `20260619125336.0.0-g4579478-20652898919-1` — exported as `RELEASE`:
- **when** = UTC build timestamp · **what** = deployed short sha · **where** = the Actions run id (the build log)
- `resolveRelease()` already prefers `RELEASE`, so it surfaces on every `/ops/errors` group **and** on `/api/version` (new `release` field)
- SemVer-syntax-compatible drop-in (timestamp replaces MAJOR)

## Safety — blue-green health check untouched

`GIT_SHA` is **left exactly as-is**. The cutover still verifies `/api/version` `.sha == GIT_SHA`; TrunkVer rides the separate `release` field. `blue-green.sh` exports `RELEASE` so `pm2 --update-env` forwards it to the process.

## Changes

| File | What |
|---|---|
| `.github/workflows/deploy.2anki.net.yml` | generate TrunkVer on the box (passes `github.run_id`/`run_attempt`), export `RELEASE`, feed web build |
| `scripts/deploy-blue-green.sh` | `export RELEASE` before `pm2 start --update-env` |
| `migrations/...widen_error_events_release...` | `release` varchar(40)→(64) so a full TrunkVer fits (metadata-only widen, no rewrite) |
| `src/lib/release.ts` | `MAX_RELEASE_LENGTH` 40→64 |
| `src/services/VersionService.ts` | add `release` to `/api/version` |

## Tests

TDD — `release.test.ts` (64-cap + full-TrunkVer-intact), `VersionService.test.ts` (reports RELEASE). 13/13 green, tsc clean, migration up/down smoke-tested on sqlite, workflow YAML + `bash -n` validated.

## Metric impact

None directly — delivery/observability. Closes the loop on the error-triage work: each `/ops/errors` group now links to its build log.

Browser check: not applicable — no `web/src/` files (deploy/server-only; web sees TrunkVer via the existing `REACT_APP_RELEASE` build arg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rollback note (migration-reviewer)

The `down` migration narrows `release` varchar(64)→(40). After this ships, any `release` value over 40 chars (a full TrunkVer is ~44) would be **silently truncated** on rollback. Postgres does not error — it truncates. Acceptable: `release` is observability metadata, not business data. But a future on-call should not roll this back blindly; prefer rolling forward. Widen and narrow are both catalog-only (no table rewrite, no lock of note). `pnpm kanel` not needed — `string | null` is unchanged by varchar length.