### PR TITLE
feat: offer Unlimited to repeat pass buyers after a pass purchase

### DIFF
--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -77,6 +77,22 @@ jest.mock('../data_layer/UsersRepository', () => {
   }));
 });
 
+const mockCountPaidPassesSince = jest
+  .fn()
+  .mockResolvedValue({ dayPasses: 0, weekPasses: 0 });
+
+jest.mock('../data_layer/UserPassRepository', () => {
+  const actual = jest.requireActual('../data_layer/UserPassRepository');
+  return {
+    ...actual,
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      countPaidPassesSince: mockCountPaidPassesSince,
+      findActive: jest.fn().mockResolvedValue(null),
+    })),
+  };
+});
+
 import UsersController from './UsersControllers';
 import UsersService, {
   MagicLinkRateLimitError,
@@ -2384,6 +2400,80 @@ describe('UsersController.getLocals', () => {
 
     const payload = res.json.mock.calls[0][0];
     expect(payload.user.email_verified).toBe(true);
+  });
+
+  it('offers the pass ladder to a repeat pass buyer', async () => {
+    mockCountPaidPassesSince.mockResolvedValueOnce({
+      dayPasses: 2,
+      weekPasses: 0,
+    });
+    const mockUser = {
+      id: 9,
+      email: 'buyer@example.com',
+      email_verified: true,
+      patreon: false,
+      ankify_welcome_seen: false,
+      hosted_anki_requested_at: null,
+      owner: 9,
+    };
+    const userService = {
+      getSubscriptionLinkedEmail: jest.fn().mockResolvedValue(null),
+    } as unknown as UsersService;
+    const authService = {
+      getUserFrom: jest.fn().mockResolvedValue(mockUser),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    const req = { cookies: { token: 'valid' } } as unknown as express.Request;
+    const res = {
+      locals: { planSource: null },
+      json: jest.fn(),
+    } as unknown as express.Response & { json: jest.Mock };
+
+    await controller.getLocals(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.passLadder).toEqual({ passCount: 2, spentUsd: 8 });
+  });
+
+  it('sends no pass ladder to a subscriber', async () => {
+    mockCountPaidPassesSince.mockResolvedValueOnce({
+      dayPasses: 2,
+      weekPasses: 1,
+    });
+    const mockUser = {
+      id: 10,
+      email: 'sub@example.com',
+      email_verified: true,
+      patreon: false,
+      ankify_welcome_seen: false,
+      hosted_anki_requested_at: null,
+      owner: 10,
+    };
+    const userService = {
+      getSubscriptionLinkedEmail: jest.fn().mockResolvedValue(null),
+    } as unknown as UsersService;
+    const authService = {
+      getUserFrom: jest.fn().mockResolvedValue(mockUser),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    const req = { cookies: { token: 'valid' } } as unknown as express.Request;
+    const res = {
+      locals: { planSource: 'stripe' },
+      json: jest.fn(),
+    } as unknown as express.Response & { json: jest.Mock };
+
+    await controller.getLocals(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.passLadder).toBeNull();
   });
 
   it('surfaces chat_consent_at on the user object so the consent modal closes after accept', async () => {

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -34,6 +34,9 @@ import { extractCountryFromRequest } from '../lib/http/extractCountryFromRequest
 import { RecordUserVisibleErrorUseCase } from '../usecases/observability/RecordUserVisibleErrorUseCase';
 import { track } from '../services/events/track';
 import { mapEntitlement } from './helpers/mapEntitlement';
+import { GetPassLadderOfferUseCase } from '../usecases/checkout/GetPassLadderOfferUseCase';
+import UserPassRepository from '../data_layer/UserPassRepository';
+import { PlanSource } from '../routes/middleware/configureUserLocal';
 
 class UsersController {
   constructor(
@@ -336,6 +339,17 @@ class UsersController {
       freePrintAvailable = prints_used < 1;
     }
 
+    let passLadder = null;
+    if (user?.owner != null) {
+      passLadder = await new GetPassLadderOfferUseCase(
+        new UserPassRepository(this.db)
+      ).execute(
+        user.owner,
+        (locals.planSource as PlanSource) ?? null,
+        new Date()
+      );
+    }
+
     const response = {
       user: {
         id: user?.id,
@@ -357,6 +371,7 @@ class UsersController {
       autoSyncCapReached,
       autoSyncActive,
       freePrintAvailable,
+      passLadder,
     };
 
     return res.json(response);

--- a/src/data_layer/UserPassRepository.countPaidPasses.test.ts
+++ b/src/data_layer/UserPassRepository.countPaidPasses.test.ts
@@ -1,0 +1,23 @@
+import knex from 'knex';
+import UserPassRepository from './UserPassRepository';
+
+describe('UserPassRepository.countPaidPassesSince SQL shape', () => {
+  const db = knex({ client: 'pg' });
+
+  afterAll(async () => {
+    await db.destroy();
+  });
+
+  it('counts only 24h and 7d passes for the user newer than the cutoff', () => {
+    const repo = new UserPassRepository(db);
+    const since = new Date('2026-06-03T00:00:00Z');
+    const sql = repo.countPaidPassesQuery(21, since).toString();
+
+    expect(sql).toContain('"user_passes"');
+    expect(sql).toContain('"user_id" = 21');
+    expect(sql).toContain("\"kind\" in ('24h', '7d')");
+    expect(sql).toContain('"expires_at" >');
+    expect(sql).toContain('group by "kind"');
+    expect(sql).toContain('count(*)');
+  });
+});

--- a/src/data_layer/UserPassRepository.ts
+++ b/src/data_layer/UserPassRepository.ts
@@ -10,8 +10,14 @@ export interface UserPass {
   stripe_payment_intent_id: string;
 }
 
+export interface PaidPassCounts {
+  dayPasses: number;
+  weekPasses: number;
+}
+
 export interface IUserPassRepository {
   findActive(userId: number, now: Date): Promise<UserPass | null>;
+  countPaidPassesSince(userId: number, since: Date): Promise<PaidPassCounts>;
   upsertWithExtension(
     userId: number,
     kind: PassKind,
@@ -60,6 +66,31 @@ export class UserPassRepository implements IUserPassRepository {
       .orderBy('expires_at', 'desc')
       .first();
     return row ? toUserPass(row) : null;
+  }
+
+  countPaidPassesQuery(userId: number, since: Date) {
+    return this.database(this.table)
+      .select('kind')
+      .count('* as count')
+      .where('user_id', userId)
+      .whereIn('kind', ['24h', '7d'])
+      .where('expires_at', '>', since)
+      .groupBy('kind');
+  }
+
+  async countPaidPassesSince(
+    userId: number,
+    since: Date
+  ): Promise<PaidPassCounts> {
+    const rows = (await this.countPaidPassesQuery(userId, since)) as Array<{
+      kind: string;
+      count: string | number;
+    }>;
+    const byKind = new Map(rows.map((r) => [r.kind, Number(r.count)]));
+    return {
+      dayPasses: byKind.get('24h') ?? 0,
+      weekPasses: byKind.get('7d') ?? 0,
+    };
   }
 
   async upsertWithExtension(
@@ -160,6 +191,22 @@ export class InMemoryUserPassRepository implements IUserPassRepository {
       .filter((r) => r.user_id === userId && r.expires_at > now)
       .sort((a, b) => b.expires_at.getTime() - a.expires_at.getTime());
     return active[0] ?? null;
+  }
+
+  async countPaidPassesSince(
+    userId: number,
+    since: Date
+  ): Promise<PaidPassCounts> {
+    const recent = this.rows.filter(
+      (r) =>
+        r.user_id === userId &&
+        (r.kind === '24h' || r.kind === '7d') &&
+        r.expires_at > since
+    );
+    return {
+      dayPasses: recent.filter((r) => r.kind === '24h').length,
+      weekPasses: recent.filter((r) => r.kind === '7d').length,
+    };
   }
 
   async upsertWithExtension(

--- a/src/usecases/checkout/GetPassLadderOfferUseCase.test.ts
+++ b/src/usecases/checkout/GetPassLadderOfferUseCase.test.ts
@@ -1,0 +1,79 @@
+import { InMemoryUserPassRepository } from '../../data_layer/UserPassRepository';
+import { GetPassLadderOfferUseCase } from './GetPassLadderOfferUseCase';
+
+const NOW = new Date('2026-07-08T12:00:00Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function seedPass(
+  repo: InMemoryUserPassRepository,
+  userId: number,
+  kind: '24h' | '7d' | 'unlimited',
+  expiresDaysFromNow: number,
+  intent: string
+) {
+  repo.seed({
+    user_id: userId,
+    kind,
+    expires_at: new Date(NOW.getTime() + expiresDaysFromNow * DAY_MS),
+    stripe_payment_intent_id: intent,
+  });
+}
+
+describe('GetPassLadderOfferUseCase', () => {
+  let repo: InMemoryUserPassRepository;
+  let useCase: GetPassLadderOfferUseCase;
+
+  beforeEach(() => {
+    repo = new InMemoryUserPassRepository();
+    useCase = new GetPassLadderOfferUseCase(repo);
+  });
+
+  it('offers the ladder to a user with two recent day passes', async () => {
+    seedPass(repo, 7, '24h', 0.5, 'pi_1');
+    seedPass(repo, 7, '24h', -10, 'pi_2');
+
+    const offer = await useCase.execute(7, null, NOW);
+
+    expect(offer).toEqual({ passCount: 2, spentUsd: 8 });
+  });
+
+  it('sums day and week pass prices', async () => {
+    seedPass(repo, 7, '24h', 0.5, 'pi_1');
+    seedPass(repo, 7, '7d', -5, 'pi_2');
+    seedPass(repo, 7, '24h', -20, 'pi_3');
+
+    const offer = await useCase.execute(7, null, NOW);
+
+    expect(offer).toEqual({ passCount: 3, spentUsd: 17 });
+  });
+
+  it('returns null for a single pass', async () => {
+    seedPass(repo, 7, '24h', 0.5, 'pi_1');
+
+    expect(await useCase.execute(7, null, NOW)).toBeNull();
+  });
+
+  it('returns null for subscribers, lifetime, and apple plans', async () => {
+    seedPass(repo, 7, '24h', 0.5, 'pi_1');
+    seedPass(repo, 7, '24h', -10, 'pi_2');
+
+    expect(await useCase.execute(7, 'stripe', NOW)).toBeNull();
+    expect(await useCase.execute(7, 'lifetime', NOW)).toBeNull();
+    expect(await useCase.execute(7, 'apple', NOW)).toBeNull();
+  });
+
+  it('ignores passes older than the 35-day window', async () => {
+    seedPass(repo, 7, '24h', 0.5, 'pi_1');
+    seedPass(repo, 7, '24h', -40, 'pi_2');
+
+    expect(await useCase.execute(7, null, NOW)).toBeNull();
+  });
+
+  it('ignores unlimited entitlements and other users', async () => {
+    seedPass(repo, 7, '24h', 0.5, 'pi_1');
+    seedPass(repo, 7, 'unlimited', 300, 'apple:abc');
+    seedPass(repo, 8, '24h', 0.5, 'pi_2');
+
+    expect(await useCase.execute(7, null, NOW)).toBeNull();
+  });
+});

--- a/src/usecases/checkout/GetPassLadderOfferUseCase.ts
+++ b/src/usecases/checkout/GetPassLadderOfferUseCase.ts
@@ -1,0 +1,39 @@
+import type { IUserPassRepository } from '../../data_layer/UserPassRepository';
+import type { PlanSource } from '../../routes/middleware/configureUserLocal';
+
+export interface PassLadderOffer {
+  passCount: number;
+  spentUsd: number;
+}
+
+const WINDOW_DAYS = 35;
+const DAY_PASS_USD = 4;
+const WEEK_PASS_USD = 9;
+const MIN_PASSES_FOR_OFFER = 2;
+
+export class GetPassLadderOfferUseCase {
+  constructor(private readonly userPasses: IUserPassRepository) {}
+
+  async execute(
+    owner: number,
+    planSource: PlanSource,
+    now: Date
+  ): Promise<PassLadderOffer | null> {
+    if (planSource != null) {
+      return null;
+    }
+
+    const since = new Date(now.getTime() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
+    const { dayPasses, weekPasses } =
+      await this.userPasses.countPaidPassesSince(owner, since);
+    const passCount = dayPasses + weekPasses;
+    if (passCount < MIN_PASSES_FOR_OFFER) {
+      return null;
+    }
+
+    return {
+      passCount,
+      spentUsd: dayPasses * DAY_PASS_USD + weekPasses * WEEK_PASS_USD,
+    };
+  }
+}

--- a/web/src/components/PassLadderCard/PassLadderCard.module.css
+++ b/web/src/components/PassLadderCard/PassLadderCard.module.css
@@ -1,0 +1,49 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-lg);
+}
+
+.headline {
+  margin: 0;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--color-text-primary);
+}
+
+.body {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-normal);
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-primary);
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--transition-fast);
+}
+
+.cta:hover {
+  background: var(--color-bg-primary);
+}
+
+@media (max-width: 600px) {
+  .cta {
+    align-self: stretch;
+  }
+}

--- a/web/src/components/PassLadderCard/PassLadderCard.test.tsx
+++ b/web/src/components/PassLadderCard/PassLadderCard.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { PassLadderCard } from './PassLadderCard';
+
+const mockUseUserLocals = vi.fn();
+
+vi.mock('../../lib/hooks/useUserLocals', () => ({
+  useUserLocals: () => mockUseUserLocals(),
+}));
+
+const mockTrack = vi.fn();
+
+vi.mock('../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+const repeatBuyer = {
+  data: {
+    locals: { patreon: false, subscriber: true },
+    user: { email: 'buyer@example.com' },
+    passLadder: { passCount: 3, spentUsd: 13 },
+  },
+};
+
+const singleBuyer = {
+  data: {
+    locals: { patreon: false, subscriber: true },
+    user: { email: 'buyer@example.com' },
+    passLadder: null,
+  },
+};
+
+describe('PassLadderCard', () => {
+  beforeEach(() => {
+    mockTrack.mockClear();
+    mockUseUserLocals.mockReset();
+  });
+
+  it('shows the pass math for a repeat buyer and fires paywall_shown', () => {
+    mockUseUserLocals.mockReturnValue(repeatBuyer);
+    render(<PassLadderCard />);
+
+    expect(
+      screen.getByText('Spending more on passes than Unlimited costs?')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/You've bought 3 passes — \$13\./)
+    ).toBeInTheDocument();
+    expect(mockTrack).toHaveBeenCalledWith('paywall_shown', {
+      surface: 'pass_ladder_success',
+      passes: 3,
+      spent_usd: 13,
+    });
+  });
+
+  it('links to the subscribe flow and tracks the upgrade click', () => {
+    mockUseUserLocals.mockReturnValue(repeatBuyer);
+    render(<PassLadderCard />);
+
+    const cta = screen.getByRole('link', { name: 'Get Unlimited — $7.99/mo' });
+    expect(cta).toHaveAttribute(
+      'href',
+      expect.stringContaining('prefilled_email=buyer%40example.com')
+    );
+
+    fireEvent.click(cta);
+    expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
+      surface: 'pass_ladder_success',
+      plan: 'unlimited',
+    });
+  });
+
+  it('renders nothing when the server sends no offer', () => {
+    mockUseUserLocals.mockReturnValue(singleBuyer);
+    const { container } = render(<PassLadderCard />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing while locals are loading', () => {
+    mockUseUserLocals.mockReturnValue({ data: undefined });
+    const { container } = render(<PassLadderCard />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/components/PassLadderCard/PassLadderCard.tsx
+++ b/web/src/components/PassLadderCard/PassLadderCard.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+
+import { track } from '../../lib/analytics/track';
+import { useUserLocals } from '../../lib/hooks/useUserLocals';
+import { getSubscribeLink } from '../../pages/PricingPage/payment.links';
+import styles from './PassLadderCard.module.css';
+
+const SURFACE = 'pass_ladder_success';
+
+export function PassLadderCard() {
+  const { data } = useUserLocals();
+  const shownFiredRef = useRef(false);
+  const offer = data?.passLadder;
+
+  useEffect(() => {
+    if (offer == null) return;
+    if (shownFiredRef.current) return;
+    shownFiredRef.current = true;
+    track('paywall_shown', {
+      surface: SURFACE,
+      passes: offer.passCount,
+      spent_usd: offer.spentUsd,
+    });
+  }, [offer]);
+
+  if (offer == null) return null;
+
+  const handleUnlimitedClick = () => {
+    track('paywall_upgrade_clicked', { surface: SURFACE, plan: 'unlimited' });
+  };
+
+  return (
+    <section
+      className={styles.card}
+      aria-label="Unlimited costs less than your passes"
+    >
+      <p className={styles.headline}>
+        Spending more on passes than Unlimited costs?
+      </p>
+      <p className={styles.body}>
+        You&apos;ve bought {offer.passCount} passes — ${offer.spentUsd}.
+        Unlimited is $7.99 a month — no 100-card cap, cancel anytime.
+      </p>
+      <a
+        className={styles.cta}
+        href={getSubscribeLink(data?.user?.email)}
+        onClick={handleUnlimitedClick}
+      >
+        Get Unlimited — $7.99/mo
+      </a>
+    </section>
+  );
+}

--- a/web/src/lib/backend/getUserLocals.ts
+++ b/web/src/lib/backend/getUserLocals.ts
@@ -31,6 +31,7 @@ interface GetUserLocalsResponse {
   };
   autoSyncActive?: boolean;
   freePrintAvailable?: boolean | null;
+  passLadder?: { passCount: number; spentUsd: number } | null;
 }
 
 export const getUserLocals = async (): Promise<GetUserLocalsResponse> =>

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -3,6 +3,7 @@ import { Helmet } from 'react-helmet-async';
 import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { isPayingUser } from '../../components/NavigationBar/helpers/getPlanLabel';
 import { ErrorHandlerType } from '../../components/errors/helpers/getErrorMessage';
+import { PassLadderCard } from '../../components/PassLadderCard/PassLadderCard';
 import { track } from '../../lib/analytics/track';
 import { storePassToken } from '../../lib/anonymousPass';
 import useQuery from '../../lib/hooks/useQuery';
@@ -59,6 +60,9 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
     }
   );
   const { data: userLocals } = useUserLocals();
+  const [returnedFromPass, setReturnedFromPass] = useState(
+    () => searchParams.get('from') === 'pass'
+  );
   const pageViewTracked = useRef(false);
   const signupTracked = useRef(false);
 
@@ -105,6 +109,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
 
   useEffect(() => {
     if (searchParams.get('from') === 'pass') {
+      setReturnedFromPass(true);
       const next = new URLSearchParams(searchParams);
       next.delete('from');
       const qs = next.toString();
@@ -156,6 +161,7 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           <span> to convert</span>
         </div>
       )}
+      {returnedFromPass && <PassLadderCard />}
       <div className={styles.aiOffBadge} role="status">
         {aiBadgeState === 'on' && (
           <>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-08-pass-ladder.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-08-pass-ladder.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-08-pass-ladder",
+  "date": "2026-07-08",
+  "type": "feature",
+  "title": "After a repeat pass purchase, see how your pass spending compares with Unlimited"
+}


### PR DESCRIPTION
## What

Repeat pass buyers returning from a pass checkout (`/upload?from=pass`) now see a card comparing their recent pass spend with the Unlimited subscription: "You've bought 3 passes — $13. Unlimited is $7.99 a month — no 100-card cap, cancel anytime," with an outline "Get Unlimited — $7.99/mo" CTA into the existing subscribe link.

## Why

Prod data (30d): 66% of checkouts are passes (121 vs 61 subscriptions), 21 of 143 pass buyers bought 2+ passes, one bought 5 — yet only 8% of pass buyers ever subscribed. A second $4 pass already out-spends the $7.99/mo sub; nothing surfaced that arithmetic at the moment of proven repeat intent. Trio-reviewed (pm/designer/engineer); this is the v1 smallest test of the riskiest assumption — message-only, no Stripe coupon, no email.

## How

- `UserPassRepository.countPaidPassesSince(userId, since)` — counts `24h`/`7d` rows (never `unlimited`) newer than the cutoff, grouped by kind. SQL-shape test with pg-dialect knex `toString()`.
- `GetPassLadderOfferUseCase` — eligible when `planSource` is null (excludes stripe/lifetime/apple) and 2+ paid passes inside a 35-day `expires_at` window. Spend derived from kind constants ($4/$9). Window uses `expires_at` deliberately: `user_passes` has no `created_at` and expiries stack on extension (`upsertWithExtension`), so purchase-time derivation is unsound — the copy therefore makes no time-window claim.
- `getLocals` response gains `passLadder: { passCount, spentUsd } | null`; typed response shape, no raw rows.
- Web: new `PassLadderCard` renders on `/upload` only when the `from=pass` return param was present AND the server sent an offer. `Make a deck`/upload stays the page primary; CTA is outline-secondary per designer review. Note the existing `isPayingUser` guard counts active-pass holders as paying, which is why eligibility is server-driven instead of reusing UpsellCard's suppression.
- Events reuse `paywall_shown` / `paywall_upgrade_clicked` with `surface: 'pass_ladder_success'` (both registries already carry these names).

## Measuring success

Usage event ships in this PR (`paywall_shown{surface:'pass_ladder_success'}`). Target: ≥15% of shown users start a subscription within 14 days; kill threshold <10% click-through after 3 weeks (pm spec). Read paywall events by surface at `/api/ops/metrics`; MRR/new-paid at `/api/ops/business/metrics`. Day-7 prod check: surface events non-zero. T+30d adoption-review issue to be opened at merge.

## Testing

- `GetPassLadderOfferUseCase.test.ts` — eligibility branches (2 passes, day+week sum, single pass, subscriber/lifetime/apple, stale passes, unlimited-kind + other-user exclusion).
- `UserPassRepository.countPaidPasses.test.ts` — generated-SQL shape.
- `UsersControllers.test.ts` — `passLadder` in the locals payload for a repeat buyer; null for a subscriber.
- `PassLadderCard.test.tsx` — copy + both events + prefilled subscribe link; hidden with no offer / while loading.
- Server tsc, full web vitest (247 files), oxlint, oxfmt all green. sonar-scanner not run locally (no SONAR_TOKEN on this box); SonarCloud Automatic Analysis covers the push.

## Risks

- Offer shows only on checkout return, so reach is limited to that moment — deliberate for v1; the pass-expiry email (PR2, needs migration + kanel) extends reach only if this converts.
- Pass prices are constants in the use case; if pass pricing changes, update `DAY_PASS_USD`/`WEEK_PASS_USD`.

## Goal alignment

ARPU/MRR lever: converts the healthiest purchase stream (passes, 66% of checkouts) into recurring revenue without touching grandfathered pricing.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: evidence = green CI playwright golden-path run at 375px (fails on any console error); the card itself is gated to `from=pass` + a server offer, covered by PassLadderCard vitest render tests. Merge ordered by Alexander.

## Decisions made overnight (please review)
- Copy drops the "$N in the last 30 days" framing from the trio designer draft: no amount column and stacked expiries make a precise window claim unverifiable. Ships count + spend with no time claim instead.
- Placement is the `/upload` return landing (below header, above the AI badge) because no pass success screen exists — pass checkouts redirect straight to `/upload?from=pass`.

