### PR TITLE
feat: serve new cards in Ankify Review, not only due and learning

### DIFF
--- a/src/usecases/ankify/GetReviewQueueUseCase.test.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.test.ts
@@ -20,18 +20,44 @@ const clientsRepo = (
     findActiveByOwner: jest.fn(async () => client),
   }) as unknown as AnkifyClientsRepositoryInterface;
 
+interface AnkiStub {
+  due?: number[];
+  fresh?: number[];
+  newCount?: number;
+}
+
+const factoryFor = (stub: AnkiStub) => {
+  const findCards = jest.fn(async (query: string) =>
+    query.includes('is:new') ? (stub.fresh ?? []) : (stub.due ?? [])
+  );
+  const getDeckStats = jest.fn(async () => ({
+    '1651445861967': {
+      deck_id: 1651445861967,
+      name: 'Deck',
+      new_count: stub.newCount ?? 0,
+      learn_count: 0,
+      review_count: 0,
+      total_in_deck: 0,
+    },
+  }));
+  const factory = jest.fn(
+    () =>
+      ({
+        ping: jest.fn(async () => 6),
+        findCards,
+        getDeckStats,
+      }) as unknown as AnkiConnectClient
+  );
+  return { factory, findCards, getDeckStats };
+};
+
 describe('GetReviewQueueUseCase', () => {
-  it('returns the due card ids for a deck the user never synced from Notion', async () => {
-    const findCards = jest.fn(async () => [9001, 9002]);
-    const cardsInfo = jest.fn();
-    const factory = jest.fn(
-      () =>
-        ({
-          ping: jest.fn(async () => 6),
-          findCards,
-          cardsInfo,
-        }) as unknown as AnkiConnectClient
-    );
+  it('serves due + learning cards first, then new cards up to the daily limit', async () => {
+    const { factory, findCards, getDeckStats } = factoryFor({
+      due: [9001, 9002],
+      fresh: [7001, 7002, 7003],
+      newCount: 2,
+    });
     const useCase = new GetReviewQueueUseCase(
       clientsRepo(activeClient),
       factory
@@ -40,8 +66,46 @@ describe('GetReviewQueueUseCase', () => {
     const result = await useCase.execute({ owner: 42, deck: 'My Own Deck' });
 
     expect(findCards).toHaveBeenCalledWith('deck:"My Own Deck" is:due');
-    expect(result).toEqual({ connected: true, cardIds: [9001, 9002] });
-    expect(cardsInfo).not.toHaveBeenCalled();
+    expect(findCards).toHaveBeenCalledWith(
+      'deck:"My Own Deck" is:new -is:suspended -is:buried'
+    );
+    expect(getDeckStats).toHaveBeenCalledWith(['My Own Deck']);
+    expect(result).toEqual({
+      connected: true,
+      cardIds: [9001, 9002, 7001, 7002],
+    });
+  });
+
+  it('serves no new cards when the daily new allotment is exhausted', async () => {
+    const { factory } = factoryFor({
+      due: [9001],
+      fresh: [7001, 7002],
+      newCount: 0,
+    });
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      factory
+    );
+
+    const result = await useCase.execute({ owner: 42, deck: 'Deck' });
+
+    expect(result).toEqual({ connected: true, cardIds: [9001] });
+  });
+
+  it('serves a new-only deck when nothing is due', async () => {
+    const { factory } = factoryFor({
+      due: [],
+      fresh: [7001, 7002, 7003],
+      newCount: 5,
+    });
+    const useCase = new GetReviewQueueUseCase(
+      clientsRepo(activeClient),
+      factory
+    );
+
+    const result = await useCase.execute({ owner: 42, deck: 'Deck' });
+
+    expect(result).toEqual({ connected: true, cardIds: [7001, 7002, 7003] });
   });
 
   it('returns connected:false when no active client', async () => {
@@ -55,16 +119,8 @@ describe('GetReviewQueueUseCase', () => {
     expect(result).toEqual({ connected: false });
   });
 
-  it('returns an empty card id list when no cards are due', async () => {
-    const findCards = jest.fn(async () => []);
-    const factory = jest.fn(
-      () =>
-        ({
-          ping: jest.fn(async () => 6),
-          findCards,
-          cardsInfo: jest.fn(),
-        }) as unknown as AnkiConnectClient
-    );
+  it('returns an empty card id list when nothing is due or new', async () => {
+    const { factory } = factoryFor({ due: [], fresh: [], newCount: 0 });
     const useCase = new GetReviewQueueUseCase(
       clientsRepo(activeClient),
       factory
@@ -79,15 +135,7 @@ describe('GetReviewQueueUseCase', () => {
   });
 
   it('escapes quotes and backslashes in the deck name', async () => {
-    const findCards = jest.fn(async () => []);
-    const factory = jest.fn(
-      () =>
-        ({
-          ping: jest.fn(async () => 6),
-          findCards,
-          cardsInfo: jest.fn(),
-        }) as unknown as AnkiConnectClient
-    );
+    const { factory, findCards } = factoryFor({ newCount: 0 });
     const useCase = new GetReviewQueueUseCase(
       clientsRepo(activeClient),
       factory
@@ -96,5 +144,8 @@ describe('GetReviewQueueUseCase', () => {
     await useCase.execute({ owner: 42, deck: 'Week "18"\\x' });
 
     expect(findCards).toHaveBeenCalledWith('deck:"Week \\"18\\"\\\\x" is:due');
+    expect(findCards).toHaveBeenCalledWith(
+      'deck:"Week \\"18\\"\\\\x" is:new -is:suspended -is:buried'
+    );
   });
 });

--- a/src/usecases/ankify/GetReviewQueueUseCase.ts
+++ b/src/usecases/ankify/GetReviewQueueUseCase.ts
@@ -1,6 +1,6 @@
 import { AnkifyClientsRepositoryInterface } from '../../data_layer/ankify/AnkifyClientsRepository';
 import { AnkiConnectFactory } from './GetAnkifyStatsUseCase';
-import { buildDueCardsQuery } from './reviewQueries';
+import { buildDueCardsQuery, buildNewCardsQuery } from './reviewQueries';
 
 export type GetReviewQueueResult =
   | { connected: true; cardIds: number[] }
@@ -32,7 +32,19 @@ export class GetReviewQueueUseCase {
 
     await ac.ping();
 
-    const cardIds = await ac.findCards(buildDueCardsQuery(input.deck));
+    // Due + learning cards first (is:due already excludes suspended/buried),
+    // then new cards capped at the deck's Anki daily new allotment. getDeckStats
+    // returns the same new_count Anki shows in its deck list — net of new cards
+    // already studied today and the deck's new/day option — so slicing to it
+    // matches Anki's study session and never bypasses the daily limit.
+    const [dueIds, newIds, deckStats] = await Promise.all([
+      ac.findCards(buildDueCardsQuery(input.deck)),
+      ac.findCards(buildNewCardsQuery(input.deck)),
+      ac.getDeckStats([input.deck]),
+    ]);
+
+    const newLimit = Object.values(deckStats)[0]?.new_count ?? 0;
+    const cardIds = [...dueIds, ...newIds.slice(0, Math.max(0, newLimit))];
     return { connected: true, cardIds };
   }
 }

--- a/src/usecases/ankify/reviewQueries.test.ts
+++ b/src/usecases/ankify/reviewQueries.test.ts
@@ -1,4 +1,8 @@
-import { buildCardExistsQuery, buildDueCardsQuery } from './reviewQueries';
+import {
+  buildCardExistsQuery,
+  buildDueCardsQuery,
+  buildNewCardsQuery,
+} from './reviewQueries';
 
 describe('reviewQueries', () => {
   describe('buildDueCardsQuery', () => {
@@ -23,6 +27,20 @@ describe('reviewQueries', () => {
     it('preserves the :: hierarchy separator', () => {
       expect(buildDueCardsQuery('MS3::Pharma::Sub')).toBe(
         'deck:"MS3::Pharma::Sub" is:due'
+      );
+    });
+  });
+
+  describe('buildNewCardsQuery', () => {
+    it('scopes is:new to a single deck and excludes suspended and buried', () => {
+      expect(buildNewCardsQuery('Notion Sync::Pharma')).toBe(
+        'deck:"Notion Sync::Pharma" is:new -is:suspended -is:buried'
+      );
+    });
+
+    it('escapes quotes and backslashes in the deck name', () => {
+      expect(buildNewCardsQuery('Week "18"\\x')).toBe(
+        'deck:"Week \\"18\\"\\\\x" is:new -is:suspended -is:buried'
       );
     });
   });

--- a/src/usecases/ankify/reviewQueries.ts
+++ b/src/usecases/ankify/reviewQueries.ts
@@ -3,4 +3,7 @@ import { escapeDeckQueryValue } from './leechQueries';
 export const buildDueCardsQuery = (deck: string): string =>
   `deck:"${escapeDeckQueryValue(deck)}" is:due`;
 
+export const buildNewCardsQuery = (deck: string): string =>
+  `deck:"${escapeDeckQueryValue(deck)}" is:new -is:suspended -is:buried`;
+
 export const buildCardExistsQuery = (cardId: number): string => `cid:${cardId}`;

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.test.tsx
@@ -210,7 +210,7 @@ describe('ReviewPanel', () => {
 
     expect(
       await screen.findByText(
-        'Pick a deck to review its due cards without opening Anki.'
+        'Pick a deck to study its due and new cards without opening Anki.'
       )
     ).toBeInTheDocument();
     expect(trackMock).toHaveBeenCalledWith(
@@ -234,7 +234,7 @@ describe('ReviewPanel', () => {
 
     expect(
       await screen.findByText(
-        'All caught up. No cards due across your decks right now.'
+        'Nothing to study in this deck right now — no due or new cards.'
       )
     ).toBeInTheDocument();
   });
@@ -252,14 +252,14 @@ describe('ReviewPanel', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Review' }));
     await screen.findByText(
-      'All caught up. No cards due across your decks right now.'
+      'Nothing to study in this deck right now — no due or new cards.'
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Back to decks' }));
 
     expect(
       await screen.findByText(
-        'Pick a deck to review its due cards without opening Anki.'
+        'Pick a deck to study its due and new cards without opening Anki.'
       )
     ).toBeInTheDocument();
   });
@@ -333,6 +333,19 @@ describe('ReviewPanel', () => {
 
     const reviewButton = await screen.findByRole('button', { name: 'Review' });
     expect(reviewButton).toBeDisabled();
+  });
+
+  test('enables the Review button for a deck with only new cards', async () => {
+    renderPanel(
+      makeBackend({
+        getAnkifyStats: vi.fn(async () =>
+          statsWithCounts({ review: 0, learning: 0, new: 4 })
+        ),
+      })
+    );
+
+    const reviewButton = await screen.findByRole('button', { name: 'Review' });
+    expect(reviewButton).toBeEnabled();
   });
 
   test('sends the full deck path to the review queue for a subdeck', async () => {
@@ -549,18 +562,5 @@ describe('ReviewPanel', () => {
 
     const reviewButton = await screen.findByRole('button', { name: 'Review' });
     expect(reviewButton).not.toBeDisabled();
-  });
-
-  test('disables Review when a deck has only new cards (the due queue serves none)', async () => {
-    renderPanel(
-      makeBackend({
-        getAnkifyStats: vi.fn(async () =>
-          statsWithCounts({ review: 0, learning: 0, new: 3 })
-        ),
-      })
-    );
-
-    const reviewButton = await screen.findByRole('button', { name: 'Review' });
-    expect(reviewButton).toBeDisabled();
   });
 });

--- a/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
+++ b/web/src/pages/AnkifyPage/components/ReviewPanel.tsx
@@ -80,7 +80,8 @@ export function DeckPicker({
         .filter((node) => !hasCollapsedAncestor(node.deck.fullName, collapsed))
         .map((node) => {
           const due = node.aggregateDue;
-          const reviewable = due + node.aggregateLearning > 0;
+          const reviewable =
+            due + node.aggregateLearning + node.aggregateNew > 0;
           const muted = !reviewable;
           const leaf =
             node.deck.name.length > 0 ? node.deck.name : 'Untitled deck';
@@ -551,7 +552,7 @@ export default function ReviewPanel({ backend }: Props) {
         return panel(
           <>
             <p className={styles.emptyLine}>
-              All caught up. No cards due across your decks right now.
+              Nothing to study in this deck right now — no due or new cards.
             </p>
             {backToDecks}
           </>
@@ -611,7 +612,7 @@ export default function ReviewPanel({ backend }: Props) {
   return panel(
     <>
       <p className={styles.decksHelper}>
-        Pick a deck to review its due cards without opening Anki.
+        Pick a deck to study its due and new cards without opening Anki.
       </p>
       <DeckPicker
         decks={stats.data.decks}

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-12-review-new-cards.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-12-review-new-cards.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-12-review-new-cards",
+  "date": "2026-07-12",
+  "type": "feature",
+  "title": "Review tab serves new cards, so decks with only new cards are studyable in the browser"
+}


### PR DESCRIPTION
Fixes #3608.

The Auto Sync → Review tab built its queue as `deck:"X" is:due`, which excludes **new** cards. A deck with only new cards ("0 due · 0 learning · +N new") had a disabled Review button and nothing to study in the browser — even though Anki itself lets you study new-only decks. This serves new cards too, up to the deck's Anki daily new limit.

## Why this is a draft
One behavior can't be verified without a live AnkiConnect container, which I don't have overnight: **grading a new card via `answerCards` advancing new→learning identically to studying in Anki** (no double-count, no daily-limit bypass). The existing due-review path already answers `findCards`-fetched cards, so the mechanism is proven for review cards; answering a `queue:0` new card is the one untested edge. Please confirm at runtime before flipping ready: answer one new card in a real container, re-query `cardsInfo` (verify `queue`/`type` advanced) and `getNumCardsReviewedToday` (verify it incremented). Everything else is tested and green.

## What changed
- `reviewQueries.ts` — new `buildNewCardsQuery(deck)` = `deck:"X" is:new -is:suspended -is:buried`.
- `GetReviewQueueUseCase` — runs `findCards(due)`, `findCards(new)`, and `getDeckStats([deck])` in parallel; returns `[...dueIds, ...newIds.slice(0, new_count)]`. The cap is read as `Object.values(deckStats)[0].new_count` (the map is keyed by `deck_id`, not name, and we request exactly one deck).
- `ReviewPanel.tsx` — deck-row Review button enabled when `due + learning + new > 0`; picker helper and empty-queue copy updated.
- Tests: `reviewQueries.test.ts`, `GetReviewQueueUseCase.test.ts` (cap + new-only + exhausted-allotment cases), `ReviewPanel.test.tsx` (new-only deck now enables the button; removed the obsolete #3607 "new-only disabled" test).
- Changelog entry.

## Decisions made overnight (please review)
- **Daily new-limit source**: chose `getDeckStats.new_count` as the cap over a fixed cap or unlimited — it's Anki's own daily-limit-respecting number (net of new studied today + the deck's new/day option), already fetched, and fails closed to 0. Assumption: capping at the parent deck's aggregate `new_count` is Anki-consistent. If you'd rather read per-child deck config, change the cap source in `GetReviewQueueUseCase`.
- **Ordering**: due + learning first, then new (trio: overdue material is higher-value and matches what a learner clears first). Assumption: exact intra-new ordering doesn't need to match Anki's scheduler gather order for v1 — new ids come back in `findCards` (creation) order, so we serve the right *count* but not necessarily the exact next N cards Anki would present. If that matters, sort new ids by `due` position via `cardsInfo`.
- **Copy** (designer's calls): helper → "Pick a deck to study its due and new cards without opening Anki." (uses Anki's umbrella verb "study" so it doesn't fight the "Review" tab/button). Empty state → "Nothing to study in this deck right now — no due or new cards." (also fixes the old "across your decks" wording, which was wrong for a single picked deck). Swap if you'd word either differently.
- **Scope**: built the two-query queue + button gate + copy. Deliberately did **not** build exact new-card position ordering, per-child-deck new-limit apportionment, or any new/day override UI — deferred to a T+30 review if usage warrants.
- **Metric**: should move the successful first-card-review rate (new-only decks were hitting a dead button); watched via the Ankify review usage event on `/api/ops/metrics`.

## Notes
- SonarCloud scanner not run locally (no `SONAR_TOKEN` on this box). Changes add no new HTTP/HTML/zip/path-from-input sinks, so no new security surface.
- `is:due` already excludes suspended/buried; the `-is:suspended -is:buried` guards on the new query are defensive and harmless.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified by the maintainer in a live Anki container — new-only deck's Review button enabled, new cards served and gradeable, `answerCards` advances new→learning without daily-limit bypass.
