### PR TITLE
style: let deck feedback end at thanks, not a pass pitch

### DIFF
--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
@@ -35,13 +35,6 @@ const freeUser = {
   },
 };
 
-const payingUser = {
-  data: {
-    locals: { patreon: false, subscriber: true },
-    user: { email: 'paying@example.com' },
-  },
-};
-
 beforeEach(() => {
   submitEmojiFeedback.mockReset();
   submitEmojiFeedback.mockResolvedValue(undefined);
@@ -159,99 +152,17 @@ describe('DeckFeedbackPrompt', () => {
   });
 });
 
-describe('DeckFeedbackPrompt — Day Pass offer after positive rating', () => {
-  it('shows the Day Pass offer to a free user after they confirm the deck worked', async () => {
-    render(<DeckFeedbackPrompt />);
-    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
-    expect(await screen.findByText('Deck came out right.')).toBeInTheDocument();
-    expect(
-      screen.getByText('Keep going without the monthly limit — Day Pass, $4.')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Get Day Pass' })
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'See all plans' })).toHaveAttribute(
-      'href',
-      '/pricing?source=deck_feedback'
-    );
-  });
-
-  it('does not show the Day Pass offer to paying users', async () => {
-    mockUseUserLocals.mockReturnValue(payingUser);
+describe('DeckFeedbackPrompt — no upsell after feedback', () => {
+  it('thanks a free user without a pass pitch after a positive rating', async () => {
     render(<DeckFeedbackPrompt />);
     fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
     expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Get Day Pass' })
     ).not.toBeInTheDocument();
-  });
-
-  it('does not show the offer after a negative rating', async () => {
-    render(<DeckFeedbackPrompt />);
-    fireEvent.click(screen.getByRole('button', { name: 'Something was off' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
-    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: 'Get Day Pass' })
-    ).not.toBeInTheDocument();
-  });
-
-  it('fires paywall_shown with surface=deck_feedback_sent when the offer renders', async () => {
-    render(<DeckFeedbackPrompt />);
-    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
-    await waitFor(() => {
-      expect(mockTrack).toHaveBeenCalledWith('paywall_shown', {
-        surface: 'deck_feedback_sent',
-      });
-    });
-  });
-
-  it('fires paywall_upgrade_clicked with plan=day_pass and redirects on Day Pass click', async () => {
-    startPassCheckout.mockResolvedValue({
-      url: 'https://checkout.stripe.com/day',
-    });
-    Object.defineProperty(globalThis, 'location', {
-      writable: true,
-      value: { href: '' },
-    });
-    render(<DeckFeedbackPrompt />);
-    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
-    const cta = await screen.findByRole('button', { name: 'Get Day Pass' });
-    fireEvent.click(cta);
-    await waitFor(() => {
-      expect(mockTrack).toHaveBeenCalledWith('paywall_upgrade_clicked', {
-        surface: 'deck_feedback_sent',
-        plan: 'day_pass',
-      });
-      expect(startPassCheckout).toHaveBeenCalledWith(
-        '24h',
-        undefined,
-        'deck_feedback_sent'
-      );
-    });
-  });
-
-  it('shows Redirecting label and disables the button while Day Pass checkout is pending', async () => {
-    let resolveCheckout: (value: { status: 'error' }) => void = () => {};
-    startPassCheckout.mockReturnValue(
-      new Promise((resolve) => {
-        resolveCheckout = resolve;
-      })
+    expect(mockTrack).not.toHaveBeenCalledWith(
+      'paywall_shown',
+      expect.objectContaining({ surface: 'deck_feedback_sent' })
     );
-    render(<DeckFeedbackPrompt />);
-    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
-    const cta = await screen.findByRole('button', { name: 'Get Day Pass' });
-    fireEvent.click(cta);
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Redirecting…' })
-      ).toBeDisabled();
-    });
-    resolveCheckout({ status: 'error' });
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Get Day Pass' })
-      ).toBeInTheDocument();
-    });
   });
 });

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
-import { track } from '../../../lib/analytics/track';
 import { get2ankiApi } from '../../../lib/backend/get2ankiApi';
-import { useUserLocals } from '../../../lib/hooks/useUserLocals';
-import { isPayingUser } from '../../../components/NavigationBar/helpers/getPlanLabel';
 import styles from './DeckFeedbackPrompt.module.css';
 
 const SUPPRESSED_UNTIL_KEY = '2anki_deck_feedback_suppressed_until';
@@ -12,7 +9,6 @@ const FEEDBACK_PAGE = 'downloads/deck_done';
 const POSITIVE_RATING = 5;
 const NEGATIVE_RATING = 1;
 const COMMENT_MAX = 2000;
-const UPSELL_SURFACE = 'deck_feedback_sent';
 
 type Stage =
   | { kind: 'prompt' }
@@ -46,18 +42,6 @@ export function DeckFeedbackPrompt() {
   const [stage, setStage] = useState<Stage>({ kind: 'prompt' });
   const [comment, setComment] = useState('');
   const [dismissed, setDismissed] = useState(false);
-  const [dayPassPending, setDayPassPending] = useState(false);
-  const { data: userLocals } = useUserLocals();
-
-  const paying = isPayingUser(userLocals?.locals);
-  const showOffer =
-    stage.kind === 'sent' && stage.rating === POSITIVE_RATING && !paying;
-
-  useEffect(() => {
-    if (showOffer) {
-      track('paywall_shown', { surface: UPSELL_SURFACE });
-    }
-  }, [showOffer]);
 
   if (dismissed) return null;
 
@@ -98,31 +82,6 @@ export function DeckFeedbackPrompt() {
 
   const handleSkipNegative = () => {
     void sendRating(NEGATIVE_RATING);
-  };
-
-  const handleDayPassClick = async () => {
-    track('paywall_upgrade_clicked', {
-      surface: UPSELL_SURFACE,
-      plan: 'day_pass',
-    });
-    setDayPassPending(true);
-    const result = await get2ankiApi().startPassCheckout(
-      '24h',
-      undefined,
-      UPSELL_SURFACE
-    );
-    if ('url' in result) {
-      globalThis.location.href = result.url;
-      return;
-    }
-    setDayPassPending(false);
-  };
-
-  const handleSeeAllPlans = () => {
-    track('paywall_upgrade_clicked', {
-      surface: UPSELL_SURFACE,
-      plan: 'pricing_page',
-    });
   };
 
   return (
@@ -193,33 +152,7 @@ export function DeckFeedbackPrompt() {
 
       {stage.kind === 'sending' && <p className={styles.status}>Sending</p>}
 
-      {showOffer && (
-        <>
-          <p className={styles.prompt}>Deck came out right.</p>
-          <p className={styles.offerBody}>
-            Keep going without the monthly limit — Day Pass, $4.
-          </p>
-          <div className={styles.actions}>
-            <button
-              type="button"
-              className={styles.primary}
-              onClick={handleDayPassClick}
-              disabled={dayPassPending}
-            >
-              {dayPassPending ? 'Redirecting…' : 'Get Day Pass'}
-            </button>
-            <a
-              className={styles.tertiary}
-              href="/pricing?source=deck_feedback"
-              onClick={handleSeeAllPlans}
-            >
-              See all plans
-            </a>
-          </div>
-        </>
-      )}
-
-      {stage.kind === 'sent' && !showOffer && (
+      {stage.kind === 'sent' && (
         <p className={styles.status}>Feedback received.</p>
       )}
 


### PR DESCRIPTION
## What

The downloads-page deck-feedback prompt no longer shows a Day Pass offer after a positive rating — every rating now ends with "Feedback received." The `deck_feedback_sent` paywall surface is retired (−156 lines).

## Why

CTA-density sweep (P1 finding): a free user below the downloads table could see two independent pass pitches at once — this post-rating offer plus the footer UpsellCard. A feedback widget that morphs into a checkout button also erodes the trust the feedback ask just built. One pass pitch per page; the UpsellCard owns it.

## Testing

DeckFeedbackPrompt suite rewritten for the no-upsell contract (12 tests: rating flows, suppression window, error retry, and an explicit no-pitch/no-paywall_shown assertion). Full DownloadsPage vitest 162 tests green, web tsc clean, oxlint/oxfmt clean. sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

No changelog entry — removes a rarely-seen upsell branch; the feedback flow itself is unchanged.

## Goal alignment

Simpler: the win-moment surfaces carry one ask each. Revenue risk minimal — `deck_feedback_sent` was a low-volume surface; the footer UpsellCard remains the page's pass pitch. Watch `checkout_completed` share by surface at /api/ops/metrics.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: evidence = CI playwright golden-path spec at 375px + rewritten component suite; change is a pure branch removal in one component.
