### PR TITLE
feat: count dropped images on the upload conversion path

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -68,6 +68,7 @@ interface PrepareDeckResult {
   mcqCount: number;
   mcqSkippedCount: number;
   warning?: string;
+  droppedImageCount: number;
 }
 
 async function convertFile(
@@ -440,6 +441,7 @@ export async function PrepareDeck(
       cardCount: claudeCardCount,
       mcqCount: 0,
       mcqSkippedCount: 0,
+      droppedImageCount: 0,
     };
   }
 
@@ -459,6 +461,7 @@ export async function PrepareDeck(
         mcqCount: 0,
         mcqSkippedCount: 0,
         warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+        droppedImageCount: parser.droppedRemoteImageCount,
       };
     }
   }
@@ -477,6 +480,7 @@ export async function PrepareDeck(
     mcqCount,
     mcqSkippedCount,
     warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+    droppedImageCount: parser.droppedRemoteImageCount,
   };
 }
 
@@ -490,6 +494,7 @@ export interface DeckInfoOnlyResult {
   mcqCount: number;
   mcqSkippedCount: number;
   warning?: string;
+  droppedImageCount: number;
   needsIndividualBuild: boolean;
 }
 
@@ -522,6 +527,7 @@ export async function prepareDeckInfoOnly(
         mcqCount: 0,
         mcqSkippedCount: 0,
         warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+        droppedImageCount: parser.droppedRemoteImageCount,
         needsIndividualBuild: true,
       };
     }
@@ -549,6 +555,7 @@ export async function prepareDeckInfoOnly(
     mcqCount,
     mcqSkippedCount,
     warning: parser.usedHeuristic ? 'markdown-heuristic' : undefined,
+    droppedImageCount: parser.droppedRemoteImageCount,
     needsIndividualBuild: false,
   };
 }

--- a/src/lib/parser/DeckParser.test.ts
+++ b/src/lib/parser/DeckParser.test.ts
@@ -1705,6 +1705,14 @@ describe('remote image rehosting', () => {
     expect(card.media).toContain(localName);
   });
 
+  test('does not count a successfully embedded remote image as dropped', async () => {
+    const ws = new Workspace(true, 'fs');
+    const parser = buildRemoteImageParser();
+    await parser.writeDeckInfo(ws);
+
+    expect(parser.droppedRemoteImageCount).toBe(0);
+  });
+
   test('keeps the original URL when the download fails so the card is never worse', async () => {
     downloadMediaOrSkipMock.mockResolvedValueOnce(null);
     const ws = new Workspace(true, 'fs');
@@ -1716,6 +1724,15 @@ describe('remote image rehosting', () => {
       'prod-files-secure.s3.us-west-2.amazonaws.com/ws/file/diagram.png'
     );
     expect(card.media).toHaveLength(0);
+  });
+
+  test('counts a remote image that could not be downloaded as dropped', async () => {
+    downloadMediaOrSkipMock.mockResolvedValueOnce(null);
+    const ws = new Workspace(true, 'fs');
+    const parser = buildRemoteImageParser();
+    await parser.writeDeckInfo(ws);
+
+    expect(parser.droppedRemoteImageCount).toBe(1);
   });
 });
 

--- a/src/lib/parser/DeckParser.ts
+++ b/src/lib/parser/DeckParser.ts
@@ -119,6 +119,8 @@ export class DeckParser {
 
   usedHeuristic: boolean;
 
+  droppedRemoteImageCount: number;
+
   workspace: Workspace;
   customExporter: CustomExporter;
 
@@ -132,6 +134,7 @@ export class DeckParser {
     this.firstDeckName = input.name;
     this.noLimits = input.noLimits;
     this.usedHeuristic = false;
+    this.droppedRemoteImageCount = 0;
     this.payload = [];
     this.workspace = input.workspace ?? new Workspace(true, 'fs');
     this.customExporter = new CustomExporter(
@@ -674,7 +677,10 @@ export class DeckParser {
     } catch {
       console.warn(`Failed to fetch remote image ${url}`);
     }
-    if (bytes == null) return;
+    if (bytes == null) {
+      this.droppedRemoteImageCount++;
+      return;
+    }
 
     const newName = remoteImageFilename(url, bytes);
     this.customExporter.addMedia(newName, bytes);

--- a/src/lib/parser/FEATURE.md
+++ b/src/lib/parser/FEATURE.md
@@ -64,6 +64,8 @@ Two entry points when enabled: `DeckParser.extractCards()` classifies a Notion t
 
 **Count threading:** `DeckParser.extractCards()` returns `{ cards, mcqCount, mcqSkippedCount }`. These are stored on the `Deck` object and summed in `PrepareDeck`, then sent as `X-MCQ-Count` / `X-MCQ-Skipped-Count` response headers.
 
+**Dropped-image threading:** `DeckParser.droppedRemoteImageCount` increments once in `embedRemoteImage` whenever a remote `<img>` fetch returns null (attempted-and-failed only — a local/zip-recovered image or an external link never reaches that drop). `PrepareDeck`/`prepareDeckInfoOnly` carry it out as `droppedImageCount`, `getPackagesFromZip` and the upload worker put it on each `Package`, and `UploadService` sums it across packages — `X-Dropped-Assets` on a single-deck sync response, `droppedImageCount` on the batch JSON. The Upload page renders the shared `ImageDropNotice` (source `upload`) from that count, mirroring the Notion-path notice. Claude-branch conversions never run `embedRemoteImage`, so their count is 0.
+
 **Authoring guide:** `web/src/pages/DocsPage/content/cards/mcq.md` — user-facing guide rendered at `/documentation/cards/mcq`. Update both the body and the brief MCQ section in `card-types.md` when the detection contract changes.
 
 ## Block-decision classifier (`intent/`)

--- a/src/lib/parser/Package.ts
+++ b/src/lib/parser/Package.ts
@@ -7,16 +7,20 @@ class Package {
 
   mcqSkippedCount: number;
 
+  droppedImageCount: number;
+
   constructor(
     name: string,
     cardCount: number = 0,
     mcqCount: number = 0,
-    mcqSkippedCount: number = 0
+    mcqSkippedCount: number = 0,
+    droppedImageCount: number = 0
   ) {
     this.name = name;
     this.cardCount = cardCount;
     this.mcqCount = mcqCount;
     this.mcqSkippedCount = mcqSkippedCount;
+    this.droppedImageCount = droppedImageCount;
   }
 }
 

--- a/src/services/UploadService.test.ts
+++ b/src/services/UploadService.test.ts
@@ -740,6 +740,58 @@ describe('UploadService.handleSyncUpload — card-limit enforcement', () => {
     expect(capturedSend()).toBeNull();
   });
 
+  it('sets X-Dropped-Assets to the summed dropped-image count across packages on a single-deck sync upload', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [
+              {
+                name: 'deck',
+                cardCount: 12,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+                droppedImageCount: 2,
+              },
+            ],
+            warnings: [],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res, capturedStatus } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(capturedStatus()).toBe(200);
+    expect(res.set).toHaveBeenCalledWith('X-Dropped-Assets', '2');
+  });
+
+  it('does not set X-Dropped-Assets when no images were dropped', async () => {
+    mockPackages([{ name: 'deck', cardCount: 12 }]);
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    expect(res.set).not.toHaveBeenCalledWith(
+      'X-Dropped-Assets',
+      expect.anything()
+    );
+  });
+
   it('surfaces a skipped-locked-PDF note on X-Warning when a ZIP entry stays locked', async () => {
     const lockedWarning =
       '2 password-protected PDFs were skipped: Ch1.pdf, Ch2.pdf. Unlock each in Preview or Adobe Reader, save a copy, and upload them on their own.';
@@ -1329,6 +1381,84 @@ describe('UploadService.handleUpload — multi-deck batch', () => {
         props: expect.objectContaining({ source: 'upload' }),
       })
     );
+  });
+
+  it('includes droppedImageCount in the batch JSON when images were dropped across the batch', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [
+              {
+                name: 'Biology 101',
+                cardCount: 3,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+                droppedImageCount: 1,
+              },
+              {
+                name: 'Chemistry',
+                cardCount: 5,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+                droppedImageCount: 2,
+              },
+            ],
+            warnings: [],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    const body = capturedJson() as { droppedImageCount?: number };
+    expect(body.droppedImageCount).toBe(3);
+  });
+
+  it('omits droppedImageCount from the batch JSON when no images were dropped', async () => {
+    MockGeneratePackagesUseCase.mockImplementation(
+      () =>
+        ({
+          execute: jest.fn().mockResolvedValue({
+            packages: [
+              {
+                name: 'Biology 101',
+                cardCount: 3,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+              },
+              {
+                name: 'Chemistry',
+                cardCount: 5,
+                mcqCount: 0,
+                mcqSkippedCount: 0,
+              },
+            ],
+            warnings: [],
+          }),
+        }) as unknown as InstanceType<typeof GeneratePackagesUseCase>
+    );
+
+    const service = new UploadService(
+      buildRepository(),
+      {} as JobRepository,
+      buildUsersRepo()
+    );
+    const req = buildRequest();
+    const { res, capturedJson } = buildResponse();
+
+    await service.handleUpload(req, res);
+
+    const body = capturedJson() as { droppedImageCount?: number };
+    expect(body.droppedImageCount).toBeUndefined();
   });
 });
 

--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -84,6 +84,7 @@ interface BatchUploadResponse {
   decks: BatchDeckResult[];
   bulkUrl: string;
   warning?: string;
+  droppedImageCount?: number;
 }
 
 const MARKDOWN_HEURISTIC_WARNING =
@@ -99,6 +100,10 @@ function resolveUploadWarning(warnings: string[] | undefined): string | null {
     return MARKDOWN_HEURISTIC_WARNING;
   }
   return null;
+}
+
+function sumDroppedImages(packages: { droppedImageCount?: number }[]): number {
+  return packages.reduce((sum, p) => sum + (p.droppedImageCount ?? 0), 0);
 }
 
 function hasSessionToken(req: express.Request): boolean {
@@ -636,6 +641,7 @@ class UploadService {
         (sum, p) => sum + (p.mcqSkippedCount ?? 0),
         0
       );
+      const totalDroppedImageCount = sumDroppedImages(packages);
       res.set('Content-Type', 'application/apkg');
       res.set('Content-Length', plen.toString());
       res.set('X-Card-Count', totalCards.toString());
@@ -647,6 +653,10 @@ class UploadService {
         'X-MCQ-Count',
         'X-MCQ-Skipped-Count',
       ];
+      if (totalDroppedImageCount > 0) {
+        res.set('X-Dropped-Assets', totalDroppedImageCount.toString());
+        exposedHeaders.push('X-Dropped-Assets');
+      }
       const warningText = resolveUploadWarning(warnings);
       if (warningText) {
         res.set('X-Warning', warningText);
@@ -687,12 +697,19 @@ class UploadService {
     }
     return res
       .status(200)
-      .json(await this.buildBatchResponse(ws, resolveUploadWarning(warnings)));
+      .json(
+        await this.buildBatchResponse(
+          ws,
+          resolveUploadWarning(warnings),
+          sumDroppedImages(packages)
+        )
+      );
   }
 
   private async buildBatchResponse(
     ws: Workspace,
-    warning: string | null = null
+    warning: string | null = null,
+    droppedImageCount = 0
   ): Promise<BatchUploadResponse> {
     const apkgFilenames = (await fs.promises.readdir(ws.location)).filter(
       (filename) => filename.endsWith('.apkg')
@@ -709,6 +726,7 @@ class UploadService {
       decks,
       bulkUrl: `/download/${ws.id}/bulk`,
       ...(warning ? { warning } : {}),
+      ...(droppedImageCount > 0 ? { droppedImageCount } : {}),
     };
   }
 

--- a/src/usecases/uploads/getPackagesFromZip.ts
+++ b/src/usecases/uploads/getPackagesFromZip.ts
@@ -121,7 +121,8 @@ async function buildDeckBatch(
           result.name,
           result.cardCount,
           result.mcqCount,
-          result.mcqSkippedCount
+          result.mcqSkippedCount,
+          result.droppedImageCount
         )
       );
       if (result.warning) warnings.push(result.warning);
@@ -177,7 +178,8 @@ async function buildStragglerDecks(
           outcome.name,
           outcome.cardCount ?? 0,
           outcome.mcqCount ?? 0,
-          outcome.mcqSkippedCount ?? 0
+          outcome.mcqSkippedCount ?? 0,
+          outcome.droppedImageCount ?? 0
         )
       );
       if (outcome.warning) warnings.push(outcome.warning);
@@ -214,7 +216,8 @@ async function buildClaudeFlashcardDeck(
         deck.name,
         deck.cardCount ?? 0,
         deck.mcqCount ?? 0,
-        deck.mcqSkippedCount ?? 0
+        deck.mcqSkippedCount ?? 0,
+        deck.droppedImageCount ?? 0
       )
     );
     if (deck.warning) warnings.push(deck.warning);
@@ -260,7 +263,8 @@ async function buildAllInOneSlot(
           outcome.name,
           outcome.cardCount ?? 0,
           outcome.mcqCount ?? 0,
-          outcome.mcqSkippedCount ?? 0
+          outcome.mcqSkippedCount ?? 0,
+          outcome.droppedImageCount ?? 0
         )
       );
       if (outcome.warning) warnings.push(outcome.warning);

--- a/src/usecases/uploads/worker.ts
+++ b/src/usecases/uploads/worker.ts
@@ -180,7 +180,8 @@ async function processFile(
           d.name,
           d.cardCount ?? 0,
           d.mcqCount ?? 0,
-          d.mcqSkippedCount ?? 0
+          d.mcqSkippedCount ?? 0,
+          d.droppedImageCount ?? 0
         )
       );
       if (d.warning) warnings.push(d.warning);

--- a/web/src/pages/DownloadsPage/components/ImageDropNotice.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ImageDropNotice.test.tsx
@@ -31,10 +31,26 @@ describe('ImageDropNotice', () => {
     ).toBeInTheDocument();
   });
 
-  it('fires the usage event with the dropped count on mount', () => {
+  it('fires the usage event with the dropped count and notion source on mount', () => {
     render(<ImageDropNotice count={3} />);
     expect(track).toHaveBeenCalledWith('image_drop_notice_shown', {
       dropped_count: 3,
+      source: 'notion',
+    });
+  });
+
+  it('uses file-oriented copy for the upload source', () => {
+    render(<ImageDropNotice count={2} source="upload" />);
+    expect(
+      screen.getByText(/links to them in your file most likely expired/)
+    ).toBeInTheDocument();
+  });
+
+  it('fires the usage event with the upload source when rendered for an upload', () => {
+    render(<ImageDropNotice count={1} source="upload" />);
+    expect(track).toHaveBeenCalledWith('image_drop_notice_shown', {
+      dropped_count: 1,
+      source: 'upload',
     });
   });
 });

--- a/web/src/pages/DownloadsPage/components/ImageDropNotice.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ImageDropNotice.test.tsx
@@ -42,8 +42,14 @@ describe('ImageDropNotice', () => {
   it('uses file-oriented copy for the upload source', () => {
     render(<ImageDropNotice count={2} source="upload" />);
     expect(
-      screen.getByText(/links to them in your file most likely expired/)
+      screen.getByText(/links to them on other sites we couldn't reach/)
     ).toBeInTheDocument();
+    expect(screen.getByText(/aren't in this deck/)).toBeInTheDocument();
+  });
+
+  it('says "your decks" for a multi-deck batch upload', () => {
+    render(<ImageDropNotice count={3} source="upload" multipleDecks />);
+    expect(screen.getByText(/aren't in your decks/)).toBeInTheDocument();
   });
 
   it('fires the usage event with the upload source when rendered for an upload', () => {

--- a/web/src/pages/DownloadsPage/components/ImageDropNotice.tsx
+++ b/web/src/pages/DownloadsPage/components/ImageDropNotice.tsx
@@ -6,6 +6,7 @@ type ImageDropSource = 'notion' | 'upload';
 interface ImageDropNoticeProps {
   count: number;
   source?: ImageDropSource;
+  multipleDecks?: boolean;
 }
 
 function notionCopy(count: number) {
@@ -27,21 +28,22 @@ function notionCopy(count: number) {
   );
 }
 
-function uploadCopy(count: number) {
+function uploadCopy(count: number, multipleDecks: boolean) {
+  const deckNoun = multipleDecks ? 'your decks' : 'this deck';
   if (count === 1) {
     return (
       <p>
-        1 image couldn&apos;t be downloaded and isn&apos;t in this deck. The
-        link to it in your file most likely expired. Convert again to try
-        fetching it.
+        1 image couldn&apos;t be downloaded and isn&apos;t in {deckNoun}. Your
+        file links to it on another site we couldn&apos;t reach. Save the image
+        into the file itself, then upload again.
       </p>
     );
   }
   return (
     <p>
-      {count} images couldn&apos;t be downloaded and aren&apos;t in this deck.
-      The links to them in your file most likely expired. Convert again to try
-      fetching them.
+      {count} images couldn&apos;t be downloaded and aren&apos;t in {deckNoun}.
+      Your file links to them on other sites we couldn&apos;t reach. Save the
+      images into the file itself, then upload again.
     </p>
   );
 }
@@ -49,10 +51,13 @@ function uploadCopy(count: number) {
 export function ImageDropNotice({
   count,
   source = 'notion',
+  multipleDecks = false,
 }: Readonly<ImageDropNoticeProps>) {
   useEffect(() => {
     track('image_drop_notice_shown', { dropped_count: count, source });
   }, [count, source]);
 
-  return source === 'upload' ? uploadCopy(count) : notionCopy(count);
+  return source === 'upload'
+    ? uploadCopy(count, multipleDecks)
+    : notionCopy(count);
 }

--- a/web/src/pages/DownloadsPage/components/ImageDropNotice.tsx
+++ b/web/src/pages/DownloadsPage/components/ImageDropNotice.tsx
@@ -1,15 +1,14 @@
 import { useEffect } from 'react';
 import { track } from '../../../lib/analytics/track';
 
+type ImageDropSource = 'notion' | 'upload';
+
 interface ImageDropNoticeProps {
   count: number;
+  source?: ImageDropSource;
 }
 
-export function ImageDropNotice({ count }: Readonly<ImageDropNoticeProps>) {
-  useEffect(() => {
-    track('image_drop_notice_shown', { dropped_count: count });
-  }, [count]);
-
+function notionCopy(count: number) {
   if (count === 1) {
     return (
       <p>
@@ -19,7 +18,6 @@ export function ImageDropNotice({ count }: Readonly<ImageDropNoticeProps>) {
       </p>
     );
   }
-
   return (
     <p>
       {count} images couldn&apos;t be downloaded and aren&apos;t in this deck.
@@ -27,4 +25,34 @@ export function ImageDropNotice({ count }: Readonly<ImageDropNoticeProps>) {
       try fetching them.
     </p>
   );
+}
+
+function uploadCopy(count: number) {
+  if (count === 1) {
+    return (
+      <p>
+        1 image couldn&apos;t be downloaded and isn&apos;t in this deck. The
+        link to it in your file most likely expired. Convert again to try
+        fetching it.
+      </p>
+    );
+  }
+  return (
+    <p>
+      {count} images couldn&apos;t be downloaded and aren&apos;t in this deck.
+      The links to them in your file most likely expired. Convert again to try
+      fetching them.
+    </p>
+  );
+}
+
+export function ImageDropNotice({
+  count,
+  source = 'notion',
+}: Readonly<ImageDropNoticeProps>) {
+  useEffect(() => {
+    track('image_drop_notice_shown', { dropped_count: count, source });
+  }, [count, source]);
+
+  return source === 'upload' ? uploadCopy(count) : notionCopy(count);
 }

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -15,6 +15,7 @@ import {
   type ConversionSuccessHandlers,
 } from './uploadResponse';
 import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadFileName';
+import { ImageDropNotice } from '../../../DownloadsPage/components/ImageDropNotice';
 import { getEmptyDeckChatPrompt } from '../../helpers/getEmptyDeckChatPrompt';
 import { useDrag } from './hooks/useDrag';
 import { useUploadFormState } from './hooks/useUploadFormState';
@@ -266,6 +267,8 @@ function UploadForm({
     setMcqCount,
     mcqSkippedCount,
     setMcqSkippedCount,
+    droppedImageCount,
+    setDroppedImageCount,
     mcqDrawerOpen,
     setMcqDrawerOpen,
     mcqShowAnswer,
@@ -341,6 +344,7 @@ function UploadForm({
     setCardCount,
     setMcqCount,
     setMcqSkippedCount,
+    setDroppedImageCount,
     setDownloadLink,
     setProgressWidth,
     setBatchResult,
@@ -892,6 +896,11 @@ function UploadForm({
       {warningMessage && (
         <p className={formStyles.warningInline}>{warningMessage}</p>
       )}
+      {droppedImageCount > 0 && (
+        <div className={formStyles.warningInline}>
+          <ImageDropNotice count={droppedImageCount} source="upload" />
+        </div>
+      )}
       {showFallback && (
         <button
           type="button"
@@ -943,6 +952,11 @@ function UploadForm({
           {deckCount} {deckCount === 1 ? 'deck' : 'decks'} ready
         </p>
         {warning && <p className={formStyles.warningInline}>{warning}</p>}
+        {droppedImageCount > 0 && (
+          <div className={formStyles.warningInline}>
+            <ImageDropNotice count={droppedImageCount} source="upload" />
+          </div>
+        )}
         <ul className={formStyles.deckList}>
           {decks.map((deck) => (
             <li key={deck.filename} className={formStyles.deckRow}>

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -954,7 +954,11 @@ function UploadForm({
         {warning && <p className={formStyles.warningInline}>{warning}</p>}
         {droppedImageCount > 0 && (
           <div className={formStyles.warningInline}>
-            <ImageDropNotice count={droppedImageCount} source="upload" />
+            <ImageDropNotice
+              count={droppedImageCount}
+              source="upload"
+              multipleDecks
+            />
           </div>
         )}
         <ul className={formStyles.deckList}>

--- a/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/hooks/useUploadFormState.ts
@@ -24,6 +24,7 @@ export interface BatchResult {
   decks: BatchDeck[];
   bulkUrl: string;
   warning?: string;
+  droppedImageCount?: number;
 }
 
 export interface LockedPdfInfo {
@@ -45,6 +46,7 @@ export function useUploadFormState(onReset: () => void) {
   const [cardCount, setCardCount] = useState<number | null>(null);
   const [mcqCount, setMcqCount] = useState<number>(0);
   const [mcqSkippedCount, setMcqSkippedCount] = useState<number>(0);
+  const [droppedImageCount, setDroppedImageCount] = useState<number>(0);
   const [mcqDrawerOpen, setMcqDrawerOpen] = useState(false);
   const [mcqShowAnswer, setMcqShowAnswer] = useState(false);
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
@@ -78,6 +80,7 @@ export function useUploadFormState(onReset: () => void) {
     setCardCount(null);
     setMcqCount(0);
     setMcqSkippedCount(0);
+    setDroppedImageCount(0);
     setMcqDrawerOpen(false);
     setMcqShowAnswer(false);
     setWarningMessage(null);
@@ -116,6 +119,8 @@ export function useUploadFormState(onReset: () => void) {
     setMcqCount,
     mcqSkippedCount,
     setMcqSkippedCount,
+    droppedImageCount,
+    setDroppedImageCount,
     mcqDrawerOpen,
     setMcqDrawerOpen,
     mcqShowAnswer,

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.test.ts
@@ -16,6 +16,7 @@ function buildHandlers(): ConversionSuccessHandlers {
     setCardCount: vi.fn(),
     setMcqCount: vi.fn(),
     setMcqSkippedCount: vi.fn(),
+    setDroppedImageCount: vi.fn(),
     setDownloadLink: vi.fn(),
     setProgressWidth: vi.fn(),
     setBatchResult: vi.fn(),
@@ -23,11 +24,12 @@ function buildHandlers(): ConversionSuccessHandlers {
   };
 }
 
-function singleDeckResponse(): Response {
+function singleDeckResponse(headers: Record<string, string> = {}): Response {
   return {
     headers: new Headers({
       'Content-Type': 'application/octet-stream',
       'X-Card-Count': '5',
+      ...headers,
     }),
     blob: () => Promise.resolve(new Blob(['fake'])),
   } as unknown as Response;
@@ -86,5 +88,50 @@ describe('applyConversionSuccess', () => {
 
     expect(gtag).not.toHaveBeenCalledWith('event', 'conversion_success');
     expect(handlers.setZoneState).toHaveBeenCalledWith('multiDeck');
+  });
+
+  it('reads the dropped-image count from the X-Dropped-Assets header on a single deck', async () => {
+    const handlers = buildHandlers();
+
+    await applyConversionSuccess(
+      singleDeckResponse({ 'X-Dropped-Assets': '3' }),
+      handlers
+    );
+
+    expect(handlers.setDroppedImageCount).toHaveBeenCalledWith(3);
+  });
+
+  it('sets the dropped-image count to 0 when the X-Dropped-Assets header is absent', async () => {
+    const handlers = buildHandlers();
+
+    await applyConversionSuccess(singleDeckResponse(), handlers);
+
+    expect(handlers.setDroppedImageCount).toHaveBeenCalledWith(0);
+  });
+
+  it('reads droppedImageCount from the batch JSON body', async () => {
+    const handlers = buildHandlers();
+    const response = {
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      json: () =>
+        Promise.resolve({
+          kind: 'batch',
+          workspaceId: 'ws-1',
+          deckCount: 1,
+          decks: [
+            {
+              name: 'A',
+              filename: 'A.apkg',
+              downloadUrl: '/download/ws-1/A.apkg',
+            },
+          ],
+          bulkUrl: '/download/ws-1/bulk',
+          droppedImageCount: 4,
+        }),
+    } as unknown as Response;
+
+    await applyConversionSuccess(response, handlers);
+
+    expect(handlers.setDroppedImageCount).toHaveBeenCalledWith(4);
   });
 });

--- a/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
+++ b/web/src/pages/UploadPage/components/UploadForm/uploadResponse.ts
@@ -33,6 +33,7 @@ export interface ConversionSuccessHandlers {
   setCardCount: (value: number | null) => void;
   setMcqCount: (value: number) => void;
   setMcqSkippedCount: (value: number) => void;
+  setDroppedImageCount: (value: number) => void;
   setDownloadLink: (value: string | null) => void;
   setProgressWidth: (value: number) => void;
   setBatchResult: (value: BatchResult) => void;
@@ -57,6 +58,7 @@ export async function applyConversionSuccess(
     const body: unknown = await response.json();
     if (isBatchResult(body)) {
       handlers.setBatchResult(body);
+      handlers.setDroppedImageCount(body.droppedImageCount ?? 0);
       handlers.setProgressWidth(100);
       handlers.setZoneState('multiDeck');
       return;
@@ -72,6 +74,9 @@ export async function applyConversionSuccess(
   );
   handlers.setMcqSkippedCount(
     parseNonNegativeIntHeader(response.headers, 'X-MCQ-Skipped-Count')
+  );
+  handlers.setDroppedImageCount(
+    parseNonNegativeIntHeader(response.headers, 'X-Dropped-Assets')
   );
   const blob = await response.blob();
   handlers.setDownloadLink(globalThis.URL.createObjectURL(blob));

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-23-upload-images-skipped.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-23-upload-images-skipped.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-23-upload-images-skipped",
+  "date": "2026-06-23",
+  "type": "fix",
+  "title": "Uploaded decks now flag when an image couldn't be included, like Notion conversions already do"
+}


### PR DESCRIPTION
## What
Extends the v1 "some images skipped" notice (#3464, Notion one-shot path) to the upload/worker conversion path. When an uploaded HTML / zip / docx / markdown deck references a remote image that can't be downloaded, the Upload result surface now shows a non-blocking notice with a count, just like Notion conversions already do.

## Why
#3465 — part 2 of #3457. A silently-missing image is the most visible first-conversion quality defect; the upload path had no disclosure at all. v1 measured and disclosed drops on the Notion path; this closes the gap for uploads. The notice does not yet plug the drop — it discloses it.

## How
The upload conversion runs in a Piscina worker, so the Notion instance-field accumulator can't cross the boundary. The count rides the existing `Package` result channel:
- `DeckParser.droppedRemoteImageCount` increments once in `embedRemoteImage` when `downloadMediaOrSkip` returns null (attempted-and-failed only — a local/zip-recovered image or an external link never reaches that drop).
- `PrepareDeck` / `prepareDeckInfoOnly` carry it out as `droppedImageCount`; `getPackagesFromZip` and the upload worker put it on each `Package`; `UploadService` sums it across packages.
- Sync single-deck response: `X-Dropped-Assets` header. Batch response: `droppedImageCount` JSON field. The web `applyConversionSuccess` reads both into a `droppedImageCount` state, and the Upload form renders the **reused** `ImageDropNotice`.
- `ImageDropNotice` gained an optional `source` prop (`notion` default, `upload` variant) so the copy fits the surface — Notion usage is unchanged; the analytics event now also carries `source`.

## Sync-vs-async decision (stated explicitly)
The drop point (`embedRemoteImage`) only runs on the **sync** upload path (non-Claude conversions of HTML/zip/docx/markdown). The **async** upload path is Claude-only (`paying && claudeAIFlashcards`), uses the Claude branch in `PrepareDeck` which never calls `embedRemoteImage`, and deletes its job row on success — so it can't carry a count and there's nothing to count. The task's premise that the async path lands a pollable done job with `dropped_assets` doesn't match the code. Chosen path: option (a) — surface the count on the sync HTTP response and render the same notice on the Upload page. **Covered: the sync upload path (single-deck + batch).** Out of scope and count 0: the async Claude upload path and the Ankify poll-sync path (`SyncNotionPageToRacUseCase`).

The DownloadsPage job-row notice (`parseDroppedAssetsPayload`) is untouched — sync uploads don't surface as job rows, so the upload count travels via headers/JSON, not the job parser.

## Measuring success
`image_drop_notice_shown` fires on render with `{ dropped_count, source }`. Filter `source = 'upload'` in funnel events to size raw drop incidence on the upload path (sizes any part-2 hardening). Server-side, `X-Dropped-Assets` on sync responses is observable in access logs.

## Testing
- Server tsc green, `pnpm arch` 0 errors, web typecheck green.
- `pnpm test src/services/UploadService.test.ts` — 40/40 pass, including: single-deck sets `X-Dropped-Assets` from the summed count; no header when 0; batch JSON includes/omits `droppedImageCount`.
- DeckParser: a failed remote image increments `droppedRemoteImageCount`; a successful one doesn't (mocks `downloadMediaOrSkip` only). The other DeckParser tests that spawn Python fail locally for the known worktree-venv reason — they pass in CI.
- Web vitest 2072 pass: `ImageDropNotice` upload-variant copy + event source; `uploadResponse` header parse + batch field round-trip.
- The frontend notice is reused unchanged in structure; only an optional source-aware copy variant was added (Notion default preserved).

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green (2 passed, no console errors at 375px). Touched the sync upload result surface, so this is a real run, not the changelog bypass.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-06-23-upload-images-skipped.json` — "Uploaded decks now flag when an image couldn't be included, like Notion conversions already do"

## Docs
No docs change — extends existing behavior. The upload docs (`start-here/upload-a-file.md`) only mention images in a format-conversion context, never image-download handling, so there's nothing to update.

## Sonar
`SONAR_TOKEN` not set locally — sonar-scanner not run. The change is mechanical counter-threading (low cognitive complexity, no new HTTP/render of user input); expect a clean pass, flagging in case of a bounce.

## Risks
- Low. The count is additive and only surfaces a notice when > 0; the unset/zero case is byte-for-byte the prior behavior.
- `X-Dropped-Assets` is added to `Access-Control-Expose-Headers` only when present, matching the existing `X-Warning` pattern.

## Goal alignment
First-conversion trust on the upload path. A deck that looks broken (missing image, no explanation) erodes the trust that feeds acquisition and retention. Metric: `image_drop_notice_shown` (source=upload) read in funnel events; no direct revenue metric — this is a quality/trust change on the core conversion funnel.
