### PR TITLE
docs: retire file-based memory system, move facts into repo

### DIFF
--- a/.claude/rules/local-dev.md
+++ b/.claude/rules/local-dev.md
@@ -1,0 +1,33 @@
+# Local dev environment (maintainer's machine)
+
+Environment-specific facts for running the toolchain, migrations, and checks on Alexander's macOS box, and for working out of a `.claude/worktrees/` git worktree. These are machine notes, not product rules — read them when a local command behaves unexpectedly, not before every task.
+
+## Toolchain PATH
+
+- `~/.local/bin` is a **trimmed symlink subset** (node, npm, claude, bunx only). The FULL toolchain lives at `/Users/a/.nvm/versions/node/v22.20.0/bin/` — `pnpm`, `npx`, `corepack`, `tsc` all exist there. If `pnpm`/`npx` is "not found", `export PATH="/Users/a/.nvm/versions/node/v22.20.0/bin:$PATH"`.
+- Repo-local tools also run directly via `./node_modules/.bin/{jest,tsc,oxlint,oxfmt,tsx}`.
+- **kanel is not a package.json dependency** — invoke it with `pnpm dlx kanel -c ./.kanelrc.js`. The kanel-in-PR hard gate (see CLAUDE.md "Run it") IS passable on this box: apply the migration to local Postgres first, then run kanel against the live schema. Local dev DB is Postgres **`n`**, user **`a`**, no password (the `DATABASE_URL` in root `.env`); `.kanelrc.js` reads discrete `POSTGRES_*` and `.env`'s `POSTGRES_USER=postgres` is stale, so override inline: `POSTGRES_HOST=localhost POSTGRES_USER=a POSTGRES_DATABASE=n pnpm dlx kanel -c ./.kanelrc.js`.
+- No `SONAR_TOKEN` on this box — note "Sonar not run locally; Automatic Analysis covers the push" in PR bodies rather than pretending it ran.
+- Pre-existing local test failure: `src/lib/pdf/getPageCount.test.ts` (needs a `pdfinfo` binary on PATH) — not your change.
+- When reading `oxfmt --check` output, read the WHOLE thing, not `tail -1` — the "issues found" line sits ABOVE the timing line, so a truncated read misses a real format failure and bounces CI.
+
+## Working from a git worktree
+
+- **First action in any fresh worktree:** `pnpm install && pnpm --filter 2anki-web install` (source-only checkout has no `node_modules`, no Oxc native bindings). See `parallel-pr-coordination.md` for the Oxc-binding recovery path.
+- **Web checks (vitest/tsc/lint) fail in a worktree** because `web/node_modules` is absent. Symlink it (gitignored, non-destructive): `ln -sfn /Users/a/src/github.com/2anki/server/web/node_modules web/node_modules`. Server jest resolves via the walk-up and needs no symlink.
+- **`knex migrate:make` fails in a worktree** (ts-node can't compile `KnexConfig.ts`, TS5011 rootDir). Hand-write the migration file — existing ones are plain JS (`exports.up/down`); pick a timestamp after the latest in `migrations/`. Run it via a tiny `tsx` script at the **worktree root** (not `/tmp` — relative imports break) that calls `knex(KnexConfig).migrate.latest()`.
+- **No Python venv in worktrees.** `create_deck/venv` only exists in the main checkout, so full `.apkg` packaging (`getPackagesFromZip` / `PrepareDeck` → genanki) fails in a worktree with `PythonExitError`. End-to-end pipeline runs must happen in the main checkout, which sets `WORKSPACE_BASE` / `CREATE_DECK_DIR` in its `.env`.
+
+## Main checkout is shared test infra — verify it's clean
+
+The main checkout (`/Users/a/src/github.com/2anki/server`) is where full-pipeline runs work, but it is Alexander's live working tree. Before trusting ANY real-pipeline result from it, `git status` it and confirm it's clean and at the expected sha (and that the feature's new files exist). A dirty tree runs the WRONG code and gives false results — a "conversion still broken" reading once turned out to be the main checkout running with a source file deleted from its working tree; on clean code it converted fine. Treat the main checkout as read-only test infra; do experiments in a worktree. Restore with `git checkout HEAD -- .` (the `safety.py` hook blocks `git reset --hard` with uncommitted changes).
+
+## Diagnosing local hook / deploy oddities
+
+- **Pre-push `tsc` hook error referencing another branch's files** during a multi-worktree session is usually NOT a cross-worktree hook bug — it's real pollution. An agent leaked branch files into the main checkout and the hook's tsc saw the broken half-state. Run `git status` in the **main checkout** first; if polluted, verify each stray file matches the PR branch copy, then discard it. Only bypass with `CLAUDE_SKIP_TYPECHECK=1` after `npx tsc -p . --noEmit` passes in the tree being pushed.
+- **A new `web/src/App.tsx` route needs a matching entry in `src/routes/knownRoutes.ts` in the same PR.** `DefaultRouter` serves the SPA shell with a 200 only for listed paths; an unregistered path renders fine via client-side navigation but returns **404 on direct load or refresh** — invisible in normal clicking and in vitest. Verify post-deploy with `curl -w "%{http_code}"` on the new URL.
+- **`Graceful shutdown exceeded 25000ms — forcing exit` in prod logs is expected on every deploy** (an in-flight conversion holds the drain past the 25s window). Don't surface it in `/deploy-status` as a concern — only flag genuine faults (`uncaught exception`, native-binding failures, `EADDRINUSE`, crash loops).
+
+## Harness mechanics
+
+- A **non-zero Bash exit cancels every still-queued tool call after it** in the same turn (including spawned Agents). Run shippable git steps in their own message, and end multi-step bash scripts with a command that exits 0 (a final `git log`/`echo`) so a mid-script failure doesn't cascade-cancel the rest.

--- a/.claude/rules/support-confidentiality.md
+++ b/.claude/rules/support-confidentiality.md
@@ -13,7 +13,6 @@ Bug reports, support emails, and feedback frequently arrive with the reporter's 
 ## Where reporter detail is okay
 
 - Local files outside the repo: `~/Downloads/reply-<name>.txt`, `~/Downloads/*.eml`, anything the user keeps offline.
-- Memory under `~/.claude/projects/.../memory/` — local to your machine, not committed.
 - The conversation with Al inside Claude Code — explaining what you found is the point of the conversation.
 - The drafted support reply itself — that obviously goes to the reporter.
 - Private support tooling (the inbox, Stripe customer record, Postgres) — Al's eyes only, not public.
@@ -32,4 +31,4 @@ You will sometimes draft something with a name in it. The fix sequence:
 
 1. Editable artifacts first (`gh pr edit <n> --body ...`, GitHub issue body, draft spec) — those are one command away.
 2. Merged commits on `main` are harder. Force-pushing `main` to scrub a name is destructive and visible to every contributor; flag the slip to Al and let him decide whether the rewrite is worth it. Default answer is usually "no, leave it, do better next time."
-3. Save the lesson to memory so the next session doesn't repeat the same shape of slip.
+3. If the slip points at a recurring hole, capture the anonymized lesson in a repo doc (this rule, or the relevant `.claude/rules/*`) — not in a local memory file (memory is retired here; see `## Memory & sensitive data` in CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@ Revenue: grow MRR past $5K — ARPU and retention are the levers; user count fol
 Allocation: every week ships at least one acquisition-facing change — landing pages, SEO, onboarding, or signup/first-conversion friction — and it ships **before** any new product surface starts that week. Acquisition is the only lane that creates users; starve it and the 300K goal stalls no matter how much else moves. History note: 2026 ran 6% acquisition work and 2023-25 ran 0% across 36 months — both starved the only lane that makes users.
 Every PR is checked against all three — does it make the experience simpler/faster/more beautiful, does it move us toward scale, and does it (for user-facing changes) state which funnel or revenue metric it should move?
 
+## Memory & sensitive data
+
+- **Do not use the file-based memory system in this project.** The harness memory under `~/.claude/projects/.../memory/` is retired here. Persist durable facts in `CLAUDE.md`, `.claude/rules/*`, or the relevant `FEATURE.md` — anything worth remembering lives in the repo, versioned and reviewable, not in per-machine local memory. Do not write new memory files; if you find yourself wanting to, add a repo doc instead.
+- **Never store sensitive or live data.** Business metrics (MRR, ARPU, churn, sub counts), pricing, Stripe/prod settings, individual subscriber or reporter identifiers — retrieve these from production when needed (prod psql, Stripe dashboard/MCP, `/api/ops/*`, `/deploy-status`), never commit them to the repo or a local file. They go stale and they leak.
+
 ## Design Context
 - **Register**: product
 - **Surface(s)**: `/ankify` (sync control panel) — first adopter of the locked DNA; widen as other surfaces follow
@@ -74,6 +79,7 @@ Load on demand — read these when the task touches the named surface (kept out 
 
 - `.claude/rules/email-templates.md` — read before editing any template under `src/services/EmailService/templates/`.
 - `.claude/rules/parallel-pr-coordination.md` — read before kicking off a multi-PR batch (more than two PRs in flight) or running `/spec-draft-pr` more than once in a row.
+- `.claude/rules/local-dev.md` — read when running toolchain/migrations/checks locally on the maintainer's machine, working out of a git worktree, or diagnosing a pre-push/deploy-status oddity.
 
 ## Git
 
@@ -102,6 +108,8 @@ Load on demand — read these when the task touches the named surface (kept out 
 - For "wait until X" (long builds, CI, deploys baking on prod), use `ScheduleWakeup` (270s if cache-warm matters, 1200s+ for genuine waits). Never busy-poll with sleep.
 - After deploys to 2anki.net, run `/deploy-status` to confirm the box is healthy.
 - If you keep approving the same read-only Bash commands, suggest `/fewer-permission-prompts`.
+- **Report tight.** State each outcome in one line; skip the "what I did / what changed / what's next" recap unless asked for status — Alexander reads the diff and PR body, don't re-narrate them. The exception is confirming a risky/destructive step first — that's safety, not chatter.
+- **Every PR/issue/run mention gets a full clickable URL** (`https://github.com/2anki/server/pull/NNNN`), never a bare `#NNNN`. Reports are read in a terminal and clicked through.
 
 ## Process
 
@@ -112,6 +120,9 @@ Load on demand — read these when the task touches the named surface (kept out 
 - Outside-in testing. Mock only external dependencies (HTTP, third-party APIs, email) — never internal services.
 - A passing suite is not proof of correctness — review affected user flows for regressions before committing.
 - Before declaring a task done, strip scaffolding, debug logs, and temporary code added during implementation.
+- When the user asks to test a PR locally, get the branch checked out in the **main repo** (`gh pr checkout <n>`) and stop — the user starts `pnpm dev` from their own terminal. Don't launch a dev server yourself.
+- When triaging a support `.eml`, extract and Read every image attachment before any code investigation — screenshots disambiguate which product surface the user means (e.g. the one-shot converter vs Ankify are different code paths). Treat "see attached" as a blocking read, not decoration.
+- When writing an agent brief, keep dictated PR/commit text and agent-behavior rules (don't merge, halt conditions) in **separate** paragraphs — a subagent pastes anything adjacent to "the body should say X" into the public PR body verbatim. After any agent opens a PR, skim the body before handing it over.
 
 ## Gotchas
 


### PR DESCRIPTION
## What

Retires the file-based (harness) memory system for this project and moves its durable, non-sensitive facts into the repo.

- **CLAUDE.md** — new `## Memory & sensitive data` section: do not use the harness memory dir here (CLAUDE.md overrides the default), and never store sensitive/live data — retrieve it from production. Plus a handful of migrated working-style bullets (`## Working speed`, `## Process`) and the new rule registered under "Load on demand".
- **`.claude/rules/local-dev.md`** (new, load-on-demand) — consolidates the durable local-dev/worktree/hook facts worth keeping (toolchain PATH + kanel-via-dlx on the darwin box, worktree web/node_modules symlink + hand-written migrations, no venv in worktrees, main-checkout-is-shared-test-infra, pre-push tsc cross-worktree diagnosis, new-route-needs-knownRoutes, graceful-shutdown-is-benign, bash-exit-cancels-queued-calls).
- **`.claude/rules/support-confidentiality.md`** — drops the now-stale "memory is an OK place for reporter detail" bullet and the "save the lesson to memory" step.
- The local memory directory (outside the repo) is deleted as part of this change.

## Why

Direct maintainer directive: "stop using memory altogether in this project. Store information in CLAUDE.md or .claude. Sensitive information should be retrieved from production not stored." File-based memory is per-machine, unversioned, unreviewable, and a leak/staleness risk for business data. Repo docs are versioned and reviewable; live data belongs in prod.

## Migration ledger (all 47 memory files)

| File | Disposition |
| --- | --- |
| MEMORY.md | DROP — index of the retired system |
| bug-netlify-preview-redirect | DROP — already in repo (CLAUDE.md Netlify gotcha) |
| dropped-anking-ioe-compat | DROP — dropped-feature decision log, not a durable dev fact |
| feedback_be_concise | MIGRATED → CLAUDE.md `## Working speed` |
| feedback_sales_safari_for_research | DROP — already in repo (`sales-safari` skill) |
| feedback_user_runs_dev_server | MIGRATED → CLAUDE.md `## Process` |
| feedback-agent-brief-leaks-into-pr-body | MIGRATED → CLAUDE.md `## Process` |
| feedback-always-link-github-artifacts | MIGRATED → CLAUDE.md `## Working speed` |
| feedback-always-read-eml-attachments | MIGRATED → CLAUDE.md `## Process` |
| feedback-first-time-fix | DROP — already in repo (`.claude/rules/first-time-fix.md`) |
| feedback-graceful-shutdown-expected | MIGRATED → `.claude/rules/local-dev.md` |
| feedback-hands-off-oxlint-migration | DROP — stale (that migration is done) |
| feedback-no-concurrent-engineers-shared-checkout | DROP — already in repo (`parallel-pr-coordination.md`) |
| feedback-no-hidden-env-feature-flags | DROP — already in repo (`code-quality.md`) |
| feedback-stash-may-be-already-merged | DROP — niche situational caution, low durable value |
| followup-annual-default-refund-friction | DROP — sensitive (pricing/refund metrics) |
| followup-photo-density-telemetry | DROP — ephemeral follow-up task; belongs in an issue/code |
| project-ankify-ankiconnect-per-user | DROP — already in repo (`src/lib/ankify/FEATURE.md` + CLAUDE.md gotcha) |
| project-blue-green-live | DROP — already in repo (`Documentation/deploy/blue-green.md`) |
| project-claude-token-spike-jun7 | DROP — sensitive (spend incident); code is source of truth |
| project-growth-analysis-2026-06-03 | DROP — sensitive (funnel/retention metrics) |
| project-ios-native-app-strategy | DROP — sensitive (pricing/strategy) |
| project-monthly-quota-rollover-incident | DROP — sensitive (purchase-drop financials) |
| project-pricing-ab-concluded-minimal | DROP — sensitive (pricing A/B) |
| reference-ankify-render-content-hash | DROP — already in repo (`src/lib/ankify/FEATURE.md`) |
| reference-ankify-review-audio-anki-play | DROP — already in repo (`src/lib/ankify/FEATURE.md`) |
| reference-bugsnag-purged | DROP — resolved historical incident (account purged) |
| reference-claude-ai-flag-gating | DROP — code-specific, drift risk; source is truth |
| reference-commit-hook-eats-heredoc | DROP — already in repo (CLAUDE.md Git) |
| reference-commit-hook-requires-why-body | DROP — already in repo (CLAUDE.md Git); the "non-zero bash exit cancels queued calls" nuance MIGRATED → `.claude/rules/local-dev.md` |
| reference-deploy-tsc-typechecks-tests | DROP — already in repo (CLAUDE.md gotcha) |
| reference-jest-esm-dep-stub | DROP — already in repo (`dependencies.md`) |
| reference-legacy-2dollar-base | DROP — sensitive (pricing/sub base) |
| reference-local-tsc-drift-masks-ci | DROP — already in repo (CLAUDE.md gotcha) |
| reference-main-checkout-venv-and-pollution | MIGRATED → `.claude/rules/local-dev.md` |
| reference-merge-attestation-separate-call | DROP — already in repo (CLAUDE.md Git) |
| reference-new-web-route-needs-knownroutes | MIGRATED → `.claude/rules/local-dev.md` |
| reference-no-pnpm-on-darwin-box | MIGRATED → `.claude/rules/local-dev.md` |
| reference-orphaned-sub-diagnosis | DROP — sensitive (subscriber diagnosis) |
| reference-prepush-tsc-hook-cross-worktree-fp | MIGRATED → `.claude/rules/local-dev.md` |
| reference-provision-stuck-stripe-subscriber | DROP — sensitive (subscriber ops) |
| reference-sonarcloud-automatic-analysis-properties | DROP — already in repo (`sonar.md`) |
| reference-stripe-revenue-recovery-on | DROP — already in repo (`dependencies.md` platform-capability rule); the specifics are sensitive |
| reference-stripe-sync-on-startup-enabled | DROP — already in repo (CLAUDE.md gotcha) |
| reference-verify-day-pass-prod | DROP — sensitive (subscriber verify) |
| reference-worktree-migration-kanel-web-checks | MIGRATED → `.claude/rules/local-dev.md` |
| wip-migration-stash | DROP — permanent fix already in repo (`src/KnexConfig.ts` `LOCAL_DEV`); recipe niche |

11 migrated, 36 dropped (18 sensitive/ephemeral, 18 already-in-repo). No reporter PII or business figures were carried into the repo.

no changelog entry — internal agent-harness docs, no user-visible change

Browser check: not applicable — no web/src files, .claude + CLAUDE.md docs only
