### PR TITLE
fix: exclude paused subs from timeseries, prefer active linked sub

### DIFF
--- a/src/services/AuthenticationService.test.ts
+++ b/src/services/AuthenticationService.test.ts
@@ -1492,3 +1492,78 @@ describe('logOutEverywhere', () => {
     expect(deleted).toBe(1);
   });
 });
+
+describe('subscription lookups by linked_email', () => {
+  let database: Knex;
+  let service: AuthenticationService;
+
+  beforeEach(async () => {
+    database = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await database.schema.createTable('subscriptions', (t) => {
+      t.increments('id').primary();
+      t.text('email').nullable();
+      t.text('linked_email').nullable();
+      t.boolean('active').notNullable().defaultTo(false);
+    });
+    service = new AuthenticationService(
+      new TokenRepository(database),
+      new UsersRepository(database)
+    );
+  });
+
+  afterEach(async () => {
+    await database.destroy();
+  });
+
+  it('getIsSubscriber returns true when an active row shares a linked_email with an older inactive one', async () => {
+    await database('subscriptions').insert([
+      {
+        email: 'gifter-old@example.com',
+        linked_email: 'recipient@example.com',
+        active: false,
+      },
+      {
+        email: 'gifter-new@example.com',
+        linked_email: 'recipient@example.com',
+        active: true,
+      },
+    ]);
+
+    const result = await service.getIsSubscriber(
+      database,
+      'recipient@example.com'
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('getSubscriptionInfo resolves the active linked row over an older inactive one', async () => {
+    await database('subscriptions').insert([
+      {
+        email: 'gifter-old@example.com',
+        linked_email: 'recipient@example.com',
+        active: false,
+      },
+      {
+        email: 'gifter-new@example.com',
+        linked_email: 'recipient@example.com',
+        active: true,
+      },
+    ]);
+
+    const result = await service.getSubscriptionInfo(
+      database,
+      'recipient@example.com'
+    );
+
+    expect(result).toEqual({
+      active: true,
+      email: 'gifter-new@example.com',
+      linked_email: 'recipient@example.com',
+    });
+  });
+});

--- a/src/services/AuthenticationService.ts
+++ b/src/services/AuthenticationService.ts
@@ -277,6 +277,7 @@ class AuthenticationService {
     const linkedEmail = await db('subscriptions')
       .select('active')
       .where({ linked_email: email.toLowerCase() })
+      .andWhere({ active: true })
       .first();
 
     if (linkedEmail?.active) {
@@ -295,6 +296,7 @@ class AuthenticationService {
     const linkedEmail = await db('subscriptions')
       .select(['active', 'email', 'linked_email'])
       .where({ linked_email: email.toLowerCase() })
+      .andWhere({ active: true })
       .first();
 
     if (linkedEmail?.active) {

--- a/src/services/ops/BusinessMetricsService.test.ts
+++ b/src/services/ops/BusinessMetricsService.test.ts
@@ -484,6 +484,36 @@ describe('BusinessMetricsService', () => {
       expect(findDay(5)?.active_paying_subs).toBe(1);
     });
 
+    it('excludes a paused subscription from the today point of both series', async () => {
+      const { service } = buildService({
+        allSubs: [
+          sub('sub_active', [monthly(1000)], { created: daysAgoEpoch(90) }),
+          sub('sub_paused', [monthly(2000)], {
+            created: daysAgoEpoch(90),
+            status: 'active',
+            pause_collection: {
+              behavior: 'void',
+              resumes_at: daysAgoEpoch(-60),
+            },
+          }),
+        ],
+      });
+
+      const result = await service.getMetrics();
+      const target = new Date(NOW_MS);
+      target.setUTCHours(0, 0, 0, 0);
+      const todayIso = target.toISOString().slice(0, 10);
+      const mrrToday = result.mrr_timeseries!.find((p) => p.t === todayIso);
+      const activeToday = result.active_subs_timeseries!.find(
+        (p) => p.t === todayIso
+      );
+
+      expect(result.mrr_usd).toBeCloseTo(10, 5);
+      expect(result.active_paying_subs).toBe(1);
+      expect(mrrToday?.mrr_usd).toBeCloseTo(10, 5);
+      expect(activeToday?.active_paying_subs).toBe(1);
+    });
+
     it('conversions_vs_churn_weekly bins by ISO week', async () => {
       const oneWeek = 7 * SECONDS_PER_DAY;
       const { service } = buildService({

--- a/src/services/ops/BusinessMetricsService.ts
+++ b/src/services/ops/BusinessMetricsService.ts
@@ -802,6 +802,7 @@ const isActiveToday = (sub: NormalizedSubscription, nowMs: number): boolean => {
 const wasActiveOn = (sub: NormalizedSubscription, atMs: number): boolean => {
   if (sub.createdMs > atMs) return false;
   if (sub.endedAtMs != null && sub.endedAtMs <= atMs) return false;
+  if (sub.paused) return false;
   return isPayingHistorical(sub.status);
 };
 


### PR DESCRIPTION
## What
Fixes two resolver-internal backend correctness bugs.

1. Ops business-metrics timeseries: `wasActiveOn` (feeds `mrr_timeseries` and `active_subs_timeseries`) had no paused-subscription check, while `isActiveToday` (feeds the headline `mrr_usd` / `active_paying_subs`) excludes paused subs. The "today" point of each series could therefore report higher MRR and active counts than the headline value for the same moment.
2. `getIsSubscriber` / `getSubscriptionInfo` looked up subscriptions by `linked_email` with no `active` filter and no ordering. When an email is `linked_email` on more than one row (e.g. a lapsed gift plus a new active gift), Postgres/Knex could return the inactive row first, producing a false "not premium" while an active granting row existed.

## Why
The timeseries diverged from the headline the moment any active subscription was paused — paused semantics (#3562: paused = excluded from active/MRR, not churn) were applied to the headline but not the historical series. The linked_email lookup silently dropped an active grant whenever a stale linked row sorted first, mirroring the safer pattern already in `SubscriptionService.getUserActiveSubscriptions` (`andWhere({ active: true })`).

## How
- `wasActiveOn` mirrors `isActiveToday`'s `if (sub.paused) return false;` (same `sub.paused` field, derived identically via `isPaused` in `normalizeSubscription`).
- Both linked_email lookups add `.andWhere({ active: true })` so an active linked row is never missed. The email-based fallback branch is unchanged; `getSubscriptionInfo`'s `{active,email,linked_email}` return shape still resolves from the active row.

## Measuring success
`/api/ops/business/metrics` (ops-gated): the last point of `mrr_timeseries` / `active_subs_timeseries` now equals the headline `mrr_usd` / `active_paying_subs` when any active sub is paused (previously higher). No caller signature changed for the auth methods (`configureUserLocal.ts` only).

## Testing
- Unit tests added:
  - BusinessMetrics: a currently-paused sub is excluded from the today point of both timeseries (fails pre-fix: today MRR 30 vs headline 10), fixed clock via `jest.useFakeTimers`.
  - AuthenticationService: two subscription rows sharing a `linked_email` (older inactive + newer active) — `getIsSubscriber` returns true and `getSubscriptionInfo` resolves the active row (both false/undefined pre-fix). Real sqlite integration reproducing wrong-row selection.
- `npx tsc -p . --noEmit` green (deploy typechecks tests). Server tests + web typecheck green. oxfmt --check clean on all four files.
- sonar-scanner: not run — no SONAR_TOKEN in this environment; changes are small resolver-internal predicate/filter edits.

## Browser check
Browser check: not applicable — backend-only, no web/src change

## Changelog
No changelog entry — internal metrics/resolver correctness, no user-visible behavior change.

## Risks
Low. `wasActiveOn` now excludes currently-paused subs from historical days too (same current-state approximation `isActiveToday` already makes); the today point becoming consistent with the headline is the intended effect. The auth filter only ever adds an active grant that was previously missed — it cannot flip an active subscriber to inactive.

## Goal alignment
None — internal ops-metrics accuracy and an auth edge case. Accurate MRR/active-subs reads support revenue decisions; the linked_email fix prevents a false paywall on a legitimately gifted (active) subscription.
