### PR TITLE
spec: failed-payment recovery nudge (payments hard rail — needs gate)

### DIFF
--- a/Documentation/specs/failed-payment-recovery.md
+++ b/Documentation/specs/failed-payment-recovery.md
@@ -1,0 +1,114 @@
+# Failed-payment recovery (involuntary-churn nudge)
+
+Status: DRAFT — payments hard rail. Requires the maintainer's explicit gate and a
+`/security-review` before any implementation. This spec proposes no live change.
+
+## Problem
+
+Business metrics show ~10 failed payments/week — larger than the entire week's ~8 new-paid
+conversions. A failed renewal charge is involuntary churn: the subscriber did not choose to
+leave, their card expired, hit a limit, or bounced. Recovering even part of this is near-zero-CAC
+MRR defense — cheaper than any acquisition dollar.
+
+We already grant paid access during dunning: `updateStoreSubscription` treats `past_due` and
+`unpaid` as access-granting statuses (`ACCESS_GRANTING_STATUSES` in `src/lib/integrations/stripe.ts`),
+so a grace window exists. The gap is that we never *tell the user* their payment failed or give them
+a one-click way to fix their card. Stripe's own retry emails are off/inconsistent for this account.
+
+## What to build
+
+A single recovery nudge triggered by Stripe's `invoice.payment_failed` webhook:
+
+1. **Trigger:** add an `invoice.payment_failed` case to the `/webhook` switch in
+   `src/routes/WebhookRouter.ts`. It is not currently handled (the `default` arm logs it as
+   unhandled). No change to any charging, provisioning, or access logic.
+2. **Resolve the account** from the invoice's customer (reuse `getCustomerId` +
+   `stripe.customers.retrieve`, same as the existing subscription cases). Skip silently if no
+   2anki account resolves (do not leak an unlinked-payment alert here — that path already exists
+   for provisioning).
+3. **Send one card-update email** with a link the user can click to fix their card. Two link
+   options — the maintainer picks (see Open decisions):
+   - **Option A (simplest, no Stripe config):** the failed invoice already carries
+     `hosted_invoice_url` — a Stripe-hosted page where the customer can pay the open invoice and
+     update the card. Zero new Stripe surface, no portal configuration.
+   - **Option B (billing portal):** `stripe.billingPortal.sessions.create({ customer })` returns a
+     managed card-update session. Requires the Stripe Customer Portal to be configured and a
+     `return_url`. More flexible but more setup and a new Stripe call.
+4. **Idempotency + cadence:** record each send in a new
+   `failed_payment_recovery_notifications` table (mirror `subscription_recovery_notifications`:
+   `id`, `email`, `stripe_invoice_id`, `sent_at`). Before sending, check we have not already
+   emailed for this `stripe_invoice_id`. Stripe fires `invoice.payment_failed` once per retry
+   attempt in the dunning schedule; without dedupe on the invoice we would email on every retry.
+5. **Template:** `src/services/EmailService/templates/failed-payment-recovery.html`, following
+   `.claude/rules/email-templates.md` exactly — mascot header, dark-mode block, responsive block,
+   footer tagline. It carries an upsell-adjacent pitch (keep your subscription), so it **must**
+   include the `{{unsubscribeUrl}}` footer and its send path **must** exclude
+   `email_preferences.marketing_opt_out = true` recipients (see Open decisions — this classification
+   is a maintainer call). The template file is scaffolded in this PR but wired to nothing.
+
+## What NOT to build
+
+- No change to charging, retry schedule, dunning grace, or `ACCESS_GRANTING_STATUSES`. Stripe owns
+  retries; we only nudge.
+- No auto-cancel or auto-downgrade on failure. The grace window already handles access; this is a
+  nudge, not an enforcement mechanism.
+- No new billing-portal surface in-product (Option B stays server-only if chosen).
+- No SMS/push. One email per failed invoice, capped.
+- No retroactive backfill of past failures. Forward-only from the day it ships.
+- Do not reuse `subscription-recovery.html` — that template is for *unlinked* payments (a payment
+  with no matching account), a different problem. This is a linked subscriber whose card failed.
+
+## Suppression rules
+
+- Skip if no 2anki account resolves for the customer.
+- Skip if `marketing_opt_out = true` (pending the transactional-vs-marketing decision below).
+- Skip if we already emailed for this `stripe_invoice_id` (per-invoice idempotency).
+- Skip if the subscription is already `canceled`/`incomplete_expired` by the time we process
+  (nothing to recover).
+- Respect the existing SendGrid suppression list.
+
+## Success metric
+
+**Recovered subs ÷ failed payments** over a trailing 4-week window. A "recovery" = a subscription
+that had an `invoice.payment_failed` and returned to `active` within the dunning window. Read from:
+- `email_batch_sent` event with `campaign: 'failed_payment_recovery'` (send volume),
+- a `customer.subscription.updated` transition `past_due|unpaid → active` following a recorded
+  failed-payment notification (recovery signal),
+- cross-check against `BusinessMetricsService` failed-payment count.
+
+Baseline to beat: current involuntary-churn recovery is whatever Stripe's own retries recover with
+no nudge. Target for the maintainer to set (proposed: recover ≥20% of failed payments that would
+otherwise churn).
+
+## Open decisions for the maintainer
+
+1. **Transactional vs marketing.** A "your payment failed, update your card" email is arguably
+   transactional (it concerns the user's paid service), not marketing — which would mean it should
+   ship *without* the `marketing_opt_out` exclusion so opted-out payers still hear that their
+   subscription is at risk. `email-templates.md` classifies any upsell-adjacent email as commercial.
+   **Maintainer's call:** treat as transactional (no opt-out filter, no unsubscribe footer) or
+   commercial (opt-out filter + unsubscribe footer). Default in this spec is commercial/conservative.
+2. **Send timing / cadence.** Send on the first `invoice.payment_failed`, or wait until the 2nd/3rd
+   retry so Stripe's silent retry can succeed first? Proposed: send on first failure (early nudge
+   recovers expired cards fastest), one email per invoice, no follow-ups.
+3. **How many retries / follow-ups.** Proposed: exactly one email per failed invoice. A second
+   nudge near the end of the dunning window is a possible v2 but adds fatigue risk.
+4. **Link mechanism.** Option A (`hosted_invoice_url`) vs Option B (billing portal). Proposed:
+   Option A — no new Stripe config, no new managed session, the invoice URL fixes the exact open
+   charge.
+5. **Migration.** The dedupe table needs a Knex migration + `pnpm kanel` in the same
+   implementation PR (hard gate). Confirm table shape before implementation.
+
+## Implementation notes (for the eventual PR, not this one)
+
+- New use case `SendFailedPaymentRecoveryUseCase` under `src/usecases/ops/`, constructed in
+  `WebhookRouter.ts` with the notifications repo + email service (mirror
+  `SendAbandonedCheckoutRecoveryOnExpiryUseCase`).
+- New repository `FailedPaymentRecoveryNotificationsRepository` mirroring
+  `SubscriptionRecoveryNotificationsRepository`, with `isMarketingOptedOut` + `claimInvoice`.
+- New `IEmailService.sendFailedPaymentRecoveryEmail(to, link, token)` method + template load in
+  `constants.ts` (this is the "wiring" deliberately omitted from the draft PR).
+- Outside-in test: drive `invoice.payment_failed` through the webhook boundary with the Stripe SDK
+  mocked; assert one email send, correct link, dedupe on second identical event, and opt-out skip.
+- Payments hard rail: `/security-review` before merge; verify signature handling is unchanged and no
+  charging side effect is introduced.

--- a/src/services/EmailService/templates/failed-payment-recovery.html
+++ b/src/services/EmailService/templates/failed-payment-recovery.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="light dark" />
+  <title>2anki.net — Your payment didn't go through</title>
+  <style>
+    @media (prefers-color-scheme: dark) {
+      body { background-color: #1a1a1a !important; }
+      .email-card { background-color: #111827 !important; }
+      .email-header { color: #f9fafb !important; border-bottom-color: #374151 !important; }
+      .email-body p { color: #f9fafb !important; }
+      .email-cta a { background-color: #60a5fa !important; }
+      .email-footer { color: #6b7280 !important; border-top-color: #374151 !important; }
+    }
+    @media only screen and (max-width: 600px) {
+      .email-card { width: 100% !important; padding: 0 !important; }
+      .email-body { padding: 24px 16px !important; }
+      .email-header { padding: 16px !important; }
+      .email-footer { padding: 12px 16px !important; }
+    }
+  </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f5f5; -webkit-font-smoothing: antialiased;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f5f5;">
+    <tr>
+      <td align="center" style="padding: 32px 16px;">
+        <table role="presentation" class="email-card" cellpadding="0" cellspacing="0" style="max-width: 580px; width: 100%; background-color: #ffffff; border-radius: 8px;">
+          <tr>
+            <td class="email-header" style="text-align: center; padding: 24px; border-bottom: 1px solid #e5e7eb;">
+              <img src="https://2anki.net/mascot/navbar-logo.png" alt="2anki" width="120" style="display: block; margin: 0 auto; height: auto;" />
+            </td>
+          </tr>
+          <tr>
+            <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
+              <p style="margin: 0 0 16px; font-size: 18px; font-weight: 600; color: #111827;">Your 2anki payment didn't go through</p>
+              <p style="margin: 0 0 16px;">The card on file for your subscription was declined, usually an expired card or a temporary hold from the bank. Your access is still on for now. Update your card to keep it that way.</p>
+              <div style="text-align: center; margin: 0 0 24px;" class="email-cta">
+                <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Update payment</a>
+              </div>
+              <p style="margin: 0 0 16px;">If something looks wrong, reply to this email — Alexander reads every one.</p>
+              <p style="margin: 0;">The 2anki Team</p>
+            </td>
+          </tr>
+          <tr>
+            <td class="email-footer" style="text-align: center; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 12px; color: #9ca3af; padding: 16px 24px; border-top: 1px solid #e5e7eb;">
+              2anki.net — Turn what you study into Anki flashcards<br />
+              <a href="{{unsubscribeUrl}}" style="color: #6b7280; text-decoration: underline;">Don't want emails like this? Unsubscribe</a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## What

Draft spec (`Documentation/specs/failed-payment-recovery.md`) for an involuntary-churn
recovery nudge: on Stripe's `invoice.payment_failed` webhook, email the affected subscriber a
card-update link so they can rescue their subscription inside the existing dunning grace window.
Ships an **inert, unwired** email template (`failed-payment-recovery.html`) so the copy and layout
are reviewable. **No code path, webhook handler, charging logic, or send path is wired in this PR.**

## Why

Business metrics show ~10 failed payments/week — larger than the entire week's ~8 new-paid
conversions. We already grant paid access during dunning (`past_due`/`unpaid` in
`ACCESS_GRANTING_STATUSES`), but we never *tell the user* their card failed. The gap is a recovery
nudge. Recovering even part of this is near-zero-CAC MRR defense — cheaper than any acquisition dollar.

## Payments hard rail — needs your gate

This touches Stripe + a commercial email, both hard rails. I deliberately did **not**:
- add the `invoice.payment_failed` case to `WebhookRouter.ts` (it is still unhandled today),
- wire the template into `EmailService`/`constants.ts` or any send path,
- change charging, retries, dunning grace, or `ACCESS_GRANTING_STATUSES`,
- register a sender or create a migration.

**Requesting:** your explicit go/no-go, plus a `/security-review` before any implementation lands.
This PR stays **draft** until then. Do not merge.

## Open decisions for you

1. **Transactional vs marketing.** "Your payment failed, update your card" is arguably transactional
   (it concerns the user's own paid service), which would mean *no* `marketing_opt_out` exclusion so
   opted-out payers still hear their subscription is at risk. `email-templates.md` classifies any
   upsell-adjacent email as commercial. The spec + template default to commercial/conservative
   (unsubscribe footer + opt-out filter). Your call.
2. **Send timing / cadence.** Send on the first `invoice.payment_failed`, or wait for the 2nd/3rd
   retry so Stripe's silent retry can succeed first? Spec proposes first-failure, one email per invoice.
3. **How many retries / follow-ups.** Spec proposes exactly one email per failed invoice.
4. **Link mechanism.** Option A (`hosted_invoice_url` — zero new Stripe config) vs Option B (billing
   portal session). Spec proposes A.
5. **Migration.** A `failed_payment_recovery_notifications` dedupe table needs a Knex migration +
   `pnpm kanel` in the implementation PR (hard gate). Confirm table shape first.

## Success metric

Recovered subs ÷ failed payments over a trailing 4-week window (a recovery = `past_due|unpaid →
active` after a recorded failed-payment notification). Send volume via `email_batch_sent`
(`campaign: 'failed_payment_recovery'`); cross-checked against `BusinessMetricsService` failed-payment
count. Proposed target for you to set: recover ≥20% of would-be involuntary churn.

## Testing

- None yet — spec + inert HTML only, no source logic. The eventual implementation PR carries an
  outside-in webhook test (Stripe SDK mocked: one send, correct link, per-invoice dedupe, opt-out skip).

## Changelog

No entry — draft spec + unwired template, no user-visible behavior ships.

## Risks

None from this PR (nothing executes). The risk surface is entirely in the future implementation and
is the reason for the gate: a mistake in the `invoice.payment_failed` handler or the send path could
email the wrong users or interact with charging. Hence draft + `/security-review` before build.

## Goal alignment

Directly targets MRR/retention — the primary lever per CLAUDE.md. Defends existing revenue against
involuntary churn at near-zero CAC. Metric to move: recovered-subs rate, read from the ops
business-metrics failed-payment count. Not an acquisition change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
