### PR TITLE
fix: prerender Article and FAQ JSON-LD into answer-page HTML

### DIFF
--- a/web/scripts/prerenderLandingPages.ts
+++ b/web/scripts/prerenderLandingPages.ts
@@ -14,6 +14,10 @@ import goodnotesCopy from '../src/pages/LandingPage/copy/goodnotes';
 import aiFlashcardGeneratorCopy from '../src/pages/LandingPage/copy/ai-flashcard-generator';
 import { CONVERT_LANDING_PAGES } from '../src/pages/ConvertLandingPage/convertLandingConfig';
 import { ANSWERS_PAGES } from '../src/pages/AnswersPage/answersConfig';
+import {
+  buildArticleJsonLd,
+  buildFaqJsonLd,
+} from '../src/pages/AnswersPage/answersJsonLd';
 import type { LandingCopy } from '../src/pages/LandingPage/types';
 
 const LANDING_COPIES: LandingCopy[] = [
@@ -308,7 +312,12 @@ export function emitAnswersPages(buildDir: string): string[] {
     const outDir = join(buildDir, slug);
     const outPath = join(outDir, 'index.html');
     mkdirSync(dirname(outPath), { recursive: true });
-    const html = rewriteRoot(rewriteHead(source, copy), copy);
+    let html = rewriteRoot(rewriteHead(source, copy), copy);
+    const jsonLdScripts = [buildArticleJsonLd(config), buildFaqJsonLd(config)]
+      .filter((jsonLd) => jsonLd != null)
+      .map((jsonLd) => `<script type="application/ld+json">${jsonLd}</script>`)
+      .join('\n  ');
+    html = html.replace(/<\/head>/, `  ${jsonLdScripts}\n</head>`);
     writeFileSync(outPath, html, 'utf8');
     emitted.push(outPath);
   }

--- a/web/src/pages/AnswersPage/AnswersPage.tsx
+++ b/web/src/pages/AnswersPage/AnswersPage.tsx
@@ -2,38 +2,11 @@ import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import NotFoundPage from '../NotFoundPage';
 import { AnswerFigure } from './AnswerFigures';
-import { AnswerConfig, ANSWERS_PAGES } from './answersConfig';
+import { ANSWERS_PAGES } from './answersConfig';
 import styles from './AnswersPage.module.css';
+import { buildArticleJsonLd, buildFaqJsonLd } from './answersJsonLd';
 
-export function buildFaqJsonLd(config: AnswerConfig): string | null {
-  if (config.faqs == null || config.faqs.length === 0) {
-    return null;
-  }
-  return JSON.stringify({
-    '@context': 'https://schema.org',
-    '@type': 'FAQPage',
-    mainEntity: config.faqs.map((faq) => ({
-      '@type': 'Question',
-      name: faq.q,
-      acceptedAnswer: { '@type': 'Answer', text: faq.a },
-    })),
-  });
-}
-
-export function buildArticleJsonLd(config: AnswerConfig): string {
-  return JSON.stringify({
-    '@context': 'https://schema.org',
-    '@type': 'Article',
-    headline: config.title,
-    description: config.description,
-    articleSection: config.sections.map((section) => section.heading),
-    articleBody: config.sections.map((section) => section.body).join('\n\n'),
-    mainEntityOfPage: {
-      '@type': 'WebPage',
-      '@id': `https://2anki.net/answers/${config.slug}`,
-    },
-  });
-}
+export { buildArticleJsonLd, buildFaqJsonLd };
 
 function AnswersPage() {
   const { slug } = useParams<{ slug: string }>();

--- a/web/src/pages/AnswersPage/answersJsonLd.ts
+++ b/web/src/pages/AnswersPage/answersJsonLd.ts
@@ -1,0 +1,31 @@
+import { AnswerConfig } from './answersConfig';
+
+export function buildArticleJsonLd(config: AnswerConfig): string {
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: config.title,
+    description: config.description,
+    articleSection: config.sections.map((section) => section.heading),
+    articleBody: config.sections.map((section) => section.body).join('\n\n'),
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': `https://2anki.net/answers/${config.slug}`,
+    },
+  });
+}
+
+export function buildFaqJsonLd(config: AnswerConfig): string | null {
+  if (config.faqs == null || config.faqs.length === 0) {
+    return null;
+  }
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: config.faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.q,
+      acceptedAnswer: { '@type': 'Answer', text: faq.a },
+    })),
+  });
+}


### PR DESCRIPTION
## What

Post-deploy verification of #3526 found the JSON-LD gap: answer-page structured data (Article + the new FAQPage block) only existed via react-helmet after client-side hydration. Raw-HTML fetchers — ChatGPT-User and PerplexityBot, the exact channel these pages target — got prerendered HTML with neither block. Confirmed on prod: `curl https://2anki.net/answers/word-to-anki/` had no FAQPage markup.

## Fix

- `buildArticleJsonLd` / `buildFaqJsonLd` move to a pure module `answersJsonLd.ts` (no React imports), re-exported from `AnswersPage.tsx` so the existing test surface is unchanged.
- `emitAnswersPages` in `prerenderLandingPages.ts` injects both `<script type="application/ld+json">` blocks into the emitted head.

## Verification

- AnswersPage vitest 15/15; full web suite green; `tsc --noEmit` clean; oxlint/oxfmt clean.
- `npm run build` then grep: `build/answers/word-to-anki/index.html` contains FAQPage, `build/answers/pdf-to-anki/index.html` contains Article.

Browser check: not applicable — head-only script-tag injection in prerendered HTML; no rendered output change.

No changelog entry — SEO plumbing, no user-visible behavior change.

Sonar: local scanner not run (no SONAR_TOKEN on this machine); push-triggered Automatic Analysis covers it. New code is a moved pure module + one string injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
