### PR TITLE
fix: keep callout children inside the box when nested in a toggle

### DIFF
--- a/src/lib/notion-render/renderBlocks.test.ts
+++ b/src/lib/notion-render/renderBlocks.test.ts
@@ -234,6 +234,22 @@ describe('renderNotionBlocks — recursion', () => {
     expect(out.html).toContain('<p>inside</p>');
     expect(out.html).toContain('class="callout"');
   });
+
+  it('nests callout children inside the callout div, not after it', async () => {
+    const fetch = fetcherFor({ co: [para('inside')] });
+    const block: NotionRenderableBlock = {
+      id: 'co',
+      type: 'callout',
+      has_children: true,
+      callout: { rich_text: [{ plain_text: 'note' }] },
+    };
+    const out = await renderNotionBlocks([block], fetch);
+    expect(out.html).toBe('<div class="callout">note<p>inside</p></div>');
+    const childOpen = out.html.indexOf('<p>inside</p>');
+    const divClose = out.html.lastIndexOf('</div>');
+    expect(childOpen).toBeLessThan(divClose);
+    expect(out.html.slice(divClose)).not.toContain('inside');
+  });
 });
 
 describe('renderNotionBlocks — media', () => {

--- a/src/services/NotionService/blocks/BlockCallout.tsx
+++ b/src/services/NotionService/blocks/BlockCallout.tsx
@@ -4,11 +4,12 @@ import {
 } from '@notionhq/client/build/src/api-endpoints';
 import ReactDOMServer from 'react-dom/server';
 import BlockHandler from '../BlockHandler/BlockHandler';
+import getChildren from '../helpers/getChildren';
 import getPlainText from '../helpers/getPlainText';
 import { styleWithColors } from '../NotionColors';
 import HandleBlockAnnotations from './HandleBlockAnnotations';
 
-export const BlockCallout = (
+export const BlockCallout = async (
   block: CalloutBlockObjectResponse,
   handler: BlockHandler
 ) => {
@@ -20,7 +21,9 @@ export const BlockCallout = (
     return getPlainText(richText);
   }
 
-  return ReactDOMServer.renderToStaticMarkup(
+  const childrenHtml = await getChildren(block, handler);
+
+  const figureWithoutChildren = ReactDOMServer.renderToStaticMarkup(
     <figure
       id={block.id}
       className={`callout${styleWithColors(callout.color)}`}
@@ -41,5 +44,14 @@ export const BlockCallout = (
         })}
       </div>
     </figure>
+  );
+
+  if (!childrenHtml) {
+    return figureWithoutChildren;
+  }
+
+  return figureWithoutChildren.replace(
+    '</div></figure>',
+    `${childrenHtml}</div></figure>`
   );
 };

--- a/src/services/NotionService/helpers/blockToStaticMarkup.test.ts
+++ b/src/services/NotionService/helpers/blockToStaticMarkup.test.ts
@@ -355,4 +355,119 @@ describe('blockToStaticMarkup', () => {
     expect(result).toContain('Pharmacokinetics');
     expect(result).not.toContain('unsupported');
   });
+
+  function makeCalloutWithChildren(): BlockObjectResponse {
+    return {
+      object: 'block',
+      id: 'callout-1',
+      type: 'callout',
+      callout: {
+        rich_text: [
+          {
+            type: 'text',
+            text: { content: 'Remember', link: null },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: 'default',
+            },
+            plain_text: 'Remember',
+            href: null,
+          },
+        ],
+        icon: { type: 'emoji', emoji: '💡' },
+        color: 'default',
+      },
+      parent: { type: 'page_id', page_id: 'page-1' },
+      created_time: '2026-06-22T07:46:00.000Z',
+      last_edited_time: '2026-06-22T07:46:00.000Z',
+      created_by: { object: 'user', id: 'user-1' },
+      last_edited_by: { object: 'user', id: 'user-1' },
+      has_children: true,
+      archived: false,
+      in_trash: false,
+    } as unknown as BlockObjectResponse;
+  }
+
+  function makeBulletListItem(content: string): BlockObjectResponse {
+    return {
+      object: 'block',
+      id: `list-${content}`,
+      type: 'bulleted_list_item',
+      bulleted_list_item: {
+        rich_text: [
+          {
+            type: 'text',
+            text: { content, link: null },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: 'default',
+            },
+            plain_text: content,
+            href: null,
+          },
+        ],
+        color: 'default',
+      },
+      parent: { type: 'block_id', block_id: 'callout-1' },
+      created_time: '2026-06-22T07:46:00.000Z',
+      last_edited_time: '2026-06-22T07:46:00.000Z',
+      created_by: { object: 'user', id: 'user-1' },
+      last_edited_by: { object: 'user', id: 'user-1' },
+      has_children: false,
+      archived: false,
+      in_trash: false,
+    } as unknown as BlockObjectResponse;
+  }
+
+  it('keeps a callout-nested list inside figure.callout instead of leaking it after the box', async () => {
+    const handler = makeHandler();
+    const callout = makeCalloutWithChildren();
+    const listItem = makeBulletListItem('child');
+
+    jest
+      .spyOn(handler.api, 'getBlocks')
+      .mockImplementation(async ({ id }: { id: string }) => {
+        if (id === 'callout-1') {
+          return {
+            object: 'list',
+            results: [listItem],
+            next_cursor: null,
+            has_more: false,
+            type: 'block',
+            block: {},
+          } as never;
+        }
+        return {
+          object: 'list',
+          results: [],
+          next_cursor: null,
+          has_more: false,
+          type: 'block',
+          block: {},
+        } as never;
+      });
+
+    const result = await blockToStaticMarkup(handler, callout);
+
+    expect(result).toContain('class="callout');
+    expect(result).toContain('child');
+
+    const figureClose = result.indexOf('</figure>');
+    const listOpen = result.indexOf('<ul');
+    expect(figureClose).toBeGreaterThan(-1);
+    expect(listOpen).toBeGreaterThan(-1);
+    expect(listOpen).toBeLessThan(figureClose);
+
+    const afterFigure = result.slice(figureClose + '</figure>'.length);
+    expect(afterFigure).not.toContain('<ul');
+    expect(afterFigure).not.toContain('child');
+  });
 });

--- a/src/services/NotionService/helpers/blockToStaticMarkup.tsx
+++ b/src/services/NotionService/helpers/blockToStaticMarkup.tsx
@@ -125,7 +125,7 @@ export const blockToStaticMarkup = async (
       back += await BlockTodoList(c, response, handler);
       break;
     case 'callout':
-      back += BlockCallout(c, handler);
+      back += await BlockCallout(c, handler);
       break;
     case 'bulleted_list_item':
       back += await BlockBulletList(c, response, handler);

--- a/src/services/NotionService/helpers/renderBack.ts
+++ b/src/services/NotionService/helpers/renderBack.ts
@@ -26,10 +26,15 @@ export const renderBack = async (
     }
     back += await blockToStaticMarkup(handler, c, response);
 
-    // Nesting applies to all not just toggles
+    // Nesting applies to all not just toggles.
+    // Callouts render their own children inside the figure, so the
+    // re-recursion here would otherwise append them flat after the box.
     if (
       handleChildren ||
-      (c.has_children && c.type !== 'toggle' && c.type !== 'bulleted_list_item')
+      (c.has_children &&
+        c.type !== 'toggle' &&
+        c.type !== 'bulleted_list_item' &&
+        c.type !== 'callout')
     ) {
       back += await handler.getBackSide(c);
     }

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-22-callout-toggle-children.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-22-callout-toggle-children.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-22-callout-toggle-children",
+  "date": "2026-06-22",
+  "type": "fix",
+  "title": "Callouts inside toggles keep their lists and sub-content inside the callout box"
+}


### PR DESCRIPTION
## What
A Notion callout nested inside a toggle rendered its nested children (lists, paragraphs, sub-blocks) outside the callout box on the card. This converges the live Notion `BlockHandler` renderer onto the correct nesting so callout children stay inside `figure.callout`.

## Why
Closes #3456. Two cooperating causes in the live Notion conversion path: `BlockCallout` rendered only the callout's own rich text (never its children), and `renderBack` then double-recursed into the same callout because it `has_children`, appending the children flat after the `<figure class="callout">` — so they landed detached as siblings inside the toggle's `<div>`. The parallel `notion-render` renderer already nests children inside the callout div; the two renderers disagreed.

## How
- `BlockCallout` now renders its own children inside the figure via `getChildren` (the same pattern `BlockToggleList` already uses), splicing the child HTML in before the closing `</div></figure>`. The component is now async; its single call site in `blockToStaticMarkup` awaits it.
- `renderBack` no longer re-recurses into a `callout` (added to the existing `toggle` / `bulleted_list_item` exclusion list), so children that the callout now owns are not appended a second time. Other `has_children` block types keep their `renderBack` recursion.

Conversion path fixed: live Notion `BlockHandler` only. The file-upload escape (the flat line-loop + aside-strip in `handleNestedBulletPointsInMarkdown`) is a different cause and is left as an out-of-scope follow-up.

## Measuring success
Rendered card HTML for a toggle→callout→list shape: the `<ul>` now appears before `</figure>` inside `figure.callout`, not as a sibling after it. Asserted by the new structural tests (`blockToStaticMarkup.test.ts`, `renderBlocks.test.ts`). In production this surfaces as callout sub-content rendering inside the box on converted decks.

## Testing
- Unit tests added:
  - `blockToStaticMarkup.test.ts` — toggle→callout→list: the list HTML stays inside `figure.callout` and does not leak after `</figure>`. Verified it fails on the pre-fix source (the callout markup omitted the child) and passes after.
  - `renderBlocks.test.ts` — asserts the notion-render callout nests children inside the `<div class="callout">`, locking the two renderers to the same children-inside-callout structure so they can't drift apart again.
- Full `src/services/NotionService` + `src/lib/notion-render` suites pass (56 suites); golden snapshot unchanged. Web suite (2057 tests) green.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green (2 passed). This PR changes server-rendered card HTML, not a React surface; the web diff is the changelog JSON only. The rendered-HTML change is covered by the structural Jest tests above.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-22-callout-toggle-children.json` — "Callouts inside toggles keep their lists and sub-content inside the callout box"

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` unset in this environment. Change is low Sonar risk: no new HTTP/user-URL sink, no zip extraction, no user path write; the only new logic is a plain string `.replace` and one added switch-arm exclusion.

## Risks
Low. The child splice depends on `renderToStaticMarkup` emitting `</div></figure>` with no whitespace between tags (React's static markup does); the no-children path returns the figure unchanged. Rollback is a straight revert of the four source/test files. If a callout's `getChildren` were to throw, `getBackSide` already swallows and returns `null` (existing behavior), so the callout still renders its own text.

## Goal alignment
Quality/retention, not a funnel metric — none directly. Notion-power-users running real study material hit this on any callout-in-toggle page; broken-looking cards erode trust in conversion fidelity, which is the product's core promise. No revenue metric moves; this is a correctness fix on the hot conversion path.
