### PR TITLE
chore: quiet expected and benign server log noise

### DIFF
--- a/src/lib/misc/isExpectedClientFault.test.ts
+++ b/src/lib/misc/isExpectedClientFault.test.ts
@@ -1,0 +1,30 @@
+import { isExpectedClientFault } from './isExpectedClientFault';
+
+describe('isExpectedClientFault', () => {
+  it('returns false for undefined', () => {
+    expect(isExpectedClientFault(undefined)).toBe(false);
+  });
+
+  it('returns true for a body-parser malformed-JSON error', () => {
+    const err = Object.assign(new SyntaxError('bad json'), {
+      type: 'entity.parse.failed',
+    });
+    expect(isExpectedClientFault(err)).toBe(true);
+  });
+
+  it('returns true for an AnkiAppExportError by name', () => {
+    const err = new Error('No cards found in this AnkiApp export.');
+    err.name = 'AnkiAppExportError';
+    expect(isExpectedClientFault(err)).toBe(true);
+  });
+
+  it('returns false for an ordinary error', () => {
+    expect(isExpectedClientFault(new Error('database exploded'))).toBe(false);
+  });
+
+  it('returns false for a SyntaxError without the body-parser type tag', () => {
+    expect(isExpectedClientFault(new SyntaxError('thrown by our code'))).toBe(
+      false
+    );
+  });
+});

--- a/src/lib/misc/isExpectedClientFault.ts
+++ b/src/lib/misc/isExpectedClientFault.ts
@@ -1,0 +1,14 @@
+// Errors that are the client's fault and fully handled by ErrorHandler as a
+// 4xx — not bugs to investigate. Logging a full stack for these floods the
+// server logs and buries real crashes. Mirrors the dashboard skip in
+// ErrorCaptureMiddleware (entity.parse.failed) and extends it to the expected
+// upload-shape errors that resolve to a clean 400.
+export const isExpectedClientFault = (error?: Error): boolean => {
+  if (!error) {
+    return false;
+  }
+  if ((error as { type?: string }).type === 'entity.parse.failed') {
+    return true;
+  }
+  return error.name === 'AnkiAppExportError';
+};

--- a/src/lib/parser/extractPdfText.ts
+++ b/src/lib/parser/extractPdfText.ts
@@ -28,8 +28,12 @@ interface PdfJsOps {
   [opName: string]: number;
 }
 
+// pdf.js v1.10 VerbosityLevel: ERRORS = 0, WARNINGS = 1, INFOS = 5.
+const PDFJS_VERBOSITY_ERRORS = 0;
+
 interface PdfJsGlobalSettings {
   disableFontFace?: boolean;
+  verbosity?: number;
 }
 
 interface PdfJsModule {
@@ -89,6 +93,10 @@ function loadPdfJs(): PdfJsModule | null {
     ) as PdfJsModule;
     const settings: PdfJsGlobalSettings = pdfjs.PDFJS ?? pdfjs;
     settings.disableFontFace = true;
+    // Silence benign per-page warnings ("Unimplemented annotation type
+    // FreeText/Ink", "TT: undefined function") that pdf.js prints for ordinary
+    // PDFs; they aren't actionable and flood the logs during conversion.
+    settings.verbosity = PDFJS_VERBOSITY_ERRORS;
     return pdfjs;
   } catch {
     return null;

--- a/src/routes/middleware/ErrorHandler.test.ts
+++ b/src/routes/middleware/ErrorHandler.test.ts
@@ -257,6 +257,55 @@ describe('ErrorHandler', () => {
     );
   });
 
+  test('does not log a stack for a malformed-JSON scanner probe, still returns 400', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+    const probe = Object.assign(new SyntaxError('bad json'), {
+      type: 'entity.parse.failed',
+    });
+
+    await ErrorHandler(res as unknown as express.Response, req, probe);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    errorSpy.mockRestore();
+  });
+
+  test('does not log a stack for an AnkiAppExportError, still returns 400', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+    const err = new Error('No cards found in this AnkiApp export.');
+    err.name = 'AnkiAppExportError';
+
+    await ErrorHandler(res as unknown as express.Response, req, err);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'No cards found in this AnkiApp export.',
+      })
+    );
+    errorSpy.mockRestore();
+  });
+
+  test('still logs a stack for a genuine server error', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const res = makeResponse(false);
+    const req = makeRequest();
+
+    await ErrorHandler(
+      res as unknown as express.Response,
+      req,
+      new Error('database connection lost')
+    );
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
   test('does not throw when headers have already been sent', async () => {
     const res = makeResponse(true);
     const req = makeRequest();

--- a/src/routes/middleware/ErrorHandler.tsx
+++ b/src/routes/middleware/ErrorHandler.tsx
@@ -4,6 +4,7 @@ import multer from 'multer';
 import nodemailer from 'nodemailer';
 import { UploadedFile } from '../../lib/storage/types';
 import { isLimitError } from '../../lib/misc/isLimitError';
+import { isExpectedClientFault } from '../../lib/misc/isExpectedClientFault';
 import { isEmptyPayload } from '../../lib/misc/isEmptyPayload';
 import { preserveFilesForDebugging } from '../../lib/debug/preserveFilesForDebugging';
 import { shouldShareFilesForDebugging } from './shouldShareFilesForDebugging';
@@ -86,9 +87,10 @@ export default async function ErrorHandler(
   err: Error
 ) {
   const uploadedFiles = req.files as UploadedFile[];
-  const skipError = isLimitError(err);
+  const isLimit = isLimitError(err);
+  const quietError = isLimit || isExpectedClientFault(err);
 
-  if (!skipError) {
+  if (!quietError) {
     console.info('Send error');
     console.error(err);
     const canShareFiles = shouldShareFilesForDebugging(req.body);
@@ -101,7 +103,7 @@ export default async function ErrorHandler(
     } catch (emailErr) {
       console.error('Failed to send error email:', emailErr);
     }
-  } else {
+  } else if (isLimit) {
     console.info('User no limit reached');
   }
 

--- a/src/services/NotionService/helpers/expandSyncedBlocks.test.ts
+++ b/src/services/NotionService/helpers/expandSyncedBlocks.test.ts
@@ -175,12 +175,12 @@ describe('expandSyncedBlocks', () => {
         throw new Error('not found');
       }),
     } as unknown as NotionAPIWrapper;
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     const result = await expandSyncedBlocks([reference], api, true);
 
     expect(result).toEqual([]);
-    expect(errorSpy).toHaveBeenCalled();
-    errorSpy.mockRestore();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/src/services/NotionService/helpers/expandSyncedBlocks.ts
+++ b/src/services/NotionService/helpers/expandSyncedBlocks.ts
@@ -52,7 +52,9 @@ async function resolveSyncedBlockChildren(
     });
     return await expandInternal(response.results, api, useAll, seen, depth + 1);
   } catch (e: unknown) {
-    console.error('[notion] failed to resolve synced_block source', e);
+    // Expected when the user hasn't shared the synced block's source with the
+    // integration — we recover by returning no children, not an error.
+    console.warn('[notion] failed to resolve synced_block source', e);
     return [];
   }
 }

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -18,6 +18,7 @@ import { isLimitError } from '../lib/misc/isLimitError';
 import { handleUploadLimitError } from '../controllers/Upload/helpers/handleUploadLimitError';
 import { getUploadValidationError } from '../lib/upload/getUploadValidationError';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
+import { isExpectedClientFault } from '../lib/misc/isExpectedClientFault';
 import {
   MARKDOWN_LIKELY_LOSSY_REASON,
   jobFailureReasonFromError,
@@ -545,6 +546,7 @@ class UploadService {
           err instanceof EmptyDeckError ||
           err instanceof ClaudeParseError ||
           err instanceof ImageOnlyContentError ||
+          (err instanceof Error && isExpectedClientFault(err)) ||
           (err instanceof Error && isPdfPasswordSentinel(err.message)) ||
           (err instanceof Error && /^docx_parse_failed/.test(err.message));
         if (isExpectedState) {


### PR DESCRIPTION
## Why

The 24h log scan after the deploy fix was dominated by non-actionable noise that buries real crashes. Everything here is expected or benign — **no user-facing behaviour change**, only log level/volume.

## What

| Source | Was | Now |
|---|---|---|
| **pdf.js** | `Unimplemented annotation type FreeText/Ink`, `TT: undefined function` on every PDF convert (14+8+4 in 30 min on the live build) | `loadPdfJs()` sets bundled pdf.js (v1.10) `verbosity = ERRORS`, beside the existing `disableFontFace` |
| **ErrorHandler** | full `console.error(err)` stack + error email for *every* non-limit error, incl. 4xx scanner probes (`entity.parse.failed`) and `AnkiAppExportError` | new `isExpectedClientFault` → skip stack/email for those; 4xx response unchanged. Mirrors the dashboard skip in #3436 |
| **UploadService async path** | error-logged `AnkiAppExportError` (absent from the expected-state allowlist) | reuses `isExpectedClientFault` |
| **expandSyncedBlocks** | `console.error` for a synced block the user hasn't shared with the integration | `console.warn` (it recovers by returning no children) |

## Already-resolved (not in this PR)

The big 24h counts — 50× `describe is not defined` (deploy crash) and 26× pdf.js `document is not defined` — were the old build / failed boots and are **already fixed** by today's deploy (#3440, #3415). The live build (green-475) was already clean apart from the benign warnings above.

## Tests

TDD — `isExpectedClientFault.test.ts` (5 cases) + ErrorHandler tests (4xx probe / AnkiAppExportError don't log a stack but still 400; genuine error still logs). 30 + 36 (UploadService) green, tsc + oxfmt clean.

Sonar not run locally (log-level/predicate change, low risk) — flagging per the rule.

Browser check: not applicable — server-side logging only, no `web/src/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)