### PR TITLE
feat: add ops command to archive legacy Unlimited prices

### DIFF
--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -21,6 +21,7 @@ import {
 import { GetUploadFunnelUseCase } from '../usecases/ops/GetUploadFunnelUseCase';
 import { GetOrphanedSubscriptionsUseCase } from '../usecases/ops/GetOrphanedSubscriptionsUseCase';
 import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/ReconcileOrphanedSubscriptionsUseCase';
+import { ArchiveLegacyPricesUseCase } from '../usecases/ops/ArchiveLegacyPricesUseCase';
 
 class OpsController {
   constructor(
@@ -41,7 +42,8 @@ class OpsController {
     private readonly setFeatureFlagUseCase?: SetFeatureFlagUseCase,
     private readonly getUploadFunnelUseCase?: GetUploadFunnelUseCase,
     private readonly getOrphanedSubscriptionsUseCase?: GetOrphanedSubscriptionsUseCase,
-    private readonly reconcileOrphanedSubscriptionsUseCase?: ReconcileOrphanedSubscriptionsUseCase
+    private readonly reconcileOrphanedSubscriptionsUseCase?: ReconcileOrphanedSubscriptionsUseCase,
+    private readonly archiveLegacyPricesUseCase?: ArchiveLegacyPricesUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -391,6 +393,31 @@ class OpsController {
       res
         .status(500)
         .json({ message: 'Failed to reconcile orphaned subscriptions' });
+    }
+  }
+
+  async archiveLegacyPrices(req: express.Request, res: express.Response) {
+    if (this.archiveLegacyPricesUseCase == null) {
+      res.status(500).json({ message: 'Archive legacy prices not configured' });
+      return;
+    }
+    try {
+      const dryRun = req.body?.dryRun !== false;
+      const result = await this.archiveLegacyPricesUseCase.execute(dryRun);
+      res.status(200).json({
+        livemode: result.livemode,
+        prices: result.prices.map((price) => ({
+          priceId: price.priceId,
+          lookupKey: price.lookupKey,
+          unitAmount: price.unitAmount,
+          interval: price.interval,
+          active: price.active,
+          action: price.action,
+        })),
+      });
+    } catch (error) {
+      console.error('[ops] archiveLegacyPrices failed', error);
+      res.status(500).json({ message: 'Failed to archive legacy prices' });
     }
   }
 }

--- a/src/routes/OpsRouter.test.ts
+++ b/src/routes/OpsRouter.test.ts
@@ -13,6 +13,15 @@ jest.mock('../lib/integrations/stripe', () => ({
     prices: {
       list: jest.fn().mockResolvedValue({ data: [] }),
       create: jest.fn().mockResolvedValue({ id: 'price_new', livemode: false }),
+      retrieve: jest.fn().mockResolvedValue({
+        id: 'price_legacy_monthly',
+        lookup_key: 'legacy_monthly',
+        unit_amount: 600,
+        recurring: { interval: 'month' },
+        active: true,
+        livemode: false,
+      }),
+      update: jest.fn(),
     },
   })),
 }));
@@ -614,6 +623,58 @@ describe('OpsRouter /api/ops/subscriptions/reconcile', () => {
         emailed: 1,
         skippedRecentlyNotified: 0,
         skippedNoEmail: 0,
+      });
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe('OpsRouter /api/ops/archive-legacy-prices', () => {
+  it('returns 404 for non-owner callers', async () => {
+    const { url, close } = await startServer(false);
+    try {
+      const response = await fetch(`${url}/api/ops/archive-legacy-prices`, {
+        method: 'POST',
+      });
+      expect(response.status).toBe(404);
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns 200 with the per-price archive plan for the ops owner', async () => {
+    process.env.UNLIMITED_MONTHLY_PRICE_ID = 'price_legacy_monthly';
+    process.env.UNLIMITED_YEARLY_PRICE_ID = '';
+    const { url, close } = await startServer(true);
+    try {
+      const response = await fetch(`${url}/api/ops/archive-legacy-prices`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: true }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({
+        livemode: false,
+        prices: [
+          {
+            priceId: 'price_legacy_monthly',
+            lookupKey: 'legacy_monthly',
+            unitAmount: 600,
+            interval: 'month',
+            active: true,
+            action: 'would_archive',
+          },
+          {
+            priceId: '',
+            lookupKey: null,
+            unitAmount: null,
+            interval: null,
+            active: null,
+            action: 'skipped_missing_env',
+          },
+        ],
       });
     } finally {
       await close();

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -55,6 +55,7 @@ import { OrphanedSubscriptionsRepository } from '../data_layer/OrphanedSubscript
 import { SubscriptionRecoveryNotificationsRepository } from '../data_layer/SubscriptionRecoveryNotificationsRepository';
 import { GetOrphanedSubscriptionsUseCase } from '../usecases/ops/GetOrphanedSubscriptionsUseCase';
 import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/ReconcileOrphanedSubscriptionsUseCase';
+import { ArchiveLegacyPricesUseCase } from '../usecases/ops/ArchiveLegacyPricesUseCase';
 
 const OpsRouter = () => {
   const router = express.Router();
@@ -138,7 +139,8 @@ const OpsRouter = () => {
         const customer = await getStripe().customers.retrieve(customerId);
         return 'email' in customer ? (customer.email ?? null) : null;
       }
-    )
+    ),
+    new ArchiveLegacyPricesUseCase(getStripe())
   );
 
   /**
@@ -556,6 +558,41 @@ const OpsRouter = () => {
     '/api/ops/subscriptions/reconcile',
     RequireOpsAccess,
     (req, res) => controller.reconcileOrphanedSubscriptions(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/archive-legacy-prices:
+   *   post:
+   *     summary: Archive the two legacy Unlimited Stripe prices
+   *     description: |
+   *       Archives the legacy $6/mo and $60/yr Unlimited prices (the
+   *       UNLIMITED_MONTHLY_PRICE_ID and UNLIMITED_YEARLY_PRICE_ID env values)
+   *       now that the lock-in window closed 21 Jun 2026 and new checkouts
+   *       resolve the v2 prices. Touches only the two configured legacy price
+   *       ids — never any other price, never products or subscriptions. Sets
+   *       active=false; never deletes, never creates. Guarded against the v2
+   *       lookup_keys (v2_monthly, v2_annual): a configured id that resolves to
+   *       a v2 price is skipped, never archived. dryRun defaults to true — pass
+   *       { "dryRun": false } to write. Existing subscriptions keep renewing on
+   *       an archived price. Internal endpoint locked to the ops owner — returns
+   *       404 for everyone else.
+   *     tags: [Ops]
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               dryRun: { type: boolean }
+   *     responses:
+   *       200:
+   *         description: Per-price result with id, amount, interval, and action
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.post('/api/ops/archive-legacy-prices', RequireOpsAccess, (req, res) =>
+    controller.archiveLegacyPrices(req, res)
   );
 
   return router;

--- a/src/usecases/ops/ArchiveLegacyPricesUseCase.test.ts
+++ b/src/usecases/ops/ArchiveLegacyPricesUseCase.test.ts
@@ -1,0 +1,190 @@
+import { ArchiveLegacyPricesUseCase } from './ArchiveLegacyPricesUseCase';
+
+type RetrieveMock = jest.Mock;
+type UpdateMock = jest.Mock;
+
+function makeStripe(retrieve: RetrieveMock, update: UpdateMock) {
+  return {
+    prices: {
+      retrieve,
+      update,
+    },
+  } as unknown as ConstructorParameters<typeof ArchiveLegacyPricesUseCase>[0];
+}
+
+function legacyPrice(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'price_legacy_monthly',
+    lookup_key: 'legacy_monthly',
+    unit_amount: 600,
+    recurring: { interval: 'month' },
+    active: true,
+    livemode: true,
+    ...overrides,
+  };
+}
+
+describe('ArchiveLegacyPricesUseCase', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      UNLIMITED_MONTHLY_PRICE_ID: 'price_legacy_monthly',
+      UNLIMITED_YEARLY_PRICE_ID: 'price_legacy_yearly',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('reports would_archive without calling update in dry-run mode', async () => {
+    const retrieve = jest.fn().mockImplementation((id: string) =>
+      Promise.resolve(
+        id === 'price_legacy_monthly'
+          ? legacyPrice()
+          : legacyPrice({
+              id: 'price_legacy_yearly',
+              lookup_key: 'legacy_yearly',
+              unit_amount: 6000,
+              recurring: { interval: 'year' },
+            })
+      )
+    );
+    const update = jest.fn();
+    const useCase = new ArchiveLegacyPricesUseCase(
+      makeStripe(retrieve, update)
+    );
+
+    const result = await useCase.execute(true);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(result.livemode).toBe(true);
+    expect(result.prices).toEqual([
+      {
+        priceId: 'price_legacy_monthly',
+        lookupKey: 'legacy_monthly',
+        unitAmount: 600,
+        interval: 'month',
+        active: true,
+        action: 'would_archive',
+      },
+      {
+        priceId: 'price_legacy_yearly',
+        lookupKey: 'legacy_yearly',
+        unitAmount: 6000,
+        interval: 'year',
+        active: true,
+        action: 'would_archive',
+      },
+    ]);
+  });
+
+  it('calls prices.update with active false and reports archived when not a dry run', async () => {
+    const retrieve = jest.fn().mockResolvedValue(legacyPrice());
+    const update = jest.fn().mockResolvedValue(legacyPrice({ active: false }));
+    process.env.UNLIMITED_YEARLY_PRICE_ID = '';
+    const useCase = new ArchiveLegacyPricesUseCase(
+      makeStripe(retrieve, update)
+    );
+
+    const result = await useCase.execute(false);
+
+    expect(update).toHaveBeenCalledWith('price_legacy_monthly', {
+      active: false,
+    });
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(result.prices[0]).toEqual({
+      priceId: 'price_legacy_monthly',
+      lookupKey: 'legacy_monthly',
+      unitAmount: 600,
+      interval: 'month',
+      active: true,
+      action: 'archived',
+    });
+  });
+
+  it('reports already_archived without calling update when the price is inactive', async () => {
+    const retrieve = jest
+      .fn()
+      .mockResolvedValue(legacyPrice({ active: false }));
+    const update = jest.fn();
+    process.env.UNLIMITED_YEARLY_PRICE_ID = '';
+    const useCase = new ArchiveLegacyPricesUseCase(
+      makeStripe(retrieve, update)
+    );
+
+    const result = await useCase.execute(false);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(result.prices[0].action).toBe('already_archived');
+    expect(result.prices[0].active).toBe(false);
+  });
+
+  it('NEVER archives a price whose lookup_key is a v2 key, reporting skipped_guard', async () => {
+    const retrieve = jest
+      .fn()
+      .mockResolvedValue(legacyPrice({ lookup_key: 'v2_monthly' }));
+    const update = jest.fn();
+    process.env.UNLIMITED_YEARLY_PRICE_ID = '';
+    const useCase = new ArchiveLegacyPricesUseCase(
+      makeStripe(retrieve, update)
+    );
+
+    const result = await useCase.execute(false);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(result.prices[0].action).toBe('skipped_guard');
+  });
+
+  it('guards the v2 annual lookup_key too', async () => {
+    const retrieve = jest
+      .fn()
+      .mockResolvedValue(legacyPrice({ lookup_key: 'v2_annual' }));
+    const update = jest.fn();
+    process.env.UNLIMITED_YEARLY_PRICE_ID = '';
+    const useCase = new ArchiveLegacyPricesUseCase(
+      makeStripe(retrieve, update)
+    );
+
+    const result = await useCase.execute(false);
+
+    expect(update).not.toHaveBeenCalled();
+    expect(result.prices[0].action).toBe('skipped_guard');
+  });
+
+  it('skips a configured id whose env var is empty, never retrieving it', async () => {
+    const retrieve = jest.fn();
+    const update = jest.fn();
+    process.env.UNLIMITED_MONTHLY_PRICE_ID = '';
+    process.env.UNLIMITED_YEARLY_PRICE_ID = '';
+    const useCase = new ArchiveLegacyPricesUseCase(
+      makeStripe(retrieve, update)
+    );
+
+    const result = await useCase.execute(true);
+
+    expect(retrieve).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(result.prices).toEqual([
+      {
+        priceId: '',
+        lookupKey: null,
+        unitAmount: null,
+        interval: null,
+        active: null,
+        action: 'skipped_missing_env',
+      },
+      {
+        priceId: '',
+        lookupKey: null,
+        unitAmount: null,
+        interval: null,
+        active: null,
+        action: 'skipped_missing_env',
+      },
+    ]);
+  });
+});

--- a/src/usecases/ops/ArchiveLegacyPricesUseCase.ts
+++ b/src/usecases/ops/ArchiveLegacyPricesUseCase.ts
@@ -1,0 +1,110 @@
+import Stripe from 'stripe';
+import type { Stripe as StripeTypes } from 'stripe/cjs/stripe.core';
+
+import {
+  V2_ANNUAL_LOOKUP_KEY,
+  V2_MONTHLY_LOOKUP_KEY,
+} from '../checkout/pricingV2';
+
+type StripeClient = InstanceType<typeof Stripe>;
+
+const GUARDED_LOOKUP_KEYS = new Set<string>([
+  V2_MONTHLY_LOOKUP_KEY,
+  V2_ANNUAL_LOOKUP_KEY,
+]);
+
+export type ArchiveLegacyPriceAction =
+  | 'would_archive'
+  | 'archived'
+  | 'already_archived'
+  | 'skipped_missing_env'
+  | 'skipped_guard';
+
+export interface ArchiveLegacyPriceResult {
+  priceId: string;
+  lookupKey: string | null;
+  unitAmount: number | null;
+  interval: string | null;
+  active: boolean | null;
+  action: ArchiveLegacyPriceAction;
+}
+
+export interface ArchiveLegacyPricesResult {
+  livemode: boolean;
+  prices: ArchiveLegacyPriceResult[];
+}
+
+export class ArchiveLegacyPricesUseCase {
+  constructor(private readonly stripe: StripeClient) {}
+
+  async execute(dryRun: boolean): Promise<ArchiveLegacyPricesResult> {
+    const configuredIds = [
+      process.env.UNLIMITED_MONTHLY_PRICE_ID ?? '',
+      process.env.UNLIMITED_YEARLY_PRICE_ID ?? '',
+    ];
+
+    const prices: ArchiveLegacyPriceResult[] = [];
+    let livemode = false;
+
+    for (const priceId of configuredIds) {
+      const result = await this.processPrice(priceId, dryRun);
+      prices.push(result.summary);
+      if (result.livemode) {
+        livemode = true;
+      }
+    }
+
+    return { livemode, prices };
+  }
+
+  private async processPrice(
+    priceId: string,
+    dryRun: boolean
+  ): Promise<{ summary: ArchiveLegacyPriceResult; livemode: boolean }> {
+    if (priceId === '') {
+      return {
+        summary: {
+          priceId: '',
+          lookupKey: null,
+          unitAmount: null,
+          interval: null,
+          active: null,
+          action: 'skipped_missing_env',
+        },
+        livemode: false,
+      };
+    }
+
+    const price = await this.stripe.prices.retrieve(priceId);
+    const summary: ArchiveLegacyPriceResult = {
+      priceId: price.id,
+      lookupKey: price.lookup_key ?? null,
+      unitAmount: price.unit_amount ?? null,
+      interval: price.recurring?.interval ?? null,
+      active: price.active,
+      action: resolveAction(price, dryRun),
+    };
+
+    if (summary.action === 'archived') {
+      await this.stripe.prices.update(price.id, { active: false });
+    }
+
+    return { summary, livemode: price.livemode };
+  }
+}
+
+function resolveAction(
+  price: StripeTypes.Price,
+  dryRun: boolean
+): ArchiveLegacyPriceAction {
+  if (price.lookup_key != null && GUARDED_LOOKUP_KEYS.has(price.lookup_key)) {
+    return 'skipped_guard';
+  }
+  if (price.active === false) {
+    return 'already_archived';
+  }
+  if (dryRun) {
+    return 'would_archive';
+  }
+  return 'archived';
+}

--- a/web/src/pages/OpsPage/CommandsTab.tsx
+++ b/web/src/pages/OpsPage/CommandsTab.tsx
@@ -13,6 +13,11 @@ import {
   OrphanedSubscriptionsResponse,
   ReconcileOrphanedSubscriptionsResponse,
 } from './orphanedSubscriptions';
+import {
+  archiveLegacyPrices,
+  ArchiveLegacyPriceResult,
+  ArchiveLegacyPricesResponse,
+} from './archiveLegacyPrices';
 
 type Status = 'idle' | 'loading' | 'success' | 'error';
 
@@ -27,6 +32,27 @@ function formatReconcileResult(
   result: ReconcileOrphanedSubscriptionsResponse
 ): string {
   return `${result.found} found, ${result.emailed} emailed, ${result.skippedRecentlyNotified} skipped (notified in last 14 days), ${result.skippedNoEmail} skipped (no email).`;
+}
+
+const ARCHIVE_ACTION_LABELS: Record<
+  ArchiveLegacyPriceResult['action'],
+  string
+> = {
+  would_archive: 'would archive',
+  archived: 'archived',
+  already_archived: 'already archived',
+  skipped_missing_env: 'skipped (no price id configured)',
+  skipped_guard: 'skipped (v2 price — guarded)',
+};
+
+function formatArchivePrice(price: ArchiveLegacyPriceResult): string {
+  if (price.priceId === '') {
+    return ARCHIVE_ACTION_LABELS[price.action];
+  }
+  const amount =
+    price.unitAmount == null ? '—' : `$${(price.unitAmount / 100).toFixed(2)}`;
+  const interval = price.interval == null ? '' : `/${price.interval}`;
+  return `${price.priceId} — ${amount}${interval} — ${ARCHIVE_ACTION_LABELS[price.action]}`;
 }
 
 async function callInactivityWarnings(
@@ -56,6 +82,11 @@ export default function CommandsTab() {
   const [orphanMessage, setOrphanMessage] = useState('');
   const [orphans, setOrphans] = useState<
     OrphanedSubscriptionsResponse['orphans']
+  >([]);
+  const [archiveStatus, setArchiveStatus] = useState<Status>('idle');
+  const [archiveMessage, setArchiveMessage] = useState('');
+  const [archivePrices, setArchivePrices] = useState<
+    ArchiveLegacyPricesResponse['prices']
   >([]);
 
   const run = async (dryRun: boolean) => {
@@ -132,6 +163,26 @@ export default function CommandsTab() {
     } catch (error) {
       setOrphanStatus('error');
       setOrphanMessage(
+        error instanceof Error ? error.message : 'Unknown error'
+      );
+    }
+  };
+
+  const runArchiveLegacyPrices = async (dryRun: boolean) => {
+    setArchiveStatus('loading');
+    setArchiveMessage('');
+    try {
+      const result = await archiveLegacyPrices(dryRun);
+      setArchivePrices(result.prices);
+      setArchiveStatus('success');
+      setArchiveMessage(
+        dryRun
+          ? `Dry run — ${result.prices.length} legacy price${result.prices.length === 1 ? '' : 's'} checked.`
+          : `Done — ${result.prices.length} legacy price${result.prices.length === 1 ? '' : 's'} processed.`
+      );
+    } catch (error) {
+      setArchiveStatus('error');
+      setArchiveMessage(
         error instanceof Error ? error.message : 'Unknown error'
       );
     }
@@ -300,6 +351,58 @@ export default function CommandsTab() {
       {orphanStatus === 'error' && orphanMessage && (
         <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
           {orphanMessage}
+        </div>
+      )}
+
+      <section className={`${sharedStyles.surface} ${styles.card}`}>
+        <h2 className={styles.cardTitle}>Archive legacy prices</h2>
+        <p className={styles.panelSubtitle}>
+          Archives the legacy $6/mo and $60/yr Unlimited prices now that the
+          lock-in window closed. Existing subscriptions keep renewing on their
+          price — new checkouts already resolve the v2 prices. Touches only the
+          two configured legacy prices, never deletes, and skips any price that
+          resolves to a v2 lookup key. Check status first.
+        </p>
+        <div className={styles.controls}>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={() => runArchiveLegacyPrices(true)}
+            disabled={archiveStatus === 'loading'}
+          >
+            {archiveStatus === 'loading' ? 'Working…' : 'Check status'}
+          </button>
+          <button
+            type="button"
+            className={sharedStyles.btnDanger}
+            onClick={() => runArchiveLegacyPrices(false)}
+            disabled={archiveStatus === 'loading'}
+          >
+            Archive prices
+          </button>
+        </div>
+        {archivePrices.length > 0 && (
+          <ul className={styles.panelSubtitle}>
+            {archivePrices.map((price, index) => (
+              <li
+                key={price.priceId === '' ? `missing-${index}` : price.priceId}
+                style={{ fontWeight: 500 }}
+              >
+                {formatArchivePrice(price)}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {archiveStatus === 'success' && archiveMessage && (
+        <div className={`${sharedStyles.alertSuccess} ${styles.banner}`}>
+          {archiveMessage}
+        </div>
+      )}
+      {archiveStatus === 'error' && archiveMessage && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {archiveMessage}
         </div>
       )}
     </>

--- a/web/src/pages/OpsPage/archiveLegacyPrices.test.ts
+++ b/web/src/pages/OpsPage/archiveLegacyPrices.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { archiveLegacyPrices } from './archiveLegacyPrices';
+
+describe('archiveLegacyPrices', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('POSTs the dryRun flag and returns the per-price plan', async () => {
+    const payload = {
+      livemode: true,
+      prices: [
+        {
+          priceId: 'price_legacy_monthly',
+          lookupKey: 'legacy_monthly',
+          unitAmount: 600,
+          interval: 'month',
+          active: true,
+          action: 'would_archive',
+        },
+        {
+          priceId: 'price_legacy_yearly',
+          lookupKey: 'legacy_yearly',
+          unitAmount: 6000,
+          interval: 'year',
+          active: true,
+          action: 'would_archive',
+        },
+      ],
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(payload),
+    });
+
+    const result = await archiveLegacyPrices(true);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/archive-legacy-prices',
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ dryRun: true }),
+      }
+    );
+    expect(result).toEqual(payload);
+  });
+
+  test('sends dryRun false when archiving for real', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve({ livemode: false, prices: [] }),
+    });
+
+    await archiveLegacyPrices(false);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/api/ops/archive-legacy-prices',
+      expect.objectContaining({ body: JSON.stringify({ dryRun: false }) })
+    );
+  });
+
+  test('throws the server message on a non-ok response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: () =>
+        Promise.resolve({ message: 'Failed to archive legacy prices' }),
+    });
+
+    await expect(archiveLegacyPrices(true)).rejects.toThrow(
+      'Failed to archive legacy prices'
+    );
+  });
+
+  test('falls back to status text when the error body has no message', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: () => Promise.reject(new Error('no body')),
+    });
+
+    await expect(archiveLegacyPrices(true)).rejects.toThrow('404 Not Found');
+  });
+});

--- a/web/src/pages/OpsPage/archiveLegacyPrices.ts
+++ b/web/src/pages/OpsPage/archiveLegacyPrices.ts
@@ -1,0 +1,38 @@
+export type ArchiveLegacyPriceAction =
+  | 'would_archive'
+  | 'archived'
+  | 'already_archived'
+  | 'skipped_missing_env'
+  | 'skipped_guard';
+
+export interface ArchiveLegacyPriceResult {
+  priceId: string;
+  lookupKey: string | null;
+  unitAmount: number | null;
+  interval: string | null;
+  active: boolean | null;
+  action: ArchiveLegacyPriceAction;
+}
+
+export interface ArchiveLegacyPricesResponse {
+  livemode: boolean;
+  prices: ArchiveLegacyPriceResult[];
+}
+
+export async function archiveLegacyPrices(
+  dryRun: boolean
+): Promise<ArchiveLegacyPricesResponse> {
+  const response = await fetch('/api/ops/archive-legacy-prices', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dryRun }),
+  });
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(
+      data.message ?? `${response.status} ${response.statusText}`
+    );
+  }
+  return response.json();
+}


### PR DESCRIPTION
## What
Adds an ops-page admin command "Archive legacy prices" that archives the two legacy Unlimited Stripe prices (the $6/mo and $60/yr prices) by setting `active=false`. Server use case + controller + route + swagger, and a card on the ops Commands tab with a dry-run "Check status" button and an "Archive prices" button.

## Why
The legacy $6/$60 lock-in window closed 21 Jun 2026 (#3211) and new checkouts already resolve the v2 prices ($7.99/mo, $64/yr). The legacy prices can now be retired. Archiving (not deleting) leaves existing subscriptions renewing on their price while removing the prices from any new checkout surface.

## How
`ArchiveLegacyPricesUseCase` (constructed with `getStripe()`) reads `UNLIMITED_MONTHLY_PRICE_ID` and `UNLIMITED_YEARLY_PRICE_ID` from env, retrieves each, and returns a typed per-price result with an `action`:
- empty env var → `skipped_missing_env` (no Stripe call)
- **hard guard**: `lookup_key` is `v2_monthly`/`v2_annual` (the `pricingV2.ts` constants) → `skipped_guard`, never archived — so a mis-set env var can never archive a live v2 price
- already `active: false` → `already_archived` (idempotent)
- dry run → `would_archive` (no write)
- otherwise → `prices.update(id, { active: false })`, `archived`

Never deletes, never creates, never touches any price other than the two configured ids. `dryRun` defaults to `true`; the controller writes only on an explicit `dryRun: false` (`req.body?.dryRun !== false`). The controller maps the use case result to an explicit typed JSON shape — no raw Stripe objects to the client.

This is the safe inverse of the removed `CreatePricingV2PricesUseCase` (#3461) and mirrors the surviving ops command structure (route → controller → use case, ops-gated, optional-injected use case).

## Measuring success
Internal tooling only — no production metric. After running with `dryRun: false`, confirm in the Stripe dashboard that the two legacy prices show as archived and that the per-price response lists `archived` (or `already_archived`). The `[ops] archiveLegacyPrices failed` log line surfaces any failure.

## Testing
- `src/usecases/ops/ArchiveLegacyPricesUseCase.test.ts` (6 tests, Stripe mocked at the edge): dry-run reports `would_archive` without calling `update`; non-dry-run calls `prices.update` with `{ active: false }`; already-archived → `already_archived` no update; **the v2-lookup_key guard → `skipped_guard`, no update** (both `v2_monthly` and `v2_annual`); empty env var → `skipped_missing_env`, no retrieve.
- `src/routes/OpsRouter.test.ts`: route exists and is ops-gated — non-owner → 404; ops owner dry-run → 200 with the typed per-price plan.
- `web/src/pages/OpsPage/archiveLegacyPrices.test.ts`: POST shape (dryRun true/false), server-message and status-text error handling.
- Server tsc, web typecheck, web vitest (2050 passed), web oxlint: all green. oxfmt run on changed files.
- sonar-scanner not run — `SONAR_TOKEN` unset locally. New code is low-complexity (one loop + a small action resolver); expect no Sonar bounce, but flagging per the rule.

## Browser check
Browser check: not applicable — adds one card with two buttons to the ops-only admin page, no golden-path surface

## Changelog
No entry — ops-only gated admin tooling, not user-facing.

## Risks
Low. The command is ops-gated (404 for everyone else), defaults to dry-run, archives only the two configured legacy ids, never deletes, and is guarded against archiving a v2 price. Archiving is reversible in the Stripe dashboard (set the price active again). Rollback is a revert of the single commit.

## Goal alignment
None — internal ops tooling. Retiring the legacy prices keeps the checkout surface on v2 pricing (which carries the ARPU lift); it does not directly move a funnel metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

no changelog entry — ops-only gated admin tooling, not user-facing
