### PR TITLE
fix: name the deck and card count in lifecycle emails

### DIFF
--- a/src/lib/storage/jobs/helpers/performConversion.ts
+++ b/src/lib/storage/jobs/helpers/performConversion.ts
@@ -242,6 +242,7 @@ export default async function performConversion(
       key,
       id,
       apkg,
+      cardCount,
     });
 
     const completeJob = new CompleteJobUseCase(jobRepository, usersRepository);

--- a/src/services/EmailService/EmailService.test.ts
+++ b/src/services/EmailService/EmailService.test.ts
@@ -123,3 +123,130 @@ describe('EmailService.sendAbandonedCheckoutRecoveryEmail', () => {
     expect(msg.html).not.toContain('{{unsubscribeUrl}}');
   });
 });
+
+describe('EmailService conversion emails name the deck and count', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SENDGRID_API_KEY = 'test-key';
+    process.env.DOMAIN = 'https://2anki.net';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function lastMessage() {
+    const calls = send.mock.calls;
+    return calls[calls.length - 1][0] as {
+      to: string;
+      subject: string;
+      html: string;
+      text: string;
+    };
+  }
+
+  it('renders the deck name and card count in the attachment email', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendConversionEmail(
+      'learner@example.com',
+      'Organic Chemistry Ch. 4',
+      Buffer.from('apkg'),
+      34
+    );
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('Organic Chemistry Ch. 4');
+    expect(msg.html).toContain('34 cards');
+    expect(msg.html).not.toContain('{{deckName}}');
+    expect(msg.html).not.toContain('{{cardCountSuffix}}');
+    expect(msg.text).toBe(
+      'Your deck is ready: Organic Chemistry Ch. 4 — 34 cards. It is attached to this email.'
+    );
+  });
+
+  it('renders the deck name, card count, and link in the link email', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendConversionLinkEmail(
+      'learner@example.com',
+      'Biochemistry',
+      'https://2anki.net/api/download/u/key-1',
+      1
+    );
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('Biochemistry');
+    expect(msg.html).toContain('1 card');
+    expect(msg.html).toContain('https://2anki.net/api/download/u/key-1');
+    expect(msg.html).not.toContain('{{link}}');
+    expect(msg.text).toContain('Your deck is ready: Biochemistry — 1 card');
+  });
+
+  it('omits the count clause when card count is absent', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendConversionEmail(
+      'learner@example.com',
+      'History Notes',
+      Buffer.from('apkg')
+    );
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('History Notes');
+    expect(msg.html).not.toContain('{{cardCountSuffix}}');
+    expect(msg.html).not.toContain('undefined');
+    expect(msg.html).not.toContain('History Notes —');
+    expect(msg.text).toBe(
+      'Your deck is ready: History Notes. It is attached to this email.'
+    );
+  });
+
+  it('falls back to Untitled deck for an empty name', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendConversionEmail(
+      'learner@example.com',
+      '   ',
+      Buffer.from('apkg'),
+      12
+    );
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('Untitled deck');
+    expect(msg.text).toBe(
+      'Your deck is ready: Untitled deck — 12 cards. It is attached to this email.'
+    );
+  });
+
+  it('escapes HTML in the deck name', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendConversionEmail(
+      'learner@example.com',
+      '<script>alert(1)</script>',
+      Buffer.from('apkg'),
+      3
+    );
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(msg.html).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('groups large card counts with a thin space', async () => {
+    const service = getDefaultEmailService();
+
+    await service.sendConversionEmail(
+      'learner@example.com',
+      'Big Deck',
+      Buffer.from('apkg'),
+      12450
+    );
+
+    const msg = lastMessage();
+    expect(msg.html).toContain('12 450 cards');
+  });
+});

--- a/src/services/EmailService/EmailService.ts
+++ b/src/services/EmailService/EmailService.ts
@@ -22,6 +22,7 @@ import {
   SUBSCRIPTION_RESUMING_SOON_TEMPLATE,
 } from './constants';
 import { isValidDeckName, addDeckNameSuffix } from '../../lib/anki/format';
+import { escapeHtml } from '../../lib/notion-render/escape';
 import { ClientResponse } from '@sendgrid/mail';
 import { SUPPORT_EMAIL_ADDRESS } from '../../lib/constants';
 import { emailHash } from '../../lib/emailHash';
@@ -37,9 +38,15 @@ export interface IEmailService {
   sendConversionEmail(
     email: string,
     filename: string,
-    contents: Buffer
+    contents: Buffer,
+    cardCount?: number
   ): Promise<[ClientResponse, {}] | null> | void;
-  sendConversionLinkEmail(email: string, filename: string, link: string): void;
+  sendConversionLinkEmail(
+    email: string,
+    filename: string,
+    link: string,
+    cardCount?: number
+  ): void;
   sendContactEmail(
     name: string,
     email: string,
@@ -101,6 +108,38 @@ export const PRICE_LOCK_IN_SUBJECTS: Record<'a' | 'b', string> = {
 
 type SgMessage = Exclude<Parameters<typeof sgMail.send>[0], unknown[]>;
 type IsEmailSuppressed = (email: string) => Promise<boolean>;
+
+const THIN_SPACE = ' ';
+
+function formatCardCount(count: number): string {
+  const label = count === 1 ? 'card' : 'cards';
+  const grouped =
+    count >= 10000
+      ? String(count).replace(/\B(?=(\d{3})+(?!\d))/g, THIN_SPACE)
+      : String(count);
+  return `${grouped} ${label}`;
+}
+
+function resolveDeckName(filename: string): string {
+  const trimmed = filename.trim();
+  return trimmed === '' ? 'Untitled deck' : trimmed;
+}
+
+function renderDeckReadyMarkup(
+  template: string,
+  deckName: string,
+  cardCount?: number
+): string {
+  const suffix = cardCount == null ? '' : ` — ${formatCardCount(cardCount)}`;
+  return template
+    .replace('{{deckName}}', escapeHtml(deckName))
+    .replace('{{cardCountSuffix}}', suffix);
+}
+
+function deckReadyText(deckName: string, cardCount?: number): string {
+  const suffix = cardCount == null ? '' : ` — ${formatCardCount(cardCount)}`;
+  return `Your deck is ready: ${deckName}${suffix}`;
+}
 
 function firstRecipient(to: SgMessage['to']): string | null {
   if (typeof to === 'string') {
@@ -166,9 +205,11 @@ export class EmailService implements IEmailService {
   sendConversionEmail(
     email: string,
     filename: string,
-    contents: Buffer
+    contents: Buffer,
+    cardCount?: number
   ): Promise<[ClientResponse, {}] | null> {
-    const markup = CONVERT_TEMPLATE;
+    const deckName = resolveDeckName(filename);
+    const markup = renderDeckReadyMarkup(CONVERT_TEMPLATE, deckName, cardCount);
 
     let attachedFilename = filename;
     if (!isValidDeckName(filename)) {
@@ -178,7 +219,7 @@ export class EmailService implements IEmailService {
       to: email,
       from: DEFAULT_SENDER,
       subject: `2anki.net - Your «${filename}» deck is ready`,
-      text: 'Attached is your deck',
+      text: `${deckReadyText(deckName, cardCount)}. It is attached to this email.`,
       html: markup,
       replyTo: 'support@2anki.net',
       attachments: [
@@ -194,13 +235,23 @@ export class EmailService implements IEmailService {
     return this.deliver(msg);
   }
 
-  async sendConversionLinkEmail(email: string, filename: string, link: string) {
-    const markup = CONVERT_LINK_TEMPLATE.replace(/{{link}}/g, link);
+  async sendConversionLinkEmail(
+    email: string,
+    filename: string,
+    link: string,
+    cardCount?: number
+  ) {
+    const deckName = resolveDeckName(filename);
+    const markup = renderDeckReadyMarkup(
+      CONVERT_LINK_TEMPLATE,
+      deckName,
+      cardCount
+    ).replace(/{{link}}/g, link);
     const msg = {
       to: email,
       from: DEFAULT_SENDER,
       subject: `2anki.net - Your «${filename}» deck is ready`,
-      text: `Download your deck here: ${link}`,
+      text: `${deckReadyText(deckName, cardCount)}. Download it here: ${link}`,
       html: markup,
       replyTo: 'support@2anki.net',
     };
@@ -319,8 +370,8 @@ export class EmailService implements IEmailService {
     const msg = {
       to,
       from: this.defaultSender,
-      subject: 'Still figuring out 2anki? We can help.',
-      text: `Hi ${name},\n\nYou signed up for 2anki a few days ago but haven't converted anything yet.\n\nWhen you're ready, visit https://2anki.net\n\nTell us what happened: ${surveyUrl}\n\nThe 2anki Team`,
+      subject: 'Still making cards by hand?',
+      text: `Hi ${name},\n\nYou signed up for 2anki a few days ago but haven't made a deck yet. Typing out flashcards is the slow part — 2anki turns a Notion page or an uploaded file into an Anki deck in under a minute.\n\nPaste a Notion page URL or upload a file at https://2anki.net to try it.\n\nStuck on something? Reply to this email — Alexander reads every one.\n\nTell us what happened: ${surveyUrl}\n\nThe 2anki Team`,
       html: markup,
       replyTo: 'support@2anki.net',
     };
@@ -706,12 +757,34 @@ export class UnimplementedEmailService implements IEmailService {
     console.info('sendResetEmail not handled', email, token);
   }
 
-  sendConversionEmail(email: string, filename: string, contents: Buffer): void {
-    console.info('sendConversionEmail not handled', email, filename, contents);
+  sendConversionEmail(
+    email: string,
+    filename: string,
+    contents: Buffer,
+    cardCount?: number
+  ): void {
+    console.info(
+      'sendConversionEmail not handled',
+      email,
+      filename,
+      contents,
+      cardCount
+    );
   }
 
-  sendConversionLinkEmail(email: string, filename: string, link: string): void {
-    console.info('sendConversionLinkEmail not handled', email, filename, link);
+  sendConversionLinkEmail(
+    email: string,
+    filename: string,
+    link: string,
+    cardCount?: number
+  ): void {
+    console.info(
+      'sendConversionLinkEmail not handled',
+      email,
+      filename,
+      link,
+      cardCount
+    );
   }
 
   sendContactEmail(

--- a/src/services/EmailService/templates/convert-link.html
+++ b/src/services/EmailService/templates/convert-link.html
@@ -36,7 +36,8 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #1f2937;">Your deck is ready</h1>
+              <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #1f2937;">Your deck is ready</h1>
+              <p style="margin: 0 0 16px; font-size: 16px;"><span style="font-weight: 500;">{{deckName}}</span>{{cardCountSuffix}}</p>
               <p style="margin: 0 0 16px;">Your deck is ready to download. The link expires in 24 hours.</p>
               <div style="text-align: center; margin: 24px 0;" class="email-cta">
                 <a href="{{link}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Download deck</a>

--- a/src/services/EmailService/templates/convert.html
+++ b/src/services/EmailService/templates/convert.html
@@ -36,7 +36,8 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #1f2937;">Your deck is ready</h1>
+              <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #1f2937;">Your deck is ready</h1>
+              <p style="margin: 0 0 16px; font-size: 16px;"><span style="font-weight: 500;">{{deckName}}</span>{{cardCountSuffix}}</p>
               <p style="margin: 0 0 16px;">Your converted deck is attached to this email. Import it into Anki to start studying.</p>
               <p style="margin: 0 0 16px;">Having trouble? Reply to this email.</p>
               <p class="email-muted" style="margin: 16px 0 0; font-size: 13px; color: #9ca3af;">Did not request this conversion? Contact us at <a href="mailto:support@2anki.net" class="email-link" style="color: #9ca3af; text-decoration: none;">support@2anki.net</a>.</p>

--- a/src/services/EmailService/templates/re-engagement.html
+++ b/src/services/EmailService/templates/re-engagement.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="color-scheme" content="light dark" />
-  <title>2anki.net - Still figuring out 2anki?</title>
+  <title>2anki.net - Still making cards by hand?</title>
   <style>
     @media (prefers-color-scheme: dark) {
       body { background-color: #1a1a1a !important; }
@@ -37,15 +37,16 @@
           </tr>
           <tr>
             <td class="email-body" style="padding: 32px 24px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px; line-height: 1.6; color: #374151;">
-              <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #1f2937;">Hi {{name}},</h1>
-              <p style="margin: 0 0 16px;">You signed up for 2anki a few days ago but haven't made a deck yet.</p>
+              <h1 style="margin: 0 0 16px; font-size: 20px; font-weight: 600; color: #1f2937;">Still making cards by hand?</h1>
+              <p style="margin: 0 0 16px;">Hi {{name}}, you signed up for 2anki a few days ago but haven't made a deck yet. Typing out flashcards is the slow part — 2anki turns a Notion page or an uploaded file into an Anki deck in under a minute.</p>
               <div style="margin: 24px 0; text-align: center;">
                 <a href="https://www.youtube.com/watch?v=UnTo_fN1jpc" style="display: block;">
                   <img src="https://img.youtube.com/vi/UnTo_fN1jpc/maxresdefault.jpg" alt="How 2anki works" width="100%" style="max-width: 600px; border-radius: 6px; display: block; margin: 0 auto;" />
                 </a>
                 <p class="video-caption" style="margin: 8px 0 0; font-size: 13px; color: #6b7280;">Watch how it works (60 sec)</p>
               </div>
-              <p style="margin: 0 0 16px;">Paste a Notion page URL or upload a file at 2anki.net. You'll have an Anki deck in under a minute.</p>
+              <p style="margin: 0 0 16px;">Paste a Notion page URL or upload a file at 2anki.net to try it.</p>
+              <p style="margin: 0 0 16px;">Stuck on something? Reply to this email — Alexander reads every one.</p>
               <!-- Click tracking via /r/email deferred: /feedback/onboarding is a survey page, not a conversion destination, and is not in the allowed-destinations allowlist. -->
               <div style="text-align: center; margin: 24px 0;" class="email-cta">
                 <a href="{{surveyUrl}}" style="display: inline-block; padding: 12px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 15px;">Tell us what happened</a>

--- a/src/services/EmailService/templates/subscription-cancelled.html
+++ b/src/services/EmailService/templates/subscription-cancelled.html
@@ -39,7 +39,8 @@
               <p style="margin: 0 0 16px;">Hi {{name}},</p>
               <p style="margin: 0 0 16px;">Your 2anki.net subscription has been cancelled.</p>
               <p style="margin: 0 0 16px;">You can resubscribe any time at <a href="https://2anki.net" class="email-link" style="color: #3b82f6; text-decoration: none;">2anki.net</a>.</p>
-              <p style="margin: 0 0 16px;">Feedback? Reply to this email.</p>
+              <p style="margin: 0 0 16px;">Need it again for one exam or chapter? A Day or Week Pass covers a single push — no subscription.</p>
+              <p style="margin: 0 0 16px;">Something we could have done better? Reply to this email — Alexander reads every one.</p>
             </td>
           </tr>
           <tr>

--- a/src/usecases/jobs/NotifyUserUseCase.test.ts
+++ b/src/usecases/jobs/NotifyUserUseCase.test.ts
@@ -43,12 +43,14 @@ describe('NotifyUserUseCase', () => {
       id: 'deck-1',
       size: 25,
       apkg: APKG,
+      cardCount: 120,
     });
 
     expect(sendConversionLinkEmail).toHaveBeenCalledWith(
       'a@example.com',
       'deck-1',
-      expect.stringContaining('/api/download/u/abc')
+      expect.stringContaining('/api/download/u/abc'),
+      120
     );
     expect(sendConversionEmail).not.toHaveBeenCalled();
   });
@@ -64,12 +66,14 @@ describe('NotifyUserUseCase', () => {
       id: 'deck-2',
       size: 5,
       apkg: APKG,
+      cardCount: 42,
     });
 
     expect(sendConversionEmail).toHaveBeenCalledWith(
       'b@example.com',
       'deck-2',
-      APKG
+      APKG,
+      42
     );
     expect(sendConversionLinkEmail).not.toHaveBeenCalled();
   });

--- a/src/usecases/jobs/NotifyUserUseCase.ts
+++ b/src/usecases/jobs/NotifyUserUseCase.ts
@@ -9,13 +9,14 @@ export interface NotifyUserUseCaseInput {
   id: string;
   size: number;
   apkg: Buffer;
+  cardCount?: number;
 }
 
 export class NotifyUserUseCase {
   constructor(private readonly usersRepository: UsersRepository) {}
 
   async execute(input: NotifyUserUseCaseInput): Promise<void> {
-    const { owner, rules, key, id, size, apkg } = input;
+    const { owner, rules, key, id, size, apkg, cardCount } = input;
 
     console.debug('rules.email', rules.EMAIL_NOTIFICATION);
 
@@ -32,9 +33,9 @@ export class NotifyUserUseCase {
     const emailService = getDefaultEmailService();
     if (shouldEmailLargeFile) {
       const link = `${process.env.DOMAIN}/api/download/u/${key}`;
-      await emailService.sendConversionLinkEmail(email, id, link);
+      await emailService.sendConversionLinkEmail(email, id, link, cardCount);
     } else {
-      await emailService.sendConversionEmail(email, id, apkg);
+      await emailService.sendConversionEmail(email, id, apkg, cardCount);
     }
   }
 }

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-14-clearer-emails.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-14-clearer-emails.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-14-clearer-emails",
+  "date": "2026-07-14",
+  "type": "fix",
+  "title": "Deck-ready emails name your deck and card count"
+}


### PR DESCRIPTION
## What
Copy improvements to three lifecycle emails. The deck-ready email (attachment and download-link variants) now names the deck and shows the card count. The re-engagement email is reframed pain-first with a founder-reply line. The cancellation email adds a one-time-pass reminder and a founder-voice feedback line.

## Why
Customer-communication review of our lifecycle emails against VOICE.md. "Your deck is ready" was generic when the deck name and card count are already in scope at the send boundary (VOICE rule #1 — specific over generic). The re-engagement email led with tool-framing ("Still figuring out 2anki?") instead of the audience's real pain (making cards by hand). The cancellation email had no soft re-entry for the "finished what I needed" churn segment, which is a natural fit for a Day/Week Pass.

## How
- `cardCount` is already computed in `performConversion` (`decks.reduce(...)`); threaded it through `NotifyUserUseCase` into `sendConversionEmail` / `sendConversionLinkEmail` as an optional arg.
- `convert.html` / `convert-link.html` gain a specific line: deck name at `font-weight: 500` + `— N cards`. Deck name is HTML-escaped (`escapeHtml`), falls back to "Untitled deck", and counts ≥ 10 000 use a thin-space separator per VOICE. Absent count degrades to just the name — no empty placeholder, no "undefined". Inline color dropped from the name span so it inherits the dark-mode paragraph color.
- `re-engagement.html`: headline → "Still making cards by hand?", body reframed to the card-creation-time pain, founder-reply line added; kept the 60-sec demo, the feedback CTA, the unsubscribe footer, and the `marketing_opt_out` send path. Subject + plain-text updated to match.
- `subscription-cancelled.html`: Day/Week Pass reminder after "resubscribe any time", plus a founder-voice feedback line. Stays transactional — no unsubscribe footer.

Construction sites checked: `NotifyUserUseCase` has one caller (`performConversion`); `sendConversionEmail`/`sendConversionLinkEmail` have one caller each (`NotifyUserUseCase`). New param is optional so the suppression test's 3-arg call still compiles.

## Measuring success
Deck-ready is the highest-volume transactional email. In SendGrid, watch open/click rate on the "…deck is ready" subject; in prod logs the send still routes through `deliver` with the existing `email.send.suppressed` line. Re-engagement success = click-through on `/feedback/onboarding?uid=`; cancellation-pass success = Day/Week Pass purchases from users whose most recent event is a cancellation.

## Testing
- Unit tests added (`EmailService.test.ts`): deck name + count render in both convert variants; singular "1 card"; count omitted cleanly when absent (no placeholder / no "undefined"); "Untitled deck" fallback; HTML-escaped deck name; thin-space grouping at 12 450.
- Updated `NotifyUserUseCase.test.ts` to assert `cardCount` is forwarded to both send methods.
- `npx tsc -p . --noEmit` clean (includes tests — deploy build compiles them). Affected Jest suites + the web changelog loader test green.
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — the only `web/src/` file is the changelog JSON.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-14-clearer-emails.json` — "Deck-ready emails name your deck and card count"

## Risks
Copy-only plus one threaded optional arg. If `cardCount` is ever undefined the count clause is omitted (verified). Rollback is a revert; no schema or config change.

## Goal alignment
Retention/MRR lever. Deck-ready is our most-opened email — a specific, on-brand confirmation reinforces the "drop something in, get a clean deck back" promise and the tool's trustworthiness. The cancellation pass reminder targets the "finished what I needed" churn segment (79% of churn is lifecycle) with a no-subscription re-entry path; the re-engagement reframe aims to lift onboarding activation. Metrics read in SendGrid (open/click) and Stripe (pass purchases post-cancel).
