### PR TITLE
fix: enable Ankify Review for decks with due-learning cards

### DIFF
--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -48,6 +48,30 @@ const statsWithDeck = (review: number): AnkifyStats => ({
   ],
 });
 
+const statsWithCounts = (counts: {
+  review: number;
+  learning: number;
+  new: number;
+}): AnkifyStats => ({
+  connected: true,
+  reviewedToday: 0,
+  reviewedThisYear: 0,
+  currentStreak: 0,
+  longestStreak: 0,
+  reviewsByDay: [],
+  decks: [
+    {
+      fullName: 'Notion Sync::Pharma',
+      name: 'Pharma',
+      depth: 1,
+      new: counts.new,
+      learning: counts.learning,
+      review: counts.review,
+      total: 120,
+    },
+  ],
+});
+
 const cardById: Record<number, ReviewQueueCard> = {
   9001: {
     cardId: 9001,
@@ -298,9 +322,13 @@ describe('ReviewPanel', () => {
     ).toBeInTheDocument();
   });
 
-  test('disables the Review button for a deck with no due cards', async () => {
+  test('disables the Review button for a deck with nothing to study', async () => {
     renderPanel(
-      makeBackend({ getAnkifyStats: vi.fn(async () => statsWithDeck(0)) })
+      makeBackend({
+        getAnkifyStats: vi.fn(async () =>
+          statsWithCounts({ review: 0, learning: 0, new: 0 })
+        ),
+      })
     );
 
     const reviewButton = await screen.findByRole('button', { name: 'Review' });
@@ -508,5 +536,31 @@ describe('ReviewPanel', () => {
     expect(
       await screen.findByText("Anki isn't connected.")
     ).toBeInTheDocument();
+  });
+
+  test('enables Review when a deck has due-learning cards but nothing review-due', async () => {
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () =>
+          statsWithCounts({ review: 0, learning: 4, new: 4 })
+        ),
+      })
+    );
+
+    const reviewButton = await screen.findByRole('button', { name: 'Review' });
+    expect(reviewButton).not.toBeDisabled();
+  });
+
+  test('disables Review when a deck has only new cards (the due queue serves none)', async () => {
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () =>
+          statsWithCounts({ review: 0, learning: 0, new: 3 })
+        ),
+      })
+    );
+
+    const reviewButton = await screen.findByRole('button', { name: 'Review' });
+    expect(reviewButton).toBeDisabled();
   });
 });

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -80,7 +80,8 @@ export function DeckPicker({
         .filter((node) => !hasCollapsedAncestor(node.deck.fullName, collapsed))
         .map((node) => {
           const due = node.aggregateDue;
-          const muted = due === 0;
+          const reviewable = due + node.aggregateLearning > 0;
+          const muted = !reviewable;
           const leaf =
             node.deck.name.length > 0 ? node.deck.name : 'Untitled deck';
           const isCollapsed = collapsed.has(node.deck.fullName);

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-12-ankify-review-learning.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-12-ankify-review-learning.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-12-ankify-review-learning",
+  "date": "2026-07-12",
+  "type": "fix",
+  "title": "Review a synced deck from Auto Sync when it has cards in learning, not only cards due"
+}


### PR DESCRIPTION
## What
Enables the **Review** button in the Auto Sync → Review tab for decks that have cards in **learning**, not only decks with review-due cards.

## Why
Reported: a deck showing "▲0 due · 4 learning · +4 new" had its Review button greyed out, even though Anki lets you study it. Root cause in `ReviewPanel.tsx`: the button's disabled state was `aggregateDue === 0` — it ignored learning entirely. But the review queue behind the button is `deck:"X" is:due`, and Anki's `is:due` matches **review-due AND learning-due** cards. So the queue would have served those learning cards; only the button gate was wrong.

## How
Gate on `due + learning > 0` instead of `due` alone (`ReviewPanel.tsx:83`).

New-only decks (e.g. "0 due · 0 learning · +1 new") **stay disabled on purpose** — the `is:due` queue does not serve new cards, so enabling there would open an empty "all caught up" session.

## Decisions made overnight (please review)
- **Scope: fixed the learning gate, did NOT add new-card review.** The reported bug is that *learning* cards were unstudyable; that's the one-line correctness fix, aligned with what the existing `is:due` queue already serves. Making new cards studyable from here (like Anki's deck list) is a real feature — it needs the queue to include `is:new`, respect the deck's new/day limit, and order new cards — which is a separate product decision, not a bug fix. Flagged as a follow-up rather than smuggled in. If you'd rather Review also introduce new cards, say so and I'll spec the queue change.

## Testing
- `ReviewPanel.test.tsx` — added: due-learning-only deck → button enabled; new-only deck → disabled; all-zero deck → disabled. Repurposed the old "no due cards" test (it asserted the buggy disabled-on-learning behavior). 20/20 green.
- Full web tsc + oxlint clean. `test:golden-path` 2/2.

## Goal alignment
Reliability of the paid Auto Sync surface for lifetime/Auto-Sync users — a working feature (review-from-2anki) was hidden behind a wrong disabled state.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: gate is unit-tested per due/learning/new combination; golden-path green.
