### PR TITLE
fix: sign the session JWT with the user id, not the whole user row

### DIFF
--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -190,7 +190,7 @@ class UsersController {
         return res.status(401).json({ message: 'Wrong email or password.' });
       }
 
-      const token = await this.authService.newJWTToken(user);
+      const token = await this.authService.newJWTToken(user.id);
       if (token) {
         await this.authService.persistToken(token, user.id.toString());
         await this.userService.updateLastLoginAt(user.id.toString());
@@ -885,7 +885,7 @@ class UsersController {
 
     await this.userService.markEmailVerified(user.id.toString());
 
-    const token = await this.authService.newJWTToken(user);
+    const token = await this.authService.newJWTToken(user.id);
     if (!token) {
       console.info('Failed to create token');
       return res
@@ -1340,7 +1340,7 @@ class UsersController {
         .send('Unknown error. Please try again or register a new account.');
     }
 
-    const token = await this.authService.newJWTToken(user);
+    const token = await this.authService.newJWTToken(user.id);
     if (!token) {
       console.info('Failed to create token for Notion login');
       return res

--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -42,6 +42,26 @@ test('newJWTToken includes an expiration claim', async () => {
   expect(decoded.exp! - decoded.iat!).toBe(SESSION_MAX_AGE_MS / 1000);
 });
 
+test('newJWTToken payload carries only the numeric user id', async () => {
+  const service = createService();
+  const token = await service.newJWTToken(42);
+  const decoded = jwt.decode(token) as jwt.JwtPayload;
+
+  expect(decoded.userId).toBe(42);
+  expect(decoded).not.toHaveProperty('password');
+  expect(decoded).not.toHaveProperty('email');
+  // guards against a caller passing the whole user row (leaks the hash + PII
+  // and overflows the access_tokens btree index)
+  expect(Object.keys(decoded).sort()).toEqual(['exp', 'iat', 'userId']);
+});
+
+test('newJWTToken rejects a non-numeric user id', async () => {
+  const service = createService();
+  await expect(
+    service.newJWTToken({ id: 42, password: 'hash' } as unknown as number)
+  ).rejects.toThrow('numeric user id');
+});
+
 describe('isValidToken', () => {
   it('resolves true for a freshly signed token', async () => {
     const service = createService();

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -188,6 +188,11 @@ class AuthenticationService {
   }
 
   newJWTToken(userId: number): Promise<string> {
+    if (typeof userId !== 'number' || !Number.isFinite(userId)) {
+      return Promise.reject(
+        new Error('newJWTToken requires a numeric user id')
+      );
+    }
     return new Promise((resolve, reject) => {
       jwt.sign(
         { userId },

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-11-login-token-fix.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-11-login-token-fix.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-11-login-token-fix",
+  "date": "2026-07-11",
+  "type": "fix",
+  "title": "Signing in with email, Notion, or after email verification reliably keeps you logged in"
+}


### PR DESCRIPTION
## What
Three login paths — email/password (`UsersControllers.ts:193`), post-email-verification (`:888`), and Notion (`:1343`) — called `newJWTToken(user)` where the signature is `newJWTToken(userId: number)`. That embedded the **entire users row — bcrypt password hash, email, name, all columns — into the signed session JWT** handed to the client cookie. Fixed to pass `user.id`, plus a runtime guard so `newJWTToken` rejects a non-numeric argument (tsc couldn't catch it: `getByEmail` returns an untyped knex `.first()`).

## Why
Two impacts, found investigating a prod `access_tokens` index error:
1. **Credential/PII exposure.** JWTs are signed, not encrypted — the password hash + PII were base64-readable by anyone who could see the cookie (the user in devtools, any log capturing cookies, any XSS). Every email/verify/Notion login.
2. **Silent logout.** A serialized user over ~2704 bytes overflowed `access_tokens_token_index` ("index row size 3480 exceeds maximum 2704"), the insert threw, no row was written, and `getUserFrom` (resolves the session by matching the token string to a DB row) returned null → logged out despite correct credentials. This was the prod error that surfaced it.

## How
`user` → `user.id` at the 3 sites; guard in `newJWTToken`. Token drops ~3.4 KB → ~180 bytes. `getUserFrom` derives owner from the `access_tokens.owner` column, not the JWT payload, so existing cookies keep resolving — **no forced logout on deploy**.

## Remediation note (your call)
Already-issued oversized cookies (full-user tokens under the 2704-byte limit that DID insert) still carry the hash in users' browsers until they expire (SESSION_MAX_AGE). To purge immediately you'd `DELETE FROM access_tokens WHERE length(token) > 500` on prod, which force-logs-out those users. Destructive + a product call — I did not run it. Say the word and I'll do it in a supervised step.

## Testing
New tests: payload is exactly `{userId, iat, exp}` with no `password`/`email`; guard rejects a non-numeric arg. AuthenticationService + UsersControllers suites 180 tests green, server tsc clean, oxfmt/oxlint clean. sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

Changelog entry included (user-facing: the silent-logout case).

## Security review
Auth-path change — `/security-review` to run before merge.

## Goal alignment
Trust/security: stops leaking password hashes to clients and fixes a silent auth failure on core login flows.

## Browser check
Browser check: not applicable — server-side token construction; no rendered output. Changelog JSON is the only web/src file.