### PR TITLE
feat: show day and week pass sales on the ops Today page

### DIFF
--- a/src/data_layer/EventsMetricsRepository.sql.test.ts
+++ b/src/data_layer/EventsMetricsRepository.sql.test.ts
@@ -68,6 +68,18 @@ describe('EventsMetricsRepository generated SQL', () => {
       'deck_downloaded',
     ]);
   });
+
+  it('counts pass checkouts by plan inside the window', () => {
+    const sql = repository.buildPassSalesQuery(sevenDaysAgo).toString();
+
+    expect(sql).toContain('"events"');
+    expect(sql).toContain("props->>'plan' as plan");
+    expect(sql).toContain('"name" = \'checkout_completed\'');
+    expect(sql).toContain('"created_at" >=');
+    expect(sql).toContain("props->>'plan' in ('24h', '7d')");
+    expect(sql).toContain('group by "plan"');
+    expect(sql).toContain('count(*)');
+  });
 });
 
 describe('mapMedianMinutesRow', () => {

--- a/src/data_layer/EventsMetricsRepository.ts
+++ b/src/data_layer/EventsMetricsRepository.ts
@@ -5,6 +5,15 @@ export interface IEventsMetricsRepository {
   uploadToDownloadRate(since: Date): Promise<number | null>;
 }
 
+export interface PassSalesCounts {
+  day_passes: number;
+  week_passes: number;
+}
+
+export interface IPassSalesRepository {
+  passSalesSince(since: Date): Promise<PassSalesCounts>;
+}
+
 export interface MedianMinutesRow {
   median_minutes: number | string | null;
 }
@@ -28,8 +37,32 @@ export function mapUploadToDownloadRateRow(
   return (Number(row.downloaders) / Number(row.uploaders)) * 100;
 }
 
-export class EventsMetricsRepository implements IEventsMetricsRepository {
+export class EventsMetricsRepository
+  implements IEventsMetricsRepository, IPassSalesRepository
+{
   constructor(private readonly database: Knex) {}
+
+  buildPassSalesQuery(since: Date): Knex.QueryBuilder {
+    return this.database('events')
+      .select(this.database.raw("props->>'plan' as plan"))
+      .count('* as count')
+      .where('name', 'checkout_completed')
+      .where('created_at', '>=', since)
+      .whereRaw("props->>'plan' in ('24h', '7d')")
+      .groupBy('plan');
+  }
+
+  async passSalesSince(since: Date): Promise<PassSalesCounts> {
+    const rows = (await this.buildPassSalesQuery(since)) as Array<{
+      plan: string;
+      count: string | number;
+    }>;
+    const byPlan = new Map(rows.map((r) => [r.plan, Number(r.count)]));
+    return {
+      day_passes: byPlan.get('24h') ?? 0,
+      week_passes: byPlan.get('7d') ?? 0,
+    };
+  }
 
   buildMedianMinutesToFirstDeckQuery(cohortStart: Date): Knex.QueryBuilder {
     const accounts = this.database('events')

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -75,6 +75,7 @@ const OpsRouter = () => {
     signupCountryRepository: new UsersRepository(database),
     signupCountsRepository: new UsersRepository(database),
     subscriptionsRepository: new SubscriptionsSourceRepository(database),
+    passSalesRepository: new EventsMetricsRepository(database),
   });
 
   const conversionMetricsService = new ConversionMetricsService(

--- a/src/services/ops/BusinessMetricsService.test.ts
+++ b/src/services/ops/BusinessMetricsService.test.ts
@@ -136,6 +136,28 @@ describe('BusinessMetricsService', () => {
     jest.useRealTimers();
   });
 
+  it('surfaces 7-day pass sales when a pass-sales repository is injected', async () => {
+    const passSalesSince = jest
+      .fn()
+      .mockResolvedValue({ day_passes: 5, week_passes: 2 });
+    const { service } = buildService(
+      {},
+      { passSalesRepository: { passSalesSince } }
+    );
+
+    const response = await service.getMetrics();
+
+    expect(response.pass_sales_7d).toEqual({ day_passes: 5, week_passes: 2 });
+    const since = passSalesSince.mock.calls[0][0] as Date;
+    expect(Date.now() - since.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it('returns null pass sales without a repository', async () => {
+    const { service } = buildService();
+    const response = await service.getMetrics();
+    expect(response.pass_sales_7d).toBeNull();
+  });
+
   it('returns the full response shape on first call', async () => {
     const { service } = buildService({
       allSubs: [

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -36,6 +36,10 @@ import {
   ISubscriptionsSourceRepository,
   InMemorySubscriptionsSourceRepository,
 } from '../../data_layer/SubscriptionsSourceRepository';
+import type {
+  IPassSalesRepository,
+  PassSalesCounts,
+} from '../../data_layer/EventsMetricsRepository';
 
 export type BusinessMetricKey =
   | 'mrr_usd'
@@ -57,7 +61,8 @@ export type BusinessMetricKey =
   | 'signup_countries_90d'
   | 'total_users'
   | 'signups_24h'
-  | 'signups_7d';
+  | 'signups_7d'
+  | 'pass_sales_7d';
 
 export interface BusinessMetricError {
   metric: BusinessMetricKey;
@@ -92,6 +97,7 @@ export interface BusinessMetricsResponse {
   churn_30d_pct: number | null;
   failed_payments_7d: number | null;
   new_paid_conversions_7d: number | null;
+  pass_sales_7d: PassSalesCounts | null;
   mrr_timeseries: MrrTimeseriesPoint[] | null;
   active_subs_timeseries: ActiveSubsTimeseriesPoint[] | null;
   conversions_vs_churn_weekly: ConversionsChurnWeekPoint[] | null;
@@ -132,6 +138,7 @@ export interface BusinessMetricsServiceDeps {
   reengagementRepository?: IReEngagementFeedbackRepository;
   signupCountryRepository?: ISignupCountryRepository;
   signupCountsRepository?: IUserSignupCountsRepository;
+  passSalesRepository?: IPassSalesRepository;
   subscriptionsRepository?: ISubscriptionsSourceRepository;
 }
 
@@ -216,6 +223,8 @@ export class BusinessMetricsService {
 
   private readonly signupCountsRepository: IUserSignupCountsRepository | null;
 
+  private readonly passSalesRepository: IPassSalesRepository | null;
+
   private readonly subscriptionsRepository: ISubscriptionsSourceRepository;
 
   private inflightSourceRefresh: Promise<SourceRefreshResult> | null = null;
@@ -235,6 +244,7 @@ export class BusinessMetricsService {
       new InMemoryReEngagementFeedbackRepository();
     this.signupCountryRepository = deps.signupCountryRepository ?? null;
     this.signupCountsRepository = deps.signupCountsRepository ?? null;
+    this.passSalesRepository = deps.passSalesRepository ?? null;
     this.subscriptionsRepository =
       deps.subscriptionsRepository ??
       new InMemorySubscriptionsSourceRepository();
@@ -304,6 +314,9 @@ export class BusinessMetricsService {
       new_paid_conversions_7d: fromSubs((s) =>
         computeNewPaidConversions7d(s, now)
       ),
+      pass_sales_7d: dbValueByKey.has('pass_sales_7d')
+        ? (dbValueByKey.get('pass_sales_7d') as PassSalesCounts | null)
+        : null,
       mrr_timeseries: fromSubs((s) => computeMrrTimeseries(s, now)),
       active_subs_timeseries: fromSubs((s) =>
         computeActiveSubsTimeseries(s, now)
@@ -440,6 +453,16 @@ export class BusinessMetricsService {
           ),
       },
     ];
+
+    if (this.passSalesRepository != null) {
+      tasks.push({
+        key: 'pass_sales_7d',
+        fetch: () =>
+          this.passSalesRepository!.passSalesSince(
+            new Date(now.getTime() - 7 * SECONDS_PER_DAY * 1000)
+          ),
+      });
+    }
 
     if (this.signupCountryRepository != null) {
       tasks.push({

--- a/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
+++ b/src/usecases/ops/GetBusinessMetricsUseCase.test.ts
@@ -13,6 +13,7 @@ describe('GetBusinessMetricsUseCase', () => {
       churn_30d_pct: 2.1,
       failed_payments_7d: 4,
       new_paid_conversions_7d: 11,
+      pass_sales_7d: { day_passes: 0, week_passes: 0 },
       mrr_timeseries: [],
       active_subs_timeseries: [],
       conversions_vs_churn_weekly: [],

--- a/web/src/pages/OpsPage/BusinessTab.test.tsx
+++ b/web/src/pages/OpsPage/BusinessTab.test.tsx
@@ -29,6 +29,7 @@ const buildSampleMetrics = (
   churn_30d_pct: 2.1,
   failed_payments_7d: 4,
   new_paid_conversions_7d: 11,
+  pass_sales_7d: null,
   mrr_timeseries: Array.from({ length: 90 }).map((_, i) => ({
     t: `2026-02-${String((i % 28) + 1).padStart(2, '0')}`,
     mrr_usd: 1000 + i * 10,

--- a/web/src/pages/OpsPage/TodayTab.test.tsx
+++ b/web/src/pages/OpsPage/TodayTab.test.tsx
@@ -21,6 +21,7 @@ const healthyBusiness = {
   churn_30d_pct: 18.2,
   failed_payments_7d: 3,
   new_paid_conversions_7d: 16,
+  pass_sales_7d: { day_passes: 4, week_passes: 1 },
   mrr_timeseries: null,
   active_subs_timeseries: null,
   conversions_vs_churn_weekly: null,
@@ -142,6 +143,15 @@ describe('TodayTab', () => {
       await screen.findByText('Nothing needs you today.')
     ).toBeInTheDocument();
     expect(screen.getByText('Healthy')).toBeInTheDocument();
+  });
+
+  test('shows day and week pass sales in the healthy strip', async () => {
+    installFetch();
+    renderTab();
+
+    expect(await screen.findByText('Day passes / wk')).toBeInTheDocument();
+    expect(screen.getByText('Week passes / wk')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
   });
 
   test('renders an attention row with a copy button when errors are unresolved', async () => {

--- a/web/src/pages/OpsPage/TodayTab.tsx
+++ b/web/src/pages/OpsPage/TodayTab.tsx
@@ -242,6 +242,20 @@ export default function TodayTab() {
         formatInteger
       ),
     },
+    {
+      title: 'Day passes / wk',
+      value: formatNumberOrDash(
+        businessData?.pass_sales_7d?.day_passes ?? null,
+        formatInteger
+      ),
+    },
+    {
+      title: 'Week passes / wk',
+      value: formatNumberOrDash(
+        businessData?.pass_sales_7d?.week_passes ?? null,
+        formatInteger
+      ),
+    },
     { title: 'Job p95', value: formatMs(p95) },
     {
       title: 'Return rate 7d',

--- a/web/src/pages/OpsPage/buildClaudePrompt.test.ts
+++ b/web/src/pages/OpsPage/buildClaudePrompt.test.ts
@@ -19,6 +19,7 @@ function makeBusiness(
     churn_30d_pct: 18.2,
     failed_payments_7d: 4,
     new_paid_conversions_7d: 16,
+    pass_sales_7d: null,
     mrr_timeseries: [{ t: '2026-06-01', mrr_usd: 1800 }],
     active_subs_timeseries: [{ t: '2026-06-01', active_paying_subs: 750 }],
     conversions_vs_churn_weekly: [

--- a/web/src/pages/OpsPage/businessTypes.ts
+++ b/web/src/pages/OpsPage/businessTypes.ts
@@ -90,6 +90,7 @@ export interface BusinessMetricsResponse {
   churn_30d_pct: number | null;
   failed_payments_7d: number | null;
   new_paid_conversions_7d: number | null;
+  pass_sales_7d: { day_passes: number; week_passes: number } | null;
   mrr_timeseries: MrrTimeseriesPoint[] | null;
   active_subs_timeseries: ActiveSubsTimeseriesPoint[] | null;
   conversions_vs_churn_weekly: ConversionsChurnWeekPoint[] | null;


### PR DESCRIPTION
## What

The /ops/today healthy strip now shows **Day passes / wk** and **Week passes / wk** next to MRR, paying subs, and new paid.

## Why

Passes are two thirds of checkouts (~121 sales / $600 per 30 days) but the daily ops read only surfaced subscription adds. With the pass ladder now feeding repeat buyers toward Unlimited, pass volume is the input metric to that funnel and belongs on the Today page.

## How

- `EventsMetricsRepository.passSalesSince(since)` counts `checkout_completed` events by `props->>'plan'` (`24h`/`7d`) — events cover anonymous and logged-in buyers, and `user_passes` has no `created_at`, so events are the reliable 7-day window. Postgres-dialect SQL-shape test included (raw `props->>` per testing.md).
- `BusinessMetricsResponse` gains `pass_sales_7d: { day_passes, week_passes } | null` behind an injected `IPassSalesRepository` (null when absent — same pattern as signup countries); wired in OpsRouter.
- TodayTab healthy strip renders both counts; dashes while loading.

## Testing

New: SQL-shape test, two service tests (injected → counts + exact 7-day window; absent → null), TodayTab strip render test. Updated exhaustive fixtures (BusinessTab, buildClaudePrompt, GetBusinessMetricsUseCase). Server tsc + jest ops/data_layer/routes suites green; full web vitest 248 files / 2 165 tests; oxfmt/oxlint clean (BusinessMetricsService warnings pre-existing). sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

No changelog entry — internal ops tooling.

## Goal alignment

Revenue visibility: the daily read now includes the pass stream the ladder converts; judged at /ops/today against `checkout_completed` by plan.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: evidence = CI playwright golden-path spec at 375px + TodayTab component tests; ops-only internal page.
