### PR TITLE
feat: instrument downloads_page_viewed and paywall_dismissed funnel events

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -54,6 +54,7 @@ export const KNOWN_EVENTS = new Set([
   'account_offer_clicked',
   'signup_completed',
   'upload_page_viewed',
+  'downloads_page_viewed',
   'onboarding_shown',
   'onboarding_skipped',
   'onboarding_completed',

--- a/web/src/lib/analytics/events.ts
+++ b/web/src/lib/analytics/events.ts
@@ -39,6 +39,7 @@ export const KNOWN_EVENTS = new Set([
   'cancel_during_generating',
   'signup_completed',
   'upload_page_viewed',
+  'downloads_page_viewed',
   'onboarding_shown',
   'onboarding_skipped',
   'onboarding_completed',

--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -983,6 +983,82 @@ describe('DownloadsPage make another deck CTA', () => {
   });
 });
 
+describe('DownloadsPage view telemetry', () => {
+  let fetchCalls: { url: string; body: Record<string, unknown> }[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-11T12:00:00Z'));
+    fetchCalls = [];
+    (globalThis as AnalyticsGlobals).hj = vi.fn();
+    (globalThis as AnalyticsGlobals).gtag = vi.fn();
+    globalThis.fetch = vi
+      .fn()
+      .mockImplementation((url: string, init?: RequestInit) => {
+        if (typeof url === 'string') {
+          try {
+            fetchCalls.push({
+              url,
+              body: JSON.parse((init?.body as string) ?? '{}'),
+            });
+          } catch {
+            /* ignore */
+          }
+        }
+        return Promise.resolve(new Response(null, { status: 200 }));
+      });
+    mockJobs = [buildJob({ status: 'done', download_key: 'deck.apkg' })];
+    mockUploads = [];
+    mockDropboxUploads = [];
+    mockGoogleDriveUploads = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete (globalThis as AnalyticsGlobals).hj;
+    delete (globalThis as AnalyticsGlobals).gtag;
+  });
+
+  const downloadsPageViewedCalls = () =>
+    fetchCalls.filter(
+      (c) =>
+        c.url === '/api/events/track' &&
+        c.body?.name === 'downloads_page_viewed'
+    );
+
+  it('fires downloads_page_viewed once on mount', () => {
+    renderAt('/downloads');
+    expect(downloadsPageViewedCalls()).toHaveLength(1);
+  });
+
+  it('fires downloads_page_viewed only once across a re-render', () => {
+    const { rerender } = render(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <MemoryRouter initialEntries={['/downloads']}>
+          <DownloadsPage setError={vi.fn()} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    rerender(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <MemoryRouter initialEntries={['/downloads']}>
+          <DownloadsPage setError={vi.fn()} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+    expect(downloadsPageViewedCalls()).toHaveLength(1);
+  });
+});
+
 describe('DownloadsPage truncation notice', () => {
   const truncatedJob = (subDeckRulesSkipped: boolean) =>
     buildJob({

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { useSearchParams, Link, useNavigate } from 'react-router-dom';
 
 import useUploads from './hooks/useUploads';
@@ -326,7 +332,14 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
     null
   );
   const [hasDownloaded, setHasDownloaded] = useState(false);
+  const pageViewTracked = useRef(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (pageViewTracked.current) return;
+    pageViewTracked.current = true;
+    track('downloads_page_viewed');
+  }, []);
 
   const rawFilter = searchParams.get('filter') ?? 'all';
   const activeFilter: FilterValue = VALID_FILTERS.has(rawFilter as FilterValue)

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.test.tsx
@@ -191,6 +191,55 @@ describe('PaywallBanner', () => {
     });
   });
 
+  it('fires paywall_dismissed on unmount when the user never clicked upgrade', async () => {
+    const { track } = await import('../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+    trackMock.mockClear();
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <PaywallBanner inProgressJob={null} />
+      </MemoryRouter>
+    );
+
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'paywall_dismissed',
+      expect.anything()
+    );
+
+    unmount();
+
+    expect(trackMock).toHaveBeenCalledWith('paywall_dismissed', {
+      surface: 'downloads_banner',
+    });
+  });
+
+  it('does not fire paywall_dismissed when the user clicked upgrade before unmount', async () => {
+    startUnlimitedCheckout.mockResolvedValue({
+      url: 'https://checkout.test/s',
+    });
+    const { track } = await import('../../../lib/analytics/track');
+    const trackMock = vi.mocked(track);
+
+    const { unmount } = render(
+      <MemoryRouter>
+        <PaywallBanner inProgressJob={null} />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      fireEvent.click(getUpgradeButton());
+    });
+
+    trackMock.mockClear();
+    unmount();
+
+    expect(trackMock).not.toHaveBeenCalledWith(
+      'paywall_dismissed',
+      expect.anything()
+    );
+  });
+
   it('starts an Unlimited checkout and redirects to the returned Stripe url', async () => {
     startUnlimitedCheckout.mockResolvedValue({
       url: 'https://checkout.stripe.test/session-123',

--- a/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
+++ b/web/src/pages/DownloadsPage/components/PaywallBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import JobResponse from '../../../schemas/public/JobResponse';
@@ -16,13 +16,22 @@ const SEE_ALL_PLANS_HREF = '/pricing?source=paywall-cancel';
 
 export function PaywallBanner({ inProgressJob }: PaywallBannerProps) {
   const [pending, setPending] = useState(false);
+  const upgradeClickedRef = useRef(false);
 
   useEffect(() => {
     firePaywallEvent('paywall_shown');
     track('paywall_shown', { surface: 'downloads_banner' });
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (upgradeClickedRef.current) return;
+      track('paywall_dismissed', { surface: 'downloads_banner' });
+    };
+  }, []);
+
   const handleUpgrade = async () => {
+    upgradeClickedRef.current = true;
     firePaywallEvent('paywall_clicked_upgrade');
     track('paywall_upgrade_clicked', { surface: 'downloads_banner' });
     setPending(true);


### PR DESCRIPTION
## What
Fills two blind spots in the download → paywall funnel: `downloads_page_viewed` now fires once when the My decks list mounts, and `paywall_dismissed` now fires when the downloads-banner paywall is dismissed (component unmounts without an upgrade click), mirroring the existing UpsellCard pattern. Registers `downloads_page_viewed` in the web and server event registries.

## Why
The spec asked for five download/paywall funnel events. Investigating each against the code turned up three problems, so this PR ships the clean, non-destructive subset and flags the rest for your call:

- **`downloads_page_viewed`** — genuinely missing. Shipped.
- **`paywall_dismissed`** — the spec said "defined but never fires." That's inaccurate: it already fires from `UpsellCard` on unmount-without-upgrade (including on this page, surface `downloads_upsell`). The real gap is the `PaywallBanner` (surface `downloads_banner`), which never fired it. Wired there.
- **`paywall_upgrade_clicked` / `paywall_pass_clicked`** — already fire and are already tested (PaywallBanner + ConversionResult). No change needed.
- **`download_initiated` (rename of `deck_downloaded`)** — NOT done. `deck_downloaded` is a load-bearing funnel stage consumed by the ops UploadFunnel dashboard (server + web), the median-time SQL, and the bulk path in `DownloadController`. Renaming it on this page would split the metric and drop DownloadsPage downloads out of the funnel. It already serves the "initiation" semantic.
- **`download_completed` (fetch-resolved)** — NOT done. The DownloadsPage download is a same-origin `<a href>` streamed download. A true completion signal requires replacing it with a blob-fetch, which violates the explicit "Do not change download logic" constraint, degrades the core stored-file path (loses native streaming, must reconstruct the filename, holds large decks in memory), and breaks the exported `renderJobStatusCell` href contract plus several tests.

## How
- `DownloadsPage.tsx`: ref-guarded mount `useEffect` fires `track('downloads_page_viewed')` once (mirrors `upload_page_viewed`).
- `PaywallBanner.tsx`: `upgradeClickedRef` set in `handleUpgrade`; an unmount `useEffect` fires `track('paywall_dismissed', { surface: 'downloads_banner' })` unless upgrade was clicked. No X button added — dismissal is inferred from unmount, matching UpsellCard, so paywall UX is unchanged.
- Added `downloads_page_viewed` to both `web/src/lib/analytics/events.ts` and `src/types/AnalyticsEvents.ts` so the server doesn't flag it `unknown`.

## Measuring success
Query the events table: `select count(*) from events where name = 'downloads_page_viewed'` should climb post-deploy, and `select props->>'surface', count(*) from events where name = 'paywall_dismissed' group by 1` should now show a `downloads_banner` row alongside the existing `downloads_upsell`. Read via `/api/ops/metrics`. The banner's dismissal-vs-upgrade ratio (`paywall_dismissed` vs `paywall_upgrade_clicked` at surface `downloads_banner`) becomes the conversion signal for that paywall.

## Testing
- Unit tests added:
  - DownloadsPage: `downloads_page_viewed` fires exactly once on mount, and only once across a re-render.
  - PaywallBanner: `paywall_dismissed` fires on unmount without an upgrade click, does not fire on mount, does not fire when upgrade was clicked before unmount.
- Full runs green: both affected vitest files (56 tests), server `EventsController` + `TrackEventUseCase` (99 tests), web typecheck, server `tsc -p . --noEmit`, web lint (no new warnings).

## Browser check
Browser check: not applicable — analytics instrumentation only, no rendered output or interaction change.

## Changelog
No changelog entry — internal analytics instrumentation, no user-visible behavior change.
No entry — internal instrumentation, no user-visible behavior change.

## Risks
Low. Two new `track` calls and one Set entry per registry; no rendered output, no download-path change, no paywall UX change. If `paywall_dismissed` from the banner proves noisy (e.g. fires on route changes we don't consider dismissals), it's a one-line revert of the unmount effect. Sonar not run locally (no scanner in this environment) — the change is two small hooks, no new branching or complexity.

## Goal alignment
Moves the funnel-visibility lever, not a user-facing surface. The download → paywall step of the acquisition/conversion funnel was partly unmeasured; `downloads_page_viewed` gives the top of the My-decks funnel and the `downloads_banner` `paywall_dismissed`/`paywall_upgrade_clicked` pair makes that paywall's conversion rate readable at `/api/ops/metrics`. Enables prioritization toward the MRR goal; no direct MRR movement itself.