### PR TITLE
fix: exempt active pass holders from cleanup jobs

### DIFF
--- a/src/data_layer/InactivityEmailRepository.activePass.sql.test.ts
+++ b/src/data_layer/InactivityEmailRepository.activePass.sql.test.ts
@@ -1,0 +1,36 @@
+import knexFactory from 'knex';
+
+import { InactivityEmailRepository } from './InactivityEmailRepository';
+
+describe('InactivityEmailRepository active-pass exemption SQL', () => {
+  const pg = knexFactory({ client: 'pg' });
+  const repository = new InactivityEmailRepository(pg);
+
+  afterAll(async () => {
+    await pg.destroy();
+  });
+
+  it('exempts active user_passes holders from the warning query', () => {
+    const sql = repository.buildUsersToNotifyQuery(500).toString();
+
+    expect(sql).toContain('"user_passes"');
+    expect(sql).toContain('user_passes.user_id = users.id');
+    expect(sql).toContain('user_passes.expires_at > now()');
+  });
+
+  it('exempts active user_passes holders from the deletion query', () => {
+    const sql = repository.buildUsersToDeleteQuery(100).toString();
+
+    expect(sql).toContain('"user_passes"');
+    expect(sql).toContain('user_passes.user_id = u.id');
+    expect(sql).toContain('user_passes.expires_at > now()');
+  });
+
+  it('exempts active user_passes holders from the dead-address candidate query', () => {
+    const sql = repository.buildDeadAddressCandidatesQuery(100).toString();
+
+    expect(sql).toContain('"user_passes"');
+    expect(sql).toContain('user_passes.user_id = u.id');
+    expect(sql).toContain('user_passes.expires_at > now()');
+  });
+});

--- a/src/data_layer/InactivityEmailRepository.ts
+++ b/src/data_layer/InactivityEmailRepository.ts
@@ -34,10 +34,8 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
 
   constructor(private readonly database: Knex) {}
 
-  async getUsersToNotify(
-    limit = 500
-  ): Promise<Array<{ id: number; name: string; email: string }>> {
-    const rows = await this.database<UserRow>('users')
+  buildUsersToNotifyQuery(limit: number) {
+    return this.database<UserRow>('users')
       .select('users.id', 'users.name', 'users.email')
       .where(function () {
         this.whereRaw(
@@ -56,6 +54,9 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
           .limit(1)
       )
       .whereNotExists(
+        this.buildActivePassExistsQuery('user_passes.user_id = users.id')
+      )
+      .whereNotExists(
         this.database(this.table)
           .whereRaw('inactivity_emails.user_id = users.id')
           .limit(1)
@@ -67,6 +68,12 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
           .limit(1)
       )
       .limit(limit);
+  }
+
+  async getUsersToNotify(
+    limit = 500
+  ): Promise<Array<{ id: number; name: string; email: string }>> {
+    const rows = await this.buildUsersToNotifyQuery(limit);
 
     return rows.map((row) => ({
       id: row.id,
@@ -75,10 +82,8 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
     }));
   }
 
-  async getUsersToDelete(
-    limit = 100
-  ): Promise<Array<{ id: number; email: string }>> {
-    const rows = await this.database<UserRow>(`${this.table} as ie`)
+  buildUsersToDeleteQuery(limit: number) {
+    return this.database<UserRow>(`${this.table} as ie`)
       .join('users as u', 'u.id', 'ie.user_id')
       .select('u.id', 'u.email')
       .whereRaw("ie.sent_at < now() - (? || ' days')::interval", [
@@ -98,8 +103,17 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
           )
           .limit(1)
       )
+      .whereNotExists(
+        this.buildActivePassExistsQuery('user_passes.user_id = u.id')
+      )
       .orderBy('ie.sent_at', 'asc')
       .limit(limit);
+  }
+
+  async getUsersToDelete(
+    limit = 100
+  ): Promise<Array<{ id: number; email: string }>> {
+    const rows = await this.buildUsersToDeleteQuery(limit);
 
     return rows.map((row) => ({ id: row.id, email: row.email }));
   }
@@ -123,8 +137,18 @@ export class InactivityEmailRepository implements IInactivityEmailRepository {
           )
           .limit(1)
       )
+      .whereNotExists(
+        this.buildActivePassExistsQuery('user_passes.user_id = u.id')
+      )
       .orderBy('u.id', 'asc')
       .limit(limit);
+  }
+
+  private buildActivePassExistsQuery(userCorrelation: string) {
+    return this.database('user_passes')
+      .whereRaw(userCorrelation)
+      .whereRaw('user_passes.expires_at > now()')
+      .limit(1);
   }
 
   async getDeadAddressCandidates(

--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.test.ts
@@ -48,4 +48,16 @@ describe('deleteNonSubScriberUploadsInDatabase', () => {
     expect(rawCall).toContain('deck_shares');
     expect(rawCall).toContain('revoked_at IS NULL');
   });
+
+  it('exempts holders of an active user pass from upload deletion', async () => {
+    const { dbFn } = makeDb([]);
+    const storage = makeStorage();
+
+    await deleteNonSubScriberUploadsInDatabase(dbFn, storage as any);
+
+    const rawCall = (dbFn.raw as jest.Mock).mock.calls[0][0] as string;
+    expect(rawCall).toContain('user_passes');
+    expect(rawCall).toContain('pass.user_id = u.id');
+    expect(rawCall).toContain('pass.expires_at > now()');
+  });
 });

--- a/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
+++ b/src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts
@@ -13,6 +13,10 @@ export const deleteNonSubScriberUploadsInDatabase = async (
     LEFT JOIN subscriptions s ON u.email = s.email OR u.email = s.linked_email
     WHERE u.patreon = false AND (s.active IS NULL OR s.active = false)
       AND NOT EXISTS (
+        SELECT 1 FROM user_passes pass
+        WHERE pass.user_id = u.id AND pass.expires_at > now()
+      )
+      AND NOT EXISTS (
         SELECT 1 FROM deck_shares ds
         WHERE ds.upload_key = up.key AND ds.revoked_at IS NULL
       );


### PR DESCRIPTION
## What
Two destructive account-lifecycle cleanup jobs decided who counts as "paid" using only `users.patreon` and the `subscriptions` table, ignoring `user_passes` entirely. Both jobs now add an identical active-pass exemption so a paying pass holder is never treated as a free user.

## Why
An active pass holder — most critically an Apple **`unlimited.monthly`** IAP subscriber — is tracked ONLY in `user_passes` (written by `RedeemAppleTransactionUseCase` via `upsertWithAbsoluteExpiry`, key `apple:<transactionId>`) and is **never** written to `subscriptions`. That meant:

1. `deleteNonSubScriberUploadsInDatabase` (`WHERE u.patreon = false AND (s.active IS NULL OR s.active = false)`) **deleted the pass holder's uploaded decks** — data loss.
2. `InactivityEmailRepository.getUsersToNotify` / `getUsersToDelete` / `buildDeadAddressCandidatesQuery` sent them an inactivity warning and ultimately **deleted the account**.

## How
Both jobs add the same clause, matching the active-pass predicate in `UserPassRepository.findActive` (`expires_at > now()`):

```sql
NOT EXISTS (SELECT 1 FROM user_passes WHERE user_passes.user_id = <user>.id AND user_passes.expires_at > now())
```

The two inlined `InactivityEmailRepository` queries were extracted into `buildUsersToNotifyQuery` / `buildUsersToDeleteQuery` builder methods (mirroring the existing `buildDeadAddressCandidatesQuery`) so the generated SQL is unit-testable against a pg-dialect knex. No other exemption logic changed.

**What I verified (code, not assumption):**
- `src/data_layer/UserPassRepository.ts` — `findActive` active predicate is `where('expires_at', '>', now)`; columns are `user_id`, `expires_at`, `kind`, `stripe_payment_intent_id` (confirmed against the kanel type `src/data_layer/public/UserPasses.ts`).
- `src/usecases/iap/products.ts` + `src/usecases/iap/RedeemAppleTransactionUseCase.ts` — Apple `unlimited.monthly` maps to `passKind: 'unlimited'` and is persisted only to `user_passes` with `stripe_payment_intent_id = apple:<txn>`; nothing writes it to `subscriptions`.
- `src/routes/middleware/configureUserLocal.ts` — reads entitlement from `UserPassRepository.findActive`, confirming the pass is the live source of truth for these users.

**Jobs fixed (both destructive lifecycle paths):**
- `src/lib/storage/jobs/helpers/deleteNonSubScriberUploadsInDatabase.ts`
- `src/data_layer/InactivityEmailRepository.ts` (all three candidate queries)

## Measuring success
Query the daily inactivity/cleanup run: users with a row in `user_passes` where `expires_at > now()` should never appear in the deletion set nor receive an inactivity email. Confirm with `SELECT count(*) FROM user_passes WHERE expires_at > now()` cross-checked against the `DeleteInactiveUsersUseCase` / `SendInactivityWarningsUseCase` audit rows — the intersection must be zero after deploy.

## Testing
- Unit tests added:
  - `src/data_layer/InactivityEmailRepository.activePass.sql.test.ts` — asserts the generated pg SQL for all three candidate queries contains the `user_passes` / `expires_at > now()` exemption.
  - `deleteNonSubScriberUploadsInDatabase.test.ts` — asserts the raw SQL passed to `db.raw` carries the `user_passes` NOT EXISTS exemption.
- TDD verified: stashed the source fix, watched all four assertions fail for the right reason (missing clause / missing builder method), restored, green.
- `npx tsc -p . --noEmit` clean (deploy build typechecks tests).
- `DeleteInactiveUsersUseCase` / `SendInactivityWarningsUseCase` / `EmailRedirectRouter` suites green (35 tests).
- oxfmt + oxlint clean on changed files. Sonar not run locally (no token in this environment); change is a small SQL-clause addition with no new taint sink.

## Browser check
Browser check: not applicable — backend-only, no web/src change

## Changelog
No changelog entry — internal data-safety fix, no user-visible behavior change for working accounts.

## Risks
The exemption only widens who is spared; it cannot delete more accounts than before. Worst case is an expired-pass user is briefly not exempted once the pass lapses (correct behavior). Rollback is a straight revert — no migration, no schema change, no `src/data_layer/public/` edit.

## Goal alignment
None — internal. Protects paying Apple IAP subscribers from silent data loss and account deletion; directly guards retention/ARPU by not destroying paid accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
