### PR TITLE
fix: fan Word heading bullets into one card per bullet

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.ts
@@ -108,7 +108,9 @@ async function convertFile(
     const result = {
       name: `${file.name}.html`,
       contents: Buffer.from(
-        await convertDocxToHTML(file.contents as Buffer, mediaSink)
+        await convertDocxToHTML(file.contents as Buffer, mediaSink, {
+          bulletFanOut: input.settings.overlappingCloze === 'off',
+        })
       ),
     };
     console.log('[PrepareDeck] convertFile docx', {

--- a/src/infrastracture/adapters/fileConversion/convertDocxToHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/convertDocxToHTML.ts
@@ -1,6 +1,9 @@
 import mammoth from 'mammoth';
 
-import { preprocessDocxHTML } from './preprocessDocxHTML';
+import {
+  preprocessDocxHTML,
+  PreprocessDocxOptions,
+} from './preprocessDocxHTML';
 import { DocxImageMediaSink } from './docxImageMediaSink';
 
 const STRIKETHROUGH_TO_TAG_STYLE_MAP = ['strike => del'];
@@ -15,7 +18,8 @@ function buildImgElementConverter(mediaSink: DocxImageMediaSink) {
 
 export async function convertDocxToHTML(
   contents: Buffer,
-  mediaSink?: DocxImageMediaSink
+  mediaSink?: DocxImageMediaSink,
+  preprocessOptions: PreprocessDocxOptions = {}
 ): Promise<string> {
   let result;
   try {
@@ -31,7 +35,7 @@ export async function convertDocxToHTML(
     throw new Error(`docx_parse_failed: ${msg}`);
   }
   try {
-    return preprocessDocxHTML(result.value);
+    return preprocessDocxHTML(result.value, preprocessOptions);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(`docx_parse_failed: ${msg}`);

--- a/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.test.ts
+++ b/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.test.ts
@@ -160,3 +160,87 @@ describe('preprocessDocxHTML', () => {
     );
   });
 });
+
+describe('preprocessDocxHTML bullet fan-out', () => {
+  const sectionHTML =
+    '<h2>Contract remedies</h2>' +
+    '<ul>' +
+    '<li>Damages compensate the injured party</li>' +
+    '<li>Specific performance forces the promised act</li>' +
+    '<li>Rescission unwinds the contract</li>' +
+    '</ul>';
+
+  it('emits one toggle per bullet with a positional cue on the front', () => {
+    const result = preprocessDocxHTML(sectionHTML, { bulletFanOut: true });
+
+    expect(result).toContain('<summary>Contract remedies — 1/3</summary>');
+    expect(result).toContain('<summary>Contract remedies — 2/3</summary>');
+    expect(result).toContain('<summary>Contract remedies — 3/3</summary>');
+    expect(result).toContain(
+      '<details><summary>Contract remedies — 1/3</summary>Damages compensate the injured party</details>'
+    );
+    expect((result.match(/<details>/g) || []).length).toBe(3);
+  });
+
+  it('keeps non-list content under the heading as its own card', () => {
+    const input =
+      '<h2>Contract remedies</h2>' +
+      '<p>Remedies restore the injured party.</p>' +
+      '<ul><li>Damages</li><li>Rescission</li></ul>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain(
+      '<details><summary>Contract remedies</summary><p>Remedies restore the injured party.</p></details>'
+    );
+    expect(result).toContain('<summary>Contract remedies — 1/2</summary>');
+    expect(result).toContain('<summary>Contract remedies — 2/2</summary>');
+  });
+
+  it('keeps a single bullet without a positional cue', () => {
+    const input = '<h2>Rule</h2><ul><li>Only one point</li></ul>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain(
+      '<details><summary>Rule</summary>Only one point</details>'
+    );
+    expect(result).not.toContain('1/1');
+  });
+
+  it('preserves nested lists inside a bullet on that card back', () => {
+    const input =
+      '<h2>Topic</h2>' +
+      '<ul><li>Parent point<ul><li>child detail</li></ul></li><li>Second</li></ul>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain(
+      '<details><summary>Topic — 1/2</summary>Parent point<ul><li>child detail</li></ul></details>'
+    );
+  });
+
+  it('keeps the image-heading model with the cue after the image', () => {
+    const input =
+      '<h2><img src="figure.png" /></h2><ul><li>First</li><li>Second</li></ul>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain('<summary><img src="figure.png"> — 1/2</summary>');
+  });
+
+  it('leaves the lumped section shape unchanged without the flag', () => {
+    const result = preprocessDocxHTML(sectionHTML);
+
+    expect((result.match(/<details>/g) || []).length).toBe(1);
+    expect(result).toContain('<summary>Contract remedies</summary>');
+  });
+
+  it('does not touch the MCQ flashcard preprocessing path', () => {
+    const input = '<ul><li>Question?<br />A. wrong<br />*B. right</li></ul>';
+
+    const result = preprocessDocxHTML(input, { bulletFanOut: true });
+
+    expect(result).toContain('<strong>B. right</strong>');
+  });
+});

--- a/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.ts
+++ b/src/infrastracture/adapters/fileConversion/preprocessDocxHTML.ts
@@ -64,7 +64,60 @@ function processListItem(html: string): string | null {
   return buildToggle(question, options, correctAnswers);
 }
 
-function convertHeadingsToToggles($: any, originalHTML: string): string {
+function buildSectionToggles(
+  $: any,
+  summary: string,
+  siblings: any[],
+  bulletFanOut: boolean
+): string {
+  if (!bulletFanOut) {
+    const contentHTML = siblings.map((el: any) => $.html(el)).join('');
+    return `<details><summary>${summary}</summary>${contentHTML}</details>`;
+  }
+
+  const bullets: string[] = [];
+  const otherParts: string[] = [];
+
+  for (const el of siblings) {
+    const $el = $(el);
+    if ($el.is('ul, ol')) {
+      $el.children('li').each((_: number, li: any) => {
+        const inner = $(li).html();
+        if (inner != null && inner.trim().length > 0) {
+          bullets.push(inner);
+        }
+      });
+    } else {
+      const html = $.html(el);
+      if (html) otherParts.push(html);
+    }
+  }
+
+  if (bullets.length === 0) {
+    return `<details><summary>${summary}</summary>${otherParts.join('')}</details>`;
+  }
+
+  const toggles: string[] = [];
+  if (otherParts.length > 0) {
+    toggles.push(
+      `<details><summary>${summary}</summary>${otherParts.join('')}</details>`
+    );
+  }
+  bullets.forEach((bullet, index) => {
+    const cue =
+      bullets.length > 1
+        ? `${summary} — ${index + 1}/${bullets.length}`
+        : summary;
+    toggles.push(`<details><summary>${cue}</summary>${bullet}</details>`);
+  });
+  return toggles.join('');
+}
+
+function convertHeadingsToToggles(
+  $: any,
+  originalHTML: string,
+  bulletFanOut: boolean
+): string {
   const headings = $('h1, h2, h3, h4, h5, h6');
   if (headings.length === 0) {
     return originalHTML;
@@ -80,34 +133,45 @@ function convertHeadingsToToggles($: any, originalHTML: string): string {
 
     const summary = hasImage ? ($heading.html() ?? headingText) : headingText;
 
-    const contentParts: string[] = [];
+    const sectionSiblings: any[] = [];
     let sibling = $heading.next();
 
     while (sibling.length > 0 && !sibling.is('h1, h2, h3, h4, h5, h6')) {
-      const html = $.html(sibling);
-      if (html) contentParts.push(html);
+      sectionSiblings.push(sibling.get(0));
       sibling = sibling.next();
     }
 
-    if (contentParts.length === 0) return;
+    if (sectionSiblings.length === 0) return;
 
-    const toggle = `<details><summary>${summary}</summary>${contentParts.join('')}</details>`;
+    const toggles = buildSectionToggles(
+      $,
+      summary,
+      sectionSiblings,
+      bulletFanOut
+    );
 
-    contentParts.forEach(() => {
+    sectionSiblings.forEach(() => {
       const next = $heading.next();
       if (next.length > 0 && !next.is('h1, h2, h3, h4, h5, h6')) {
         next.remove();
       }
     });
 
-    $heading.replaceWith(toggle);
+    $heading.replaceWith(toggles);
     converted = true;
   });
 
   return converted ? $.html() : originalHTML;
 }
 
-export function preprocessDocxHTML(html: string): string {
+export interface PreprocessDocxOptions {
+  bulletFanOut?: boolean;
+}
+
+export function preprocessDocxHTML(
+  html: string,
+  options: PreprocessDocxOptions = {}
+): string {
   const $ = cheerio.load(html, { xmlMode: false });
 
   let mcConverted = false;
@@ -137,5 +201,5 @@ export function preprocessDocxHTML(html: string): string {
     return $.html();
   }
 
-  return convertHeadingsToToggles($, html);
+  return convertHeadingsToToggles($, html, options.bulletFanOut === true);
 }

--- a/src/lib/parser/DeckParser.docxOverlappingCloze.test.ts
+++ b/src/lib/parser/DeckParser.docxOverlappingCloze.test.ts
@@ -26,7 +26,12 @@ async function buildDocxDeck(overlapping: string) {
       'overlapping-cloze': overlapping,
     }),
     files: [
-      { name: 'notes.docx.html', contents: preprocessDocxHTML(docxHTML) },
+      {
+        name: 'notes.docx.html',
+        contents: preprocessDocxHTML(docxHTML, {
+          bulletFanOut: overlapping === 'off',
+        }),
+      },
     ],
     noLimits: true,
     workspace,
@@ -49,10 +54,15 @@ test('docx heading+bullets fans into one cloze card per bullet with overlapping 
   );
 });
 
-test('docx heading+bullets stays one lumped card with overlapping cloze off', async () => {
+test('docx heading+bullets fans into one basic card per bullet with overlapping cloze off', async () => {
   const deck = await buildDocxDeck('off');
-  expect(deck.cards.length).toBe(1);
-  expect(deck.cards[0].name).toContain('Contract remedies');
+  expect(deck.cards.length).toBe(3);
+  expect(deck.cards[0].name).toContain('Contract remedies — 1/3');
   expect(deck.cards[0].back).toContain('Damages compensate the injured party');
-  expect(deck.cards[0].back).toContain('Rescission unwinds the contract');
+  expect(deck.cards[0].back).not.toContain('Specific performance');
+  expect(deck.cards[2].name).toContain('Contract remedies — 3/3');
+  expect(deck.cards[2].back).toContain('Rescission unwinds the contract');
+  for (const card of deck.cards) {
+    expect(countC1(card.name)).toBe(0);
+  }
 });

--- a/web/src/pages/UploadPage/UploadPage.test.tsx
+++ b/web/src/pages/UploadPage/UploadPage.test.tsx
@@ -132,7 +132,7 @@ describe('UploadPage doc/docx hint', () => {
     renderPage();
     expect(
       screen.getByText(
-        /In Word docs, headings become card fronts and the body text under each heading becomes the back\./i
+        /In Word docs, headings become card fronts; each bullet under a heading becomes its own card/i
       )
     ).toBeInTheDocument();
   });

--- a/web/src/pages/UploadPage/UploadPage.tsx
+++ b/web/src/pages/UploadPage/UploadPage.tsx
@@ -268,9 +268,10 @@ export function UploadPage({ setErrorMessage }: Readonly<Props>) {
               <p className={pageStyles.stepTitle}>Drop or choose a file</p>
               <p className={pageStyles.stepBody}>
                 PDF, Word, Notion export, Markdown, HTML, Excel, CSV, or
-                PowerPoint. In Word docs, headings become card fronts and the
-                body text under each heading becomes the back. Images land on
-                the back, and strikethrough text on a card becomes an Anki tag.
+                PowerPoint. In Word docs, headings become card fronts; each
+                bullet under a heading becomes its own card, and other text
+                becomes the back. Images land on the back, and strikethrough
+                text on a card becomes an Anki tag.
               </p>
               <p className={pageStyles.stepBody}>
                 Coming from Notion?{' '}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-10-word-bullet-cards.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-10-word-bullet-cards.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-10-word-bullet-cards",
+  "date": "2026-07-10",
+  "type": "fix",
+  "title": "Word docs with headings and bullets — each bullet becomes its own card instead of one giant card per heading"
+}


### PR DESCRIPTION
## What
A Word doc with headings over bullet lists now converts to **one card per bullet**: front = heading + positional cue ("Contract remedies — 2/3"), back = the single bullet (nested sub-lists ride along). Non-list text under a heading stays its own card. Single-bullet sections get no cue. With **overlapping cloze on**, nothing changes — the lumped section shape is preserved so the per-bullet cloze fan-out (#3010/#3534) keeps its sibling-visible rendering.

## Why
Fixes #3524 — reported by a paid tester (user 21936): every bullet under a heading merged into one giant back, which is what pushed her to convert Word→PDF and hit the #3521 card explosion. Trio direction from that review: the bullet is the semantic unit; the positional cue answers the designer's interference concern (N identical fronts).

## Regression review (whole git log on docx/heading/cloze before coding)
- #3534 pinned fan-out test: ON-case untouched and green; OFF-case characterization **deliberately rewritten** to the new per-bullet contract (that test existed to make this change conscious).
- #3405 image headings: cue appends after the image; test added.
- #3407 strikethrough tags: `<del>` stays inside bullet content — unaffected.
- #3403 upload-page heading-model copy: updated in the same PR (step 1 hint + its test).
- MCQ docx flashcard preprocessing: runs before heading handling, untouched; test added.
- Chat attachment text-extraction caller passes no flag → byte-identical old output (pinned by existing byte-identical tests).

## How
`preprocessDocxHTML(html, { bulletFanOut })`; `convertDocxToHTML` forwards it; `PrepareDeck` sets it from `settings.overlappingCloze === 'off'`. 7 new preprocessor tests + rewritten DeckParser contract test.

## Testing
Parser + infra suites 78/78 (676 tests), full web vitest 249 files / 2 173 tests, both tsc clean, oxfmt/oxlint clean (2 warnings pre-existing). sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

Changelog entry included (user-visible fix).

## Goal alignment
Conversion quality is the product; this closes the defect that made a paying tester's decks unusable and feeds the empty-back/over-split quality push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: evidence = CI playwright golden-path spec; web change is one copy string + its test.