### PR TITLE
fix: split Notion page by deck_is heading rule

### DIFF
--- a/src/services/NotionService/BlockHandler/BlockHandler.ts
+++ b/src/services/NotionService/BlockHandler/BlockHandler.ts
@@ -84,16 +84,10 @@ const PAGE_LIKE_DECK_TYPES = new Set([
   'child_database',
 ]);
 
-function activeNonPageDeckTypes(
-  rules: ParserRules,
-  splitSectionsIntoDecks: boolean
-): Set<string> {
-  if (splitSectionsIntoDecks) {
-    return new Set(
-      rules.deckTypes().filter((type) => !PAGE_LIKE_DECK_TYPES.has(type))
-    );
-  }
-  return new Set();
+function activeNonPageDeckTypes(rules: ParserRules): Set<string> {
+  return new Set(
+    rules.deckTypes().filter((type) => !PAGE_LIKE_DECK_TYPES.has(type))
+  );
 }
 
 interface PlainTextItem {
@@ -681,10 +675,7 @@ class BlockHandler {
     }
 
     const currentDeckName = toText(getDeckName(parentName, title));
-    const nonPageDeckTypes = activeNonPageDeckTypes(
-      rules,
-      this.settings.splitSectionsIntoDecks
-    );
+    const nonPageDeckTypes = activeNonPageDeckTypes(rules);
 
     // Depth-first traversal: process current page, then children
     if (rules.permitsDeckAsPage() && page) {

--- a/src/services/NotionService/BlockHandler/__tests__/nonPageDeckTypes.test.ts
+++ b/src/services/NotionService/BlockHandler/__tests__/nonPageDeckTypes.test.ts
@@ -218,7 +218,7 @@ describe('findFlashcardsFromPage non-page deck types', () => {
     expect(rootDeck.cards.map((c) => c.name)).toEqual(['A toggle']);
   });
 
-  it('keeps two headings on one page as a single deck when the option is off', async () => {
+  it('splits two headings into separate decks from deck_is even when split-sections-into-decks is off', async () => {
     const firstCard = toggle('card-1', 'German question');
     const secondCard = toggle('card-2', 'Maths question');
     const germanHeading = heading('german', 'German');
@@ -238,7 +238,10 @@ describe('findFlashcardsFromPage non-page deck types', () => {
       parentName: '',
     });
 
-    expect(decks.map((d) => d.name)).toEqual(['Root page']);
+    const germanDeck = decks.find((d) => d.name.includes('German'));
+    const mathsDeck = decks.find((d) => d.name.includes('Maths'));
+    expect(germanDeck?.cards.map((c) => c.name)).toEqual(['German question']);
+    expect(mathsDeck?.cards.map((c) => c.name)).toEqual(['Maths question']);
   });
 
   it('splits two headings into separate top-level decks when the option is on', async () => {

--- a/web/src/components/CardOptionsForm/CardOptionsForm.tsx
+++ b/web/src/components/CardOptionsForm/CardOptionsForm.tsx
@@ -105,13 +105,7 @@ const DEFAULT_USER_INSTRUCTIONS = `Some extra rules and explanations:
 const OPTION_GROUPS: Array<{ label: string; keys: string[] }> = [
   {
     label: 'Content',
-    keys: [
-      'all',
-      'paragraph',
-      'max-one-toggle-per-card',
-      'perserve-newlines',
-      'split-sections-into-decks',
-    ],
+    keys: ['all', 'paragraph', 'max-one-toggle-per-card', 'perserve-newlines'],
   },
   {
     label: 'Card types',
@@ -160,6 +154,7 @@ const HIDDEN_KEYS = [
   'remove-mp3-links',
   'cloze-from-toggle-content',
   'group-cloze-per-toggle',
+  'split-sections-into-decks',
 ];
 const GROUPED_KEYS = new Set([
   ...OPTION_GROUPS.flatMap((g) => g.keys),

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-02-heading-deck-split.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-02-heading-deck-split.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-02-heading-deck-split",
+  "date": "2026-07-02",
+  "type": "fix",
+  "title": "Choosing Heading 1 as a deck type now splits your Notion page into separate decks"
+}


### PR DESCRIPTION
## What
Deck splitting now derives from the `deck_is` rule. When a user's `deck_is` rule contains a non-page deck type (`heading_1/2/3`, `toggle`, `bulleted_list_item`, `numbered_list_item`, `quote`, `column_list`), the page splits into decks by that type — regardless of the separate `split-sections-into-decks` card option. The explicit `deck_is` rule is the intent, so it is the single source of truth. The now-redundant `split-sections-into-decks` checkbox is removed from the card options UI.

## Why
Fixes #3502. A Notion user who set `deck_is=Heading1` on the Rules page expected their page to split into decks by H1, but splitting only ran if the separate `split-sections-into-decks` option (default off) was also enabled — so it silently did nothing. Two controls that had to agree was the bug.

## How
- `activeNonPageDeckTypes(rules)` now returns the non-page deck types straight from `rules.deckTypes()` (the `deck_is` selection), dropping the `splitSectionsIntoDecks` boolean gate. Call site at `BlockHandler.ts` updated.
- Default `deck_is` stays `['page','database']` (verified in `ParserRules`), so a default user still gets exactly one deck — no re-explosion.
- The `split-sections-into-decks` option is **kept** in the server types and parser for back-compat; only the UI control is removed (moved to `HIDDEN_KEYS` in `CardOptionsForm.tsx` so it neither renders in a group nor leaks into the ungrouped "general options" fallback).
- Rules page copy (`advancedHint` / `advancedWarning`) already described heading types as splitting the page — the fix makes those strings true, so they are left unchanged.

## Measuring success
Conversions where `parser_rules.deck_is` contains a non-page type should now yield >1 deck. Spot-check post-deploy: a converted page with `deck_is` heading types produces multiple decks in the `.apkg`; issue #3502 reporter confirms. No new log line added — the deck count is observable in the output deck and existing conversion job records.

## Testing
- Updated `__tests__/nonPageDeckTypes.test.ts` (the outside-in split-decision test):
  - (a) `deck_is` with `heading_1` splits two headings into separate decks **even with `split-sections-into-decks` off** (was asserting the buggy single-deck behavior).
  - (b) default `deck_is=['page','database']` → one deck, no split.
  - (c) `page`/`database`-only `deck_is` never explodes.
  - the option-on path still splits (no regression).
- `activeNonPageDeckTypes` has one construction/consumption site (`BlockHandler.findFlashcardsFromPage`); grepped `activeNonPageDeckTypes` — no other callers.
- Server tsc, web typecheck, web vitest (2105 passed), web lint (pre-existing warnings only), oxfmt --check on touched files: all green.
- sonar-scanner: **not run** — `SONAR_TOKEN` not set in this environment. Change is small (one branch removed, one helper signature narrowed, one UI key moved); low sonar risk.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Card options form renders without the removed checkbox; the option no longer appears in any group or in the general-options fallback.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-02-heading-deck-split.json` — "Choosing Heading 1 as a deck type now splits your Notion page into separate decks"

## Risks
The parser gate is kept, so default users (deck_is = page/database) are unaffected. **The one real risk:** if legacy prod `parser_rules` rows carry a stray non-page `deck_is` type that a user did NOT intend, those pages will start splitting after this ships. We cannot inspect prod data overnight. Reviewer should spot-check before merge:
```sql
select deck, count(*) from parser_rules where deck_is ~ 'heading|toggle|list|quote|column';
```
If that count is non-trivial and looks unintentional, hold. Rollback is a straight revert.

## Goal alignment
Simpler/faster: removes a two-controls-must-agree footgun so `deck_is` does what it says — one control, one source of truth. Fixes a reported conversion bug (#3502), which protects activation/retention on the Notion→Anki golden path. Funnel metric: reduces silent-failure on the convert step (upload → download). Not directly a revenue change — internal correctness fix on the core conversion surface.

## Decisions made overnight (please review)
- **Bound splitting to the `deck_is` rule instead of a second toggle** (trio call — option a with subtraction). The explicit rule is the intent.
- **KEPT the parser gate** (`split-sections-into-decks` option stays in server types/parser) to avoid re-exploding legacy data we can't inspect overnight. Assumption: default `deck_is` is `page`/`database`, so default users are unaffected. If legacy prod `parser_rules` carry stray heading/toggle/list/quote/column types, those pages will start splitting — see the spot-check SQL above before merge.
- **Removed the redundant UI control** so `deck_is` is the single source of truth.
- **Note for coordination:** this PR and #3504 both edit `CardOptionsForm.tsx` / `CardOption.ts` / `supportedOptions.ts` — expect a likely rebase conflict; whichever merges second should rebase.

Closes #3502
