### PR TITLE
refactor: consolidate the /ops sidebar to seven rows

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -115,10 +115,6 @@ const PreviewApkgPage = lazyWithRetry(
   () => import('./pages/PreviewApkgPage'),
   './pages/PreviewApkgPage'
 );
-const FlagsTab = lazyWithRetry(
-  () => import('./pages/OpsPage/FlagsTab'),
-  './pages/OpsPage/FlagsTab'
-);
 const AnkifyPage = lazyWithRetry(
   () => import('./pages/AnkifyPage'),
   './pages/AnkifyPage'
@@ -139,33 +135,25 @@ const TodayTab = lazyWithRetry(
   () => import('./pages/OpsPage/TodayTab'),
   './pages/OpsPage/TodayTab'
 );
-const EngineeringTab = lazyWithRetry(
-  () => import('./pages/OpsPage/EngineeringTab'),
-  './pages/OpsPage/EngineeringTab'
+const GrowthTab = lazyWithRetry(
+  () => import('./pages/OpsPage/GrowthTab'),
+  './pages/OpsPage/GrowthTab'
+);
+const SystemTab = lazyWithRetry(
+  () => import('./pages/OpsPage/SystemTab'),
+  './pages/OpsPage/SystemTab'
+);
+const ControlsTab = lazyWithRetry(
+  () => import('./pages/OpsPage/ControlsTab'),
+  './pages/OpsPage/ControlsTab'
 );
 const ErrorsTab = lazyWithRetry(
   () => import('./pages/OpsPage/ErrorsTab'),
   './pages/OpsPage/ErrorsTab'
 );
-const PerformanceTab = lazyWithRetry(
-  () => import('./pages/OpsPage/PerformanceTab'),
-  './pages/OpsPage/PerformanceTab'
-);
-const ConversionsTab = lazyWithRetry(
-  () => import('./pages/OpsPage/ConversionsTab'),
-  './pages/OpsPage/ConversionsTab'
-);
-const ReturnRateTab = lazyWithRetry(
-  () => import('./pages/OpsPage/ReturnRateTab'),
-  './pages/OpsPage/ReturnRateTab'
-);
 const BusinessTab = lazyWithRetry(
   () => import('./pages/OpsPage/BusinessTab'),
   './pages/OpsPage/BusinessTab'
-);
-const ShowcaseTab = lazyWithRetry(
-  () => import('./pages/OpsPage/ShowcaseTab'),
-  './pages/OpsPage/ShowcaseTab'
 );
 const InterviewsTab = lazyWithRetry(
   () => import('./pages/OpsPage/InterviewsTab'),
@@ -174,14 +162,6 @@ const InterviewsTab = lazyWithRetry(
 const ContactMessagesTab = lazyWithRetry(
   () => import('./pages/OpsPage/ContactMessagesTab'),
   './pages/OpsPage/ContactMessagesTab'
-);
-const CommandsTab = lazyWithRetry(
-  () => import('./pages/OpsPage/CommandsTab'),
-  './pages/OpsPage/CommandsTab'
-);
-const UploadFunnelTab = lazyWithRetry(
-  () => import('./pages/OpsPage/UploadFunnelTab'),
-  './pages/OpsPage/UploadFunnelTab'
 );
 const FeedbackPage = lazyWithRetry(
   () => import('./pages/FeedbackPage/FeedbackPage'),
@@ -521,19 +501,39 @@ function AppContent({
               element={requireAuth(<AnkifyHistoryPage />)}
             />
             <Route path="/ops" element={requireAuth(<OpsLayout />)}>
-              <Route index element={<EngineeringTab />} />
+              <Route index element={<SystemTab />} />
               <Route path="today" element={<TodayTab />} />
-              <Route path="errors" element={<ErrorsTab />} />
-              <Route path="performance" element={<PerformanceTab />} />
-              <Route path="conversions" element={<ConversionsTab />} />
-              <Route path="return-rate" element={<ReturnRateTab />} />
-              <Route path="upload-funnel" element={<UploadFunnelTab />} />
+              <Route path="growth" element={<GrowthTab />} />
               <Route path="business" element={<BusinessTab />} />
-              <Route path="showcase" element={<ShowcaseTab />} />
-              <Route path="interviews" element={<InterviewsTab />} />
+              <Route path="system" element={<SystemTab />} />
+              <Route path="errors" element={<ErrorsTab />} />
               <Route path="messages" element={<ContactMessagesTab />} />
-              <Route path="commands" element={<CommandsTab />} />
-              <Route path="flags" element={<FlagsTab />} />
+              <Route path="commands" element={<ControlsTab />} />
+              <Route path="interviews" element={<InterviewsTab />} />
+              <Route
+                path="conversions"
+                element={<Navigate to="/ops/growth" replace />}
+              />
+              <Route
+                path="upload-funnel"
+                element={<Navigate to="/ops/growth" replace />}
+              />
+              <Route
+                path="return-rate"
+                element={<Navigate to="/ops/growth" replace />}
+              />
+              <Route
+                path="performance"
+                element={<Navigate to="/ops/system" replace />}
+              />
+              <Route
+                path="flags"
+                element={<Navigate to="/ops/commands" replace />}
+              />
+              <Route
+                path="showcase"
+                element={<Navigate to="/ops/commands" replace />}
+              />
             </Route>
             <Route path="/feedback" element={requireAuth(<FeedbackPage />)} />
             <Route path="/settings" element={requireAuth(<AccountPage />)} />

--- a/web/src/components/AppShell/AppShell.module.css
+++ b/web/src/components/AppShell/AppShell.module.css
@@ -269,22 +269,6 @@
   padding-left: 44px;
 }
 
-.sidebarFolderGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-
-.sidebarFolderGroupLabel {
-  margin: var(--space-2) 0 var(--space-1);
-  padding: 0 0.75rem 0 44px;
-  font-size: var(--text-xs);
-  font-weight: var(--font-semibold);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
 .sidebarSpacer {
   flex: 1 1 auto;
 }

--- a/web/src/components/AppShell/Sidebar.test.tsx
+++ b/web/src/components/AppShell/Sidebar.test.tsx
@@ -256,44 +256,65 @@ describe('Sidebar Ops folder', () => {
       'aria-expanded',
       'true'
     );
-    expect(screen.getByRole('link', { name: 'Engineering' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'System' })).toHaveAttribute(
       'href',
-      '/ops'
+      '/ops/system'
     );
-    expect(screen.getByRole('link', { name: 'Flags' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Commands' })).toHaveAttribute(
       'href',
-      '/ops/flags'
+      '/ops/commands'
     );
   });
 
-  it('renders the ops tabs under their group headers', () => {
+  it('lists the seven consolidated rows and none of the retired ones', () => {
     renderSidebar({ ops: true, pathname: '/ops/errors' });
-    expect(screen.getByText('Growth')).toBeInTheDocument();
-    expect(screen.getByText('System')).toBeInTheDocument();
-    expect(screen.getByText('Voice')).toBeInTheDocument();
-    expect(screen.getByText('Controls')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'Pricing A/B' })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'Mindmaps' })
-    ).not.toBeInTheDocument();
+    for (const [label, href] of [
+      ['Today', '/ops/today'],
+      ['Growth', '/ops/growth'],
+      ['Business', '/ops/business'],
+      ['System', '/ops/system'],
+      ['Errors', '/ops/errors'],
+      ['Messages', '/ops/messages'],
+      ['Commands', '/ops/commands'],
+    ] as const) {
+      expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+        'href',
+        href
+      );
+    }
+    for (const retired of [
+      'Engineering',
+      'Performance',
+      'Conversions',
+      'Upload funnel',
+      'Return rate',
+      'Flags',
+      'Showcase',
+      'Interviews',
+      'Pricing A/B',
+      'Mindmaps',
+    ]) {
+      expect(
+        screen.queryByRole('link', { name: retired })
+      ).not.toBeInTheDocument();
+    }
   });
 
-  it('marks exactly the current tab active, not the Engineering index', () => {
+  it('marks exactly the current row active', () => {
     renderSidebar({ ops: true, pathname: '/ops/errors' });
     expect(screen.getByRole('link', { name: 'Errors' })).toHaveAttribute(
       'aria-current',
       'page'
     );
-    expect(
-      screen.getByRole('link', { name: 'Engineering' })
-    ).not.toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'System' })).not.toHaveAttribute(
+      'aria-current',
+      'page'
+    );
   });
 
-  it('marks Engineering active only on the /ops index', () => {
+  it('marks System active on the /ops index', () => {
     renderSidebar({ ops: true, pathname: '/ops' });
-    expect(screen.getByRole('link', { name: 'Engineering' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'System' })).toHaveAttribute(
       'aria-current',
       'page'
     );

--- a/web/src/components/AppShell/Sidebar.tsx
+++ b/web/src/components/AppShell/Sidebar.tsx
@@ -27,7 +27,7 @@ import UserCircleIcon from '../icons/UserCircleIcon';
 import SettingsIcon from '../icons/SettingsIcon';
 import WrenchIcon from '../icons/WrenchIcon';
 import ShareIcon from '../icons/ShareIcon';
-import { OPS_TAB_GROUPS } from '../../pages/OpsPage/opsTabs';
+import { OPS_TABS } from '../../pages/OpsPage/opsTabs';
 import { ThemeSwitcher } from '../ThemeSwitcher/ThemeSwitcher';
 import { ThemeToggle } from '../ThemeSwitcher/ThemeToggle';
 import styles from './AppShell.module.css';
@@ -89,6 +89,7 @@ interface SidebarRowProps {
   href: string;
   pathname: string;
   matchPrefix?: boolean;
+  active?: boolean;
   onClick?: React.MouseEventHandler<HTMLAnchorElement>;
   icon?: React.ComponentType<{ width?: number; height?: number }>;
   children: React.ReactNode;
@@ -104,11 +105,12 @@ function SidebarRow({
   href,
   pathname,
   matchPrefix = true,
+  active: activeOverride,
   onClick,
   icon: Icon,
   children,
 }: Readonly<SidebarRowProps>) {
-  const active = isActiveRoute(pathname, href, matchPrefix);
+  const active = activeOverride ?? isActiveRoute(pathname, href, matchPrefix);
   const label = typeof children === 'string' ? children : undefined;
   return (
     <Link
@@ -181,21 +183,16 @@ function OpsSidebarFolder({
           aria-label="Ops"
           className={styles.sidebarFolderItems}
         >
-          {OPS_TAB_GROUPS.map((group) => (
-            <div key={group.label} className={styles.sidebarFolderGroup}>
-              <p className={styles.sidebarFolderGroupLabel}>{group.label}</p>
-              {group.tabs.map((tab) => (
-                <SidebarRow
-                  key={tab.to}
-                  href={tab.to}
-                  pathname={pathname}
-                  matchPrefix={tab.to !== '/ops'}
-                  onClick={onNavigate}
-                >
-                  {tab.label}
-                </SidebarRow>
-              ))}
-            </div>
+          {OPS_TABS.map((tab) => (
+            <SidebarRow
+              key={tab.to}
+              href={tab.to}
+              pathname={pathname}
+              active={tab.match(pathname)}
+              onClick={onNavigate}
+            >
+              {tab.label}
+            </SidebarRow>
           ))}
         </div>
       )}

--- a/web/src/pages/OpsPage/ControlsTab.test.tsx
+++ b/web/src/pages/OpsPage/ControlsTab.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ControlsTab from './ControlsTab';
+
+const renderTab = () =>
+  render(
+    <MemoryRouter>
+      <ControlsTab />
+    </MemoryRouter>
+  );
+
+describe('ControlsTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('stacks the commands, flags, and showcase sections', () => {
+    renderTab();
+
+    expect(screen.getByText('Commands')).toBeInTheDocument();
+    expect(screen.getByText('Flags')).toBeInTheDocument();
+    expect(screen.getByText('Homepage showcase')).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/OpsPage/ControlsTab.tsx
+++ b/web/src/pages/OpsPage/ControlsTab.tsx
@@ -1,0 +1,22 @@
+import CommandsTab from './CommandsTab';
+import FlagsTab from './FlagsTab';
+import ShowcaseTab from './ShowcaseTab';
+import styles from './OpsPage.module.css';
+
+export default function ControlsTab() {
+  return (
+    <>
+      <section className={styles.compositeSection}>
+        <CommandsTab />
+      </section>
+
+      <section className={styles.compositeSection}>
+        <FlagsTab />
+      </section>
+
+      <section className={styles.compositeSection}>
+        <ShowcaseTab />
+      </section>
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/GrowthTab.test.tsx
+++ b/web/src/pages/OpsPage/GrowthTab.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import GrowthTab from './GrowthTab';
+
+const renderTab = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <GrowthTab />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('GrowthTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('stacks the conversions, upload funnel, and return rate sections', () => {
+    renderTab();
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Conversions' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Upload funnel' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Return rate' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/OpsPage/GrowthTab.tsx
+++ b/web/src/pages/OpsPage/GrowthTab.tsx
@@ -1,0 +1,40 @@
+import ConversionsTab from './ConversionsTab';
+import ReturnRateTab from './ReturnRateTab';
+import UploadFunnelTab from './UploadFunnelTab';
+import styles from './OpsPage.module.css';
+
+export default function GrowthTab() {
+  return (
+    <>
+      <section
+        className={styles.compositeSection}
+        aria-labelledby="growth-conversions"
+      >
+        <h2 id="growth-conversions" className={styles.compositeHeading}>
+          Conversions
+        </h2>
+        <ConversionsTab />
+      </section>
+
+      <section
+        className={styles.compositeSection}
+        aria-labelledby="growth-upload-funnel"
+      >
+        <h2 id="growth-upload-funnel" className={styles.compositeHeading}>
+          Upload funnel
+        </h2>
+        <UploadFunnelTab />
+      </section>
+
+      <section
+        className={styles.compositeSection}
+        aria-labelledby="growth-return-rate"
+      >
+        <h2 id="growth-return-rate" className={styles.compositeHeading}>
+          Return rate
+        </h2>
+        <ReturnRateTab />
+      </section>
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/OpsLayout.test.tsx
+++ b/web/src/pages/OpsPage/OpsLayout.test.tsx
@@ -24,7 +24,7 @@ describe('OpsLayout', () => {
   test('renders the Ops heading and the active section breadcrumb', () => {
     renderAt('/ops');
     expect(screen.getByRole('heading', { name: 'Ops' })).toBeInTheDocument();
-    const section = screen.getByText('Engineering');
+    const section = screen.getByText('System');
     expect(section).toHaveAttribute('aria-current', 'page');
     expect(screen.getByTestId('engineering')).toBeInTheDocument();
   });
@@ -35,7 +35,7 @@ describe('OpsLayout', () => {
       'aria-current',
       'page'
     );
-    expect(screen.queryByText('Engineering')).not.toBeInTheDocument();
+    expect(screen.queryByText('System')).not.toBeInTheDocument();
     expect(screen.getByTestId('business')).toBeInTheDocument();
   });
 

--- a/web/src/pages/OpsPage/OpsPage.module.css
+++ b/web/src/pages/OpsPage/OpsPage.module.css
@@ -178,6 +178,22 @@
   margin: 0;
 }
 
+.compositeSection {
+  margin-bottom: 2.5rem;
+}
+
+.compositeSection + .compositeSection {
+  border-top: 1px solid var(--color-border);
+  padding-top: 1.5rem;
+}
+
+.compositeHeading {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+  margin: 0 0 1rem;
+}
+
 .panel {
   display: flex;
   flex-direction: column;

--- a/web/src/pages/OpsPage/SystemTab.test.tsx
+++ b/web/src/pages/OpsPage/SystemTab.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import SystemTab from './SystemTab';
+
+const renderTab = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <SystemTab />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+};
+
+describe('SystemTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('stacks the engineering and performance sections', () => {
+    renderTab();
+
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Engineering' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Performance' })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/OpsPage/SystemTab.tsx
+++ b/web/src/pages/OpsPage/SystemTab.tsx
@@ -1,0 +1,29 @@
+import EngineeringTab from './EngineeringTab';
+import PerformanceTab from './PerformanceTab';
+import styles from './OpsPage.module.css';
+
+export default function SystemTab() {
+  return (
+    <>
+      <section
+        className={styles.compositeSection}
+        aria-labelledby="system-engineering"
+      >
+        <h2 id="system-engineering" className={styles.compositeHeading}>
+          Engineering
+        </h2>
+        <EngineeringTab />
+      </section>
+
+      <section
+        className={styles.compositeSection}
+        aria-labelledby="system-performance"
+      >
+        <h2 id="system-performance" className={styles.compositeHeading}>
+          Performance
+        </h2>
+        <PerformanceTab />
+      </section>
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/opsTabs.test.ts
+++ b/web/src/pages/OpsPage/opsTabs.test.ts
@@ -1,32 +1,51 @@
 import { describe, expect, it } from 'vitest';
-import { OPS_TABS, OPS_TAB_GROUPS } from './opsTabs';
+import { OPS_TABS } from './opsTabs';
 
-describe('OPS_TAB_GROUPS', () => {
-  it('groups the tabs into Today, Growth, System, Voice, and Controls', () => {
-    expect(OPS_TAB_GROUPS.map((group) => group.label)).toEqual([
+describe('OPS_TABS', () => {
+  it('lists the seven consolidated rows in order', () => {
+    expect(OPS_TABS.map((tab) => tab.label)).toEqual([
       'Today',
       'Growth',
+      'Business',
       'System',
-      'Voice',
-      'Controls',
+      'Errors',
+      'Messages',
+      'Commands',
     ]);
   });
 
-  it('places Engineering first in the System group', () => {
-    const system = OPS_TAB_GROUPS.find((group) => group.label === 'System');
-    expect(system?.tabs[0]).toMatchObject({ to: '/ops', label: 'Engineering' });
+  it('points each row at its consolidated route', () => {
+    expect(OPS_TABS.map((tab) => tab.to)).toEqual([
+      '/ops/today',
+      '/ops/growth',
+      '/ops/business',
+      '/ops/system',
+      '/ops/errors',
+      '/ops/messages',
+      '/ops/commands',
+    ]);
   });
-});
 
-describe('OPS_TABS', () => {
-  it('flattens every group into 13 tabs', () => {
-    expect(OPS_TABS).toHaveLength(13);
+  it('does not list routes that now redirect', () => {
+    const paths = OPS_TABS.map((tab) => tab.to);
+    for (const redirected of [
+      '/ops/conversions',
+      '/ops/upload-funnel',
+      '/ops/return-rate',
+      '/ops/performance',
+      '/ops/flags',
+      '/ops/showcase',
+    ]) {
+      expect(paths).not.toContain(redirected);
+    }
   });
 
-  it('no longer lists the retired Mindmaps and Pricing A/B tabs', () => {
+  it('does not list the retired or unlisted rows', () => {
     const paths = OPS_TABS.map((tab) => tab.to);
     expect(paths).not.toContain('/ops/mindmaps');
     expect(paths).not.toContain('/ops/pricing-ab');
+    expect(paths).not.toContain('/ops/interviews');
+    expect(paths).not.toContain('/ops/engineering');
   });
 
   it('has a unique route for every tab', () => {
@@ -34,26 +53,19 @@ describe('OPS_TABS', () => {
     expect(new Set(paths).size).toBe(paths.length);
   });
 
-  it('matches the Engineering index only on /ops, not on child routes', () => {
-    const index = OPS_TABS.find((tab) => tab.to === '/ops');
-    expect(index?.match('/ops')).toBe(true);
-    expect(index?.match('/ops?window=24h')).toBe(true);
-    expect(index?.match('/ops/errors')).toBe(false);
+  it('matches the System row on /ops, /ops/system, and query strings, not other children', () => {
+    const system = OPS_TABS.find((tab) => tab.to === '/ops/system');
+    expect(system?.match('/ops')).toBe(true);
+    expect(system?.match('/ops/system')).toBe(true);
+    expect(system?.match('/ops?window=24h')).toBe(true);
+    expect(system?.match('/ops/errors')).toBe(false);
+    expect(system?.match('/ops/growth')).toBe(false);
   });
 
-  it('matches a child tab on its own route', () => {
-    const errors = OPS_TABS.find((tab) => tab.to === '/ops/errors');
-    expect(errors?.match('/ops/errors')).toBe(true);
-    expect(errors?.match('/ops')).toBe(false);
-  });
-
-  it('puts the Today home in the first group', () => {
-    expect(OPS_TAB_GROUPS[0].label).toBe('Today');
-    expect(OPS_TAB_GROUPS[0].tabs[0]).toMatchObject({
-      to: '/ops/today',
-      label: 'Today',
-    });
-    const index = OPS_TABS.find((tab) => tab.to === '/ops');
-    expect(index?.match('/ops/today')).toBe(false);
+  it('matches a child row only on its own route', () => {
+    const growth = OPS_TABS.find((tab) => tab.to === '/ops/growth');
+    expect(growth?.match('/ops/growth')).toBe(true);
+    expect(growth?.match('/ops')).toBe(false);
+    expect(growth?.match('/ops/today')).toBe(false);
   });
 });

--- a/web/src/pages/OpsPage/opsTabs.ts
+++ b/web/src/pages/OpsPage/opsTabs.ts
@@ -4,109 +4,50 @@ export interface OpsTab {
   match: (path: string) => boolean;
 }
 
-export interface OpsTabGroup {
-  label: string;
-  tabs: OpsTab[];
-}
-
 const childRoute =
   (prefix: string) =>
   (path: string): boolean =>
     path.startsWith(prefix);
 
-const engineeringIndex: OpsTab = {
-  to: '/ops',
-  label: 'Engineering',
-  match: (path) => path === '/ops' || path.startsWith('/ops?'),
+const systemTab: OpsTab = {
+  to: '/ops/system',
+  label: 'System',
+  match: (path) =>
+    path === '/ops' ||
+    path.startsWith('/ops?') ||
+    path.startsWith('/ops/system'),
 };
 
-export const OPS_TAB_GROUPS: OpsTabGroup[] = [
+export const OPS_TABS: OpsTab[] = [
   {
+    to: '/ops/today',
     label: 'Today',
-    tabs: [
-      {
-        to: '/ops/today',
-        label: 'Today',
-        match: childRoute('/ops/today'),
-      },
-    ],
+    match: childRoute('/ops/today'),
   },
   {
+    to: '/ops/growth',
     label: 'Growth',
-    tabs: [
-      {
-        to: '/ops/conversions',
-        label: 'Conversions',
-        match: childRoute('/ops/conversions'),
-      },
-      {
-        to: '/ops/upload-funnel',
-        label: 'Upload funnel',
-        match: childRoute('/ops/upload-funnel'),
-      },
-      {
-        to: '/ops/return-rate',
-        label: 'Return rate',
-        match: childRoute('/ops/return-rate'),
-      },
-      {
-        to: '/ops/business',
-        label: 'Business',
-        match: childRoute('/ops/business'),
-      },
-    ],
+    match: childRoute('/ops/growth'),
   },
   {
-    label: 'System',
-    tabs: [
-      engineeringIndex,
-      {
-        to: '/ops/errors',
-        label: 'Errors',
-        match: childRoute('/ops/errors'),
-      },
-      {
-        to: '/ops/performance',
-        label: 'Performance',
-        match: childRoute('/ops/performance'),
-      },
-    ],
+    to: '/ops/business',
+    label: 'Business',
+    match: childRoute('/ops/business'),
+  },
+  systemTab,
+  {
+    to: '/ops/errors',
+    label: 'Errors',
+    match: childRoute('/ops/errors'),
   },
   {
-    label: 'Voice',
-    tabs: [
-      {
-        to: '/ops/messages',
-        label: 'Messages',
-        match: childRoute('/ops/messages'),
-      },
-      {
-        to: '/ops/interviews',
-        label: 'Interviews',
-        match: childRoute('/ops/interviews'),
-      },
-      {
-        to: '/ops/showcase',
-        label: 'Showcase',
-        match: childRoute('/ops/showcase'),
-      },
-    ],
+    to: '/ops/messages',
+    label: 'Messages',
+    match: childRoute('/ops/messages'),
   },
   {
-    label: 'Controls',
-    tabs: [
-      {
-        to: '/ops/commands',
-        label: 'Commands',
-        match: childRoute('/ops/commands'),
-      },
-      {
-        to: '/ops/flags',
-        label: 'Flags',
-        match: childRoute('/ops/flags'),
-      },
-    ],
+    to: '/ops/commands',
+    label: 'Commands',
+    match: childRoute('/ops/commands'),
   },
 ];
-
-export const OPS_TABS: OpsTab[] = OPS_TAB_GROUPS.flatMap((group) => group.tabs);


### PR DESCRIPTION
## What

Consolidates the `/ops` sidebar from 13 rows to 7 by merging pages, not just relabelling them. Three new composite screens each stack existing tab components — every hook, window selector, and copy-for-Claude button stays exactly as it was; the pages are composed, not rewritten.

## Why

The shipped ops regroup (nav groups + Today home) still surfaced 13 visible sidebar rows. The ops owner reviewed it and read the list as a wall of links rather than a set of decisions, and asked for fewer rows. This applies the one-screen-per-recurring-decision principle: the low-traffic analytics and controls pages that were never reviewed in isolation now live together on the screen that owns that decision.

## The seven rows

| # | Row | Page |
| --- | --- | --- |
| 1 | Today | unchanged |
| 2 | Growth | new composite: Conversions + Upload funnel + Return rate, stacked with section headings |
| 3 | Business | unchanged |
| 4 | System | new composite: Engineering + Performance, stacked (Engineering first); also the `/ops` index |
| 5 | Errors | unchanged (its master-detail workflow earns its own row) |
| 6 | Messages | unchanged |
| 7 | Commands | existing actions, plus Flags and Showcase stacked below them |

The single-item groups (each remaining group had exactly one row) added no scanning value, so the grouping layer is dropped in favour of a flat seven-row list. The old group-header markup and its now-orphaned CSS are removed.

## Redirects (no old bookmark 404s)

Every retired child route redirects with `<Navigate replace>`:

- `/ops/conversions`, `/ops/upload-funnel`, `/ops/return-rate` → `/ops/growth`
- `/ops/performance` → `/ops/system`
- `/ops/flags`, `/ops/showcase` → `/ops/commands`

The `/ops` index now renders the System composite. `/ops/interviews` stays routable but loses its sidebar row — it is unlisted pending a product verdict on whether the interviews surface stays, not deleted.

## Measuring success

Internal ops tooling. The success signal is qualitative: the ops owner opens the sidebar and sees seven rows that map to seven decisions. No funnel or revenue metric.

## Testing

- `opsTabs.test.ts` rewritten for the flat seven-row list: order, routes, redirect targets absent from the tab list, retired/unlisted rows absent, System matching `/ops`, `/ops/system`, and query strings.
- Smoke tests for the two new composite analytics pages (`GrowthTab`, `SystemTab`) and the Commands composite (`ControlsTab`) — each renders its stacked sections without crashing with fetch mocked at the network edge.
- `Sidebar.test.tsx` and `OpsLayout.test.tsx` updated for the seven rows and the System breadcrumb on the index.
- Full web vitest suite green (2164 tests), web tsc clean.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: left unticked for the ops owner to walk the seven rows on their own environment — the sidebar and composite layout are the whole point of the review.

## Changelog

No changelog entry — internal ops tooling, not user-visible.

## Sonar

`sonar-scanner` was not run locally (no `SONAR_TOKEN` in this environment). The change is composition and routing over existing components with no new user-input-to-sink paths.

## Risks

Low. If a composite page mis-stacks, the underlying tab components are untouched and each old route redirects to a working page. Rollback is a straight revert of the single commit.

## Goal alignment

None — internal ops tooling. It makes the owner's weekly review faster to read, which indirectly protects the time spent acting on the growth and business metrics that do move MRR.

