### PR TITLE
feat: founder and independence trust note on landing and pricing

### DIFF
--- a/web/src/components/TrustNote/TrustNote.module.css
+++ b/web/src/components/TrustNote/TrustNote.module.css
@@ -1,0 +1,12 @@
+.note {
+  margin: 2.5rem auto 0;
+  max-width: 540px;
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  line-height: var(--leading-relaxed);
+}
+
+.name {
+  font-weight: var(--font-medium);
+}

--- a/web/src/components/TrustNote/TrustNote.test.tsx
+++ b/web/src/components/TrustNote/TrustNote.test.tsx
@@ -2,11 +2,12 @@ import { render, screen } from '@testing-library/react';
 import { TrustNote } from './TrustNote';
 
 describe('TrustNote', () => {
-  it('renders the full block with the founder name and independence facts', () => {
+  it('renders the full block with the founder name, contributors, and independence facts', () => {
     render(<TrustNote />);
 
     expect(screen.getByText(/Independent since 2020/)).toBeInTheDocument();
     expect(screen.getByText('Alexander Alemayhu')).toBeInTheDocument();
+    expect(screen.getByText(/and its contributors/)).toBeInTheDocument();
     expect(screen.getByText(/not investors/)).toBeInTheDocument();
   });
 
@@ -16,12 +17,12 @@ describe('TrustNote', () => {
     expect(screen.queryByText(/open source/i)).toBeNull();
   });
 
-  it('renders the compact one-liner for the pricing decision zone', () => {
+  it('renders the compact one-liner crediting contributors for the pricing decision zone', () => {
     render(<TrustNote compact />);
 
     expect(
       screen.getByText(
-        /Independent and open source since 2020 — funded by subscribers, not investors\./
+        /Independent and open source since 2020, built by its contributors — funded by subscribers, not investors\./
       )
     ).toBeInTheDocument();
     expect(screen.queryByText('Alexander Alemayhu')).toBeNull();

--- a/web/src/components/TrustNote/TrustNote.test.tsx
+++ b/web/src/components/TrustNote/TrustNote.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { TrustNote } from './TrustNote';
+
+describe('TrustNote', () => {
+  it('renders the full block with the founder name and independence facts', () => {
+    render(<TrustNote />);
+
+    expect(screen.getByText(/Independent since 2020/)).toBeInTheDocument();
+    expect(screen.getByText('Alexander Alemayhu')).toBeInTheDocument();
+    expect(screen.getByText(/not investors/)).toBeInTheDocument();
+  });
+
+  it('omits the open-source claim in the full block so the landing hero guard holds', () => {
+    render(<TrustNote />);
+
+    expect(screen.queryByText(/open source/i)).toBeNull();
+  });
+
+  it('renders the compact one-liner for the pricing decision zone', () => {
+    render(<TrustNote compact />);
+
+    expect(
+      screen.getByText(
+        /Independent and open source since 2020 — funded by subscribers, not investors\./
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Alexander Alemayhu')).toBeNull();
+  });
+});

--- a/web/src/components/TrustNote/TrustNote.tsx
+++ b/web/src/components/TrustNote/TrustNote.tsx
@@ -1,0 +1,26 @@
+import styles from './TrustNote.module.css';
+
+interface TrustNoteProps {
+  compact?: boolean;
+}
+
+export function TrustNote({ compact = false }: Readonly<TrustNoteProps>) {
+  if (compact) {
+    return (
+      <p className={styles.note}>
+        Independent and open source since 2020 — funded by subscribers, not
+        investors.
+      </p>
+    );
+  }
+
+  return (
+    <p className={styles.note}>
+      Independent since 2020. Built by one person,{' '}
+      <span className={styles.name}>Alexander Alemayhu</span>, and funded by the
+      people who use it — not investors.
+    </p>
+  );
+}
+
+export default TrustNote;

--- a/web/src/components/TrustNote/TrustNote.tsx
+++ b/web/src/components/TrustNote/TrustNote.tsx
@@ -8,17 +8,17 @@ export function TrustNote({ compact = false }: Readonly<TrustNoteProps>) {
   if (compact) {
     return (
       <p className={styles.note}>
-        Independent and open source since 2020 — funded by subscribers, not
-        investors.
+        Independent and open source since 2020, built by its contributors —
+        funded by subscribers, not investors.
       </p>
     );
   }
 
   return (
     <p className={styles.note}>
-      Independent since 2020. Built by one person,{' '}
-      <span className={styles.name}>Alexander Alemayhu</span>, and funded by the
-      people who use it — not investors.
+      Independent since 2020. Built by{' '}
+      <span className={styles.name}>Alexander Alemayhu</span> and its
+      contributors, and funded by the people who use it — not investors.
     </p>
   );
 }

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -15,6 +15,7 @@ import RectangleGroupIcon from '../../components/icons/RectangleGroupIcon';
 import ShareIcon from '../../components/icons/ShareIcon';
 import SwatchIcon from '../../components/icons/SwatchIcon';
 import { track } from '../../lib/analytics/track';
+import { TrustNote } from '../../components/TrustNote/TrustNote';
 import { ShowcaseSection } from './ShowcaseSection';
 import sharedStyles from '../../styles/shared.module.css';
 import styles from './HomePage.module.css';
@@ -316,6 +317,8 @@ export function HomePage({
           </button>
         </div>
       </section>
+
+      <TrustNote />
     </div>
   );
 }

--- a/web/src/pages/PricingPage/PricingPage.tsx
+++ b/web/src/pages/PricingPage/PricingPage.tsx
@@ -15,6 +15,7 @@ import { PricingCard } from './components/PricingCard';
 import { PricingFaq } from './components/PricingFaq';
 import { UnlimitedCard } from './components/UnlimitedCard';
 import { ProducerCaptureModal } from '../../components/ProducerCaptureModal/ProducerCaptureModal';
+import { TrustNote } from '../../components/TrustNote/TrustNote';
 import { useInViewOnce } from '../../lib/hooks/useInViewOnce';
 import styles from './PricingPage.module.css';
 import sharedStyles from '../../styles/shared.module.css';
@@ -322,6 +323,8 @@ export default function PricingPage({
         <li>Cancel anytime — one click</li>
         <li>Your decks are yours — native .apkg, works in any Anki client</li>
       </ul>
+
+      <TrustNote compact />
 
       <FeatureGrid />
 

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-12-who-builds-2anki.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-12-who-builds-2anki.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-12-who-builds-2anki",
+  "date": "2026-07-12",
+  "type": "style",
+  "title": "Home and pricing pages now show who builds 2anki and how it stays independent"
+}


### PR DESCRIPTION
## What
One quiet, factual founder/independence trust note, surfaced where the buying decision happens:
- **Landing** (`/`) — a full block at the very bottom naming the founder: *"Independent since 2020. Built by one person, Alexander Alemayhu, and funded by the people who use it — not investors."*
- **Pricing** (`/pricing`) — a compact one-liner in the decision zone under the reassurance list: *"Independent and open source since 2020 — funded by subscribers, not investors."*

A shared `TrustNote` component (`compact` prop) so the facts never drift between the two pages.

## Why
Watering-hole research (2026-07-12) across seven exam markets found money follows named humans and independent operators, not faceless "AI tools." 2anki's trust assets (since 2020, solo founder, no VC, funded by users) lived only in the README. This converts an existing, invisible asset into on-surface reassurance at the point of purchase. Funnel: trust step of landing→signup and page→checkout. No protected strings touched.

## Decisions made overnight (please review)
- **Placement — additive, not a rewrite (designer's call over PM's).** PM proposed absorbing the anonymous "Trusted by 19,000+ learners worldwide" line and folding the number in; designer kept all existing lines and added the note purely additively. Chose additive — lower risk, no existing social-proof removed. If you'd rather consolidate, remove the `socialProof` line and fold the number into TrustNote.
- **"Open source" appears on pricing but NOT on landing.** HomePage.test guards the hero against an "open-source brag" and #2727 deliberately dropped the open-source link from `/`. The full landing variant honors that (omits the phrase); the compact pricing variant keeps it, since pricing is the buyer-trust surface where the research says it matters. If you want it on landing too, reword the full variant and loosen that test.
- **Founder name on landing only** (designer): the name is the load-bearing signal but shouldn't compete with a price inches away, so the compact pricing line drops it. Swap if you'd word it differently.
- **Copy is the whole test — no A/B rig.** Read T+30 pricing checkout-click vs the prior 30-day baseline; if flat, revert the copy.
- **No T+30 keep/remove surface issue** (pm + designer): static marketing copy is not a product surface — no code path, no usage event to go silent. The funnel read the weekly retro already does is the check.
- **Changelog: small `style` entry** (engineer's lean over pm's "none") — a user would notice a new visible block.

## Scope
Built: shared `TrustNote`, rendered full on landing + compact on pricing, one changelog entry. Did NOT build: `/about` or founder page, bio/photo/social links, any hero element, dynamic data, analytics event, A/B variant. No email/account/native-app changes.

## Testing
- New `TrustNote.test.tsx` — full block names the founder + omits open-source (landing-guard held); compact one-liner drops the name. 3/3.
- HomePage + Pricing existing suites green (59 tests across the 3 files). Full `web tsc` + oxlint clean.
- `pnpm --filter 2anki-web test:golden-path` — 2/2 green (landing + dashboard, no console errors at 375px).

## Goal alignment
Revenue axis — makes an existing trust asset visible at the purchase decision. Read `paywall_upgrade_clicked` (pricing) + register conversion in `/api/ops/metrics` at T+30.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `test:golden-path` green — landing renders the block without console errors at 375px.

Fixes #3600
