### PR TITLE
fix: align premium status flags with real access gates

### DIFF
--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -21,6 +21,7 @@ import type AuthenticationService from '../../services/AuthenticationService';
 import type { UserWithOwner } from '../../services/AuthenticationService';
 import type UsersService from '../../services/UsersService';
 import type { PersistStripeSessionUseCase } from '../../usecases/checkout/PersistStripeSessionUseCase';
+import type { IUserPassRepository } from '../../data_layer/UserPassRepository';
 import type Subscriptions from '../../data_layer/public/Subscriptions';
 import type { SubscriptionsId } from '../../data_layer/public/Subscriptions';
 import type { UsersId } from '../../data_layer/public/Users';
@@ -126,6 +127,7 @@ interface ControllerHarness {
   usersService: { updateSubScriptionEmailUsingPrimaryEmail: jest.Mock };
   persistStripeSessionUseCase: { execute: jest.Mock };
   stripe: StripeMock;
+  userPassRepository: { findActive: jest.Mock };
 }
 
 function buildController(): ControllerHarness {
@@ -141,11 +143,15 @@ function buildController(): ControllerHarness {
   const stripe: StripeMock = {
     checkout: { sessions: { retrieve: jest.fn() } },
   };
+  const userPassRepository = {
+    findActive: jest.fn().mockResolvedValue(null),
+  };
   const controller = new StripeController(
     authService as unknown as AuthenticationService,
     usersService as unknown as UsersService,
     persistStripeSessionUseCase as unknown as PersistStripeSessionUseCase,
-    stripe as unknown as Pick<StripeTypes, 'checkout'>
+    stripe as unknown as Pick<StripeTypes, 'checkout'>,
+    userPassRepository as unknown as IUserPassRepository
   );
   return {
     controller,
@@ -153,6 +159,7 @@ function buildController(): ControllerHarness {
     usersService,
     persistStripeSessionUseCase,
     stripe,
+    userPassRepository,
   };
 }
 
@@ -177,6 +184,29 @@ describe('StripeController', () => {
       expect(h.persistStripeSessionUseCase.execute).toHaveBeenCalledWith(
         'cs_test_123'
       );
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ hasActiveSubscription: true })
+      );
+    });
+
+    it('returns hasActiveSubscription true when the user holds an active pass', async () => {
+      const h = buildController();
+      mockedExtractToken.mockReturnValue('abc');
+      h.authService.getUserFrom.mockResolvedValue(buildUser({ patreon: false }));
+      mockedGetActiveSubscriptions.mockResolvedValue([]);
+      h.userPassRepository.findActive.mockResolvedValue({
+        id: 1,
+        user_id: 1,
+        kind: 'unlimited',
+        expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        stripe_payment_intent_id: 'apple:tx_1',
+      });
+
+      const req = mockRequest();
+      const res = mockResponse();
+
+      await h.controller.checkSubscriptionStatus(req, res);
+
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({ hasActiveSubscription: true })
       );

--- a/src/controllers/StripeController/StripeController.test.ts
+++ b/src/controllers/StripeController/StripeController.test.ts
@@ -192,7 +192,9 @@ describe('StripeController', () => {
     it('returns hasActiveSubscription true when the user holds an active pass', async () => {
       const h = buildController();
       mockedExtractToken.mockReturnValue('abc');
-      h.authService.getUserFrom.mockResolvedValue(buildUser({ patreon: false }));
+      h.authService.getUserFrom.mockResolvedValue(
+        buildUser({ patreon: false })
+      );
       mockedGetActiveSubscriptions.mockResolvedValue([]);
       h.userPassRepository.findActive.mockResolvedValue({
         id: 1,

--- a/src/controllers/StripeController/StripeController.ts
+++ b/src/controllers/StripeController/StripeController.ts
@@ -7,6 +7,7 @@ import type UsersService from '../../services/UsersService';
 import { extractTokenFromCookies } from './extractTokenFromCookies';
 import SubscriptionService from '../../services/SubscriptionService';
 import type { PersistStripeSessionUseCase } from '../../usecases/checkout/PersistStripeSessionUseCase';
+import type { IUserPassRepository } from '../../data_layer/UserPassRepository';
 
 type StripeClient = Pick<StripeTypes, 'checkout'>;
 
@@ -15,7 +16,8 @@ export class StripeController {
     private readonly authService: AuthenticationService,
     private readonly usersService: UsersService,
     private readonly persistStripeSessionUseCase: PersistStripeSessionUseCase,
-    private readonly stripe: StripeClient
+    private readonly stripe: StripeClient,
+    private readonly userPassRepository: IUserPassRepository
   ) {}
 
   async getSuccessfulCheckout(req: express.Request, res: express.Response) {
@@ -61,7 +63,15 @@ export class StripeController {
       const activeSubscriptions =
         await SubscriptionService.getUserActiveSubscriptions(user.email);
       let hasActiveSubscription =
-        activeSubscriptions.length > 0 || user.patreon;
+        activeSubscriptions.length > 0 || user.patreon === true;
+
+      if (!hasActiveSubscription) {
+        const activePass = await this.userPassRepository.findActive(
+          user.id,
+          new Date()
+        );
+        hasActiveSubscription = activePass != null;
+      }
 
       if (!hasActiveSubscription) {
         const sessionId = req.query.session_id as string;

--- a/src/controllers/UsersControllers.test.ts
+++ b/src/controllers/UsersControllers.test.ts
@@ -2463,6 +2463,42 @@ describe('UsersController.getLocals', () => {
     expect(payload.user.email_verified).toBe(true);
   });
 
+  it('marks autoSyncActive true for a patreon lifetime user with no Auto Sync subscription', async () => {
+    (
+      SubscriptionService.getUserActiveSubscriptions as jest.Mock
+    ).mockResolvedValueOnce([]);
+    const mockUser = {
+      id: 42,
+      email: 'lifetime@example.com',
+      email_verified: true,
+      patreon: true,
+      ankify_welcome_seen: false,
+      hosted_anki_requested_at: null,
+      owner: 42,
+    };
+    const userService = {
+      getSubscriptionLinkedEmail: jest.fn().mockResolvedValue(null),
+    } as unknown as UsersService;
+    const authService = {
+      getUserFrom: jest.fn().mockResolvedValue(mockUser),
+    } as unknown as AuthenticationService;
+    const controller = new UsersController(
+      userService,
+      authService,
+      {} as ReturnType<typeof import('../data_layer').getDatabase>
+    );
+    const req = { cookies: { token: 'valid' } } as unknown as express.Request;
+    const res = {
+      locals: {},
+      json: jest.fn(),
+    } as unknown as express.Response & { json: jest.Mock };
+
+    await controller.getLocals(req, res);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.autoSyncActive).toBe(true);
+  });
+
   it('offers the pass ladder to a repeat pass buyer', async () => {
     mockCountPaidPassesSince.mockResolvedValueOnce({
       dayPasses: 2,

--- a/src/controllers/UsersControllers.ts
+++ b/src/controllers/UsersControllers.ts
@@ -40,6 +40,7 @@ import { track } from '../services/events/track';
 import { mapEntitlement } from './helpers/mapEntitlement';
 import { GetPassLadderOfferUseCase } from '../usecases/checkout/GetPassLadderOfferUseCase';
 import UserPassRepository from '../data_layer/UserPassRepository';
+import { hasAnkifyAccess } from '../lib/ankify/access';
 import { PlanSource } from '../routes/middleware/configureUserLocal';
 
 function readFirstTouchCookie(req: express.Request): FirstTouchAttribution {
@@ -347,14 +348,7 @@ class UsersController {
     const userSubs = user?.email
       ? await SubscriptionService.getUserActiveSubscriptions(user.email)
       : [];
-    const autoSyncActive =
-      autoSyncProductId !== '' &&
-      userSubs.some(
-        (s) =>
-          s.active &&
-          (s as { stripe_product_id?: string | null }).stripe_product_id ===
-            autoSyncProductId
-      );
+    const autoSyncActive = hasAnkifyAccess(user, userSubs, autoSyncProductId);
 
     let freePrintAvailable: boolean | null = null;
     if (user?.owner != null) {

--- a/src/routes/WebhookRouter.ts
+++ b/src/routes/WebhookRouter.ts
@@ -53,7 +53,8 @@ const WebhooksRouter = () => {
     authService,
     usersService,
     persistStripeSessionUseCase,
-    stripe
+    stripe,
+    new UserPassRepository(database)
   );
   const abandonedCheckoutRecoveryUseCase =
     new SendAbandonedCheckoutRecoveryOnExpiryUseCase(


### PR DESCRIPTION
## What
Aligns two premium status/display flags with the canonical access gates so they stop contradicting granted access.

- `getLocals` `autoSyncActive` (`UsersControllers.ts`): re-derived the Ankify gate inline and dropped the `patreon` OR-branch. A lifetime Patreon user with no Auto Sync Stripe subscription got `autoSyncActive: false` in the API/UI while actually passing `hasAnkifyAccess` at the real gate. Now reuses `hasAnkifyAccess(user, userSubs, AUTO_SYNC_PRODUCT_ID)` directly — single source of truth.
- `checkSubscriptionStatus` `hasActiveSubscription` (`StripeController.ts`): computed `activeSubscriptions.length > 0 || user.patreon`, ignoring active `UserPass` holders (incl `apple:` passes). A pass holder saw `hasActiveSubscription: false`. Now also checks `UserPassRepository.findActive`.

## Why
Both flags are what the frontend reads to decide whether to show a paid/premium signal, and both omitted a real premium path — a status that contradicts the access the user was actually granted. Display-only consistency; **no access gate is changed**.

## How
- `UsersControllers.getLocals`: replaced the inline `userSubs.some(...)` derivation with a call to `hasAnkifyAccess`.
- `StripeController`: injected `IUserPassRepository` via the constructor (wired in `WebhookRouter.ts`, the only production construction site) and added an `findActive` OR-branch to `checkSubscriptionStatus`. Both `new StripeController` sites (WebhookRouter + test harness) were updated.

## Measuring success
No new metric. A lifetime Patreon user's `GET /users/locals` response now returns `autoSyncActive: true`; a pass holder's `checkSubscriptionStatus` returns `hasActiveSubscription: true`. Confirmable via the existing response bodies for those two endpoints.

## Testing
- Unit tests added:
  - `UsersControllers.test.ts` — patreon lifetime user with no Auto Sync subscription now yields `autoSyncActive: true` (fails against pre-fix source).
  - `StripeController.test.ts` — user with an active pass, no Stripe sub, not patreon now yields `hasActiveSubscription: true` (fails against pre-fix source).
- Both new tests verified red against the unfixed source, then green after the fix.
- Full suite for both files green (118 tests). `npx tsc -p . --noEmit` (deploy typechecks tests) exits 0 — the added 5th constructor param is wired at both `new StripeController` sites.
- Sonar: not run locally (no `SONAR_TOKEN` in this environment); change is a small logic simplification with no new nesting/complexity.

## Browser check
Browser check: not applicable — backend controller fix, no `web/src` change

## Changelog
No changelog entry — internal status-flag consistency, no user-visible behavior change. The two frontend consumers of `autoSyncActive` (`Sidebar.tsx`, `SendToAnkifyButton.tsx`) already OR `patreon` separately, so a lifetime user's badge was not visibly broken; this fixes the flag itself, not a rendered surface.

## Risks
Low. `StripeController` gains one DB read (`user_passes` lookup by `user_id`) only when the user has no active subscription and is not patreon — an indexed point lookup on a cold path. No gate logic changed, so no access can be granted or revoked by this PR. Rollback: revert the single commit.

## Goal alignment
None — internal. Corrects two paid-status display flags for existing premium users (lifetime Patreon, pass holders); no funnel or MRR metric moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
