### PR TITLE
fix: resolve webhook subscriptions through linked_email

### DIFF
--- a/src/lib/integrations/stripe.test.ts
+++ b/src/lib/integrations/stripe.test.ts
@@ -265,7 +265,7 @@ describe('updateStoreSubscription linked_email resolution', () => {
     expect(sub.linked_email).toBe('account@example.com');
   });
 
-  test('does not borrow another subscription row\'s linked_email', async () => {
+  test("does not borrow another subscription row's linked_email", async () => {
     await db('users').insert({
       email: 'other-account@example.com',
       stripe_customer_id: null,
@@ -291,4 +291,3 @@ describe('updateStoreSubscription linked_email resolution', () => {
     expect(user.stripe_customer_id).toBeNull();
   });
 });
-

--- a/src/lib/integrations/stripe.test.ts
+++ b/src/lib/integrations/stripe.test.ts
@@ -206,3 +206,89 @@ describe('updateStoreSubscription', () => {
     expect(row.linked_email).toBe('account@example.com');
   });
 });
+
+describe('updateStoreSubscription linked_email resolution', () => {
+  let db: Knex;
+
+  beforeEach(async () => {
+    db = knexLib({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await db.schema.createTable('users', (t) => {
+      t.increments('id');
+      t.string('email');
+      t.string('stripe_customer_id');
+    });
+    await db.schema.createTable('subscriptions', (t) => {
+      t.increments('id');
+      t.string('email').unique();
+      t.boolean('active');
+      t.json('payload');
+      t.string('stripe_product_id');
+      t.string('linked_email');
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  test('resolves a manually reconciled sub through subscriptions.linked_email and backfills the customer id', async () => {
+    await db('users').insert({
+      email: 'account@example.com',
+      stripe_customer_id: null,
+    });
+    await db('subscriptions').insert({
+      email: 'old-stripe@example.com',
+      active: true,
+      payload: '{}',
+      stripe_product_id: 'prod_legacy',
+      linked_email: 'account@example.com',
+    });
+
+    const result = await updateStoreSubscription(
+      db,
+      makeCustomer('old-stripe@example.com', 'cus_legacy1'),
+      makeSubscription('active', 'prod_legacy', { customer: 'cus_legacy1' })
+    );
+
+    expect(result.status).toBe('linked');
+    const user = await db('users')
+      .where({ email: 'account@example.com' })
+      .first();
+    expect(user.stripe_customer_id).toBe('cus_legacy1');
+    const sub = await db('subscriptions')
+      .where({ email: 'old-stripe@example.com' })
+      .first();
+    expect(sub.linked_email).toBe('account@example.com');
+  });
+
+  test('does not borrow another subscription row\'s linked_email', async () => {
+    await db('users').insert({
+      email: 'other-account@example.com',
+      stripe_customer_id: null,
+    });
+    await db('subscriptions').insert({
+      email: 'someone-else@example.com',
+      active: true,
+      payload: '{}',
+      stripe_product_id: 'prod_legacy',
+      linked_email: 'other-account@example.com',
+    });
+
+    const result = await updateStoreSubscription(
+      db,
+      makeCustomer('stranger@example.com', 'cus_stranger'),
+      makeSubscription('active', 'prod_legacy', { customer: 'cus_stranger' })
+    );
+
+    expect(result.status).toBe('unlinked');
+    const user = await db('users')
+      .where({ email: 'other-account@example.com' })
+      .first();
+    expect(user.stripe_customer_id).toBeNull();
+  });
+});
+

--- a/src/lib/integrations/stripe.ts
+++ b/src/lib/integrations/stripe.ts
@@ -92,6 +92,22 @@ export const resolveAccountForSubscription = async (
     if (byEmail != null) {
       return { id: byEmail.id, email: byEmail.email ?? null };
     }
+
+    const ownSubscriptionRow = await db('subscriptions')
+      .whereRaw('lower(trim(email)) = ?', [stripeEmail])
+      .whereNotNull('linked_email')
+      .select('linked_email')
+      .first();
+    const linkedEmail = normalizeEmail(ownSubscriptionRow?.linked_email);
+    if (linkedEmail != null) {
+      const byLinkedEmail = await db('users')
+        .whereRaw('lower(trim(email)) = ?', [linkedEmail])
+        .select('id', 'email')
+        .first();
+      if (byLinkedEmail != null) {
+        return { id: byLinkedEmail.id, email: byLinkedEmail.email ?? null };
+      }
+    }
   }
 
   return null;


### PR DESCRIPTION
## What
The Stripe webhook's account resolver gains a fourth key: when the Stripe customer email matches no user, it follows the subscription's own `linked_email` to the account. The existing post-resolution backfill then writes `users.stripe_customer_id`, so each subscription self-heals onto the fast key after one webhook.

## Why
Fixes #3459. Ground-truthed in prod: the two genuine 2024 orphans from the issue are resolved (email-key orphan query = 0 rows), but the unlinked-payment alert still fired daily — 75+ active paying subs were manually reconciled via `linked_email`, which the resolver never consulted, so every renewal re-alerted forever. Not lost revenue; a blind resolver. With this fix the alert stream dies out organically as renewals process, leaving the alert meaningful again for real orphans.

## Security review (payments path — run before this PR)
Adversarial review of the account-takeover question: the lookup is scoped to the subscription's own row (one account's linked_email cannot be borrowed by a different customer email); resolution grants an entitlement, never a session; the only user-reachable `linked_email` writer sets it on the caller's own row; and the new key is strictly narrower than the pre-existing stripe-email key 3, which already permits the theoretical gift-and-overwrite shape this could at most replicate. Bound SQL params only; no new logging. No findings at the exploitability bar.

## Testing
TDD: failing test first (manually reconciled sub resolves + customer id backfilled), plus a scoping test (a different customer's email cannot borrow another row's linked_email). stripe.test.ts 10/10, WebhookRouter + integrations + ops suites 110 tests green, tsc clean, oxfmt/oxlint clean. sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

No changelog entry — the affected users' access already worked; this fixes alert integrity, no user-visible behavior change.

## Measuring success
`unlinked_payment` rows in user_visible_errors trend to zero over ~1 billing cycle; any new alert after that is a genuine orphan worth reading.

## Goal alignment
Restores signal to a revenue-adjacent alert; unblocks closing the last high-priority issue that needed supervised payments work.