### PR TITLE
fix: soft-delete on immediate cancel so /ops churn is exact

### DIFF
--- a/src/services/SubscriptionService.test.ts
+++ b/src/services/SubscriptionService.test.ts
@@ -235,6 +235,12 @@ describe('SubscriptionService.cancelUserSubscriptions', () => {
       cancel_at_period_end: true,
       cancel_at: periodEndSeconds,
     });
+    stripe.subscriptions.cancel.mockResolvedValue({
+      ...activeSub,
+      status: 'canceled',
+      canceled_at: periodEndSeconds,
+      ended_at: periodEndSeconds,
+    });
   });
 
   it('schedules cancellation at period end by default', async () => {
@@ -257,14 +263,23 @@ describe('SubscriptionService.cancelUserSubscriptions', () => {
     expect(sendScheduledEmail).not.toHaveBeenCalled();
   });
 
-  it('deletes the local DB subscription rows on immediate cancel', async () => {
+  it('soft-deletes the local DB subscription row on immediate cancel so churn keeps it', async () => {
     const db = buildDbMock();
     (getDatabase as jest.Mock).mockReturnValue(db);
 
     await SubscriptionService.cancelUserSubscriptions(email, 'immediate');
 
-    expect(db.deleteSpy).toHaveBeenCalled();
-    expect(db.updateSpy).not.toHaveBeenCalled();
+    expect(db.deleteSpy).not.toHaveBeenCalled();
+    expect(db.updateSpy).toHaveBeenCalledTimes(1);
+    const updatePayload = db.updateSpy.mock.calls[0][0] as {
+      active: boolean;
+      payload: string;
+    };
+    expect(updatePayload.active).toBe(false);
+    expect(JSON.parse(updatePayload.payload).status).toBe('canceled');
+    expect(db.whereRawSpy).toHaveBeenCalledWith("payload->>'id' = ?", [
+      'sub_123',
+    ]);
   });
 
   it('does not touch the DB for period_end cancel', async () => {
@@ -412,9 +427,15 @@ describe('SubscriptionService.cancelSubscriptionById', () => {
     expect(stripe.subscriptions.update).not.toHaveBeenCalled();
   });
 
-  it('deletes only the targeted DB row scoped by the Stripe id on immediate cancel', async () => {
+  it('soft-deletes only the targeted DB row scoped by the Stripe id on immediate cancel', async () => {
     const db = buildDbMock();
     (getDatabase as jest.Mock).mockReturnValue(db);
+    stripe.subscriptions.cancel.mockResolvedValue({
+      id: 'sub_owned',
+      status: 'canceled',
+      canceled_at: 1800000000,
+      ended_at: 1800000000,
+    });
 
     await SubscriptionService.cancelSubscriptionById(
       email,
@@ -425,7 +446,14 @@ describe('SubscriptionService.cancelSubscriptionById', () => {
     expect(db.whereRawSpy).toHaveBeenCalledWith("payload->>'id' = ?", [
       'sub_owned',
     ]);
-    expect(db.deleteSpy).toHaveBeenCalledTimes(1);
+    expect(db.deleteSpy).not.toHaveBeenCalled();
+    expect(db.updateSpy).toHaveBeenCalledTimes(1);
+    const updatePayload = db.updateSpy.mock.calls[0][0] as {
+      active: boolean;
+      payload: string;
+    };
+    expect(updatePayload.active).toBe(false);
+    expect(JSON.parse(updatePayload.payload).status).toBe('canceled');
   });
 
   it('does not touch the DB for period_end cancel', async () => {

--- a/src/services/SubscriptionService.ts
+++ b/src/services/SubscriptionService.ts
@@ -7,6 +7,19 @@ import { isPaused } from '../lib/subscriptions/isPaused';
 
 export type CancelMode = 'immediate' | 'period_end';
 
+async function softDeleteLocalSubscription(
+  db: ReturnType<typeof getDatabase>,
+  stripeSubscriptionId: string,
+  canceledPayload: StripeTypes.Subscription
+): Promise<void> {
+  await db('subscriptions')
+    .whereRaw("payload->>'id' = ?", [stripeSubscriptionId])
+    .update({
+      active: false,
+      payload: JSON.stringify(canceledPayload),
+    });
+}
+
 export const VALID_PAUSE_MONTHS = [1, 2, 3] as const;
 export type PauseMonths = (typeof VALID_PAUSE_MONTHS)[number];
 const MIN_TENURE_DAYS_TO_PAUSE = 30;
@@ -141,10 +154,13 @@ export class SubscriptionService {
       `Found ${subs.length} active Stripe subscription(s) to process`
     );
 
+    const db = getDatabase();
+
     for (const sub of subs) {
       if (mode === 'immediate') {
         console.log(`Cancelling Stripe subscription ${sub.id} immediately`);
-        await stripe.subscriptions.cancel(sub.id);
+        const canceled = await stripe.subscriptions.cancel(sub.id);
+        await softDeleteLocalSubscription(db, sub.id, canceled);
         if (sendEmail) {
           await emailService.sendSubscriptionCancelledEmail(
             userEmail,
@@ -170,18 +186,6 @@ export class SubscriptionService {
       }
     }
 
-    if (mode === 'immediate' && subs.length > 0) {
-      const normalized = userEmail.toLowerCase();
-      const db = getDatabase();
-      await db('subscriptions')
-        .where(function () {
-          this.where({ email: normalized }).orWhere({
-            linked_email: normalized,
-          });
-        })
-        .delete();
-    }
-
     return subs.length;
   }
 
@@ -199,9 +203,8 @@ export class SubscriptionService {
     const stripe = getStripe();
 
     if (mode === 'immediate') {
-      await stripe.subscriptions.cancel(id);
-      const db = getDatabase();
-      await db('subscriptions').whereRaw("payload->>'id' = ?", [id]).delete();
+      const canceled = await stripe.subscriptions.cancel(id);
+      await softDeleteLocalSubscription(getDatabase(), id, canceled);
     } else {
       await stripe.subscriptions.update(id, { cancel_at_period_end: true });
     }


### PR DESCRIPTION
## What
Self-serve immediate cancels now **soft-delete** the local subscriptions row (active:false + the canceled Stripe payload) instead of hard-DELETEing it, at both sites: `cancelUserSubscriptions` (bulk) and `cancelSubscriptionById` (by `payload->>'id'`). Shared `softDeleteLocalSubscription` helper.

## Why
Fixes #3519 (follow-up to #3500, which moved /ops metrics onto the local table). Naturally-ended subs are retained by the reconcile (active:false, `ended_at` in payload) and counted by churn; immediate-cancel rows vanished, so `computeChurn30dPct` / net-new / conversions-vs-churn timeseries ran slightly under. Keeping the row with its canceled payload (same `ended_at` shape) makes churn exact.

## Safety
A soft-deleted row is correctly **not entitled** — every access gate keys on `active:true` (`getIsSubscriber`, `hasAnkifyAccess`), so an inactive row fails all of them. Verified. No migration — reuses existing `active` + `payload` columns. Removes a destructive DELETE in favor of an update.

## Testing
Both immediate-cancel tests rewritten to assert soft-delete (update with active:false + canceled payload, scoped by payload id, no delete). SubscriptionService + ops + subscription-controller suites 105 tests green, server tsc clean, oxfmt/oxlint clean. sonar-scanner not run locally (no SONAR_TOKEN); Automatic Analysis covers the push.

No changelog entry — ops-metrics accuracy, not user-facing (per the issue: "Not user-facing").

## Goal alignment
Revenue instrumentation: churn/MRR reads drive the retention lane; this makes the churn number exact rather than under-counted.

## Security review
Cancel flow (payments-adjacent) — `/security-review` to run before merge.

Browser check: not applicable — server-side metrics/cancel logic, no rendered output.