### PR TITLE
fix: register new ops composite routes in known routes

### DIFF
--- a/src/routes/knownRoutes.ts
+++ b/src/routes/knownRoutes.ts
@@ -48,6 +48,9 @@ const APP_ROUTES = new Set<string>([
 
 const OPS_ROUTES = new Set<string>([
   '/ops',
+  '/ops/today',
+  '/ops/growth',
+  '/ops/system',
   '/ops/errors',
   '/ops/performance',
   '/ops/conversions',


### PR DESCRIPTION
Post-deploy verification of #3541 caught direct loads of /ops/today, /ops/growth, /ops/system returning 404 from DefaultRouter — the web routes shipped (#3538/#3541) without knownRoutes registration; client-side nav masked it. Same class as #3528. Adds the three entries; old ops paths stay (their SPA redirects need the shell served on refresh).

DefaultRouter + knownRoutes suites green, tsc clean.

No changelog entry — internal ops tooling. Browser check: not applicable — server-side route registry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)