### PR TITLE
chore: remove DigitalOcean attribution from footer and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,6 @@ The trio is powered by Claude subagents in `.claude/agents/`. Use `/trio <task>`
 
 We'd love your help! See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get started, run the test gate, and submit a PR.
 
-## Supported by
-
-<p>This project is supported by:</p>
-<p>
-  <a href="https://www.digitalocean.com/?utm_medium=opensource&utm_source=2anki">
-    <img src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg" width="201px" alt="DigitalOcean" />
-  </a>
-</p>
-
 ## License
 
 The code is licensed under the [MIT](./LICENSE) Copyright (c) 2020-2026, [Alexander Alemayhu](https://alemayhu.com). See [CREDITS.md](./CREDITS.md) for contributors.

--- a/web/src/components/Footer.module.css
+++ b/web/src/components/Footer.module.css
@@ -80,24 +80,6 @@
   gap: 1.25rem;
 }
 
-.sponsor {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  text-decoration: none;
-}
-
-.sponsorLabel {
-  font-size: var(--text-xs);
-  color: var(--color-text-tertiary);
-}
-
-.sponsorLogo {
-  height: 18px;
-  width: auto;
-  display: block;
-}
-
 .githubLink {
   color: var(--color-text-tertiary);
   transition: color var(--transition-fast);

--- a/web/src/components/Footer.test.tsx
+++ b/web/src/components/Footer.test.tsx
@@ -54,15 +54,19 @@ describe('Footer', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('attributes the DigitalOcean sponsorship with a link to digitalocean.com', () => {
+  it('does not show a DigitalOcean attribution', () => {
     render(<Footer />);
-    const sponsor = screen.getByRole('link', {
-      name: 'Supported by DigitalOcean',
-    });
-    expect(sponsor).toHaveAttribute(
+    expect(
+      screen.queryByRole('link', { name: 'Supported by DigitalOcean' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByAltText('DigitalOcean')).not.toBeInTheDocument();
+  });
+
+  it('links to the GitHub repository', () => {
+    render(<Footer />);
+    expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
       'href',
-      'https://www.digitalocean.com/?utm_medium=opensource&utm_source=2anki'
+      'https://github.com/2anki/server'
     );
-    expect(screen.getByAltText('DigitalOcean')).toBeInTheDocument();
   });
 });

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -36,20 +36,6 @@ function Footer() {
         </span>
         <div className={styles.bottomRight}>
           <a
-            href="https://www.digitalocean.com/?utm_medium=opensource&utm_source=2anki"
-            target="_blank"
-            rel="noreferrer"
-            className={styles.sponsor}
-            aria-label="Supported by DigitalOcean"
-          >
-            <span className={styles.sponsorLabel}>Supported by</span>
-            <img
-              src="https://opensource.nyc3.cdn.digitaloceanspaces.com/attribution/assets/SVG/DO_Logo_horizontal_blue.svg"
-              alt="DigitalOcean"
-              className={styles.sponsorLogo}
-            />
-          </a>
-          <a
             href="https://github.com/2anki/server"
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
## What

Removes the DigitalOcean sponsorship attribution from the site footer and the project README.

## Why

The DigitalOcean attribution is no longer wanted on the site or in the README.

## How

- `Footer.tsx` — drop the "Supported by DigitalOcean" badge link; the footer's bottom-right now holds just the GitHub link.
- `Footer.module.css` — remove the now-unused `.sponsor` / `.sponsorLabel` / `.sponsorLogo` classes.
- `Footer.test.tsx` — flip the attribution test into a regression guard that the DigitalOcean link/logo stays gone, and add a GitHub-link assertion.
- `README.md` — remove the "Supported by" section.

## Scope — deliberately NOT changed

The DigitalOcean entry in the privacy policy (`DocsPage/content/reference/privacy.md`) is left untouched. That is a legal subprocessor / data-processing disclosure, not attribution — removing it could misrepresent how data is handled, and any change there needs legal review (and confirmation of whether DO storage is still in use). The self-hosting doc's DO mention is instructional, also out of scope.

## Testing

- `web` vitest: 2107 pass (Footer suite updated — asserts no DigitalOcean link/logo, asserts GitHub link).
- `pnpm typecheck` clean, oxlint clean, oxfmt clean on changed files.
- Golden-path e2e: 2 passed at 375px, no console errors.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: backed by `pnpm --filter 2anki-web test:golden-path` — 2 passed at 375px, zero console errors. Footer renders with the badge removed.

## Goal alignment

Housekeeping — no funnel or revenue impact. Removes an unwanted third-party badge from the footer and README.
