### PR TITLE
style: demote the anon AI badge to a quiet inline hint

### DIFF
--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -47,11 +47,11 @@ describe('HomePage (anonymous)', () => {
     expect(screen.queryByText(/open source/i)).toBeNull();
   });
 
-  it('shows the AI-off badge inviting anon visitors to create an account', () => {
+  it('shows a quiet AI hint inviting anon visitors to create an account', () => {
     renderHome();
-    expect(screen.getByText('AI is off')).toBeInTheDocument();
+    expect(screen.queryByText('AI is off')).toBeNull();
     const link = screen.getByRole('link', {
-      name: /create an account to turn it on/i,
+      name: /create an account to turn on AI/i,
     });
     expect(link).toHaveAttribute('href', '/register?redirect=/card-options');
   });

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -205,22 +205,16 @@ export function HomePage({
           HTML, and CSV too.
         </p>
         <div className={styles.heroControls}>
-          <div
-            className={`${sharedStyles.aiOffBadge} ${styles.heroAiBadge}`}
-            role="status"
-          >
-            <span className={sharedStyles.badgeWarning}>AI is off</span>
-            <span className={sharedStyles.aiOffBadgeBody}>
-              {' '}
-              <Link
-                to="/register?redirect=/card-options"
-                onClick={() => track('home_ai_anon_badge_clicked')}
-              >
-                Create an account to turn it on
-              </Link>
-              .
-            </span>
-          </div>
+          <p className={`${sharedStyles.aiOffBadgeBody} ${styles.heroAiBadge}`}>
+            Claude can write your cards —{' '}
+            <Link
+              to="/register?redirect=/card-options"
+              onClick={() => track('home_ai_anon_badge_clicked')}
+            >
+              create an account to turn on AI
+            </Link>
+            .
+          </p>
           <Link
             to="/card-options"
             className={styles.cardOptionsLink}

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -150,7 +150,7 @@ describe('UploadPage doc/docx hint', () => {
 describe('UploadPage AI badge anon link', () => {
   it('links to /login?redirect=/card-options so user lands on card options after sign-in', () => {
     renderPage();
-    const link = screen.getByRole('link', { name: /sign in to turn it on/i });
+    const link = screen.getByRole('link', { name: /sign in to turn on AI/i });
     expect(link).toHaveAttribute('href', '/login?redirect=/card-options');
   });
 });
@@ -164,7 +164,7 @@ describe('UploadPage AI badge placement', () => {
     renderPage();
     const uploadForm = screen.getByTestId('upload-form-stub');
     const badge = screen
-      .getByRole('link', { name: /sign in to turn it on/i })
+      .getByRole('link', { name: /sign in to turn on AI/i })
       .closest('[role="status"]') as HTMLElement;
     expect(badge).toBeInTheDocument();
     expect(
@@ -421,7 +421,9 @@ describe('UploadPage AI badge survives browser translation', () => {
 
   it('renders no bare text nodes in the anon branch', () => {
     renderPage();
-    expect(collectUnwrappedTextNodes(badgeFor(/AI is off/))).toEqual([]);
+    expect(
+      collectUnwrappedTextNodes(badgeFor(/Claude can write your cards/))
+    ).toEqual([]);
   });
 
   it('renders no bare text nodes in the free branch', () => {

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -239,19 +239,16 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
           </>
         )}
         {aiBadgeState === 'anon' && (
-          <>
-            <span className={styles.badgeWarning}>AI is off</span>
-            <span className={styles.aiOffBadgeBody}>
-              {' '}
-              <Link
-                to="/login?redirect=/card-options"
-                onClick={() => track('upload_ai_anon_badge_clicked')}
-              >
-                Sign in to turn it on
-              </Link>
-              <span>.</span>
-            </span>
-          </>
+          <span className={styles.aiOffBadgeBody}>
+            <span>Claude can write your cards — </span>
+            <Link
+              to="/login?redirect=/card-options"
+              onClick={() => track('upload_ai_anon_badge_clicked')}
+            >
+              sign in to turn on AI
+            </Link>
+            <span>.</span>
+          </span>
         )}
       </div>
       <UploadForm


### PR DESCRIPTION
## What

Logged-out visitors no longer see the amber "AI is off" pill on the home hero and upload page. They get one quiet sentence instead: "Claude can write your cards — create an account to turn on AI" (home) / "— sign in to turn on AI" (upload). Signed-in badge states (on/off/free) and the toggle are unchanged.

## Why

CTA-density sweep: the anon badge got 12 407 views → 108 clicks in 30 days (0.87% CTR) while sitting above the drop zone in warning styling — an attention tax that reads like something is broken to people who haven't even converted yet. The AI feature itself is used (37 AI-on activations, 95 photo conversions/30d) and keeps its discovery line — just demoted from alarm-pill to hint. Alexander's call: demote, don't kill.

## Testing

HomePage + UploadPage suites updated (new copy, link names, translation-safety bare-text-node check for the new anon branch). Full web vitest 249 files / 2 178 tests green, web tsc clean, oxfmt/oxlint clean. sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

No changelog entry — visual demotion of a marketing chip; no capability change.

## Measuring success

`home_ai_anon_badge_clicked` / `upload_ai_anon_badge_clicked` keep their names — compare CTR before/after at /api/ops/metrics. Guardrail: anon signup rate must not dip (the hint links to /register).

## Goal alignment

Simpler: the anon home/upload view carries one primary action (convert). Funnel: removes noise above the widest-intake surface.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: evidence = CI playwright golden-path spec at 375px + updated component suites; change is copy/styling of one badge state.
