### PR TITLE
style: one offer per deck-ready screen via a success-offer slot

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -52,6 +52,8 @@ export const KNOWN_EVENTS = new Set([
   'ai_conversion_completed',
   'feature_flag_changed',
   'account_created',
+  'account_offer_shown',
+  'account_offer_clicked',
   'signup_completed',
   'upload_page_viewed',
   'onboarding_shown',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -79,6 +79,11 @@ const AnkifyReviewPreviewPage = import.meta.env.DEV
       () => import('./pages/AnkifyReviewPreviewPage/AnkifyReviewPreviewPage')
     )
   : null;
+const UploadSuccessPreviewPage = import.meta.env.DEV
+  ? lazy(
+      () => import('./pages/UploadSuccessPreviewPage/UploadSuccessPreviewPage')
+    )
+  : null;
 const SuccessfulCheckoutPage = lazyWithRetry(
   () => import('./pages/SuccessfulCheckout/SuccessfulCheckout'),
   './pages/SuccessfulCheckout/SuccessfulCheckout'
@@ -477,6 +482,12 @@ function AppContent({
               <Route
                 path="/dev/ankify-review-preview"
                 element={<AnkifyReviewPreviewPage />}
+              />
+            )}
+            {UploadSuccessPreviewPage && (
+              <Route
+                path="/dev/upload-success-preview"
+                element={<UploadSuccessPreviewPage />}
               />
             )}
             <Route

--- a/web/src/components/CreateAccountNotice/CreateAccountNotice.test.tsx
+++ b/web/src/components/CreateAccountNotice/CreateAccountNotice.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { CreateAccountNotice } from './CreateAccountNotice';
+
+const mockTrack = vi.fn();
+
+vi.mock('../../lib/analytics/track', () => ({
+  track: (...args: unknown[]) => mockTrack(...args),
+}));
+
+describe('CreateAccountNotice', () => {
+  beforeEach(() => {
+    mockTrack.mockClear();
+  });
+
+  it('renders the account offer and fires account_offer_shown', () => {
+    render(<CreateAccountNotice />, { wrapper: MemoryRouter });
+
+    expect(screen.getByText('Keep your next decks')).toBeInTheDocument();
+    expect(mockTrack).toHaveBeenCalledWith('account_offer_shown', {
+      surface: 'upload_success_signup',
+    });
+  });
+
+  it('links to registration and tracks the click', () => {
+    render(<CreateAccountNotice />, { wrapper: MemoryRouter });
+
+    const cta = screen.getByRole('link', { name: 'Create a free account' });
+    expect(cta).toHaveAttribute('href', '/register?redirect=/upload');
+
+    fireEvent.click(cta);
+    expect(mockTrack).toHaveBeenCalledWith('account_offer_clicked', {
+      surface: 'upload_success_signup',
+    });
+  });
+});

--- a/web/src/components/CreateAccountNotice/CreateAccountNotice.tsx
+++ b/web/src/components/CreateAccountNotice/CreateAccountNotice.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+
+import { track } from '../../lib/analytics/track';
+import styles from '../PassLadderCard/PassLadderCard.module.css';
+
+const SURFACE = 'upload_success_signup';
+
+export function CreateAccountNotice() {
+  const shownFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (shownFiredRef.current) return;
+    shownFiredRef.current = true;
+    track('account_offer_shown', { surface: SURFACE });
+  }, []);
+
+  return (
+    <section className={styles.card} aria-label="Save your next decks">
+      <p className={styles.headline}>Keep your next decks</p>
+      <p className={styles.body}>
+        With a free account, every deck you convert is saved to your downloads
+        history — re-download any of them later.
+      </p>
+      <Link
+        className={styles.cta}
+        to="/register?redirect=/upload"
+        onClick={() => track('account_offer_clicked', { surface: SURFACE })}
+      >
+        Create a free account
+      </Link>
+    </section>
+  );
+}

--- a/web/src/components/PassLadderCard/PassLadderCard.tsx
+++ b/web/src/components/PassLadderCard/PassLadderCard.tsx
@@ -7,10 +7,18 @@ import styles from './PassLadderCard.module.css';
 
 const SURFACE = 'pass_ladder_success';
 
-export function PassLadderCard() {
+interface PassLadderCardProps {
+  readonly offerOverride?: { passCount: number; spentUsd: number };
+  readonly emailOverride?: string;
+}
+
+export function PassLadderCard({
+  offerOverride,
+  emailOverride,
+}: PassLadderCardProps = {}) {
   const { data } = useUserLocals();
   const shownFiredRef = useRef(false);
-  const offer = data?.passLadder;
+  const offer = offerOverride ?? data?.passLadder;
 
   useEffect(() => {
     if (offer == null) return;
@@ -43,7 +51,7 @@ export function PassLadderCard() {
       </p>
       <a
         className={styles.cta}
-        href={getSubscribeLink(data?.user?.email)}
+        href={getSubscribeLink(emailOverride ?? data?.user?.email)}
         onClick={handleUnlimitedClick}
       >
         Get Unlimited — $7.99/mo

--- a/web/src/components/UpsellCard/UpsellCard.test.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 import { UpsellCard } from './UpsellCard';
 
@@ -9,7 +10,9 @@ function renderCard(ui: React.ReactElement) {
     defaultOptions: { queries: { retry: false } },
   });
   return render(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
   );
 }
 
@@ -62,16 +65,15 @@ describe('UpsellCard', () => {
     mockUseCardUsage.mockReturnValue(null);
   });
 
-  it('renders three CTAs with prices for free users', () => {
+  it('renders one pass CTA and a plans link for free users', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     renderCard(<UpsellCard surface="downloads_upsell" />);
     expect(
       screen.getByRole('button', { name: 'Get Day Pass — $4' })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Get Week Pass — $9' })
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Unlimited' })).toBeInTheDocument();
+    const plans = screen.getByRole('link', { name: 'See plans' });
+    expect(plans).toHaveAttribute('href', '/pricing');
+    expect(screen.queryByRole('button', { name: /Week Pass/ })).toBeNull();
   });
 
   it('renders nothing for paying users', () => {
@@ -156,43 +158,17 @@ describe('UpsellCard', () => {
     });
   });
 
-  it('fires paywall_upgrade_clicked with plan=week_pass when Week Pass is clicked', async () => {
-    mockUseUserLocals.mockReturnValue(freeUser);
-    mockStartPassCheckout.mockResolvedValue({
-      url: 'https://checkout.stripe.com/week',
-    });
-    Object.defineProperty(globalThis, 'location', {
-      writable: true,
-      value: { href: '' },
-    });
-
-    renderCard(<UpsellCard surface="upload_success_upsell" />);
-    fireEvent.click(screen.getByRole('button', { name: /Week Pass/ }));
-
-    await waitFor(() => {
-      expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
-        surface: 'upload_success_upsell',
-        plan: 'week_pass',
-      });
-      expect(mockStartPassCheckout).toHaveBeenCalledWith(
-        '7d',
-        undefined,
-        'upload_success_upsell'
-      );
-    });
-  });
-
-  it('fires paywall_upgrade_clicked with plan=unlimited when Unlimited is clicked', () => {
+  it('fires paywall_upgrade_clicked with plan=see_plans when See plans is clicked', () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     renderCard(<UpsellCard surface="downloads_upsell" />);
-    fireEvent.click(screen.getByRole('link', { name: 'Unlimited' }));
+    fireEvent.click(screen.getByRole('link', { name: 'See plans' }));
     expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
       surface: 'downloads_upsell',
-      plan: 'unlimited',
+      plan: 'see_plans',
     });
   });
 
-  it('shows Redirecting label and disables buttons while pass checkout is pending', async () => {
+  it('shows the starting-checkout label and disables the button while pass checkout is pending', async () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     let resolveCheckout: (value: { status: 'error' }) => void = () => {};
     mockStartPassCheckout.mockReturnValue(
@@ -206,7 +182,7 @@ describe('UpsellCard', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: 'Redirecting…' })
+        screen.getByRole('button', { name: 'Starting checkout' })
       ).toBeDisabled();
     });
 
@@ -218,7 +194,7 @@ describe('UpsellCard', () => {
     });
   });
 
-  it('clears the Redirecting label when the page is restored from the back-forward cache', async () => {
+  it('clears the starting-checkout label when the page is restored from the back-forward cache', async () => {
     mockUseUserLocals.mockReturnValue(freeUser);
     mockStartPassCheckout.mockReturnValue(new Promise(() => {}));
 
@@ -227,7 +203,7 @@ describe('UpsellCard', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: 'Redirecting…' })
+        screen.getByRole('button', { name: 'Starting checkout' })
       ).toBeDisabled();
     });
 
@@ -259,7 +235,7 @@ describe('UpsellCard', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByRole('button', { name: 'Redirecting…' })
+        screen.getByRole('button', { name: 'Starting checkout' })
       ).toBeDisabled();
     });
 

--- a/web/src/components/UpsellCard/UpsellCard.tsx
+++ b/web/src/components/UpsellCard/UpsellCard.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 
 import { track } from '../../lib/analytics/track';
 import { get2ankiApi } from '../../lib/backend/get2ankiApi';
 import { useCardUsage } from '../../lib/hooks/useCardUsage';
 import { useUserLocals } from '../../lib/hooks/useUserLocals';
 import { isPayingUser } from '../NavigationBar/helpers/getPlanLabel';
-import {
-  getSubscribeLink,
-  PASS_PRICES,
-} from '../../pages/PricingPage/payment.links';
+import { PASS_PRICES } from '../../pages/PricingPage/payment.links';
 import styles from './UpsellCard.module.css';
 
 type Surface = 'downloads_upsell' | 'upload_success_upsell';
@@ -81,8 +79,6 @@ export function UpsellCard({
 
   if (suppress) return null;
 
-  const email = data?.user?.email;
-
   const handlePassClick = async (kind: '24h' | '7d') => {
     upgradeClickedRef.current = true;
     track('paywall_upgrade_clicked', {
@@ -102,9 +98,9 @@ export function UpsellCard({
     setPendingKind(null);
   };
 
-  const handleUnlimitedClick = () => {
+  const handleSeePlansClick = () => {
     upgradeClickedRef.current = true;
-    track('paywall_upgrade_clicked', { surface, plan: 'unlimited' });
+    track('paywall_upgrade_clicked', { surface, plan: 'see_plans' });
   };
 
   return (
@@ -122,29 +118,16 @@ export function UpsellCard({
           disabled={pendingKind != null}
         >
           {pendingKind === '24h'
-            ? 'Redirecting…'
+            ? 'Starting checkout'
             : `Get Day Pass — ${PASS_PRICES['24h']}`}
         </button>
-        <button
-          type="button"
+        <Link
           className={styles.secondary}
-          onClick={() => handlePassClick('7d')}
-          disabled={pendingKind != null}
+          to="/pricing"
+          onClick={handleSeePlansClick}
         >
-          {pendingKind === '7d'
-            ? 'Redirecting…'
-            : `Get Week Pass — ${PASS_PRICES['7d']}`}
-        </button>
-        <span className={styles.dot} aria-hidden="true">
-          ·
-        </span>
-        <a
-          className={styles.secondary}
-          href={getSubscribeLink(email)}
-          onClick={handleUnlimitedClick}
-        >
-          Unlimited
-        </a>
+          See plans
+        </Link>
       </div>
     </section>
   );

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -13,6 +13,8 @@ export const KNOWN_EVENTS = new Set([
   'paywall_shown',
   'paywall_upgrade_clicked',
   'paywall_pass_clicked',
+  'account_offer_shown',
+  'account_offer_clicked',
   'purchase',
   'photo_entry_point_viewed',
   'photo_entry_point_clicked',

--- a/web/src/lib/promo/resolveSuccessOffer.test.ts
+++ b/web/src/lib/promo/resolveSuccessOffer.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSuccessOffer } from './resolveSuccessOffer';
+
+const OFFER = { passCount: 3, spentUsd: 13 };
+
+describe('resolveSuccessOffer', () => {
+  it('offers account creation to anonymous users', () => {
+    expect(
+      resolveSuccessOffer({
+        anonymous: true,
+        paying: false,
+        passLadder: null,
+        passLadderShownOnPage: false,
+      })
+    ).toBe('anon_signup');
+  });
+
+  it('offers the pass ladder to eligible repeat buyers', () => {
+    expect(
+      resolveSuccessOffer({
+        anonymous: false,
+        paying: true,
+        passLadder: OFFER,
+        passLadderShownOnPage: false,
+      })
+    ).toBe('pass_ladder');
+  });
+
+  it('shows nothing when the pass ladder is already on the page', () => {
+    expect(
+      resolveSuccessOffer({
+        anonymous: false,
+        paying: true,
+        passLadder: OFFER,
+        passLadderShownOnPage: true,
+      })
+    ).toBeNull();
+  });
+
+  it('shows nothing to paying users without a ladder offer', () => {
+    expect(
+      resolveSuccessOffer({
+        anonymous: false,
+        paying: true,
+        passLadder: null,
+        passLadderShownOnPage: false,
+      })
+    ).toBeNull();
+  });
+
+  it('falls back to the pass upsell for logged-in free users', () => {
+    expect(
+      resolveSuccessOffer({
+        anonymous: false,
+        paying: false,
+        passLadder: null,
+        passLadderShownOnPage: false,
+      })
+    ).toBe('upsell');
+  });
+});

--- a/web/src/lib/promo/resolveSuccessOffer.ts
+++ b/web/src/lib/promo/resolveSuccessOffer.ts
@@ -1,0 +1,23 @@
+export type SuccessOfferKind = 'anon_signup' | 'pass_ladder' | 'upsell';
+
+export interface SuccessOfferContext {
+  anonymous: boolean;
+  paying: boolean;
+  passLadder: { passCount: number; spentUsd: number } | null | undefined;
+  passLadderShownOnPage: boolean;
+}
+
+export function resolveSuccessOffer(
+  context: SuccessOfferContext
+): SuccessOfferKind | null {
+  if (context.anonymous) {
+    return 'anon_signup';
+  }
+  if (context.passLadder != null) {
+    return context.passLadderShownOnPage ? null : 'pass_ladder';
+  }
+  if (context.paying) {
+    return null;
+  }
+  return 'upsell';
+}

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -254,7 +254,11 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           </>
         )}
       </div>
-      <UploadForm setErrorMessage={setErrorMessage} aiOn={isAiOn} />
+      <UploadForm
+        setErrorMessage={setErrorMessage}
+        aiOn={isAiOn}
+        passLadderShownOnPage={returnedFromPass}
+      />
       {isSignedIn && <RecentSources />}
       <ExploreCard />
       <section className={pageStyles.howItWorks}>

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -36,6 +36,10 @@ import { fireAnalyticsEvent } from '../../../../lib/analytics/fireAnalyticsEvent
 import { track } from '../../../../lib/analytics/track';
 import ChatPanel from '../../../../components/ChatPanel/ChatPanel';
 import { UpsellCard } from '../../../../components/UpsellCard';
+import { CreateAccountNotice } from '../../../../components/CreateAccountNotice/CreateAccountNotice';
+import { PassLadderCard } from '../../../../components/PassLadderCard/PassLadderCard';
+import { isPayingUser } from '../../../../components/NavigationBar/helpers/getPlanLabel';
+import { resolveSuccessOffer } from '../../../../lib/promo/resolveSuccessOffer';
 import formStyles from './UploadForm.module.css';
 import sharedStyles from '../../../../styles/shared.module.css';
 
@@ -48,6 +52,7 @@ import type {
 interface UploadFormProps {
   setErrorMessage: ErrorHandlerType;
   aiOn?: boolean;
+  passLadderShownOnPage?: boolean;
 }
 
 const FORMATS = [
@@ -240,6 +245,7 @@ function WarningIcon({ className }: Readonly<{ className?: string }>) {
 function UploadForm({
   setErrorMessage,
   aiOn = false,
+  passLadderShownOnPage = false,
 }: Readonly<UploadFormProps>) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const convertRef = useRef<HTMLButtonElement>(null);
@@ -851,6 +857,13 @@ function UploadForm({
     </div>
   );
 
+  const successOffer = resolveSuccessOffer({
+    anonymous: userLocals != null && userLocals.user?.email == null,
+    paying: isPayingUser(userLocals?.locals),
+    passLadder: userLocals?.passLadder,
+    passLadderShownOnPage,
+  });
+
   const renderSuccessState = () => (
     <div className={formStyles.stateContent}>
       <CheckCircleIcon className={formStyles.iconSuccess} />
@@ -908,7 +921,11 @@ function UploadForm({
           Didn't get the file? Download it here.
         </button>
       )}
-      <UpsellCard surface="upload_success_upsell" hideForAnonymous />
+      {successOffer === 'anon_signup' && <CreateAccountNotice />}
+      {successOffer === 'pass_ladder' && <PassLadderCard />}
+      {successOffer === 'upsell' && (
+        <UpsellCard surface="upload_success_upsell" hideForAnonymous />
+      )}
       <button
         type="button"
         className={sharedStyles.btnSecondary}

--- a/web/src/pages/UploadSuccessPreviewPage/UploadSuccessPreviewPage.tsx
+++ b/web/src/pages/UploadSuccessPreviewPage/UploadSuccessPreviewPage.tsx
@@ -1,0 +1,57 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { CreateAccountNotice } from '../../components/CreateAccountNotice/CreateAccountNotice';
+import { PassLadderCard } from '../../components/PassLadderCard/PassLadderCard';
+import { UpsellCard } from '../../components/UpsellCard';
+import sharedStyles from '../../styles/shared.module.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function Variant({
+  title,
+  children,
+}: Readonly<{ title: string; children: React.ReactNode }>) {
+  return (
+    <section
+      style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
+    >
+      <h2 className={sharedStyles.sectionTitle}>{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+export default function UploadSuccessPreviewPage() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <div
+        className={sharedStyles.page}
+        style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}
+      >
+        <h1>Success-offer slot preview</h1>
+        <p>
+          The success state renders exactly one of these, resolved by
+          resolveSuccessOffer: anonymous → account offer, ladder-eligible → pass
+          ladder, logged-in free → pass upsell, paying → nothing.
+        </p>
+        <Variant title="Anonymous — account offer">
+          <CreateAccountNotice />
+        </Variant>
+        <Variant title="Repeat pass buyer — pass ladder">
+          <PassLadderCard
+            offerOverride={{ passCount: 3, spentUsd: 13 }}
+            emailOverride="preview@example.com"
+          />
+        </Variant>
+        <Variant title="Logged-in free — pass upsell">
+          <UpsellCard surface="upload_success_upsell" />
+        </Variant>
+        <Variant title="Paying — no card">
+          <p>(nothing renders)</p>
+        </Variant>
+      </div>
+    </QueryClientProvider>
+  );
+}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-08-success-screen-one-offer.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-08-success-screen-one-offer.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-08-success-screen-one-offer",
+  "date": "2026-07-08",
+  "type": "style",
+  "title": "A calmer deck-ready screen — one clear next step instead of a stack of offers"
+}


### PR DESCRIPTION
## What

The deck-ready screen now shows exactly one offer, chosen by a pure `resolveSuccessOffer` arbiter:

- **Anonymous** → new account offer ("Keep your next decks" — create a free account and every deck lands in your downloads history). New `account_offer_shown`/`account_offer_clicked` events in both registries.
- **Ladder-eligible repeat pass buyer** → the pass-ladder card, suppressed when the page-level `from=pass` card is already visible (fixes a live double-paywall where both fired `paywall_shown`).
- **Paying** → nothing.
- **Logged-in free** → the pass upsell, demoted from three buttons (Day/Week/Unlimited) to one Day Pass CTA + a "See plans" link; "Redirecting…" → "Starting checkout" per VOICE (no ellipsis loading states).

Dev-only `/dev/upload-success-preview` renders all four outcomes side by side (tree-shaken out of prod builds).

## Why

Trio CTA-density sweep found up to 10 actionable elements on the success screen — three simultaneous monetization surfaces at the single highest-intent moment — and a real double-paywall for ladder-eligible users. One slot, one card, hard no-offer gate for payers. The anon arm targets the 19.3% download→signup edge (adds are the #1 constraint); copy is deliberately honest — anon decks are not retained server-side today, so it never promises "keep this deck."

## Testing

- `resolveSuccessOffer.test.ts` — all four branches + page-suppression rule.
- `CreateAccountNotice.test.tsx` — render, both events, CTA href.
- `UpsellCard.test.tsx` rewritten for the one-CTA design (See plans link + tracking, starting-checkout pending label).
- Full web vitest 249 files / 2,175 tests, server + web tsc, oxlint/oxfmt clean (remaining UploadForm warnings pre-existing).
- sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

## Risks

- UpsellCard's week-pass button is gone from both surfaces (`upload_success_upsell`, `downloads_upsell`); week passes remain purchasable on /pricing. Watch the week-pass share in `checkout_completed` — if it collapses without a compensating Day/Unlimited lift, restore a second CTA.
- Anon offer reach: renders on every anon success (no dismissal state in v1).

## Measuring success

`paywall_shown` per success view drops 2→1 for `from=pass` sessions; anon funnel `account_offer_shown → account_offer_clicked → signup_completed` against the 19.3% baseline; week-pass guardrail above. All at `/api/ops/metrics`.

## Goal alignment

Simpler/faster/more beautiful: the win moment carries one next step. Funnel: anon→account (the widest leak) gets the slot it never had.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `/dev/upload-success-preview` renders all four arbiter outcomes for visual review with `pnpm dev`.

