### PR TITLE
fix: capture upload bytes at receipt to survive temp-file reaping

### DIFF
--- a/src/lib/misc/GetUploadHandler.test.ts
+++ b/src/lib/misc/GetUploadHandler.test.ts
@@ -1,0 +1,94 @@
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { withNormalizedFilenames } from './GetUploadHandler';
+import { UploadedFile } from '../storage/types';
+import { getFileContents } from '../../usecases/uploads/worker';
+
+function makeDiskFile(filePath: string, name = 'notes.html'): UploadedFile {
+  return {
+    originalname: name,
+    key: name,
+    path: filePath,
+  } as UploadedFile;
+}
+
+function makeReqRes(files: UploadedFile[]): {
+  req: express.Request;
+  res: express.Response;
+} {
+  const req = { files } as unknown as express.Request;
+  const res = {} as express.Response;
+  return { req, res };
+}
+
+describe('withNormalizedFilenames', () => {
+  let tmpDir: string;
+  let tmpPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'upload-handler-'));
+    tmpPath = path.join(tmpDir, 'abc123def456'); // multer dest names have no extension
+    fs.writeFileSync(tmpPath, Buffer.from('disk-bytes'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('snapshots disk bytes into buffer the moment multer finishes writing', () => {
+    const file = makeDiskFile(tmpPath);
+    const { req, res } = makeReqRes([file]);
+    const wrapped = withNormalizedFilenames((_req, _res, next) => next());
+
+    const callback = jest.fn();
+    wrapped(req, res, callback);
+
+    expect(callback).toHaveBeenCalledWith();
+    expect(file.buffer).toEqual(Buffer.from('disk-bytes'));
+  });
+
+  it('keeps the conversion alive when the temp file is reaped after receipt', () => {
+    const file = makeDiskFile(tmpPath);
+    const { req, res } = makeReqRes([file]);
+    const wrapped = withNormalizedFilenames((_req, _res, next) => next());
+
+    wrapped(req, res, jest.fn());
+    // The temp file under UPLOAD_BASE vanishes before the worker reads it.
+    fs.rmSync(tmpPath);
+
+    // Before this fix the snapshot ran too late (inside the use case, after an
+    // async hop), so by request time the file was already gone and the worker
+    // threw "no longer available on disk and has no buffer fallback". The
+    // receipt-time capture populates the buffer fallback instead.
+    expect(getFileContents(file)).toEqual(Buffer.from('disk-bytes'));
+  });
+
+  it('decodes the filename before snapshotting and still captures bytes', () => {
+    const mojibake = Buffer.from('résumé', 'utf8').toString('latin1');
+    const file = makeDiskFile(tmpPath, `${mojibake}.html`);
+    const { req, res } = makeReqRes([file]);
+    const wrapped = withNormalizedFilenames((_req, _res, next) => next());
+
+    wrapped(req, res, jest.fn());
+
+    expect(file.originalname).toBe('résumé.html');
+    expect(file.buffer).toEqual(Buffer.from('disk-bytes'));
+  });
+
+  it('forwards multer errors without snapshotting', () => {
+    const file = makeDiskFile(tmpPath);
+    const { req, res } = makeReqRes([file]);
+    const multerError = new Error('LIMIT_FILE_SIZE');
+    const wrapped = withNormalizedFilenames((_req, _res, next) =>
+      next(multerError)
+    );
+
+    const callback = jest.fn();
+    wrapped(req, res, callback);
+
+    expect(callback).toHaveBeenCalledWith(multerError);
+    expect(file.buffer).toBeUndefined();
+  });
+});

--- a/src/lib/misc/GetUploadHandler.ts
+++ b/src/lib/misc/GetUploadHandler.ts
@@ -4,6 +4,8 @@ import { getUploadLimits } from './getUploadLimits';
 import { getMaxUploadCount } from './getMaxUploadCount';
 import { isPaying } from '../isPaying';
 import { decodeMultipartFilename } from './decodeMultipartFilename';
+import { ensureUploadBytes } from '../../usecases/uploads/ensureUploadBytes';
+import { UploadedFile } from '../storage/types';
 
 type UploadHandler = (
   req: express.Request,
@@ -11,7 +13,13 @@ type UploadHandler = (
   callback: (error?: Error) => void
 ) => void;
 
-function withNormalizedFilenames(
+// Snapshot multer's disk-storage bytes the instant the upload finishes writing,
+// before any async hop (auth, settings lookup, the Piscina queue). Multer's
+// `dest` engine gives each file a `path` but no `buffer`; the conversion reads
+// the file later in a worker, and the temp file under UPLOAD_BASE can vanish in
+// the gap. Capturing here — while the file is provably on disk — populates the
+// worker's buffer fallback so the conversion survives the file being reaped.
+export function withNormalizedFilenames(
   handler: express.RequestHandler
 ): UploadHandler {
   return (req, res, callback) => {
@@ -20,14 +28,16 @@ function withNormalizedFilenames(
         callback(error);
         return;
       }
-      const files = req.files as Express.Multer.File[] | undefined;
+      const files = req.files as UploadedFile[] | undefined;
       if (files) {
         for (const file of files) {
           file.originalname = decodeMultipartFilename(file.originalname);
         }
+        ensureUploadBytes(files);
       }
       if (req.file) {
         req.file.originalname = decodeMultipartFilename(req.file.originalname);
+        ensureUploadBytes([req.file as UploadedFile]);
       }
       callback();
     });

--- a/src/usecases/uploads/ensureUploadBytes.ts
+++ b/src/usecases/uploads/ensureUploadBytes.ts
@@ -3,15 +3,16 @@ import path from 'node:path';
 import { UploadedFile } from '../../lib/storage/types';
 
 // Multer disk storage gives each upload a `path` but no `buffer`. The conversion
-// runs later in a Piscina worker that reads the file lazily; when the pool queue
-// is busy the OS or multer can reap the temp file out of UPLOAD_BASE before the
-// worker reads it, and the job dies with "Uploaded file is no longer available
-// on disk and has no buffer fallback" (#3414).
+// runs later in a Piscina worker that reads the file lazily; the temp file under
+// UPLOAD_BASE can vanish before the worker reads it, and the job dies with
+// "Uploaded file is no longer available on disk and has no buffer fallback".
 //
-// Capture the bytes here — in the request thread, where the file is guaranteed
-// to still exist — so the worker's buffer fallback is actually populated. The
-// worker still prefers the disk path on the happy path; the buffer only matters
-// when the temp file vanished mid-dwell.
+// Called from the multer callback in GetUploadHandler — the instant the upload
+// finishes writing, before any async hop (auth, settings lookup, the Piscina
+// queue) — so the bytes are captured while the file is provably on disk. This
+// populates the worker's buffer fallback so the conversion survives the reaping.
+// The worker still prefers the disk path on the happy path; the buffer only
+// matters when the file vanished. (#3414 / supersedes #3416's late snapshot.)
 export function ensureUploadBytes(files: UploadedFile[]): void {
   for (const file of files) {
     if (file.buffer != null || !file.path) continue;

--- a/src/usecases/uploads/worker.test.ts
+++ b/src/usecases/uploads/worker.test.ts
@@ -105,6 +105,19 @@ describe('getFileContents', () => {
     );
   });
 
+  it('falls back to the snapshot buffer when the disk file was reaped', () => {
+    // The receipt-time snapshot (GetUploadHandler) populates file.buffer while
+    // the disk path is still set. When the temp file is reaped before the
+    // worker runs, getFileContents must serve the captured bytes, not throw.
+    const snapshot = Buffer.from('snapshot bytes');
+    const file = makeFile({ path: '/tmp/upload-reaped', buffer: snapshot });
+    mockFs.existsSync = jest.fn().mockReturnValue(false);
+
+    const result = getFileContents(file);
+
+    expect(result).toEqual(snapshot);
+  });
+
   it('throws when neither path nor buffer is present', () => {
     const file = makeFile({ path: '', buffer: undefined as never });
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-23-upload-bytes-preserved.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-23-upload-bytes-preserved.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-23-upload-bytes-preserved",
+  "date": "2026-06-23",
+  "type": "fix",
+  "title": "Uploaded files convert reliably even when the temporary copy is cleaned up early"
+}


### PR DESCRIPTION
## What
Uploaded files intermittently failed to convert with `Error: Uploaded file is no longer available on disk and has no buffer fallback` — 21 failed uploads in a 48h prod window. Multer's disk-storage engine (`dest: UPLOAD_BASE`) gives each upload a `path` but no `buffer`; the conversion reads the file later in a Piscina worker, and the temp file can be gone by then. #3416 added an `ensureUploadBytes` snapshot to populate the worker's buffer fallback, but called it from inside `GeneratePackagesUseCase.execute` — after the request-handler's async hop — so by the time it ran the file was already gone and the snapshot itself threw. This moves the snapshot to the multer callback in `GetUploadHandler`, the instant the upload finishes writing, while the file is provably on disk.

## Symptom (sanitized)
```
Error: Uploaded file is no longer available on disk and has no buffer fallback
  at GeneratePackagesUseCase.execute (src/usecases/uploads/GeneratePackagesUseCase.ts)
  at UploadService.handleSyncUpload (src/services/UploadService.ts)
```

## Why it broke
#3416 assumed the temp file was reaped *during* the Piscina worker dwell, so it snapshotted bytes at the start of `GeneratePackagesUseCase.execute`. But `execute` runs *after* the request handler's async work (auth, settings lookup). The evidence contradicts the dwell theory:
- The snapshot's `readFileSync` logged `could not snapshot upload bytes` exactly 21 times — matching the 21 failures. The file was already gone *at request-handler time*, before the worker ran.
- Worker dwell-mode distribution was 1147 `disk`, 0 `buffer`, 0 `buffer-fallback`. The buffer fallback never once fired, because the buffer was never populated — the snapshot either wasn't needed (disk present) or failed (file already gone).

So the snapshot ran too late: by the time `execute` was reached, the temp file under `UPLOAD_BASE` was no longer on disk.

## How the fix works
`ensureUploadBytes` now runs in the `withNormalizedFilenames` callback inside `GetUploadHandler` — the synchronous moment multer finishes writing the file, before any `await`, before the use case, before the Piscina queue. At that point the file is guaranteed on disk, so the read succeeds and `file.buffer` is populated. The `Buffer` rides the structured-clone handoff into the worker, where `getFileContents` serves it via the existing buffer fallback if the disk read fails. Disk stays the happy path (it works 1147×); the fallback is now genuinely populated for the reaping case.

The `ensureUploadBytes(files)` call inside `GeneratePackagesUseCase.execute` is kept as idempotent defense-in-depth (it short-circuits when the buffer is already set), so any non-multer call site is still covered.

## Upload paths verified (first-time-fix)
- **Sync path** (`handleSyncUpload` → `GeneratePackagesUseCase.execute`): the prod-failing path. Now snapshotted at receipt by `GetUploadHandler`.
- **Async path** (`handleAsyncUpload`, Claude flashcards): same `req.files` from the same multer handler — also snapshotted at receipt.
- **Dropbox / Google Drive** (`handleDropbox` / `handleGoogleDrive`): set `file.buffer` directly with no `path`, so they never touched disk and were never affected; `ensureUploadBytes` is a no-op for them.

Both multer paths go through the single `getUploadHandler` → `withNormalizedFilenames` seam, so the capture is reachable on both.

## Regression test
- `src/lib/misc/GetUploadHandler.test.ts` — drives `withNormalizedFilenames`, asserts the disk bytes are captured into `file.buffer` at receipt, then deletes the temp file and asserts `getFileContents` still returns the bytes (the exact reaping scenario). Fails on pre-fix code: the wiring did not exist.
- `src/usecases/uploads/worker.test.ts` — adds an explicit buffer-fallback case (disk path set + file missing + snapshot buffer present → returns bytes), locking a branch that had 0 prod hits.

## Goal alignment
Internal reliability fix on the core upload→convert path. The metric to move is upload failure count (`Uploaded file is no longer available...` should drop to ~0 in pm2 logs); read it on the prod box after deploy. A broken conversion pipeline loses users at the most important moment — first conversion.

## Sonar
`sonar-scanner` not run locally — `SONAR_TOKEN` is unset in this environment. The change is a small mechanical move of an existing call plus tests; expect no new code smells.

Browser check: not applicable — server-side upload-handling fix, changelog only on web/src
