### PR TITLE
fix: fail fast with a clear message on incomplete uploads

### DIFF
--- a/src/services/UploadService.ts
+++ b/src/services/UploadService.ts
@@ -18,6 +18,7 @@ import { isLimitError } from '../lib/misc/isLimitError';
 import { handleUploadLimitError } from '../controllers/Upload/helpers/handleUploadLimitError';
 import { getUploadValidationError } from '../lib/upload/getUploadValidationError';
 import { EmptyDeckError } from '../usecases/jobs/EmptyDeckError';
+import { UploadFileUnavailableError } from '../usecases/uploads/UploadFileUnavailableError';
 import { isExpectedClientFault } from '../lib/misc/isExpectedClientFault';
 import {
   MARKDOWN_LIKELY_LOSSY_REASON,
@@ -456,6 +457,21 @@ class UploadService {
             'This export is too large to process in one go. Try splitting it into smaller pages, removing embedded images, or enabling Claude AI in settings to process it in chunks.',
         };
         return res.status(400).json(body);
+      } else if (err instanceof UploadFileUnavailableError) {
+        const owner = getOwner(res);
+        track('conversion_failed', {
+          userId: owner != null ? Number(owner) : null,
+          anonymousId: this.resolveAnonId(req),
+          props: {
+            source: this.resolveUploadSource(req),
+            reason: 'upload_incomplete',
+          },
+        });
+        return res.status(400).json({
+          code: 'upload_incomplete',
+          message:
+            'Your upload didn’t finish, so there was nothing to convert. Upload the file again.',
+        });
       } else if (err instanceof Error && isPdfPasswordSentinel(err.message)) {
         const filename = parsePdfPasswordSentinel(err.message) ?? 'your file';
         return res.status(400).json({

--- a/src/usecases/uploads/GeneratePackagesUseCase.test.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.test.ts
@@ -10,6 +10,7 @@ import CardOption from '../../lib/parser/Settings/CardOption';
 import Workspace from '../../lib/parser/WorkSpace';
 import { UploadedFile } from '../../lib/storage/types';
 import { EmptyDeckError } from '../jobs/EmptyDeckError';
+import { UploadFileUnavailableError } from './UploadFileUnavailableError';
 import { UploadGenerationTask } from './uploadGenerationTypes';
 
 const mockRunUploadGeneration = runUploadGeneration as jest.MockedFunction<
@@ -259,6 +260,49 @@ describe('GeneratePackagesUseCase', () => {
 
     expect(err).toBeInstanceOf(EmptyDeckError);
     expect((err as EmptyDeckError).sourceFormat).toBe('markdown');
+  });
+
+  it('rejects with UploadFileUnavailableError when an upload temp file is gone and has no buffer', async () => {
+    const useCase = new GeneratePackagesUseCase();
+    const file = makeFile('lecture.zip');
+    file.path = '/media/storage/uploads/does-not-exist-1234567890';
+    file.buffer = undefined as never;
+
+    const err = await useCase
+      .execute(false, [file], makeSettings(), makeWorkspace())
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(UploadFileUnavailableError);
+    expect((err as UploadFileUnavailableError).filename).toBe('lecture.zip');
+  });
+
+  it('does not dispatch the conversion pool when an upload temp file is unavailable', async () => {
+    const useCase = new GeneratePackagesUseCase();
+    const file = makeFile('lecture.zip');
+    file.path = '/media/storage/uploads/does-not-exist-1234567890';
+    file.buffer = undefined as never;
+
+    await useCase
+      .execute(false, [file], makeSettings(), makeWorkspace())
+      .catch(() => undefined);
+
+    expect(mockRunUploadGeneration).not.toHaveBeenCalled();
+  });
+
+  it('still dispatches when the temp file is gone but a buffer fallback was captured', async () => {
+    mockRunUploadGeneration.mockResolvedValueOnce({
+      ok: true,
+      packages: [],
+      warnings: [],
+    });
+    const useCase = new GeneratePackagesUseCase();
+    const file = makeFile('lecture.zip');
+    file.path = '/media/storage/uploads/does-not-exist-1234567890';
+    file.buffer = Buffer.from('fallback bytes');
+
+    await useCase.execute(false, [file], makeSettings(), makeWorkspace());
+
+    expect(mockRunUploadGeneration).toHaveBeenCalledTimes(1);
   });
 
   it('preserves error name on the rejected Error for non-EmptyDeckError named errors', async () => {

--- a/src/usecases/uploads/GeneratePackagesUseCase.ts
+++ b/src/usecases/uploads/GeneratePackagesUseCase.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { MessageChannel } from 'node:worker_threads';
 import Package from '../../lib/parser/Package';
 import CardOption from '../../lib/parser/Settings/CardOption';
@@ -7,6 +8,19 @@ import { EmptyDeckError } from '../jobs/EmptyDeckError';
 import { runUploadGeneration } from '../../lib/conversionPool';
 import { UploadGenerationFailure } from './uploadGenerationTypes';
 import { ensureUploadBytes } from './ensureUploadBytes';
+import { UploadFileUnavailableError } from './UploadFileUnavailableError';
+
+function findUnavailableUpload(
+  files: UploadedFile[]
+): UploadedFile | undefined {
+  return files.find(
+    (file) =>
+      file.buffer == null &&
+      file.path != null &&
+      file.path !== '' &&
+      !fs.existsSync(file.path)
+  );
+}
 
 export interface PackageResult {
   packages: Package[];
@@ -44,6 +58,10 @@ class GeneratePackagesUseCase {
     userId: number | null = null
   ): Promise<PackageResult> {
     ensureUploadBytes(files);
+    const unavailable = findUnavailableUpload(files);
+    if (unavailable) {
+      throw new UploadFileUnavailableError(unavailable.originalname);
+    }
     const enqueuedAt = Date.now();
     const channel = onProgress ? new MessageChannel() : null;
     channel?.port1.on('message', (step: string) => onProgress?.(step));

--- a/src/usecases/uploads/UploadFileUnavailableError.test.ts
+++ b/src/usecases/uploads/UploadFileUnavailableError.test.ts
@@ -1,0 +1,19 @@
+import { UploadFileUnavailableError } from './UploadFileUnavailableError';
+
+describe('UploadFileUnavailableError', () => {
+  it('is an Error with the expected name and a clear message', () => {
+    const err = new UploadFileUnavailableError('lecture.zip');
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('UploadFileUnavailableError');
+    expect(err.message).toBe(
+      'Uploaded file is no longer available — the upload did not finish.'
+    );
+  });
+
+  it('carries the originating filename', () => {
+    const err = new UploadFileUnavailableError('notes.html');
+
+    expect(err.filename).toBe('notes.html');
+  });
+});

--- a/src/usecases/uploads/UploadFileUnavailableError.ts
+++ b/src/usecases/uploads/UploadFileUnavailableError.ts
@@ -1,0 +1,9 @@
+export class UploadFileUnavailableError extends Error {
+  readonly filename: string;
+
+  constructor(filename: string) {
+    super('Uploaded file is no longer available — the upload did not finish.');
+    this.name = 'UploadFileUnavailableError';
+    this.filename = filename;
+  }
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-06-29-upload-incomplete-message.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-06-29-upload-incomplete-message.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-06-29-upload-incomplete-message",
+  "date": "2026-06-29",
+  "type": "fix",
+  "title": "Uploads that don't finish now tell you to try again instead of showing a generic error"
+}


### PR DESCRIPTION
## What

When an upload's temp file is gone by the time the conversion worker reads it — and no buffer fallback was captured — the worker died with a generic `Uploaded file is no longer available on disk and has no buffer fallback`, which the user saw as an opaque failure on the synchronous upload path (they dropped a file, waited, got nothing). This detects the unavailable file early and returns a clear, actionable message instead.

## Why

Prod logs (recent 72h window): 3 hard `no buffer fallback` failures on `handleSyncUpload` plus 63 `could not snapshot upload bytes` warnings — files vanishing from `UPLOAD_BASE` before the request could read them. The user-facing result was a generic error with no next step. Closes #3482.

## How

Presentation-and-control-flow only; no new payment/auth/storage code.
- `UploadFileUnavailableError` (new typed error) thrown at the single `GeneratePackagesUseCase.execute` choke point — covers both the sync and async (Claude) upload paths — when a file has `buffer == null` AND a non-empty `path` that no longer exists on disk. The doomed Piscina job is never enqueued.
- The guard deliberately does NOT fire when the path is empty (test/in-memory fixtures) or when a buffer fallback was captured — the happy path and the #3469 buffer path are untouched.
- `UploadService.handleUpload` maps the error to `400 { code: 'upload_incomplete', message }` (mirrors the existing empty-deck/docx/pdf error shape the frontend already renders) and fires `conversion_failed` with `reason: 'upload_incomplete'`.

## Scope / what this does NOT do

This is the user-facing failure fix, not the root cause of *why* the temp file vanishes (most likely client-aborted uploads — needs a prod owner/timing trace, which can't run unattended). The `deleteOldFiles` no-op reaper bug noted in #3482 is deliberately left out: fixing it makes cleanup more aggressive (2h vs the cron's 1-day), which is orthogonal-to-slightly-worse for these failures, and belongs in its own change.

## Decisions made overnight (please review)
- Copy: "Your upload didn’t finish, so there was nothing to convert. Upload the file again." — written per VOICE.md (what happened + what to do, no hedging). Reword if you'd phrase it differently; it's the only user-visible string.
- HTTP status: `400` to match the sibling upload errors (empty/docx/pdf) the frontend already handles, rather than introducing a `422` the client doesn't special-case.
- Scope: shipped the fail-fast + clear message; deliberately did NOT fix the reaper path-join bug or chase the vanish root cause (see Scope above).

## Testing

- New use-case tests: throws `UploadFileUnavailableError` (with filename) when path is set but missing and no buffer; does NOT dispatch the conversion pool in that case; still dispatches when a buffer fallback exists. Existing 11 cases unchanged/green.
- Colocated `UploadFileUnavailableError.test.ts` (name/message/filename).
- `/check`: server tsc ✅, web tsc ✅, web vitest 2106 ✅, oxlint (no new warnings on changed lines), oxfmt ✅.
- sonar-scanner not run in this autonomous session.

## Browser check
Browser check: not applicable — the only `web/src` file is a changelog JSON entry; no rendered UI change.

## Goal alignment

A failed upload on the sync path is the most direct "the product is broken" moment a user hits — actively waiting, gets nothing. Turning the opaque crash into a clear retry protects first-conversion success at the top of the funnel.
