### PR TITLE
refactor: drop unreachable lifetime subscription view

### DIFF
--- a/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.test.tsx
@@ -131,24 +131,6 @@ describe('SubscriptionManagement', () => {
     expect(mockUseStripeSubscriptions).not.toHaveBeenCalled();
   });
 
-  it("shows lifetime copy and no controls for planSource 'lifetime'", () => {
-    render(
-      <SubscriptionManagement
-        user={user}
-        locals={{ subscriber: true, planSource: 'lifetime' }}
-        hasActivePlan
-        onRefetch={vi.fn().mockResolvedValue(undefined)}
-      />
-    );
-
-    expect(screen.getByText(/Lifetime access/)).toBeTruthy();
-    expect(
-      screen.queryByRole('button', { name: 'Cancel subscription' })
-    ).toBeNull();
-    expect(screen.queryByLabelText('Subscription email')).toBeNull();
-    expect(mockUseStripeSubscriptions).not.toHaveBeenCalled();
-  });
-
   it("renders the existing Stripe controls for planSource 'stripe'", () => {
     stubStripeActive();
 

--- a/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
+++ b/web/src/pages/AccountPage/components/SubscriptionManagement.tsx
@@ -227,15 +227,6 @@ function AppleSubscriptionManagement() {
   );
 }
 
-function LifetimeSubscriptionManagement() {
-  return (
-    <section className={styles.section}>
-      <p className={styles.statusLine}>Lifetime access</p>
-      <p className={sharedStyles.smallDescription}>No renewal, no billing.</p>
-    </section>
-  );
-}
-
 function PausedState({
   subscription,
   planLabel,
@@ -300,17 +291,12 @@ export function SubscriptionManagement(props: SubscriptionManagementProps) {
     return <AppleSubscriptionManagement />;
   }
 
-  if (locals.planSource === 'lifetime') {
-    return <LifetimeSubscriptionManagement />;
-  }
-
   return <StripeSubscriptionManagement {...props} />;
 }
 
 function StripeSubscriptionManagement({
   user,
   locals,
-  hasActivePlan,
   onRefetch,
 }: SubscriptionManagementProps) {
   const {


### PR DESCRIPTION
## What
Removes the `LifetimeSubscriptionManagement` component and its `planSource===\047lifetime\047` branch in `SubscriptionManagement`, plus the now-unused `hasActivePlan` param and the test that exercised the dead branch.

## Why
The top-level gate returns null when `locals.subscriber` is false, and `planSource===\047lifetime\047` only occurs when subscriber is false (per `resolvePlanSource`). So the lifetime branch was unreachable dead code. `PlanDetails` (rendered above, `AccountPage.tsx:85`) already shows lifetime members "Lifetime · All current and future features", so no user-visible status is lost. Follow-up to the closed #3593, which wrongly tried to make this redundant block reachable.

## Testing
- Typecheck clean, full web suite green (2190), oxfmt + oxlint clean.
- The removed test used an impossible `subscriber:true + planSource:\047lifetime\047` combo to reach the branch.

## Changelog
No entry — dead-code removal, no user-visible behavior change.

## Browser check
Browser check: not applicable — removes an unreachable code path, no rendered output changes.