### PR TITLE
fix: render template preview modal without a container-query scale

### DIFF
--- a/web/src/pages/TemplatesPage/TemplatesPage.module.css
+++ b/web/src/pages/TemplatesPage/TemplatesPage.module.css
@@ -317,18 +317,15 @@
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  container-type: inline-size;
 }
 
 .modalFrame {
   position: absolute;
   top: 0;
   left: 0;
-  width: 800px;
-  height: 600px;
+  width: 100%;
+  height: 100%;
   border: 0;
-  transform-origin: top left;
-  transform: scale(calc(100cqw / 800px));
 }
 
 .dialog {

--- a/web/src/pages/TemplatesPage/TemplatesPage.test.tsx
+++ b/web/src/pages/TemplatesPage/TemplatesPage.test.tsx
@@ -196,6 +196,24 @@ describe('TemplatesPage', () => {
     expect(screen.getByText('Back')).toBeInTheDocument();
   });
 
+  it('renders the modal preview iframes with the field content in srcDoc', async () => {
+    getDefaults.mockResolvedValue([sampleStarter]);
+    renderPage();
+
+    const name = await screen.findByRole('button', { name: 'Clean Basic' });
+    fireEvent.click(name);
+    await screen.findByRole('dialog');
+
+    const frontFrame = screen.getByTitle(
+      'Clean Basic front preview'
+    ) as HTMLIFrameElement;
+    const backFrame = screen.getByTitle(
+      'Clean Basic back preview'
+    ) as HTMLIFrameElement;
+    expect(frontFrame.srcdoc).toContain('Capital of France?');
+    expect(backFrame.srcdoc).toContain('Paris');
+  });
+
   it('opens a preview dialog when the Preview button is clicked', async () => {
     getDefaults.mockResolvedValue([sampleStarter]);
     renderPage();

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-10-template-preview-fix.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-10-template-preview-fix.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-10-template-preview-fix",
+  "date": "2026-07-10",
+  "type": "fix",
+  "title": "Template preview popup shows the card content again instead of a blank panel"
+}


### PR DESCRIPTION
## What
The /templates preview popup rendered the card background but no text — blank front/back panels. The modal iframe now fills its wrapper directly instead of scaling a fixed 800×600 document with a container-query transform.

## Why
`transform: scale(100cqw / 800px)` relies on the wrapper's container inline-size. Inside the `<dialog>` opened via `showModal()`, that size isn't established when the iframe paints, so `100cqw` resolves to 0 → `scale(0)` collapses the card content to a point, leaving only the card background colour visible. The grid-card previews use the same trick but sit in normal flow (container width always resolved), which is why only the modal broke. Reported on prod; confirmed the data pipeline is fine (prod `/api/templates/defaults` payload carries full previewData, and the renderer outputs correct HTML) — the fault was purely this CSS scale timing.

## How
Wrapper drops `container-type`; iframe goes `width/height: 100%` with no transform. The preview document's own CSS is already viewport-responsive (`font-size: clamp(8px, 2.5vw, 16px)` on `html`), so the card renders correctly at the wrapper's size without manual scaling.

## Testing
New component test asserts both modal iframes carry the field content ("Capital of France?" / "Paris") in `srcDoc`. TemplatesPage suite 53 tests, full web vitest 249 files / 2 174, web tsc + oxfmt clean. sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

Changelog entry included (user-visible fix).

## Goal alignment
Conversion quality / trust: /templates is a paid-power-user surface; a blank preview makes the gallery look broken.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: CSS-only display fix + a srcDoc content assertion; verify visually by opening any template preview on `pnpm dev` — the card content now fills the panel.