### PR TITLE
fix: serialize conversion telemetry writes to avoid worker-pool contention

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -555,6 +555,61 @@ describe('performConversion — workspace cleanup', () => {
     );
   });
 
+  it('waits for the unsupported-block write before starting the output-stats write', async () => {
+    let releaseUnsupported: () => void = () => undefined;
+    const unsupportedGate = new Promise<void>((resolve) => {
+      releaseUnsupported = resolve;
+    });
+    mockRecordUnsupported.mockReturnValueOnce(unsupportedGate);
+    mockRecordOutputStats.mockClear();
+
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: {
+          cardCount: 3,
+          emptyBackCount: 0,
+          unsupportedBlockTypes: ['html'],
+        },
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [1, 2, 3] }]),
+    }));
+    (CheckMonthlyCardLimitUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (BuildDeckForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest
+        .fn()
+        .mockResolvedValue({ size: 1, key: 'k', apkg: Buffer.from('') }),
+    }));
+    (NotifyUserUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (CompleteJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+    await Promise.resolve();
+
+    expect(mockRecordUnsupported).toHaveBeenCalledWith(['html']);
+    expect(mockRecordOutputStats).not.toHaveBeenCalled();
+
+    releaseUnsupported();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockRecordOutputStats).toHaveBeenCalledWith(
+      'convert',
+      expect.objectContaining({ cards: 3, emptyBack: 0 })
+    );
+  });
+
   it('does not fail the conversion when the conversion-output-stats write rejects with a pool timeout', async () => {
     mockRecordOutputStats.mockRejectedValueOnce(
       new Error(

--- a/src/lib/storage/jobs/helpers/performConversion.test.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.test.ts
@@ -33,6 +33,13 @@ jest.mock('../../../../data_layer/UnsupportedNotionBlockRepository', () => ({
     .mockImplementation(() => ({ record: mockRecordUnsupported })),
 }));
 
+const mockRecordOutputStats = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../data_layer/ConversionOutputStatsRepository', () => ({
+  ConversionOutputStatsRepository: jest
+    .fn()
+    .mockImplementation(() => ({ record: mockRecordOutputStats })),
+}));
+
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -540,6 +547,53 @@ describe('performConversion — workspace cleanup', () => {
 
     await performConversion(mockDatabase, baseRequest);
 
+    expect(track).toHaveBeenCalledWith(
+      'conversion_succeeded',
+      expect.objectContaining({
+        props: expect.objectContaining({ source: 'notion' }),
+      })
+    );
+  });
+
+  it('does not fail the conversion when the conversion-output-stats write rejects with a pool timeout', async () => {
+    mockRecordOutputStats.mockRejectedValueOnce(
+      new Error(
+        'Knex: Timeout acquiring a connection. The pool is probably full.'
+      )
+    );
+    (CreateJobWorkSpaceUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue({
+        ws: {},
+        exporter: {},
+        settings: {},
+        bl: { cardCount: 3, emptyBackCount: 0, unsupportedBlockTypes: [] },
+        rules: {},
+      }),
+    }));
+    (CreateFlashcardsForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue([{ cards: [1, 2, 3] }]),
+    }));
+    (CheckMonthlyCardLimitUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (BuildDeckForJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest
+        .fn()
+        .mockResolvedValue({ size: 1, key: 'k', apkg: Buffer.from('') }),
+    }));
+    (NotifyUserUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+    (CompleteJobUseCase as jest.Mock).mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    await performConversion(mockDatabase, baseRequest);
+
+    expect(mockRecordOutputStats).toHaveBeenCalledWith(
+      'convert',
+      expect.objectContaining({ cards: 3, emptyBack: 0 })
+    );
     expect(track).toHaveBeenCalledWith(
       'conversion_succeeded',
       expect.objectContaining({

--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -65,43 +65,46 @@ function toAnonymousId(anonId?: string): string | null {
   return typeof anonId === 'string' && anonId.length > 0 ? anonId : null;
 }
 
-function recordUnsupportedBlocks(database: Knex, types: string[]): void {
+async function recordUnsupportedBlocks(
+  database: Knex,
+  types: string[]
+): Promise<void> {
   if (types == null || types.length === 0) {
     return;
   }
   try {
-    void new UnsupportedNotionBlockRepository(database)
-      .record(types)
-      .catch((error) => {
-        console.error(
-          '[conversion] failed to record unsupported blocks',
-          error
-        );
-      });
+    await new UnsupportedNotionBlockRepository(database).record(types);
   } catch (error) {
     console.error('[conversion] failed to record unsupported blocks', error);
   }
 }
 
-function recordConversionOutputStats(
+async function recordConversionOutputStats(
   database: Knex,
   delta: { decks: number; cards: number; emptyBack: number }
-): void {
+): Promise<void> {
   try {
-    void new ConversionOutputStatsRepository(database)
-      .record('convert', delta)
-      .catch((error) => {
-        console.error(
-          '[conversion] failed to record conversion output stats',
-          error
-        );
-      });
+    await new ConversionOutputStatsRepository(database).record(
+      'convert',
+      delta
+    );
   } catch (error) {
     console.error(
       '[conversion] failed to record conversion output stats',
       error
     );
   }
+}
+
+async function recordConversionTelemetry(
+  database: Knex,
+  telemetry: {
+    unsupportedBlockTypes: string[];
+    stats: { decks: number; cards: number; emptyBack: number };
+  }
+): Promise<void> {
+  await recordUnsupportedBlocks(database, telemetry.unsupportedBlockTypes);
+  await recordConversionOutputStats(database, telemetry.stats);
 }
 
 function trackConversionFailed(
@@ -250,11 +253,13 @@ export default async function performConversion(
       bl.droppedAssetCount
     );
 
-    recordUnsupportedBlocks(database, bl.unsupportedBlockTypes);
-    recordConversionOutputStats(database, {
-      decks: decks.length,
-      cards: bl.cardCount,
-      emptyBack: bl.emptyBackCount,
+    void recordConversionTelemetry(database, {
+      unsupportedBlockTypes: bl.unsupportedBlockTypes,
+      stats: {
+        decks: decks.length,
+        cards: bl.cardCount,
+        emptyBack: bl.emptyBackCount,
+      },
     });
 
     const userId = Number.isFinite(Number(owner)) ? Number(owner) : null;


### PR DESCRIPTION
## What
The two end-of-conversion telemetry writes (`recordUnsupportedBlocks` and `recordConversionOutputStats`) previously fired detached-in-parallel. This serializes them: the output-stats write now runs only after the unsupported-block write resolves. They remain fire-and-forget and post-delivery, so the conversion never fails on a telemetry pool timeout.

## Why
A prod conversion hit `KnexTimeoutError: Timeout acquiring a connection. The pool is probably full.` on `ConversionOutputStatsRepository.record`.

Diagnosis (verified): both telemetry writes are off the user's critical path — the deck is already built, delivered (`NotifyUserUseCase`), and the job completed (`CompleteJobUseCase`) before they run, and each already swallows its own error. So the user's conversion succeeded; nothing was lost and there is no connection leak. The timeout is contention on the **Piscina worker's own knex pool** (`src/lib/conversionPool.ts`, `pool: { min: 0, max: 2 }`), not the server's pool. Firing both writes in parallel demanded 2 worker-pool connections at the same instant — the exact ceiling — and because the writes are detached, the worker can pick up the next queued job whose own queries then overlap the still-in-flight writes, stampeding a 2-connection pool.

## How
- `recordUnsupportedBlocks` / `recordConversionOutputStats` are now `async` and `await` their repo call inside a single try/catch (collapsing the old try + `.catch` double-guard). Each still resolves on failure — a pool timeout is logged, never thrown.
- New `recordConversionTelemetry` awaits the two in sequence; `performConversion` fires it once with `void` so the user path stays non-blocking and post-delivery latency is irrelevant.
- Net effect: a finishing job demands at most **one** telemetry connection at a time instead of two, without adding any connections.

### Connection-ceiling evaluation (why no pool bump)
Worker knex `max` = 2 per Piscina thread; `maxThreads` default = 4 (`resolveConversionWorkers`) → worst case 8 worker connections; server pool `max` = 20 (`KnexConfig.ts`) → ~28 total, comfortably under Postgres' default `max_connections` (100). Raising the worker `max` would work within the ceiling, but serialization removes the contention at the source without spending any connection headroom, so the pool `max` is left at 2. If the pool proves too small even after serialization under real load, a later modest bump (e.g. 2→3) is still ceiling-safe, but is not warranted now.

## Measuring success
Absence of `KnexTimeoutError` / "Timeout acquiring a connection. The pool is probably full." on `ConversionOutputStatsRepository.record` and `UnsupportedNotionBlockRepository.record` in prod logs, and no `[conversion] failed to record conversion output stats` lines carrying a pool-timeout cause. Watch the conversion-worker logs after deploy.

## Testing
- Unit tests added: a serialization test proving the output-stats write does not start until the unsupported-block write resolves (a deferred first write keeps the second uncalled; releasing it lets the second fire). It fails on the old parallel code for the right reason (second write called too early) and passes on the fix.
- Existing regression test retained: the conversion still succeeds when the output-stats write rejects with a pool timeout, and the non-fatal contract of both writes is preserved.
- `npx tsc -p . --noEmit` green (typechecks tests too); full `performConversion.test.ts` suite green (17/17); `oxfmt` clean.

## Browser check
Not applicable — no `web/src/` files; server-side worker code only.

## Changelog
No changelog entry — internal reliability, no user-visible behavior change (the affected writes were already post-delivery and error-swallowed; users never saw a failure).

## Risks
Low. The change only reorders two already-detached, already-error-swallowed telemetry writes and does not touch the user's critical path. Worst case, the two writes complete a few milliseconds apart instead of concurrently. Rollback is a straight revert of this commit.

## Goal alignment
None — internal reliability. Removes noisy false-alarm `KnexTimeoutError` log spam on healthy conversions so real conversion failures stay visible; does not move a funnel or revenue metric directly.

