### PR TITLE
feat: show emoji feedback comments in the ops Today voice block

### DIFF
--- a/web/src/pages/OpsPage/TodayTab.test.tsx
+++ b/web/src/pages/OpsPage/TodayTab.test.tsx
@@ -78,6 +78,7 @@ const jsonResponse = (body: unknown) => ({
 
 interface RouteOverrides {
   errorGroups?: unknown;
+  business?: unknown;
 }
 
 const installFetch = (overrides: RouteOverrides = {}) => {
@@ -89,7 +90,9 @@ const installFetch = (overrides: RouteOverrides = {}) => {
       );
     }
     if (url.includes('/api/ops/business/metrics')) {
-      return Promise.resolve(jsonResponse(healthyBusiness));
+      return Promise.resolve(
+        jsonResponse(overrides.business ?? healthyBusiness)
+      );
     }
     if (url.includes('/api/ops/conversion/metrics')) {
       return Promise.resolve(jsonResponse(healthyConversion));
@@ -170,6 +173,27 @@ describe('TodayTab', () => {
     expect(screen.getByText('7 occurrences')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Copy for Claude Code' })
+    ).toBeInTheDocument();
+  });
+
+  it('shows recent emoji feedback comments in the voice block', async () => {
+    installFetch({
+      business: {
+        ...healthyBusiness,
+        emoji_feedback_comments: [
+          {
+            rating: 2,
+            comment: 'The deck came out empty',
+            page: '/upload',
+            created_at: '2026-07-08T09:00:00Z',
+          },
+        ],
+      },
+    });
+    renderTab();
+
+    expect(
+      await screen.findByText(/The deck came out empty/)
     ).toBeInTheDocument();
   });
 });

--- a/web/src/pages/OpsPage/TodayTab.tsx
+++ b/web/src/pages/OpsPage/TodayTab.tsx
@@ -10,7 +10,10 @@ import {
   formatPercentOneDecimal,
   formatUsd,
 } from './businessHelpers';
-import { CancellationCommentPoint } from './businessTypes';
+import {
+  EmojiFeedbackCommentPoint,
+  CancellationCommentPoint,
+} from './businessTypes';
 import styles from './OpsPage.module.css';
 import CopyForClaudeButton from './CopyForClaudeButton';
 import { TodaySignal, computeTodaySignals } from './todaySignals';
@@ -89,16 +92,27 @@ function useContactMessages() {
   return messages;
 }
 
+const EMOJI_BY_RATING: Record<number, string> = {
+  1: '\u{1F620}',
+  2: '\u{1F615}',
+  3: '\u{1F610}',
+  4: '\u{1F642}',
+  5: '\u{1F929}',
+};
+
 function VoiceOfUserBlock({
   messages,
   cancellations,
+  emojiComments,
 }: Readonly<{
   messages: ContactMessage[];
   cancellations: CancellationCommentPoint[];
+  emojiComments: EmojiFeedbackCommentPoint[];
 }>) {
   const unread = messages.filter((m) => !m.is_acknowledged);
   const recentMessages = unread.slice(0, MESSAGE_PREVIEW_MAX);
   const recentCancellations = cancellations.slice(0, MESSAGE_PREVIEW_MAX);
+  const recentEmoji = emojiComments.slice(0, MESSAGE_PREVIEW_MAX);
 
   return (
     <section className={styles.todaySection}>
@@ -121,6 +135,13 @@ function VoiceOfUserBlock({
           <li key={`${c.created_at}-${c.reason}`} className={styles.voiceRow}>
             <Link to="/ops/business" className={styles.voicePreview}>
               Cancelled — {c.reason}: {c.comment}
+            </Link>
+          </li>
+        ))}
+        {recentEmoji.map((e) => (
+          <li key={`${e.created_at}-${e.page}`} className={styles.voiceRow}>
+            <Link to="/ops/business" className={styles.voicePreview}>
+              {EMOJI_BY_RATING[e.rating] ?? e.rating} {e.comment} — {e.page}
             </Link>
           </li>
         ))}
@@ -237,6 +258,7 @@ export default function TodayTab() {
       <VoiceOfUserBlock
         messages={messages}
         cancellations={businessData?.cancellation_comments_recent ?? []}
+        emojiComments={businessData?.emoji_feedback_comments ?? []}
       />
       <HealthyStrip stats={healthyStats} />
     </div>


### PR DESCRIPTION
Adds the in-app emoji widget's recent comments to /ops/today's Voice of user block — rating emoji + comment + page, linked to the Business drill-down. Data already rides the business-metrics payload Today fetches; zero backend change.

Tests: new TodayTab case (emoji row renders from an overridden business payload); OpsPage suite 175 green; web tsc clean.

No changelog entry — internal ops tooling, not user-visible.

Browser check: not applicable — ops-gated internal page; verify visually on /ops/today with pnpm dev.

Sonar: local scanner not run (no SONAR_TOKEN on this machine); Automatic Analysis on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)