### PR TITLE
docs: Auto Sync is request-only or included with Lifetime

### DIFF
--- a/web/src/pages/DocsPage/content/reference/plans.md
+++ b/web/src/pages/DocsPage/content/reference/plans.md
@@ -38,10 +38,10 @@ Use this when you have a week to prep for an exam or a sprint to digitize a stac
 | Cards per month                                     | 100     | unlimited | unlimited | unlimited       | unlimited      |
 | PDF support                                         | —       | ✓         | ✓         | ✓               | ✓              |
 | [AI flashcards](/documentation/cards/ai-flashcards) | —       | ✓         | ✓         | ✓               | ✓              |
-| [Auto Sync](/documentation/sync/how-it-works)       | —       | —         | —         | $30/mo add-on   | ✓              |
+| [Auto Sync](/documentation/sync/how-it-works)       | —       | —         | —         | by request      | ✓              |
 | Recurring charge                                    | —       | —         | —         | monthly         | —              |
 
-Day Pass and Week Pass do not include Auto Sync. If you need ongoing Notion → Anki sync, you need a Subscription with Auto Sync or a Lifetime plan.
+Day Pass and Week Pass do not include Auto Sync. Auto Sync isn't sold as a plan right now — it's included with Lifetime, and on any other plan you can email [support@2anki.net](mailto:support@2anki.net) to have it switched on so you can try it.
 
 ## Pausing a subscription
 

--- a/web/src/pages/DocsPage/content/sync/how-it-works.md
+++ b/web/src/pages/DocsPage/content/sync/how-it-works.md
@@ -30,8 +30,8 @@ Notion page  →  2anki sync   →  AnkiConnect (your Anki)
 
 A background job polls your subscribed pages, diffs them against what's already synced, and pushes only the changes to Anki. Reviews and scheduling state are preserved because card IDs are stable across runs.
 
-## Free vs paid
+## Getting Auto Sync access
 
-Auto Sync is a paid feature — $30/mo, or included with a Lifetime account. The conversion features that ship today — Connect Notion + download deck, plus file uploads — stay free.
+Auto Sync isn't sold as a standalone plan right now — not enough people were using it to keep it on the pricing page. It's included with a Lifetime account. On any other plan, email [support@2anki.net](mailto:support@2anki.net) and we'll switch it on for your account so you can try it. The conversion features that ship today — Connect Notion + download deck, plus file uploads — stay free.
 
 See the [pricing page](/pricing) for current plans, and [When sync gets stuck](/documentation/sync/troubleshooting) if a sync isn't running.


### PR DESCRIPTION
## What
Updates the two docs pages that describe Auto Sync access:
- `sync/how-it-works.md` — "Free vs paid" → "Getting Auto Sync access": no longer a $30/mo plan; included with Lifetime, or email support to have it enabled on any other plan to try.
- `reference/plans.md` — comparison-table Auto Sync cell for Unlimited (sub) changed from "$30/mo add-on" to "by request", and the trailing sentence rewritten to match.

## Why
Auto Sync was retired as a standalone plan for lack of interest, but the docs still pointed users to buy it as a $30/mo add-on — a purchase path that no longer exists. A real paying user (Unlimited annual) just asked whether their plan includes sync; the docs would have sent them looking for a plan we don't sell. This makes the docs tell the truth: Lifetime includes it, everyone else asks and we switch it on.

## Testing
DocsPage vitest suite green (57 tests, incl. content-links + DocContent render). Tree-wide `oxfmt --check src web/src` clean.

## Goal alignment
Trust/clarity on the paid experience — removes a stale purchase path that would confuse a paying user. Docs-only; no changelog (not user-facing app behavior).

## Browser check
Browser check: not applicable — documentation copy change (two content .md files), no code path or runtime behavior affected; DocsPage render suite green.
