### PR TITLE
test: stabilize the two flaky CI tests

### DIFF
--- a/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
+++ b/src/infrastracture/adapters/fileConversion/PrepareDeck.test.ts
@@ -213,19 +213,24 @@ describe('PrepareDeck — HTML generation concurrency window', () => {
     });
 
     const flush = () => new Promise((r) => setImmediate(r));
-    const waitUntil = async (predicate: () => boolean) => {
-      for (let i = 0; i < 100 && !predicate(); i++) {
+    const waitUntil = async (predicate: () => boolean, label: string) => {
+      for (let i = 0; i < 2000; i++) {
+        if (predicate()) return;
         await flush();
       }
+      throw new Error(`waitUntil exhausted 2000 flushes waiting for ${label}`);
     };
 
-    await waitUntil(() => callOrder.length >= 3);
+    await waitUntil(() => callOrder.length >= 3, 'first 3 calls in flight');
 
     expect(inFlight).toBe(3);
 
     const resolveOrder = [2, 0, 1, 5, 3, 6, 4];
     for (const index of resolveOrder) {
-      await waitUntil(() => Boolean(resolvers[index]));
+      await waitUntil(
+        () => Boolean(resolvers[index]),
+        `resolver for page-${index}`
+      );
       resolvers[index](deckArrayFor(`page-${index}`));
       await flush();
     }

--- a/web/src/pages/DownloadsPage/components/ProducerPrompt.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ProducerPrompt.test.tsx
@@ -77,12 +77,15 @@ describe('ProducerPrompt', () => {
     trackMock.mockClear();
     render(<ProducerPrompt uploads={makeUploads(21)} />);
     await screen.findByText('Making decks for other people?');
+    await waitFor(() => {
+      expect(trackMock).toHaveBeenCalledWith('producer_entry_viewed', {
+        source: 'heavy_uploader_prompt',
+      });
+    });
     const viewed = trackMock.mock.calls.filter(
       ([name]) => name === 'producer_entry_viewed'
     );
-    expect(viewed).toEqual([
-      ['producer_entry_viewed', { source: 'heavy_uploader_prompt' }],
-    ]);
+    expect(viewed).toHaveLength(1);
   });
 
   it('does not fire producer_entry_viewed for an ineligible user', async () => {


### PR DESCRIPTION
## What
Hardens synchronization in the two tests behind this week's four CI bounces: PrepareDeck concurrency-window (poll cap 100→2000 flushes, exhaustion now throws a labeled error instead of asserting on a half-ready state) and ProducerPrompt view-event (waits for the passive effect before asserting, then pins exactly-once).

## Why
Each bounce costs a rerun cycle and erodes trust in red CI. Neither test found a real defect this week; both raced runner load.

## Testing
Repeated runs green: 3× jest PrepareDeck, 5× vitest ProducerPrompt. Contracts unchanged — same assertions, hardened waits. sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

No changelog entry — test-only.

Browser check: not applicable — test-only change, no rendered output.