### PR TITLE
chore: weekly retro 2026-W26 + refresh business baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,9 @@ Every PR is checked against all three — does it make the experience simpler/fa
 - **Color**: reuse `web/src/styles/base.css` tokens (5 themes), one blue accent + the status triad — no new ramp
 - **Constraints**: React, WCAG AA, the 5-theme token system, product restraint (one signature move exempt)
 
-### Business baseline (as of 2026-06-10 — weekly-retro updates this block)
+### Business baseline (as of 2026-06-23 — weekly-retro updates this block)
 
-MRR $1,710 · 763 paying subs · ARPU $2.24 · 18.9%/mo churn (79% lifecycle, not price) · 34 new paid/wk trailing · ~19,580 registered. Read live at `/api/ops/business/metrics` (ops-gated) and Stripe; funnel events at `/api/ops/metrics`.
+MRR $1,823 · 759 paying subs · ARPU $2.40 · 18.2%/mo churn (79% lifecycle, not price) · 16 new paid/wk · 17,861 registered. Read live at `/api/ops/business/metrics` (ops-gated) and Stripe; funnel events at `/api/ops/metrics`.
 Pricing v2 shipped 2026-06-10: $7.99/mo + $64/yr for new members, legacy $6/$60 lock-in until 21 Jun, annual default. Scheduled reads: v2 funnel week of 15 Jun (targets: ≥70 new paid/wk, page→checkout ≥10%, checkout→paid ≥50%); minimal-layout CTR guardrail 24 Jun.
 
 ## Tech stack

--- a/Documentation/retros/2026-W26.md
+++ b/Documentation/retros/2026-W26.md
@@ -1,0 +1,65 @@
+# Weekly retro — 2026-W26
+
+Filled 2026-06-23 from prod ops metrics (`/api/ops/business/metrics`, `BusinessMetricsService`) + prod DB. GA4 (property 286902985) unavailable this run — analytics-mcp not connected (see Gaps).
+
+## Numbers
+
+Ops-backed (prod):
+
+| Metric | This week | Prior week | Δ |
+| --- | --- | --- | --- |
+| Registered users (total) | 17 861 | — | 0.06% of 300K goal |
+| Signups (7d) | 253 | 291 | −13% |
+| MRR (USD) | $1 823 | ~$1 748 (16 Jun) | +4% |
+| Active paying subs | 762 | 779 (31 May) | −2% |
+| ARPU | $2.40 | $2.24 | +7% |
+| New paid conversions (7d) | 16 | 21 (wk 15 Jun) | −24% |
+| 30-day paid churn | 18.2% | 18.9% | −0.7pt |
+| Failed payments (7d) | 9 | 11 (wk 15 Jun) | −2 |
+
+**Registered-user correction:** the baseline block carried ~19 580 (and W23 read 19 664); the actual `count(*) FROM users` is **17 861**. Prior retros over-counted — baseline corrected this run.
+
+**MRR is recovering on ARPU, not volume.** MRR bottomed at $1 622 on 31 May and is up ~$200 since the v2 reprice (10 Jun) — but active subs kept sliding (779 → 762) and new-paid collapsed to **16/wk against the ≥70 v2 target (23% of it)**. We are refilling a leaking bucket with a thinner stream of higher-value subscribers. ARPU $2.24 → $2.40 confirms the reprice is doing its job; volume is the unlevered axis.
+
+**Cancellation reasons (top):** "I finished what I needed" 27 · "I don't use it enough" 22 · "Too expensive" 9. Lifecycle, not price — the 79%-lifecycle read holds, and the reprice is safe.
+
+**Conversions vs churn (weekly):** churned ≥ new-paying in 4 of the last 5 complete weeks. Last full week (15 Jun): 21 new, 30 churned (net −9).
+
+**Negative product feedback clusters on first-conversion** (`emoji_feedback`, 1-star): "why do I have to pay", wrong columns, "not enough cards", images dropped, reverse cards wrong. Two are tracked: #3457 (images dropped) and #3456 (callout escapes toggle).
+
+## Traffic Sources (GA4)
+
+**GAP — analytics-mcp not connected this session.** No sessions / channel / engagement / new-vs-returning data. The bot/referrer-spam self-check could not run. Headline real-user traffic for the week is unverified; treat ops-backed paid metrics as the load-bearing signal.
+
+## Work-mix (last 7 days, ~37 merged PRs)
+
+| Bucket | Share |
+| --- | --- |
+| Process (deps, harness sensors, tests, log-noise) | ~49% |
+| Core-quality (Ankify, conversion fixes, reliability) | ~32% |
+| Acquisition (5× /app native-app marketing page) | ~14% |
+| Monetization (stop selling Auto Sync) | ~3% |
+| New-surface | 0% |
+
+**Acquisition flag: FIRES — 14% < 25%.** The entire acquisition budget went to the /app native-app page — a small lever next to the web funnel.
+
+**Treadmill alarm: FIRES.** Process/chore+fix share elevated (~50%) while signups −13% and new-paid weak (16). This is the busy-graph / flat-growth signature named in CLAUDE.md (the 2023–25 stagnation shape).
+
+## Single biggest gap
+
+**Signup → paid conversion.** 253 signups/wk, only 16 convert (~6%). The v2 funnel read (page→checkout ≥10%, checkout→paid ≥50%) scheduled for the week of 15 Jun was **never pulled** — so we cannot say where the 16-vs-70 gap leaks. ARPU is handled; new-paid volume is the unmeasured, unlevered metric.
+
+## Tie to goal
+
+Scale + monetization, not product-beauty. The pipeline ships fixes weekly, but the only lane that makes paying users is both underfed (14% acquisition) and unmeasured (v2 funnel unread). Gross user growth is ~1.4%/wk — below the **2.7%/wk** needed for even a 24-month path to 300K (3.6%/wk for 18mo, 5.4%/wk for 12mo) — and signups are *declining* WoW. Polish weeks will not close that.
+
+## Recommendation (one)
+
+**Pause /app native-surface polish. Next 7 days: pull the overdue v2 funnel read (page→checkout, checkout→paid) and ship one first-conversion friction fix on /upload from what it shows.** We can't fix what we haven't measured; the funnel numbers are the load-bearing input. This is the acquisition-before-new-surface allocation rule enforcing itself.
+
+## Gaps to close before next retro
+
+- **GA4 traffic / engagement + bot self-check** — analytics-mcp not connected this run. Wire it or paste the GA4 export next retro.
+- **v2 funnel conversion rates** (page→checkout, checkout→paid) — scheduled 15 Jun, still unread. Load-bearing for the recommendation above.
+- **Apply GA4 bot/referrer-spam filter** — manual GA4 admin action; deferred because the traffic data was unavailable to flag against.
+- **W24 and W25 retros were skipped** — the conversions-vs-churn trend has a two-week hole.


### PR DESCRIPTION
Weekly retro for 2026-W26 (`Documentation/retros/2026-W26.md`) plus the `CLAUDE.md` business-baseline refresh that the retro owns.

## Headline
- MRR $1 823 (+4%, recovering on ARPU $2.24→$2.40) but **new-paid 16/wk vs the 70 v2 target** — recovery is volume-starved.
- Active subs 762, still sliding (779 on 31 May). Churn 18.2%, lifecycle-driven (top reason "finished what I needed").
- **Acquisition work-mix flag fires** (14% < 25%) and **treadmill alarm fires** (process-heavy week, signups −13%).
- **Recommendation:** pause /app native-surface polish; pull the overdue v2 funnel read and ship one /upload first-conversion fix.

## Baseline correction
Registered users was carried as ~19 580; actual `count(*) FROM users` is **17 861**. Corrected in the baseline block.

## Gaps logged for next retro
GA4/analytics-mcp not connected this run (no traffic section, no bot self-check); v2 funnel conversion rates still unread; W24/W25 retros were skipped.

No changelog entry — internal docs + baseline, no user-visible behavior change.