### PR TITLE
fix: grant paid access during dunning (past_due/unpaid)

### DIFF
--- a/src/lib/integrations/stripe.test.ts
+++ b/src/lib/integrations/stripe.test.ts
@@ -111,6 +111,68 @@ describe('updateStoreSubscription', () => {
     expect(Boolean(row.active)).toBe(false);
   });
 
+  test('keeps active=true during dunning when status is past_due', async () => {
+    await db('users').insert({ email: 'user@example.com' });
+
+    await updateStoreSubscription(
+      db,
+      makeCustomer('user@example.com'),
+      makeSubscription('past_due', 'prod_auto_sync')
+    );
+
+    const row = await db('subscriptions')
+      .where({ email: 'user@example.com' })
+      .first();
+    expect(Boolean(row.active)).toBe(true);
+  });
+
+  test('keeps active=true during dunning when status is unpaid', async () => {
+    await db('users').insert({ email: 'user@example.com' });
+
+    await updateStoreSubscription(
+      db,
+      makeCustomer('user@example.com'),
+      makeSubscription('unpaid', 'prod_auto_sync')
+    );
+
+    const row = await db('subscriptions')
+      .where({ email: 'user@example.com' })
+      .first();
+    expect(Boolean(row.active)).toBe(true);
+  });
+
+  test('marks active=false when a past_due subscription is also paused', async () => {
+    await db('users').insert({ email: 'user@example.com' });
+
+    await updateStoreSubscription(
+      db,
+      makeCustomer('user@example.com'),
+      makeSubscription('past_due', 'prod_auto_sync', {
+        pauseCollection: { behavior: 'void', resumes_at: 1893456000 },
+      })
+    );
+
+    const row = await db('subscriptions')
+      .where({ email: 'user@example.com' })
+      .first();
+    expect(Boolean(row.active)).toBe(false);
+  });
+
+  test('marks active=false for a never-paid incomplete subscription', async () => {
+    await db('users').insert({ email: 'user@example.com' });
+
+    await updateStoreSubscription(
+      db,
+      makeCustomer('user@example.com'),
+      makeSubscription('incomplete', 'prod_auto_sync')
+    );
+
+    const row = await db('subscriptions')
+      .where({ email: 'user@example.com' })
+      .first();
+    expect(Boolean(row.active)).toBe(false);
+  });
+
   test('links by metadata.user_id even when the Stripe email differs from the account', async () => {
     await db('users').insert({
       email: 'account@example.com',

--- a/src/lib/integrations/stripe.ts
+++ b/src/lib/integrations/stripe.ts
@@ -113,17 +113,23 @@ export const resolveAccountForSubscription = async (
   return null;
 };
 
+const ACCESS_GRANTING_STATUSES = new Set<StripeTypes.Subscription['status']>([
+  'active',
+  'past_due',
+  'unpaid',
+]);
+
 export const updateStoreSubscription = async (
   db: Knex,
   customer: StripeTypes.Customer,
   subscription: StripeTypes.Subscription
 ): Promise<ProvisionResult> => {
   const stripeEmail = normalizeEmail(customer.email);
-  const isActive = subscription.status === 'active';
+  const grantsAccess = ACCESS_GRANTING_STATUSES.has(subscription.status);
   const isCancelScheduled = subscription.cancel_at_period_end === true;
 
-  let shouldRemainActive = isActive;
-  if (isActive && isCancelScheduled) {
+  let shouldRemainActive = grantsAccess;
+  if (grantsAccess && isCancelScheduled) {
     const periodEndDate = new Date((subscription.cancel_at ?? 0) * 1000);
     const currentDate = new Date();
     shouldRemainActive = currentDate < periodEndDate;


### PR DESCRIPTION
## What
Broadens the access-granting Stripe status set in `updateStoreSubscription` from `{active}` to `{active, past_due, unpaid}`, so a subscription in dunning keeps `subscriptions.active=true`. Paused subs still force `active=false`; never-paid `incomplete` stays denied.

## Why
Resolves the #6 divergence from the premium audit. `BusinessMetricsService.isActiveNow` counts `active + past_due + unpaid` toward `/ops` MRR, but access (`updateStoreSubscription`) granted only `active`. A customer whose card fails was **counted as paying revenue while locked out of the product** during Stripe's dunning retry window (~2-3 weeks). Churn here is 79% lifecycle — locking out a customer over a transient card glitch manufactures avoidable churn. This gives them the grace window and converges the two definitions of "active".

Decision: Alexander chose grace-access (option A) over cutting MRR or documenting the split.

## How
- Module-level `ACCESS_GRANTING_STATUSES = {active, past_due, unpaid}`.
- `grantsAccess` replaces the `status===active` check; paused exclusion and cancel-at-period-end window unchanged.
- When dunning exhausts and Stripe sets `canceled`, access ends as before.

## Testing
- New Jest cases: past_due -> active true, unpaid -> active true, paused+past_due -> false, incomplete -> false. TDD (the two grace cases failed first).
- `pnpm test src/lib/integrations/stripe.test.ts` 14/14; `tsc -p .` clean; oxfmt clean.

## Security
Payments change reviewed: reads `subscription.status` from the HMAC-verified Stripe webhook against a fixed set — no user input, no injection, no authz bypass. Deliberate entitlement-policy broadening.

## Changelog
no changelog entry — billing-lifecycle edge; access-during-dunning is not a broad user-facing capability and describing it would be more alarming than useful.

## Browser check
Browser check: not applicable — backend billing logic, no web/src change.
