### PR TITLE
docs: list all answer pages in llms.txt

### DIFF
--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -63,4 +63,11 @@ minutes. No exports, no manual steps. $30/month.
 - Notion Auto Sync: https://2anki.net/answers/notion-to-anki-sync
 - PDF to Anki guide: https://2anki.net/answers/pdf-to-anki
 - Quizlet to Anki guide: https://2anki.net/answers/quizlet-to-anki
+- FSRS explained: https://2anki.net/answers/fsrs-explained
+- Lecture notes to Anki: https://2anki.net/answers/lecture-notes-to-anki
+- Word to Anki: https://2anki.net/answers/word-to-anki
+- Image occlusion: https://2anki.net/answers/image-occlusion-anki
+- Google Docs to Anki: https://2anki.net/answers/google-docs-to-anki
+- Handwritten notes to Anki: https://2anki.net/answers/handwritten-notes-to-anki
+- Textbook to Anki: https://2anki.net/answers/textbook-to-anki
 - Documentation: https://2anki.net/documentation


### PR DESCRIPTION
## What
llms.txt canonical-URL section gains the seven answer pages shipped since it was written (FSRS, lecture-notes, word, image-occlusion, google-docs, handwritten-notes, textbook).

## Why
AI crawlers out-request Googlebot ~3:1 here; llms.txt is the assistants' index of us. New pages were invisible to the channel they target.

## Testing
Static text file; no code path. sonar not applicable.

No changelog entry — not an in-app change.

Browser check: not applicable — static text file under web/public, no rendered output.