### PR TITLE
fix: render Notion tables and columns on the Ankify sync path

### DIFF
--- a/src/lib/notion-render/FEATURE.md
+++ b/src/lib/notion-render/FEATURE.md
@@ -1,0 +1,17 @@
+# notion-render — Ankify sync render path
+
+Pure Notion-block → card-HTML renderer for the Ankify Auto-Sync product. `renderNotionBlocks(blocks, fetchChildren, options)` walks a page's blocks and returns `{ html, media, unsupportedTypes }`. Consumed by `src/services/ankify/notionPageWalker.ts`; this is the sync path, distinct from the one-shot convert path in `src/services/NotionService/` (`BlockHandler` / `blockToStaticMarkup`).
+
+## What's here
+
+- `renderBlocks.ts` — the block-type `switch`. Emits card HTML for every supported type and recurses into container blocks (`toggle`, `callout`, `column_list`, `column`) via `ctx.fetchChildren`, respecting `ctx.maxDepth` (default 8).
+- `richText.ts` — inline rich-text renderer shared across block types (annotations, colors, inline equations, links).
+- `escape.ts`, `highlightCode.ts`, `embedUrl.ts` — HTML escaping, code highlighting, embed/video URL resolution.
+- `types.ts` — `NotionRenderableBlock` (the subset of Notion block shapes the renderer reads) and `RenderedBlocks`.
+
+## Things to know before editing
+
+- **Table and column blocks are rendered on the sync path.** `table`/`table_row` emit an HTML `<table>` (with `<thead>`/`<th>` when `has_column_header`, else `<tbody>`/`<td>`), matching the convert path's `BlockTable` output; `column_list`/`column` are containers that recurse into their children and concatenate the result. Before this, the `switch` had no case for them, so they fell to `default` and were silently dropped — 56× `table` / 28× `column_list` in one prod window per the unsupported-blocks metric. Both paths (convert + sync) must keep table/column parity so a synced card matches a converted one.
+- **Media collection flows through `ctx.media`.** Any image/audio/video/file inside a recursed subtree (including inside a column) pushes its ref onto the shared `ctx.media` array, so the `.apkg` packager bundles the bytes. Don't render a container's children without threading the same `ctx` through, or media inside it is lost.
+- **`unsupportedTypes` feeds the unsupported-blocks metric.** A block type with no `switch` case is pushed here (and counted in prod). Adding a real case removes the type from that count — the metric is how we detect the next dropped-content gap.
+- **Pure module.** No `axios`, `knex`, or `@notionhq/client` here — child fetching is injected as `fetchChildren`.

--- a/src/lib/notion-render/golden/__snapshots__/renderBlocksGolden.test.ts.snap
+++ b/src/lib/notion-render/golden/__snapshots__/renderBlocksGolden.test.ts.snap
@@ -17,7 +17,10 @@ exports[`produces a stable rendered page for a mixed Notion block tree 1`] = `
 <details><summary>Reveal answer</summary><p>ATP is the energy currency.</p></details>
 [sound:ankify-audio1.mp3]
 <iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ?" frameborder="0" allowfullscreen></iframe>
-<a href="https://example.com/source">https://example.com/source</a>",
+<a href="https://example.com/source">https://example.com/source</a>
+<table><thead><tr><th>Organelle</th><th>Role</th></tr></thead><tbody><tr><td>Mitochondria</td><td>ATP synthesis</td></tr></tbody></table>
+<p>Left column note.</p>
+<p>Right column note.</p>",
   "media": [
     {
       "block_id": "diagram1",

--- a/src/lib/notion-render/golden/renderBlocksGolden.test.ts
+++ b/src/lib/notion-render/golden/renderBlocksGolden.test.ts
@@ -126,11 +126,45 @@ const kitchenSinkPage: NotionRenderableBlock[] = [
     id: 'bm1',
     bookmark: { url: 'https://example.com/source' },
   },
+  {
+    type: 'table',
+    id: 'table1',
+    has_children: true,
+    table: { has_column_header: true },
+  },
+  {
+    type: 'column_list',
+    id: 'collist1',
+    has_children: true,
+  },
 ];
 
 const childrenByParent = {
   callout1: [para('Cells were first observed by Hooke.')],
   toggle1: [para('ATP is the energy currency.')],
+  table1: [
+    {
+      type: 'table_row',
+      table_row: {
+        cells: [[{ plain_text: 'Organelle' }], [{ plain_text: 'Role' }]],
+      },
+    },
+    {
+      type: 'table_row',
+      table_row: {
+        cells: [
+          [{ plain_text: 'Mitochondria' }],
+          [{ plain_text: 'ATP synthesis' }],
+        ],
+      },
+    },
+  ],
+  collist1: [
+    { id: 'coll1', type: 'column', has_children: true },
+    { id: 'coll2', type: 'column', has_children: true },
+  ],
+  coll1: [para('Left column note.')],
+  coll2: [para('Right column note.')],
 };
 
 it('produces a stable rendered page for a mixed Notion block tree', async () => {

--- a/src/lib/notion-render/renderBlocks.test.ts
+++ b/src/lib/notion-render/renderBlocks.test.ts
@@ -466,3 +466,161 @@ describe('renderNotionBlocks — media', () => {
     expect(out.unsupportedTypes).toEqual([]);
   });
 });
+
+describe('renderNotionBlocks — tables', () => {
+  const row = (...cells: string[][]): NotionRenderableBlock => ({
+    type: 'table_row',
+    table_row: {
+      cells: cells.map((texts) => texts.map((t) => ({ plain_text: t }))),
+    },
+  });
+
+  it('renders a table with rows and cells as <td> (was dropped)', async () => {
+    const table: NotionRenderableBlock = {
+      id: 't1',
+      type: 'table',
+      has_children: true,
+      table: { has_column_header: false },
+    };
+    const fetch = fetcherFor({
+      t1: [row(['A1'], ['B1']), row(['A2'], ['B2'])],
+    });
+    const out = await renderNotionBlocks([table], fetch);
+    expect(out.html).toBe(
+      '<table><tbody>' +
+        '<tr><td>A1</td><td>B1</td></tr>' +
+        '<tr><td>A2</td><td>B2</td></tr>' +
+        '</tbody></table>'
+    );
+  });
+
+  it('renders the first row as <thead>/<th> when has_column_header is set', async () => {
+    const table: NotionRenderableBlock = {
+      id: 't2',
+      type: 'table',
+      has_children: true,
+      table: { has_column_header: true },
+    };
+    const fetch = fetcherFor({
+      t2: [row(['Term'], ['Definition']), row(['ATP'], ['energy'])],
+    });
+    const out = await renderNotionBlocks([table], fetch);
+    expect(out.html).toBe(
+      '<table>' +
+        '<thead><tr><th>Term</th><th>Definition</th></tr></thead>' +
+        '<tbody><tr><td>ATP</td><td>energy</td></tr></tbody>' +
+        '</table>'
+    );
+  });
+
+  it('renders known siblings around a table without dropping them', async () => {
+    const table: NotionRenderableBlock = {
+      id: 't3',
+      type: 'table',
+      has_children: true,
+      table: {},
+    };
+    const fetch = fetcherFor({ t3: [row(['x'])] });
+    const out = await renderNotionBlocks(
+      [para('before'), table, para('after')],
+      fetch
+    );
+    expect(out.html).toBe(
+      '<p>before</p>\n' +
+        '<table><tbody><tr><td>x</td></tr></tbody></table>\n' +
+        '<p>after</p>'
+    );
+  });
+});
+
+describe('renderNotionBlocks — columns', () => {
+  it('renders all columns content in a column_list (was dropped)', async () => {
+    const columnList: NotionRenderableBlock = {
+      id: 'cl1',
+      type: 'column_list',
+      has_children: true,
+    };
+    const fetch = fetcherFor({
+      cl1: [
+        { id: 'col1', type: 'column', has_children: true },
+        { id: 'col2', type: 'column', has_children: true },
+      ],
+      col1: [para('left one'), para('left two')],
+      col2: [para('right one')],
+    });
+    const out = await renderNotionBlocks([columnList], fetch);
+    expect(out.html).toContain('<p>left one</p>');
+    expect(out.html).toContain('<p>left two</p>');
+    expect(out.html).toContain('<p>right one</p>');
+  });
+
+  it('renders nested content (a toggle) inside a column', async () => {
+    const columnList: NotionRenderableBlock = {
+      id: 'cl2',
+      type: 'column_list',
+      has_children: true,
+    };
+    const fetch = fetcherFor({
+      cl2: [{ id: 'col', type: 'column', has_children: true }],
+      col: [
+        {
+          id: 'tog',
+          type: 'toggle',
+          has_children: true,
+          toggle: { rich_text: [{ plain_text: 'Q' }] },
+        },
+      ],
+      tog: [para('deep answer')],
+    });
+    const out = await renderNotionBlocks([columnList], fetch);
+    expect(out.html).toContain(
+      '<details><summary>Q</summary><p>deep answer</p></details>'
+    );
+  });
+
+  it('renders known siblings around a column_list without dropping them', async () => {
+    const columnList: NotionRenderableBlock = {
+      id: 'cl3',
+      type: 'column_list',
+      has_children: true,
+    };
+    const fetch = fetcherFor({
+      cl3: [{ id: 'colA', type: 'column', has_children: true }],
+      colA: [para('inside column')],
+    });
+    const out = await renderNotionBlocks(
+      [para('before'), columnList, para('after')],
+      fetch
+    );
+    expect(out.html).toBe('<p>before</p>\n<p>inside column</p>\n<p>after</p>');
+  });
+
+  it('collects media from an image inside a column subtree', async () => {
+    const columnList: NotionRenderableBlock = {
+      id: 'cl4',
+      type: 'column_list',
+      has_children: true,
+    };
+    const fetch = fetcherFor({
+      cl4: [{ id: 'colX', type: 'column', has_children: true }],
+      colX: [
+        {
+          id: 'imgcol',
+          type: 'image',
+          image: { type: 'external', external: { url: 'https://x/c.png' } },
+        },
+      ],
+    });
+    const out = await renderNotionBlocks([columnList], fetch);
+    expect(out.html).toContain('<img src="ankify-imgcol.png">');
+    expect(out.media).toEqual([
+      {
+        block_id: 'imgcol',
+        kind: 'image',
+        source: 'external',
+        url: 'https://x/c.png',
+        filename: 'ankify-imgcol.png',
+      },
+    ]);
+  });
+});

--- a/src/lib/notion-render/renderBlocks.ts
+++ b/src/lib/notion-render/renderBlocks.ts
@@ -308,6 +308,54 @@ const renderChildren = async (
   return await renderBlockList(children, ctx, depth + 1);
 };
 
+const renderTableRow = (
+  block: NotionRenderableBlock,
+  isHeader: boolean
+): string => {
+  const tag = isHeader ? 'th' : 'td';
+  const cells = (block.table_row?.cells ?? [])
+    .map((cell) => `<${tag}>${renderRichText(cell)}</${tag}>`)
+    .join('');
+  return `<tr>${cells}</tr>`;
+};
+
+const renderTable = async (
+  block: NotionRenderableBlock,
+  ctx: RenderContext,
+  depth: number
+): Promise<string> => {
+  if (block.has_children !== true || block.id == null) return '';
+  if (depth >= ctx.maxDepth) return '';
+  const children = await ctx.fetchChildren(block.id);
+  const rows = children.filter((child) => child.type === 'table_row');
+  if (rows.length === 0) return '';
+  if (block.table?.has_column_header === true) {
+    const [headerRow, ...bodyRows] = rows;
+    const thead = `<thead>${renderTableRow(headerRow, true)}</thead>`;
+    const body = bodyRows.map((r) => renderTableRow(r, false)).join('');
+    return `<table>${thead}<tbody>${body}</tbody></table>`;
+  }
+  const body = rows.map((r) => renderTableRow(r, false)).join('');
+  return `<table><tbody>${body}</tbody></table>`;
+};
+
+const renderColumnList = async (
+  block: NotionRenderableBlock,
+  ctx: RenderContext,
+  depth: number
+): Promise<string> => {
+  if (block.has_children !== true || block.id == null) return '';
+  if (depth >= ctx.maxDepth) return '';
+  const columns = await ctx.fetchChildren(block.id);
+  const parts: string[] = [];
+  for (const column of columns) {
+    if (column.type !== 'column') continue;
+    const inner = await renderChildren(column, ctx, depth + 1);
+    if (inner !== '') parts.push(inner);
+  }
+  return parts.join('\n');
+};
+
 const renderBlockList = async (
   blocks: NotionRenderableBlock[],
   ctx: RenderContext,
@@ -403,6 +451,17 @@ const renderBlockList = async (
       case 'child_page':
       case 'child_database':
         out.push(renderChildPageTitle(block));
+        break;
+      case 'table':
+        out.push(await renderTable(block, ctx, depth));
+        break;
+      case 'table_row':
+        break;
+      case 'column_list':
+        out.push(await renderColumnList(block, ctx, depth));
+        break;
+      case 'column':
+        out.push(await renderChildren(block, ctx, depth));
         break;
       default:
         ctx.unsupportedTypes.push(block.type);

--- a/src/lib/notion-render/types.ts
+++ b/src/lib/notion-render/types.ts
@@ -54,6 +54,10 @@ export interface NotionRenderableBlock {
   divider?: Record<string, never>;
   child_page?: { title?: string };
   child_database?: { title?: string };
+  table?: { has_column_header?: boolean; table_width?: number };
+  table_row?: { cells?: NotionRichTextItem[][] };
+  column_list?: Record<string, never>;
+  column?: Record<string, never>;
 }
 
 export type WalkedMediaKind = 'image' | 'video' | 'audio' | 'file';

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-03-ankify-sync-tables-columns.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-03-ankify-sync-tables-columns.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-03-ankify-sync-tables-columns",
+  "date": "2026-07-03",
+  "type": "fix",
+  "title": "Notion tables and multi-column layouts now sync to your Anki cards"
+}


### PR DESCRIPTION
## What
Adds `table`/`table_row` and `column_list`/`column` rendering to the Ankify Auto-Sync renderer (`src/lib/notion-render/renderBlocks.ts`). These block types had no `switch` case, so they fell to `default` and were silently dropped from synced cards. Tables now render as HTML `<table>` (with `<thead>`/`<th>` when the table has a column header, else `<tbody>`/`<td>`); column layouts recurse into their columns and render all of their content.

## Why
The new unsupported-blocks metric (#3513) showed the sync path dropping `table` 56× and `column_list` 28× in one prod window. The convert-with-Notion path already renders both (`BlockTable` / `BlockColumnList`), so synced decks diverged from what the user sees in Notion. On the paid Auto-Sync tier this is silent content loss — a direct churn risk for the highest-value users.

## How
Faithful port of the convert path's markup, not a shared abstraction — this is only the 2nd occurrence, so no premature DRY. `table` fetches its `table_row` children via the injected `fetchChildren` and mirrors `BlockTable`'s thead/tbody shape; `column_list` recurses into each `column` child (respecting `ctx.maxDepth`) and concatenates. Media inside a column subtree is threaded through the shared `ctx.media` array, so images in columns still get bundled into the `.apkg`. Both the single-page walk and the database walk flow through the one `renderNotionBlocks` entry point, so this covers every sync trigger (polling, manual, webhook).

## Measuring success
The unsupported-blocks metric should stop incrementing `table` and `column_list` on the sync path after deploy — that metric is what caught this, so it's also the validation. Existing rows stay as the historical record. Confirm by watching the sync-path unsupported-blocks counts for `table`/`column_list` go flat post-deploy.

## Testing
- Unit tests added to `renderBlocks.test.ts`: table with rows→`<td>`, header row→`<thead>`/`<th>`, siblings around a table survive; column_list renders all columns, nested toggle inside a column survives, siblings around a column_list survive, image inside a column subtree lands in `media`.
- Golden snapshot (`renderBlocksGolden.test.ts`) extended with a table + column_list and regenerated intentionally — eyeballed: table renders thead/th + tbody/td, both columns' paragraphs present.
- Server `tsc -p . --noEmit` green (typechecks tests too), web typecheck green, WhatsNewPage vitest green, oxfmt clean.
- `sonar-scanner` could not run locally — no `SONAR_TOKEN` in this environment (auth failed). oxlint on the changed files is clean apart from a pre-existing `no-nested-ternary` warning in `renderHeading` (unrelated to this change). The new helpers are small and flat (no nested ternaries, low cognitive complexity).

## Browser check
Browser check: not applicable — changelog-only web/src change (JSON entry), no rendered component touched.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-03-ankify-sync-tables-columns.json` — "Notion tables and multi-column layouts now sync to your Anki cards"

## Risks
Low. Additive `switch` cases plus four optional type fields — no existing block type changes behavior. Table markup mirrors the already-shipped convert path. `content_hash` on already-synced cards changes because the rendered HTML changes, so unedited pages containing tables/columns rewrite those notes once on their first post-deploy sync (same recolour-on-deploy behavior documented for renderer changes). Rollback is a straight revert.

## Goal alignment
Retention on the paid Auto-Sync tier. Silent content loss for the highest-value users (lifetime / Auto-Sync subscribers running a live sync) is a churn driver; restoring tables and columns makes synced decks match what users see in Notion. No new acquisition surface — this is a correctness fix on an existing paid surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXwaVZmQhog3sWX2osXshM
