### PR TITLE
fix: sell day and week passes to logged-out buyers

### DIFF
--- a/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
@@ -207,7 +207,7 @@ describe('PaywallBanner', () => {
     });
 
     expect(startUnlimitedCheckout).toHaveBeenCalledWith(
-      'month',
+      'year',
       undefined,
       'downloads_banner'
     );

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
@@ -27,7 +27,7 @@ export function PaywallBanner({ inProgressJob }: PaywallBannerProps) {
     track('paywall_upgrade_clicked', { surface: 'downloads_banner' });
     setPending(true);
     const result = await get2ankiApi().startUnlimitedCheckout(
-      'month',
+      'year',
       undefined,
       'downloads_banner'
     );

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -417,11 +417,14 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
     mockUseCardUsage.mockReturnValue(null);
   });
 
-  it('tracks paywall_upgrade_clicked then redirects to login for an anonymous Day Pass click', async () => {
+  it('starts an anonymous Day Pass checkout without a login detour', async () => {
     const { track } = await import('../../lib/analytics/track');
     const trackMock = vi.mocked(track);
     trackMock.mockClear();
     mockStartPassCheckout.mockClear();
+    mockStartPassCheckout.mockResolvedValue({
+      url: 'https://checkout.stripe.test/anon-day',
+    });
     Object.defineProperty(globalThis, 'location', {
       writable: true,
       value: { href: '' },
@@ -435,15 +438,26 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
       plan: 'day_pass',
       variant: 'minimal',
     });
-    expect(globalThis.location.href).toBe('/login?redirect=/pricing');
-    expect(mockStartPassCheckout).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockStartPassCheckout).toHaveBeenCalledWith(
+        '24h',
+        'minimal',
+        'pricing_page'
+      );
+      expect(globalThis.location.href).toBe(
+        'https://checkout.stripe.test/anon-day'
+      );
+    });
   });
 
-  it('tracks paywall_upgrade_clicked then redirects to login for an anonymous Week Pass click', async () => {
+  it('starts an anonymous Week Pass checkout without a login detour', async () => {
     const { track } = await import('../../lib/analytics/track');
     const trackMock = vi.mocked(track);
     trackMock.mockClear();
     mockStartPassCheckout.mockClear();
+    mockStartPassCheckout.mockResolvedValue({
+      url: 'https://checkout.stripe.test/anon-week',
+    });
     Object.defineProperty(globalThis, 'location', {
       writable: true,
       value: { href: '' },
@@ -457,8 +471,16 @@ describe('PricingPage anonymous upgrade-click tracking', () => {
       plan: 'week_pass',
       variant: 'minimal',
     });
-    expect(globalThis.location.href).toBe('/login?redirect=/pricing');
-    expect(mockStartPassCheckout).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockStartPassCheckout).toHaveBeenCalledWith(
+        '7d',
+        'minimal',
+        'pricing_page'
+      );
+      expect(globalThis.location.href).toBe(
+        'https://checkout.stripe.test/anon-week'
+      );
+    });
   });
 
   it('tracks paywall_upgrade_clicked then redirects to login for an anonymous Unlimited click', async () => {

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -132,10 +132,6 @@ export default function PricingPage({
       plan: kind === '24h' ? 'day_pass' : 'week_pass',
       variant: pricingOrder,
     });
-    if (!isLoggedIn) {
-      globalThis.location.href = '/login?redirect=/pricing';
-      return;
-    }
     if (kind === '24h') {
       setDayPassState('pending');
     } else {

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-25-pass-without-account.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-25-pass-without-account.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-25-pass-without-account",
+  "date": "2026-06-25",
+  "type": "feature",
+  "title": "Buy a Day or Week pass without creating an account first"
+}


### PR DESCRIPTION
## What

Two fixes that unblock the upgrade-click → purchase leak, found by a trio review of fresh prod analytics.

1. **Sell Day/Week passes to logged-out buyers.** The pricing page bounced anonymous Day/Week Pass clicks to `/login` at the moment of purchase intent. The checkout backend already supports anonymous pass purchase (`optionalAuthMiddleware`) and redemption (`pass_session` on `/upload`) — the frontend login detour was the only blocker. Subscriptions still require an account (unchanged).
2. **Point the downloads paywall's Upgrade button at annual.** `PaywallBanner` hardcoded `startUnlimitedCheckout('month', …)` — the warmest upgrade path on the site sent everyone to the lower-ARPU monthly plan. Now `'year'`.

## Why (prod data, last 30d)

- 1160 unique `paywall_upgrade_clicked`, **75% anonymous** (872) → only ~50 purchases.
- `checkout_completed` split: auth Day-Pass 92, auth Week 19, auth sub 42, anon sub 52, **anonymous passes: 0** — anon buyers physically could not complete a pass.
- Subscription interval mix 66% monthly / 34% annual despite annual being the page default — the hardcoded monthly paywall button is part of why.

## Metric this should move

`checkout_completed` (anonymous pass checkouts unlock from 0) and the annual share of `plan_interval_selected`. Read on the ops upload-funnel tab T+14d.

## Tests

- Updated unit tests: anonymous Day/Week Pass clicks now start checkout instead of redirecting to login; `PaywallBanner` asserts annual. Full web suite green (2074).
- Security note: no payments-code change — only removes a frontend redirect on an already-anon-capable backend route. `/security-review` recommended before merge per CLAUDE.md (payments-adjacent).
- Sonar: change reduces a branch + a literal; not run locally (no scanner here) — low risk, net complexity decrease.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green (landing + dashboard, no console errors). Pass-button behavior covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
