### PR TITLE
style: declutter the landing hero control row

### DIFF
--- a/web/src/pages/HomePage/HomePage.module.css
+++ b/web/src/pages/HomePage/HomePage.module.css
@@ -38,14 +38,16 @@
 
 .heroControls {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin: 1rem auto 0.75rem;
+  justify-content: center;
+  margin: 1rem auto 1.25rem;
+  max-width: 520px;
 }
 
 .heroAiBadge {
   margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-align: center;
 }
 
 .cardOptionsLink {

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -222,6 +222,9 @@ export function HomePage({
             </Link>
             .
           </p>
+        </div>
+        <UploadForm setErrorMessage={setErrorMessage} />
+        <div className={styles.heroFooter}>
           <Link
             to="/card-options"
             className={styles.cardOptionsLink}
@@ -229,6 +232,7 @@ export function HomePage({
           >
             Card options
           </Link>
+          <span className={styles.footerDot} aria-hidden="true" />
           <Link
             to="/app"
             className={styles.cardOptionsLink}
@@ -237,7 +241,6 @@ export function HomePage({
             Also on iPhone, iPad &amp; Mac →
           </Link>
         </div>
-        <UploadForm setErrorMessage={setErrorMessage} />
       </section>
 
       <section className={styles.stepsSection}>


### PR DESCRIPTION
## What
Cleans up the three-link control row above the upload dropzone on the anon landing hero. The AI nudge stays as one centered, muted line directly above the dropzone; "Card options" and "Also on iPhone, iPad & Mac →" move into the existing (previously dormant) `.heroFooter` dot-separated row below the dropzone.

## Why
User-reported: the row was ugly. `.heroControls` was a `space-between` flex row cramming a full AI-upsell sentence (wrapped to two lines on the left) beside two same-styled links (one line, right), with three competing CTAs stacked above the primary upload action.

## How
- `.heroControls` now holds only the AI nudge, centered, `text-sm`, `--color-text-secondary`.
- The two secondary links move below the upload form into `.heroFooter` (already defined in the module CSS, was unused) with a `.footerDot` separator.
- Same links, same destinations, same `track()` events (`home_ai_anon_badge_clicked`, `home_card_options_link_clicked`, `home_native_app_link_clicked`) — layout only.

## Trio
- **designer**: keep AI nudge above dropzone as one muted line; relocate the two links to the dormant `.heroFooter` pattern (verdict: ship).
- **pm**: all three are secondary to "upload a file"; native-app + card-options don't earn hero space above the fold. (PM also floated moving the AI nudge to a post-upload surface — deferred: that surface doesn't exist yet, would be a separate spec, out of scope for a layout fix.)
- **engineer**: pure CSS/JSX reflow, no logic.

## Testing
- Existing HomePage tests' link assertions still pass (links relocated, not removed).
- Full web suite green (2191). Typecheck + oxfmt clean.
- Golden-path spec green.

## Goal alignment
Acquisition lane: a cleaner hero with one focused action above the dropzone reduces distraction on the primary activation surface. No metric target — cosmetic declutter.

## Changelog
No entry — cosmetic reflow of the anon landing hero; no capability or behavior change a user "can now do".

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: golden-path spec green; links + tracking unchanged, verified by existing HomePage tests.
