### PR TITLE
chore: run designer review before flipping a PR ready

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -36,6 +36,7 @@ When `$ARGUMENTS` is a PR number or URL (or you can find a draft PR titled `spec
 6. **Add a changelog entry if this PR changes user-visible behavior.** See CLAUDE.md > Changelog for the rules (file path, when to add, voice). One line, user-facing prose — no implementation details. If you can't write the entry without referencing internal code, the PR probably doesn't need one. Commit as `chore: add changelog entry for <feature>`.
 7. **Update user docs if this PR adds or changes a user-visible feature.** User docs live at `web/src/pages/DocsPage/content/` (rendered in-app at 2anki.net/docs). Add a new MDX file or update an existing one whenever you ship: a new input format, a new converter capability, a changed flow the existing docs already describe, or a new account-level feature. The trigger is stricter than the changelog rule — skip when: pure bug fix (the docs were already correct), internal refactor, copy-only tweak, or a change so small a user would never look it up. Follow VOICE.md for prose; sentence-case headings; no implementation details. If you add a new MDX page, register it in `web/src/pages/DocsPage/sidebar.ts` so it shows up in navigation. Commit as `docs: update user docs for <feature>`.
 8. Run `/check` (parallel tsc + web typecheck + web vitest + web lint). All green before flipping the PR.
+8b. **If the PR is user-facing, run the `designer` review NOW — before flipping ready — and commit any must-fix it returns.** Designer validates UX *before* the PR ships, per the trio policy; do not defer it to the pre-merge checklist below. A must-fix found *after* `gh pr ready` can race a merge — Alexander may merge a ready PR before the follow-up lands (this happened with #3446: the silent-no-op gating fix raced the merge and had to ship as a separate follow-up #3447). The PR is not ready until designer-clean.
 9. Graduate the PR from draft to ready, and rename the title to match the implementation prefix:
    ```
    gh pr edit <n> --title "<type>: <feature name>"   # feat: / fix: / refactor: / ...
@@ -48,7 +49,7 @@ Before merging:
 - All checks green.
 - Changelog entry added if the PR is user-visible (or explicit note in the PR body that no entry is warranted).
 - User docs updated if the PR adds or changes a user-visible feature (or explicit note in the PR body that none are needed).
-- If user-facing, ping the `designer` agent for a review pass.
+- Designer review is done pre-ready (step 8b), not here. Re-ping the `designer` agent only if the diff changed materially after flipping ready.
 - If the change touches auth, payments, or external-API integration, run `/security-review` first.
 - Note goal alignment in the PR body (per `CLAUDE.md`).
 

--- a/.claude/commands/spec-draft-pr.md
+++ b/.claude/commands/spec-draft-pr.md
@@ -31,8 +31,10 @@ Launch the following three agents **simultaneously** using the Agent tool (one m
 - Verdict: changes needed to the pm's scope, or "no UI changes required"
 
 **engineer** — given the same input, produce a technical pre-flight:
+- **Verify, do not trust, any code-map claim in the issue/source** ("the fix lives in X", "Y is not in the live path", "both paths share Z"). Grep/read the named symbols before repeating them in the spec — a wrong claim propagated into the spec becomes a wrong v1 floor. (Issue #3180 claimed the live Notion-sync path used `DeckParser`/`TagRegistry` interchangeably and that `TagRegistry` was "not in the live tag path"; both false — the sync path is a separate engine that can't host the feature at all. Only caught at implement, after a full spec round.)
 - Which layers are touched (`routes` / `controllers` / `usecases` / `services` / `data_layer` / `web`)
 - Files likely in play (list them)
+- **If the feature has two delivery paths (file upload via `DeckParser` vs live Notion sync via `BlockHandler`), confirm each path can actually host the feature** — they are independent engines with different tag/card-extraction code; a feature meaningful on one may be a structural no-op on the other.
 - Any cross-language coordination needed (TypeScript ↔ Python)
 - Estimated effort: S / M / L and why
 - Any security, testing, or migration concerns to address before work starts


### PR DESCRIPTION
## What
Two fixes to the trio workflow commands, both learned from the #3180 → #3446/#3447 session:

1. **`implement.md` — designer review moves to a pre-ready gate (new step 8b).** It previously sat in the "Before merging" checklist, *after* `gh pr ready`. A user-facing must-fix found there races the merge.
2. **`spec-draft-pr.md` — engineer pre-flight must verify, not trust, an issue's code-map claims**, and confirm each delivery path (upload `DeckParser` vs live Notion-sync `BlockHandler`) can actually host the feature.

## Why
- #3446 was flipped ready, *then* the designer pass found a silent-no-op gating bug. The fix was still uncommitted when the PR got merged → it had to ship as a separate follow-up (#3447), and main briefly carried the trap. Designer validates UX **before** ship per the trio policy; the command contradicted that.
- The #3180 spec propagated a false code-map claim from the issue (live Notion-sync uses `DeckParser`/`TagRegistry` interchangeably; `TagRegistry` "not in live path"). Both false — the sync path is a separate engine that can't host the feature. Only caught at implement, after a full spec round.

## How
Surgical: +4/-1 lines across the two command files. No code, no behavior change to the app.

## Goal alignment
Internal tooling — sharpens the agent harness so the next user-facing PR doesn't repeat the merge-race. No funnel/MRR metric.

No changelog (not user-visible). Browser check: not applicable — `.claude/` tooling docs, no runtime output.
