### PR TITLE
fix: convert plain-text uploads and guide unsupported Pages files

### DIFF
--- a/src/lib/parser/experimental/FallbackParser.test.ts
+++ b/src/lib/parser/experimental/FallbackParser.test.ts
@@ -93,3 +93,64 @@ describe('FallbackParser nested lists', () => {
     expect(innerOccurrences).toBe(1);
   });
 });
+
+describe('FallbackParser unstructured text (no tabs, no bullets)', () => {
+  it('creates cards from a .txt of "question - answer" pairs, one per line', () => {
+    const content = 'What is the capital of France? - Paris\nWhat is 2+2? - 4';
+    const parser = new FallbackParser([
+      { name: 'study.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(1);
+    expect(decks[0].cards).toHaveLength(2);
+    expect(decks[0].cards[0].name).toBe('What is the capital of France?');
+    expect(decks[0].cards[0].back).toBe('Paris');
+    expect(decks[0].cards[1].name).toBe('What is 2+2?');
+    expect(decks[0].cards[1].back).toBe('4');
+  });
+
+  it('creates cards from "question = answer" pairs', () => {
+    const content = 'H2O = Water\nNaCl = Salt';
+    const parser = new FallbackParser([
+      { name: 'chem.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(1);
+    expect(decks[0].cards).toHaveLength(2);
+    expect(decks[0].cards[0].name).toBe('H2O');
+    expect(decks[0].cards[0].back).toBe('Water');
+  });
+
+  it('produces an empty deck for a prose .txt with no card shape', () => {
+    const content =
+      'The mitochondria is the powerhouse of the cell.\nIt produces ATP through respiration.\nThis is just prose with no separators.';
+    const parser = new FallbackParser([
+      { name: 'notes.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(0);
+  });
+
+  it('keeps only the structured card when prose surrounds one pair', () => {
+    const content =
+      'Some introductory prose with no separator.\nWhat is the powerhouse of the cell? - Mitochondria\nMore trailing prose here.';
+    const parser = new FallbackParser([
+      { name: 'mixed.txt', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(1);
+    expect(decks[0].cards).toHaveLength(1);
+    expect(decks[0].cards[0].name).toBe('What is the powerhouse of the cell?');
+    expect(decks[0].cards[0].back).toBe('Mitochondria');
+  });
+
+  it('produces an empty deck for a prose .md export with no bullets', () => {
+    const content =
+      '# My Notes\n\nThis is a paragraph of prose exported from Notion.\nIt has no toggles and no bullet points at all.';
+    const parser = new FallbackParser([
+      { name: 'My Notes.md', contents: Buffer.from(content) },
+    ]);
+    const decks = parser.run({} as any);
+    expect(decks).toHaveLength(0);
+  });
+});

--- a/src/lib/parser/experimental/FallbackParser.ts
+++ b/src/lib/parser/experimental/FallbackParser.ts
@@ -16,6 +16,17 @@ import { Flashcard, isClozeFlashcard } from './PlainTextParser/types';
 import get16DigitRandomId from '../../../shared/helpers/get16DigitRandomId';
 import { getCardsFromCSV } from '@2anki/csv-to-apkg';
 
+function isStructuredFlashcard(card: Flashcard): boolean {
+  if (isClozeFlashcard(card)) {
+    return true;
+  }
+  return (
+    'back' in card &&
+    typeof card.back === 'string' &&
+    card.back.trim().length > 0
+  );
+}
+
 class FallbackParser {
   constructor(private readonly files: File[]) {}
 
@@ -78,7 +89,7 @@ class FallbackParser {
    * @returns array of bullet points or null if no bullet points found
    */
   getMarkdownBulletLists(markdown: string) {
-    const bulletListRegex = /[-*+][ \t]+.*/g;
+    const bulletListRegex = /^[ \t]*[-*+][ \t]+.*/gm;
     return markdown.match(bulletListRegex);
   }
 
@@ -170,14 +181,47 @@ class FallbackParser {
       };
     }
     const items = this.getMarkdownBulletLists(contents);
-    if (!items) {
+    if (items) {
+      const plainTextParser = new PlainTextParser();
+      const found = plainTextParser.parse(items.join('\n'));
+      return {
+        cards: this.mapCardsToNotes(found),
+        deckName: this.getTitleMarkdown(contents),
+      };
+    }
+    return this.parseUnstructuredText(contents, fileName);
+  }
+
+  /**
+   * Last resort for a .txt/.md file with no tabs and no bullet markers: parse
+   * one card per line so `question - answer` / `question = answer` pairs still
+   * become cards. Each line is fed to PlainTextParser as its own chunk (it
+   * otherwise only splits on blank lines), and only structured cards — a cloze
+   * or a non-empty back — are kept, so a file of plain prose stays an empty
+   * deck instead of producing one junk card.
+   */
+  private parseUnstructuredText(
+    contents: string,
+    fileName: string
+  ): { cards: Note[]; deckName: string } | null {
+    const lines = contents
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    if (lines.length === 0) {
       return null;
     }
     const plainTextParser = new PlainTextParser();
-    const found = plainTextParser.parse(items.join('\n'));
+    const structured = plainTextParser
+      .parse(lines.join('\n\n'))
+      .filter(isStructuredFlashcard);
+    if (structured.length === 0) {
+      return null;
+    }
+    const title = this.getTitleMarkdown(contents);
     return {
-      cards: this.mapCardsToNotes(found),
-      deckName: this.getTitleMarkdown(contents),
+      cards: this.mapCardsToNotes(structured),
+      deckName: title === 'Default' ? fileName.replace(/\.[^/.]+$/, '') : title,
     };
   }
 

--- a/src/lib/storage/checks.ts
+++ b/src/lib/storage/checks.ts
@@ -94,6 +94,11 @@ export const isAnkiDeckFile = (
 
 export const isXmlFile = (fileName: string) => /\.xml$/i.test(fileName);
 
+export const isPagesFile = (fileName: string | null | undefined): boolean => {
+  if (typeof fileName !== 'string') return false;
+  return /\.pages$/i.test(fileName);
+};
+
 const ANKI_APP_SNIFF_BYTES = 2048;
 
 export const isAnkiAppExportXml = (

--- a/src/lib/upload/getUploadValidationError.test.ts
+++ b/src/lib/upload/getUploadValidationError.test.ts
@@ -77,6 +77,24 @@ describe('getUploadValidationError', () => {
     expect(error!.message).toContain('invalid');
   });
 
+  test('returns a Pages-specific error for an Apple Pages file', () => {
+    const error = getUploadValidationError([
+      makeFile({ originalname: 'Week 18 notes.pages', size: 183022 }),
+    ]);
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain("We can't read Pages files");
+    expect(error!.message).toContain('Week 18 notes.pages');
+    expect(error!.message).toContain('.docx');
+  });
+
+  test('rejects an uppercase .PAGES file too', () => {
+    const error = getUploadValidationError([
+      makeFile({ originalname: 'NOTES.PAGES', size: 183022 }),
+    ]);
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain("We can't read Pages files");
+  });
+
   test('returns null for .docx file', () => {
     const error = getUploadValidationError([
       makeFile({ originalname: 'exam questions.docx', size: 30264 }),

--- a/src/lib/upload/getUploadValidationError.ts
+++ b/src/lib/upload/getUploadValidationError.ts
@@ -1,5 +1,5 @@
 import { UploadedFile } from '../storage/types';
-import { isAnkiDeckFile } from '../storage/checks';
+import { isAnkiDeckFile, isPagesFile } from '../storage/checks';
 
 interface ValidationOptions {
   allowApkg?: boolean;
@@ -27,6 +27,12 @@ export function getUploadValidationError(
     if (isEmptyFile(file)) {
       return new Error(
         `"${file.originalname}" appears to be empty. Please re-export your file and try again.`
+      );
+    }
+
+    if (isPagesFile(file.originalname)) {
+      return new Error(
+        `We can't read Pages files. Open ${file.originalname} in Apple Pages, export it as PDF, Word (.docx), or HTML, then upload that.`
       );
     }
 

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -876,6 +876,49 @@ describe('UploadForm analytics events', () => {
     });
   });
 
+  it('shows text-file-specific empty copy when a .txt yields 0 cards', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        redirected: false,
+        status: 200,
+        headers: new Headers({
+          'Content-Type': 'application/octet-stream',
+          'X-Card-Count': '0',
+        }),
+        blob: () => Promise.resolve(new Blob(['fake'])),
+      })
+    );
+
+    const { container } = renderUploadForm(
+      <UploadForm setErrorMessage={vi.fn()} />
+    );
+    const fileInput = container.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    const file = new File(['just prose'], 'study notes.txt', {
+      type: 'text/plain',
+    });
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+      configurable: true,
+    });
+
+    const form = container.querySelector('form')!;
+    await act(async () => {
+      form.dispatchEvent(
+        new Event('submit', { bubbles: true, cancelable: true })
+      );
+    });
+
+    await waitFor(() => {
+      const body = container.querySelector('[class*="emptyBody"]');
+      expect(body?.textContent).toContain('No cards in this file.');
+      expect(body?.textContent).toContain('question - answer');
+      expect(body?.textContent).toContain('separate the two with a tab');
+    });
+  });
+
   it('routes a 400 with code=empty_export into the emptyDeck info card', async () => {
     const jsonBody = {
       code: 'empty_export',

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -1042,6 +1042,17 @@ function UploadForm({
         </p>
       );
     }
+    if (/\.txt$/i.test(currentFilename())) {
+      return (
+        <p className={formStyles.emptyBody}>
+          No cards in this file. For a text file, put one card per line as
+          question - answer or question = answer, separate the two with a tab,
+          or use a bullet list. See{' '}
+          <a href="/documentation/help/common-problems">common problems</a> for
+          the formats that work.
+        </p>
+      );
+    }
     return (
       <p className={formStyles.emptyBody}>
         No cards were found in this file. Most files need a toggle-list (Notion)

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-25-plain-text-uploads.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-25-plain-text-uploads.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-25-plain-text-uploads",
+  "date": "2026-06-25",
+  "type": "fix",
+  "title": "Plain-text uploads with question - answer pairs now convert to cards"
+}


### PR DESCRIPTION
Fixes #3473.

48h prod logs showed 17 × `POST /api/upload/file` → 400 on `.txt` and `.pages` uploads — real learners hitting the acquisition front door and bouncing with nothing.

## Root cause
A `.txt` of question/answer pairs separated by ` - ` or ` = ` (no bullet markers, no tabs) produced an empty deck. `FallbackParser.getMarkdownBulletLists` used an unanchored regex (`/[-*+][ \t]+.*/g`) that matched the ` - ` *separator* as a mid-line bullet marker — contradicting its own docstring ("lines starting with -, *, or +"). That mis-routed the pairs into the bullet branch, where `PlainTextParser` mangled them and `Deck.CleanCards` dropped the result to zero. `.pages` (an Apple Pages iWork zip) fell through to a generic empty-deck 400 with no guidance.

## Fix
- **Anchor the bullet regex to line starts** (`/^[ \t]*[-*+][ \t]+.*/gm`) — a correctness fix matching the docstring. ` - `/` = ` pairs no longer look like bullets.
- **New structured-only fallthrough** in `parseTextFile`: when there are no tabs and no bullets, parse one card per line and keep only *structured* cards (a cloze, or a non-empty back). Pure prose still yields an empty deck — no junk one-card decks.
- **`.pages` gets a specific message** at the validation boundary telling the user to export as PDF/.docx/HTML.
- **Empty-deck copy for `.txt`** now names the supported shapes (question - answer, question = answer, tab-separated, bullet list).

## Decisions made overnight (please review)
- **Scope of `.txt` fix**: chose the minimal "fix the gating + structured-card filter" over adding new separator syntaxes / encoding detection / heading splitting — trio's call; the bug was purely the gate, and `PlainTextParser` already handles ` - `/` = `. If you want broader `.txt` formats, that's a follow-up.
- **`.pages`**: chose a tailored rejection message over unwrapping the iWork zip — unwrapping packed iWork XML is an afternoon, not a night, for a far lower-volume format than the `.txt` pairs. Assumption: guiding to PDF/.docx/HTML is acceptable. If you'd rather actually parse `.pages`, reopen as its own issue.
- **`.pages` wiring**: tailored message ships as a plain-text 400 from `getUploadValidationError` (rendered verbatim by the existing `extractErrorMessage` text fallback), not via the `getErrorMessage.ts` code map — smaller diff, fully working. Swap to a coded error if you want the title/detail split.
- **Copy (designer's exact words)**: `.pages` → "We can't read Pages files. Open NAME in Apple Pages, export it as PDF, Word (.docx), or HTML, then upload that." Empty `.txt` → "No cards in this file. For a text file, put one card per line as question - answer or question = answer, separate the two with a tab, or use a bullet list. See common problems for the formats that work." Reword if you'd phrase either differently.
- **Empty-`.txt` copy branch**: fires only when the uploaded filename ends in `.txt` (frontend reads the file input). Non-text empty uploads keep the existing toggle-list framing.

## Expected impact
Moves **first-conversion success on /upload** (deck downloads after first upload) — read from funnel events at `/api/ops/metrics`. Those 17 rejections/48h now get a real deck (`.txt` pairs) or a clear next step (`.pages`) instead of a bare 400.

## Tests
- `FallbackParser.test.ts`: ` - ` pairs convert, ` = ` pairs convert, prose `.txt` → 0 cards, prose surrounding one pair → only the structured card, prose `.md` → 0 cards (regression guard for the regex widening).
- `getUploadValidationError.test.ts`: `.pages` / `.PAGES` → tailored error.
- `UploadForm.test.tsx`: `.txt` + 0 cards → text-specific copy.
- `/check` green (server tsc, arch, web typecheck, web vitest 2074 pass, web lint). sonar-scanner couldn't post (no `SONAR_TOKEN` in this env — auth failure, not a smell); oxlint's Sonar-mirror rules ran clean on the changed files.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path spec (pnpm --filter 2anki-web test:golden-path) passes 2/2 at 375px with no console errors — machine-backs both boxes. The two web-visible strings are also asserted in UploadForm.test.tsx / validator tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)