### PR TITLE
fix: enable invoice_creation on one-time pass Checkout sessions

### DIFF
--- a/src/usecases/checkout/CreatePassCheckoutUseCase.test.ts
+++ b/src/usecases/checkout/CreatePassCheckoutUseCase.test.ts
@@ -104,6 +104,21 @@ describe('CreatePassCheckoutUseCase', () => {
     );
   });
 
+  it('enables Stripe invoice creation for Fiken bookkeeping', async () => {
+    mockStripeCreateSession.mockResolvedValue({
+      url: 'https://checkout.stripe.com/24h',
+    });
+
+    const uc = new CreatePassCheckoutUseCase(makeStripe(), 'price_24h', '24h');
+    await uc.execute({ userEmail: 'user@example.com', userId: 7 });
+
+    expect(mockStripeCreateSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice_creation: { enabled: true },
+      })
+    );
+  });
+
   it('uses APP_URL env var for success and cancel URLs', async () => {
     process.env.APP_URL = 'https://staging.2anki.net';
     mockStripeCreateSession.mockResolvedValue({

--- a/src/usecases/checkout/CreatePassCheckoutUseCase.ts
+++ b/src/usecases/checkout/CreatePassCheckoutUseCase.ts
@@ -47,6 +47,7 @@ export class CreatePassCheckoutUseCase {
 
     const sessionParams: StripeTypes.Checkout.SessionCreateParams = {
       mode: 'payment',
+      invoice_creation: { enabled: true },
       line_items: [{ price: this.priceId, quantity: 1 }],
       success_url: successUrl,
       cancel_url: `${appUrl}/pricing`,


### PR DESCRIPTION
## What
Adds `invoice_creation: { enabled: true }` to the one-time Day/Week Pass Stripe Checkout session (`CreatePassCheckoutUseCase`, `mode: 'payment'`). Stripe now generates an invoice for every completed pass payment.

## Why
Fixes #3601. One-time pass purchases go through Checkout in `payment` mode without an invoice, so the Fiken bookkeeping integration (Striperegnskap.no) — which only books charges tied to invoices — silently drops every Day/Week Pass sale from the accounts on an ongoing basis. Subscription-mode checkout already invoices; only the one-time pass path was missing it.

## How
Single additive param on the pass session create. Nothing else changes — mode, price, line items, metadata, amounts, customer handling are all untouched. Verified the only `payment`-mode Checkout session is the pass one; `AutoSyncCheckoutUseCase` and `UnlimitedCheckoutUseCase` are `mode: 'subscription'` and were not touched.

Passes use Checkout session create, not Payment Links — grepped `payment_link` / `buy.stripe.com` / `PASS_*_PRICE_ID`; the pass flow is code-driven via `PASS_24H_PRICE_ID` / `PASS_7D_PRICE_ID` price IDs on a `sessions.create` call, so the toggle is code-settable. No Payment Link is involved, so no Dashboard link toggle is required for this path.

## Measuring success
After deploy, buy a Day Pass in live mode → the resulting Stripe payment should carry an `invoice_number` (Dashboard → payment → invoice), and the sale should appear in Fiken within ~1 day as `Salg registrert via API` + `Betaling (faktura #...)`. In Stripe, filter Invoices by the pass price to confirm one invoice per completed pass Checkout.

## Testing
- Unit test added: asserts the pass Checkout session is created with `invoice_creation: { enabled: true }` (Stripe SDK mocked at the `checkout.sessions.create` edge). Existing subscription-checkout tests unchanged and green. `npx tsc -p . --noEmit` clean; 17/17 in the file pass.
- Sonar not run locally (no SONAR_TOKEN on this box) — Automatic Analysis covers the push. Change is a single additive object literal, no new complexity.

## Browser check
Browser check: not applicable — server-only change, no `web/src/` files.

## Changelog
No changelog entry — internal/bookkeeping change, no user-visible behavior (a Stripe invoice is generated behind the scenes; the buyer's checkout is identical).

## Risks
Stripe Invoicing Starter pricing applies per post-payment invoice (small capped percentage) — negligible at Day/Week Pass price points. Enabling `invoice_creation` may require account-side Stripe invoice settings (a default footer / memo) to be configured before invoices render cleanly — please confirm in the Stripe Dashboard (Settings → Invoicing) before this ships. Rollback is a one-line revert; no data migration.

## Goal alignment
None — internal bookkeeping correctness (revenue that already happened now reconciles in Fiken). No funnel or MRR metric moves; this closes an accounting gap, not a conversion one.

---
**Payments change — needs your gate.** Per the payments hard rail this is opened as a **DRAFT**; do not merge without your review + `/security-review` + confirming the Stripe Dashboard invoice settings above.

Fixes #3601

