### PR TITLE
fix: await configureUserLocal in RequirePaying middleware

### DIFF
--- a/src/routes/middleware/RequirePaying.test.ts
+++ b/src/routes/middleware/RequirePaying.test.ts
@@ -1,0 +1,77 @@
+import express, { NextFunction } from 'express';
+
+import { configureUserLocal } from './configureUserLocal';
+import RequirePaying from './RequirePaying';
+
+jest.mock('./configureUserLocal');
+jest.mock('../../data_layer', () => ({
+  getDatabase: jest.fn(() => ({})),
+}));
+jest.mock('../../data_layer/TokenRepository', () => jest.fn());
+jest.mock('../../data_layer/UsersRepository', () => jest.fn());
+jest.mock('../../services/AuthenticationService', () => jest.fn());
+
+const configureUserLocalMock = configureUserLocal as jest.MockedFunction<
+  typeof configureUserLocal
+>;
+
+function makeResponse(locals: Record<string, unknown>) {
+  const res = {
+    locals,
+    redirectedTo: undefined as string | undefined,
+    redirect(location: string) {
+      this.redirectedTo = location;
+      return this;
+    },
+  };
+  return res as unknown as express.Response & { redirectedTo: string | undefined };
+}
+
+describe('RequirePaying', () => {
+  beforeEach(() => {
+    configureUserLocalMock.mockReset();
+  });
+
+  it('lets a paying subscriber through once locals resolve asynchronously', async () => {
+    configureUserLocalMock.mockImplementation(async (_req, res) => {
+      await Promise.resolve();
+      res.locals.subscriber = true;
+    });
+    const res = makeResponse({});
+    const next = jest.fn() as unknown as NextFunction;
+
+    await RequirePaying({ cookies: {} } as express.Request, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.redirectedTo).toBeUndefined();
+  });
+
+  it('lets a lifetime patreon through once locals resolve asynchronously', async () => {
+    configureUserLocalMock.mockImplementation(async (_req, res) => {
+      await Promise.resolve();
+      res.locals.patreon = true;
+    });
+    const res = makeResponse({});
+    const next = jest.fn() as unknown as NextFunction;
+
+    await RequirePaying({ cookies: {} } as express.Request, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.redirectedTo).toBeUndefined();
+  });
+
+  it('redirects a genuinely non-paying user to /pricing', async () => {
+    configureUserLocalMock.mockImplementation(async (_req, res) => {
+      await Promise.resolve();
+      res.locals.subscriber = false;
+      res.locals.patreon = false;
+    });
+    const res = makeResponse({});
+    const next = jest.fn() as unknown as NextFunction;
+
+    await RequirePaying({ cookies: {} } as express.Request, res, next);
+
+    expect(res.redirectedTo).toBe('/pricing');
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/middleware/RequirePaying.test.ts
+++ b/src/routes/middleware/RequirePaying.test.ts
@@ -24,7 +24,9 @@ function makeResponse(locals: Record<string, unknown>) {
       return this;
     },
   };
-  return res as unknown as express.Response & { redirectedTo: string | undefined };
+  return res as unknown as express.Response & {
+    redirectedTo: string | undefined;
+  };
 }
 
 describe('RequirePaying', () => {

--- a/src/routes/middleware/RequirePaying.ts
+++ b/src/routes/middleware/RequirePaying.ts
@@ -7,7 +7,7 @@ import { getDatabase } from '../../data_layer';
 import { configureUserLocal } from './configureUserLocal';
 import { isPaying } from '../../lib/isPaying';
 
-const RequirePaying = (
+const RequirePaying = async (
   req: express.Request,
   res: express.Response,
   next: NextFunction
@@ -17,7 +17,7 @@ const RequirePaying = (
     new TokenRepository(database),
     new UsersRepository(database)
   );
-  configureUserLocal(req, res, authService, database);
+  await configureUserLocal(req, res, authService, database);
 
   if (!isPaying(res.locals)) {
     return res.redirect('/pricing');

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-12-notion-block-paid-plans.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-12-notion-block-paid-plans.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-12-notion-block-paid-plans",
+  "date": "2026-07-12",
+  "type": "fix",
+  "title": "Editing and rendering Notion blocks works on paid plans"
+}


### PR DESCRIPTION
## What
`RequirePaying` middleware called `configureUserLocal` without `await`, so the `isPaying(res.locals)` check ran before `res.locals.patreon` / `res.locals.subscriber` were populated. Every request — including paying users — evaluated as non-paying and was redirected to `/pricing`. This blocked the two routes that use `RequirePaying` as their only entitlement gate: `DELETE /api/notion/block/:id` and `GET /api/notion/render-block/:id`.

## Why
Paying users (patreon lifetime, Stripe subscriber, or any active pass) could not delete or render Notion blocks — a hard entitlement failure for 100% of paid traffic on those routes. Fixes the missing-await finding in `src/routes/middleware/RequirePaying.ts:20`.

## How
Made `RequirePaying` `async` and awaited `configureUserLocal(...)`, matching the sibling `RequireAuthentication` / `RequireAllowedOrigin` middlewares that already await it. Express 5 handles async middleware natively (returned promise, errors propagate to `ErrorHandler`). Both call sites in `NotionRouter.ts` use it as a standard `RequestHandler` — no caller change needed. Grepped all usages: the only two are the Notion block routes.

## Measuring success
The `/pricing` redirect on `DELETE /api/notion/block/:id` and `GET /api/notion/render-block/:id` should stop for authenticated paying users — the 302→`/pricing` rate on those two paths in access logs drops to non-paying traffic only, and block delete/render 2xx responses return for paid accounts.

## Testing
- Unit tests added: `RequirePaying.test.ts` — reproduces the bug (paying subscriber / lifetime patreon reach `next()` once locals resolve async; the pre-fix code redirected them) and covers the genuine non-paying redirect. Failing-first confirmed: the two paying cases failed with "next not called, redirect fired" before the await, all green after.
- `npx tsc -p . --noEmit` clean (prod deploy typechecks tests).
- Web typecheck clean; changelog loader test green with the new entry.
- Sonar: `sonar-scanner` not run — no token in this environment; change is a one-keyword async/await fix with no new branching, so no new complexity/security smells expected.

## Browser check
Browser check: not applicable — backend fix, only a changelog JSON touches web/src

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-12-notion-block-paid-plans.json` — "Editing and rendering Notion blocks works on paid plans"

## Risks
Low. Behavior for genuine non-paying users is unchanged (still redirected to `/pricing`), now correctly evaluated after locals load. Rollback is a one-line revert.

## Goal alignment
Retention/entitlement fix: paying users regain a feature they were silently locked out of, removing a churn-risk surface for paid accounts. Metric: 302→/pricing rate on the two Notion block routes for authenticated paying users (read from access logs) should fall to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
