### PR TITLE
test: stub metascraper so jest survives its ESM-only deps

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,9 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   moduleNameMapper: {
     '^puppeteer$': '<rootDir>/src/test/mocks/puppeteer.ts',
+    '^metascraper$': '<rootDir>/src/test/mocks/metascraper.ts',
+    '^metascraper-(description|image|logo-favicon|title|url)$':
+      '<rootDir>/src/test/mocks/metascraperPlugin.ts',
   },
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',

--- a/src/test/mocks/metascraper.ts
+++ b/src/test/mocks/metascraper.ts
@@ -1,0 +1,10 @@
+// Jest stub for the metascraper factory. The real package (and its
+// @metascraper/helpers dependency chain) ships ESM-only modules
+// (condense-whitespace, mime) that the CommonJS jest transform can't parse.
+// Tests never exercise real scraping — useMetadata.test.ts mocks the scraper
+// directly — so this stub keeps the ESM chain out of the jest module graph.
+const metascraper =
+  (_plugins?: unknown[]) =>
+  async (_options?: unknown): Promise<Record<string, unknown>> => ({});
+
+export = metascraper;

--- a/src/test/mocks/metascraperPlugin.ts
+++ b/src/test/mocks/metascraperPlugin.ts
@@ -1,0 +1,3 @@
+// Jest stub for metascraper-* plugin packages (passed into the metascraper
+// factory). See metascraper.ts for why the real packages are kept out of jest.
+export = {};


### PR DESCRIPTION
## What
Stub `metascraper` and its plugin packages in jest via `moduleNameMapper`, so the jest test suite parses again after the metascraper 5.51.1 bump.

## Why
The production-dependencies bump `46a6f58` (metascraper 5.50.6 → 5.51.1) pulled ESM-only transitive packages — `condense-whitespace@3`, `mime@4` via `@metascraper/helpers` — that the project's CommonJS jest transform cannot parse. This broke `src/services/NotionService/BlockHandler/BlockHandler.test.ts` and `src/controllers/NotionController.test.ts` (both import metascraper transitively through `BlockBookmark`), turning a CI test shard red and **blocking every merge**, not just one PR. It was masked locally because stale `node_modules` still held the old CJS versions (classic local-drift-masks-CI).

## How
- `src/test/mocks/metascraper.ts` — stub factory; `src/test/mocks/metascraperPlugin.ts` — stub for `metascraper-{description,image,logo-favicon,title,url}`.
- `moduleNameMapper` routes those package names to the stubs (same pattern as the existing `puppeteer` mock), keeping the whole ESM chain out of the jest module graph.
- Behaviour-neutral: no test exercises real scraping — `useMetadata.test.ts` already mocks the scraper directly.
- Chosen over `transformIgnorePatterns` whitelisting, which is whack-a-mole — it only moved the failure from `condense-whitespace` to the next ESM leaf (`mime`).

## Testing
- The two previously-red suites now pass; `useMetadata.test.ts` still green (6/6 in that group).
- Server-scoped full run (`--roots src`): 544 suites / 4885 tests pass. The only failures are 2 local `pdfinfo`-ENOENT cases (poppler not installed on this machine; present on CI) — unrelated.

## Risks
Low — test-config + test-only stubs, no app code. If a future test needs real metascraper behaviour, it would need its own un-mock.

## Goal alignment
Unblocks the merge pipeline (CI green) so shipping can continue. Internal — no funnel/MRR metric.

No changelog — test infrastructure, no user-visible behaviour change. Browser check: not applicable — no `web/src/` runtime change (stubs live under `src/test/`).
