### PR TITLE
fix: guard undefined card answer in Claude chunk telemetry

### DIFF
--- a/src/lib/claude/ClaudeService.test.ts
+++ b/src/lib/claude/ClaudeService.test.ts
@@ -1295,3 +1295,51 @@ describe('generateDeckInfo — floor v1 (comprehensive CardOption)', () => {
     expect(mockStream.finalMessage.mock.calls.length).toBeLessThan(6 + 6 + 6);
   });
 });
+
+describe('generateDeckInfo — card with a missing answer field', () => {
+  const textHtml =
+    '<html><body><h1>Cells</h1><p>The cell is the basic unit of life.</p></body></html>';
+
+  function responseWith(cards: Array<Record<string, unknown>>) {
+    return {
+      content: [
+        { type: 'text', text: JSON.stringify([{ deck: 'Biology', cards }]) },
+      ],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 100, output_tokens: 50 },
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStreamFn.mockReturnValue(mockStream);
+    mockStream.on.mockReturnThis();
+  });
+
+  it('converts a cloze card that omits the answer field instead of failing the chunk', async () => {
+    mockStream.finalMessage.mockResolvedValue(
+      responseWith([
+        { q: 'The {{c1::cell}} is the basic unit of life', cloze: true },
+      ])
+    );
+
+    const result = await generateDeckInfo(textHtml, []);
+
+    const cards = result.flatMap((deck) => deck.cards);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].cloze).toBe(true);
+    expect(cards[0].back).toBe('');
+  });
+
+  it('converts a basic card whose answer is undefined instead of throwing', async () => {
+    mockStream.finalMessage.mockResolvedValue(
+      responseWith([{ q: 'What is the basic unit of life?' }])
+    );
+
+    const result = await generateDeckInfo(textHtml, []);
+
+    const cards = result.flatMap((deck) => deck.cards);
+    expect(cards).toHaveLength(1);
+    expect(cards[0].back).toBe('');
+  });
+});

--- a/src/lib/claude/ClaudeService.ts
+++ b/src/lib/claude/ClaudeService.ts
@@ -296,7 +296,7 @@ function expandCompactDeckInfo(
     },
     cards: d.cards.map((c) => {
       const { back: rewrittenBack, audioFilenames } = rewriteAudioAnchors(
-        stripPathsFromCardHtml(c.a)
+        stripPathsFromCardHtml(c.a ?? '')
       );
       const declaredMedia = (c.media ?? []).map((m) =>
         resolveMediaPath(m, availableMediaFiles)
@@ -736,7 +736,7 @@ async function generateDeckInfoFromChunk(
             (sum, d) =>
               sum +
               d.cards.reduce(
-                (s, c) => s + c.a.replace(/<[^>]*>/g, '').length,
+                (s, c) => s + (c.a ?? '').replace(/<[^>]*>/g, '').length,
                 0
               ),
             0
@@ -754,7 +754,7 @@ async function generateDeckInfoFromChunk(
             (sum, d) =>
               sum +
               d.cards.reduce(
-                (s, c) => s + c.a.replace(/<[^>]*>/g, '').length,
+                (s, c) => s + (c.a ?? '').replace(/<[^>]*>/g, '').length,
                 0
               ),
             0
@@ -895,7 +895,7 @@ function collectExistingFronts(decks: DeckInfo[]): string[] {
 function buildTopUpInstruction(existingFronts: string[]): string {
   const sample = existingFronts
     .slice(0, 80)
-    .map((f) => f.replace(/<[^>]*>/g, '').slice(0, 120));
+    .map((f) => (f ?? '').replace(/<[^>]*>/g, '').slice(0, 120));
   const list = sample.map((s) => `- ${s}`).join('\n');
   return `Extract MORE single-fact cards from the same content. Do NOT repeat any of these fronts:\n${list}\n\nReturn only net-new cards.`;
 }

--- a/src/lib/claude/splitOversizedCards.ts
+++ b/src/lib/claude/splitOversizedCards.ts
@@ -54,7 +54,7 @@ function splitCard(card: CompactCard): CompactCard[] {
     return [card];
   }
 
-  const plain = stripHtmlTags(card.a);
+  const plain = stripHtmlTags(card.a ?? '');
   if (plain.length <= ANSWER_CEILING) {
     return [card];
   }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-13-claude-cloze-answer.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-13-claude-cloze-answer.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-13-claude-cloze-answer",
+  "date": "2026-07-13",
+  "type": "fix",
+  "title": "AI conversions with cloze cards convert even when a card has no separate answer"
+}


### PR DESCRIPTION
## What
A cloze card — or any Claude-returned card with a missing `a` (answer) field — has an undefined answer at runtime. The avg-answer-length telemetry computed `c.a.replace(...)` on it, which threw a `TypeError` and failed the entire chunk, degrading the whole AI conversion. This guards every place that reads the card answer as a string with `?? ''` so the non-essential logging math (and the expand/split answer reads on the same path) never throw on an absent answer.

## Why
Seen in prod logs: `[Claude] floor v1 chunk failed { reason: "TypeError: Cannot read properties of undefined (reading 'replace')" }`. `CompactCard.a` is typed non-optional, but the parse path (`parseDeckResponse`) accepts a card that is valid with only `q` + `cloze: true` and no `a` (see the `hasA || cloze === true` validation), so `a` is undefined at runtime even though tsc can't see it. Telemetry math must never fail a conversion.

## How
Guard the receiver before `.replace` / the string reads:
- `avgAnswerLenBefore` / `avgAnswerLenAfter` telemetry reductions: `(c.a ?? '').replace(...)`.
- `expandCompactDeckInfo`: `stripPathsFromCardHtml(c.a ?? '')` (`cheerio.load(undefined)` throws).
- `buildTopUpInstruction`: `(f ?? '').replace(...)` for the front sample.
- `splitOversizedCards.splitCard`: `stripHtmlTags(card.a ?? '')` (reached only by non-cloze cards, guarded for the same undefined-answer class).

No restructure of the reduces; minimal `?? ''` guards only.

## Measuring success
The `[Claude] floor v1 chunk failed` warn line with `reason: "TypeError: ...reading 'replace'"` should stop appearing in prod logs. Conversions that previously died on this trace now log `[Claude] splitOversizedCards` and `[Claude] chunk done` for the same chunk instead.

## Testing
- Unit tests added (outside-in via `generateDeckInfo`, Anthropic SDK mocked at the module edge):
  - a cloze card that omits `a` converts to 1 card with `cloze: true` and empty back, instead of failing the chunk.
  - a basic card whose `a` is undefined converts to 1 card with empty back instead of throwing.
- Both tests fail on `origin/main` with the exact prod `TypeError` before the guard, green after.
- `npx tsc -p . --noEmit` clean (typechecks tests too); `oxfmt` run on touched files.

## Browser check
Browser check: not applicable — changelog JSON only, no rendered UI change

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-13-claude-cloze-answer.json` — "AI conversions with cloze cards convert even when a card has no separate answer"

## Risks
Very low. The guards only substitute `''` for an absent answer, which is the correct value for a cloze card's back (empty). No behavior change for cards that already have a string answer. Rollback is a straight revert.

## Goal alignment
Reliability of the AI conversion hot path — a paid-only surface. Cloze-heavy decks (med/law learners) were silently degrading or failing; this keeps those conversions completing. Metric to watch: the floor-v1 chunk-failure rate in prod logs (should drop), supporting retention/ARPU on the paid tier. Not an acquisition change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
