### PR TITLE
feat: capture deck-feedback ideas on a positive rating

### DIFF
--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.test.tsx
@@ -62,9 +62,42 @@ describe('DeckFeedbackPrompt', () => {
     ).toBeInTheDocument();
   });
 
-  it('posts rating 5 with page="downloads/deck_done" when user confirms the deck worked', async () => {
+  it('opens the idea textarea when the user confirms the deck worked', () => {
     render(<DeckFeedbackPrompt />);
     fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    expect(
+      screen.getByLabelText(
+        'Glad it came out right. Anything that would make it better?'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Skip' })).toBeInTheDocument();
+  });
+
+  it('posts rating 5 with the idea comment when the user fills the follow-up and sends', async () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    fireEvent.change(
+      screen.getByLabelText(
+        'Glad it came out right. Anything that would make it better?'
+      ),
+      { target: { value: 'add a tag to each card' } }
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    await waitFor(() => {
+      expect(submitEmojiFeedback).toHaveBeenCalledWith(
+        5,
+        'downloads/deck_done',
+        'add a tag to each card'
+      );
+    });
+    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
+  });
+
+  it('posts rating 5 with no comment when the user skips the idea follow-up', async () => {
+    render(<DeckFeedbackPrompt />);
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
     await waitFor(() => {
       expect(submitEmojiFeedback).toHaveBeenCalledWith(
         5,
@@ -72,6 +105,7 @@ describe('DeckFeedbackPrompt', () => {
         undefined
       );
     });
+    expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
   });
 
   it('opens the follow-up textarea when the user reports a problem', () => {
@@ -122,6 +156,7 @@ describe('DeckFeedbackPrompt', () => {
   it('writes the suppression timestamp on successful submit', async () => {
     render(<DeckFeedbackPrompt />);
     fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
     await waitFor(() => {
       expect(isDeckFeedbackSuppressed()).toBe(true);
     });
@@ -131,6 +166,7 @@ describe('DeckFeedbackPrompt', () => {
     submitEmojiFeedback.mockRejectedValueOnce(new Error('network'));
     render(<DeckFeedbackPrompt />);
     fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
     expect(await screen.findByText("Couldn't send that.")).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Try again' })
@@ -156,6 +192,7 @@ describe('DeckFeedbackPrompt — no upsell after feedback', () => {
   it('thanks a free user without a pass pitch after a positive rating', async () => {
     render(<DeckFeedbackPrompt />);
     fireEvent.click(screen.getByRole('button', { name: 'Yes, it worked' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
     expect(await screen.findByText('Feedback received.')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Get Day Pass' })

--- a/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
+++ b/web/src/pages/DownloadsPage/components/DeckFeedbackPrompt.tsx
@@ -12,7 +12,7 @@ const COMMENT_MAX = 2000;
 
 type Stage =
   | { kind: 'prompt' }
-  | { kind: 'follow-up' }
+  | { kind: 'follow-up'; rating: number }
   | { kind: 'sending' }
   | { kind: 'sent'; rating: number }
   | { kind: 'error'; retry: () => void };
@@ -69,19 +69,19 @@ export function DeckFeedbackPrompt() {
   };
 
   const handlePositive = () => {
-    void sendRating(POSITIVE_RATING);
+    setStage({ kind: 'follow-up', rating: POSITIVE_RATING });
   };
 
   const handleNegative = () => {
-    setStage({ kind: 'follow-up' });
+    setStage({ kind: 'follow-up', rating: NEGATIVE_RATING });
   };
 
-  const handleSendNegative = () => {
-    void sendRating(NEGATIVE_RATING, comment.slice(0, COMMENT_MAX));
+  const handleSend = (rating: number) => {
+    void sendRating(rating, comment.slice(0, COMMENT_MAX));
   };
 
-  const handleSkipNegative = () => {
-    void sendRating(NEGATIVE_RATING);
+  const handleSkip = (rating: number) => {
+    void sendRating(rating);
   };
 
   return (
@@ -120,12 +120,18 @@ export function DeckFeedbackPrompt() {
       {stage.kind === 'follow-up' && (
         <>
           <label className={styles.prompt} htmlFor="deck-feedback-comment">
-            What went wrong?
+            {stage.rating === POSITIVE_RATING
+              ? 'Glad it came out right. Anything that would make it better?'
+              : 'What went wrong?'}
           </label>
           <textarea
             id="deck-feedback-comment"
             className={styles.textarea}
-            placeholder="For example: images didn't come through, or cards were empty."
+            placeholder={
+              stage.rating === POSITIVE_RATING
+                ? 'For example: keep my headings, or add a tag to each card.'
+                : "For example: images didn't come through, or cards were empty."
+            }
             value={comment}
             onChange={(e) => setComment(e.target.value)}
             rows={2}
@@ -135,14 +141,14 @@ export function DeckFeedbackPrompt() {
             <button
               type="button"
               className={styles.primary}
-              onClick={handleSendNegative}
+              onClick={() => handleSend(stage.rating)}
             >
               Send
             </button>
             <button
               type="button"
               className={styles.secondary}
-              onClick={handleSkipNegative}
+              onClick={() => handleSkip(stage.rating)}
             >
               Skip
             </button>

--- a/web/src/pages/WhatsNewPage/changelog/2026-07-14-deck-feedback-ideas.json
+++ b/web/src/pages/WhatsNewPage/changelog/2026-07-14-deck-feedback-ideas.json
@@ -1,0 +1,6 @@
+{
+  "id": "2026-07-14-deck-feedback-ideas",
+  "date": "2026-07-14",
+  "type": "feature",
+  "title": "Deck feedback now asks what would make your cards better, not just what went wrong"
+}


### PR DESCRIPTION
## What
The deck-ready feedback prompt now captures feature ideas on a thumbs-up, not just bug reports on a thumbs-down. A positive rating opens an idea box that mirrors the existing negative flow: Send posts the rating plus the comment, Skip records the rating with no comment. A thumbs-down is unchanged.

## Why
Today we only capture a bug signal — a thumbs-down opens "What went wrong?", but a thumbs-up submits immediately with no way to say what would improve the cards. That discards feature ideas at the peak-trust moment, right after a deck came out right. Those comments already feed the /ops Customer Signals view.

## How
`DeckFeedbackPrompt.tsx` only: the positive handler now routes to the same follow-up stage as the negative one, keyed on rating, and the follow-up render swaps its label and placeholder for positive vs negative. Reuses the same `comment` state, `sendRating`, `COMMENT_MAX`, and styles. The `emoji_feedback` table already has a free-text `comment` and the endpoint already accepts it — no migration, no backend change, no new rating value or surface.

## Measuring success
`emoji_feedback` rows with `rating = 5` and a non-null `comment` on `page = downloads/deck_done` — previously always null. Read in the /ops `/ops/growth` Customer Signals view alongside existing negative comments.

## Testing
- Unit tests added/updated (Vitest): 👍 now opens the idea textarea; Send posts rating 5 + comment; Skip posts rating 5 with no comment; the negative flow (rating 1 + comment / skip) still works; suppression, retry, and no-upsell tests updated to click through the new stage.

## Browser check
- [x] Golden path on localhost:3000
- [x] No console errors at 375px
Notes: verified via `pnpm --filter 2anki-web test:golden-path` — 2 passed, no console errors at 375px.

## Changelog
`web/src/pages/WhatsNewPage/changelog/2026-07-14-deck-feedback-ideas.json` — "Deck feedback now asks what would make your cards better, not just what went wrong"

## Risks
Low. Single component, no backend or schema change. Worst case a positive rater now sees one extra step before the rating records; Skip preserves the rating so a positive signal is never lost. Rollback = revert the one commit.

## Goal alignment
Feeds the /ops Customer Signals loop with feature ideas from happy users at the deck-ready peak-trust moment — the retention/roadmap input that ARPU and retention work depends on. Metric to move: count of positive-rating comments on `downloads/deck_done`, read in the /ops Customer Signals view, expected to rise from ~0 within days of ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
