### PR TITLE
chore: enforce three honor-system rules with hooks

### DIFF
--- a/.claude/hooks/check-changelog-on-merge.py
+++ b/.claude/hooks/check-changelog-on-merge.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+PreToolUse -> Bash: block `gh pr merge` when a user-visible PR (a feat: or fix:
+commit touching non-test source) ships without a changelog entry AND without an
+explicit out-clause in the PR body.
+
+Mirrors check-browser-attestation.py: fetches the PR via gh, fails open on any
+tooling error, exempts dependabot. The out-clause keeps it from over-firing on
+internal feat:/fix: work that genuinely needs no entry.
+
+CLAUDE.md > Changelog is the rule this enforces.
+"""
+import json
+import re
+import subprocess
+import sys
+
+
+CHANGELOG_DIR_PREFIX = "web/src/pages/WhatsNewPage/changelog/"
+OUT_CLAUSE = re.compile(r"no changelog entry", re.IGNORECASE)
+
+GH_PR_MERGE = re.compile(r"\bgh\s+pr\s+merge\b")
+PR_URL = re.compile(r"https?://github\.com/[^/]+/[^/]+/pull/(\d+)")
+USER_VISIBLE_PREFIX = re.compile(r"^(feat|fix)(\([^)]*\))?!?:", re.IGNORECASE)
+
+
+def allow():
+    print(json.dumps({"continue": True}))
+    sys.exit(0)
+
+
+def deny(reason):
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    sys.exit(0)
+
+
+def is_gh_pr_merge(cmd):
+    return bool(GH_PR_MERGE.search(cmd))
+
+
+def extract_pr_ref(cmd):
+    after = GH_PR_MERGE.split(cmd, 1)[1]
+    after = re.split(r"[;&|]", after, 1)[0]
+    url_match = PR_URL.search(after)
+    if url_match:
+        return url_match.group(1)
+    tokens = [t for t in after.split() if not t.startswith("-")]
+    for token in tokens:
+        if token.isdigit():
+            return token
+    return None
+
+
+def fetch_pr_data(pr_ref):
+    args = ["gh", "pr", "view"]
+    if pr_ref is not None:
+        args.append(pr_ref)
+    args.extend(["--json", "author,body,files,commits"])
+    try:
+        result = subprocess.run(args, capture_output=True, text=True, timeout=15)
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        sys.stderr.write(
+            f"[check-changelog-on-merge] could not run gh ({exc}); allowing merge.\n"
+        )
+        return None
+    if result.returncode != 0:
+        sys.stderr.write(
+            "[check-changelog-on-merge] gh pr view failed; allowing merge. "
+            f"stderr: {result.stderr.strip()[:300]}\n"
+        )
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write(
+            "[check-changelog-on-merge] could not parse gh JSON; allowing merge.\n"
+        )
+        return None
+
+
+def has_user_visible_commit(commits):
+    for commit in commits:
+        headline = commit.get("messageHeadline") or ""
+        if USER_VISIBLE_PREFIX.match(headline.strip()):
+            return True
+    return False
+
+
+def is_non_test_source(path):
+    if not (path.startswith("src/") or path.startswith("web/src/")):
+        return False
+    if not (path.endswith(".ts") or path.endswith(".tsx")):
+        return False
+    if path.endswith(".d.ts") or ".test." in path:
+        return False
+    if "/migrations/" in path or "/templates/" in path or "/fixtures/" in path:
+        return False
+    if path.startswith("src/data_layer/public/"):
+        return False
+    return True
+
+
+def main():
+    try:
+        data = json.loads(sys.stdin.read())
+    except json.JSONDecodeError:
+        allow()
+
+    if data.get("tool_name") != "Bash":
+        allow()
+
+    cmd = data.get("tool_input", {}).get("command", "")
+    if not is_gh_pr_merge(cmd):
+        allow()
+
+    pr_data = fetch_pr_data(extract_pr_ref(cmd))
+    if pr_data is None:
+        allow()
+
+    if pr_data.get("author", {}).get("login", "") == "dependabot[bot]":
+        allow()
+
+    if not has_user_visible_commit(pr_data.get("commits") or []):
+        allow()
+
+    paths = [f.get("path", "") for f in (pr_data.get("files") or [])]
+
+    if not any(is_non_test_source(p) for p in paths):
+        allow()
+
+    if any(p.startswith(CHANGELOG_DIR_PREFIX) and p.endswith(".json") for p in paths):
+        allow()
+
+    if OUT_CLAUSE.search(pr_data.get("body") or ""):
+        allow()
+
+    deny(
+        "Refusing `gh pr merge` — this PR has a feat:/fix: commit touching source "
+        "but ships no changelog entry.\n\n"
+        "CLAUDE.md > Changelog: user-visible changes ship with an entry in the same PR.\n\n"
+        "  Add one:   web/src/pages/WhatsNewPage/changelog/YYYY-MM-DD-slug.json\n"
+        "             (see CLAUDE.md > Changelog for the file shape and voice)\n\n"
+        "  Or, if no user would notice this change, state so in the PR body with a line\n"
+        "  containing \"no changelog entry\" (e.g. \"no changelog entry — internal refactor\").\n\n"
+        "Dependabot PRs are exempt automatically."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/check-changelog-on-merge.test.py
+++ b/.claude/hooks/check-changelog-on-merge.test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+HOOKS_DIR = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "check_changelog_on_merge",
+    os.path.join(HOOKS_DIR, "check-changelog-on-merge.py"),
+)
+hook = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(hook)
+
+
+def make_input(command, tool_name="Bash"):
+    return json.dumps({"tool_name": tool_name, "tool_input": {"command": command}})
+
+
+def run_hook(command, tool_name="Bash", subprocess_side_effect=None, subprocess_result=None):
+    stdin_data = make_input(command, tool_name)
+    captured = {}
+
+    def fake_allow():
+        captured["result"] = "allow"
+        sys.exit(0)
+
+    def fake_deny(reason):
+        captured["result"] = "deny"
+        captured["reason"] = reason
+        sys.exit(0)
+
+    if subprocess_side_effect is not None:
+        run_patcher = patch("subprocess.run", side_effect=subprocess_side_effect)
+    elif subprocess_result is not None:
+        run_patcher = patch("subprocess.run", return_value=MagicMock(
+            returncode=subprocess_result.get("returncode", 0),
+            stdout=subprocess_result.get("stdout", ""),
+            stderr=subprocess_result.get("stderr", ""),
+        ))
+    else:
+        run_patcher = None
+
+    with patch.object(hook, "allow", side_effect=fake_allow), \
+         patch.object(hook, "deny", side_effect=fake_deny), \
+         patch("sys.stdin") as mock_stdin:
+        mock_stdin.read.return_value = stdin_data
+        if run_patcher is not None:
+            with run_patcher:
+                try:
+                    hook.main()
+                except SystemExit:
+                    pass
+        else:
+            try:
+                hook.main()
+            except SystemExit:
+                pass
+
+    return captured
+
+
+def make_pr_json(author_login, body, files, commit_headlines):
+    return json.dumps({
+        "author": {"login": author_login},
+        "body": body,
+        "files": [{"path": f} for f in files],
+        "commits": [{"messageHeadline": h} for h in commit_headlines],
+    })
+
+
+CHANGELOG = "web/src/pages/WhatsNewPage/changelog/2026-06-19-x.json"
+
+
+class TestPassthrough(unittest.TestCase):
+    def test_non_gh_command_allows(self):
+        self.assertEqual(run_hook("git status")["result"], "allow")
+
+    def test_gh_pr_view_allows(self):
+        self.assertEqual(run_hook("gh pr view 42")["result"], "allow")
+
+    def test_non_bash_tool_allows(self):
+        self.assertEqual(run_hook("gh pr merge 42", tool_name="Write")["result"], "allow")
+
+
+class TestExemptions(unittest.TestCase):
+    def test_dependabot_allows(self):
+        stdout = make_pr_json("dependabot[bot]", "", ["src/server.ts"], ["fix: bump"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "allow")
+
+    def test_no_feat_or_fix_commit_allows(self):
+        stdout = make_pr_json("alex", "", ["src/server.ts"], ["chore: tidy", "refactor: rename"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "allow")
+
+    def test_feat_but_no_source_touched_allows(self):
+        stdout = make_pr_json("alex", "", ["README.md", "docs/x.md"], ["feat: docs only"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "allow")
+
+    def test_only_test_files_touched_allows(self):
+        stdout = make_pr_json("alex", "", ["src/foo.test.ts"], ["fix: test"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "allow")
+
+    def test_changelog_entry_present_allows(self):
+        stdout = make_pr_json("alex", "", ["src/server.ts", CHANGELOG], ["feat: thing"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "allow")
+
+    def test_out_clause_allows(self):
+        body = "What: internal refactor.\nno changelog entry — internal only"
+        stdout = make_pr_json("alex", body, ["src/server.ts"], ["fix: internal"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "allow")
+
+
+class TestDenies(unittest.TestCase):
+    def test_feat_source_no_changelog_no_outclause_denies(self):
+        stdout = make_pr_json("alex", "Just a feature.", ["src/server.ts"], ["feat: thing"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "deny")
+
+    def test_fix_web_src_denies(self):
+        stdout = make_pr_json("alex", "A fix.", ["web/src/App.tsx"], ["fix: bug"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "deny")
+
+    def test_scoped_feat_prefix_denies(self):
+        stdout = make_pr_json("alex", "x", ["src/server.ts"], ["feat(parser): thing"])
+        self.assertEqual(run_hook("gh pr merge 42", subprocess_result={"stdout": stdout})["result"], "deny")
+
+
+class TestToolingErrors(unittest.TestCase):
+    def test_gh_not_found_allows(self):
+        result = run_hook("gh pr merge 42", subprocess_side_effect=FileNotFoundError("gh"))
+        self.assertEqual(result["result"], "allow")
+
+    def test_gh_nonzero_exit_allows(self):
+        result = run_hook("gh pr merge 42", subprocess_result={"returncode": 1, "stdout": ""})
+        self.assertEqual(result["result"], "allow")
+
+    def test_gh_timeout_allows(self):
+        import subprocess
+        result = run_hook("gh pr merge 42", subprocess_side_effect=subprocess.TimeoutExpired("gh", 15))
+        self.assertEqual(result["result"], "allow")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/pre-write-secret-scan.py
+++ b/.claude/hooks/pre-write-secret-scan.py
@@ -88,6 +88,11 @@ def get_content(data):
     return None, None
 
 
+def is_generated_data_layer(path):
+    norm = (path or "").replace("\\", "/")
+    return "src/data_layer/public/" in norm
+
+
 def is_test_or_fixture(path):
     p = path.lower()
     return (
@@ -112,6 +117,16 @@ def main():
         allow()
 
     path, content = get_content(data)
+
+    if is_generated_data_layer(path):
+        deny(
+            f"Refusing to write to {path}: this is Kanel-generated code under "
+            "src/data_layer/public/.\n"
+            "Hand-edits are silently overwritten on the next `pnpm kanel`.\n"
+            "Change the migration and re-run `pnpm kanel` to regenerate these types instead.\n"
+            "If you genuinely must touch it, set CLAUDE_SKIP_SAFETY=1 for this call."
+        )
+
     if content is None or not content.strip():
         allow()
 

--- a/.claude/hooks/stop-test-coverage.py
+++ b/.claude/hooks/stop-test-coverage.py
@@ -13,8 +13,23 @@ Bypass: CLAUDE_SKIP_STOP_CHECK=1 (env on the wrapping process).
 """
 import json
 import os
+import re
 import subprocess
 import sys
+
+
+DEBUG_ARTIFACT_PATTERNS = [
+    ("console.log", re.compile(r"\bconsole\.log\s*\(")),
+    ("debugger", re.compile(r"\bdebugger\b")),
+]
+
+TEST_ISOLATION_PATTERNS = [
+    ("focused test (.only)", re.compile(r"\.only\s*\(")),
+    ("xdescribe", re.compile(r"\bxdescribe\b")),
+    ("xit", re.compile(r"\bxit\b")),
+    ("fdescribe", re.compile(r"\bfdescribe\b")),
+    ("fit", re.compile(r"\bfit\s*\(")),
+]
 
 
 def quiet_pass():
@@ -88,6 +103,32 @@ def expected_test(path):
     return path[:-3] + ".test.ts"
 
 
+def is_ts_under_src(path):
+    if not (path.startswith("src/") or path.startswith("web/src/")):
+        return False
+    if not (path.endswith(".ts") or path.endswith(".tsx")):
+        return False
+    return not path.endswith(".d.ts")
+
+
+def debug_artifacts(changed):
+    offenders = []
+    for path in changed:
+        if not is_ts_under_src(path) or not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                content = handle.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        is_test = ".test." in path
+        patterns = TEST_ISOLATION_PATTERNS if is_test else DEBUG_ARTIFACT_PATTERNS
+        hits = [label for label, pat in patterns if pat.search(content)]
+        if hits:
+            offenders.append((path, hits))
+    return offenders
+
+
 def main():
     if os.environ.get("CLAUDE_SKIP_STOP_CHECK"):
         quiet_pass()
@@ -137,6 +178,17 @@ def main():
             "FEATURE.md was updated. If responsibilities, layering, or constraints "
             "shifted, take a moment to refresh the relevant doc — the next session "
             "starts cold from these files."
+        )
+
+    offenders = debug_artifacts(changed)
+    if offenders:
+        lines = "\n".join(
+            f"  - {path}: {', '.join(hits)}" for path, hits in offenders
+        )
+        nudges.append(
+            "Debug/scaffolding artifacts left in changed files — strip before pushing "
+            "(code-quality.md, testing.md):\n"
+            f"{lines}"
         )
 
     if nudges:

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -8,7 +8,7 @@ Patterns the SonarCloud quality gate, the project RULES.md, and review history h
 | Do not write `if (!ready) { … } else { … }`. | Lead with the positive: `if (ready) { … } else { … }` (Sonar S7735). Negation + else forces mental inversion. | — |
 | Do not deduplicate code on the second occurrence. | Wait for the third. Premature abstraction is harder to undo than three honest copies. | — |
 | Do not introduce `any`, `as any`, or `@ts-ignore` without a one-line justification on the same line. | Reach for a real type; if it is genuinely unknown, use `unknown` and narrow at the boundary. | CWE-704 |
-| Do not edit anything under `src/data_layer/public/`. | Run `pnpm kanel` after migrations — those files regenerate. | — |
+| Do not edit anything under `src/data_layer/public/`. | Run `pnpm kanel` after migrations — those files regenerate. (Write/Edit to this path is blocked by `.claude/hooks/pre-write-secret-scan.py`.) | — |
 | Do not leave `console.log`, `debugger`, or `xdescribe` in committed code. | Strip before pushing. The Stop hook nudges; review will block. | CWE-489 |
 | Do not skip layers (controller → repository, route → service). | Route → controller → use case → service → data layer. Each layer's CLAUDE.md says what belongs there. | — |
 | Do not put business logic in routes or controllers. | Controllers shape HTTP; use cases orchestrate; services hold reusable domain logic. | — |

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -105,6 +105,10 @@
           },
           {
             "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/check-changelog-on-merge.py"
+          },
+          {
+            "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/check-duplicate-commit-message.py"
           },
           {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ One new surface in flight at a time. The next surface does not start until the p
 
 ## Changelog
 
-User-visible changes ship with a changelog entry in the **same PR**. The entry lands as a new JSON file in `web/src/pages/WhatsNewPage/changelog/` and renders in the in-app "What's New" page. One entry = one file, so parallel PRs never conflict.
+User-visible changes ship with a changelog entry in the **same PR**. The entry lands as a new JSON file in `web/src/pages/WhatsNewPage/changelog/` and renders in the in-app "What's New" page. One entry = one file, so parallel PRs never conflict. Enforced at merge: `.claude/hooks/check-changelog-on-merge.py` blocks `gh pr merge` when a `feat:`/`fix:` commit touches source but adds no changelog JSON and the PR body has no "no changelog entry" out-clause.
 
 **When to add an entry.** Add one if a real user would notice the change. Don't add one if they wouldn't.
 


### PR DESCRIPTION
## What
Turns three honor-system rules into computational sensors (harness-audit findings):

1. **`pre-write-secret-scan.py`** — now denies Write/Edit to `src/data_layer/public/` (Kanel-generated). Banned in three prose spots but `Edit(src/**)` permitted it; hand-edits are silently overwritten on the next `pnpm kanel`.
2. **`stop-test-coverage.py`** — now nudges on `console.log`/`debugger` left in source and `.only`/`xdescribe`/`xit`/`fdescribe`/`fit` left in tests. `code-quality.md` claimed "the Stop hook nudges" for these — **it didn't**. The doc advertised a sensor that didn't exist; now it does.
3. **`check-changelog-on-merge.py`** (new) — blocks `gh pr merge` when a `feat:`/`fix:` commit touches non-test source but the PR adds no changelog JSON and the body has no `no changelog entry` out-clause. Mirrors `check-browser-attestation.py`: dependabot-exempt, fails open on any `gh` error, out-clause prevents over-firing.

Docs (`code-quality.md`, CLAUDE.md) updated to name the new sensors so prose and enforcement agree.

## Why
A rule nobody enforces is a rule that rots — and #2 was worse: the doc lied about a hook that didn't exist. These three are the cheap, deterministic, high-value gaps from the audit. Explicitly left as prose (no cheap sensor): designer-before-ready, goal-alignment line, VOICE quality, trio classification, outside-in testing.

## How
- `+` 2 hooks (one new + its test), 2 hook edits, settings wiring, 2 doc notes. No app code.
- New hook has a 15-case test (`check-changelog-on-merge.test.py`) mirroring the browser-attestation test: passthrough, exemptions, denies, tooling-error fail-open. All green.
- Existing hooks behavior-tested via stdin (deny on generated path, allow on normal; pattern hits on console.log/.only).

## Testing
`python3 .claude/hooks/check-changelog-on-merge.test.py` → 15 passed. Manual stdin checks on the two edited hooks pass.

## Risks
- New merge gate could block a legit merge — mitigated by the `no changelog entry` out-clause and dependabot exemption, and it fails open on any `gh` hiccup.
- The Stop nudge is non-blocking (matches the documented "nudge" wording), so no workflow halt.

## Goal alignment
Internal harness hardening — keeps the agent honest so rules don't silently rot. No funnel/MRR metric.

No changelog entry — internal tooling, no user-visible behavior change. Browser check: not applicable — `.claude/` hooks + docs, no runtime output.
