### PR TITLE
feat: measure producer entry impressions for the smoke test

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -85,6 +85,7 @@ export const KNOWN_EVENTS = new Set([
   'ankify_review_session_exited',
   'image_drop_notice_shown',
   'producer_intent_captured',
+  'producer_entry_viewed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -67,6 +67,7 @@ export const KNOWN_EVENTS = new Set([
   'ankify_decklist_sorted',
   'image_drop_notice_shown',
   'producer_intent_captured',
+  'producer_entry_viewed',
 ] as const);
 
 export type KnownEvent = typeof KNOWN_EVENTS extends Set<infer T> ? T : never;

--- a/web/src/lib/hooks/useInViewOnce.test.tsx
+++ b/web/src/lib/hooks/useInViewOnce.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useInViewOnce } from './useInViewOnce';
+
+function Probe({ onInView }: Readonly<{ onInView: () => void }>) {
+  const ref = useInViewOnce<HTMLDivElement>(onInView);
+  return <div ref={ref}>probe</div>;
+}
+
+describe('useInViewOnce', () => {
+  it('calls onInView once when the element intersects', () => {
+    const onInView = vi.fn();
+    const { rerender } = render(<Probe onInView={onInView} />);
+    rerender(<Probe onInView={onInView} />);
+    expect(onInView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/hooks/useInViewOnce.ts
+++ b/web/src/lib/hooks/useInViewOnce.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+export function useInViewOnce<T extends Element>(onInView: () => void) {
+  const ref = useRef<T | null>(null);
+  const callbackRef = useRef(onInView);
+  callbackRef.current = onInView;
+
+  useEffect(() => {
+    const element = ref.current;
+    if (element == null) return;
+    if (typeof IntersectionObserver === 'undefined') return;
+
+    let fired = false;
+    const observer = new IntersectionObserver((entries) => {
+      if (fired) return;
+      if (entries.some((entry) => entry.isIntersecting)) {
+        fired = true;
+        callbackRef.current();
+        observer.disconnect();
+      }
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return ref;
+}

--- a/web/src/pages/DownloadsPage/components/ProducerPrompt.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ProducerPrompt.test.tsx
@@ -71,6 +71,36 @@ describe('ProducerPrompt', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('fires producer_entry_viewed once when the card becomes visible', async () => {
+    const { track } = await import('../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    render(<ProducerPrompt uploads={makeUploads(21)} />);
+    await screen.findByText('Making decks for other people?');
+    const viewed = trackMock.mock.calls.filter(
+      ([name]) => name === 'producer_entry_viewed'
+    );
+    expect(viewed).toEqual([
+      ['producer_entry_viewed', { source: 'heavy_uploader_prompt' }],
+    ]);
+  });
+
+  it('does not fire producer_entry_viewed for an ineligible user', async () => {
+    mockGetPitchEligibility.mockResolvedValue({
+      convertSuccess: false,
+      accountBanner: false,
+      producerPrompt: false,
+    });
+    const { track } = await import('../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    render(<ProducerPrompt uploads={makeUploads(21)} />);
+    await waitFor(() => expect(mockGetPitchEligibility).toHaveBeenCalled());
+    expect(
+      trackMock.mock.calls.filter(([name]) => name === 'producer_entry_viewed')
+    ).toEqual([]);
+  });
+
   it('persists the dismissal and hides the card on Not now', async () => {
     render(<ProducerPrompt uploads={makeUploads(21)} />);
     fireEvent.click(await screen.findByText('Not now'));

--- a/web/src/pages/DownloadsPage/components/ProducerPrompt.tsx
+++ b/web/src/pages/DownloadsPage/components/ProducerPrompt.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ProducerCaptureModal } from '../../../components/ProducerCaptureModal/ProducerCaptureModal';
+import { track } from '../../../lib/analytics/track';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
 import UserUpload from '../../../lib/interfaces/UserUpload';
 import { isHeavyUploader } from '../helpers/producerUploadGate';
@@ -21,6 +22,14 @@ export function ProducerPrompt({
   const [eligible, setEligible] = useState<boolean | null>(null);
   const [open, setOpen] = useState(false);
   const [hidden, setHidden] = useState(false);
+  const viewFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (heavy && eligible === true && !viewFiredRef.current) {
+      viewFiredRef.current = true;
+      track('producer_entry_viewed', { source: 'heavy_uploader_prompt' });
+    }
+  }, [heavy, eligible]);
 
   useEffect(() => {
     if (!heavy) return;

--- a/web/src/pages/PricingPage/PricingPage.test.tsx
+++ b/web/src/pages/PricingPage/PricingPage.test.tsx
@@ -668,4 +668,18 @@ describe('PricingPage Unlimited billing toggle', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Get Unlimited' }));
     expect(globalThis.location.href).toBe('/login?redirect=/pricing');
   });
+
+  it('fires producer_entry_viewed once when the educators section is seen', async () => {
+    const { track } = await import('../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+    renderAt('/pricing');
+    await waitFor(() =>
+      expect(
+        trackMock.mock.calls.filter(
+          ([name]) => name === 'producer_entry_viewed'
+        )
+      ).toEqual([['producer_entry_viewed', { source: 'pricing_page' }]])
+    );
+  });
 });

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -15,6 +15,7 @@ import { PricingCard } from './components/PricingCard';
 import { PricingFaq } from './components/PricingFaq';
 import { UnlimitedCard } from './components/UnlimitedCard';
 import { ProducerCaptureModal } from '../../components/ProducerCaptureModal/ProducerCaptureModal';
+import { useInViewOnce } from '../../lib/hooks/useInViewOnce';
 import styles from './PricingPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
 import { getLifetimeLink } from './payment.links';
@@ -40,6 +41,9 @@ export default function PricingPage({
   const [weekPassState, setWeekPassState] = useState<PassState>('idle');
   const [billingCycle, setBillingCycle] = useState<'month' | 'year'>('year');
   const [producerModalOpen, setProducerModalOpen] = useState(false);
+  const educatorsRef = useInViewOnce<HTMLElement>(() =>
+    track('producer_entry_viewed', { source: 'pricing_page' })
+  );
   const [unlimitedPending, setUnlimitedPending] = useState(false);
   const [unlimitedError, setUnlimitedError] = useState(false);
   const [pricing, setPricing] = useState(LEGACY_UNLIMITED_PRICING);
@@ -327,7 +331,7 @@ export default function PricingPage({
 
       <PricingFaq />
 
-      <section className={styles.educators}>
+      <section ref={educatorsRef} className={styles.educators}>
         <h2 className={styles.educatorsTitle}>For educators and teams</h2>
         <p className={styles.educatorsBody}>
           Making decks for a class, a tutoring group, or a course you sell?

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -5,3 +5,25 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+global.IntersectionObserver = class IntersectionObserver {
+  constructor(callback: IntersectionObserverCallback) {
+    this.callback = callback;
+  }
+  callback: IntersectionObserverCallback;
+  observe(target: Element) {
+    this.callback(
+      [{ isIntersecting: true, target } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver
+    );
+  }
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+  root = null;
+  rootMargin = '';
+  scrollMargin = '';
+  thresholds = [];
+} as unknown as typeof IntersectionObserver;


### PR DESCRIPTION
## What
Adds a `producer_entry_viewed` impression event to the producer/teams demand smoke test (#3477) — fired once when the "For educators and teams" pricing section **scrolls into view** (IntersectionObserver, not a page load) and once when the gated in-product prompt appears.

## Why
The smoke test fired an event **only on form submit**, leaving no denominator. At the 2026-07-09 decision point, a near-zero capture count couldn't distinguish "nobody saw the entry" from "saw it, didn't want it" — and the pricing entry sits below the FAQ, so most visitors never scroll to it. Without an impression signal we could burn the entire 14-day window on an uninterpretable result. This turns the capture count into a real conversion rate (`producer_intent_captured / producer_entry_viewed`).

## How
- New `useInViewOnce` hook — fires a callback once when an element first intersects the viewport, then disconnects.
- `PricingPage` attaches it to the educators `<section>` → `producer_entry_viewed { source: 'pricing_page' }`.
- `ProducerPrompt` fires `producer_entry_viewed { source: 'heavy_uploader_prompt' }` once when the gated card becomes visible (ref-guarded).
- Registered the event in both analytics allowlists; added a controllable `IntersectionObserver` mock to `setupTests`.

## Measuring success
At T+14d, read `producer_intent_captured` against `producer_entry_viewed` per source at `/api/ops/metrics` — capture rate, not a bare count. Disambiguates the kill/iterate/build decision.

## Testing
New tests: `useInViewOnce` fires once; `ProducerPrompt` fires on appear and not when ineligible; `PricingPage` fires on the section being seen. Full web suite 2092 green; server tsc + web typecheck clean; golden-path green.

## Risks
Internal analytics only — no UI, copy, or behavior change. IntersectionObserver is widely supported; the hook no-ops where it's absent.

## Goal alignment
Protects the only experiment on the path to 30x MRR from producing an ambiguous result. No revenue change itself — it's measurement infrastructure for the producer/teams bet.

No changelog entry — internal analytics instrumentation, no user-visible change.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` green. Impression-fire behavior covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
