### PR TITLE
feat: instrument native-app activation via IAP redeem event

### DIFF
--- a/src/types/AnalyticsEvents.ts
+++ b/src/types/AnalyticsEvents.ts
@@ -69,6 +69,7 @@ export const KNOWN_EVENTS = new Set([
   'native_app_page_viewed',
   'native_app_interest_clicked',
   'native_app_store_clicked',
+  'native_app_activated',
   'checkout_started',
   'plan_interval_selected',
   'ankify_stats_viewed',

--- a/src/usecases/iap/RedeemAppleTransactionUseCase.test.ts
+++ b/src/usecases/iap/RedeemAppleTransactionUseCase.test.ts
@@ -6,8 +6,27 @@ import {
   type DecodedAppleTransaction,
   type IAppleStoreKitService,
 } from '../../services/AppleStoreKitService';
+jest.mock('../../services/events/eventsSinkInstance', () => {
+  const recorded: unknown[] = [];
+  return {
+    getEventsSink: () => ({
+      record: jest.fn((row: unknown) => recorded.push(row)),
+    }),
+    resetEventsSinkForTesting: jest.fn(),
+    __recorded: recorded,
+  };
+});
+
 import { RedeemAppleTransactionUseCase } from './RedeemAppleTransactionUseCase';
 import { IapRedeemError } from './IapRedeemError';
+
+function recordedEvents(): Array<Record<string, unknown>> {
+  return (
+    jest.requireMock('../../services/events/eventsSinkInstance') as {
+      __recorded: Array<Record<string, unknown>>;
+    }
+  ).__recorded;
+}
 
 const NOW = new Date('2026-06-01T00:00:00.000Z');
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -50,6 +69,10 @@ function build(service: IAppleStoreKitService) {
 describe('RedeemAppleTransactionUseCase', () => {
   beforeAll(() => {
     process.env.THE_HASHING_SECRET = 'test-hashing-secret';
+  });
+
+  beforeEach(() => {
+    recordedEvents().length = 0;
   });
 
   it.each([
@@ -191,6 +214,101 @@ describe('RedeemAppleTransactionUseCase', () => {
         productId: 'lifetime.forever',
       })
     ).rejects.toBeInstanceOf(IapRedeemError);
+  });
+
+  describe('native_app_activated telemetry', () => {
+    it('emits native_app_activated with attribution props on a consumable grant', async () => {
+      const { useCase } = build(
+        serviceReturning(
+          decoded({ productId: 'daypass.24h', transactionId: 't' })
+        )
+      );
+
+      await useCase.execute({
+        userId: USER_ID,
+        jws: 'signed',
+        productId: 'daypass.24h',
+      });
+
+      expect(recordedEvents()).toHaveLength(1);
+      expect(recordedEvents()[0]).toMatchObject({
+        name: 'native_app_activated',
+        user_id: USER_ID,
+        props: {
+          platform: 'apple',
+          product_kind: 'consumable',
+          pass_kind: '24h',
+          environment: 'Sandbox',
+        },
+      });
+    });
+
+    it('emits native_app_activated for a subscription grant', async () => {
+      const { useCase } = build(
+        serviceReturning(
+          decoded({
+            productId: 'unlimited.monthly',
+            transactionId: 'sub-1',
+            environment: 'Production',
+            expiresDateMs: new Date('2026-07-01T00:00:00.000Z').getTime(),
+          })
+        )
+      );
+
+      await useCase.execute({
+        userId: USER_ID,
+        jws: 'signed',
+        productId: 'unlimited.monthly',
+      });
+
+      expect(recordedEvents()[0]).toMatchObject({
+        name: 'native_app_activated',
+        props: {
+          product_kind: 'subscription',
+          pass_kind: 'unlimited',
+          environment: 'Production',
+        },
+      });
+    });
+
+    it('does not emit native_app_activated when verification fails', async () => {
+      const { useCase } = build(serviceThrowing(new AppleVerificationError()));
+
+      await expect(
+        useCase.execute({
+          userId: USER_ID,
+          jws: 'bad',
+          productId: 'daypass.24h',
+        })
+      ).rejects.toMatchObject({ status: 400 });
+
+      expect(recordedEvents()).toHaveLength(0);
+    });
+
+    it('does not emit native_app_activated for an already-credited transaction', async () => {
+      const { useCase, ledger } = build(
+        serviceReturning(decoded({ transactionId: 'dupe' }))
+      );
+      await ledger.record(
+        {
+          userId: USER_ID,
+          transactionId: 'dupe',
+          productId: 'daypass.24h',
+          environment: 'Sandbox',
+        },
+        NOW
+      );
+
+      await expect(
+        useCase.execute({
+          userId: USER_ID,
+          jws: 'signed',
+          productId: 'daypass.24h',
+        })
+      ).rejects.toMatchObject({ status: 409 });
+
+      expect(recordedEvents()).toHaveLength(0);
+    });
   });
 
   describe('unlimited.monthly subscription', () => {

--- a/src/usecases/iap/RedeemAppleTransactionUseCase.ts
+++ b/src/usecases/iap/RedeemAppleTransactionUseCase.ts
@@ -13,6 +13,7 @@ import {
   type IAppleStoreKitService,
 } from '../../services/AppleStoreKitService';
 import hashToken from '../../lib/misc/hashToken';
+import { track } from '../../services/events/track';
 import { IapRedeemError } from './IapRedeemError';
 import { findAppleProduct, type SubscriptionProduct } from './products';
 
@@ -95,6 +96,16 @@ export class RedeemAppleTransactionUseCase {
       environment: decoded.environment,
       expires_at: pass.expires_at.toISOString(),
       transaction_id_hash: hashToken(decoded.transactionId),
+    });
+
+    track('native_app_activated', {
+      userId: input.userId,
+      props: {
+        platform: 'apple',
+        product_kind: product.kind,
+        pass_kind: product.passKind,
+        environment: decoded.environment,
+      },
     });
 
     return {


### PR DESCRIPTION
## What
Emits a new `native_app_activated` analytics event when the server verifies a native-app Apple in-app purchase (`POST /api/iap/redeem`). The event flows through the existing `track(...)` pipeline (no new integration, no new credential) and carries `platform`, `product_kind`, `pass_kind`, and `environment` for attribution.

## Why
Fixes #3579. The native iOS soft launch tripled signups, but conversion happens on-device via StoreKit 2, so the app cohort's activation and paid conversion were invisible to the server — only ~4% showed up as upload+job. The verified IAP redeem is the earliest server-observable moment of native paid activation: the app already POSTs the StoreKit 2 JWS to `/api/iap/redeem`, and the server verifies it against Apple before granting the pass. That grant is the natural point to count a native activation server-side.

Scope note: this instruments the paid-activation signal (IAP redeem), which is the one unambiguous native-app server call that exists today. The issue's broader asks — tagging web-vs-app on every signup/session and reporting app-originated free conversions — need a client-source tag threaded through the app's authenticated calls (extends #2998) and are not in this PR. A free-tier app user who never purchases still emits no distinct native signal today; closing that gap requires the app to send a source tag on its API calls. This PR makes native *paid* conversion countable now and documents the remaining gap.

## How
`RedeemAppleTransactionUseCase.execute` already logged `iap.redeem.granted` after a successful grant + ledger write. Added a `track('native_app_activated', …)` call immediately after, following the module-import pattern used in `performConversion.ts`. The event only fires on a genuine grant — verification failures (400), unavailable-Apple (502), and duplicate transactions (409) all throw before the `track` call, so no false activations are recorded. Added `native_app_activated` to `KNOWN_EVENTS` in `AnalyticsEvents.ts`.

## Measuring success
Query the events table for `native_app_activated` (read at `/api/ops/metrics`): a weekly count of distinct `user_id` gives native paid-conversion volume, and `props.product_kind` / `props.pass_kind` split Day/Week pass vs Unlimited subscription. Before this PR the count is structurally zero; after deploy a non-zero weekly number replaces the ~4% visibility estimate for the paid slice.

## Testing
- Unit tests added to `RedeemAppleTransactionUseCase.test.ts` (events sink mocked at the module edge):
  - emits `native_app_activated` with attribution props on a consumable (Day Pass) grant
  - emits it for a subscription (Unlimited) grant with the right `product_kind`/`pass_kind`
  - does NOT emit when Apple verification fails
  - does NOT emit for an already-credited (duplicate) transaction
- `npx tsc -p . --noEmit` clean (typechecks tests too). `npx oxfmt` clean on changed files.
- Sonar not run locally (no `SONAR_TOKEN` on this box); Automatic Analysis covers the push.

## Browser check
Browser check: not applicable — server-side analytics only, no `web/src/` change.

## Changelog
No entry — internal analytics instrumentation, no user-visible behavior change.

## Risks
Low. One added `track` call on the IAP redeem path; `track` is fire-and-forget (buffers in the events sink, never throws into the request). If the events sink is unavailable the redeem still succeeds. Rollback is reverting the single commit.

## Goal alignment
Directly serves the 300K-user and MRR goals by making the biggest 2026 acquisition win (native app) measurable: native paid conversion becomes countable server-side, read at `/api/ops/metrics`, so the weekly retro can finally state the app cohort's paid-conversion number instead of guessing ~4%. Measurement is the precondition for optimizing app activation and ARPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cs4pvvQ4BKVpvEtGA9GXTn
