### PR TITLE
feat: add ops customer-signals view ranking first-party signal

### DIFF
--- a/src/controllers/OpsController.test.ts
+++ b/src/controllers/OpsController.test.ts
@@ -6,6 +6,7 @@ import { GetBusinessMetricsUseCase } from '../usecases/ops/GetBusinessMetricsUse
 import { GetReturnRateMetricsUseCase } from '../usecases/ops/GetReturnRateMetricsUseCase';
 import { DeleteInactiveUsersUseCase } from '../usecases/ops/DeleteInactiveUsersUseCase';
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
+import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 
 const buildRes = () => {
   const json = jest.fn();
@@ -262,6 +263,90 @@ describe('OpsController.getLandingPageYield', () => {
       .mockImplementation(() => undefined);
 
     await controller.getLandingPageYield(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+    errSpy.mockRestore();
+  });
+});
+
+describe('OpsController.getCustomerSignals', () => {
+  const buildController = (useCase?: GetCustomerSignalsUseCase) =>
+    new OpsController(
+      {} as unknown as GetOpsMetricsUseCase,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      useCase
+    );
+
+  it('passes the window down and returns the payload', async () => {
+    const payload = {
+      signals: [
+        {
+          source: 'failed_conversion',
+          label: 'Notion export unreadable',
+          count: 12,
+          bucket: 'pain-killer',
+        },
+      ],
+      since: '2026-06-01T00:00:00.000Z',
+      as_of: '2026-07-01T00:00:00.000Z',
+    };
+    const useCase = {
+      execute: jest.fn().mockResolvedValue(payload),
+    } as unknown as GetCustomerSignalsUseCase;
+    const controller = buildController(useCase);
+    const req = { query: { window: '7d' } } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getCustomerSignals(req, res);
+
+    expect(useCase.execute as jest.Mock).toHaveBeenCalledWith('7d');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(payload);
+  });
+
+  it('responds 503 when the use case is not configured', async () => {
+    const controller = buildController(undefined);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+
+    await controller.getCustomerSignals(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) })
+    );
+  });
+
+  it('responds 500 when the use case throws', async () => {
+    const useCase = {
+      execute: jest.fn().mockRejectedValue(new Error('db down')),
+    } as unknown as GetCustomerSignalsUseCase;
+    const controller = buildController(useCase);
+    const req = { query: {} } as unknown as express.Request;
+    const res = buildRes();
+    const errSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    await controller.getCustomerSignals(req, res);
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith(

--- a/src/controllers/OpsController.ts
+++ b/src/controllers/OpsController.ts
@@ -20,6 +20,7 @@ import { GetUploadFunnelUseCase } from '../usecases/ops/GetUploadFunnelUseCase';
 import { GetOrphanedSubscriptionsUseCase } from '../usecases/ops/GetOrphanedSubscriptionsUseCase';
 import { ReconcileOrphanedSubscriptionsUseCase } from '../usecases/ops/ReconcileOrphanedSubscriptionsUseCase';
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
+import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
 
 class OpsController {
   constructor(
@@ -39,7 +40,8 @@ class OpsController {
     private readonly getUploadFunnelUseCase?: GetUploadFunnelUseCase,
     private readonly getOrphanedSubscriptionsUseCase?: GetOrphanedSubscriptionsUseCase,
     private readonly reconcileOrphanedSubscriptionsUseCase?: ReconcileOrphanedSubscriptionsUseCase,
-    private readonly getLandingPageYieldUseCase?: GetLandingPageYieldUseCase
+    private readonly getLandingPageYieldUseCase?: GetLandingPageYieldUseCase,
+    private readonly getCustomerSignalsUseCase?: GetCustomerSignalsUseCase
   ) {}
 
   async getMetrics(req: express.Request, res: express.Response) {
@@ -321,6 +323,22 @@ class OpsController {
     } catch (error) {
       console.error('[ops] getLandingPageYield failed', error);
       res.status(500).json({ message: 'Failed to load landing page yield' });
+    }
+  }
+
+  async getCustomerSignals(req: express.Request, res: express.Response) {
+    if (this.getCustomerSignalsUseCase == null) {
+      res.status(503).json({ message: 'Customer signals not configured' });
+      return;
+    }
+    try {
+      const window =
+        typeof req.query.window === 'string' ? req.query.window : undefined;
+      const result = await this.getCustomerSignalsUseCase.execute(window);
+      res.status(200).json(result);
+    } catch (error) {
+      console.error('[ops] getCustomerSignals failed', error);
+      res.status(500).json({ message: 'Failed to load customer signals' });
     }
   }
 

--- a/src/routes/OpsRouter.ts
+++ b/src/routes/OpsRouter.ts
@@ -48,6 +48,8 @@ import { UploadFunnelService } from '../services/ops/UploadFunnelService';
 import { GetLandingPageYieldUseCase } from '../usecases/ops/GetLandingPageYieldUseCase';
 import { LandingPageYieldService } from '../services/ops/LandingPageYieldService';
 import { LandingPageYieldRepository } from '../data_layer/LandingPageYieldRepository';
+import { GetCustomerSignalsUseCase } from '../usecases/ops/GetCustomerSignalsUseCase';
+import { CustomerSignalsService } from '../services/ops/CustomerSignalsService';
 import { updateStripeSubscriptions } from '../lib/storage/jobs/helpers/updateStripeSubscriptions';
 import EventsRepository from '../data_layer/EventsRepository';
 import { FeatureFlagsRepository } from '../data_layer/FeatureFlagsRepository';
@@ -148,6 +150,14 @@ const OpsRouter = () => {
     new GetLandingPageYieldUseCase(
       new LandingPageYieldService({
         repo: new LandingPageYieldRepository(database),
+      })
+    ),
+    new GetCustomerSignalsUseCase(
+      new CustomerSignalsService({
+        cancellation: new CancellationFeedbackRepository(database),
+        emoji: new EmojiFeedbackRepository(database),
+        failedConversion: new JobsMetricsRepository(database),
+        emptyBack: new ConversionOutputStatsRepository(database),
       })
     )
   );
@@ -505,6 +515,38 @@ const OpsRouter = () => {
     '/api/ops/growth/landing-page-yield',
     RequireOpsAccess,
     (req, res) => controller.getLandingPageYield(req, res)
+  );
+
+  /**
+   * @swagger
+   * /api/ops/growth/customer-signals:
+   *   get:
+   *     summary: First-party customer signal aggregated into one ranked list
+   *     description: |
+   *       Aggregates DB-resident customer signal — cancellation reasons and
+   *       comments, deck-ready emoji feedback comments, failed-conversion
+   *       reasons, and empty-back card counts — into a single list ranked by
+   *       volume. Each row carries a pain-killer / money-multiplier / unknown
+   *       bucket, and free-text sources return verbatim sample quotes. No user
+   *       identity is joined. Defaults to the last 30 days; pass
+   *       ?window=7d|14d|30d|60d|90d. Internal endpoint locked to the ops owner
+   *       — returns 404 for everyone else.
+   *     tags: [Ops]
+   *     parameters:
+   *       - in: query
+   *         name: window
+   *         schema:
+   *           type: string
+   *           enum: ['7d', '14d', '30d', '60d', '90d']
+   *         description: Lookback window. Defaults to 30d.
+   *     responses:
+   *       200:
+   *         description: Customer signals payload
+   *       404:
+   *         description: Not the ops owner
+   */
+  router.get('/api/ops/growth/customer-signals', RequireOpsAccess, (req, res) =>
+    controller.getCustomerSignals(req, res)
   );
 
   /**

--- a/src/services/ops/CustomerSignalsService.test.ts
+++ b/src/services/ops/CustomerSignalsService.test.ts
@@ -1,0 +1,198 @@
+import type {
+  CancellationCommentEntry,
+  CancellationReasonCount,
+} from '../../data_layer/CancellationFeedbackRepository';
+import type { EmojiFeedbackCommentEntry } from '../../data_layer/EmojiFeedbackRepository';
+import type { ConversionOutputStatsRow } from '../../data_layer/ConversionOutputStatsRepository';
+import type { ConversionErrorCount } from './ConversionMetricsService';
+import {
+  CancellationSignalSource,
+  CustomerSignalsService,
+  EmojiSignalSource,
+  EmptyBackSignalSource,
+  FailedConversionSignalSource,
+} from './CustomerSignalsService';
+
+interface FakeSources {
+  cancelReasons?: CancellationReasonCount[];
+  cancelComments?: CancellationCommentEntry[];
+  emojiComments?: EmojiFeedbackCommentEntry[];
+  failureReasons?: ConversionErrorCount[];
+  emptyBack?: ConversionOutputStatsRow[];
+  throwOn?: 'cancellation' | 'emoji' | 'failedConversion' | 'emptyBack';
+}
+
+function buildService(sources: FakeSources): CustomerSignalsService {
+  const cancellation: CancellationSignalSource = {
+    countByReason: async () => {
+      if (sources.throwOn === 'cancellation') throw new Error('cancel down');
+      return sources.cancelReasons ?? [];
+    },
+    recentComments: async () => sources.cancelComments ?? [],
+  };
+  const emoji: EmojiSignalSource = {
+    recentComments: async () => {
+      if (sources.throwOn === 'emoji') throw new Error('emoji down');
+      return sources.emojiComments ?? [];
+    },
+  };
+  const failedConversion: FailedConversionSignalSource = {
+    topFailureReasons7d: async () => {
+      if (sources.throwOn === 'failedConversion') throw new Error('jobs down');
+      return sources.failureReasons ?? [];
+    },
+  };
+  const emptyBack: EmptyBackSignalSource = {
+    list: async () => {
+      if (sources.throwOn === 'emptyBack') throw new Error('stats down');
+      return sources.emptyBack ?? [];
+    },
+  };
+  return new CustomerSignalsService({
+    cancellation,
+    emoji,
+    failedConversion,
+    emptyBack,
+  });
+}
+
+const statsRow = (
+  source: string,
+  emptyBack: number
+): ConversionOutputStatsRow => ({
+  source,
+  decks: 1,
+  cards: 100,
+  empty_back_cards: emptyBack,
+  first_seen: '2026-01-01T00:00:00.000Z',
+  last_seen: '2026-07-01T00:00:00.000Z',
+});
+
+describe('CustomerSignalsService', () => {
+  const since = new Date('2026-06-01T00:00:00.000Z');
+
+  it('ranks structured signals by count desc and maps buckets', async () => {
+    const service = buildService({
+      cancelReasons: [
+        { reason: 'too expensive', count: 4 },
+        { reason: 'finished what I needed', count: 9 },
+      ],
+      failureReasons: [{ reason: 'Notion export unreadable', count: 12 }],
+      emptyBack: [statsRow('notion', 30), statsRow('upload', 7)],
+    });
+
+    const result = await service.getSignals(since);
+
+    expect(result.error).toBeUndefined();
+    expect(result.since).toBe('2026-06-01T00:00:00.000Z');
+    expect(result.signals).toEqual([
+      {
+        source: 'empty_back',
+        label: 'Cards generated with an empty back (all-time)',
+        count: 37,
+        bucket: 'pain-killer',
+      },
+      {
+        source: 'failed_conversion',
+        label: 'Notion export unreadable',
+        count: 12,
+        bucket: 'pain-killer',
+      },
+      {
+        source: 'cancel_reason',
+        label: 'finished what I needed',
+        count: 9,
+        bucket: 'unknown',
+      },
+      {
+        source: 'cancel_reason',
+        label: 'too expensive',
+        count: 4,
+        bucket: 'unknown',
+      },
+    ]);
+  });
+
+  it('returns truncated verbatim quotes for free-text sources within the window', async () => {
+    const longComment = 'x'.repeat(250);
+    const service = buildService({
+      cancelComments: [
+        {
+          reason: 'too expensive',
+          comment: 'wish it were cheaper for students',
+          created_at: '2026-06-15T00:00:00.000Z',
+        },
+        {
+          reason: 'don’t use enough',
+          comment: 'stale one',
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+      emojiComments: [
+        {
+          rating: 2,
+          comment: longComment,
+          page: 'Biochem',
+          created_at: '2026-06-20T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await service.getSignals(since);
+
+    const cancelComment = result.signals?.find(
+      (row) => row.source === 'cancel_comment'
+    );
+    expect(cancelComment).toEqual({
+      source: 'cancel_comment',
+      label: 'too expensive',
+      count: 1,
+      bucket: 'unknown',
+      sampleQuote: 'wish it were cheaper for students',
+    });
+
+    const emojiComment = result.signals?.find(
+      (row) => row.source === 'emoji_feedback'
+    );
+    expect(emojiComment?.sampleQuote).toHaveLength(200);
+    expect(emojiComment?.sampleQuote?.endsWith('…')).toBe(true);
+    expect(emojiComment?.label).toBe('Deck-ready rating 2');
+  });
+
+  it('drops free-text comments older than the window', async () => {
+    const service = buildService({
+      cancelComments: [
+        {
+          reason: 'too expensive',
+          comment: 'old feedback',
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await service.getSignals(since);
+
+    expect(result.signals?.some((row) => row.source === 'cancel_comment')).toBe(
+      false
+    );
+  });
+
+  it('omits the empty-back row when no empty backs exist', async () => {
+    const service = buildService({ emptyBack: [statsRow('notion', 0)] });
+
+    const result = await service.getSignals(since);
+
+    expect(result.signals?.some((row) => row.source === 'empty_back')).toBe(
+      false
+    );
+  });
+
+  it('returns a null list and the error message when a source throws', async () => {
+    const service = buildService({ throwOn: 'failedConversion' });
+
+    const result = await service.getSignals(since);
+
+    expect(result.signals).toBeNull();
+    expect(result.error).toBe('jobs down');
+  });
+});

--- a/src/services/ops/CustomerSignalsService.ts
+++ b/src/services/ops/CustomerSignalsService.ts
@@ -1,0 +1,200 @@
+import type {
+  CancellationCommentEntry,
+  CancellationReasonCount,
+} from '../../data_layer/CancellationFeedbackRepository';
+import type { EmojiFeedbackCommentEntry } from '../../data_layer/EmojiFeedbackRepository';
+import type { ConversionOutputStatsRow } from '../../data_layer/ConversionOutputStatsRepository';
+import type { ConversionErrorCount } from './ConversionMetricsService';
+
+export type CustomerSignalSource =
+  | 'cancel_reason'
+  | 'cancel_comment'
+  | 'emoji_feedback'
+  | 'failed_conversion'
+  | 'empty_back';
+
+export type CustomerSignalBucket =
+  | 'pain-killer'
+  | 'money-multiplier'
+  | 'unknown';
+
+export interface CustomerSignalRow {
+  source: CustomerSignalSource;
+  label: string;
+  count: number;
+  bucket: CustomerSignalBucket;
+  sampleQuote?: string;
+}
+
+export interface CustomerSignalsResponse {
+  signals: CustomerSignalRow[] | null;
+  since: string;
+  as_of: string;
+  error?: string;
+}
+
+export interface CancellationSignalSource {
+  countByReason(since: Date): Promise<CancellationReasonCount[]>;
+  recentComments(limit: number): Promise<CancellationCommentEntry[]>;
+}
+
+export interface EmojiSignalSource {
+  recentComments(limit: number): Promise<EmojiFeedbackCommentEntry[]>;
+}
+
+export interface FailedConversionSignalSource {
+  topFailureReasons7d(since: Date): Promise<ConversionErrorCount[]>;
+}
+
+export interface EmptyBackSignalSource {
+  list(): Promise<ConversionOutputStatsRow[]>;
+}
+
+interface CustomerSignalsServiceDeps {
+  cancellation: CancellationSignalSource;
+  emoji: EmojiSignalSource;
+  failedConversion: FailedConversionSignalSource;
+  emptyBack: EmptyBackSignalSource;
+}
+
+const SAMPLE_LIMIT = 10;
+const COMMENT_FETCH_LIMIT = 100;
+const QUOTE_MAX_LENGTH = 200;
+const ELLIPSIS = '…';
+
+function truncateQuote(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= QUOTE_MAX_LENGTH) return trimmed;
+  return `${trimmed.slice(0, QUOTE_MAX_LENGTH - 1).trimEnd()}${ELLIPSIS}`;
+}
+
+function withinWindow(createdAt: string, since: Date): boolean {
+  const at = new Date(createdAt);
+  if (Number.isNaN(at.getTime())) return false;
+  return at.getTime() >= since.getTime();
+}
+
+export class CustomerSignalsService {
+  private readonly cancellation: CancellationSignalSource;
+  private readonly emoji: EmojiSignalSource;
+  private readonly failedConversion: FailedConversionSignalSource;
+  private readonly emptyBack: EmptyBackSignalSource;
+
+  constructor(deps: CustomerSignalsServiceDeps) {
+    this.cancellation = deps.cancellation;
+    this.emoji = deps.emoji;
+    this.failedConversion = deps.failedConversion;
+    this.emptyBack = deps.emptyBack;
+  }
+
+  async getSignals(since: Date): Promise<CustomerSignalsResponse> {
+    const as_of = new Date().toISOString();
+    const sinceStr = since.toISOString();
+
+    try {
+      const rows = await this.collectRows(since);
+      const signals = rows.sort((a, b) => b.count - a.count);
+      return { signals, since: sinceStr, as_of };
+    } catch (err) {
+      return {
+        signals: null,
+        since: sinceStr,
+        as_of,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  private async collectRows(since: Date): Promise<CustomerSignalRow[]> {
+    const [
+      cancelReasons,
+      cancelComments,
+      emojiComments,
+      failureReasons,
+      emptyBackStats,
+    ] = await Promise.all([
+      this.cancellation.countByReason(since),
+      this.cancellation.recentComments(COMMENT_FETCH_LIMIT),
+      this.emoji.recentComments(COMMENT_FETCH_LIMIT),
+      this.failedConversion.topFailureReasons7d(since),
+      this.emptyBack.list(),
+    ]);
+
+    return [
+      ...toCancelReasonRows(cancelReasons),
+      ...toFailedConversionRows(failureReasons),
+      ...toEmptyBackRows(emptyBackStats),
+      ...toCancelCommentRows(cancelComments, since),
+      ...toEmojiCommentRows(emojiComments, since),
+    ];
+  }
+}
+
+function toCancelReasonRows(
+  reasons: CancellationReasonCount[]
+): CustomerSignalRow[] {
+  return reasons.map((row) => ({
+    source: 'cancel_reason' as const,
+    label: row.reason,
+    count: row.count,
+    bucket: 'unknown' as const,
+  }));
+}
+
+function toFailedConversionRows(
+  reasons: ConversionErrorCount[]
+): CustomerSignalRow[] {
+  return reasons.map((row) => ({
+    source: 'failed_conversion' as const,
+    label: row.reason,
+    count: row.count,
+    bucket: 'pain-killer' as const,
+  }));
+}
+
+function toEmptyBackRows(
+  stats: ConversionOutputStatsRow[]
+): CustomerSignalRow[] {
+  const total = stats.reduce((sum, row) => sum + row.empty_back_cards, 0);
+  if (total <= 0) return [];
+  return [
+    {
+      source: 'empty_back' as const,
+      label: 'Cards generated with an empty back (all-time)',
+      count: total,
+      bucket: 'pain-killer' as const,
+    },
+  ];
+}
+
+function toCancelCommentRows(
+  comments: CancellationCommentEntry[],
+  since: Date
+): CustomerSignalRow[] {
+  return comments
+    .filter((row) => withinWindow(row.created_at, since))
+    .slice(0, SAMPLE_LIMIT)
+    .map((row) => ({
+      source: 'cancel_comment' as const,
+      label: row.reason,
+      count: 1,
+      bucket: 'unknown' as const,
+      sampleQuote: truncateQuote(row.comment),
+    }));
+}
+
+function toEmojiCommentRows(
+  comments: EmojiFeedbackCommentEntry[],
+  since: Date
+): CustomerSignalRow[] {
+  return comments
+    .filter((row) => withinWindow(row.created_at, since))
+    .slice(0, SAMPLE_LIMIT)
+    .map((row) => ({
+      source: 'emoji_feedback' as const,
+      label: `Deck-ready rating ${row.rating}`,
+      count: 1,
+      bucket: 'unknown' as const,
+      sampleQuote: truncateQuote(row.comment),
+    }));
+}

--- a/src/usecases/ops/GetCustomerSignalsUseCase.test.ts
+++ b/src/usecases/ops/GetCustomerSignalsUseCase.test.ts
@@ -1,0 +1,47 @@
+import {
+  CustomerSignalsResponse,
+  CustomerSignalsService,
+} from '../../services/ops/CustomerSignalsService';
+import { GetCustomerSignalsUseCase } from './GetCustomerSignalsUseCase';
+
+const emptyResponse: CustomerSignalsResponse = {
+  signals: [],
+  since: '',
+  as_of: '',
+};
+
+function buildUseCase() {
+  const getSignals = jest.fn().mockResolvedValue(emptyResponse);
+  const service = { getSignals } as unknown as CustomerSignalsService;
+  return { useCase: new GetCustomerSignalsUseCase(service), getSignals };
+}
+
+const daysAgo = (since: Date): number =>
+  Math.round((Date.now() - since.getTime()) / (24 * 60 * 60 * 1000));
+
+describe('GetCustomerSignalsUseCase', () => {
+  it('defaults to a 30-day window', async () => {
+    const { useCase, getSignals } = buildUseCase();
+
+    await useCase.execute(undefined);
+
+    expect(getSignals).toHaveBeenCalledTimes(1);
+    expect(daysAgo(getSignals.mock.calls[0][0] as Date)).toBe(30);
+  });
+
+  it('honours a valid window', async () => {
+    const { useCase, getSignals } = buildUseCase();
+
+    await useCase.execute('7d');
+
+    expect(daysAgo(getSignals.mock.calls[0][0] as Date)).toBe(7);
+  });
+
+  it('falls back to 30 days for an unknown window', async () => {
+    const { useCase, getSignals } = buildUseCase();
+
+    await useCase.execute('all-time');
+
+    expect(daysAgo(getSignals.mock.calls[0][0] as Date)).toBe(30);
+  });
+});

--- a/src/usecases/ops/GetCustomerSignalsUseCase.ts
+++ b/src/usecases/ops/GetCustomerSignalsUseCase.ts
@@ -1,0 +1,28 @@
+import {
+  CustomerSignalsResponse,
+  CustomerSignalsService,
+} from '../../services/ops/CustomerSignalsService';
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+const WINDOW_DAYS: Record<string, number> = {
+  '7d': 7,
+  '14d': 14,
+  '30d': 30,
+  '60d': 60,
+  '90d': 90,
+};
+
+const DEFAULT_WINDOW = '30d';
+
+export class GetCustomerSignalsUseCase {
+  constructor(private readonly service: CustomerSignalsService) {}
+
+  execute(window: string | undefined): Promise<CustomerSignalsResponse> {
+    const key =
+      window != null && WINDOW_DAYS[window] != null ? window : DEFAULT_WINDOW;
+    const days = WINDOW_DAYS[key];
+    const since = new Date(Date.now() - days * SECONDS_PER_DAY * 1000);
+    return this.service.getSignals(since);
+  }
+}

--- a/web/src/pages/OpsPage/CustomerSignalsTab.test.tsx
+++ b/web/src/pages/OpsPage/CustomerSignalsTab.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import CustomerSignalsTab from './CustomerSignalsTab';
+import { CustomerSignalsResponse } from './customerSignalsTypes';
+
+const mockFetch = (payload: CustomerSignalsResponse) => {
+  (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => payload,
+  });
+};
+
+describe('CustomerSignalsTab', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test('renders a ranked row per signal with source, count, and bucket', async () => {
+    mockFetch({
+      signals: [
+        {
+          source: 'failed_conversion',
+          label: 'Notion export unreadable',
+          count: 12450,
+          bucket: 'pain-killer',
+        },
+        {
+          source: 'cancel_reason',
+          label: 'finished what I needed',
+          count: 9,
+          bucket: 'unknown',
+        },
+      ],
+      since: '2026-06-01T00:00:00.000Z',
+      as_of: '2026-06-30T00:00:00.000Z',
+    });
+
+    render(<CustomerSignalsTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Notion export unreadable')).toBeInTheDocument()
+    );
+    expect(screen.getByText('Failed conversion')).toBeInTheDocument();
+    expect(screen.getByText('12 450')).toBeInTheDocument();
+    expect(screen.getByText('Pain killer')).toBeInTheDocument();
+    expect(screen.getByText('finished what I needed')).toBeInTheDocument();
+  });
+
+  test('shows the verbatim sample quote for free-text sources', async () => {
+    mockFetch({
+      signals: [
+        {
+          source: 'cancel_comment',
+          label: 'too expensive',
+          count: 1,
+          bucket: 'unknown',
+          sampleQuote: 'wish it were cheaper for students',
+        },
+      ],
+      since: '2026-06-01T00:00:00.000Z',
+      as_of: '2026-06-30T00:00:00.000Z',
+    });
+
+    render(<CustomerSignalsTab />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('wish it were cheaper for students')
+      ).toBeInTheDocument()
+    );
+    expect(screen.getByText('Cancellation comment')).toBeInTheDocument();
+  });
+
+  test('shows the empty state when there is no signal', async () => {
+    mockFetch({
+      signals: [],
+      since: '2026-06-01T00:00:00.000Z',
+      as_of: '2026-06-30T00:00:00.000Z',
+    });
+
+    render(<CustomerSignalsTab />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('No customer signal in this window yet.')
+      ).toBeInTheDocument()
+    );
+  });
+
+  test('renders the server error message in the danger banner', async () => {
+    mockFetch({
+      signals: null,
+      since: '2026-06-01T00:00:00.000Z',
+      as_of: '2026-06-30T00:00:00.000Z',
+      error: 'relation "cancellation_feedback" does not exist',
+    });
+
+    render(<CustomerSignalsTab />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('relation "cancellation_feedback" does not exist')
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText('No customer signal in this window yet.')
+    ).toBeNull();
+  });
+});

--- a/web/src/pages/OpsPage/CustomerSignalsTab.tsx
+++ b/web/src/pages/OpsPage/CustomerSignalsTab.tsx
@@ -1,0 +1,141 @@
+import sharedStyles from '../../styles/shared.module.css';
+import styles from './OpsPage.module.css';
+import { formatCount } from './opsHelpers';
+import {
+  CUSTOMER_SIGNALS_WINDOWS,
+  useCustomerSignals,
+} from './useCustomerSignals';
+import {
+  CustomerSignalBucket,
+  CustomerSignalRow,
+  CustomerSignalSource,
+} from './customerSignalsTypes';
+
+const SOURCE_LABELS: Record<CustomerSignalSource, string> = {
+  cancel_reason: 'Cancellation reason',
+  cancel_comment: 'Cancellation comment',
+  emoji_feedback: 'Deck-ready feedback',
+  failed_conversion: 'Failed conversion',
+  empty_back: 'Empty-back cards',
+};
+
+const BUCKET_LABELS: Record<CustomerSignalBucket, string> = {
+  'pain-killer': 'Pain killer',
+  'money-multiplier': 'Money multiplier',
+  unknown: '—',
+};
+
+function renderRows(signals: CustomerSignalRow[]) {
+  if (signals.length === 0) {
+    return (
+      <p className={styles.emptyHint}>No customer signal in this window yet.</p>
+    );
+  }
+  return (
+    <div className={styles.tableScroll}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Source</th>
+            <th>Signal</th>
+            <th>Count</th>
+            <th>Bucket</th>
+          </tr>
+        </thead>
+        <tbody>
+          {signals.map((signal, index) => (
+            <tr key={`${signal.source}-${signal.label}-${index}`}>
+              <td>{SOURCE_LABELS[signal.source]}</td>
+              <td>
+                {signal.label}
+                {signal.sampleQuote != null && (
+                  <p className={styles.commentBody} data-hj-suppress>
+                    {signal.sampleQuote}
+                  </p>
+                )}
+              </td>
+              <td className={styles.numeric}>{formatCount(signal.count)}</td>
+              <td>{BUCKET_LABELS[signal.bucket]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function CustomerSignalsTab() {
+  const { data, loading, error, window, setWindow, refresh } =
+    useCustomerSignals();
+
+  const signals = data?.signals ?? null;
+
+  return (
+    <>
+      <p className={styles.panelTitle}>Customer signals</p>
+      <p className={styles.panelSubtitle}>
+        First-party signal ranked by volume — cancellation reasons and comments,
+        deck-ready feedback, failed conversions, and empty-back cards. Counts
+        cover the rolling window; empty-back cards are all-time.
+      </p>
+
+      <div className={styles.tabHeader}>
+        <div className={styles.controls}>
+          <label
+            htmlFor="customer-signals-window"
+            className={styles.controlsLabel}
+          >
+            Window
+          </label>
+          <select
+            id="customer-signals-window"
+            className={`${sharedStyles.select} ${styles.windowSelect}`}
+            value={window}
+            onChange={(e) =>
+              setWindow(
+                e.target.value as (typeof CUSTOMER_SIGNALS_WINDOWS)[number]
+              )
+            }
+          >
+            {CUSTOMER_SIGNALS_WINDOWS.map((w) => (
+              <option key={w} value={w}>
+                {w}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className={sharedStyles.btnSmall}
+            onClick={refresh}
+            disabled={loading}
+          >
+            {loading ? 'Reading' : 'Refresh'}
+          </button>
+        </div>
+        {data != null && (
+          <p className={styles.refreshHint}>
+            as of {new Date(data.as_of).toLocaleString()}
+          </p>
+        )}
+      </div>
+
+      {error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {error}
+        </div>
+      )}
+
+      {data?.error != null && (
+        <div className={`${sharedStyles.alertDanger} ${styles.banner}`}>
+          {data.error}
+        </div>
+      )}
+
+      {signals != null && renderRows(signals)}
+
+      {loading && data == null && (
+        <p className={styles.emptyHint}>Reading customer signals</p>
+      )}
+    </>
+  );
+}

--- a/web/src/pages/OpsPage/GrowthTab.tsx
+++ b/web/src/pages/OpsPage/GrowthTab.tsx
@@ -2,6 +2,7 @@ import ConversionsTab from './ConversionsTab';
 import ReturnRateTab from './ReturnRateTab';
 import UploadFunnelTab from './UploadFunnelTab';
 import LandingPageYieldTab from './LandingPageYieldTab';
+import CustomerSignalsTab from './CustomerSignalsTab';
 import styles from './OpsPage.module.css';
 
 export default function GrowthTab() {
@@ -35,6 +36,16 @@ export default function GrowthTab() {
           Landing page yield
         </h2>
         <LandingPageYieldTab />
+      </section>
+
+      <section
+        className={styles.compositeSection}
+        aria-labelledby="growth-customer-signals"
+      >
+        <h2 id="growth-customer-signals" className={styles.compositeHeading}>
+          Customer signals
+        </h2>
+        <CustomerSignalsTab />
       </section>
 
       <section

--- a/web/src/pages/OpsPage/customerSignalsTypes.ts
+++ b/web/src/pages/OpsPage/customerSignalsTypes.ts
@@ -1,0 +1,26 @@
+export type CustomerSignalSource =
+  | 'cancel_reason'
+  | 'cancel_comment'
+  | 'emoji_feedback'
+  | 'failed_conversion'
+  | 'empty_back';
+
+export type CustomerSignalBucket =
+  | 'pain-killer'
+  | 'money-multiplier'
+  | 'unknown';
+
+export interface CustomerSignalRow {
+  source: CustomerSignalSource;
+  label: string;
+  count: number;
+  bucket: CustomerSignalBucket;
+  sampleQuote?: string;
+}
+
+export interface CustomerSignalsResponse {
+  signals: CustomerSignalRow[] | null;
+  since: string;
+  as_of: string;
+  error?: string;
+}

--- a/web/src/pages/OpsPage/useCustomerSignals.ts
+++ b/web/src/pages/OpsPage/useCustomerSignals.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from 'react';
+import { CustomerSignalsResponse } from './customerSignalsTypes';
+
+const ALLOWED_WINDOWS = ['7d', '14d', '30d', '60d', '90d'] as const;
+type SignalsWindow = (typeof ALLOWED_WINDOWS)[number];
+
+interface UseCustomerSignalsResult {
+  data: CustomerSignalsResponse | null;
+  loading: boolean;
+  error: string | null;
+  window: SignalsWindow;
+  setWindow: (w: SignalsWindow) => void;
+  refresh: () => void;
+}
+
+export const CUSTOMER_SIGNALS_WINDOWS: readonly SignalsWindow[] =
+  ALLOWED_WINDOWS;
+
+export function useCustomerSignals(): UseCustomerSignalsResult {
+  const [data, setData] = useState<CustomerSignalsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [currentWindow, setCurrentWindow] = useState<SignalsWindow>('30d');
+  const [tick, setTick] = useState(0);
+
+  const refresh = useCallback(() => {
+    setTick((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/api/ops/growth/customer-signals?window=${currentWindow}`, {
+      credentials: 'include',
+    })
+      .then((res) => {
+        if (!res.ok) {
+          return res.json().then((body: { message?: string }) => {
+            throw new Error(body.message ?? `${res.status} ${res.statusText}`);
+          });
+        }
+        return res.json() as Promise<CustomerSignalsResponse>;
+      })
+      .then((result) => {
+        if (!cancelled) {
+          setData(result);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentWindow, tick]);
+
+  return {
+    data,
+    loading,
+    error,
+    window: currentWindow,
+    setWindow: setCurrentWindow,
+    refresh,
+  };
+}


### PR DESCRIPTION
## What
Adds a read-only "Customer signals" view to `/ops/growth` that aggregates 2anki's DB-resident first-party signal into one ranked list — a first-party Sales Safari. New endpoint `GET /api/ops/growth/customer-signals` (RequireOpsAccess) plus a section on the Growth tab.

## Why
Product decisions have leaned on the support inbox and gut feel. The database already holds signal customers give us directly — cancellation reasons and comments, deck-ready emoji feedback, failed-conversion reasons, empty-back card counts — but it's scattered across separate ops slices. One ranked list makes those decisions evidence-driven from our own customers instead of anecdote.

## How
Composes four already-shipped repositories (cancellation feedback, emoji feedback, jobs failure reasons, conversion output stats) behind narrow source interfaces in a new `CustomerSignalsService` → `GetCustomerSignalsUseCase` → `OpsController.getCustomerSignals` → route. The use case is the **last** optional `OpsController` constructor param so positional construction and existing test stubs don't shift.

Each row is `{ source, label, count, bucket, sampleQuote? }`, ranked by count desc over a rolling window (default 30d; `?window=7d|14d|30d|60d|90d`). Structured sources (cancel reason, failed conversion, empty back) return counts; free-text sources (cancel comments, deck-ready feedback) return the top verbatim samples, filtered to the window and truncated to 200 chars. Failed-conversion and empty-back are tagged `pain-killer`; everything else stays `unknown` per the brief. No user identity is joined — comment bodies are treated as data only.

Tradeoff (per CLAUDE.md "two valid paths → less code"): reused the existing repositories rather than writing a new raw-SQL repo, to avoid duplicating shipped, tested queries. Consequence: no new raw-SQL repo method, so the pg-dialect generated-SQL test in `testing.md` doesn't apply here (nothing new to assert SQL shape on); the ranking/bucket/window logic is covered by the service test instead.

## Measuring success
This is an internal ops report — success is the endpoint returning a ranked list. Confirm in prod with ops access: `GET /api/ops/growth/customer-signals?window=30d` returns `signals[]` ordered by count desc, and the `[ops] getCustomerSignals failed` log line stays absent.

## Testing
- Unit tests added:
  - `CustomerSignalsService.test.ts` — ranking by count desc, bucket mapping, verbatim-quote truncation, in-window filtering of comments, empty-back omitted at zero, error passthrough.
  - `GetCustomerSignalsUseCase.test.ts` — 30d default, valid window honoured, unknown window falls back to 30d.
  - `OpsController.test.ts` — null use case → 503, success → 200 with window passthrough, throw → 500.
  - `CustomerSignalsTab.test.tsx` — ranked rows render (source/count/bucket), verbatim sample quote for free-text sources, empty state, server-error banner.
- `npx tsc -p . --noEmit`, `pnpm --filter 2anki-web typecheck`, `pnpm --filter 2anki-web lint` all green; full server + web suites green.
- Sonar not run locally (no `SONAR_TOKEN` on this box) — Automatic Analysis covers the push.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: attested on the maintainer's merge authorization — ops-only `/ops/growth` surface behind RequireOpsAccess, read-only, not on the golden path and renders no public UI.

## Changelog
No changelog entry — internal ops report, no user-visible product change.

## Risks
Low. Read-only over existing tables, no migration, ops-gated. If a source table query throws, the service returns `signals: null` + an error string surfaced in the tab's danger banner rather than 500-ing the endpoint. Empty-back count is all-time (cumulative counters, no per-row timestamp) and labelled as such, so it can rank above windowed counts by design.

## Goal alignment
Internal ops tooling — moves no funnel metric directly. It serves the 300K/MRR goals indirectly by making prioritization evidence-driven from first-party customer signal (which pains to kill, which asks are money-multipliers) instead of the support inbox alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn

