### PR TITLE
fix: hide the chat message counter for paid subscribers

### DIFF
--- a/web/src/components/ChatPanel/ChatPanel.test.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.test.tsx
@@ -1040,3 +1040,31 @@ describe('consumeSseEvents', () => {
     expect(received).toEqual([['token', '"split"']]);
   });
 });
+
+describe('ChatPanel — monthly usage counter', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  it('shows the free counter when the usage endpoint returns a numeric limit', async () => {
+    mockGet.mockResolvedValue({ used: 18, limit: 20 });
+    renderChatPanel();
+
+    expect(
+      await screen.findByText('2 of 20 messages left this month')
+    ).toBeInTheDocument();
+  });
+
+  it('hides the counter for premium users (limit null), even with messages used', async () => {
+    mockGet.mockResolvedValue({ used: 18, limit: null });
+    renderChatPanel();
+
+    await waitFor(() => {
+      expect(get).toHaveBeenCalledWith('/api/chat/usage', { redirect: false });
+    });
+
+    expect(
+      screen.queryByText(/messages left this month/)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/ChatPanel/ChatPanel.tsx
+++ b/web/src/components/ChatPanel/ChatPanel.tsx
@@ -570,7 +570,6 @@ export default function ChatPanel({
   onTemplateChange,
 }: ChatPanelProps) {
   const { data: userLocals, refetch: refetchUserLocals } = useUserLocals();
-  const isPatreon = userLocals?.user?.patreon === true;
   const hasConsented = userLocals?.user?.chat_consent_at != null;
   const [showConsentModal, setShowConsentModal] = useState(false);
   const [userDismissedConsent, setUserDismissedConsent] = useState(false);
@@ -602,6 +601,7 @@ export default function ChatPanel({
   const [limitReached, setLimitReached] = useState(false);
   const [resetDate, setResetDate] = useState<string | null>(null);
   const [messagesUsedThisMonth, setMessagesUsedThisMonth] = useState(0);
+  const [monthlyLimit, setMonthlyLimit] = useState<number | null>(null);
   const [chips, setChips] = useState<AttachmentChip[]>([]);
   const [isDragging, setIsDragging] = useState(false);
   const [userScrolledAway, setUserScrolledAway] = useState(false);
@@ -616,6 +616,7 @@ export default function ChatPanel({
       .then((data: ApiUsageResponse | undefined) => {
         if (data != null) {
           setMessagesUsedThisMonth(data.used);
+          setMonthlyLimit(data.limit);
           if (data.limit != null && data.used >= data.limit) {
             setLimitReached(true);
           }
@@ -668,7 +669,8 @@ export default function ChatPanel({
     return () => clearTimeout(handle);
   }, [inputValue, activeConversationId]);
 
-  const remainingMessages = FREE_MONTHLY_LIMIT - messagesUsedThisMonth;
+  const remainingMessages =
+    (monthlyLimit ?? FREE_MONTHLY_LIMIT) - messagesUsedThisMonth;
 
   const readyChips = chips.filter((c) => c.state === 'idle');
   const canSend =
@@ -1116,13 +1118,15 @@ export default function ChatPanel({
               {networkError != null && (
                 <p className={styles.networkError}>{networkError}</p>
               )}
-              {!isPatreon && !limitReached && messagesUsedThisMonth > 0 && (
-                <p className={styles.usageLine}>
-                  {remainingMessages === 1
-                    ? '1 message left this month — your next send uses it'
-                    : `${remainingMessages} of ${FREE_MONTHLY_LIMIT} messages left this month`}
-                </p>
-              )}
+              {monthlyLimit != null &&
+                !limitReached &&
+                messagesUsedThisMonth > 0 && (
+                  <p className={styles.usageLine}>
+                    {remainingMessages === 1
+                      ? '1 message left this month — your next send uses it'
+                      : `${remainingMessages} of ${monthlyLimit} messages left this month`}
+                  </p>
+                )}
             </div>
           </div>
         ) : (
@@ -1230,13 +1234,15 @@ export default function ChatPanel({
                 </div>
               )}
               <ComposerPill {...composerProps} />
-              {!isPatreon && !limitReached && messagesUsedThisMonth > 0 && (
-                <p className={styles.usageLine}>
-                  {remainingMessages === 1
-                    ? '1 message left this month — your next send uses it'
-                    : `${remainingMessages} of ${FREE_MONTHLY_LIMIT} messages left this month`}
-                </p>
-              )}
+              {monthlyLimit != null &&
+                !limitReached &&
+                messagesUsedThisMonth > 0 && (
+                  <p className={styles.usageLine}>
+                    {remainingMessages === 1
+                      ? '1 message left this month — your next send uses it'
+                      : `${remainingMessages} of ${monthlyLimit} messages left this month`}
+                  </p>
+                )}
               {networkError != null && (
                 <p className={styles.networkError}>{networkError}</p>
               )}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-12-chat-counter-subscribers.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-12-chat-counter-subscribers.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-12-chat-counter-subscribers",
+  "date": "2026-07-12",
+  "type": "fix",
+  "title": "Chat message counter hidden for paid subscribers"
+}


### PR DESCRIPTION
## What
The chat "X of 20 messages left this month" counter no longer renders for paid subscribers. It was gated only on the lifetime `patreon` flag, so Stripe and Unlimited subscribers (`patreon = false`, `subscriber = true`) saw a free-tier quota counter.

## Why
A paying Unlimited annual subscriber reported the chat saying "18 of 20 messages left for this month" and worried they were being quota-capped — while the docs say the 20/mo limit is free-plan only. It was a **display-only** defect: the server never limited them. `assertWithinMonthlyQuota` bypasses on `isPremium = patreon || subscriber`, and `GET /api/chat/usage` already returns `limit: null` for premium. But `ChatPanel` fetched that response, kept only `used`, discarded `limit`, and computed the counter from a hardcoded `FREE_MONTHLY_LIMIT = 20`, gated on `isPatreon` (lifetime only). A worried paying customer is a churn/refund risk.

## How
Make `/api/chat/usage`'s `limit` the single source of truth in `ChatPanel`:
- store `limit` in a `monthlyLimit` state (`number | null`)
- hide both counter render sites when `monthlyLimit === null`
- render the real `monthlyLimit` in the "of N" string instead of the constant
- drop the now-unused `isPatreon` derivation — the endpoint already resolves premium via `patreon || subscriber`, so this fixes lifetime, Stripe, and Unlimited-pass users in one change

## Measuring success
No metric target — trust/support fix. Should reduce "am I being quota-limited?" support contacts from paid chat users.

## Testing
- New Vitest cases in `ChatPanel.test.tsx`: `limit: 20, used: 18` → "2 of 20 messages left this month"; `limit: null, used: 18` → no counter. Wrote the premium case failing first, watched it show "2 of 20", then fixed.
- Full web suite green (2176 tests).
- `pnpm --filter 2anki-web test:golden-path` green — no console errors at 375px.

## Risks
Low — frontend-only, conditional render. No server/quota change.

## Goal alignment
Protects retention/ARPU (the stated MRR levers) by not scaring a paying subscriber into thinking they hit a cap they don't have.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path spec green; chat-specific premium/free counter behavior covered by the two new Vitest cases.