### PR TITLE
feat: machine-enforce design-token contrast and orphan ratchet

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -24,7 +24,7 @@ The DNA governs the whole `/ankify` surface, not just the deck list: the workspa
 
 ## Color tokens
 No new ramp. Source of truth = `web/src/styles/base.css` (`:root` + the 5 theme blocks: light, dark, gold, purple, pink). Accent = `--color-primary` (#3b82f6), used once per view. Status is the functional triad already defined: `--color-success` (running), `--color-warning` (starting), `--color-text-danger` (error). Tertiary text = the corrected `#838b99`-class value from PR #3341 (distinct from secondary).
-Contrast: inherited from base.css (audited per theme in #3341 — tertiary clears ≥3:1 on every theme background; accent/primary text clears AA).
+Contrast: inherited from base.css (audited per theme in #3341 — tertiary clears ≥3:1 on every theme background; accent/primary text clears AA). This is now machine-enforced: `web/scripts/designTokens.ts` + its colocated test fail the suite if any audited text/background pair drops below its AA floor on any of the 5 themes, and ratchet against new orphaned color tokens. Add a pair to `CONTRAST_PAIRS` when a new on-screen text/bg combination ships.
 
 ## Space, shape, depth
 - Spacing scale: existing `--space-*` (4/8/12/16/20/24/32px). Map ad-hoc rem in `AnkifyPage.module.css` onto it during implementation.

--- a/web/scripts/designTokens.test.ts
+++ b/web/scripts/designTokens.test.ts
@@ -1,0 +1,133 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  auditContrast,
+  collectColorTokenNames,
+  contrastRatio,
+  findOrphanTokens,
+  formatContrastFindings,
+  hexToRgb,
+  parseThemeTokens,
+} from './designTokens';
+
+const BASE_CSS = readFileSync(
+  join(__dirname, '../src/styles/base.css'),
+  'utf8'
+);
+
+function readSourceTree(dir: string): string {
+  let combined = '';
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'generated') {
+        continue;
+      }
+      combined += readSourceTree(full);
+    } else if (/\.(ts|tsx|css|module\.css)$/.test(entry.name)) {
+      combined += readFileSync(full, 'utf8');
+    }
+  }
+  return combined;
+}
+
+describe('contrastRatio', () => {
+  it('is 21 for black on white', () => {
+    expect(contrastRatio('#000000', '#ffffff')).toBeCloseTo(21, 5);
+  });
+
+  it('is 1 for a colour against itself', () => {
+    expect(contrastRatio('#3b82f6', '#3b82f6')).toBeCloseTo(1, 5);
+  });
+
+  it('is order-independent', () => {
+    expect(contrastRatio('#1f2937', '#ffffff')).toBeCloseTo(
+      contrastRatio('#ffffff', '#1f2937'),
+      5
+    );
+  });
+
+  it('expands 3-digit hex', () => {
+    expect(hexToRgb('#fff')).toEqual([255, 255, 255]);
+    expect(hexToRgb('#000')).toEqual([0, 0, 0]);
+  });
+});
+
+describe('parseThemeTokens', () => {
+  it('parses all five themes from base.css', () => {
+    const themes = parseThemeTokens(BASE_CSS);
+    expect(themes.map((t) => t.theme)).toEqual([
+      'light',
+      'dark',
+      'gold',
+      'purple',
+      'hotpink',
+    ]);
+    expect(themes[0].tokens['--color-bg-primary']).toBe('#ffffff');
+  });
+});
+
+describe('base.css contrast (WCAG AA, every theme)', () => {
+  it('clears the AA floor for every audited pair', () => {
+    const findings = auditContrast(parseThemeTokens(BASE_CSS));
+    expect(
+      findings,
+      `Sub-AA contrast pairs:\n${formatContrastFindings(findings)}`
+    ).toEqual([]);
+  });
+});
+
+describe('findOrphanTokens', () => {
+  it('flags a defined-but-unreferenced token in a fixture', () => {
+    const css = ':root { --color-used: #fff; --color-orphan: #000; }';
+    const source = `${css}\n.a { color: var(--color-used); }`;
+    expect(findOrphanTokens(css, source)).toEqual(['--color-orphan']);
+  });
+
+  it('treats a token referenced only inside base.css as used', () => {
+    const css =
+      ':root { --color-only-base: #fff; }\nbody { color: var(--color-only-base); }';
+    expect(findOrphanTokens(css, css)).toEqual([]);
+  });
+
+  // Color tokens defined in base.css but referenced nowhere today. They are
+  // not deleted here: --color-gold-* and --color-indigo are documented in
+  // DESIGN.md as the Lifetime/Pro card palette, so removing them is a product
+  // call, not a tooling one. This baseline is a ratchet — a NEW orphan fails
+  // the suite, and wiring one up (or deleting it) requires trimming this list.
+  const KNOWN_UNUSED_TOKENS = [
+    '--color-text-success',
+    '--color-gold-bg',
+    '--color-gold-bg-end',
+    '--color-gold-border',
+    '--color-gold-border-light',
+    '--color-gold-border-hover',
+    '--color-gold-text',
+    '--color-gold-text-dark',
+    '--color-gold-text-darker',
+    '--color-gold-shadow',
+    '--color-indigo',
+  ];
+
+  it('introduces no orphaned color tokens beyond the known baseline', () => {
+    const orphans = findOrphanTokens(
+      BASE_CSS,
+      BASE_CSS + readSourceTree(join(__dirname, '../src'))
+    );
+    const unexpected = orphans.filter((t) => !KNOWN_UNUSED_TOKENS.includes(t));
+    expect(
+      unexpected,
+      `New orphaned color tokens (define + use, or delete):\n  ${unexpected.join('\n  ')}`
+    ).toEqual([]);
+    const revived = KNOWN_UNUSED_TOKENS.filter((t) => !orphans.includes(t));
+    expect(
+      revived,
+      `Tokens now in use — remove from KNOWN_UNUSED_TOKENS:\n  ${revived.join('\n  ')}`
+    ).toEqual([]);
+  });
+
+  it('defines color tokens in :root', () => {
+    expect(collectColorTokenNames(BASE_CSS).length).toBeGreaterThan(30);
+  });
+});

--- a/web/scripts/designTokens.ts
+++ b/web/scripts/designTokens.ts
@@ -1,0 +1,245 @@
+/**
+ * Pure helpers for auditing the design-token system in
+ * `web/src/styles/base.css`: WCAG-AA contrast per theme and orphaned
+ * (defined-but-unreferenced) color tokens.
+ *
+ * No filesystem access here — callers pass the CSS and source text in
+ * (the colocated test reads the real files). This is the machine check
+ * that DESIGN.md's colour rules describe in prose, so a sub-AA pairing
+ * (the kind PR #3341 caught by hand) fails the suite instead of shipping.
+ */
+
+export type ThemeName = 'light' | 'dark' | 'gold' | 'purple' | 'hotpink';
+
+export interface ThemeTokens {
+  theme: ThemeName;
+  tokens: Record<string, string>;
+}
+
+const SELECTOR_TO_THEME: Record<string, ThemeName> = {
+  ':root': 'light',
+  "[data-theme='dark']": 'dark',
+  "[data-theme='gold']": 'gold',
+  "[data-theme='purple']": 'purple',
+  "[data-theme='hotpink']": 'hotpink',
+};
+
+/** A foreground/background token pair that actually co-occurs on screen,
+ *  with the WCAG-AA ratio it must clear. */
+export interface ContrastPair {
+  label: string;
+  foreground: string;
+  background: string;
+  minRatio: number;
+}
+
+const NORMAL_TEXT_AA = 4.5;
+// Tertiary text is metadata / placeholder copy — DESIGN.md commits it to
+// the large-text / non-essential AA floor of 3:1, not 4.5:1.
+const LARGE_TEXT_AA = 3;
+
+export const CONTRAST_PAIRS: ContrastPair[] = [
+  {
+    label: 'primary text on primary bg',
+    foreground: '--color-text-primary',
+    background: '--color-bg-primary',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'primary text on secondary bg',
+    foreground: '--color-text-primary',
+    background: '--color-bg-secondary',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'secondary text on primary bg',
+    foreground: '--color-text-secondary',
+    background: '--color-bg-primary',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'secondary text on secondary bg',
+    foreground: '--color-text-secondary',
+    background: '--color-bg-secondary',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'tertiary text on primary bg',
+    foreground: '--color-text-tertiary',
+    background: '--color-bg-primary',
+    minRatio: LARGE_TEXT_AA,
+  },
+  {
+    label: 'tertiary text on secondary bg',
+    foreground: '--color-text-tertiary',
+    background: '--color-bg-secondary',
+    minRatio: LARGE_TEXT_AA,
+  },
+  {
+    label: 'link text on primary bg',
+    foreground: '--color-text-link',
+    background: '--color-bg-primary',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'link text on secondary bg',
+    foreground: '--color-text-link',
+    background: '--color-bg-secondary',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'danger text on danger-light bg',
+    foreground: '--color-danger-text',
+    background: '--color-danger-light',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'success text on success-light bg',
+    foreground: '--color-success-text',
+    background: '--color-success-light',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'warning text on warning-light bg',
+    foreground: '--color-warning-text',
+    background: '--color-warning-light',
+    minRatio: NORMAL_TEXT_AA,
+  },
+  {
+    label: 'info text on info-light bg',
+    foreground: '--color-info-text',
+    background: '--color-info-light',
+    minRatio: NORMAL_TEXT_AA,
+  },
+];
+
+export function hexToRgb(hex: string): [number, number, number] {
+  const value = hex.trim().replace(/^#/, '');
+  const full =
+    value.length === 3
+      ? value
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : value;
+  if (!/^[0-9a-fA-F]{6}$/.test(full)) {
+    throw new Error(`Not a 6-digit hex colour: ${hex}`);
+  }
+  const int = parseInt(full, 16);
+  return [(int >> 16) & 255, (int >> 8) & 255, int & 255];
+}
+
+function channelLuminance(channel: number): number {
+  const c = channel / 255;
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+export function relativeLuminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex);
+  return (
+    0.2126 * channelLuminance(r) +
+    0.7152 * channelLuminance(g) +
+    0.0722 * channelLuminance(b)
+  );
+}
+
+/** WCAG contrast ratio in [1, 21]; order-independent. */
+export function contrastRatio(hexA: string, hexB: string): number {
+  const lumA = relativeLuminance(hexA);
+  const lumB = relativeLuminance(hexB);
+  const lighter = Math.max(lumA, lumB);
+  const darker = Math.min(lumA, lumB);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Parse each theme block in base.css into its token map. */
+export function parseThemeTokens(css: string): ThemeTokens[] {
+  const results: ThemeTokens[] = [];
+  for (const [selector, theme] of Object.entries(SELECTOR_TO_THEME)) {
+    const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const block = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+    if (!block) {
+      continue;
+    }
+    const tokens: Record<string, string> = {};
+    const tokenRe = /(--[\w-]+):\s*([^;]+);/g;
+    let match: RegExpExecArray | null;
+    while ((match = tokenRe.exec(block[1])) !== null) {
+      tokens[match[1]] = match[2].trim();
+    }
+    results.push({ theme, tokens });
+  }
+  return results;
+}
+
+export interface ContrastFinding {
+  theme: ThemeName;
+  pair: string;
+  ratio: number;
+  minRatio: number;
+}
+
+/** Every pair below its AA floor, across every theme. Empty = all pass. */
+export function auditContrast(
+  themes: ThemeTokens[],
+  pairs: ContrastPair[] = CONTRAST_PAIRS
+): ContrastFinding[] {
+  const findings: ContrastFinding[] = [];
+  for (const { theme, tokens } of themes) {
+    for (const pair of pairs) {
+      const fg = tokens[pair.foreground];
+      const bg = tokens[pair.background];
+      if (fg == null || bg == null) {
+        continue;
+      }
+      const ratio = contrastRatio(fg, bg);
+      if (ratio < pair.minRatio) {
+        findings.push({
+          theme,
+          pair: pair.label,
+          ratio,
+          minRatio: pair.minRatio,
+        });
+      }
+    }
+  }
+  return findings;
+}
+
+/** Color token names defined in :root (the canonical superset). */
+export function collectColorTokenNames(css: string): string[] {
+  const root = new RegExp(':root\\s*\\{([^}]*)\\}').exec(css);
+  if (!root) {
+    return [];
+  }
+  const names: string[] = [];
+  const tokenRe = /(--color-[\w-]+):/g;
+  let match: RegExpExecArray | null;
+  while ((match = tokenRe.exec(root[1])) !== null) {
+    names.push(match[1]);
+  }
+  return names;
+}
+
+/**
+ * Color tokens defined in :root but never read via `var(--token)` anywhere
+ * in the provided source (which must include base.css itself, so a token
+ * consumed only by a base-stylesheet rule still counts as used).
+ */
+export function findOrphanTokens(
+  css: string,
+  combinedSource: string
+): string[] {
+  return collectColorTokenNames(css).filter(
+    (name) => !combinedSource.includes(`var(${name})`)
+  );
+}
+
+export function formatContrastFindings(findings: ContrastFinding[]): string {
+  return findings
+    .map(
+      (f) =>
+        `  ${f.theme}: ${f.pair} — ${f.ratio.toFixed(2)}:1 (needs ${f.minRatio}:1)`
+    )
+    .join('\n');
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-23-theme-link-contrast.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-23-theme-link-contrast.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-23-theme-link-contrast",
+  "date": "2026-06-23",
+  "type": "fix",
+  "title": "Links in the purple and hot-pink themes are darker so they pass accessibility contrast"
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -260,8 +260,8 @@
   --color-text-tertiary: #8a84a0;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
-  --color-text-link: #7c6cc4;
-  --color-text-link-hover: #6b59b3;
+  --color-text-link: #6b59b3;
+  --color-text-link-hover: #5d4ea3;
   --color-bg-primary: #faf9fd;
   --color-bg-secondary: #f3f1f9;
   --color-bg-tertiary: #ebe8f3;
@@ -327,8 +327,8 @@
   --color-text-tertiary: #bd4f7c;
   --color-text-danger: #dc2626;
   --color-text-success: #059669;
-  --color-text-link: #db2777;
-  --color-text-link-hover: #be185d;
+  --color-text-link: #be185d;
+  --color-text-link-hover: #9d174d;
   --color-bg-primary: #fff7f9;
   --color-bg-secondary: #fdf2f8;
   --color-bg-tertiary: #fce7f3;


### PR DESCRIPTION
## What & why

The design.md / Google Stitch idea making a design system machine-checkable so AI (and humans) don't drift from it is sound. But adopting the Google format wholesale would **fight our system**: its lint requires colors as flat hex, and we run HSLA-style hex tokens across **5 themes** — flattening to one hex set would kill theming, and the format is alpha + single-vendor. So this takes the *good part* (a machine check behind the design doc) and fits it to our tokens.

Adds `web/scripts/designTokens.ts` — pure WCAG-AA contrast math, per-theme token parsing, and orphaned-token detection. The **colocated test is the enforcement**: it rides the existing `pnpm test` → `/check` → CI path, so a sub-AA text/background pair (the class `#3341` caught by hand) now fails the suite instead of shipping.

## The audit found 4 real failures

`--color-text-link` was below WCAG AA on two themes:
- **purple**: 4.17:1 (primary bg), 3.91:1 (secondary bg)
- **hot-pink**: 4.36:1, 4.21:1

Darkened link + link-hover one step on both themes to clear 4.5:1 everywhere (purple link → 5.4/5.1, hot-pink → 5.7/5.5). Other 3 themes already passed; untouched.

## Orphaned-token ratchet

The orphan check ships against a documented baseline of **11 currently-unused color tokens** (the `--color-gold-*` / `--color-indigo` card palette that DESIGN.md documents for the Lifetime/Pro cards). It blocks **new** orphans without me unilaterally deleting a documented palette in a tooling PR. **Flag for you:** those 11 are dead today — worth a follow-up to either wire up or delete (would trim ~40 lines across the theme blocks).

## Verification
- `pnpm --filter 2anki-web test:run scripts/designTokens.test.ts` — 10/10
- `pnpm --filter 2anki-web typecheck` — clean
- `pnpm --filter 2anki-web lint` — clean on new files (remaining warnings pre-existing, unrelated)
- Sonar not run locally — MCP analysis tools not wired this session, no scanner. New code is small pure functions (no `Math.random`, no `console.log`, `== null` guards); expect clean, will fix any bounce.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: change is CSS-variable hex values only (theme link colors); `pnpm --filter 2anki-web test:golden-path` passed 2/2 at 375px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)