### PR TITLE
test: pin docx heading+bullet fan-out through overlapping cloze

### DIFF
--- a/src/lib/parser/DeckParser.docxOverlappingCloze.test.ts
+++ b/src/lib/parser/DeckParser.docxOverlappingCloze.test.ts
@@ -1,0 +1,58 @@
+import { setupTests } from '../../test/configure-jest';
+import { DeckParser } from './DeckParser';
+import CardOption from './Settings';
+import Workspace from './WorkSpace';
+import { preprocessDocxHTML } from '../../infrastracture/adapters/fileConversion/preprocessDocxHTML';
+
+beforeEach(() => {
+  setupTests();
+});
+
+const docxHTML =
+  '<h2>Contract remedies</h2>' +
+  '<ul>' +
+  '<li>Damages compensate the injured party</li>' +
+  '<li>Specific performance forces the promised act</li>' +
+  '<li>Rescission unwinds the contract</li>' +
+  '</ul>';
+
+async function buildDocxDeck(overlapping: string) {
+  const workspace = new Workspace(true, 'fs');
+  const parser = new DeckParser({
+    name: 'notes.docx.html',
+    settings: new CardOption({
+      cherry: 'false',
+      cloze: 'true',
+      'overlapping-cloze': overlapping,
+    }),
+    files: [
+      { name: 'notes.docx.html', contents: preprocessDocxHTML(docxHTML) },
+    ],
+    noLimits: true,
+    workspace,
+  });
+  await parser.writeDeckInfo(workspace);
+  return parser.payload[0];
+}
+
+const countC1 = (text: string) => (text.match(/\{\{c1::/g) || []).length;
+
+test('docx heading+bullets fans into one cloze card per bullet with overlapping cloze on', async () => {
+  const deck = await buildDocxDeck('show-all');
+  expect(deck.cards.length).toBe(3);
+  for (const card of deck.cards) {
+    expect(card.cloze).toBe(true);
+    expect(countC1(card.name)).toBe(1);
+  }
+  expect(deck.cards[0].name).toContain(
+    '{{c1::Damages compensate the injured party}}'
+  );
+});
+
+test('docx heading+bullets stays one lumped card with overlapping cloze off', async () => {
+  const deck = await buildDocxDeck('off');
+  expect(deck.cards.length).toBe(1);
+  expect(deck.cards[0].name).toContain('Contract remedies');
+  expect(deck.cards[0].back).toContain('Damages compensate the injured party');
+  expect(deck.cards[0].back).toContain('Rescission unwinds the contract');
+});

--- a/web/src/pages/DocsPage/content/cards/overlapping-cloze.md
+++ b/web/src/pages/DocsPage/content/cards/overlapping-cloze.md
@@ -63,4 +63,6 @@ The same goes for a song or poem whose lines sit in separate blocks — each lin
 
 Overlapping cloze fires when a card's answer is a list of 2 or more items, or when a page is a single paragraph that splits into 2 or more sentences or clauses. A single item or clause becomes one normal cloze card. Other cards are untouched.
 
+This includes Word documents. A .docx section — a heading followed by a bullet list — normally converts to one card with the whole list on the back. With overlapping cloze on, that list fans out into one card per bullet instead.
+
 The result is a standard Cloze deck — it downloads, syncs, and studies like any other.


### PR DESCRIPTION
## What

Issue #3524 (docx: one card per heading lumps all bullets into a single back). Trio verdict overnight: **the requested capability already exists** — a docx heading+bullet section's lumped `<ul>` fans into one cloze card per bullet when the `overlapping-cloze` CardOption is on, verified end-to-end in code (preprocessDocxHTML keeps the `<ul>` intact → DeckParser's `buildOverlappingClozeNotes` runs on every card, source-agnostic → `extractListItems` reads the top-level `<li>`s → per-item c1 notes). The gap is discoverability plus zero tests pinning the reach.

Ships: a regression pair driven through the real docx preprocessor (fans out when on; stays one lumped card when off) and a docs paragraph on the overlapping-cloze page naming Word exports as a target case.

## Decisions made overnight (please review)

- **Did NOT flip the docx default to per-bullet cards** — that changes card type and note count for every existing docx user (pm + engineer both flagged the regression surface; designer's standing veto on naive front=heading/back=bullet across N siblings stands). If you want per-bullet as default, the endorsed shape is cloze-grouped via the existing `handleOverlappingCloze`, applied only when a section body is a single ≥2-item list — that's a deliberate default change worth its own round. Assumption: the reporter's need is met by the existing option once discoverable; if wrong, reopen #3524 for the default flip.
- Docs copy shipped: "This includes Word documents. A .docx section — a heading followed by a bullet list — normally converts to one card with the whole list on the back. With overlapping cloze on, that list fans out into one card per bullet instead."
- No changelog entry — no behavior change (test + docs only). Deliberately NOT titled `fix:` per the false-artifact rule.

## Testing

New suite 2/2 green; preprocessDocxHTML suite untouched and green; server tsc clean. Sonar: local scanner unavailable (no SONAR_TOKEN); Automatic Analysis on push.

Browser check: not applicable — server test + one MDX docs paragraph, no runtime-visible web change.

Refs #3524 (leaving the issue open for Alexander's default-flip verdict; close it if the option + docs is the answer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
