### PR TITLE
fix: show plan management for Patreon lifetime members

### DIFF
--- a/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
@@ -149,6 +149,23 @@ describe('SubscriptionManagement', () => {
     expect(mockUseStripeSubscriptions).not.toHaveBeenCalled();
   });
 
+  it('shows lifetime copy for a Patreon member with no active Stripe subscription', () => {
+    render(
+      <SubscriptionManagement
+        user={user}
+        locals={{ subscriber: false, planSource: 'lifetime' }}
+        hasActivePlan
+        onRefetch={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByText(/Lifetime access/)).toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: 'Cancel subscription' })
+    ).toBeNull();
+    expect(mockUseStripeSubscriptions).not.toHaveBeenCalled();
+  });
+
   it("renders the existing Stripe controls for planSource 'stripe'", () => {
     stubStripeActive();
 

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -290,9 +290,9 @@ function PausedState({
 }
 
 export function SubscriptionManagement(props: SubscriptionManagementProps) {
-  const { locals } = props;
+  const { locals, hasActivePlan } = props;
 
-  if (!locals?.subscriber) {
+  if (!hasActivePlan) {
     return null;
   }
 
@@ -310,7 +310,6 @@ export function SubscriptionManagement(props: SubscriptionManagementProps) {
 function StripeSubscriptionManagement({
   user,
   locals,
-  hasActivePlan,
   onRefetch,
 }: SubscriptionManagementProps) {
   const {

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-12-lifetime-plan-account.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-12-lifetime-plan-account.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-12-lifetime-plan-account",
+  "date": "2026-07-12",
+  "type": "fix",
+  "title": "Lifetime members can see their plan status on the account page"
+}


### PR DESCRIPTION
## What
The Account page "Manage subscription" section is now visible to Patreon lifetime members. Previously the whole section disappeared for them, taking the "Lifetime access · No renewal, no billing" view down with it.

## Why
The top-level gate in `SubscriptionManagement` returned `null` on `!locals.subscriber`. `locals.subscriber` is only true for an active Stripe subscription or an active pass — it is never set from `patreon`. A Patreon lifetime member (`patreon: true`, `subscriber: false`, no Stripe sub, no pass) hit that early return, so the entire section — including the `LifetimeSubscriptionManagement` view built specifically for them — was unreachable dead code.

## How
The component already receives a correctly computed `hasActivePlan` prop from `useSubscriptionStatus` (which ORs in `patreon`). The gate now trusts that prop instead of recomputing an incomplete `locals.subscriber` check. `planSource === 'lifetime'` then routes lifetime members to the lifetime view; Stripe/pass users still reach the Stripe view. Also dropped the now-dead `hasActivePlan` param from `StripeSubscriptionManagement` (it was destructured but unused).

## Measuring success
No new event. Confirm in production by loading `/account` as a Patreon lifetime user (`patreon: true`, no Stripe sub) — the "Lifetime access" block renders instead of an empty section.

## Testing
- Unit tests added: `SubscriptionManagement.test.tsx` — a Patreon member with `subscriber: false`, `planSource: 'lifetime'`, `hasActivePlan: true` sees the "Lifetime access" copy (previously rendered nothing). Existing test that a non-premium user (`subscriber: false`, `hasActivePlan: false`) sees nothing still passes.
- Golden-path spec green: `pnpm --filter 2anki-web test:golden-path`.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: Backed by a green `pnpm --filter 2anki-web test:golden-path` (2 passed, 375px viewport, no console errors).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-12-lifetime-plan-account.json` — "Lifetime members can see their plan status on the account page"

## Risks
Low. The gate widens strictly: any user who saw the section before (`subscriber: true` implies `hasActivePlan: true`) still sees it. It only adds Patreon lifetime members, who reach `LifetimeSubscriptionManagement` (static copy, no Stripe hooks fire). Rollback is a one-line revert.

## Goal alignment
Retention/trust for lifetime members — a paying cohort seeing a blank Account section reads as a broken product. No funnel metric moves directly; this removes a correctness defect on a paid surface.
