### PR TITLE
fix: register new answer-page slugs in known routes

### DIFF
--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -102,6 +102,9 @@ const ANSWERS_SLUGS = new Set<string>([
   'pdf-to-anki',
   'quizlet-to-anki',
   'fsrs-explained',
+  'lecture-notes-to-anki',
+  'word-to-anki',
+  'image-occlusion-anki',
 ]);
 
 const PARAM_PREFIXES = [


### PR DESCRIPTION
PR #3526 added three answer pages to the config and sitemap but not to `ANSWERS_SLUGS` in `src/routes/knownRoutes.ts` — 3 DefaultRouter suites red on main, new pages outside known-route handling. Adds the three slugs; DefaultRouter + knownRoutes suites 98/98 green, tsc clean.

No changelog entry — internal route-registry consistency, no user-visible behavior change.

Browser check: not applicable — server-side route registry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)