### PR TITLE
fix: stop a stray migrations test file from crashing every deploy

### DIFF
--- a/src/data_layer/pitchDismissalsMigrationShape.test.ts
+++ b/src/data_layer/pitchDismissalsMigrationShape.test.ts
@@ -15,9 +15,15 @@ describe('20260805000000_add_pitch_dismissals migration DDL shape', () => {
     const sql = db.schema
       .createTable('pitch_dismissals', (t) => {
         t.increments('id').primary();
-        t.integer('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+        t.integer('user_id')
+          .notNullable()
+          .references('id')
+          .inTable('users')
+          .onDelete('CASCADE');
         t.text('placement').notNullable();
-        t.timestamp('dismissed_at', { useTz: true }).notNullable().defaultTo(db.fn.now());
+        t.timestamp('dismissed_at', { useTz: true })
+          .notNullable()
+          .defaultTo(db.fn.now());
         t.unique(['user_id', 'placement']);
         t.index('user_id');
       })
@@ -37,7 +43,11 @@ describe('20260805000000_add_pitch_dismissals migration DDL shape', () => {
 
     const pitchSql = db.schema
       .createTable('pitch_dismissals', (t) => {
-        t.integer('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+        t.integer('user_id')
+          .notNullable()
+          .references('id')
+          .inTable('users')
+          .onDelete('CASCADE');
       })
       .toSQL();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,7 +70,7 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "exclude": ["web", "scripts", "ops"],
+  "exclude": ["web", "scripts", "ops", "migrations"],
   "ts-node": {
     "transpileOnly": true
   }


### PR DESCRIPTION
## Incident

**Every production deploy has failed since 2026-06-18** (~21h). The site stayed up, so it was silent — but nothing shipped and merges piled up undeployed (the box is still on a 22h-old build).

### Root cause

`migrations/20260805000000_add_pitch_dismissals.test.ts`.

`tsconfig.json` has no `outDir`, so the deploy's `tsc` build compiled that test **in place** to `migrations/...test.js`. On startup the server runs knex `Migrator.latest()`, which loads **every file in the migrations directory** as a migration. The compiled test calls `describe()` — undefined at runtime — so migration loading throws `ReferenceError: describe is not defined`, the process exits 1, pm2 hits 10 unstable restarts, the new blue-green color never goes healthy, and the cutover correctly keeps the old color live and exits 1.

```
PM2 | App [server-green:474] exited with code [1]
PM2 | Script .../src/server.js had too many unstable restarts (10). Stopped. "errored"
ReferenceError: describe is not defined
    at migrations/20260805000000_add_pitch_dismissals.test.js:7:1
    at Migrator.latest (knex .../migrate/Migrator.js)
```

### Fix (defense in depth)

1. **Move** the DDL-shape test out of `migrations/` → `src/data_layer/`. Jest `testMatch` is repo-wide (`**/*.test.ts`) so it still runs; the test is self-contained (no import from the migration), so the move is mechanical. 2/2 green.
2. **Exclude `migrations/` from tsc** (`tsconfig` `exclude`) so a future stray `.ts` there can never compile into a runtime `.js` the migrator loads.

The migrations directory must contain only migrations.

### Verified

- No `src` file imports from `migrations/` (exclude is safe)
- `tsc --noEmit` clean, moved test green (2/2), `migrations/` has zero test files
- oxfmt clean

## Impact

**Unblocks CD.** Once merged + deployed, the new color boots and the ~5 queued PRs (the error-noise fixes + TrunkVer) ship together.

Browser check: not applicable — server build/test config, no `web/src/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)