### PR TITLE
style: lead landing and decks copy with clean deterministic output

### DIFF
--- a/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.test.tsx
@@ -303,12 +303,22 @@ describe('DownloadsPage source labels', () => {
     delete (globalThis as AnalyticsGlobals).gtag;
   });
 
-  it('shows "AI-generated from upload" label for claude jobs', () => {
+  it('shows "Written with Claude" label for claude jobs', () => {
     mockJobs = [
       buildJob({ type: 'claude', status: 'done', title: 'Claude deck' }),
     ];
     renderAt('/downloads');
-    expect(screen.getByText('AI-generated from upload')).toBeInTheDocument();
+    expect(screen.getByText('Written with Claude')).toBeInTheDocument();
+  });
+
+  it('leads the page subtitle with clean-deck output', () => {
+    mockJobs = [];
+    renderAt('/downloads');
+    expect(
+      screen.getByText(
+        /Clean decks — proper cloze, atomic cards, no empty backs/i
+      )
+    ).toBeInTheDocument();
   });
 
   it('shows "Notion" source label for notion jobs', () => {

--- a/web/src/pages/DownloadsPage/DownloadsPage.tsx
+++ b/web/src/pages/DownloadsPage/DownloadsPage.tsx
@@ -466,7 +466,8 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
       <div className={sharedStyles.pageHeader}>
         <h1 className={sharedStyles.title}>My decks</h1>
         <p className={sharedStyles.subtitle}>
-          Your converted decks, ready to download into Anki.
+          Clean decks — proper cloze, atomic cards, no empty backs. Download
+          straight into Anki.
         </p>
       </div>
 
@@ -598,7 +599,7 @@ export function DownloadsPage({ setError }: Readonly<DownloadsPageProps>) {
                                   <span className={sharedStyles.badge}>
                                     {row.source === 'upload' &&
                                     row.job.type === 'claude'
-                                      ? 'AI-generated from upload'
+                                      ? 'Written with Claude'
                                       : getSourceLabel(row.source)}
                                   </span>
                                 </td>

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.test.tsx
@@ -169,6 +169,33 @@ describe('ConversionResult — paywalled variant', () => {
   });
 });
 
+describe('ConversionResult — success variant', () => {
+  it('renders the card count and the clean-cards confirmation for a finished deck', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult variant="success" count={34} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('34')).toBeInTheDocument();
+    expect(screen.getByText('cards')).toBeInTheDocument();
+    expect(
+      screen.getByText('No empty backs, no stray characters. Ready for Anki.')
+    ).toBeInTheDocument();
+  });
+
+  it('uses the singular noun for a one-card deck', () => {
+    render(
+      <MemoryRouter>
+        <ConversionResult variant="success" count={1} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('card')).toBeInTheDocument();
+  });
+});
+
 describe('ConversionResult — failed variant', () => {
   it('renders the error message from classifyUploadError', () => {
     render(

--- a/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
+++ b/web/src/pages/DownloadsPage/components/ConversionResult/ConversionResult.tsx
@@ -52,7 +52,16 @@ interface FailedProps {
   onMapColumns: () => void;
 }
 
-type ConversionResultProps = ProcessingProps | PaywalledProps | FailedProps;
+interface SuccessProps {
+  variant: 'success';
+  count: number;
+}
+
+type ConversionResultProps =
+  | ProcessingProps
+  | PaywalledProps
+  | FailedProps
+  | SuccessProps;
 
 function buildPaywallHeadline(cardsUsed: number, limit: number): string {
   if (cardsUsed >= limit) {
@@ -226,9 +235,28 @@ function FailedVariant({
   );
 }
 
+function SuccessVariant({ count }: Omit<SuccessProps, 'variant'>) {
+  const noun = count === 1 ? 'card' : 'cards';
+  return (
+    <div className={styles.success}>
+      <span className={styles.cardCount}>
+        <span className={styles.cardCountNumber}>{count}</span>
+        <span className={styles.cardCountLabel}>{noun}</span>
+      </span>
+      <span className={styles.helperText}>
+        No empty backs, no stray characters. Ready for Anki.
+      </span>
+    </div>
+  );
+}
+
 export function ConversionResult(props: Readonly<ConversionResultProps>) {
   if (props.variant === 'processing') {
     return <>{props.children}</>;
+  }
+
+  if (props.variant === 'success') {
+    return <SuccessVariant count={props.count} />;
   }
 
   if (props.variant === 'paywalled') {

--- a/web/src/pages/HomePage/HomePage.test.tsx
+++ b/web/src/pages/HomePage/HomePage.test.tsx
@@ -68,11 +68,13 @@ describe('HomePage (anonymous)', () => {
     expect(screen.queryByText(/open source/i)).toBeNull();
   });
 
-  it('shows a quiet AI hint inviting anon visitors to create an account', () => {
+  it('leads the hero badge with clean-card output and keeps AI as a quiet opt-in', () => {
     renderHome();
-    expect(screen.queryByText('AI is off')).toBeNull();
+    expect(
+      screen.getByText(/Clean cards, ready to study/i)
+    ).toBeInTheDocument();
     const link = screen.getByRole('link', {
-      name: /create an account to turn on AI/i,
+      name: /create an account/i,
     });
     expect(link).toHaveAttribute('href', '/register?redirect=/card-options');
   });

--- a/web/src/pages/HomePage/HomePage.tsx
+++ b/web/src/pages/HomePage/HomePage.tsx
@@ -47,7 +47,7 @@ const STEPS = [
   },
   {
     title: 'Convert',
-    body: '2anki builds your deck in seconds. Images, audio, code blocks, and cloze deletions all transfer.',
+    body: '2anki builds your deck in seconds — clean cloze, atomic cards, no empty backs. Images, audio, and code blocks come across too.',
     Icon: SparklesIcon,
   },
   {
@@ -97,7 +97,7 @@ const FEATURES = [
   {
     href: '/chat',
     label: 'Chat',
-    body: 'Ask AI to write cards from your notes.',
+    body: 'Turn your own notes into cards with AI.',
     Icon: ChatBubbleIcon,
   },
   {
@@ -214,12 +214,13 @@ export function HomePage({
         </p>
         <div className={styles.heroControls}>
           <p className={`${sharedStyles.aiOffBadgeBody} ${styles.heroAiBadge}`}>
-            Claude can write your cards —{' '}
+            Clean cards, ready to study — proper cloze, atomic front and back,
+            no empty backs. Prefer AI drafts?{' '}
             <Link
               to="/register?redirect=/card-options"
               onClick={() => track('home_ai_anon_badge_clicked')}
             >
-              create an account to turn on AI
+              Create an account
             </Link>
             .
           </p>

--- a/web/src/pages/LandingPage/copy/ankiFidelityProof.ts
+++ b/web/src/pages/LandingPage/copy/ankiFidelityProof.ts
@@ -17,4 +17,8 @@ export const ankiFidelityProof: WhatComesAcrossItem[] = [
     title: 'Correct note types',
     body: 'Basic, Cloze, and front/back map to the right Anki note type so import is clean.',
   },
+  {
+    title: 'No junk in your cards',
+    body: 'No empty backs, no stray #, *, or $ characters left over from your notes.',
+  },
 ];

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.test.tsx
@@ -1165,8 +1165,8 @@ describe('UploadForm analytics events', () => {
 
     await waitFor(() => {
       expect(
-        container.querySelector('[class*="successPrimary"]')
-      ).not.toBeNull();
+        screen.getByText('No empty backs, no stray characters. Ready for Anki.')
+      ).toBeInTheDocument();
     });
 
     const calls = trackMock.mock.calls.filter(

--- a/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
+++ b/web/src/pages/UploadPage/components/UploadForm/UploadForm.tsx
@@ -16,6 +16,7 @@ import {
 } from './uploadResponse';
 import { getDownloadFileName } from '../../../DownloadsPage/helpers/getDownloadFileName';
 import { ImageDropNotice } from '../../../DownloadsPage/components/ImageDropNotice';
+import { ConversionResult } from '../../../DownloadsPage/components/ConversionResult/ConversionResult';
 import { OverSplitNotice } from './OverSplitNotice';
 import { getEmptyDeckChatPrompt } from '../../helpers/getEmptyDeckChatPrompt';
 import { useDrag } from './hooks/useDrag';
@@ -881,14 +882,11 @@ function UploadForm({
   const renderSuccessState = () => (
     <div className={formStyles.stateContent}>
       <CheckCircleIcon className={formStyles.iconSuccess} />
-      <p className={formStyles.successPrimary}>
-        Your deck is ready
-        {cardCount != null && (
-          <span className={formStyles.cardCount}>
-            &nbsp;&mdash; {cardCount} {cardCount === 1 ? 'card' : 'cards'}
-          </span>
-        )}
-      </p>
+      {cardCount == null ? (
+        <p className={formStyles.successPrimary}>Your deck is ready</p>
+      ) : (
+        <ConversionResult variant="success" count={cardCount} />
+      )}
       {mcqCount > 0 && (
         <>
           <button

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-14-clean-cards-messaging.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-14-clean-cards-messaging.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-14-clean-cards-messaging",
+  "date": "2026-07-14",
+  "type": "style",
+  "title": "The deck-ready screen confirms your cards are clean — no empty backs, no stray characters"
+}


### PR DESCRIPTION
## What
Repositions the fidelity/reliability story across the landing hero badge, the "How it works" convert step, the Chat feature card, the SEO fidelity list, the "My decks" page, and the deck-ready success surface. AI is demoted from the headline and framed as a quiet opt-in; the copy now leads with what 2anki's deterministic conversion already guarantees — renders what you wrote, drops empty backs, strips stray characters. Adds a small deck-ready success line (card count as the hero + a clean-cards confirmation).

## Why
Implements #3597 (trio-approved: pm + designer). Sales Safari on r/anki surfaced strong anti-AI-slop / pro-fidelity sentiment; our conversion's real strength is deterministic, faithful output, and the previous copy led with AI. The user-visible outcome: the landing and decks surfaces now name an existing strength instead of leading with the thing our SEO audience is skeptical of.

## How
- HomePage: hero badge (keeps the `home_ai_anon_badge_*` tracking + register link), Convert step, Chat feature-card body.
- LandingPage: one new `ankiFidelityProof` item — client-rendered on the SEO landing pages (the prerender script only rewrites meta tags, so no static-HTML regeneration applies; the new copy ships in the JS bundle).
- DownloadsPage: subtitle + the claude-source badge ("Written with Claude").
- ConversionResult: new `success` variant using the pre-existing unused `.success/.cardCount*/.helperText` tokens (no new component, no new color). Wired into the UploadForm deck-ready state from the `X-Card-Count` note count (server-computed via `parseApkgNotes`). Falls back to "Your deck is ready" when the count is absent.
- The "no empty backs / no stray characters" claim is verified against the pipeline: `Note.isValidBasicNote` requires a non-empty trimmed back and `Deck.CleanCards` filters invalid notes, so empty-back basics are dropped; markdown is rendered to HTML (syntax chars consumed) with additional inline-markdown stripping.

## Measuring success
Landing → signup CTR at `/api/ops/metrics` (`landing_page_viewed` → register), and the existing `home_ai_anon_badge_clicked` event on the hero badge link. Watch over 1–2 weeks.

## Testing
- Unit tests added/updated (Vitest): ConversionResult success variant (count hero + confirmation line, singular/plural noun); HomePage hero badge new copy + register link intact; DownloadsPage subtitle + "Written with Claude" badge; UploadForm success-state wait updated to the new confirmation line.
- Full web suite green; `pnpm --filter 2anki-web typecheck` + `oxlint` + `oxfmt` clean on changed files.
- Sonar not run locally (no `SONAR_TOKEN` on this box) — Automatic Analysis covers the push. Copy/one-variant change, low smell surface.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: `pnpm --filter 2anki-web test:golden-path` — 2 passed (landing + signed-in dashboard at 375px, no console errors).

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-14-clean-cards-messaging.json` — "The deck-ready screen confirms your cards are clean — no empty backs, no stray characters"

## Risks
Low. Pure copy + one additive success line; no data or API changes. **pm caveat:** this rests on the assumption that our SEO traffic shares r/anki's anti-AI values. Recommendation: read landing → signup for 1–2 weeks and revert if it dips. Rollback is a straight revert of this PR.

## Goal alignment
Acquisition lane. Every changed surface is on the landing → signup path or the immediate post-conversion trust moment. Target metric: landing → signup CTR (read at `/api/ops/metrics`); secondary: the hero badge click event. No pricing or revenue-surface change.
