### PR TITLE
fix: handle empty/malformed body in ops performance metrics fetch

### DIFF
--- a/web/src/pages/OpsPage/usePerformanceMetrics.test.ts
+++ b/web/src/pages/OpsPage/usePerformanceMetrics.test.ts
@@ -1,0 +1,100 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { usePerformanceMetrics } from './usePerformanceMetrics';
+
+const wrap = (client: QueryClient) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client }, children);
+  };
+
+const noRetryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+describe('usePerformanceMetrics', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('parses a valid JSON body into the payload', async () => {
+    const payload = {
+      generated_at: '2026-07-05T09:00:00.000Z',
+      durations: [],
+      status_breakdown_24h: [],
+      slowest_jobs_24h: [],
+      signup_countries_7d: [],
+      user_visible_errors_24h: [],
+      user_visible_errors_7d: [],
+    };
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify(payload),
+    });
+
+    const { result } = renderHook(() => usePerformanceMetrics(), {
+      wrapper: wrap(noRetryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+  });
+
+  test('surfaces a clean error when a 200 has an empty body', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '',
+    });
+
+    const { result } = renderHook(() => usePerformanceMetrics(), {
+      wrapper: wrap(noRetryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('empty response body');
+  });
+
+  test('surfaces a clean error when a 200 body is not JSON', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '<html>gateway timeout</html>',
+    });
+
+    const { result } = renderHook(() => usePerformanceMetrics(), {
+      wrapper: wrap(noRetryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('malformed response body');
+  });
+
+  test('surfaces status text on a non-ok response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: async () => '{"message":"Failed to load performance metrics"}',
+    });
+
+    const { result } = renderHook(() => usePerformanceMetrics(), {
+      wrapper: wrap(noRetryClient()),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('500 Internal Server Error');
+  });
+});

--- a/web/src/pages/OpsPage/usePerformanceMetrics.ts
+++ b/web/src/pages/OpsPage/usePerformanceMetrics.ts
@@ -12,7 +12,15 @@ const fetchPerformanceMetrics =
     if (!response.ok) {
       throw new Error(`${response.status} ${response.statusText}`);
     }
-    return response.json();
+    const body = await response.text();
+    if (body.trim() === '') {
+      throw new Error('empty response body');
+    }
+    try {
+      return JSON.parse(body) as PerformanceMetricsResponse;
+    } catch {
+      throw new Error('malformed response body');
+    }
   };
 
 export const usePerformanceMetrics = () => {


### PR DESCRIPTION
## What

The ops **Performance** tab surfaced a raw `Failed to execute 'json' on 'Response': Unexpected end of JSON input` in its error banner. The fetcher called `response.json()` on any 2xx response; when the upstream returned **200 with an empty or non-JSON body** (an interrupted / proxy-buffered response over the 7 heavy parallel `jobs` scans that back `/api/ops/performance/metrics`), the raw DOMException leaked through.

## Fix

Read the body as text first:
- empty body → `empty response body`
- unparseable body → `malformed response body`

react-query still keeps last-good data behind the banner, now with a clean message instead of a DOMException.

Scope kept to the reported fetcher. `useConversionMetrics` shares the same shape but wasn't reported — left alone (2 occurrences, not abstracting yet).

## Tests

Added `usePerformanceMetrics.test.ts`: valid JSON, empty-200, non-JSON-200, and non-ok status. Full web suite green (2077 tests), `tsc` clean.

No changelog entry — `/ops` is an admin-only internal surface, not user-facing.

## Browser check
Browser check: not applicable — admin-only ops page behind RequireOpsAccess, not on the golden path; change only alters an error-banner string on a gated surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)